### PR TITLE
MathML: update BCD Info

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -9,8 +9,7 @@ tags:
   - Deprecated
 browser-compat: mathml.elements.maction
 ---
-{{MathMLRef}}
-{{deprecated_header}}
+{{MathMLRef}}{{Deprecated_Header}}
 
 The deprecated MathML **`<maction>`** element used to provide a possibility to bind an actions to mathematical expressions. Nowadays, it is recommended to rely on [JavaScript](/en-US/docs/Web/JavaScript) and other Web technologies to implement this use case. Some browsers will just render the first child of an `<maction>` element and ignore its `actiontype` and `selection` attributes.
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -7,10 +7,10 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+  - Non-standard
 browser-compat: mathml.elements.mfenced
 ---
-{{MathMLRef}}
-{{deprecated_header}}
+{{MathMLRef}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The deprecated MathML `<mfenced>` element used to provide the possibility to add custom opening and closing parentheses (such as brackets) and separators (such as commas or semicolons) to an expression. It has been removed from the latest MathML standard and modern browsers no longer support it. Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead.
 

--- a/files/en-us/web/mathml/global_attributes/mathbackground/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathbackground/index.md
@@ -5,9 +5,10 @@ tags:
   - Global attributes
   - MathML
   - Reference
+  - Deprecated
 browser-compat: mathml.global_attributes.mathbackground
 ---
-{{MathMLRef("Global_attributes")}}
+{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathbackground`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [background-color](/en-US/docs/Web/CSS/background-color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathcolor/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathcolor/index.md
@@ -5,9 +5,10 @@ tags:
   - Global attributes
   - MathML
   - Reference
+  - Deprecated
 browser-compat: mathml.global_attributes.mathcolor
 ---
-{{MathMLRef("Global_attributes")}}
+{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathcolor`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [color](/en-US/docs/Web/CSS/color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -5,9 +5,10 @@ tags:
   - Global attributes
   - MathML
   - Reference
+  - Deprecated
 browser-compat: mathml.global_attributes.mathsize
 ---
-{{MathMLRef("Global_attributes")}}
+{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathsize`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [font-size](/en-US/docs/Web/CSS/font-size) of a MathML element.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for MathML pages.

There is only deprecation status to update in MathML

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
