### PR TITLE
[Role: Grid] More information about keyboard interactions

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: grid role"
+title: 'ARIA: grid role'
 slug: Web/Accessibility/ARIA/Roles/grid_role
 tags:
   - ARIA
@@ -14,7 +14,6 @@ tags:
 spec-urls:
   - https://w3c.github.io/aria/#grid
 ---
-
 The grid role is for a widget that contains one or more rows of cells. The position of each cell is significant and can be focused using keyboard input.
 
 ## Description
@@ -23,9 +22,7 @@ The `grid` role is a composite widget containing a collection of one or more row
 
 ```html
 <table role="grid" aria-labelledby="id-select-your-seat">
-  <caption id="id-select-your-seat">
-    Select your seat
-  </caption>
+  <caption id="id-select-your-seat">Select your seat</caption>
   <tbody role="presentation">
     <tr role="presentation">
       <td></td>
@@ -90,10 +87,10 @@ When a keyboard user encounters a grid, they navigate the rows and columns using
 
 | Key                               | Action                                                                                                                                                                                                                                |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <kbd>→</kbd>                      | Moves focus one cell to the right. Optionally (layout grids), if focus is on the right-most cell in the row, focus may move to the first cell in the following row. If focus is on the last cell in the grid, focus does not move.    |
-| <kbd>←</kbd>                      | Moves focus one cell to the left. Optionally (layout grids), if focus is on the left-most cell in the row, focus may move to the last cell in the previous row. If focus is on the first cell in the grid, focus does not move.       |
-| <kbd>↓</kbd>                      | Moves focus one cell down. Optionally (layout grids), if focus is on the bottom cell in the column, focus may move to the top cell in the following column. If focus is on the last cell in the grid, focus does not move.            |
-| <kbd>↑</kbd>                      | Moves focus one cell up. Optionally (layout grids), if focus is on the top cell in the column, focus may move to the bottom cell in the previous column. If focus is on the first cell in the grid, focus does not move.              |
+| <kbd>→</kbd>                      | Moves focus one cell to the right. Optionally (layout grids), if focus is on the right-most cell in the row, focus may move to the first cell in the following row. If focus is on the last cell in the grid, focus does not move.                                                                                                                                |
+| <kbd>←</kbd>                      | Moves focus one cell to the left. Optionally (layout grids), if focus is on the left-most cell in the row, focus may move to the last cell in the previous row. If focus is on the first cell in the grid, focus does not move.                                                                                                                                  |
+| <kbd>↓</kbd>                      | Moves focus one cell down. Optionally (layout grids), if focus is on the bottom cell in the column, focus may move to the top cell in the following column. If focus is on the last cell in the grid, focus does not move.                                                                                                                                         |
+| <kbd>↑</kbd>                      | Moves focus one cell up. Optionally (layout grids), if focus is on the top cell in the column, focus may move to the bottom cell in the previous column. If focus is on the first cell in the grid, focus does not move.                                                                                                                                              |
 | <kbd>Page Down</kbd>              | Moves focus down an author-determined number of rows, typically scrolling so the bottom row in the currently visible set of rows becomes one of the first visible rows. If focus is in the last row of the grid, focus does not move. |
 | <kbd>Page Up</kbd>                | Moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.      |
 | <kbd>Home</kbd>                   | Moves focus to the first cell in the row that contains focus.                                                                                                                                                                         |
@@ -123,9 +120,7 @@ If cells, rows, or columns can be selected, the following key combination are co
 
 ```html
 <table role="grid" aria-labelledby="calendarheader">
-  <caption id="calendarheader">
-    September 2018
-  </caption>
+  <caption id="calendarheader">September 2018</caption>
   <thead role="rowgroup">
     <tr role="row">
       <td></td>
@@ -151,47 +146,105 @@ If cells, rows, or columns can be selected, the following key combination are co
     </tr>
     <tr role="row">
       <th scope="row" role="rowheader">Week 2</th>
