### PR TITLE
rm useless CSS attribute

### DIFF
--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.md
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.md
@@ -265,7 +265,6 @@ blockquote i {
   display   : block;
   font-size : 0.8em;
   margin-top: 1rem;
-  text-style: italic;
   text-align: right;
 }
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

HTML tag `<i>` has default style: `font-style: italic`, and `text-style` isn't a CSS attribute.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
