### PR TITLE
fix link in PWA/installable_pwas

### DIFF
--- a/files/en-us/web/progressive_web_apps/installable_pwas/index.md
+++ b/files/en-us/web/progressive_web_apps/installable_pwas/index.md
@@ -10,7 +10,7 @@ tags:
   - js13kGames
   - progressive
 ---
-{{PreviousMenuNext("Web/Apps/Progressive/Offline_Service_workers", "Web/Apps/Progressive/Re-engageable_Notifications_Push", "Web/Apps/Progressive")}}
+{{PreviousMenuNext("Web/Progressive_web_apps/Offline_Service_workers", "Web/Progressive_web_apps/Re-engageable_Notifications_Push", "Web/Progressive_web_apps")}}
 
 In the last article, we read about how the example application, [js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/), works offline thanks to its [service worker](/en-US/docs/Web/API/Service_Worker_API), but we can go even further and allow users to install the web app on mobile and desktop browsers that support doing so. The installed web app can then be launched by users just as if it were any native app. This article explains how to achieve this using the web app's manifest.
 
@@ -119,6 +119,6 @@ For more information on a2hs, be sure to read our [Add to Home screen guide](/en
 
 Now let's move to the last piece of the PWA puzzle: using push notifications to share announcements with the user, and to help the user re-engage with your app.
 
-{{PreviousMenuNext("Web/Apps/Progressive/Offline_Service_workers", "Web/Apps/Progressive/Re-engageable_Notifications_Push", "Web/Apps/Progressive")}}
+{{PreviousMenuNext("Web/Progressive_web_apps/Offline_Service_workers", "Web/Progressive_web_apps/Re-engageable_Notifications_Push", "Web/Progressive_web_apps")}}
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Progressive_web_apps/")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The reference link is error when I tried to localize PWA page. The main cause is that they used `Apps/Progressive` instead of 
 `Progressive_web_apps`. So I performed the change from `App/Progressive` to `Progressive_web_apps`, and now it works properly in localized docs.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
Make further people localizing the page easier.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
N/A
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
[mdn/translated-content#8056](https://github.com/mdn/translated-content/pull/8056#issue-1353220678)
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
