### PR TITLE
fix(workflows): skip ping if dependabot merged

### DIFF
--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -13,7 +13,10 @@ on:
     branches: [main]
 jobs:
   ping:
-    if: github.repository == 'mdn/content' # Won’t be run from forks
+    # Don't run in forks, or when Dependabot merges a PR.
+    if: |
+      github.repository == 'mdn/content' &&
+      github.triggering_actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Ping w3c/mdn-spec-links


### PR DESCRIPTION
See: https://github.com/mdn/yari/pull/6949

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Avoids that the ping workflow (which requires write permissions) runs for Dependabot merges (which are restricted to read permission):

<img width="584" alt="image" src="https://user-images.githubusercontent.com/495429/187748491-a02f1b27-dc84-400e-9d2b-e2b248207c02.png">


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
