### PR TITLE
CSS: update BCD Info

### DIFF
--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -35,11 +35,11 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 
 ### Values
 
-- `none`
+- `none` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The element does not respond to user input, and it does not become {{CSSxRef(":active")}}.
-- `enabled`
+- `enabled` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The element accepts user input. For textboxes, this is the default behavior. **Please note that this value is no longer supported in Firefox 60 onwards ({{bug(1405087)}}).**
-- `disabled`
+- `disabled` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The element does not accept user input. However, this is not the same as setting `disabled` to true, in that the element is drawn normally. **Please note that this value is no longer supported in Firefox 60 onwards ({{bug(1405087)}}).**
 
 ## Formal definition

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -50,7 +50,7 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
   - : Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values.
 - {{cssxref("@font-face/line-gap-override", "line-gap-override")}}
   - : Defines the line gap metric for the font.
-- {{cssxref("@font-face/size-adjust", "size-adjust")}} {{experimental_inline}}
+- {{cssxref("@font-face/size-adjust", "size-adjust")}}
   - : Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.
 - {{cssxref("@font-face/src", "src")}}
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -128,7 +128,7 @@ Media feature expressions test for their presence or value, and are entirely opt
 - {{cssxref("@media/scripting", "scripting")}}
   - : Detects whether scripting (i.e. JavaScript) is available.
     Added in Media Queries Level 5.
-- {{cssxref("@media/update-frequency", "update")}}
+- {{cssxref("@media/update-frequency", "update")}} {{Experimental_Inline}}
   - : How frequently the output device can modify the appearance of content.
     Added in Media Queries Level 4.
 - {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -29,11 +29,11 @@ The `@property` rule represents a custom property registration directly in a sty
 
 ### Descriptors
 
-- {{cssxref("@property/syntax","syntax")}}
+- {{cssxref("@property/syntax","syntax")}} {{Experimental_Inline}}
   - : Describes the allowable syntax for the property.
-- {{cssxref("@property/inherits","inherits")}}
+- {{cssxref("@property/inherits","inherits")}} {{Experimental_Inline}}
   - : Controls whether the custom property registration specified by `@property` inherits by default.
-- {{cssxref("@property/initial-value","initial-value")}}
+- {{cssxref("@property/initial-value","initial-value")}} {{Experimental_Inline}}
   - : Sets the initial value for the property.
 
 A valid `@property` rule represents a custom property registration, with the property name being the serialization of the in the rule's prelude.

--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -39,7 +39,7 @@ The `column-fill` property is specified as one of the keyword values listed belo
   - : Columns are filled sequentially. Content takes up only the room it needs, possibly resulting in some columns remaining empty.
 - `balance`
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/Paged_Media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.
-- `balance-all`
+- `balance-all` {{Experimental_Inline}}
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/Paged_Media), all fragments are balanced.
 
 ## Formal definition

--- a/files/en-us/web/css/env/index.md
+++ b/files/en-us/web/css/env/index.md
@@ -45,7 +45,7 @@ env(safe-area-inset-left, 1.4rem);
 
 - `safe-area-inset-top`, `safe-area-inset-right`, `safe-area-inset-bottom`, `safe-area-inset-left`
   - : The `safe-area-inset-*` variables are four environment variables that define a rectangle by its top, right, bottom, and left insets from the edge of the viewport, which is safe to put content into without risking it being cut off by the shape of a non‑rectangular display. For rectangular viewports, like your average laptop monitor, their value is equal to zero. For non-rectangular displays — like a round watch face — the four values set by the user agent form a rectangle such that all content inside the rectangle is visible.
