### PR TITLE
FontFace() - add how to use descriptors

### DIFF
--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -66,7 +66,11 @@ new FontFace(family, source, descriptors)
 
 ```js
 async function loadFonts() {
-    const font = new FontFace('myfont', 'url(myfont.woff)');
+    const font = new FontFace('myfont', 'url(myfont.woff)',{
+      style: 'normal',
+      weight: '400',
+      stretch: 'condensed'
+      });
     // wait for font to be loaded
     await font.load();
     // add font to document


### PR DESCRIPTION
FontFace() takes descriptors. IN theory it was obvious how they were used, but in practice this was not demonstrated.

This is a minor update. I hope to come back and do a live example at some point.