### PR TITLE
Remove deprecated MathML math@mode attribute

### DIFF
--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -15,7 +15,7 @@ The `<math>` element is the top-level MathML element, used to write a single mat
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attribute:
 
 - `display`
 
@@ -25,10 +25,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
     - `inline`, which means that this element will be displayed inside the current span of text and with [`math-style`](/en-US/docs/Web/CSS/math-style) set to `compact`.
 
     If not present, its default value is `inline`.
-
-- `mode` {{deprecated_inline}}
-  - : Deprecated in favor of the [display attribute](#attr-display).
-    Possible values are: `display` (which has the same effect as `display="block"`) and `inline`.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary

Remove documentation for the mode attribute of the math element.

#### Motivation

See https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features

#### Supporting details

See https://github.com/mdn/browser-compat-data/pull/17624

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17624

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
