### PR TITLE
HTML: update BCD Info

### DIFF
--- a/files/en-us/web/html/element/hgroup/index.md
+++ b/files/en-us/web/html/element/hgroup/index.md
@@ -2,9 +2,7 @@
 title: <hgroup>
 slug: Web/HTML/Element/hgroup
 tags:
-  - Deprecated
   - Element
-  - Experimental
   - HTML
   - Reference
   - Web

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -176,7 +176,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     If the attribute is not present, the resource is fetched without a {{Glossary("CORS")}} request (i.e. without sending the `Origin` HTTP header), preventing its non-tainted usage. If invalid, it is handled as if the enumerated keyword **anonymous** was used.
     See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for additional information.
 
-- {{HTMLAttrDef("disabled")}}
+- {{HTMLAttrDef("disabled")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
 
   - : For `rel="stylesheet"` only, the `disabled` Boolean attribute indicates whether or not the described stylesheet should be loaded and applied to the document.
     If `disabled` is specified in the HTML when it is loaded, the stylesheet will not be loaded during page load.
@@ -184,7 +184,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     Setting the `disabled` property in the DOM causes the stylesheet to be removed from the document's {{domxref("Document.styleSheets")}} list.
 
-- {{htmlattrdef("fetchpriority")}}
+- {{htmlattrdef("fetchpriority")}} {{Experimental_Inline}}
 
   - : Provides a hint of the relative priority to use when fetching a preloaded resource. Allowed values:
 
@@ -206,7 +206,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : For `rel="preload"` and `as="image"` only, the `imagesizes` attribute is [a sizes attribute](https://html.spec.whatwg.org/multipage/images.html#sizes-attribute) that indicates to preload the appropriate resource used by an `img` element with corresponding values for its `srcset` and `sizes` attributes.
 - {{HTMLAttrDef("imagesrcset")}}
   - : For `rel="preload"` and `as="image"` only, the `imagesrcset` attribute is [a sourceset attribute](https://html.spec.whatwg.org/multipage/images.html#srcset-attribute) that indicates to preload the appropriate resource used by an `img` element with corresponding values for its `srcset` and `sizes` attributes.
-- {{HTMLAttrDef("integrity")}} {{Experimental_Inline}}
+- {{HTMLAttrDef("integrity")}}
   - : Contains inline metadata — a base64-encoded cryptographic hash of the resource (file) you're telling the browser to fetch.
     The browser can use this to verify that the fetched resource has been delivered free of unexpected manipulation.
     See [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity).
@@ -224,7 +224,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - {{HTMLAttrDef("prefetch")}} {{secureContext_inline}} {{experimental_inline}}
   - : Identifies a resource that might be required by the next navigation and that the user agent should retrieve it.
     This allows the user agent to respond faster when the resource is requested in the future.
-- {{HTMLAttrDef("referrerpolicy")}} {{Experimental_Inline}}
+- {{HTMLAttrDef("referrerpolicy")}}
 
   - : A string indicating which referrer to use when fetching the resource:
 
@@ -238,7 +238,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{HTMLAttrDef("rel")}}
   - : This attribute names a relationship of the linked document to the current document. The attribute must be a space-separated list of [link type values](/en-US/docs/Web/HTML/Link_types).
-- {{HTMLAttrDef("sizes")}}
+- {{HTMLAttrDef("sizes")}} {{Experimental_Inline}}
 
   - : This attribute defines the sizes of the icons for visual media contained in the resource.
     It must be present only if the {{HTMLAttrxRef("rel", "link")}} contains a value of `icon` or a non-standard type such as Apple's `apple-touch-icon`.
@@ -261,13 +261,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ### Non-standard attributes
 
-- {{HTMLAttrDef("methods")}} {{Non-standard_Inline}}
+- {{HTMLAttrDef("methods")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : The value of this attribute provides information about the functions that might be performed on an object.
     The values generally are given by the HTTP protocol when it is used, but it might (for similar reasons as for the **title** attribute) be useful to include advisory information in advance in the link.
     For example, the browser might choose a different rendering of a link as a function of the methods specified;
     something that is searchable might get a different icon, or an outside link might render with an indication of leaving the current site.
     This attribute is not well understood nor supported, even by the defining browser, Internet Explorer 4.
-- {{HTMLAttrDef("target")}} {{Non-standard_Inline}}
+- {{HTMLAttrDef("target")}} {{Deprecated_Inline}}
   - : Defines the frame or window name that has the defined linking relationship or that will show the rendering of any linked resource.
 
 ### Obsolete attributes

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.marquee
 ---
 
-{{deprecated_header}}
+{{Deprecated_Header}}
 
 The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes.
 
@@ -26,27 +26,27 @@ The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scr
 
 ## Attributes
 
-- {{htmlattrdef("behavior")}}
+- {{htmlattrdef("behavior")}} {{Deprecated_Inline}}
   - : Sets how the text is scrolled within the marquee. Possible values are `scroll`, `slide` and `alternate`. If no value is specified, the default value is `scroll`.
-- {{htmlattrdef("bgcolor")}}
+- {{htmlattrdef("bgcolor")}} {{Deprecated_Inline}}
   - : Sets the background color through color name or hexadecimal value.
-- {{htmlattrdef("direction")}}
+- {{htmlattrdef("direction")}} {{Deprecated_Inline}}
   - : Sets the direction of the scrolling within the marquee. Possible values are `left`, `right`, `up` and `down`. If no value is specified, the default value is `left`.
-- {{htmlattrdef("height")}}
+- {{htmlattrdef("height")}} {{Deprecated_Inline}}
   - : Sets the height in pixels or percentage value.
-- {{htmlattrdef("hspace")}}
+- {{htmlattrdef("hspace")}} {{Deprecated_Inline}}
   - : Sets the horizontal margin
-- {{htmlattrdef("loop")}}
+- {{htmlattrdef("loop")}} {{Deprecated_Inline}}
   - : Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously.
-- {{htmlattrdef("scrollamount")}}
+- {{htmlattrdef("scrollamount")}} {{Deprecated_Inline}}
   - : Sets the amount of scrolling at each interval in pixels. The default value is 6.
-- {{htmlattrdef("scrolldelay")}}
+- {{htmlattrdef("scrolldelay")}} {{Deprecated_Inline}}
   - : Sets the interval between each scroll movement in milliseconds. The default value is 85. Note that any value smaller than 60 is ignored and the value 60 is used instead, unless` truespeed `is specified.
-- {{htmlattrdef("truespeed")}}
+- {{htmlattrdef("truespeed")}} {{Deprecated_Inline}}
   - : By default,` scrolldelay `values lower than 60 are ignored. If` truespeed `is present, those values are not ignored.
-- {{htmlattrdef("vspace")}}
+- {{htmlattrdef("vspace")}} {{Deprecated_Inline}}
   - : Sets the vertical margin in pixels or percentage value.
-- {{htmlattrdef("width")}}
+- {{htmlattrdef("width")}} {{Deprecated_Inline}}
   - : Sets the width in pixels or percentage value.
 
 ## Event handlers

--- a/files/en-us/web/html/element/menuitem/index.md
+++ b/files/en-us/web/html/element/menuitem/index.md
@@ -14,10 +14,11 @@ tags:
   - User experience
   - Web
   - menuitem
+  - Non-standard
 browser-compat: html.elements.menuitem
 ---
 
-{{HTMLRef}}{{Deprecated_Header}}
+{{HTMLRef}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`<menuitem>`** [HTML](/en-US/docs/Web/HTML) element represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button.
 
@@ -67,21 +68,21 @@ A command can either be defined explicitly, with a textual label and optional ic
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes); in particular `title` can be used to describe the command, or provide usage hints.
 
-- {{HTMLAttrDef("checked")}}
+- {{HTMLAttrDef("checked")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Boolean attribute which indicates whether the command is selected. May only be used when the `type` attribute is `checkbox` or `radio`.
-- {{HTMLAttrDef("command")}}
+- {{HTMLAttrDef("command")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Specifies the ID of a separate element, indicating a command to be invoked indirectly. May not be used within a menu item that also includes the attributes `checked`, `disabled`, `icon`, `label`, `radiogroup` or `type`.
-- {{HTMLAttrDef("default")}}
+- {{HTMLAttrDef("default")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : This Boolean attribute indicates use of the same command as the menu's subject element (such as a `button` or `input`).
-- {{HTMLAttrDef("disabled")}}
+- {{HTMLAttrDef("disabled")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Boolean attribute which indicates that the command is not available in the current state. Note that `disabled` is distinct from `hidden`; the `disabled` attribute is appropriate in any context where a change in circumstances might render the command relevant.
-- {{HTMLAttrDef("icon")}}
+- {{HTMLAttrDef("icon")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Image URL, used to provide a picture to represent the command.
 - {{HTMLAttrDef("label")}}
   - : The name of the command as shown to the user. Required when a `command` attribute is not present.
-- {{HTMLAttrDef("radiogroup")}}
+- {{HTMLAttrDef("radiogroup")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : This attribute specifies the name of a group of commands to be toggled as radio buttons when selected. May only be used where the `type` attribute is `radio`.
-- {{HTMLAttrDef("type")}}
+- {{HTMLAttrDef("type")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
 
   - : This attribute indicates the kind of command, and can be one of three values.
 

--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -111,7 +111,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     This attribute allows the elimination of **parser-blocking JavaScript** where the browser would have to load and evaluate scripts before continuing to parse. `async` has a similar effect in this case.
 
-- {{htmlattrdef("fetchpriority")}}
+- {{htmlattrdef("fetchpriority")}} {{Experimental_Inline}}
 
   - : Provides a hint of the relative priority to use when fetching an external script. Allowed values:
 
@@ -159,7 +159,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("charset")}} {{Deprecated_inline}}
   - : If present, its value must be an ASCII case-insensitive match for "`utf-8`". It's unnecessary to specify the `charset` attribute, because documents must use UTF-8, and the `script` element inherits its character encoding from the document.
-- {{htmlattrdef("language")}} {{Deprecated_inline}}
+- {{htmlattrdef("language")}} {{Deprecated_inline}} {{Non-standard_Inline}}
   - : Like the `type` attribute, this attribute identifies the scripting language in use. Unlike the `type` attribute, however, this attribute's possible values were never standardized. The `type` attribute should be used instead.
 
 ## Notes

--- a/files/en-us/web/html/element/shadow/index.md
+++ b/files/en-us/web/html/element/shadow/index.md
@@ -11,10 +11,11 @@ tags:
   - Web Components
   - shadow
   - shadow dom
+  - Non-standard
 browser-compat: html.elements.shadow
 ---
 
-{{deprecated_header}}
+{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`<shadow>`** [HTML](/en-US/docs/Web/HTML) element—an obsolete part of the [Web Components](/en-US/docs/Web/Web_Components) technology suite—was intended to be used as a shadow DOM {{glossary("insertion point")}}. You might have used it if you have created multiple shadow roots under a shadow host. It is not useful in ordinary HTML.
 

--- a/files/en-us/web/html/element/th/index.md
+++ b/files/en-us/web/html/element/th/index.md
@@ -121,7 +121,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     > **Note:** Do not use this attribute as it is obsolete in the latest standard: use the {{htmlattrxref("scope", "th")}} attribute instead.
 
-- {{htmlattrdef("bgcolor")}} {{Non-standard_inline}}
+- {{htmlattrdef("bgcolor")}} {{Deprecated_Inline}}
 
   - : This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in [sRGB](https://www.w3.org/Graphics/Color/sRGB) and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:
 

--- a/files/en-us/web/html/element/thead/index.md
+++ b/files/en-us/web/html/element/thead/index.md
@@ -95,7 +95,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     >
     > - To align values, use the CSS {{cssxref("text-align")}} property instead.
 
-- {{htmlattrdef("bgcolor")}} {{Non-standard_inline}}
+- {{htmlattrdef("bgcolor")}} {{Deprecated_Inline}}
 
   - : This attribute defines the background color of each cell of the column. It accepts a 6-digit hexadecimal color or a named color.  Alphatransparency is not supported.
 

--- a/files/en-us/web/html/element/ul/index.md
+++ b/files/en-us/web/html/element/ul/index.md
@@ -86,13 +86,13 @@ The **`<ul>`** [HTML](/en-US/docs/Web/HTML) element represents an unordered list
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{ htmlattrdef("compact") }} {{Deprecated_inline}}
+- {{ htmlattrdef("compact") }} {{Deprecated_inline}} {{Non-standard_Inline}}
 
   - : This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the {{glossary("user agent")}}, and it doesn't work in all browsers.
 
     > **Warning:** Do not use this attribute, as it has been deprecated: use [CSS](/en-US/docs/Web/CSS) instead. To give a similar effect as the `compact` attribute, the CSS property {{cssxref("line-height")}} can be used with a value of `80%`.
 
-- {{ htmlattrdef("type") }} {{Deprecated_inline}}
+- {{ htmlattrdef("type") }} {{Deprecated_inline}} {{Non-standard_Inline}}
 
   - : This attribute sets the bullet style for the list. The values defined under HTML3.2 and the transitional version of HTML 4.0/4.01 are:
 

--- a/files/en-us/web/html/global_attributes/contextmenu/index.md
+++ b/files/en-us/web/html/global_attributes/contextmenu/index.md
@@ -7,10 +7,11 @@ tags:
   - HTML
   - Reference
   - contextmenu
+  - Non-standard
 browser-compat: html.global_attributes.contextmenu
 ---
 
-{{HTMLSidebar("Global_attributes")}}
+{{HTMLSidebar("Global_attributes")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 > **Warning:** The [contextmenu attribute is obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#attr-contextmenu) and will be removed from all browsers
 

--- a/files/en-us/web/html/link_types/manifest/index.md
+++ b/files/en-us/web/html/link_types/manifest/index.md
@@ -9,8 +9,11 @@ tags:
   - Link types
   - Manifest
   - Reference
+  - Experimental
 browser-compat: html.elements.link.rel.manifest
 ---
+
+{{SeeCompatTable}}
 
 The **`manifest`** keyword for the {{HTMLAttrxRef("rel", "link")}} attribute of the {{HTMLElement("link")}} element indicates that the target resource is a [Web app manifest](/en-US/docs/Web/Manifest).
 

--- a/files/en-us/web/html/link_types/modulepreload/index.md
+++ b/files/en-us/web/html/link_types/modulepreload/index.md
@@ -7,8 +7,11 @@ tags:
   - Link
   - Link types
   - Reference
+  - Experimental
 browser-compat: html.elements.link.rel.modulepreload
 ---
+
+{{SeeCompatTable}}
 
 The **`modulepreload`** keyword for the {{HTMLAttrxRef("rel", "link")}} attribute of the {{HTMLElement("link")}} element provides a declarative way to preemptively fetch a [module script](/en-US/docs/Web/JavaScript/Guide/Modules) and its dependencies, and store them in the document's module map for later evaluation.
 

--- a/files/en-us/web/html/link_types/prerender/index.md
+++ b/files/en-us/web/html/link_types/prerender/index.md
@@ -7,8 +7,11 @@ tags:
   - Link
   - Link types
   - Reference
+  - Experimental
 browser-compat: html.elements.link.rel.prerender
 ---
+
+{{SeeCompatTable}}
 
 The **`prerender`** keyword for the {{HTMLAttrxRef("rel", "link")}} attribute of the {{HTMLElement("link")}} element is a hint to browsers that the user might need the target resource for the next navigation, and therefore the browser can likely improve the user experience by preemptively fetching and processing the resource — for example, by fetching its subresources or performing some rendering in the background offscreen.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTML pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

This completes all the BCD changes in HTML pages.

*** 
**Note:** W3 [decided to drop](https://lists.w3.org/Archives/Public/public-html-admin/2013Apr/0003.html) `<hgroup>` in 2013, but it is very much [alive in the current specs](https://html.spec.whatwg.org/#the-hgroup-element) after 9+ years. So removed those tags as per the BCD.