### PR TITLE
API: update BCD Info

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/index.md
@@ -33,7 +33,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
-- {{domxref("HTMLCanvasElement.captureStream()")}} {{experimental_inline}}
+- {{domxref("HTMLCanvasElement.captureStream()")}}
   - : Returns a {{domxref("CanvasCaptureMediaStreamTrack")}} that is a real-time video capture of the surface of the canvas.
 - {{domxref("HTMLCanvasElement.getContext()")}}
   - : Returns a drawing context on the canvas, or null if the context ID is not supported. A drawing context lets you draw on the canvas. Calling getContext with `"2d"` returns a {{domxref("CanvasRenderingContext2D")}} object, whereas calling it with `"webgl"` (or `"experimental-webgl"`) returns a {{domxref("WebGLRenderingContext")}} object. This context is only available on browsers that implement [WebGL](/en-US/docs/Web/API/WebGL_API).

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -44,7 +44,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
     > **Note:** The exact processing details for these attributes are complex, involving many different aspects of HTML, and therefore are scattered throughout the specification. [These algorithms](https://html.spec.whatwg.org/multipage/scripting.html) describe the core ideas, but they rely on the parsing rules for {{HTMLElement("script")}} [start](https://html.spec.whatwg.org/multipage/syntax.html) and [end](https://html.spec.whatwg.org/multipage/syntax.html) tags in HTML, [in foreign content](https://html.spec.whatwg.org/multipage/syntax.html), and [in XML](https://html.spec.whatwg.org/multipage/xhtml.html); the rules for the [`document.write()`](/en-US/docs/Web/API/Document/write) method; the handling of [scripting](https://html.spec.whatwg.org/multipage/webappapis.html); and so on.
 
-- {{domxref("HTMLScriptElement.crossOrigin")}} {{experimental_inline}}
+- {{domxref("HTMLScriptElement.crossOrigin")}}
   - : A string reflecting the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for the script element. For scripts from other [origins](/en-US/docs/Glossary/Origin), this controls if error information will be exposed.
 - {{domxref("HTMLScriptElement.text")}}
 
@@ -52,7 +52,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
     > **Note:** When inserted using the [`document.write()`](/en-US/docs/Web/API/Document/write) method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using [`innerHTML`](/en-US/docs/Web/API/Element/innerHTML) or [`outerHTML`](/en-US/docs/Web/API/Element/outerHTML), they do not execute at all.
 
-- {{domxref("HTMLScriptElement.fetchPriority")}}
+- {{domxref("HTMLScriptElement.fetchPriority")}} {{Experimental_Inline}}
   - : An optional string representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLScriptElement.noModule")}}
   - : A boolean value that if true, stops the script's execution in browsers that support [ES modules](/en-US/docs/Web/JavaScript/Guide/Modules) — used to run fallback scripts in older browsers that do _not_ support JavaScript modules.

--- a/files/en-us/web/api/htmlsourceelement/index.md
+++ b/files/en-us/web/api/htmlsourceelement/index.md
@@ -21,7 +21,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLSourceElement.media")}}
   - : A string reflecting the {{ htmlattrxref("media", "source") }} HTML attribute, containing the intended type of the media resource.
-- {{domxref("HTMLSourceElement.sizes")}} {{experimental_inline}}
+- {{domxref("HTMLSourceElement.sizes")}}
   - : A string representing image sizes between breakpoints
 - {{domxref("HTMLSourceElement.src")}}
 
@@ -29,7 +29,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
     > **Note:** If the `src` property is updated (along with any siblings), the parent {{domxref("HTMLMediaElement")}}'s `load` method should be called when done, since `<source>` elements are not re-scanned automatically.
 
-- {{domxref("HTMLSourceElement.srcset")}} {{experimental_inline}}
+- {{domxref("HTMLSourceElement.srcset")}}
   - : A string reflecting the {{ htmlattrxref("srcset", "source") }} HTML attribute, containing a list of candidate images, separated by a comma (`',', U+002C COMMA`). A candidate image is a URL followed by a `'w'` with the width of the images, or an `'x'` followed by the pixel density.
 - {{domxref("HTMLSourceElement.type")}}
   - : A string reflecting the {{ htmlattrxref("type", "source") }} HTML attribute, containing the type of the media resource.

--- a/files/en-us/web/api/htmlvideoelement/index.md
+++ b/files/en-us/web/api/htmlvideoelement/index.md
@@ -72,7 +72,7 @@ _Inherits properties from its ancestor interfaces, {{domxref("HTMLMediaElement")
 
 _Inherits methods from its parent, {{domxref("HTMLMediaElement")}}, and from its ancestor {{domxref("HTMLElement")}}._
 
-- {{domxref("HTMLVideoElement.getVideoPlaybackQuality()")}} {{experimental_inline}}
+- {{domxref("HTMLVideoElement.getVideoPlaybackQuality()")}}
   - : Returns a {{domxref("VideoPlaybackQuality")}} object that contains the current playback metrics. This information includes things like the number of dropped or corrupted frames, as well as the total number of frames.
 - {{DOMxRef("HTMLVideoElement.requestPictureInPicture()")}}
   - : Requests that the user agent make video enters picture-in-picture mode

--- a/files/en-us/web/api/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/index.md
@@ -19,7 +19,7 @@ It is created using the {{domxref("ImageData.ImageData", "ImageData()")}} constr
 
 ## Constructors
 
-- {{domxref("ImageData.ImageData", "ImageData()")}} {{experimental_inline}}
+- {{domxref("ImageData.ImageData", "ImageData()")}}
   - : Creates an `ImageData` object from a given {{jsxref("Uint8ClampedArray")}} and the size of the image it contains. If no array is given, it creates an image of a transparent black rectangle. Note that this is the most common way to create such an object in workers as {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}} is not available there.
 
 ## Properties

--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -28,9 +28,9 @@ The **`KeyframeEffect`** interface of the [Web Animations API](/en-US/docs/Web/A
 
 - {{domxref("KeyframeEffect.target")}}
   - : Gets and sets the element, or originating element of the pseudo-element, being animated by this object. This may be `null` for animations that do not target a specific element or pseudo-element.
-- {{domxref("KeyframeEffect.pseudoElement")}} {{Experimental_Inline}}
+- {{domxref("KeyframeEffect.pseudoElement")}}
   - : Gets and sets the selector of the pseudo-element being animated by this object. This may be `null` for animations that do not target a pseudo-element.
-- {{domxref("KeyframeEffect.iterationComposite")}}
+- {{domxref("KeyframeEffect.iterationComposite")}} {{Experimental_Inline}}
   - : Gets and sets the iteration composite operation for resolving the property value changes of this keyframe effect.
 - {{domxref("KeyframeEffect.composite")}}
   - : Gets and sets the composite operation property for resolving the property value changes between this and other keyframe effects.

--- a/files/en-us/web/api/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/index.md
@@ -34,9 +34,9 @@ The **`MediaRecorder`** interface of the [MediaStream Recording API](/en-US/docs
   - : Returns the current state of the `MediaRecorder` object (`inactive`, `recording`, or `paused`.)
 - {{domxref("MediaRecorder.stream")}} {{ReadOnlyInline}}
   - : Returns the stream that was passed into the constructor when the `MediaRecorder` was created.
-- {{domxref("MediaRecorder.videoBitsPerSecond")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{domxref("MediaRecorder.videoBitsPerSecond")}} {{ReadOnlyInline}}
   - : Returns the video encoding bit rate in use. This may differ from the bit rate specified in the constructor (if it was provided).
-- {{domxref("MediaRecorder.audioBitsPerSecond")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{domxref("MediaRecorder.audioBitsPerSecond")}} {{ReadOnlyInline}}
   - : Returns the audio encoding bit rate in use. This may differ from the bit rate specified in the constructor (if it was provided).
 
 ## Methods

--- a/files/en-us/web/api/navigator/mediacapabilities/index.md
+++ b/files/en-us/web/api/navigator/mediacapabilities/index.md
@@ -11,6 +11,8 @@ tags:
 browser-compat: api.Navigator.mediaCapabilities
 ---
 
+{{APIRef("HTML DOM")}}
+
 The **`Navigator.mediaCapabilities`** read-only property
 returns a {{domxref("MediaCapabilities")}} object that can expose information about the
 decoding and encoding capabilities for a given format and output capabilities as defined
@@ -56,5 +58,3 @@ navigator.mediaCapabilities.decodingInfo({
 
 - [Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API)
 - {{domxref("Navigator")}}
-
-{{APIRef("HTML DOM")}}

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -13,6 +13,8 @@ tags:
 browser-compat: api.PerformanceEventTiming
 ---
 
+{{APIRef}}
+
 The `PerformanceEventTiming` interface of the Event Timing API provides timing information for the event types listed below.
 
 - {{domxref("Element/auxclick_event", "auxclick")}}

--- a/files/en-us/web/api/window/appinstalled_event/index.md
+++ b/files/en-us/web/api/window/appinstalled_event/index.md
@@ -13,6 +13,8 @@ tags:
 browser-compat: api.Window.appinstalled_event
 ---
 
+{{APIRef}}
+
 The **`appinstalled`** event of the [Web Manifest API](/en-US/docs/Web/Manifest) is fired when the browser has successfully installed a page as an application.
 
 This event is not cancelable and does not bubble.

--- a/files/en-us/web/api/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/index.md
@@ -42,13 +42,13 @@ Using `XRRigidTransform` in these places rather than bare arrays that provide th
 
 ## Properties
 
-- {{DOMxRef("XRRigidTransform.position")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{DOMxRef("XRRigidTransform.position")}} {{ReadOnlyInline}}
   - : A {{DOMxRef("DOMPointReadOnly")}} specifying a 3-dimensional point, expressed in meters, describing the translation component of the transform. The {{DOMxRef("DOMPointReadonly.w", "w")}} property is always `1.0`.
-- {{DOMxRef("XRRigidTransform.orientation")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{DOMxRef("XRRigidTransform.orientation")}} {{ReadOnlyInline}}
   - : A {{DOMxRef("DOMPointReadOnly")}} which contains a unit quaternion describing the rotational component of the transform. As a unit quaternion, its length is always normalized to `1.0`.
-- {{DOMxRef("XRRigidTransform.matrix")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{DOMxRef("XRRigidTransform.matrix")}} {{ReadOnlyInline}}
   - : Returns the transform matrix in the form of a 16-member {{jsxref("Float32Array")}}. See the section [Matrix format](/en-US/docs/Web/API/XRRigidTransform/matrix#matrix_format) for how the array is used to represent a matrix.
-- {{DOMxRef("XRRigidTransform.inverse")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{DOMxRef("XRRigidTransform.inverse")}} {{ReadOnlyInline}}
   - : Returns a `XRRigidTransform` which is the inverse of this transform. That is, if applied to an object that had been previously transformed by the original transform, it will undo the transform and return the original object.
 
 ## Usage notes

--- a/files/en-us/web/api/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - AR
   - Augmented Reality
-  - Experimental
   - Interface
   - Reference
   - VR
@@ -17,7 +16,7 @@ tags:
   - XRWebGLLayer
 browser-compat: api.XRWebGLLayer
 ---
-{{SecureContext_Header}}{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
+{{SecureContext_Header}}{{APIRef("WebXR Device API")}}
 
 The **`XRWebGLLayer`** interface of the WebXR Device API provides a linkage between the WebXR device (or simulated XR device, in the case of an inline session) and a WebGL context used to render the scene for display on the device. In particular, it provides access to the WebGL framebuffer and viewport to ease access to the context.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185.

This removes 'experimental' statuses.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.