-      <td role="gridcell" tabindex="-1">2</td>
-      <td role="gridcell" tabindex="-1">3</td>
-      <td role="gridcell" tabindex="-1">4</td>
-      <td role="gridcell" tabindex="-1">5</td>
-      <td role="gridcell" tabindex="-1">6</td>
-      <td role="gridcell" tabindex="-1">7</td>
-      <td role="gridcell" tabindex="-1">8</td>
+      <td role="gridcell" tabindex="-1">
+        2
+      </td>
+      <td role="gridcell" tabindex="-1">
+        3
+      </td>
+      <td role="gridcell" tabindex="-1">
+        4
+      </td>
+      <td role="gridcell" tabindex="-1">
+        5
+      </td>
+      <td role="gridcell" tabindex="-1">
+        6
+      </td>
+      <td role="gridcell" tabindex="-1">
+        7
+      </td>
+      <td role="gridcell" tabindex="-1">
+        8
+      </td>
     </tr>
     <tr role="row">
       <th scope="row" role="rowheader">Week 3</th>
-      <td role="gridcell" tabindex="-1">9</td>
-      <td role="gridcell" tabindex="-1">10</td>
-      <td role="gridcell" tabindex="-1">11</td>
-      <td role="gridcell" tabindex="-1">12</td>
-      <td role="gridcell" tabindex="-1">13</td>
-      <td role="gridcell" tabindex="-1">14</td>
-      <td role="gridcell" tabindex="-1">15</td>
+      <td role="gridcell" tabindex="-1">
+        9
+      </td>
+      <td role="gridcell" tabindex="-1">
+        10
+      </td>
+      <td role="gridcell" tabindex="-1">
+        11
+      </td>
+      <td role="gridcell" tabindex="-1">
+        12
+      </td>
+      <td role="gridcell" tabindex="-1">
+        13
+      </td>
+      <td role="gridcell" tabindex="-1">
+        14
+      </td>
+      <td role="gridcell" tabindex="-1">
+        15
+      </td>
     </tr>
     <tr role="row">
       <th scope="row" role="rowheader">Week 4</th>
-      <td role="gridcell" tabindex="-1">16</td>
-      <td role="gridcell" tabindex="-1">17</td>
-      <td role="gridcell" tabindex="-1">18</td>
-      <td role="gridcell" tabindex="-1">19</td>
-      <td role="gridcell" tabindex="-1">20</td>
-      <td role="gridcell" tabindex="-1">21</td>
-      <td role="gridcell" tabindex="-1">22</td>
+      <td role="gridcell" tabindex="-1">
+        16
+      </td>
+      <td role="gridcell" tabindex="-1">
+        17
+      </td>
+      <td role="gridcell" tabindex="-1">
+        18
+      </td>
+      <td role="gridcell" tabindex="-1">
+        19
+      </td>
+      <td role="gridcell" tabindex="-1">
+        20
+      </td>
+      <td role="gridcell" tabindex="-1">
+        21
+      </td>
+      <td role="gridcell" tabindex="-1">
+        22
+      </td>
     </tr>
     <tr role="row">
       <th scope="row" role="rowheader">Week 5</th>
-      <td role="gridcell" tabindex="-1">23</td>
-      <td role="gridcell" tabindex="-1">24</td>
-      <td role="gridcell" tabindex="-1">25</td>
-      <td role="gridcell" tabindex="-1">26</td>
-      <td role="gridcell" tabindex="-1">27</td>
-      <td role="gridcell" tabindex="-1">28</td>
-      <td role="gridcell" tabindex="-1">29</td>
-    </tr>
+      <td role="gridcell" tabindex="-1">
+        23
+      </td>
+      <td role="gridcell" tabindex="-1">
+        24
+      </td>
+      <td role="gridcell" tabindex="-1">
+        25
+      </td>
+      <td role="gridcell" tabindex="-1">
+        26
+      </td>
+      <td role="gridcell" tabindex="-1">
+        27
+      </td>
+      <td role="gridcell" tabindex="-1">
+        28
+      </td>
+      <td role="gridcell" tabindex="-1">
+        29
+      </td>
+    </tr> 
     <tr role="row">
       <th scope="row" role="rowheader">Week 6</th>