-- `titlebar-area-x`, `titlebar-area-y`, `titlebar-area-width`, `titlebar-area-height`
+- `titlebar-area-x`, `titlebar-area-y`, `titlebar-area-width`, `titlebar-area-height` {{Experimental_Inline}}
   - : The `titlebar-area-*` variables are useful for PWA installed on Desktop devices. When a desktop PWA uses the `window-controls-overlay` [display_override](/en-US/docs/Web/Manifest/display_override) value, then it can use the `titlebar-area-*` variables to make sure content doesn't overlap with the window control buttons (i.e. minimize, maximize, and close).
 
 > **Note:** Unlike other CSS properties, user agent-defined property names are case-sensitive.

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -48,11 +48,11 @@ Font lengths define the `<length>` value in terms of the size of a particular ch
   - : Represents the [x-height](https://en.wikipedia.org/wiki/X-height) of the element's {{Cssxref("font")}}. In fonts with the `x` letter, this is generally the height of lowercase letters in the font; `1ex ≈ 0.5em` in many fonts.
 - `ic`
   - : Equal to the used {{Glossary("advance measure")}} of the "水" glyph (CJK water ideograph, U+6C34), found in the font used to render it.
-- `lh` {{experimental_inline}}
+- `lh` {{experimental_inline}} {{Non-standard_Inline}}
   - : Equal to the computed value of the {{Cssxref("line-height")}} property of the element on which it is used, converted to an absolute length.
 - `rem`
   - : Represents the {{Cssxref("font-size")}} of the root element (typically {{HTMLElement("html")}}). When used within the root element {{Cssxref("font-size")}}, it represents its initial value (a common browser default is `16px`, but user-defined preferences may modify this).
-- `rlh` {{experimental_inline}}
+- `rlh` {{experimental_inline}} {{Non-standard_Inline}}
   - : Equal to the computed value of the {{Cssxref("line-height")}} property on the root element (typically {{HTMLElement("html")}}), converted to an absolute length. When used on the {{Cssxref("font-size")}} or {{Cssxref("line-height")}} properties of the root element, it refers to the properties' initial value.
 
 ### Relative length units based on viewport

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -140,7 +140,7 @@ Note that:
   - : Korean hanja numbering.
 - `lao`, `-moz-lao`
   - : Laotian numbering.
-- `lower-armenian`\*
+- `lower-armenian`
   - : Lowercase Armenian numbering.
 - `malayalam`, `-moz-malayalam`
   - : Malayalam numbering.
@@ -162,13 +162,13 @@ Note that:
   - : Telugu numbering.
 - `thai`, `-moz-thai`
   - : Thai numbering.
-- `tibetan`\*
+- `tibetan`
   - : Tibetan numbering.
 - `trad-chinese-formal`
   - : Traditional Chinese formal numbering.
 - `trad-chinese-informal`
   - : Traditional Chinese informal numbering.
-- `upper-armenian`\*
+- `upper-armenian`
   - : Traditional uppercase Armenian numbering.
 - `disclosure-open`
   - : Symbol indicating that a disclosure widget such as {{HTMLElement("details")}} is opened.

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -78,7 +78,7 @@ Note that:
   - : A filled square.
 - `decimal`
   - : Decimal numbers, beginning with 1.
-- `cjk-decimal` {{experimental_inline}}
+- `cjk-decimal`
   - : Han decimal numbers.
 - `decimal-leading-zero`
   - : Decimal numbers, padded by initial zeros.
@@ -104,11 +104,11 @@ Note that:
   - : Han "Earthly Branch" ordinals.
 - `cjk-heavenly-stem`, `-moz-cjk-heavenly-stem`
   - : Han "Heavenly Stem" ordinals.
-- `cjk-ideographic` {{experimental_inline}}
+- `cjk-ideographic`
   - : Identical to `trad-chinese-informal`.
 - `devanagari`, `-moz-devanagari`
   - : Devanagari numbering.
-- `ethiopic-numeric` {{experimental_inline}}
+- `ethiopic-numeric`
   - : Ethiopic numbering.
 - `georgian`
   - : Traditional Georgian numbering.
@@ -116,63 +116,63 @@ Note that:
   - : Gujarati numbering.
 - `gurmukhi`, `-moz-gurmukhi`
   - : Gurmukhi numbering.
-- `hebrew` {{experimental_inline}}
+- `hebrew`
   - : Traditional Hebrew numbering
-- `hiragana` {{experimental_inline}}
+- `hiragana`
   - : Dictionary-order hiragana lettering.
-- `hiragana-iroha` {{experimental_inline}}
+- `hiragana-iroha`
   - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) hiragana lettering
