### PR TITLE
Manifest: update BCD Info

### DIFF
--- a/files/en-us/web/manifest/background_color/index.md
+++ b/files/en-us/web/manifest/background_color/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Web
   - background_color
+  - Experimental
 browser-compat: html.manifest.background_color
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Web
   - categories
+  - Experimental
 browser-compat: html.manifest.categories
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -6,9 +6,10 @@ tags:
   - Web
   - display
   - display_override
+  - Experimental
 browser-compat: html.manifest.display_override
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/orientation/index.md
+++ b/files/en-us/web/manifest/orientation/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Orientation
   - Web
+  - Experimental
 browser-compat: html.manifest.orientation
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Web
   - prefer_related_applications
+  - Experimental
 browser-compat: html.manifest.prefer_related_applications
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/protocol_handlers/index.md
+++ b/files/en-us/web/manifest/protocol_handlers/index.md
@@ -5,10 +5,10 @@ tags:
   - protocol_handlers
   - Manifest
   - Web
-  - Non-standard
+  - Experimental
 browser-compat: html.manifest.protocol_handlers
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Web
   - related_applications
+  - Experimental
 browser-compat: html.manifest.related_applications
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Screenshots
   - Web
+  - Experimental
 browser-compat: html.manifest.screenshots
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -5,9 +5,10 @@ tags:
   - Manifest
   - Web
   - shortcuts
+  - Experimental
 browser-compat: html.manifest.shortcuts
 ---
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for Web App Manifest pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

Simple changes that adds missing experimental status.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
