### PR TITLE
Add spec-urls to Max-Forwards

### DIFF
--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-browser-compat: http.headers.Max-Forwards
+spec-urls: https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.2
 ---
 {{HTTPSidebar}}
 
@@ -44,7 +44,7 @@ Max-Forwards: 10
 
 ## Browser compatibility
 
-{{Compat}}
+This feature is neither targeted, nor implemented, at browsers.
 
 ## See also
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -44,7 +44,8 @@ Max-Forwards: 10
 
 ## Browser compatibility
 
-This feature is neither targeted, nor implemented, at browsers.
+This feature is neither targeted at, nor implemented in, browsers.
+
 
 ## See also
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-spec-urls: https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.2
+spec-urls: https://www.ietf.org/rfc/rfc7231.html#section-5.1.2
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-spec-urls: https://www.ietf.org/rfc/rfc7231.html#section-5.1.2
+spec-urls: https://httpwg.org/specs/rfc7231.html#header.max-forwards
 ---
 {{HTTPSidebar}}
 


### PR DESCRIPTION
The `Max-Forwards` HTTP header is not implemented by browsers but is helpful when debugging systems.

This hardcodes the browser compatibility text and adds a `spec-urls` YAML header.