### PR TITLE
HTTP: update BCD Info

### DIFF
--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.md
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.md
@@ -9,10 +9,9 @@ tags:
   - Response header
   - Deprecated
   - Non-standard
-  - Experimental
 browser-compat: http.headers.Accept-CH-Lifetime
 ---
-{{HTTPSidebar}}{{securecontext_header}}{{Deprecated_header}}
+{{HTTPSidebar}}{{securecontext_header}}{{Deprecated_header}}{{Non-standard_header}}
 
 > **Warning:** The header was removed from the specification in [draft 8](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-08).
 

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -9,7 +9,7 @@ tags:
   - Response header
 browser-compat: http.headers.Accept-CH
 ---
-{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
+{{HTTPSidebar}}{{securecontext_header}}
 
 The **`Accept-CH`** header may be set by a server to specify
 which [client hints](/en-US/docs/Web/HTTP/Client_hints) headers a client

--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -9,10 +9,9 @@ tags:
   - Response header
   - Deprecated
   - Non-standard
-  - Experimental
 browser-compat: http.headers.Content-DPR
 ---
-{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
+{{HTTPSidebar}}{{deprecated_header}}{{securecontext_header}}{{Non-standard_header}}
 
 The **`Content-DPR`** response header is used to confirm the _image_ device to pixel ratio in requests where the screen {{HTTPHeader("DPR")}} [client hint](/en-US/docs/Web/HTTP/Client_hints) was used to select an image resource.
 

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -9,10 +9,9 @@ tags:
   - Request header
   - Deprecated
   - Non-standard
-  -  Experimental
 browser-compat: http.headers.DPR
 ---
-{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
+{{HTTPSidebar}}{{Deprecated_Header}}{{SecureContext_Header}}{{Non-standard_Header}}
 
 The **`DPR`** [device client hint](/en-US/docs/Web/HTTP/Client_hints) request header provides the client device pixel ratio. This ratio is the number of physical device pixels corresponding to every {{Glossary("CSS pixel")}}.
 

--- a/files/en-us/web/http/headers/feature-policy/camera/index.md
+++ b/files/en-us/web/http/headers/feature-policy/camera/index.md
@@ -8,10 +8,9 @@ tags:
   - HTTP
   - Reference
   - camera
-  - Experimental
 browser-compat: http.headers.Feature-Policy.camera
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header
 `camera` directive controls whether the current document is allowed to use

--- a/files/en-us/web/http/headers/feature-policy/display-capture/index.md
+++ b/files/en-us/web/http/headers/feature-policy/display-capture/index.md
@@ -7,10 +7,9 @@ tags:
   - HTTP
   - Reference
   - display-capture
-  - Experimental
 browser-compat: http.headers.Feature-Policy.display-capture
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header `display-capture` directive controls whether or not the document is permitted to use [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API), that is, {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} to capture the screen's contents.
 

--- a/files/en-us/web/http/headers/feature-policy/fullscreen/index.md
+++ b/files/en-us/web/http/headers/feature-policy/fullscreen/index.md
@@ -7,10 +7,9 @@ tags:
   - HTTP
   - fullscreen
   - header
-  - Experimental
 browser-compat: http.headers.Feature-Policy.fullscreen
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header `fullscreen` directive controls whether the current document is allowed to use {{domxref('Element.requestFullscreen()')}}. When this policy is enabled, the returned {{jsxref('Promise')}} rejects with a {{jsxref('TypeError')}}.
 

--- a/files/en-us/web/http/headers/feature-policy/geolocation/index.md
+++ b/files/en-us/web/http/headers/feature-policy/geolocation/index.md
@@ -6,10 +6,9 @@ tags:
   - Geolocation
   - HTTP
   - header
-  - Experimental
 browser-compat: http.headers.Feature-Policy.geolocation
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header
 `geolocation` directive controls whether the current document is allowed to

--- a/files/en-us/web/http/headers/feature-policy/microphone/index.md
+++ b/files/en-us/web/http/headers/feature-policy/microphone/index.md
@@ -7,10 +7,9 @@ tags:
   - HTTP
   - header
   - microphone
-  - Experimental
 browser-compat: http.headers.Feature-Policy.microphone
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header
 `microphone` directive controls whether the current document is allowed to

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Arch
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Arch`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's underlying CPU architecture, such as ARM or x86.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Bitness
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Bitness`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the "bitness" of the user-agent's underlying CPU architecture.
 This is the size in bits of an integer or memory address—typically 64 or 32 bits.

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Full-Version-List
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Full-Version-List`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and full version information.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Mobile
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Mobile`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header indicates whether the browser is on a mobile device.
 It can also be used by a desktop browser to indicate a preference for a "mobile" user experience.

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Model
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Model`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header indicates the device model on which the browser is running.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Platform-Version
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Platform-Version`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the version of the operating system on which the user agent is running.
 

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA-Platform
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA-Platform`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the platform or operating system on which the user agent is running.
 For example: "Windows" or "Android".

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Experimental
 browser-compat: http.headers.Sec-CH-UA
 ---
-{{HTTPSidebar}} {{SeeCompatTable}} {{securecontext_header}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sec-CH-UA`** [user agent client hint](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints) request header provides the user-agent's branding and significant version information.
 

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -9,10 +9,9 @@ tags:
   - Request header
   - Deprecated
   - Non-standard
-  -  Experimental
 browser-compat: http.headers.Viewport-Width
 ---
-{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
+{{HTTPSidebar}}{{Deprecated_Header}}{{SecureContext_header}}{{Non-standard_Header}}
 
 The **`Viewport-Width`** [device client hint](/en-US/docs/Web/HTTP/Client_hints) request header provides the client's layout viewport width in {{Glossary("CSS pixel","CSS pixels")}}. The value is rounded up to the smallest following integer (i.e. ceiling value).
 

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -8,11 +8,11 @@ tags:
   - HTTP
   - HTTP Header
   - Request header
-  - Experimental
   - Deprecated
+  - Non-standard
 browser-compat: http.headers.Width
 ---
-{{HTTPSidebar}} {{deprecated_header}}{{securecontext_header}}
+{{HTTPSidebar}}{{Deprecated_Header}}{{SecureContext_header}}{{Non-standard_Header}}
 
 The **`Width`** [device client hint](/en-US/docs/Web/HTTP/Client_hints#device_client_hints) request header field indicates the desired resource width in physical pixels — the intrinsic size of an image. The provided pixel value is a number rounded to the smallest following integer (i.e. ceiling value).
 

--- a/files/en-us/web/http/status/425/index.md
+++ b/files/en-us/web/http/status/425/index.md
@@ -8,7 +8,7 @@ tags:
   - Status code
 browser-compat: http.status.425
 ---
-{{SeeCompatTable}}{{HTTPSidebar}}
+{{HTTPSidebar}}
 
 The HyperText Transfer Protocol (HTTP) **`425 Too Early`**
 response status code indicates that the server is unwilling to risk processing a request


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTTP pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

This focuses on files where only change is to remove experimental status.
Also updates small indentation issue in some files.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.
