### PR TITLE
Remove MathML attributes subscriptshift/superscriptshift/align

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -50,9 +50,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>align</code> {{deprecated_inline}}</td>
       <td>
-        {{ MathMLElement("mtable") }}<br />{{ MathMLElement("munder") }},
-        {{ MathMLElement("mover") }},
-        {{ MathMLElement("munderover") }}
+        {{ MathMLElement("mtable") }}
       </td>
       <td>
         Specifies different alignments of several elements (see element pages
@@ -438,30 +436,6 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td>
         Specifies whether the operator stretches to the size of the adjacent
         element.
-      </td>
-    </tr>
-    <tr>
-      <td><code>subscriptshift</code> {{deprecated_inline}}</td>
-      <td>
-        {{ MathMLElement("mmultiscripts") }},
-        {{ MathMLElement("msub") }},
-        {{ MathMLElement("msubsup") }}
-      </td>
-      <td>
-        The minimum space by which to shift the subscript below the baseline of
-        the expression.
-      </td>
-    </tr>
-    <tr>
-      <td><code>supscriptshift</code> {{deprecated_inline}}</td>
-      <td>
-        {{ MathMLElement("mmultiscripts") }},
-        {{ MathMLElement("msup") }},
-        {{ MathMLElement("msubsup") }}
-      </td>
-      <td>
-        The minimum space by which to shift the superscript above the baseline
-        of the expression.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -19,9 +19,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accent`
   - : If `true` the over-script is an _accent_, which is drawn closer to the base expression.
     If `false` (default value) the over-script is a _limit_ over the base expression.
-- `align` {{deprecated_inline}}
-  - : The alignment of the over-script. Possible values are: `left`, `center`, and `right`.
-    This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -18,10 +18,6 @@ It uses the following syntax: `<msub> base subscript </msub>`.
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- `subscriptshift` {{deprecated_inline}}
-  - : The minimum space by which to shift the subscript below the baseline of the expression, as a [length value](/en-US/docs/Web/MathML/Attribute/Values#lengths).
-    This attribute is deprecated and will be removed in the future.
-
 ## Examples
 
 Sample rendering: ![x1](msub.png)

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -18,13 +18,6 @@ It uses the following syntax: `<msubsup> base subscript superscript </msubsup>`.
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- `subscriptshift` {{deprecated_inline}}
-  - : The minimum space by which to shift the subscript below the baseline of the expression, as a [length value.](/en-US/docs/Web/MathML/Attribute/Values#lengths)
-    This attribute is deprecated and will be removed in the future.
-- `superscriptshift` {{deprecated_inline}}
-  - : The minimum space by which to shift the superscript above the baseline of the expression, as a [length value.](/en-US/docs/Web/MathML/Attribute/Values#lengths)
-    This attribute is deprecated and will be removed in the future.
-
 ## Examples
 
 Sample rendering: ![x1](msubsup.png)

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -18,10 +18,6 @@ It uses the following syntax: `<msup> base superscript </msup>`.
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- `superscriptshift` {{deprecated_inline}}
-  - : The minimum space by which to shift the superscript up from the baseline of the expression, as a [length value.](/en-US/docs/Web/MathML/Attribute/Values#lengths)
-    This attribute is deprecated and will be removed in the future.
-
 ## Examples
 
 Sample rendering: ![x1](msup.png)

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -19,9 +19,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : If `true`, the element is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the element is a _limit_ under the base expression.
-- `align` {{deprecated_inline}}
-  - : The alignment of the underscript. Possible values are: `left`, `center`, and `right`.
-    This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -24,9 +24,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : If `true`, the underscript is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the underscript is a _limit_ under the base expression.
-- `align` {{deprecated_inline}}
-  - : The alignment of both underscript and overscript. Possible values are: `left`, `center`, and `right`.
-    This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary

The following attributes are removed:
- subscriptshift/superscriptshift on msub/msup/msubsup/mmultiscripts
- align on munder/mover/munderover

#### Motivation

They meet requirement for https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features

#### Supporting details

See browser-compat-data PRs [1] [2].

#### Related issues

[1] https://github.com/mdn/browser-compat-data/pull/17617
[2] https://github.com/mdn/browser-compat-data/pull/17620

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
