### PR TITLE
SVG: update BCD Info

### DIFF
--- a/files/en-us/web/svg/attribute/side/index.md
+++ b/files/en-us/web/svg/attribute/side/index.md
@@ -4,9 +4,10 @@ slug: Web/SVG/Attribute/side
 tags:
   - SVG
   - SVG Attribute
+  - Experimental
 browser-compat: svg.elements.textPath.side
 ---
-{{SVGRef}}
+{{SVGRef}}{{SeeCompatTable}}
 
 The **`side`** attribute determines the side of a path the text is placed on (relative to the path direction).
 

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.md
@@ -4,9 +4,10 @@ slug: Web/SVG/Attribute/xml:lang
 tags:
   - SVG
   - SVG Attribute
+  - Deprecated
 browser-compat: svg.attributes.core.xml_lang
 ---
-{{SVGRef}}
+{{SVGRef}}{{Deprecated_Header}}
 
 The **`xml:lang`** attribute specifies the primary language used in contents and attributes containing text content of particular elements.
 

--- a/files/en-us/web/svg/element/cursor/index.md
+++ b/files/en-us/web/svg/element/cursor/index.md
@@ -31,8 +31,8 @@ The PNG format is recommended because it supports the ability to define a transp
 
 ### Specific attributes
 
-- {{SVGAttr("x")}}
-- {{SVGAttr("y")}}
+- {{SVGAttr("x")}} {{Deprecated_Inline}}
+- {{SVGAttr("y")}} {{Deprecated_Inline}}
 - {{SVGAttr("xlink:href")}}
 
 ## DOM Interface

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -31,7 +31,7 @@ The **`<filter>`** [SVG](/en-US/docs/Web/SVG) element defines a custom filter ef
 - {{SVGAttr("y")}}
 - {{SVGAttr("width")}}
 - {{SVGAttr("height")}}
-- {{SVGAttr("filterRes")}}
+- {{SVGAttr("filterRes")}} {{Deprecated_Inline}}
 - {{SVGAttr("filterUnits")}}
 - {{SVGAttr("primitiveUnits")}}
 - {{SVGAttr("xlink:href")}}

--- a/files/en-us/web/svg/element/font-face-format/index.md
+++ b/files/en-us/web/svg/element/font-face-format/index.md
@@ -26,7 +26,7 @@ The **`<font-face-format>`** [SVG](/en-US/docs/Web/SVG) element describes the ty
 
 ### Specific attributes
 
