### PR TITLE
fix accessing parentStyleSheet from cssRules list

### DIFF
--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -23,7 +23,7 @@ A {{domxref("StyleSheet")}} object.
 ## Examples
 
 ```js
-let myRules = document.styleSheets[0].cssRules;
+const docRules = document.styleSheets[0].cssRules;
 console.log(myRules[0].parentStyleSheet == document.styleSheets[0]); //returns true 
 ```
 

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -24,7 +24,7 @@ A {{domxref("StyleSheet")}} object.
 
 ```js
 let myRules = document.styleSheets[0].cssRules;
-console.log(myRules.parentStyleSheet);
+console.log(myRules[0].parentStyleSheet == document.styleSheets[0]); //returns true 
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -24,7 +24,7 @@ A {{domxref("StyleSheet")}} object.
 
 ```js
 const docRules = document.styleSheets[0].cssRules;
-console.log(myRules[0].parentStyleSheet == document.styleSheets[0]); //returns true 
+console.log(docRules[0].parentStyleSheet == document.styleSheets[0]); // returns true 
 ```
 
 ## Specifications


### PR DESCRIPTION
Here myRules carry a list of type cssRulesList which has no parentStyleSheet inside of it, but instead we can access parentStyleSheet of any of its element.

Regarding  changing the log to be (myRules[0].parentStyleSheet == document.styleSheets[0]), because I think this will make the property value clear to the reader

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
