### PR TITLE
Add missing const

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -305,7 +305,7 @@ function draw() {
     // Don't add a canvas for the frame image
     if (document.images[i].getAttribute("id") !== "frame") {
       // Create canvas element
-      canvas = document.createElement("canvas");
+      const canvas = document.createElement("canvas");
       canvas.setAttribute("width", 132);
       canvas.setAttribute("height", 150);
 


### PR DESCRIPTION
Hello I am learning Canvas API here, and I have a question for you.

#### Summary
I thought that there should be declaration and wondered why you didn't write it.
Is it okay writing like, `cavas = ...` rather `const canvas = ...` ?