-- `japanese-formal` {{experimental_inline}}
+- `japanese-formal`
   - : Japanese formal numbering to be used in legal or financial documents. The kanjis are designed so that they can't be modified to look like another correct one.
-- `japanese-informal` {{experimental_inline}}
+- `japanese-informal`
   - : Japanese informal numbering.
 - `kannada`, `-moz-kannada`
   - : Kannada numbering.
-- `katakana` {{experimental_inline}}
+- `katakana`
   - : Dictionary-order katakana lettering
-- `katakana-iroha` {{experimental_inline}}
+- `katakana-iroha`
   - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) katakana lettering
-- `korean-hangul-formal` {{experimental_inline}}
+- `korean-hangul-formal`
   - : Korean hangul numbering.
-- `korean-hanja-formal` {{experimental_inline}}
+- `korean-hanja-formal`
   - : Formal Korean Han numbering.
-- `korean-hanja-informal` {{experimental_inline}}
+- `korean-hanja-informal`
   - : Korean hanja numbering.
 - `lao`, `-moz-lao`
   - : Laotian numbering.
-- `lower-armenian` {{experimental_inline}}\*
+- `lower-armenian`\*
   - : Lowercase Armenian numbering.
 - `malayalam`, `-moz-malayalam`
   - : Malayalam numbering.
-- `mongolian` {{experimental_inline}}
+- `mongolian`
   - : Mongolian numbering.
 - `myanmar`, `-moz-myanmar`
   - : Myanmar (Burmese) numbering.
 - `oriya`, `-moz-oriya`
   - : Oriya numbering.
-- `persian` {{experimental_inline}}, `-moz-persian`
+- `persian`, `-moz-persian`
   - : Persian numbering
-- `simp-chinese-formal` {{experimental_inline}}
+- `simp-chinese-formal`
   - : Simplified Chinese formal numbering.
-- `simp-chinese-informal` {{experimental_inline}}
+- `simp-chinese-informal`
   - : Simplified Chinese informal numbering.
-- `tamil` {{experimental_inline}}, `-moz-tamil`
+- `tamil`, `-moz-tamil`
   - : Tamil numbering.
 - `telugu`, `-moz-telugu`
   - : Telugu numbering.
 - `thai`, `-moz-thai`
   - : Thai numbering.
-- `tibetan` {{experimental_inline}}\*
+- `tibetan`\*
   - : Tibetan numbering.
-- `trad-chinese-formal` {{experimental_inline}}
+- `trad-chinese-formal`
   - : Traditional Chinese formal numbering.
-- `trad-chinese-informal` {{experimental_inline}}
+- `trad-chinese-informal`
   - : Traditional Chinese informal numbering.
-- `upper-armenian` {{experimental_inline}}\*
+- `upper-armenian`\*
   - : Traditional uppercase Armenian numbering.
-- `disclosure-open` {{experimental_inline}}
+- `disclosure-open`
   - : Symbol indicating that a disclosure widget such as {{HTMLElement("details")}} is opened.
-- `disclosure-closed` {{experimental_inline}}
+- `disclosure-closed`
   - : Symbol indicating that a disclosure widget, like {{HTMLElement("details")}} is closed.
 
 ### Non-standard extensions

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -56,11 +56,11 @@ One or more of the keyword values listed below, separated by commas.
   - : The position is relative to the border box.
 - `margin-box`
   - : The position is relative to the margin box.
