### PR TITLE
Use querySelector when using only first element that matches

### DIFF
--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -6,6 +6,7 @@ tags:
   - Glossary
   - HTML
 ---
+
 An **attribute** extends an HTML or XML {{Glossary("element")}}, changing its behavior or providing metadata.
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
@@ -13,11 +14,11 @@ An attribute always has the form `name="value"` (the attribute's identifier foll
 You may see attributes without the equals sign or a value. That is a shorthand for providing the empty string in HTML, or the attribute's name in XML.
 
 ```html
-<input required>
+<input required />
 <!-- is the same as… -->
-<input required="">
+<input required="" />
 <!-- or -->
-<input required="required">
+<input required="required" />
 ```
 
 ## Reflection of an attribute
@@ -31,26 +32,20 @@ For example, the `placeholder` below is reflected into {{domxref("HTMLInputEleme
 Considering the following HTML:
 
 ```html
-<input placeholder="Original placeholder">
+<input placeholder="Original placeholder" />
 ```
 
 We can check the reflection between {{domxref("HTMLInputElement.placeholder")}} and the attribute using:
 
 ```js
-let input = document.getElementsByTagName("input")[0];
-let attr = input.getAttributeNode("placeholder")
+const input = document.querySelector("input");
+const attr = input.getAttributeNode("placeholder");
 console.log(attr.value);
-console.log(input.placeholder); //Returns the same value as `attr.value`
-```
+console.log(input.placeholder); // Prints the same value as `attr.value`
 
-and
-
-```js
-let input2 = document.getElementsByTagName("input")[0];
-let attr2 = input.getAttributeNode("placeholder")
-console.log(attr2.value); // Returns `Original placeholder`
-input2.placeholder = "Modified placeholder"; // Also change the value of the reflected attribute.
-console.log(attr2.value); // Returns `Modified placeholder`
+// Changing placeholder value will also change the value of the reflected attribute.
+input.placeholder = "Modified placeholder";
+console.log(attr.value); // Prints `Modified placeholder`
 ```
 
 ## See also

--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -12,6 +12,7 @@ tags:
   - Web
   - regex
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/UI_pseudo-classes", "Learn/Forms/Sending_and_retrieving_form_data", "Learn/HTML/Forms")}}
 
 Before submitting data to the server, it is important to ensure all required form controls are filled out, in the correct format.
@@ -67,7 +68,7 @@ There are three main reasons:
 - **We want to get the right data, in the right format.** Our applications won't work properly if our users' data is stored in the wrong format, is incorrect, or is omitted altogether.
 - **We want to protect our users' data**. Forcing our users to enter secure passwords makes it easier to protect their account information.
 - **We want to protect ourselves**. There are many ways that malicious users can misuse unprotected forms to damage the application. See [Website security](/en-US/docs/Learn/Server-side/First_steps/Website_security).
-  
+
   > **Warning:** Never trust data passed to your server from the client. Even if your form is validating correctly and preventing malformed input on the client-side, a malicious user can still alter the network request.
 
 ## Different types of client-side validation
@@ -119,7 +120,7 @@ Find the source code on GitHub at [fruit-start.html](https://github.com/mdn/lear
 ```html
 <form>
   <label for="choose">Would you prefer a banana or cherry?</label>
-  <input id="choose" name="i_like">
+  <input id="choose" name="i-like" />
   <button>Submit</button>
 </form>
 ```
@@ -150,7 +151,7 @@ Add a `required` attribute to your input, as shown below.
 ```html
 <form>
   <label for="choose">Would you prefer a banana or cherry? (required)</label>
-  <input id="choose" name="i_like" required>
+  <input id="choose" name="i-like" required />
   <button>Submit</button>
 </form>
 ```
@@ -211,7 +212,7 @@ Update your HTML to add a [`pattern`](/en-US/docs/Web/HTML/Attributes/pattern) a
 ```html
 <form>
   <label for="choose">Would you prefer a banana or a cherry?</label>
-  <input id="choose" name="i_like" required pattern="[Bb]anana|[Cc]herry">
+  <input id="choose" name="i-like" required pattern="[Bb]anana|[Cc]herry" />
   <button>Submit</button>
 </form>
 ```
@@ -266,11 +267,17 @@ Now delete the contents of the `<body>` element, and replace it with the followi
 <form>
   <div>
     <label for="choose">Would you prefer a banana or a cherry?</label>
-    <input type="text" id="choose" name="i_like" required minlength="6" maxlength="6">
+    <input
+      type="text"
+      id="choose"
+      name="i-like"
+      required
+      minlength="6"
+      maxlength="6" />
   </div>
   <div>
     <label for="number">How many would you like?</label>
-    <input type="number" id="number" name="amount" value="1" min="1" max="10">
+    <input type="number" id="number" name="amount" value="1" min="1" max="10" />
   </div>
   <div>
     <button>Submit</button>
@@ -378,7 +385,7 @@ input[type="email"],
 input[type="number"],
 textarea,
 fieldset {
-  width : 100%;
+  width: 100%;
   border: 1px solid #333;
   box-sizing: border-box;
 }
@@ -456,8 +463,10 @@ We'll start with some simple HTML (feel free to put this in a blank HTML file; u
 
 ```html
 <form>
-  <label for="mail">I would like you to provide me with an e-mail address:</label>
-  <input type="email" id="mail" name="mail">
+  <label for="mail">
+    I would like you to provide me with an e-mail address:
+  </label>
+  <input type="email" id="mail" name="mail" />
   <button>Submit</button>
 </form>
 ```
@@ -500,7 +509,7 @@ First, the HTML. Again, feel free to build this along with us:
   <p>
     <label for="mail">
       <span>Please enter an email address:</span>
-      <input type="email" id="mail" name="mail" required minlength="8">
+      <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>
   </p>
@@ -526,14 +535,14 @@ body {
   font: 1em sans-serif;
   width: 200px;
   padding: 0;
-  margin : 0 auto;
+  margin: 0 auto;
 }
 
 p * {
   display: block;
 }
 
-input[type=email]{
+input[type="email"] {
   appearance: none;
 
   width: 100%;
@@ -547,9 +556,9 @@ input[type=email]{
 }
 
 /* This is our style for the invalid fields */
-input:invalid{
+input:invalid {
   border-color: #900;
-  background-color: #FDD;
+  background-color: #fdd;
 }
 
 input:focus:invalid {
@@ -558,7 +567,7 @@ input:focus:invalid {
 
 /* This is the style of our error messages */
 .error {
-  width  : 100%;
+  width: 100%;
   padding: 0;
 
   font-size: 80%;
@@ -579,29 +588,27 @@ Now let's look at the JavaScript that implements the custom error validation.
 ```js
 // There are many ways to pick a DOM node; here we get the form itself and the email
 // input box, as well as the span element into which we will place the error message.
-const form  = document.getElementsByTagName('form')[0];
+const form = document.querySelector("form");
+const email = document.getElementById("mail");
+const emailError = document.querySelector("#mail + span.error");
 
-const email = document.getElementById('mail');
-const emailError = document.querySelector('#mail + span.error');
-
-email.addEventListener('input', (event) => {
+email.addEventListener("input", (event) => {
   // Each time the user types something, we check if the
   // form fields are valid.
 
   if (email.validity.valid) {
     // In case there is an error message visible, if the field
     // is valid, we remove the error message.
-    emailError.textContent = ''; // Reset the content of the message
-    emailError.className = 'error'; // Reset the visual state of the message
+    emailError.textContent = ""; // Reset the content of the message
+    emailError.className = "error"; // Reset the visual state of the message
   } else {
     // If there is still an error, show the correct error
     showError();
   }
 });
 
-form.addEventListener('submit', (event) => {
+form.addEventListener("submit", (event) => {
   // if the email field is valid, we let the form submit
-
   if (!email.validity.valid) {
     // If it isn't, we display an appropriate error message
     showError();
@@ -614,11 +621,11 @@ function showError() {
   if (email.validity.valueMissing) {
     // If the field is empty,
     // display the following error message.
-    emailError.textContent = 'You need to enter an e-mail address.';
+    emailError.textContent = "You need to enter an e-mail address.";
   } else if (email.validity.typeMismatch) {
     // If the field doesn't contain an email address,
     // display the following error message.
-    emailError.textContent = 'Entered value needs to be an e-mail address.';
+    emailError.textContent = "Entered value needs to be an e-mail address.";
   } else if (email.validity.tooShort) {
     // If the data is too short,
     // display the following error message.
@@ -626,7 +633,7 @@ function showError() {
   }
 
   // Set the styling appropriately
-  emailError.className = 'error active';
+  emailError.className = "error active";
 }
 ```
 
@@ -682,9 +689,9 @@ The HTML is almost the same; we just removed the HTML validation features.
 <form>
   <p>
     <label for="mail">
-        <span>Please enter an email address:</span>
-        <input type="text" id="mail" name="mail">
-        <span class="error" aria-live="polite"></span>
+      <span>Please enter an email address:</span>
+      <input type="text" id="mail" name="mail" />
+      <span class="error" aria-live="polite"></span>
     </label>
   </p>
   <button>Submit</button>
@@ -698,7 +705,7 @@ body {
   font: 1em sans-serif;
   width: 200px;
   padding: 0;
-  margin : 0 auto;
+  margin: 0 auto;
 }
 
 form {
@@ -722,9 +729,9 @@ input.mail {
 }
 
 /* This is our style for the invalid fields */
-input.invalid{
+input.invalid {
   border-color: #900;
-  background-color: #FDD;
+  background-color: #fdd;
 }
 
 input:focus.invalid {
@@ -733,7 +740,7 @@ input:focus.invalid {
 
 /* This is the style of our error messages */
 .error {
-  width  : 100%;
+  width: 100%;
   padding: 0;
 
   font-size: 80%;
@@ -751,12 +758,13 @@ input:focus.invalid {
 The big changes are in the JavaScript code, which needs to do much more heavy lifting.
 
 ```js
-const form  = document.querySelector('form');
-const email = document.getElementById('mail');
+const form = document.querySelector("form");
+const email = document.getElementById("mail");
 const error = email.nextElementSibling;
 
 // As per the HTML Specification
-const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+const emailRegExp =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
 
 // Now we can rebuild our validation constraint
 // Because we do not rely on CSS pseudo-class, we have to
@@ -764,15 +772,14 @@ const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z
 window.addEventListener("load", () => {
   // Here, we test if the field is empty (remember, the field is not required)
   // If it is not, we check if its content is a well-formed e-mail address.
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
-
-  email.className = test ? "valid" : "invalid";
+  const isValid = email.value.length === 0 || emailRegExp.test(email.value);
+  email.className = isValid ? "valid" : "invalid";
 });
 
 // This defines what happens when the user types in the field
 email.addEventListener("input", () => {
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
-  if (test) {
+  const isValid = email.value.length === 0 || emailRegExp.test(email.value);
+  if (isValid) {
     email.className = "valid";
     error.textContent = "";
     error.className = "error";
@@ -785,8 +792,8 @@ email.addEventListener("input", () => {
 form.addEventListener("submit", (event) => {
   event.preventDefault();
 
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
-  if (!test) {
+  const isValid = email.value.length === 0 || emailRegExp.test(email.value);
+  if (!isValid) {
     email.className = "invalid";
     error.textContent = "I expect an e-mail, darling!";
     error.className = "error active";

--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.after
 ---
+
 {{APIRef("DOM")}}
 
 The **`after()`** method of the {{domxref("CharacterData")}} interface
@@ -41,10 +42,10 @@ after(...nodes)
 The `after()` method allows you to insert new nodes after a `CharacterData` node.
 
 ```js
-const h1TextNode = document.getElementsByTagName('h1')[0].firstChild;
+const h1TextNode = document.querySelector("h1").firstChild;
 h1TextNode.after(" #h1");
 
-h1TextNode.parentElement.childNodes
+h1TextNode.parentElement.childNodes;
 // NodeList [#text "CharacterData.after()", #text " #h1"]
 
 h1TextNode.data;

--- a/files/en-us/web/api/characterdata/appenddata/index.md
+++ b/files/en-us/web/api/characterdata/appenddata/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.appendData
 ---
+
 {{APIRef("DOM")}}
 
 The **`appendData()`** method of the {{domxref("CharacterData")}} interface
@@ -34,8 +35,8 @@ None.
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
 textnode.appendData(" - appended text.");
 ```

--- a/files/en-us/web/api/characterdata/before/index.md
+++ b/files/en-us/web/api/characterdata/before/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.before
 ---
+
 {{APIRef("DOM")}}
 
 The **`before()`** method of the {{domxref("CharacterData")}} interface
@@ -41,10 +42,10 @@ The `before()` method allows you to insert new nodes before a
 `CharacterData` node leaving the current node's data unchanged.
 
 ```js
-const h1TextNode = document.getElementsByTagName('h1')[0].firstChild;
+const h1TextNode = document.querySelector("h1").firstChild;
 h1TextNode.before("h1# ");
 
-h1TextNode.parentElement.childNodes
+h1TextNode.parentElement.childNodes;
 // NodeList [#text "h1# ", #text "CharacterData.before()"]
 
 h1TextNode.data;

--- a/files/en-us/web/api/characterdata/data/index.md
+++ b/files/en-us/web/api/characterdata/data/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.data
 ---
+
 {{APIRef("DOM")}}
 
 The **`data`** property of the {{domxref("CharacterData")}} interface represent the value of the current object's data.
@@ -23,13 +24,13 @@ A string with the character information contained in the {{domxref("CharacterDat
 ### Reading a comment using data
 
 ```html
-<!-- This is an HTML comment !-->
-<output id="Result"></output>
+<!-- This is an HTML comment -->
+<output id="result"></output>
 ```
 
 ```js
-let comment = document.body.childNodes[1];
-let output = document.getElementById("Result");
+const comment = document.body.childNodes[1];
+const output = document.getElementById("result");
 
 output.value = comment.data;
 ```
@@ -43,10 +44,10 @@ output.value = comment.data;
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
-textnode.data = "This text has been set using textnode.data."
+textnode.data = "This text has been set using 'textnode.data'.";
 ```
 
 {{EmbedLiveSample("Setting_the_content_of_a_text_node_using_data", "100%", 50)}}

--- a/files/en-us/web/api/characterdata/deletedata/index.md
+++ b/files/en-us/web/api/characterdata/deletedata/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.deleteData
 ---
+
 {{APIRef("DOM")}}
 
 The **`deleteData()`** method of the {{domxref("CharacterData")}} interface
@@ -42,8 +43,8 @@ None.
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
 textnode.deleteData(1, 5);
 ```

--- a/files/en-us/web/api/characterdata/insertdata/index.md
+++ b/files/en-us/web/api/characterdata/insertdata/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.insertData
 ---
+
 {{APIRef("DOM")}}
 
 The **`insertData()`** method of the {{domxref("CharacterData")}} interface
@@ -44,8 +45,8 @@ None.
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
 textnode.insertData(2, "long ");
 ```

--- a/files/en-us/web/api/characterdata/length/index.md
+++ b/files/en-us/web/api/characterdata/length/index.md
@@ -8,6 +8,7 @@ tags:
   - Read-only
 browser-compat: api.CharacterData.length
 ---
+
 {{APIRef("DOM")}}
 
 The read-only **`CharacterData.length`** property
@@ -27,8 +28,8 @@ Length of the string in the <code>Text</code> node: <output></output>
 ```
 
 ```js
-let output = document.getElementsByTagName("output")[0];
-let textnode = new Text("This text has been set using textnode.data.");
+const output = document.querySelector("output");
+const textnode = new Text("This text has been set using 'textnode.data'.");
 
 output.value = textnode.length;
 ```

--- a/files/en-us/web/api/characterdata/nextelementsibling/index.md
+++ b/files/en-us/web/api/characterdata/nextelementsibling/index.md
@@ -8,6 +8,7 @@ tags:
   - Read-only
 browser-compat: api.CharacterData.nextElementSibling
 ---
+
 {{APIRef("DOM")}}
 
 The read-only **`nextElementSibling`** property of the {{domxref("CharacterData")}} interface
@@ -30,16 +31,16 @@ TEXT2
 
 ```js
 // Initially, set node to the Text node with `TEXT`
-let node = document.getElementById('div-01').previousSibling;
+let node = document.getElementById("div-01").previousSibling;
 
-let result = 'Next element siblings of TEXT:\n';
+let result = "Next element siblings of TEXT:\n";
 
 while (node) {
   result += `${node.nodeName}\n`;
   node = node.nextElementSibling; // The first node is a CharacterData, the others Element objects
 }
 
-document.getElementsByTagName('pre')[0].textContent = result;
+document.querySelector("pre").textContent = result;
 ```
 
 {{EmbedLiveSample("Example", "100%", "230")}}

--- a/files/en-us/web/api/characterdata/nextelementsibling/index.md
+++ b/files/en-us/web/api/characterdata/nextelementsibling/index.md
@@ -36,12 +36,11 @@ let node = document.getElementById("div-01").previousSibling;
 let result = "Next element siblings of TEXT:\n";
 
 while (node) {
-  // The first node is a CharacterData, the others Element objects
-  node = node.nextElementSibling;
   result += `${node.nodeName}\n`;
+  node = node.nextElementSibling; // The first node is a CharacterData, the others Element objects
 }
 
-document.querySelector("pre").textContent += result;
+document.querySelector("pre").textContent = result;
 ```
 
 {{EmbedLiveSample("Example", "100%", "230")}}

--- a/files/en-us/web/api/characterdata/nextelementsibling/index.md
+++ b/files/en-us/web/api/characterdata/nextelementsibling/index.md
@@ -36,11 +36,12 @@ let node = document.getElementById("div-01").previousSibling;
 let result = "Next element siblings of TEXT:\n";
 
 while (node) {
+  // The first node is a CharacterData, the others Element objects
+  node = node.nextElementSibling;
   result += `${node.nodeName}\n`;
-  node = node.nextElementSibling; // The first node is a CharacterData, the others Element objects
 }
 
-document.querySelector("pre").textContent = result;
+document.querySelector("pre").textContent += result;
 ```
 
 {{EmbedLiveSample("Example", "100%", "230")}}

--- a/files/en-us/web/api/characterdata/previouselementsibling/index.md
+++ b/files/en-us/web/api/characterdata/previouselementsibling/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
 browser-compat: api.Element.previousElementSibling
 ---
+
 {{APIRef("DOM")}}
 
 The read-only **`previousElementSibling`** of the {{domxref("CharacterData")}} interface
@@ -31,16 +32,16 @@ SOME TEXT
 
 ```js
 // Initially set node to the Text node with `SOME TEXT`
-let node = document.getElementById('div-02').nextSibling;
+let node = document.getElementById("div-02").nextSibling;
 
-let result = 'Previous element siblings of SOME TEXT:\n';
+let result = "Previous element siblings of SOME TEXT:\n";
 
 while (node) {
   result += `${node.nodeName}\n`;
   node = node.previousElementSibling;
 }
 
-document.getElementsByTagName('pre')[0].textContent = result;
+document.querySelector("pre").textContent = result;
 ```
 
 {{EmbedLiveSample("Example", "100%", "200")}}

--- a/files/en-us/web/api/characterdata/remove/index.md
+++ b/files/en-us/web/api/characterdata/remove/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.remove
 ---
+
 {{APIRef("DOM")}}
 
 The **`remove()`** method of the {{domxref("CharacterData")}} removes the text contained in the node.
@@ -30,8 +31,8 @@ None.
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
 textnode.remove(); // Removes the text
 ```

--- a/files/en-us/web/api/characterdata/replacedata/index.md
+++ b/files/en-us/web/api/characterdata/replacedata/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
 browser-compat: api.CharacterData.replaceData
 ---
+
 {{APIRef("DOM")}}
 
 The **`replaceData()`** method of the {{domxref("CharacterData")}} interface removes a certain number of characters of the existing text in a given `CharacterData` node and replaces those characters with the text provided.
@@ -43,8 +44,8 @@ None.
 ```
 
 ```js
-let span = document.getElementsByTagName("span")[0];
-let textnode = span.nextSibling;
+const span = document.querySelector("span");
+const textnode = span.nextSibling;
 
 textnode.replaceData(2, 4, "replaced");
 ```

--- a/files/en-us/web/api/document/createcdatasection/index.md
+++ b/files/en-us/web/api/document/createcdatasection/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
 browser-compat: api.Document.createCDATASection
 ---
+
 {{APIRef("DOM")}}
 
 **`createCDATASection()`** creates a new CDATA section node,
@@ -32,13 +33,10 @@ A [CDATA Section](/en-US/docs/Web/API/CDATASection) node.
 ## Examples
 
 ```js
-const docu = new DOMParser().parseFromString('<xml></xml>', 'application/xml')
-
-const cdata = docu.createCDATASection('Some <CDATA> data & then some');
-
-docu.getElementsByTagName('xml')[0].appendChild(cdata);
-
-alert(new XMLSerializer().serializeToString(docu));
+const docu = new DOMParser().parseFromString("<xml></xml>", "application/xml");
+const cdata = docu.createCDATASection("Some <CDATA> data & then some");
+docu.querySelector("xml").appendChild(cdata);
+console.log(new XMLSerializer().serializeToString(docu));
 // Displays: <xml><![CDATA[Some <CDATA> data & then some]]></xml>
 ```
 

--- a/files/en-us/web/api/document/createcomment/index.md
+++ b/files/en-us/web/api/document/createcomment/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
 browser-compat: api.Document.createComment
 ---
+
 {{APIRef("DOM")}}
 
 **`createComment()`** creates a new comment node, and returns
@@ -32,12 +33,14 @@ A new {{domxref("Comment")}} object.
 ## Examples
 
 ```js
-const docu = new DOMParser().parseFromString('<xml></xml>',  'application/xml');
-const comment = docu.createComment('This is a not-so-secret comment in your document');
+const docu = new DOMParser().parseFromString("<xml></xml>", "application/xml");
+const comment = docu.createComment(
+  "This is a not-so-secret comment in your document"
+);
 
-docu.getElementsByTagName('xml')[0].appendChild(comment);
+docu.querySelector("xml").appendChild(comment);
 
-alert(new XMLSerializer().serializeToString(docu));
+console.log(new XMLSerializer().serializeToString(docu));
 // Displays: <xml><!--This is a not-so-secret comment in your document--></xml>
 ```
 

--- a/files/en-us/web/api/document/createexpression/index.md
+++ b/files/en-us/web/api/document/createexpression/index.md
@@ -11,6 +11,7 @@ tags:
   - createExpression
 browser-compat: api.Document.createExpression
 ---
+
 {{APIRef("DOM")}}
 
 This method compiles an {{DOMxRef("XPathExpression")}} which can then be used for
@@ -41,11 +42,11 @@ it on the same document.")}}
 ## Examples
 
 ```js
-let xpathExpr = document.createExpression('//div');
-let xpathResult = xpathExpr.evaluate(document); // returns an XPathResult object
-let nodeContext = document.getElementsByTagName('nav')[0];
+const xpathExpr = document.createExpression("//div");
+const xpathResult = xpathExpr.evaluate(document); // returns an XPathResult object
+const nodeContext = document.querySelector("nav");
 // Re-using the XPathExpression "xpathExpr"
-let otherResult = xpathExpr.evaluate(nodeContext); // returns an XPathResult object
+const otherResult = xpathExpr.evaluate(nodeContext); // returns an XPathResult object
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/document/registerelement/index.md
+++ b/files/en-us/web/api/document/registerelement/index.md
@@ -12,6 +12,7 @@ tags:
   - Non-standard
 browser-compat: api.Document.registerElement
 ---
+
 {{APIRef("DOM")}}{{Deprecated_header}}{{Non-standard_header}}
 
 > **Warning:** `document.registerElement()` is deprecated in
@@ -48,15 +49,15 @@ None ({{jsxref("undefined")}}).
 Here is a very simple example:
 
 ```js
-const Mytag = document.registerElement('my-tag');
+const MyTag = document.registerElement("my-tag");
 ```
 
-Now the new tag is registered in the browser. The `Mytag` variable holds a
+Now the new tag is registered in the browser. The `MyTag` variable holds a
 constructor that you can use to create a `my-tag` element in the document as
 follows:
 
 ```js
-document.body.appendChild(new Mytag());
+document.body.appendChild(new MyTag());
 ```
 
 This inserts an empty `my-tag` element that will be visible if you use the
@@ -65,8 +66,8 @@ capability. And it won't be visible in the browser unless you add some content t
 tag. Here is one way to add content to the new tag:
 
 ```js
-const mytag = document.getElementsByTagName("my-tag")[0];
-mytag.textContent = "I am a my-tag element.";
+const myTagElement = document.querySelector("my-tag");
+myTagElement.textContent = "I am a my-tag element.";
 ```
 
 ## Browser compatibility


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Motivation was to change `document.getElements*()[0]` to just use `querySelector()`. 

Updated code examples to follow code guidelines where needed. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