-      <td role="gridcell" tabindex="-1">30</td>
+      <td role="gridcell" tabindex="-1">
+        30
+      </td>
       <td>1</td>
       <td>2</td>
       <td>3</td>
@@ -199,7 +252,7 @@ If cells, rows, or columns can be selected, the following key combination are co
       <td>5</td>
       <td>6</td>
     </tr>
-  </tbody>
+    </tbody>
 </table>
 ```
 
@@ -212,8 +265,7 @@ table {
   font-variant-numeric: tabular-nums;
 }
 
-tbody th,
-tbody td {
+tbody th, tbody td {
   padding: 5px;
 }
 
@@ -227,10 +279,8 @@ tbody td[role="gridcell"] {
   color: #000;
 }
 
-tbody td[role="gridcell"]:hover,
-tbody td[role="gridcell"]:focus {
-  background-color: #f6f6f6;
-  outline: 3px solid blue;
+tbody td[role="gridcell"]:hover, tbody td[role="gridcell"]:focus {
+  background-color: #f6f6f6; outline: 3px solid blue;
 }
 ```
 
@@ -239,36 +289,32 @@ tbody td[role="gridcell"]:focus {
 ```js
 const selectables = document.querySelectorAll('table td[role="gridcell"]');
 
-selectables[0].setAttribute("tabindex", 0);
+selectables[0].setAttribute('tabindex', 0);
 
-const trs = document.querySelectorAll("table tbody tr");
+const trs = document.querySelectorAll('table tbody tr');
 let row = 0;
 let col = 0;
 let maxrow = trs.length - 1;
 let maxcol = 0;
 
 trs.forEach((gridrow) => {
-  gridrow.querySelectorAll("td").forEach((el) => {
+  gridrow.querySelectorAll('td').forEach((el) => {
     el.dataset.row = row;
     el.dataset.col = col;
     col++;
   });
-  if (col > maxcol) {
-    maxcol = col - 1;
-  }
+  if (col > maxcol) { maxcol = col - 1; }
   col = 0;
   row++;
 });
 
 function moveto(newrow, newcol) {
-  const tgt = document.querySelector(
-    `[data-row="${newrow}"][data-col="${newcol}"]`
-  );
-  if (tgt?.getAttribute("role") === "gridcell") {
-    document.querySelectorAll("[role=gridcell]").forEach((el) => {
-      el.setAttribute("tabindex", "-1");
+  const tgt = document.querySelector(`[data-row="${newrow}"][data-col="${newcol}"]`);
+  if (tgt?.getAttribute('role') === 'gridcell') {
+    document.querySelectorAll('[role=gridcell]').forEach((el) => {
+      el.setAttribute('tabindex', '-1');
     });
-    tgt.setAttribute("tabindex", "0");
+    tgt.setAttribute('tabindex', '0');
     tgt.focus();
     return true;
   } else {
@@ -276,28 +322,27 @@ function moveto(newrow, newcol) {
   }
 }
 
-document.querySelector("table").addEventListener("keydown", (event) => {
-  const currentCol = parseInt(event.target.dataset.col, 10);
-  const currentRow = parseInt(event.target.dataset.row, 10);
-
+document.querySelector('table').addEventListener("keydown", (event) => {
+  const col = parseInt(event.target.dataset.col, 10);
+  const row = parseInt(event.target.dataset.row, 10);
   switch (event.key) {
     case "ArrowRight": {
-      const nextCol = currentCol === 6 ? 0 : currentCol + 1;
-      const nextRow = currentCol === 6 ? currentRow + 1 : currentRow;
-      moveto(nextRow, nextCol);
+      const newrow = col === 6 ? row + 1 : row;
+      const newcol = col === 6 ? 0 : col + 1;
+      moveto(newrow, newcol);
       break;
     }
     case "ArrowLeft": {
-      const nextCol = currentCol === 0 ? 6 : currentCol - 1;
-      const nextRow = currentCol === 0 ? currentRow - 1 : currentRow;
-      moveto(nextRow, nextCol);
+      const newrow = col === 0 ? row - 1 : row;
+      const newcol = col === 0 ? 6 : col - 1;
+      moveto(newrow, newcol);
       break;
     }
     case "ArrowDown":
-      moveto(currentRow + 1, currentCol);
+      moveto(row + 1, col);
       break;
     case "ArrowUp":
-      moveto(currentRow - 1, currentCol);
+      moveto(row - 1, col);
       break;
     case "Home": {
       if (event.ctrlKey) {
@@ -312,7 +357,7 @@ document.querySelector("table").addEventListener("keydown", (event) => {
           i++;
         } while (!result);
       } else {
-        moveto(currentRow, 0);
+        moveto(row, 0);
       }
       break;
     }
@@ -329,12 +374,7 @@ document.querySelector("table").addEventListener("keydown", (event) => {
           i--;
         } while (!result);
       } else {
-        moveto(
-          currentRow,
-          document.querySelector(
-            `[data-row="${event.target.dataset.row}"]:last-of-type`
-          ).dataset.col
-        );
+        moveto(row, document.querySelector(`[data-row="${event.target.dataset.row}"]:last-of-type`).dataset.col);
       }
       break;
     }
@@ -342,7 +382,7 @@ document.querySelector("table").addEventListener("keydown", (event) => {
       let i = 0;
       let result;
       do {
-        result = moveto(i, currentCol);
+        result = moveto(i, col);
         i++;
       } while (!result);
       break;
@@ -351,7 +391,7 @@ document.querySelector("table").addEventListener("keydown", (event) => {
       let i = maxrow;
       let result;
       do {
-        result = moveto(i, currentCol);
+        result = moveto(i, col);
         i--;
       } while (!result);
       break;
@@ -398,6 +438,6 @@ Even if the keyboard use is properly implemented, some users might not be aware 
 
 1. [**WAI-ARIA roles**](/en-US/docs/Web/Accessibility/ARIA/Roles)
 
-   {{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}
+    {{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}
 
 </section>

--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARIA: grid role'
+title: "ARIA: grid role"
 slug: Web/Accessibility/ARIA/Roles/grid_role
 tags:
   - ARIA
@@ -14,6 +14,7 @@ tags:
 spec-urls:
   - https://w3c.github.io/aria/#grid
 ---
+
 The grid role is for a widget that contains one or more rows of cells. The position of each cell is significant and can be focused using keyboard input.
 
 ## Description
@@ -22,7 +23,9 @@ The `grid` role is a composite widget containing a collection of one or more row
 
 ```html
 <table role="grid" aria-labelledby="id-select-your-seat">
-  <caption id="id-select-your-seat">Select your seat</caption>
+  <caption id="id-select-your-seat">
+    Select your seat
+  </caption>
   <tbody role="presentation">
     <tr role="presentation">
       <td></td>
@@ -53,7 +56,7 @@ The `grid` role is a composite widget containing a collection of one or more row
 </table>
 ```
 
-A grid widget contains one or more rows with one or more cells of thematically related interactive content. While it does not imply a specific visual presentation, it implies a relationship among elements. Uses fall into two categories: presenting tabular information (data grids) and grouping other widgets (layout grids). Even though both data grids and layout grids employ the same ARIA roles, states, and properties, differences in their content and purpose surface factors that are important to consider in keyboard interaction design. See [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) for more details
+A grid widget contains one or more rows with one or more cells of thematically related interactive content. While it does not imply a specific visual presentation, it implies a relationship among elements. Uses fall into two categories: presenting tabular information (data grids) and grouping other widgets (layout grids). Even though both data grids and layout grids employ the same ARIA roles, states, and properties, differences in their content and purpose surface factors that are important to consider in keyboard interaction design. See [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) for more details.
 
 Cell elements have the role [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), unless they are a row or column header. Then the elements are [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role) and [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role), respectively. Cell elements need to be owned by elements with a [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role) role. Rows can be grouped using `rowgroups`.
 
@@ -87,10 +90,10 @@ When a keyboard user encounters a grid, they navigate the rows and columns using
 
 | Key                               | Action                                                                                                                                                                                                                                |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <kbd>→</kbd>                      | Moves focus one cell to the right. If focus is on the right-most cell in the row, focus does not move.                                                                                                                                |
-| <kbd>←</kbd>                      | Moves focus one cell to the left. If focus is on the left-most cell in the row, focus does not move.                                                                                                                                  |
-| <kbd>↓</kbd>                      | Moves focus one cell down. If focus is on the bottom cell in the column, focus does not move.                                                                                                                                         |
-| <kbd>↑</kbd>                      | Moves focus one cell up. If focus is on the top cell in the column, focus does not move.                                                                                                                                              |
+| <kbd>→</kbd>                      | Moves focus one cell to the right. Optionally (layout grids), if focus is on the right-most cell in the row, focus may move to the first cell in the following row. If focus is on the last cell in the grid, focus does not move.    |
+| <kbd>←</kbd>                      | Moves focus one cell to the left. Optionally (layout grids), if focus is on the left-most cell in the row, focus may move to the last cell in the previous row. If focus is on the first cell in the grid, focus does not move.       |
+| <kbd>↓</kbd>                      | Moves focus one cell down. Optionally (layout grids), if focus is on the bottom cell in the column, focus may move to the top cell in the following column. If focus is on the last cell in the grid, focus does not move.            |
+| <kbd>↑</kbd>                      | Moves focus one cell up. Optionally (layout grids), if focus is on the top cell in the column, focus may move to the bottom cell in the previous column. If focus is on the first cell in the grid, focus does not move.              |
 | <kbd>Page Down</kbd>              | Moves focus down an author-determined number of rows, typically scrolling so the bottom row in the currently visible set of rows becomes one of the first visible rows. If focus is in the last row of the grid, focus does not move. |
 | <kbd>Page Up</kbd>                | Moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.      |
 | <kbd>Home</kbd>                   | Moves focus to the first cell in the row that contains focus.                                                                                                                                                                         |
@@ -120,7 +123,9 @@ If cells, rows, or columns can be selected, the following key combination are co
 
 ```html
 <table role="grid" aria-labelledby="calendarheader">
-  <caption id="calendarheader">September 2018</caption>
+  <caption id="calendarheader">
+    September 2018
+  </caption>
   <thead role="rowgroup">
     <tr role="row">
       <td></td>
@@ -135,7 +140,7 @@ If cells, rows, or columns can be selected, the following key combination are co
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <th scope="row" role="rowheader">Week 35</th>
+      <th scope="row" role="rowheader">Week 1</th>
       <td>26</td>
       <td>27</td>
       <td>28</td>
@@ -145,106 +150,48 @@ If cells, rows, or columns can be selected, the following key combination are co
       <td role="gridcell" tabindex="-1">1</td>
     </tr>
     <tr role="row">
-      <th scope="row" role="rowheader">Week 36</th>
-      <td role="gridcell" tabindex="-1">
-        2
-      </td>
-      <td role="gridcell" tabindex="-1">
-        3
-      </td>
-      <td role="gridcell" tabindex="-1">
-        4
-      </td>
-      <td role="gridcell" tabindex="-1">
-        5
-      </td>
-      <td role="gridcell" tabindex="-1">
-        6
-      </td>
-      <td role="gridcell" tabindex="-1">
-        7
-      </td>
-      <td role="gridcell" tabindex="-1">
-        8
-      </td>
+      <th scope="row" role="rowheader">Week 2</th>
+      <td role="gridcell" tabindex="-1">2</td>
+      <td role="gridcell" tabindex="-1">3</td>
+      <td role="gridcell" tabindex="-1">4</td>
+      <td role="gridcell" tabindex="-1">5</td>
+      <td role="gridcell" tabindex="-1">6</td>
+      <td role="gridcell" tabindex="-1">7</td>
+      <td role="gridcell" tabindex="-1">8</td>
     </tr>
     <tr role="row">
-      <th scope="row" role="rowheader">Week 36</th>
-      <td role="gridcell" tabindex="-1">
-        9
-      </td>
-      <td role="gridcell" tabindex="-1">
-        10
-      </td>
-      <td role="gridcell" tabindex="-1">
-        11
-      </td>
-      <td role="gridcell" tabindex="-1">
-        12
-      </td>
-      <td role="gridcell" tabindex="-1">
-        13
-      </td>
-      <td role="gridcell" tabindex="-1">
-        14
-      </td>
-      <td role="gridcell" tabindex="-1">
-        15
-      </td>
+      <th scope="row" role="rowheader">Week 3</th>
+      <td role="gridcell" tabindex="-1">9</td>
+      <td role="gridcell" tabindex="-1">10</td>
+      <td role="gridcell" tabindex="-1">11</td>
+      <td role="gridcell" tabindex="-1">12</td>
+      <td role="gridcell" tabindex="-1">13</td>
+      <td role="gridcell" tabindex="-1">14</td>
+      <td role="gridcell" tabindex="-1">15</td>
     </tr>
     <tr role="row">
-      <th scope="row" role="rowheader">Week 36</th>
-      <td role="gridcell" tabindex="-1">
-        16
-      </td>
-      <td role="gridcell" tabindex="-1">
-        17
-      </td>
-      <td role="gridcell" tabindex="-1">
-        18
-      </td>
-      <td role="gridcell" tabindex="-1">
-        19
-      </td>
-      <td role="gridcell" tabindex="-1">
-        20
-      </td>
-      <td role="gridcell" tabindex="-1">
-        21
-      </td>
-      <td role="gridcell" tabindex="-1">
-        22
-      </td>
+      <th scope="row" role="rowheader">Week 4</th>
+      <td role="gridcell" tabindex="-1">16</td>
+      <td role="gridcell" tabindex="-1">17</td>
+      <td role="gridcell" tabindex="-1">18</td>
+      <td role="gridcell" tabindex="-1">19</td>
+      <td role="gridcell" tabindex="-1">20</td>
+      <td role="gridcell" tabindex="-1">21</td>
+      <td role="gridcell" tabindex="-1">22</td>
     </tr>
     <tr role="row">
-      <th scope="row" role="rowheader">Week 36</th>
-      <td role="gridcell" tabindex="-1">
-        23
-      </td>
-      <td role="gridcell" tabindex="-1">
-        24
-      </td>
-      <td role="gridcell" tabindex="-1">
-        25
-      </td>
-      <td role="gridcell" tabindex="-1">
-        26
-      </td>
-      <td role="gridcell" tabindex="-1">
-        27
-      </td>
-      <td role="gridcell" tabindex="-1">
-        28
-      </td>
-      <td role="gridcell" tabindex="-1">
-        29
-      </td>
-    </tr> 
+      <th scope="row" role="rowheader">Week 5</th>
+      <td role="gridcell" tabindex="-1">23</td>
+      <td role="gridcell" tabindex="-1">24</td>
+      <td role="gridcell" tabindex="-1">25</td>
+      <td role="gridcell" tabindex="-1">26</td>
+      <td role="gridcell" tabindex="-1">27</td>
+      <td role="gridcell" tabindex="-1">28</td>
+      <td role="gridcell" tabindex="-1">29</td>
+    </tr>
     <tr role="row">
-      <th scope="row" role="rowheader">Week 36</th>
-      <td role="gridcell" tabindex="-1">
-        30
-      </td>
+      <th scope="row" role="rowheader">Week 6</th>
+      <td role="gridcell" tabindex="-1">30</td>
       <td>1</td>
       <td>2</td>
       <td>3</td>
@@ -252,7 +199,7 @@ If cells, rows, or columns can be selected, the following key combination are co
       <td>5</td>
       <td>6</td>
     </tr>
-    </tbody>
+  </tbody>
 </table>
 ```
 
@@ -265,7 +212,8 @@ table {
   font-variant-numeric: tabular-nums;
 }
 
-tbody th, tbody td {
+tbody th,
+tbody td {
   padding: 5px;
 }
 
@@ -279,8 +227,10 @@ tbody td[role="gridcell"] {
   color: #000;
 }
 
-tbody td[role="gridcell"]:hover, tbody td[role="gridcell"]:focus {
-  background-color: #f6f6f6; outline: 3px solid blue;
+tbody td[role="gridcell"]:hover,
+tbody td[role="gridcell"]:focus {
+  background-color: #f6f6f6;
+  outline: 3px solid blue;
 }
 ```
 
@@ -289,32 +239,36 @@ tbody td[role="gridcell"]:hover, tbody td[role="gridcell"]:focus {
 ```js
 const selectables = document.querySelectorAll('table td[role="gridcell"]');
 
-selectables[0].setAttribute('tabindex', 0);
+selectables[0].setAttribute("tabindex", 0);
 
-const trs = document.querySelectorAll('table tbody tr');
+const trs = document.querySelectorAll("table tbody tr");
 let row = 0;
 let col = 0;
 let maxrow = trs.length - 1;
 let maxcol = 0;
 
 trs.forEach((gridrow) => {
-  gridrow.querySelectorAll('td').forEach((el) => {
+  gridrow.querySelectorAll("td").forEach((el) => {
     el.dataset.row = row;
     el.dataset.col = col;
     col++;
   });
-  if (col > maxcol) { maxcol = col - 1; }
+  if (col > maxcol) {
+    maxcol = col - 1;
+  }
   col = 0;
   row++;
 });
 
 function moveto(newrow, newcol) {
-  const tgt = document.querySelector(`[data-row="${newrow}"][data-col="${newcol}"]`);
-  if (tgt?.getAttribute('role') === 'gridcell') {
-    document.querySelectorAll('[role=gridcell]').forEach((el) => {
-      el.setAttribute('tabindex', '-1');
+  const tgt = document.querySelector(
+    `[data-row="${newrow}"][data-col="${newcol}"]`
+  );
+  if (tgt?.getAttribute("role") === "gridcell") {
+    document.querySelectorAll("[role=gridcell]").forEach((el) => {
+      el.setAttribute("tabindex", "-1");
     });
-    tgt.setAttribute('tabindex', '0');
+    tgt.setAttribute("tabindex", "0");
     tgt.focus();
     return true;
   } else {
@@ -322,19 +276,28 @@ function moveto(newrow, newcol) {
   }
 }
 
-document.querySelector('table').addEventListener("keydown", (event) => {
+document.querySelector("table").addEventListener("keydown", (event) => {
+  const currentCol = parseInt(event.target.dataset.col, 10);
+  const currentRow = parseInt(event.target.dataset.row, 10);
+
   switch (event.key) {
-    case "ArrowRight":
-      moveto(parseInt(event.target.dataset.row, 10), parseInt(event.target.dataset.col, 10) + 1);
+    case "ArrowRight": {
+      const nextCol = currentCol === 6 ? 0 : currentCol + 1;
+      const nextRow = currentCol === 6 ? currentRow + 1 : currentRow;
+      moveto(nextRow, nextCol);
       break;
-    case "ArrowLeft":
-      moveto(parseInt(event.target.dataset.row, 10), parseInt(event.target.dataset.col, 10) - 1);
+    }
+    case "ArrowLeft": {
+      const nextCol = currentCol === 0 ? 6 : currentCol - 1;
+      const nextRow = currentCol === 0 ? currentRow - 1 : currentRow;
+      moveto(nextRow, nextCol);
       break;
+    }
     case "ArrowDown":
-      moveto(parseInt(event.target.dataset.row, 10) + 1, parseInt(event.target.dataset.col, 10));
+      moveto(currentRow + 1, currentCol);
       break;
     case "ArrowUp":
-      moveto(parseInt(event.target.dataset.row, 10) - 1, parseInt(event.target.dataset.col, 10));
+      moveto(currentRow - 1, currentCol);
       break;
     case "Home": {
       if (event.ctrlKey) {
@@ -349,7 +312,7 @@ document.querySelector('table').addEventListener("keydown", (event) => {
           i++;
         } while (!result);
       } else {
-        moveto(parseInt(event.target.dataset.row, 10), 0);
+        moveto(currentRow, 0);
       }
       break;
     }
@@ -366,7 +329,12 @@ document.querySelector('table').addEventListener("keydown", (event) => {
           i--;
         } while (!result);
       } else {
-        moveto(parseInt(event.target.dataset.row, 10), document.querySelector(`[data-row="${event.target.dataset.row}"]:last-of-type`).dataset.col);
+        moveto(
+          currentRow,
+          document.querySelector(
+            `[data-row="${event.target.dataset.row}"]:last-of-type`
+          ).dataset.col
+        );
       }
       break;
     }
@@ -374,7 +342,7 @@ document.querySelector('table').addEventListener("keydown", (event) => {
       let i = 0;
       let result;
       do {
-        result = moveto(i, event.target.dataset.col);
+        result = moveto(i, currentCol);
         i++;
       } while (!result);
       break;
@@ -383,7 +351,7 @@ document.querySelector('table').addEventListener("keydown", (event) => {
       let i = maxrow;
       let result;
       do {
-        result = moveto(i, event.target.dataset.col);
+        result = moveto(i, currentCol);
         i--;
       } while (!result);
       break;
@@ -430,6 +398,6 @@ Even if the keyboard use is properly implemented, some users might not be aware 
 
 1. [**WAI-ARIA roles**](/en-US/docs/Web/Accessibility/ARIA/Roles)
 
-    {{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}
+   {{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}
 
 </section>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
According to w3 [docs](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) about `role="grid"` in `Keyboard Interaction For Layout Grids` (sorry, there are no anchor links) section focus can actully move in `Layout grids` (but not in `Data grids`):

> - ➡️: Moves focus one cell to the right. Optionally, if focus is on the right-most cell in the row, focus may move to the first cell in the following row. If focus is on the last cell in the grid, focus does not move.
> - ⬅️: Moves focus one cell to the left. Optionally, if focus is on the left-most cell in the row, focus may move to the last cell in the previous row. If focus is on the first cell in the grid, focus does not move.
> - ⬇️: Moves focus one cell down. Optionally, if focus is on the bottom cell in the column, focus may move to the top cell in the following column. If focus is on the last cell in the grid, focus does not move.
> - ⬆️: Moves focus one cell up. Optionally, if focus is on the top cell in the column, focus may move to the bottom cell in the previous column. If focus is on the first cell in the grid, focus does not move.

And since the calendar's demo is a `Layout grid`, I've updated the left and right key interaction as it is in w3 [calendar's demo](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html).


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
More detailed info, right now it looks like we can't move focus at all for both grid types in dead ends.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

1. [w3 docs with keyboard interaction sections for both types of grids](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)
2. [w3 layout grids examples](https://www.w3.org/WAI/ARIA/apg/example-index/grid/LayoutGrids.html)
3. [w3 data grids examples](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids.html)
4. [w3 calendar's demo (as layout grid)](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
