### PR TITLE
HTTP: update BCD Info

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Security
   - block-all-mixed-content
+  - Deprecated
 browser-compat: http.headers.Content-Security-Policy.block-all-mixed-content
 ---
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
@@ -11,9 +11,11 @@ tags:
   - Plugin
   - Plugins
   - Security
+  - Deprecated
+  - Non-standard
 browser-compat: http.headers.Content-Security-Policy.plugin-types
 ---
-{{HTTPSidebar}}{{deprecated_header}}
+{{HTTPSidebar}}{{deprecated_header}}{{Non-standard_header}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`plugin-types`** directive restricts the set of plugins that

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - Security
   - referrer
+  - Non-standard
 browser-compat: http.headers.Content-Security-Policy.referrer
 ---
-{{HTTPSidebar}} {{deprecated_header}}
+{{HTTPSidebar}} {{deprecated_header}}{{Non-standard_header}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`referrer`** directive used to specify information in the

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Reference
   - Security
+  - Deprecated
 browser-compat: http.headers.Content-Security-Policy.report-uri
 ---
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
@@ -9,9 +9,11 @@ tags:
   - Security
   - Subresource Integrity
   - require-sri-for
+  - Deprecated
+  - Non-standard
 browser-compat: http.headers.Content-Security-Policy.require-sri-for
 ---
-{{deprecated_header}}
+{{deprecated_header}}{{Non-standard_header}}
 
 The [HTTP](/en-US/docs/Web/HTTP) {{HTTPHeader("Content-Security-Policy")}}
 **`require-sri-for`** directive instructs the client to require

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - header
+  - Deprecated
 browser-compat: http.headers.DNT
 ---
 {{HTTPSidebar}}{{Deprecated_header}}

--- a/files/en-us/web/http/headers/feature-policy/sync-xhr/index.md
+++ b/files/en-us/web/http/headers/feature-policy/sync-xhr/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - XMLHttpRequest
   - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.sync-xhr
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}
 
 The HTTP {{HTTPHeader("Feature-Policy")}} header `sync-xhr` directive controls whether the current document is allowed to make synchronous {{domxref("XMLHttpRequest")}} requests.
 

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -11,7 +11,7 @@ tags:
   - Non-standard
 browser-compat: http.headers.Large-Allocation
 ---
-{{HTTPSidebar}} {{Deprecated_Header}}
+{{HTTPSidebar}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The non-standard **`Large-Allocation`** response header tells the browser that the page being loaded is going to want to perform a large allocation.
 It's not implemented in current versions of any browser, but is harmless to send to any browser.

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -8,10 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-  -  Experimental
+  - Deprecated
 browser-compat: http.headers.Sec-CH-UA-Full-Version
 ---
-{{HTTPSidebar}} {{deprecated_header}} {{securecontext_header}}
+{{HTTPSidebar}}{{Deprecated_Header}}{{SecureContext_Header}}
 
 > **Note:** This is being replaced by the {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}.
 

--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -8,6 +8,7 @@ tags:
   - Response
   - header
   - tracking
+  - Deprecated
 browser-compat: http.headers.Tk
 ---
 {{HTTPSidebar}}{{Deprecated_header}}

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -6,9 +6,10 @@ tags:
   - HTTP
   - X-DNS-Prefetch-Control
   - header
+  - Non-standard
 browser-compat: http.headers.X-DNS-Prefetch-Control
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{Non-standard_header}}
 
 The **`X-DNS-Prefetch-Control`** HTTP response header controls
 DNS prefetching, a feature by which browsers proactively perform domain name resolution

--- a/files/en-us/web/http/headers/x-xss-protection/index.md
+++ b/files/en-us/web/http/headers/x-xss-protection/index.md
@@ -7,9 +7,10 @@ tags:
   - Security
   - XSS
   - header
+  - Non-standard
 browser-compat: http.headers.X-XSS-Protection
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{Non-standard_header}}
 
 The HTTP **`X-XSS-Protection`** response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting ({{Glossary("Cross-site_scripting", "XSS")}}) attacks. These protections are largely unnecessary in modern browsers when sites implement a strong {{HTTPHeader("Content-Security-Policy")}} that disables the use of inline JavaScript (`'unsafe-inline'`).
 

--- a/files/en-us/web/http/network_error_logging/index.md
+++ b/files/en-us/web/http/network_error_logging/index.md
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Network Error Logging
   - Reference
+  - Experimental
 browser-compat: http.headers.NEL
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTTP pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

This focuses on updating 'deprecated' and 'non-standard' headers/tags.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.