-- {{SVGAttr("string")}}
+{{SVGAttr("string")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/font-face-name/index.md
+++ b/files/en-us/web/svg/element/font-face-name/index.md
@@ -26,7 +26,7 @@ The **`<font-face-name>`** element points to a locally installed copy of this fo
 
 ### Specific attributes
 
-- {{SVGATTR("name")}}
+- {{SVGATTR("name")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/font-face/index.md
+++ b/files/en-us/web/svg/element/font-face/index.md
@@ -28,39 +28,39 @@ The **`<font-face>`** [SVG](/en-US/docs/Web/SVG) element corresponds to the CSS 
 
 ### Specific attributes
 
-- {{SVGAttr("font-family")}}
-- {{SVGAttr("font-style")}}
-- {{SVGAttr("font-variant")}}
-- {{SVGAttr("font-weight")}}
-- {{SVGAttr("font-stretch")}}
-- {{SVGAttr("font-size")}}
-- {{SVGAttr("unicode-range")}}
-- {{SVGAttr("units-per-em")}}
-- {{SVGAttr("panose-1")}}
-- {{SVGAttr("stemv")}}
-- {{SVGAttr("stemh")}}
-- {{SVGAttr("slope")}}
-- {{SVGAttr("cap-height")}}
-- {{SVGAttr("x-height")}}
-- {{SVGAttr("accent-height")}}
-- {{SVGAttr("ascent")}}
-- {{SVGAttr("descent")}}
-- {{SVGAttr("widths")}}
-- {{SVGAttr("bbox")}}
-- {{SVGAttr("ideographic")}}
-- {{SVGAttr("alphabetic")}}
-- {{SVGAttr("mathematical")}}
-- {{SVGAttr("hanging")}}
-- {{SVGAttr("v-ideographic")}}
-- {{SVGAttr("v-alphabetic")}}
-- {{SVGAttr("v-mathematical")}}
-- {{SVGAttr("v-hanging")}}
-- {{SVGAttr("underline-position")}}
-- {{SVGAttr("underline-thickness")}}
-- {{SVGAttr("strikethrough-position")}}
-- {{SVGAttr("strikethrough-thickness")}}
-- {{SVGAttr("overline-position")}}
-- {{SVGAttr("overline-thickness")}}
+- {{SVGAttr("font-family")}} {{Deprecated_Inline}}
+- {{SVGAttr("font-style")}} {{Deprecated_Inline}}
+- {{SVGAttr("font-variant")}} {{Deprecated_Inline}}
+- {{SVGAttr("font-weight")}} {{Deprecated_Inline}}
+- {{SVGAttr("font-stretch")}} {{Deprecated_Inline}}
+- {{SVGAttr("font-size")}} {{Deprecated_Inline}}
+- {{SVGAttr("unicode-range")}} {{Deprecated_Inline}}
+- {{SVGAttr("units-per-em")}} {{Deprecated_Inline}}
+- {{SVGAttr("panose-1")}} {{Deprecated_Inline}}
+- {{SVGAttr("stemv")}} {{Deprecated_Inline}}
+- {{SVGAttr("stemh")}} {{Deprecated_Inline}}
+- {{SVGAttr("slope")}} {{Deprecated_Inline}}
+- {{SVGAttr("cap-height")}} {{Deprecated_Inline}}
+- {{SVGAttr("x-height")}} {{Deprecated_Inline}}
+- {{SVGAttr("accent-height")}} {{Deprecated_Inline}}
+- {{SVGAttr("ascent")}} {{Deprecated_Inline}}
+- {{SVGAttr("descent")}} {{Deprecated_Inline}}
+- {{SVGAttr("widths")}} {{Deprecated_Inline}}
+- {{SVGAttr("bbox")}} {{Deprecated_Inline}}
+- {{SVGAttr("ideographic")}} {{Deprecated_Inline}}
+- {{SVGAttr("alphabetic")}} {{Deprecated_Inline}}
+- {{SVGAttr("mathematical")}} {{Deprecated_Inline}}
+- {{SVGAttr("hanging")}} {{Deprecated_Inline}}
+- {{SVGAttr("v-ideographic")}} {{Deprecated_Inline}}
+- {{SVGAttr("v-alphabetic")}} {{Deprecated_Inline}}
+- {{SVGAttr("v-mathematical")}} {{Deprecated_Inline}}
+- {{SVGAttr("v-hanging")}} {{Deprecated_Inline}}
+- {{SVGAttr("underline-position")}} {{Deprecated_Inline}}
+- {{SVGAttr("underline-thickness")}} {{Deprecated_Inline}}
+- {{SVGAttr("strikethrough-position")}} {{Deprecated_Inline}}
+- {{SVGAttr("strikethrough-thickness")}} {{Deprecated_Inline}}
+- {{SVGAttr("overline-position")}} {{Deprecated_Inline}}
+- {{SVGAttr("overline-thickness")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/font/index.md
+++ b/files/en-us/web/svg/element/font/index.md
@@ -29,12 +29,12 @@ The **`<font>`** [SVG](/en-US/docs/Web/SVG) element defines a font to be used fo
 
 ### Specific attributes
 
-- {{SVGAttr("horiz-origin-x")}}
-- {{SVGAttr("horiz-origin-y")}}
-- {{SVGAttr("horiz-adv-x")}}
-- {{SVGAttr("vert-origin-x")}}
-- {{SVGAttr("vert-origin-y")}}
-- {{SVGAttr("vert-adv-y")}}
+- {{SVGAttr("horiz-origin-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("horiz-origin-y")}} {{Deprecated_Inline}}
+- {{SVGAttr("horiz-adv-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-y")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-adv-y")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/glyph/index.md
+++ b/files/en-us/web/svg/element/glyph/index.md
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+  - Deprecated
 browser-compat: svg.elements.glyph
 ---
 {{SVGRef}}{{deprecated_header}}
@@ -27,16 +28,16 @@ A **`<glyph>`** defines a single glyph in an SVG font.
 
 ### Specific attributes
 
-- {{SVGAttr("d")}}
-- {{SVGAttr("horiz-adv-x")}}
-- {{SVGAttr("vert-origin-x")}}
-- {{SVGAttr("vert-origin-y")}}
-- {{SVGAttr("vert-adv-y")}}
-- {{SVGAttr("unicode")}}
-- {{SVGAttr("glyph-name")}}
-- {{SVGAttr("orientation")}}
-- {{SVGAttr("arabic-form")}}
-- {{SVGAttr("lang")}}
+- {{SVGAttr("d")}} {{Deprecated_Inline}}
+- {{SVGAttr("horiz-adv-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-y")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-adv-y")}} {{Deprecated_Inline}}
+- {{SVGAttr("unicode")}} {{Deprecated_Inline}}
+- {{SVGAttr("glyph-name")}} {{Deprecated_Inline}}
+- {{SVGAttr("orientation")}} {{Deprecated_Inline}}
+- {{SVGAttr("arabic-form")}} {{Deprecated_Inline}}
+- {{SVGAttr("lang")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/glyphref/index.md
+++ b/files/en-us/web/svg/element/glyphref/index.md
@@ -30,12 +30,12 @@ The `glyphRef` element provides a single possible glyph to the referencing {{ SV
 
 ### Specific attributes
 
-- {{SVGAttr("x")}}
-- {{SVGAttr("y")}}
-- {{SVGAttr("dx")}}
-- {{SVGAttr("dy")}}
-- {{SVGAttr("glyphRef")}}
-- {{SVGAttr("format")}}
+- {{SVGAttr("x")}} {{Deprecated_Inline}}
+- {{SVGAttr("y")}} {{Deprecated_Inline}}
+- {{SVGAttr("dx")}} {{Deprecated_Inline}}
+- {{SVGAttr("dy")}} {{Deprecated_Inline}}
+- {{SVGAttr("glyphRef")}} {{Deprecated_Inline}}
+- {{SVGAttr("format")}} {{Deprecated_Inline}}
 - {{SVGAttr("xlink:href")}}
 
 ## DOM Interface

--- a/files/en-us/web/svg/element/hkern/index.md
+++ b/files/en-us/web/svg/element/hkern/index.md
@@ -26,11 +26,11 @@ The **`<hkern>`** [SVG](/en-US/docs/Web/SVG) element allows to fine-tweak the ho
 
 ### Specific attributes
 
-- {{SVGAttr("u1")}}
-- {{SVGAttr("g1")}}
-- {{SVGAttr("u2")}}
-- {{SVGAttr("g2")}}
-- {{SVGAttr("k")}}
+- {{SVGAttr("u1")}} {{Deprecated_Inline}}
+- {{SVGAttr("g1")}} {{Deprecated_Inline}}
+- {{SVGAttr("u2")}} {{Deprecated_Inline}}
+- {{SVGAttr("g2")}} {{Deprecated_Inline}}
+- {{SVGAttr("k")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/missing-glyph/index.md
+++ b/files/en-us/web/svg/element/missing-glyph/index.md
@@ -28,11 +28,11 @@ The **`<missing-glyph>`** [SVG](/en-US/docs/Web/SVG) element's content is render
 
 ### Specific attributes
 
-- {{SVGAttr("d")}}
-- {{SVGAttr("horiz-adv-x")}}
-- {{SVGAttr("vert-origin-x")}}
-- {{SVGAttr("vert-origin-y")}}
-- {{SVGAttr("vert-adv-y")}}
+- {{SVGAttr("d")}} {{Deprecated_Inline}}
+- {{SVGAttr("horiz-adv-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-x")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-origin-y")}} {{Deprecated_Inline}}
+- {{SVGAttr("vert-adv-y")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/view/index.md
+++ b/files/en-us/web/svg/element/view/index.md
@@ -28,7 +28,7 @@ A view is a defined way to view the image, like a zoom level or a detail view.
 
 - {{SVGAttr("viewBox")}}
 - {{SVGAttr("preserveAspectRatio")}}
-- {{SVGAttr("zoomAndPan")}}
+- {{SVGAttr("zoomAndPan")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
 - {{SVGAttr("viewTarget")}}
 
 ## Example

--- a/files/en-us/web/svg/element/vkern/index.md
+++ b/files/en-us/web/svg/element/vkern/index.md
@@ -26,11 +26,11 @@ The **`<vkern>`** SVG element allows to fine-tweak the vertical distance between
 
 ### Specific attributes
 
-- {{SVGAttr("u1")}}
-- {{SVGAttr("g1")}}
-- {{SVGAttr("u2")}}
-- {{SVGAttr("g2")}}
-- {{SVGAttr("k")}}
+- {{SVGAttr("u1")}} {{Deprecated_Inline}}
+- {{SVGAttr("g1")}} {{Deprecated_Inline}}
+- {{SVGAttr("u2")}} {{Deprecated_Inline}}
+- {{SVGAttr("g2")}} {{Deprecated_Inline}}
+- {{SVGAttr("k")}} {{Deprecated_Inline}}
 
 ## DOM Interface
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTTP pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

:warning: This completes SVG updates

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.