### PR TITLE
fix: MD050 consistent asterisk strong style

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -99,7 +99,9 @@
     "style": "fenced"
   },
   "MD049": false,
-  "MD050": false,
+  "MD050": {
+    "style": "asterisk"
+  },
   "MD051": false,
   "MD052": false
 }

--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -81,7 +81,7 @@ What are these extra properties, and where do they come from?
 
 Every object in JavaScript has a built-in property, which is called its **prototype**. The prototype is itself an object, so the prototype will have its own prototype, making what's called a **prototype chain**. The chain ends when we reach a prototype that has `null` for its own prototype.
 
-> **Note:** The property of an object that points to its prototype is **not** called `prototype`. Its name is not standard, but in practice all browsers use {{jsxref("Object/__proto__", "__proto__")}}. The standard way to access an object's prototype is the {{jsxref("Object/getPrototypeOf", "Object.getPrototypeOf()")}} method.
+> **Note:** The property of an object that points to its prototype is **not** called `prototype`. Its name is not standard, but in practice all browsers use [`__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto). The standard way to access an object's prototype is the {{jsxref("Object/getPrototypeOf", "Object.getPrototypeOf()")}} method.
 
 When you try to access a property of an object: if the property can't be found in the object itself, the prototype is searched for the property. If the property still can't be found, then the prototype's prototype is searched, and so on until either the property is found, or the end of the chain is reached, in which case `undefined` is returned.
 

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -42,7 +42,7 @@ Highlights:
 ### JavaScript
 
 - The [`RegExp` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) no longer throws when the first argument is a `RegExp` and the second `flags` argument is present ({{bug(1108949)}}).
-- The `Object.prototype.noSuchMethod` property is now deprecated and throws a console warning (see {{bug(1140428)}} and this [platform announcement](https://groups.google.com/forum/#!topic/mozilla.dev.platform/0EkHgphxUo8)).
+- The `Object.prototype.__noSuchMethod__` property is now deprecated and throws a console warning (see {{bug(1140428)}} and this [platform announcement](https://groups.google.com/forum/#!topic/mozilla.dev.platform/0EkHgphxUo8)).
 - The implementation of the {{jsxref("Proxy")}} object has been updated to comply more with the ES2015 specification:
 
   - The {{jsxref("Global_Objects/Proxy/Proxy/defineProperty", "defineProperty")}} and {{jsxref("Global_Objects/Proxy/Proxy/set", "set")}} handlers now need to explicitly return `true` to be successful, otherwise a {{jsxref("TypeError")}} exception will be thrown in strict mode ({{bug(1132522)}}).

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -42,7 +42,7 @@ Highlights:
 ### JavaScript
 
 - The [`RegExp` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) no longer throws when the first argument is a `RegExp` and the second `flags` argument is present ({{bug(1108949)}}).
-- The {{jsxref("Object.noSuchMethod", "Object.prototype.__noSuchMethod__")}} property is now deprecated and throws a console warning (see {{bug(1140428)}} and this [platform announcement](https://groups.google.com/forum/#!topic/mozilla.dev.platform/0EkHgphxUo8)).
+- The `Object.prototype.noSuchMethod` property is now deprecated and throws a console warning (see {{bug(1140428)}} and this [platform announcement](https://groups.google.com/forum/#!topic/mozilla.dev.platform/0EkHgphxUo8)).
 - The implementation of the {{jsxref("Proxy")}} object has been updated to comply more with the ES2015 specification:
 
   - The {{jsxref("Global_Objects/Proxy/Proxy/defineProperty", "defineProperty")}} and {{jsxref("Global_Objects/Proxy/Proxy/set", "set")}} handlers now need to explicitly return `true` to be successful, otherwise a {{jsxref("TypeError")}} exception will be thrown in strict mode ({{bug(1132522)}}).

--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -91,7 +91,7 @@ Highlights:
 #### Removals
 
 - Support for the non-standard [`let` blocks](/en-US/docs/Web/JavaScript/Reference/Statements/let#let_blocks) has been dropped ({{bug(1167029)}}.
-- The non-standard and deprecated property {{jsxref("Object.noSuchMethod", "Object.prototype.__noSuchMethod__")}} has been removed ({{bug(683218)}}).
+- The non-standard and deprecated property `Object.prototype.__noSuchMethod__` has been removed ({{bug(683218)}}).
 
 ### Interfaces/APIs/DOM
 

--- a/files/en-us/mozilla/firefox/releases/48/index.md
+++ b/files/en-us/mozilla/firefox/releases/48/index.md
@@ -81,7 +81,7 @@ tags:
 - The deprecated [old Proxy API](/en-US/docs/Archive/Web/Old_Proxy_API) (`Proxy.create` and `Proxy.createFunction()`) has been removed. Use the standard {{jsxref("Proxy")}} object instead ({{bug(892903)}}).
 - The `String.prototype.contains()` method has been removed (it was deprecated since version 40). Use the {{jsxref("String.prototype.includes()")}} method instead ({{bug(1103588)}}).
 - The non-standard `RegExp.multiline` property (not {{jsxref("RegExp.prototype.multiline")}}) has been removed. Use the standard [m flag](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags) instead ({{bug(1219757)}}).
-- The {{jsxref("Object.__defineGetter__", "__defineGetter__")}} and {{jsxref("Object.__defineSetter__", "__defineSetter__")}} methods can no longer be called at the global scope without any object. ({{bug(1253016)}}).
+- The [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__) and [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__) methods can no longer be called at the global scope without any object. ({{bug(1253016)}}).
 
 ### Interfaces/APIs/DOM
 

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -713,7 +713,7 @@ Object.setPrototypeOf(obj, anotherObj);
 
 ### With the \_\_proto__ accessor
 
-All objects inherit the {{jsxref("Object/proto","Object.prototype.__proto__")}} setter, which can be used to set the `[[Prototype]]` of an existing object (if the `__proto__` key is not overridden on the object).
+All objects inherit the [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) setter, which can be used to set the `[[Prototype]]` of an existing object (if the `__proto__` key is not overridden on the object).
 
 > **Warning:** `Object.prototype.__proto__` accessors are **non-standard** and deprecated. You should almost always use `Object.setPrototypeOf` instead.
 

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -217,6 +217,6 @@ console.log(
 - [Setter](/en-US/docs/Web/JavaScript/Reference/Functions/set)
 - {{jsxref("Operators/delete", "delete")}}
 - {{jsxref("Object.defineProperty()")}}
-- {{jsxref("Object/__defineGetter__", "__defineGetter__")}}
-- {{jsxref("Object/__defineSetter__", "__defineSetter__")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
 - [Defining getters and setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters) in JavaScript Guide

--- a/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -87,11 +87,11 @@ console.log(o.gimmeFive); // 5
 ## See also
 
 - [Polyfill of `Object.prototype.__defineGetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
-- {{jsxref("Object.prototype.__defineSetter__()")}}
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
 - {{jsxref("Functions/get", "get")}} operator
 - {{jsxref("Object.defineProperty()")}}
-- {{jsxref("Object.prototype.__lookupGetter__()")}}
-- {{jsxref("Object.prototype.__lookupSetter__()")}}
+- [`Object.prototype.__lookupGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__)
+- [`Object.prototype.__lookupSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__)
 - [JS Guide: Defining Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters)
 - [\[Blog Post\] Deprecation of \_\_defineGetter\_\_ and \_\_defineSetter\_\_](https://whereswalden.com/2010/04/16/more-spidermonkey-changes-ancient-esoteric-very-rarely-used-syntax-for-creating-getters-and-setters-is-being-removed/)
 - {{bug(647423)}}

--- a/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.md
@@ -95,11 +95,11 @@ console.log(o.anotherValue); // 5
 ## See also
 
 - [Polyfill of `Object.prototype.__defineSetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
-- {{jsxref("Object.prototype.__defineGetter__()")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
 - {{jsxref("Functions/set", "set")}} operator
 - {{jsxref("Object.defineProperty()")}}
-- {{jsxref("Object.prototype.__lookupGetter__()")}}
-- {{jsxref("Object.prototype.__lookupSetter__()")}}
+- [`Object.prototype.__lookupGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__)
+- [`Object.prototype.__lookupSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__)
 - [JS Guide: Defining Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters)
 - [\[Blog Post\] Deprecation of \_\_defineGetter\_\_ and \_\_defineSetter\_\_](https://whereswalden.com/2010/04/16/more-spidermonkey-changes-ancient-esoteric-very-rarely-used-syntax-for-creating-getters-and-setters-is-being-removed/)
 - {{bug(647423)}}

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
@@ -72,10 +72,10 @@ Object.getOwnPropertyDescriptor(obj, "foo").get;
 ## See also
 
 - [Polyfill of `Object.prototype.__lookupGetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
-- {{jsxref("Object.prototype.__lookupSetter__()")}}
+- [`Object.prototype.__lookupSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__)
 - {{jsxref("Functions/get", "get")}} operator
 - {{jsxref("Object.getOwnPropertyDescriptor()")}} and
   {{jsxref("Object.getPrototypeOf()")}}
-- {{jsxref("Object.prototype.__defineGetter__()")}}
-- {{jsxref("Object.prototype.__defineSetter__()")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
 - [JS Guide: Defining Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters)

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
@@ -71,10 +71,10 @@ Object.getOwnPropertyDescriptor(obj, 'foo').set;
 ## See also
 
 - [Polyfill of `Object.prototype.__lookupSetter__` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
-- {{jsxref("Object.prototype.__lookupGetter__()")}}
+- [`Object.prototype.__lookupGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__)
 - {{jsxref("Functions/set", "set")}} operator
 - {{jsxref("Object.getOwnPropertyDescriptor()")}} and
   {{jsxref("Object.getPrototypeOf()")}}
-- {{jsxref("Object.prototype.__defineGetter__()")}}
-- {{jsxref("Object.prototype.__defineSetter__()")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
 - [JS Guide: Defining Getters and Setters](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#defining_getters_and_setters)

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -68,6 +68,6 @@ Object.getPrototypeOf('foo');
 - [Polyfill of `Object.getPrototypeOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.setPrototypeOf()")}}
-- {{jsxref("Object/proto","Object.prototype.__proto__")}}
+- [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
 - John Resig's post on [getPrototypeOf](https://johnresig.com/blog/objectgetprototypeof/)
 - {{jsxref("Reflect.getPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -85,19 +85,19 @@ There isn't any method in an Object itself to delete its own properties (such as
 
 - {{jsxref("Object.prototype.constructor")}}
   - : Specifies the function that creates an object's prototype.
-- {{jsxref("Object/proto","Object.prototype.__proto__")}}
+- [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
   - : Points to the object which was used as prototype when the object was instantiated.
 
 ## Instance methods
 
-- {{jsxref("Object.prototype.__defineGetter__()")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
   - : Associates a function with a property that, when accessed, executes that function and returns its return value.
-- {{jsxref("Object.prototype.__defineSetter__()")}}
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
   - : Associates a function with a property that, when set, executes that function which modifies the property.
-- {{jsxref("Object.prototype.__lookupGetter__()")}}
-  - : Returns the function associated with the specified property by the {{jsxref("Object.prototype.__defineGetter__()", "__defineGetter__()")}} method.
-- {{jsxref("Object.prototype.__lookupSetter__()")}}
-  - : Returns the function associated with the specified property by the {{jsxref("Object.prototype.__defineSetter__()", "__defineSetter__()")}} method.
+- [`Object.prototype.__lookupGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__)
+  - : Returns the function associated with the specified property by the [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__) method.
+- [`Object.prototype.__lookupSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__)
+  - : Returns the function associated with the specified property by the [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__) method.
 - {{jsxref("Object.prototype.hasOwnProperty()")}}
   - : Returns a boolean indicating whether an object contains the specified property as a direct property of that object and not inherited through the prototype chain.
 - {{jsxref("Object.prototype.isPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -51,8 +51,8 @@ The **`handler.defineProperty()`** method is a trap for
 
 This trap can intercept these operations:
 
-- {{jsxref("Object.prototype.__defineGetter__()")}}
-- {{jsxref("Object.prototype.__defineSetter__()")}}
+- [`Object.prototype.__defineGetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
+- [`Object.prototype.__defineSetter__()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Reflect.defineProperty()")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -45,7 +45,7 @@ This trap can intercept these operations:
 
 - {{jsxref("Object.getPrototypeOf()")}}
 - {{jsxref("Reflect.getPrototypeOf()")}}
-- {{jsxref("Object/proto", "__proto__")}}
+- [`__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Operators/instanceof", "instanceof")}}
 

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -299,7 +299,7 @@ const obj3 = { ['__prot' + 'o__']: 17 };
 console.log(obj3.__proto__ === 17);
 ```
 
-Note that the `__proto__` key is standardized syntax, in contrast to the non-standard and non-performant {{jsxref("Object/proto", "Object.prototype.__proto__")}} accessors. It sets the `[[Prototype]]` during object creation, similar to {{jsxref("Object.create")}} — instead of mutating the prototype chain.
+Note that the `__proto__` key is standardized syntax, in contrast to the non-standard and non-performant [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) accessors. It sets the `[[Prototype]]` during object creation, similar to {{jsxref("Object.create")}} — instead of mutating the prototype chain.
 
 ## Specifications
 


### PR DESCRIPTION
This is another one of those markdown vs. macros edge cases.
Will see if the escaping breaks the macro or not