### PR TITLE
Flip the text for null vs object arg for the framebuffer param

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -13,7 +13,7 @@ browser-compat: api.WebGLRenderingContext.bindFramebuffer
 {{APIRef("WebGL")}}
 
 The **`WebGLRenderingContext.bindFramebuffer()`** method of the
-[WebGL API](/en-US/docs/Web/API/WebGL_API) binds to the specified target the default {{domxref("WebGLFramebuffer")}}, or, if the second argument is non-null, the provided {{domxref("WebGLFramebuffer")}}.
+[WebGL API](/en-US/docs/Web/API/WebGL_API) binds to the specified target the provided {{domxref("WebGLFramebuffer")}}, or, if the `framebuffer` argument is null, the default {{domxref("WebGLFramebuffer")}}, which is associated with the canvas rendering context.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Based on [feedback](https://github.com/mdn/content/issues/1578#issuecomment-1221250349) by @greggman, the text order is reversed. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

People mostly use this API call to specify a framebuffer different to the default one, and it's sensible to list the general case first, and default, second.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
https://github.com/mdn/content/issues/1578
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
