### PR TITLE
CSS: update BCD Info

### DIFF
--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -9,9 +9,10 @@ tags:
   - Function
   - Non-standard
   - Reference
+  - Experimental
 browser-compat: css.types.-moz-image-rect
 ---
-{{CSSRef}}{{Non-standard_Header}}
+{{CSSRef}}{{Non-standard_Header}}{{SeeCompatTable}}
 
 The **`-moz-image-rect`** value for [CSS](/en-US/docs/Web/CSS) {{CSSxRef("background-image")}} lets you use a portion of a larger image as a background.
 

--- a/files/en-us/web/css/@media/prefers-reduced-data/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-data/index.md
@@ -7,6 +7,7 @@ tags:
   - Media Queries
   - Reference
   - media feature
+  - Experimental
 browser-compat: css.at-rules.media.prefers-reduced-data
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/@media/update-frequency/index.md
+++ b/files/en-us/web/css/@media/update-frequency/index.md
@@ -7,9 +7,10 @@ tags:
   - Media Queries
   - Reference
   - media feature
+  - Experimental
 browser-compat: css.at-rules.media.update
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`update`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) can be used to test how frequently (if at all) the output device is able to modify the appearance of content.
 

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -7,6 +7,7 @@ tags:
   - Web
   - Property
   - Houdini
+  - Experimental
 browser-compat: css.at-rules.property.inherits
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -7,6 +7,7 @@ tags:
   - Web
   - Property
   - Houdini
+  - Experimental
 browser-compat: css.at-rules.property.initial-value
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -7,6 +7,7 @@ tags:
   - Web
   - Property
   - Houdini
+  - Experimental
 browser-compat: css.at-rules.property.syntax
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/@scroll-timeline/index.md
+++ b/files/en-us/web/css/@scroll-timeline/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.at-rules.scroll-timeline
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`@scroll-timeline`** CSS [at-rule](/en-US/docs/Web/CSS/At-rule) defines an [`AnimationTimeline`](/en-US/docs/Web/API/AnimationTimeline) whose time values are determined by scrolling progress within a scroll container and not by minutes or seconds. Once specified, a scroll timeline is associated with a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) by using the `animation-timeline` property.
 
@@ -31,7 +31,7 @@ The **`@scroll-timeline`** CSS [at-rule](/en-US/docs/Web/CSS/At-rule) defines an
 
   - : A name identifying the scroll timeline. This name is used when specifying the scroll timeline with the [`animation-timeline`](/en-US/docs/Web/CSS/animation-timeline) property.
 
-- `source`
+- `source` {{Experimental_Inline}}
 
   - : The scrollable element whose scrolling position drives the progress of the timeline. Can be:
 
@@ -46,7 +46,7 @@ The **`@scroll-timeline`** CSS [at-rule](/en-US/docs/Web/CSS/At-rule) defines an
     - `none`
       - : No scroll container specified.
 
-- `orientation`
+- `orientation` {{Experimental_Inline}}
 
   - : The scroll timeline's orientation:
 
@@ -69,7 +69,7 @@ The **`@scroll-timeline`** CSS [at-rule](/en-US/docs/Web/CSS/At-rule) defines an
     - `vertical`
       - : Uses the vertical scroll position, regardless of writing mode or directionality.
 
-- `scroll-offsets`
+- `scroll-offsets` {{Experimental_Inline}}
 
   - : Determines the scroll timeline's scroll offsets:
 

--- a/files/en-us/web/css/_colon_user-invalid/index.md
+++ b/files/en-us/web/css/_colon_user-invalid/index.md
@@ -7,9 +7,10 @@ tags:
   - Pseudo-class
   - Reference
   - Selector
