### PR TITLE
Tweaked SR text for em, strong

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -779,7 +779,7 @@ When we want to add emphasis in spoken language, we _stress_ certain words, subt
 
 The first sentence sounds genuinely relieved that the person wasn't late. In contrast, the second one, with both the words "glad" and "late" in italics, sounds sarcastic or passive-aggressive, expressing annoyance that the person arrived a bit late.
 
-In HTML we use the {{htmlelement("em")}} (emphasis) element to mark up such instances. As well as making the document more interesting to read, these are recognized by screen readers and spoken out in a different tone of voice. Browsers style this as italic by default, but you shouldn't use this tag purely to get italic styling. To do that, you'd use a {{htmlelement("span")}} element and some CSS, or perhaps an {{htmlelement("i")}} element (see below).
+In HTML we use the {{htmlelement("em")}} (emphasis) element to mark up such instances. As well as making the document more interesting to read, these are recognized by screen readers, which can be configured to speak them in a different tone of voice. Browsers style this as italic by default, but you shouldn't use this tag purely to get italic styling. To do that, you'd use a {{htmlelement("span")}} element and some CSS, or perhaps an {{htmlelement("i")}} element (see below).
 
 ```html
 <p>I am <em>glad</em> you weren't <em>late</em>.</p>
@@ -793,7 +793,7 @@ To emphasize important words, we tend to stress them in spoken language and **bo
 >
 > I am counting on you. **Do not** be late!
 
-In HTML we use the {{htmlelement("strong")}} (strong importance) element to mark up such instances. As well as making the document more useful, again these are recognized by screen readers and spoken in a different tone of voice. Browsers style this as bold text by default, but you shouldn't use this tag purely to get bold styling. To do that, you'd use a {{htmlelement("span")}} element and some CSS, or perhaps a {{htmlelement("b")}} element (see below).
+In HTML we use the {{htmlelement("strong")}} (strong importance) element to mark up such instances. As well as making the document more useful, again these are recognized by screen readers, which can be configured to speak them in a different tone of voice. Browsers style this as bold text by default, but you shouldn't use this tag purely to get bold styling. To do that, you'd use a {{htmlelement("span")}} element and some CSS, or perhaps a {{htmlelement("b")}} element (see below).
 
 ```html
 <p>This liquid is <strong>highly toxic</strong>.</p>


### PR DESCRIPTION
#### Summary
Screen readers do not announce `<em>` or `<strong>` differently by default. A user has to configure their screen reader to do so (if supported).

#### Motivation
 I have had testers either assert this page says they do or claim a dev mis-used `<em>` or `<strong>` because it was not announced.

#### Supporting details
Tested in:
- JAWS 2022 / Chrome 104
- NVDA 2022.2 / Firefox 103
- Narrator / Windows 11 / Edge 104
- VoiceOver / macOS 12.5 / Safari 15.6
- TalkBack 12.2 / Android 12 / Chrome 103
- VoiceOver / iOS 15.5 / Safari 15.5
- which matches as far back as I can remember into the low twenty-teens

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

