### PR TITLE
HTTP: update BCD Info

### DIFF
--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -174,7 +174,7 @@ The report JSON object contains the following data:
     Some browsers may provide different values, such as Chrome providing `style-src-elem`/`style-src-attr`, even when the actually enforced directive was `style-src`.
 - `original-policy`
   - : The original policy as specified by the `Content-Security-Policy` HTTP header.
-- `referrer`
+- `referrer` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The referrer of the document in which the violation occurred.
 - `script-sample`
   - : The first 40 characters of the inline script, event handler, or style that caused the violation.

--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -45,7 +45,7 @@ Clear-Site-Data: "*"
 
 > **Note:** All directives must comply with the [quoted-string grammar](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6). A directive that does not include the double quotes is invalid.
 
-- `"cache"`
+- `"cache"` {{Experimental_Inline}}
   - : Indicates that the server wishes to remove locally cached data (the browser cache, see [HTTP caching](/en-US/docs/Web/HTTP/Caching)) for the origin of the response URL. Depending on the browser, this might also clear out things like pre-rendered pages, script caches, WebGL shader caches, or address bar suggestions.
 - `"cookies"`
   - : Indicates that the server wishes to remove all cookies for the origin of the response URL. HTTP authentication credentials are also cleared out. This affects the entire registered domain, including subdomains. So `https://example.com` as well as `https://stage.example.com`, will have cookies cleared.
