### PR TITLE
make preserving defaults for property descriptor's properties more ge…

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -100,7 +100,7 @@ descriptor has both \[`value` or `writable`] and \[`get` or `set`] keys, an exce
 
 Bear in mind that these attributes are not necessarily the descriptor's own properties.
 Inherited properties will be considered as well. In order to ensure these defaults are
-preserved, you might freeze the {{jsxref("Object")}} upfront, specify all
+preserved, you might freeze all objects existed in the prototype chain of the provided descriptor object upfront, specify all
 options explicitly, or point to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) with {{jsxref("Object.create",
   "Object.create(null)")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -100,7 +100,7 @@ descriptor has both \[`value` or `writable`] and \[`get` or `set`] keys, an exce
 
 Bear in mind that these attributes are not necessarily the descriptor's own properties.
 Inherited properties will be considered as well. In order to ensure these defaults are
-preserved, you might freeze all objects existed in the prototype chain of the provided descriptor object upfront, specify all
+preserved, you might freeze existing objects in the descriptor object's prototype chain upfront, specify all
 options explicitly, or point to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) with {{jsxref("Object.create",
   "Object.create(null)")}}.
 


### PR DESCRIPTION
…neral to match all cases

As we can pass a descriptor object that inherits from another object (not Object Object directly), then we should generalize the sentence to match all cases.

for ex: 
function descriptorCreator(configurable) {
    this.configurable = configurable ;
}
descriptorCreator.prototype.writable = true
Object.prototype.enumerable = true;

let descriptor = new descriptorCreator(true) ; 
let obj = {}
Object.defineProperty(obj, "y",descriptor); 

console.log(Object.getOwnPropertyDescriptor(obj, 'y')) // {value: undefined, writable:true, enumerable:true, configurable:true}

//here writable is true (not default = not false) because it is inherited from the descriptorCreator object as it exists in the descriptor object  prototype chain
// the same for enumerable as Object object  also in the descriptor object prototype chain and no objects comes after in this chain shadows this value
// descriptor -> descriptorCreator -> Object

so we should here freeze descriptorCreator.prototype object, and Object.prototype object

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