-- `fill-box`
+- `fill-box` {{Experimental_Inline}}
   - : The position is relative to the object bounding box.
-- `stroke-box`
+- `stroke-box` {{Experimental_Inline}}
   - : The position is relative to the stroke bounding box.
-- `view-box`
+- `view-box` {{Experimental_Inline}}
   - : Uses the nearest SVG viewport as reference box. If a {{svgattr("viewBox")}} attribute is specified for the element creating the SVG viewport, the reference box is positioned at the origin of the coordinate system established by the `viewBox` attribute and the dimension of the reference box is set to the width and height values of the `viewBox` attribute.
 - `content` {{non-standard_inline}}
   - : Same as `content-box`.

--- a/files/en-us/web/css/overflow-x/index.md
+++ b/files/en-us/web/css/overflow-x/index.md
@@ -41,7 +41,7 @@ The `overflow-x` property is specified as a single keyword chosen from the list 
   - : Content is not clipped and may be rendered outside the padding box's left and right edges. If {{cssxref("overflow-y")}} is `hidden`, `scroll` or `auto` and this property is `visible`, it will implicitly compute to `auto`.
 - `hidden`
   - : Content is clipped if necessary to fit horizontally in the padding box. No scrollbars are provided.
-- `clip` {{experimental_inline}}
+- `clip`
   - : Like for `hidden`, the content is clipped to the element's padding box. The difference between `clip` and `hidden` is that the `clip` keyword also forbids all scrolling, including programmatic scrolling. The box is not a scroll container, and does not start a new formatting context. If you wish to start a new formatting context, you can use {{cssxref("display", "display: flow-root", "#flow-root")}} to do so.
 - `scroll`
   - : Content is clipped if necessary to fit horizontally in the padding box. Browsers display scrollbars whether or not any content is actually clipped. (This prevents scrollbars from appearing or disappearing when the content changes.) Printers may still print overflowing content.

--- a/files/en-us/web/css/overflow-y/index.md
+++ b/files/en-us/web/css/overflow-y/index.md
@@ -43,7 +43,7 @@ If {{cssxref("overflow-x")}} is `hidden`, `scroll` or `auto` and this property i
   - : Content is not clipped and may be rendered outside the padding box's top and bottom edges.
 - `hidden`
   - : Content is clipped if necessary to fit vertically in the padding box. No scrollbars are provided.
-- `clip` {{experimental_inline}}
+- `clip`
   - : Like for `hidden`, the content is clipped to the element's padding box. The difference between `clip` and `hidden` is that the `clip` keyword also forbids all scrolling, including programmatic scrolling. The box is not a scroll container, and does not start a new formatting context. If you wish to start a new formatting context, you can use {{cssxref("display", "display: flow-root", "#flow-root")}} to do so.
 - `scroll`
   - : Content is clipped if necessary to fit vertically in the padding box. Browsers display scrollbars whether or not any content is actually clipped. (This prevents scrollbars from appearing or disappearing when the content changes.) Printers may still print overflowing content.

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -38,9 +38,9 @@ ruby-position: unset;
   - : ![Over example](screen_shot_2015-03-04_at_13.02.20.png)Is a keyword indicating that the ruby has to be placed over the main text for horizontal scripts and right to it for vertical scripts.
 - `under`
   - : ![Under example](screen_shot_2015-03-04_at_13.02.07.png)Is a keyword indicating that the ruby has to be placed under the main text for horizontal scripts and left to it for vertical scripts.
-- `inter-character`
+- `inter-character` {{Experimental_Inline}}
   - : Is a keyword indicating that the ruby has to be placed between the different characters.
-- `alternate`
+- `alternate` {{Experimental_Inline}}
   - : Is a keyword indicating that the ruby alternates between over and under, when there are multiple levels of annotation.
 
 ## Formal definition