@@ -61,7 +61,7 @@ Clear-Site-Data: "*"
     - [FileSystem API data](/en-US/docs/Web/API/File_and_Directory_Entries_API),
     - Plugin data (Flash via [`NPP_ClearSiteData`](https://wiki.mozilla.org/NPAPI:ClearSiteData)).
 
-- `"executionContexts"`
+- `"executionContexts"` {{Experimental_Inline}}
   - : Indicates that the server wishes to reload all browsing contexts for the origin of the response ({{domxref("Location.reload")}}).
 - `"*"` (wildcard)
   - : Indicates that the server wishes to clear all types of data for the origin of the response. If more data types are added in future versions of this header, they will also be covered by it.

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -60,7 +60,7 @@ Content-Encoding: deflate, gzip
   - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib)
     structure (defined in {{rfc(1950)}}) with the [deflate](https://en.wikipedia.org/wiki/Deflate) compression
     algorithm (defined in {{rfc(1951)}}).
-- `br`
+- `br` {{Non-standard_Inline}}
   - : A format using the [Brotli](https://en.wikipedia.org/wiki/Brotli) algorithm.
 
 ## Examples

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -90,18 +90,18 @@ where `<policy-directive>` consists of:
   - : Specifies valid sources to be prefetched or prerendered.
 - {{CSP("script-src")}}
   - : Specifies valid sources for JavaScript.
-- {{CSP("script-src-elem")}} {{experimental_inline}}
+- {{CSP("script-src-elem")}}
   - : Specifies valid sources for JavaScript {{HTMLElement("script")}} elements.
-- {{CSP("script-src-attr")}} {{experimental_inline}}
+- {{CSP("script-src-attr")}}
   - : Specifies valid sources for JavaScript inline event handlers.
 - {{CSP("style-src")}}
   - : Specifies valid sources for stylesheets.
-- {{CSP("style-src-elem")}} {{experimental_inline}}
+- {{CSP("style-src-elem")}}
   - : Specifies valid sources for stylesheets {{HTMLElement("style")}} elements and
     {{HTMLElement("link")}} elements with `rel="stylesheet"`.
-- {{CSP("style-src-attr")}} {{experimental_inline}}
+- {{CSP("style-src-attr")}}
   - : Specifies valid sources for inline styles applied to individual DOM elements.
-- {{CSP("worker-src")}} {{experimental_inline}}
+- {{CSP("worker-src")}}
   - : Specifies valid sources for {{domxref("Worker")}}, {{domxref("SharedWorker")}}, or
     {{domxref("ServiceWorker")}} scripts.
 
@@ -159,12 +159,12 @@ Reporting directives control the reporting process of CSP violations. See also t
     > In browsers that support {{CSP("report-to")}},
     > the **`report-uri`** directive will be ignored.
 
-- {{CSP("report-to")}} {{experimental_inline}}
+- {{CSP("report-to")}}
   - : Fires a `SecurityPolicyViolationEvent`.
 
 ### Other directives
 
-- {{CSP("require-sri-for")}} {{experimental_inline}}
+- {{CSP("require-sri-for")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Requires the use of {{Glossary("SRI")}} for scripts or styles on the page.
 - {{CSP("require-trusted-types-for")}} {{experimental_inline}}
   - : Enforces [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) at the DOM XSS injection sinks.
@@ -182,7 +182,7 @@ Reporting directives control the reporting process of CSP violations. See also t
 
 - {{CSP("block-all-mixed-content")}} {{deprecated_inline}}
   - : Prevents loading any assets using HTTP when the page is loaded using HTTPS.
-- {{CSP("plugin-types")}} {{deprecated_inline}}
+- {{CSP("plugin-types")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Restricts the set of plugins that can be embedded into a document by limiting the
     types of resources which can be loaded.
 - {{CSP("referrer")}} {{deprecated_inline}} {{non-standard_inline}}
@@ -200,9 +200,9 @@ For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Cont
   - : Won't allow loading of any resources.
 - `self`
   - : Only allow resources from the current origin.
-- `strict-dynamic` {{experimental_inline}}
+- `strict-dynamic`
   - : The trust granted to a script in the page due to an accompanying nonce or hash is extended to the scripts it loads.
-- `report-sample` {{experimental_inline}}
+- `report-sample`
   - : Require a sample of the violating code to be included in the violation report.
 
 ### Unsafe keyword values
@@ -211,7 +211,7 @@ For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Cont
   - : Allow use of inline resources.
 - `unsafe-eval`
   - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("Window.setImmediate", "setImmediate")}} {{non-standard_inline}}, and `window.execScript` {{non-standard_inline}}.
-- `unsafe-hashes` {{experimental_inline}}
+- `unsafe-hashes`
   - : Allows enabling specific inline event handlers.
 - `unsafe-allow-redirects` {{experimental_inline}}
   - : TBD

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
@@ -9,9 +9,10 @@ tags:
   - Navigation
   - Reference
   - Security
+  - Experimental
 browser-compat: http.headers.Content-Security-Policy.navigate-to
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`navigate-to`** directive

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -8,9 +8,10 @@ tags:
   - HTTP
   - Reference
   - prefetch-src
+  - Experimental
 browser-compat: http.headers.Content-Security-Policy.prefetch-src
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`prefetch-src`** directive specifies valid resources that may

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -6,9 +6,10 @@ tags:
   - Directive
   - HTTP
   - Security
+  - Experimental
 browser-compat: http.headers.Content-Security-Policy.require-trusted-types-for
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`require-trusted-types-for`** {{experimental_inline}} directive instructs user agents to control the data passed to DOM XSS sink functions, like {{DOMxRef("Element.innerHTML")}} setter.
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -6,9 +6,10 @@ tags:
   - Directive
   - HTTP
   - Security
+  - Experimental
 browser-compat: http.headers.Content-Security-Policy.trusted-types
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`trusted-types`** {{experimental_inline}} directive instructs user agents to restrict the creation of Trusted Types policies - functions that build non-spoofable, typed values intended to be passed to DOM XSS sinks in place of strings.
 

--- a/files/en-us/web/http/headers/feature-policy/index.md
+++ b/files/en-us/web/http/headers/feature-policy/index.md
@@ -3,7 +3,6 @@ title: Feature-Policy
 slug: Web/HTTP/Headers/Feature-Policy
 tags:
   - Authorization
-  - Experimental
   - Feature-Policy
   - HTTP
   - Permissions
@@ -13,7 +12,7 @@ tags:
   - header
 browser-compat: http.headers.Feature-Policy
 ---
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 > **Warning:** The header has now been renamed to `Permissions-Policy` in the spec, and this article will eventually be updated to reflect that change.
 
@@ -61,21 +60,21 @@ Feature-Policy: <directive> <allowlist>
 
 ## Directives
 
-- {{httpheader('Feature-Policy/accelerometer','accelerometer')}}
+- {{httpheader('Feature-Policy/accelerometer','accelerometer')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to gather information about the acceleration of the device through the {{DOMxRef("Accelerometer")}} interface.
-- {{httpheader('Feature-Policy/ambient-light-sensor','ambient-light-sensor')}}
+- {{httpheader('Feature-Policy/ambient-light-sensor','ambient-light-sensor')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to gather information about the amount of light in the environment around the device through the {{DOMxRef("AmbientLightSensor")}} interface.
-- {{httpheader('Feature-Policy/autoplay','autoplay')}}
+- {{httpheader('Feature-Policy/autoplay','autoplay')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to autoplay media requested through the {{domxref("HTMLMediaElement")}} interface. When this policy is disabled and there were no user gestures, the {{jsxref("Promise")}} returned by {{domxref("HTMLMediaElement.play()")}} will reject with a {{domxref("DOMException")}}. The autoplay attribute on {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements will be ignored.
-- {{httpheader('Feature-Policy/battery','battery')}}
+- {{httpheader('Feature-Policy/battery','battery')}} {{Experimental_Inline}}
   - : Controls whether the use of the [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is allowed. When this policy is disabled, the {{JSxRef("Promise")}} returned by {{DOMxRef("Navigator.getBattery","Navigator.getBattery()")}} will reject with a `NotAllowedError` {{DOMxRef("DOMException")}}.
 - {{httpheader('Feature-Policy/camera', 'camera')}}
   - : Controls whether the current document is allowed to use video input devices. When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} will reject with a `NotAllowedError` {{DOMxRef("DOMException")}}.
 - {{HTTPHeader('Feature-Policy/display-capture', 'display-capture')}}
   - : Controls whether or not the current document is permitted to use the {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} method to capture screen contents. When this policy is disabled, the promise returned by `getDisplayMedia()` will reject with a `NotAllowedError` if permission is not obtained to capture the display's contents.
-- {{httpheader('Feature-Policy/document-domain','document-domain')}}
+- {{httpheader('Feature-Policy/document-domain','document-domain')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to set {{domxref("document.domain")}}. When this policy is disabled, attempting to set {{domxref("document.domain")}} will fail and cause a `SecurityError` {{domxref("DOMException")}} to be thrown.
-- {{httpheader('Feature-Policy/encrypted-media', 'encrypted-media')}}
+- {{httpheader('Feature-Policy/encrypted-media', 'encrypted-media')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Encrypted Media Extensions](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) API (EME). When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("Navigator.requestMediaKeySystemAccess()")}} will reject with a {{domxref("DOMException")}}.
 - {{httpheader('Feature-Policy/execution-while-not-rendered', 'execution-while-not-rendered')}}
   - : Controls whether tasks should execute in frames while they're not being rendered (e.g. if an iframe is [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) or `display: none`).
@@ -83,48 +82,48 @@ Feature-Policy: <directive> <allowlist>
   - : Controls whether tasks should execute in frames while they're outside of the visible viewport.
 - {{httpheader('Feature-Policy/fullscreen','fullscreen')}}
   - : Controls whether the current document is allowed to use {{DOMxRef("Element.requestFullscreen()")}}. When this policy is disabled, the returned {{JSxRef("Promise")}} rejects with a {{JSxRef("TypeError")}}.
-- {{httpheader('Feature-Policy/gamepad','gamepad')}}
+- {{httpheader('Feature-Policy/gamepad','gamepad')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Gamepad API](/en-US/docs/Web/API/Gamepad_API).
     When this policy is disabled, calls to {{domxref('Navigator.getGamepads()')}} will throw a `SecurityError` {{domxref('DOMException')}}, and the {{domxref("Window.gamepadconnected_event", "gamepadconnected")}} and {{domxref("Window.gamepaddisconnected_event", "gamepaddisconnected")}} events will not fire.
 - {{httpheader('Feature-Policy/geolocation','geolocation')}}
   - : Controls whether the current document is allowed to use the {{domxref('Geolocation')}} Interface. When this policy is disabled, calls to {{domxref('Geolocation.getCurrentPosition','getCurrentPosition()')}} and {{domxref('Geolocation.watchPosition','watchPosition()')}} will cause those functions' callbacks to be invoked with a {{domxref('GeolocationPositionError')}} code of `PERMISSION_DENIED`.
-- {{httpheader('Feature-Policy/gyroscope','gyroscope')}}
+- {{httpheader('Feature-Policy/gyroscope','gyroscope')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to gather information about the orientation of the device through the {{DOMxRef("Gyroscope")}} interface.
-- {{httpheader('Feature-Policy/layout-animations','layout-animations')}}
+- {{httpheader('Feature-Policy/layout-animations','layout-animations')}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to show layout animations.
-- {{httpheader('Feature-Policy/legacy-image-formats','legacy-image-formats')}}
+- {{httpheader('Feature-Policy/legacy-image-formats','legacy-image-formats')}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to display images in legacy formats.
-- {{httpheader('Feature-Policy/magnetometer','magnetometer')}}
+- {{httpheader('Feature-Policy/magnetometer','magnetometer')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to gather information about the orientation of the device through the {{DOMxRef("Magnetometer")}} interface.
 - {{httpheader('Feature-Policy/microphone','microphone')}}
   - : Controls whether the current document is allowed to use audio input devices. When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("MediaDevices.getUserMedia()")}} will reject with a `NotAllowedError` {{domxref("DOMException")}}.
-- {{httpheader('Feature-Policy/midi', 'midi')}}
+- {{httpheader('Feature-Policy/midi', 'midi')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API). When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("Navigator.requestMIDIAccess()")}} will reject with a {{domxref("DOMException")}}.
 - {{httpheader('Feature-Policy/navigation-override','navigation-override')}}
   - : Controls the availability of mechanisms that enables the page author to take control over the behavior of [spatial navigation](https://www.w3.org/TR/css-nav/), or to cancel it outright.
-- {{httpheader('Feature-Policy/oversized-images','oversized-images')}}
+- {{httpheader('Feature-Policy/oversized-images','oversized-images')}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to download and display large images.
-- {{httpheader('Feature-Policy/payment', 'payment')}}
+- {{httpheader('Feature-Policy/payment', 'payment')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API). When this policy is enabled, the {{domxref("PaymentRequest","PaymentRequest()")}} constructor will throw a `SecurityError` {{domxref("DOMException")}}.
-- {{httpheader('Feature-Policy/picture-in-picture', 'picture-in-picture')}}
+- {{httpheader('Feature-Policy/picture-in-picture', 'picture-in-picture')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to play a video in a Picture-in-Picture mode via the corresponding API.
-- {{httpheader("Feature-Policy/publickey-credentials-get", "publickey-credentials-get")}}
+- {{httpheader("Feature-Policy/publickey-credentials-get", "publickey-credentials-get")}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve already stored public-key credentials, i.e. via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey: ..., ...})")}}.
-- {{httpheader("Feature-Policy/speaker-selection", "speaker-selection")}}
+- {{httpheader("Feature-Policy/speaker-selection", "speaker-selection")}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [Audio Output Devices API](/en-US/docs/Web/API/Audio_Output_Devices_API) to list and select speakers.
-- {{httpheader('Feature-Policy/sync-xhr', 'sync-xhr')}}
+- {{httpheader('Feature-Policy/sync-xhr', 'sync-xhr')}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to make synchronous {{DOMxRef("XMLHttpRequest")}} requests.
 - {{httpheader('Feature-Policy/unoptimized-images', 'unoptimized-images')}} {{experimental_inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to download and display unoptimized images.
 - {{httpheader('Feature-Policy/unsized-media', 'unsized-media')}} {{experimental_inline}} {{Non-standard_Inline}}
   - : Controls whether the current document is allowed to change the size of media elements after the initial layout is complete.
-- {{httpheader('Feature-Policy/usb', 'usb')}}
+- {{httpheader('Feature-Policy/usb', 'usb')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the [WebUSB API](https://wicg.github.io/webusb/).
-- {{httpheader('Feature-Policy/screen-wake-lock', 'screen-wake-lock')}}
+- {{httpheader('Feature-Policy/screen-wake-lock', 'screen-wake-lock')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use [Screen Wake Lock API](/en-US/docs/Web/API/Screen_Wake_Lock_API) to indicate that device should not turn off or dim the screen.
-- {{httpheader("Feature-Policy/web-share", "web-share")}}
+- {{httpheader("Feature-Policy/web-share", "web-share")}} {{Experimental_Inline}}
   - : Controls whether or not the current document is allowed to use the {{domxref("Navigator.share","Navigator.share()")}} of Web Share API to share text, links, images, and other content to arbitrary destinations of user's choice, e.g. mobile apps.
-- {{httpheader("Feature-Policy/xr-spatial-tracking", "xr-spatial-tracking")}}
+- {{httpheader("Feature-Policy/xr-spatial-tracking", "xr-spatial-tracking")}} {{Experimental_Inline}}
   - : Controls whether or not the current document is allowed to use the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) to interact with a WebXR session.
 
 ## Example

--- a/files/en-us/web/http/headers/nel/index.md
+++ b/files/en-us/web/http/headers/nel/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Response Header
   - header
+  - Experimental
 browser-compat: http.headers.NEL
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP **`NEL`** response header is used to configure network request logging.
 

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -8,9 +8,10 @@ tags:
   - HTTP Header
   - Reference
   - Request header
+  - Experimental
 browser-compat: http.headers.Save-Data
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The **`Save-Data`** [network client hint](/en-US/docs/Web/HTTP/Client_hints#network_client_hints) request header field is a boolean which indicates the client's preference for reduced data usage.
 This could be for reasons such as high transfer costs, slow connection speeds, etc.

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -8,9 +8,10 @@ tags:
   - NeedsCompatTable
   - NeedsContent
   - Status code
+  - Experimental
 browser-compat: http.status.103
 ---
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP **`103 Early Hints`** information response status code
 is primarily intended to be used with the {{HTTPHeader("Link")}} header to allow the


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTTP pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

:warning: This completes updates in HTTP.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.
