### PR TITLE
Update comment in string.replace() code example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -70,7 +70,7 @@ The replacement string can include the following special replacement patterns:
 
 ```js
 "foo".replace(/(f)/, "$2"); // "$2oo"; the regex doesn't have the second group
-"foo".replace("f", "$1"); // "$1oo"
+"foo".replace("f", "$1"); // "$1oo"; the pattern is a string, so it doesn't have any groups
 "foo".replace(/(f)|(g)/, "$2"); // "oo"; the second group exists but isn't matched
 ```
 


### PR DESCRIPTION
The example on line 73 has no explanation for the output, whereas the examples surrounding it do. 
The behaviour shown in line 73 is explained in the text above, but that is also the case for the other examples . For consistency I have added `the pattern is a string, so it doesn't have any groups` as an explanation.
This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