+  - Experimental
 browser-compat: css.selectors.user-invalid
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`:user-invalid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any validated form element whose value isn't valid based on their [validation constraints](/en-US/docs/Learn/Forms#constraint_validation), after the user has interacted with it.
 

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -7,9 +7,10 @@ tags:
   - Pseudo-class
   - Reference
   - Selector
+  - Experimental
 browser-compat: css.selectors.user-valid
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`:user-valid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any validated form element whose value validates correctly based on its [validation constraints](/en-US/docs/Learn/Forms#constraint_validation). However, unlike {{cssxref(":valid")}} it only matches once the user has interacted with it.
 

--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Selector
   - Web
+  - Experimental
 browser-compat: css.selectors.target-text
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/align-tracks/index.md
+++ b/files/en-us/web/css/align-tracks/index.md
@@ -12,9 +12,8 @@ tags:
   - masonry
 browser-compat: css.properties.align-tracks
 ---
-{{CSSRef}}
 
-{{SeeCompatTable}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`align-tracks`** CSS property sets the alignment in the masonry axis for grid containers that have [masonry](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) in their block axis.
 

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -7,9 +7,10 @@ tags:
   - CSS Property
   - Reference
   - recipe:css-property
+  - Experimental
 browser-compat: css.properties.animation-timeline
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`animation-timeline`** [CSS](/en-US/docs/Web/CSS) property specifies the names of one or more {{cssxref("@scroll-timeline")}} at-rules describing the scroll animations to apply to the element.
 

--- a/files/en-us/web/css/color_value/color-contrast/index.md
+++ b/files/en-us/web/css/color_value/color-contrast/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Web
   - color-contrast
+  - Experimental
 browser-compat: css.types.color.color-contrast
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`color-contrast()`** functional notation takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values, selecting the one with the highest contrast from the list.
 

--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Web
   - color-mix
+  - Experimental
 browser-compat: css.types.color.color-mix
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`color-mix()`** functional notation takes two {{cssxref("color_value","color")}} values and returns the result of mixing them in a given colorspace by a given amount.
 

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Web
   - color
+  - Experimental
 browser-compat: css.types.color.color
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`color()`** functional notation allows a color to be specified in a particular, specified colorspace rather than the implicit sRGB colorspace that most of the other color functions operate in.
 

--- a/files/en-us/web/css/color_value/lab/index.md
+++ b/files/en-us/web/css/color_value/lab/index.md
@@ -9,9 +9,10 @@ tags:
   - Web
   - color
   - lab
+  - Experimental
 browser-compat: css.types.color.lab
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`lab()`** functional notation expresses a given color in the CIE L\*a\*b\* color space. Lab represents the entire range of color that humans can see.
 

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -9,9 +9,10 @@ tags:
   - Web
   - color
   - lch
+  - Experimental
 browser-compat: css.types.color.lch
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`lch()`** functional notation expresses a given color in the LCH color space. It has the same L axis as {{cssxref("color_value/lab","lab()")}}, but uses polar coordinates C (Chroma) and H (Hue).
 

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -12,7 +12,7 @@ tags:
   - Experimental
 browser-compat: css.types.color.oklab
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`oklab()`** functional notation expresses a given color in the Oklab perpetual color space, which attempts to mimic how color is perceived by the human eye.
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -12,7 +12,7 @@ tags:
   - Experimental
 browser-compat: css.types.color.oklch
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`oklch()`** functional notation expresses a given color in the OKLCH color space. It has the same L axis as {{cssxref("color_value/oklab","oklab()")}}, but uses polar coordinates C (Chroma) and H (Hue).
 

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -9,10 +9,11 @@ tags:
   - Reference
   - Web
   - cos
+  - Experimental
 browser-compat: css.types.cos
 spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`cos()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is a trigonometric function that returns the cosine of a number, which is a value between `-1` and `1`. The function contains a single calculation that must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}} by interpreting the result of the argument as radians. That is, `cos(45deg)`, `cos(0.125turn)`, and `cos(3.14159 / 4)` all represent the same value, approximately `0.707`.
 

--- a/files/en-us/web/css/element/index.md
+++ b/files/en-us/web/css/element/index.md
@@ -9,6 +9,7 @@ tags:
   - Layout
   - Reference
   - Web
+  - Experimental
 browser-compat: css.types.image.element
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/initial-letter/index.md
+++ b/files/en-us/web/css/initial-letter/index.md
@@ -13,7 +13,7 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.initial-letter
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The `initial-letter` CSS property sets styling for dropped, raised, and sunken initial letters.
 

--- a/files/en-us/web/css/justify-tracks/index.md
+++ b/files/en-us/web/css/justify-tracks/index.md
@@ -11,9 +11,8 @@ tags:
   - masonry
 browser-compat: css.properties.justify-tracks
 ---
-{{CSSRef}}
 
-{{SeeCompatTable}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`justify-tracks`** CSS property sets the alignment in the masonry axis for grid containers that have [masonry](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) in their inline axis.
 

--- a/files/en-us/web/css/line-height-step/index.md
+++ b/files/en-us/web/css/line-height-step/index.md
@@ -7,11 +7,11 @@ tags:
   - CSS Property
   - Reference
   - recipe:css-property
+  - Experimental
 browser-compat: css.properties.line-height-step
 ---
-{{CSSRef}}
 
-{{SeeCompatTable}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`line-height-step`** CSS property sets the step unit for line box heights. When the property is set, line box heights are rounded up to the closest multiple of the unit.
 

--- a/files/en-us/web/css/margin-trim/index.md
+++ b/files/en-us/web/css/margin-trim/index.md
@@ -13,7 +13,7 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.margin-trim
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The `margin-trim` property allows the container to trim the margins of its children where they adjoin the container's edges.
 

--- a/files/en-us/web/css/masonry-auto-flow/index.md
+++ b/files/en-us/web/css/masonry-auto-flow/index.md
@@ -11,9 +11,8 @@ tags:
   - masonry-auto-flow
 browser-compat: css.properties.masonry-auto-flow
 ---
-{{CSSRef}}
 
-{{SeeCompatTable}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`masonry-auto-flow`** CSS property modifies how items are placed when using [masonry](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) in [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout).
 

--- a/files/en-us/web/css/math-depth/index.md
+++ b/files/en-us/web/css/math-depth/index.md
@@ -7,9 +7,10 @@ tags:
   - Property
   - Reference
   - math-depth
+  - Experimental
 browser-compat: css.properties.math-depth
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`math-depth`** property describes a notion of _depth_ for each element of a mathematical formula, with respect to the top-level container of that formula. Concretely, this is used to determine the computed value of the [font-size](/en-US/docs/Web/CSS/font-size) property when its specified value is `math`.
 

--- a/files/en-us/web/css/math-style/index.md
+++ b/files/en-us/web/css/math-style/index.md
@@ -7,9 +7,10 @@ tags:
   - Property
   - Reference
   - math-style
+  - Experimental
 browser-compat: css.properties.math-style
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The `math-style` property indicates whether MathML equations should render with normal or compact height.
 

--- a/files/en-us/web/css/overflow-clip-margin/index.md
+++ b/files/en-us/web/css/overflow-clip-margin/index.md
@@ -7,9 +7,10 @@ tags:
   - CSS Property
   - Reference
   - recipe:css-property
+  - Experimental
 browser-compat: css.properties.overflow-clip-margin
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`overflow-clip-margin`** [CSS](/en-US/docs/Web/CSS) property determines how far outside its bounds an element with [`overflow: clip`](/en-US/docs/Web/CSS/overflow) may be painted before being clipped.
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -7,9 +7,10 @@ tags:
   - Keyword
   - Reference
   - revert-layer
+  - Experimental
 browser-compat: css.types.global_keywords.revert-layer
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`revert-layer`** CSS keyword rolls back the value of a property in a {{cssxref("@layer", "cascade layer")}} to the value of the property in a CSS rule matching the element in a previous cascade layer. The value of the property with this keyword is recalculated as if no rules were specified on the target element in the current cascade layer.
 

--- a/files/en-us/web/css/ruby-align/index.md
+++ b/files/en-us/web/css/ruby-align/index.md
@@ -7,9 +7,10 @@ tags:
   - CSS Ruby
   - Reference
   - recipe:css-property
+  - Experimental
 browser-compat: css.properties.ruby-align
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`ruby-align`** CSS property defines the distribution of the different ruby elements over the base.
 

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -9,10 +9,11 @@ tags:
   - Reference
   - Web
   - sin
+  - Experimental
 browser-compat: css.types.sin
 spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`sin()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is a trigonometric function that returns the sine of a number, which is a value between `-1` and `1`. The function contains a single calculation that must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}} by interpreting the result of the argument as radians. That is, `sin(45deg)`, `sin(0.125turn)`, and `sin(3.14159 / 4)` all represent the same value, approximately `0.707`.
 

--- a/files/en-us/web/css/text-decoration-skip/index.md
+++ b/files/en-us/web/css/text-decoration-skip/index.md
@@ -12,7 +12,7 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.text-decoration-skip
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`text-decoration-skip`** [CSS](/en-US/docs/Web/CSS) property sets what parts of an element's content any text decoration affecting the element must skip over. It controls all text decoration lines drawn by the element and also any text decoration lines drawn by its ancestors.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for CSS pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

Simple changes that adds missing experimental status.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
