### PR TITLE
Removing extra attribute spacing.

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/table_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/table_role/index.md
@@ -103,15 +103,15 @@ None. For sortable columns, see the [columnheader](/en-US/docs/Web/Accessibility
        <span role="cell">header</span>
        <span role="cell">h1</span>
     </div>
-    <div role="row"  aria-rowindex="16">
+    <div role="row" aria-rowindex="16">
       <span role="cell">header</span>
       <span role="cell">h6</span>
     </div>
-    <div role="row"  aria-rowindex="18">
+    <div role="row" aria-rowindex="18">
       <span role="cell">rowgroup</span>
       <span role="cell">thead</span>
     </div>
-    <div role="row"  aria-rowindex="24">
+    <div role="row" aria-rowindex="24">
       <span role="cell">term</span>
       <span role="cell">dt</span>
     </div>


### PR DESCRIPTION
Updated attributes in Examples to remove extra spacing between the role and aria-rowindex attributes.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removing extra spacing between a few attributes in an Example section 

#### Motivation
To remove extra spacing and have similar lines follow the same aesthetics.

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
N/A

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
