### PR TITLE
CSS: update BCD Info

### DIFF
--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -9,9 +9,10 @@ tags:
   - NeedsCompatTable
   - Non-standard
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-float-edge
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property specifies whether the height and width properties of the element include the margin, border, or padding thickness.
 

--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -7,9 +7,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-force-broken-image-icon
 ---
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}{{CSSRef}}{{Deprecated_Header}}
 
 The **`-moz-force-broken-image-icon`** extended CSS property can be used to force the broken image icon to be shown even when a broken image has an `alt` attribute.
 

--- a/files/en-us/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/en-us/web/css/-moz-outline-radius-bottomleft/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-outline-radius-bottomleft
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 In Mozilla applications, the **`-moz-outline-radius-bottomleft`** [CSS](/en-US/docs/Web/CSS) property can be used to round the bottom-left corner of an element's {{cssxref("outline")}}.
 

--- a/files/en-us/web/css/-moz-outline-radius-bottomright/index.md
+++ b/files/en-us/web/css/-moz-outline-radius-bottomright/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-outline-radius-bottomright
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 In Mozilla applications, the **`-moz-outline-radius-bottomright`** [CSS](/en-US/docs/Web/CSS) property can be used to round the bottom-right corner of an element's {{cssxref("outline")}}.
 

--- a/files/en-us/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/en-us/web/css/-moz-outline-radius-topleft/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-outline-radius-topleft
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 In Mozilla applications, the **`-moz-outline-radius-topleft`** [CSS](/en-US/docs/Web/CSS) property can be used to round the top-left corner of an element's {{cssxref("outline")}}.
 

--- a/files/en-us/web/css/-moz-outline-radius-topright/index.md
+++ b/files/en-us/web/css/-moz-outline-radius-topright/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.-moz-outline-radius-topright
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 In Mozilla applications, the **`-moz-outline-radius-topright`** [CSS](/en-US/docs/Web/CSS) property can be used to round the top-right corner of an element's {{cssxref("outline")}}.
 

--- a/files/en-us/web/css/-moz-outline-radius/index.md
+++ b/files/en-us/web/css/-moz-outline-radius/index.md
@@ -8,9 +8,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-shorthand-property
+  - Deprecated
 browser-compat: css.properties.-moz-outline-radius
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 In Mozilla applications like Firefox, the **`-moz-outline-radius`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) can be used to give an element's {{cssxref("outline")}} rounded corners.
 

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -7,9 +7,11 @@ tags:
   - Reference
   - WebKit
   - media feature
+  - Deprecated
+  - Non-standard
 browser-compat: css.at-rules.media.-webkit-animation
 ---
-{{ CSSRef }} {{ Non-standard_header }}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Note:** All browsers support the [`animation`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-animation` media feature. No browsers support `animation`, without the prefix, as a media query. Use the [`@supports (animation)`](/en-US/docs/Web/CSS/@supports) feature query instead.
 

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -8,9 +8,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-align
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard.
 

--- a/files/en-us/web/css/box-direction/index.md
+++ b/files/en-us/web/css/box-direction/index.md
@@ -6,9 +6,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-direction
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. The `-moz-box-direction` will only be used for XUL while the previous standard `box-direction` has been replaced by `flex-direction`. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-flex-group/index.md
+++ b/files/en-us/web/css/box-flex-group/index.md
@@ -7,9 +7,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-flex-group
 ---
-{{CSSRef}}{{Non-standard_Header}}
+{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - box-flex
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-flex
 ---
-{{CSSRef}}{{Non-standard_Header}}
+{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property for controlling parts of the XUL box model. It does not match either the old CSS Flexible Box Layout Module drafts for '`box-flex`' (which were based on this property) or the behavior of '`-webkit-box-flex`' (which is based on those drafts). See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-lines/index.md
+++ b/files/en-us/web/css/box-lines/index.md
@@ -7,9 +7,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-lines
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-ordinal-group/index.md
+++ b/files/en-us/web/css/box-ordinal-group/index.md
@@ -7,9 +7,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-ordinal-group
 ---
-{{CSSRef}}{{Non-standard_Header}}
+{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-orient/index.md
+++ b/files/en-us/web/css/box-orient/index.md
@@ -6,9 +6,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-orient
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/box-pack/index.md
+++ b/files/en-us/web/css/box-pack/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - box-pack
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.box-pack
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{Deprecated_Header}}
 
 > **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard. See [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) for information about the current standard.
 

--- a/files/en-us/web/css/clip/index.md
+++ b/files/en-us/web/css/clip/index.md
@@ -10,7 +10,7 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.clip
 ---
-{{CSSRef}}
+{{CSSRef}}{{Deprecated_Header}}
 
 The **`clip`** [CSS](/en-US/docs/Web/CSS) property defines a visible portion of an element. The `clip` property applies only to absolutely positioned elements — that is, elements with {{cssxref("position","position:absolute")}} or {{cssxref("position","position:fixed")}}.
 

--- a/files/en-us/web/css/css_device_adaptation/index.md
+++ b/files/en-us/web/css/css_device_adaptation/index.md
@@ -7,9 +7,10 @@ tags:
   - Guide
   - Overview
   - Reference
+  - Deprecated
 browser-compat: css.at-rules.viewport
 ---
-{{CSSRef}}
+{{CSSRef}}{{Deprecated_Header}}
 
 **CSS Device Adaptation** is a module of CSS that lets you define the size, zoom factor, and orientation of the viewport.
 

--- a/files/en-us/web/css/scroll-snap-type-x/index.md
+++ b/files/en-us/web/css/scroll-snap-type-x/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.scroll-snap-type-x
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`scroll-snap-type-x`** [CSS](/en-US/docs/Web/CSS) property defines how strictly snap points are enforced on the horizontal axis of the scroll container in case there is one.
 

--- a/files/en-us/web/css/scroll-snap-type-y/index.md
+++ b/files/en-us/web/css/scroll-snap-type-y/index.md
@@ -9,9 +9,10 @@ tags:
   - Non-standard
   - Reference
   - recipe:css-property
+  - Deprecated
 browser-compat: css.properties.scroll-snap-type-y
 ---
-{{CSSRef}}{{deprecated_header}}
+{{CSSRef}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`scroll-snap-type-y`** [CSS](/en-US/docs/Web/CSS) property defines how strictly snap points are enforced on the vertical axis of the scroll container in case there is one.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for CSS pages.

Pulling pages that require only missing 'deprecated' status.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
