### PR TITLE
fix: keyboard interactions link in ARIA: grid

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -57,7 +57,7 @@ A grid widget contains one or more rows with one or more cells of thematically r
 
 Cell elements have the role [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), unless they are a row or column header. Then the elements are [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role) and [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role), respectively. Cell elements need to be owned by elements with a [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role) role. Rows can be grouped using `rowgroups`.
 
-If the grid is used as an interactive widget, [keyboard](#keyboard-use) interactions need to be implemented.
+If the grid is used as an interactive widget, [keyboard interactions](#keyboard_interactions) need to be implemented.
 
 ### Associated ARIA roles, states, and properties
 


### PR DESCRIPTION
#### Summary
Correct anchor link has been added in [ARIA: grid](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) docs

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Previous [link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role#keyboard-use) doesn't work

#### Supporting details
None

#### Related issues
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error