--- a/files/en-us/web/css/text-decoration/index.md
+++ b/files/en-us/web/css/text-decoration/index.md
@@ -24,7 +24,7 @@ This property is a shorthand for the following CSS properties:
 - [`text-decoration-color`](/en-US/docs/Web/CSS/text-decoration-color)
 - [`text-decoration-line`](/en-US/docs/Web/CSS/text-decoration-line)
 - [`text-decoration-style`](/en-US/docs/Web/CSS/text-decoration-style)
-- [`text-decoration-thickness`](/en-US/docs/Web/CSS/text-decoration-thickness)
+- [`text-decoration-thickness`](/en-US/docs/Web/CSS/text-decoration-thickness) {{Non-standard_Inline}}
 
 ## Syntax
 

--- a/files/en-us/web/css/text-indent/index.md
+++ b/files/en-us/web/css/text-indent/index.md
@@ -50,9 +50,9 @@ text-indent: unset;
   - : Indentation is specified as an absolute {{cssxref("&lt;length&gt;")}}. Negative values are allowed. See {{cssxref("&lt;length&gt;")}} values for possible units.
 - {{cssxref("&lt;percentage&gt;")}}
   - : Indentation is a {{cssxref("&lt;percentage&gt;")}} of the containing block's width.
-- `each-line` {{experimental_inline}}
+- `each-line`
   - : Indentation affects the first line of the block container as well as each line after a _forced line break_, but does not affect lines after a _soft wrap break_.
-- `hanging` {{experimental_inline}}
+- `hanging`
   - : Inverts which lines are indented. All lines _except_ the first line will be indented.
 
 ## Formal definition

--- a/files/en-us/web/css/text-rendering/index.md
+++ b/files/en-us/web/css/text-rendering/index.md
@@ -44,13 +44,13 @@ One very visible effect is `optimizeLegibility`, which enables ligatures (ff, fi
 
 ### Values
 
-- `auto`
+- `auto` {{Non-standard_Inline}}
   - : The browser makes educated guesses about when to optimize for speed, legibility, and geometric precision while drawing text. For differences in how this value is interpreted by the browser, see the compatibility table.
 - `optimizeSpeed`
   - : The browser emphasizes rendering speed over legibility and geometric precision when drawing text. It disables kerning and ligatures.
 - `optimizeLegibility`
   - : The browser emphasizes legibility over rendering speed and geometric precision. This enables kerning and optional ligatures.
-- `geometricPrecision`
+- `geometricPrecision` {{Non-standard_Inline}}
 
   - : The browser emphasizes geometric precision over rendering speed and legibility. Certain aspects of fonts — such as kerning — don't scale linearly. So this value can make text using those fonts look good.
 

--- a/files/en-us/web/css/text-underline-position/index.md
+++ b/files/en-us/web/css/text-underline-position/index.md
@@ -48,7 +48,7 @@ text-underline-position: unset;
   - : In vertical writing-modes, this keyword forces the line to be placed on the _left_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
 - `right`
   - : In vertical writing-modes, this keyword forces the line to be placed on the _right_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
-- `auto-pos` {{non-standard_inline}}
+- `auto-pos` {{non-standard_inline}} {{Experimental_Inline}}
   - : A synonym of `auto`, which should be used instead.
 - `above` {{non-standard_inline}}
   - : Forces the line to be above the text. When used with East-Asian text, using the `auto` keyword will lead to a similar effect.

--- a/files/en-us/web/css/user-modify/index.md
+++ b/files/en-us/web/css/user-modify/index.md
@@ -41,7 +41,7 @@ The `-moz-user-modify` property is specified as one of the keyword values from t
   - : Default value. Contents are read-only.
 - `read-write`
   - : The user is able to read and write contents.
-- `read-write-plaintext-only` {{Non-standard_Inline}}
+- `read-write-plaintext-only` {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Same as `read-write`, but rich text formatting will be lost.
 - `write-only`
   - : The user is able to edit the content, but not to read it.


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for CSS pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

:notebook: This completes changes in CSS.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
