### PR TITLE
Update HTTP spec-urls frontmatter keys to current HTTP spec

### DIFF
--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -15,7 +15,7 @@ tags:
   - port
   - query
   - resources
-spec-urls: https://httpwg.org/specs/rfc7230.html#section-2.7
+spec-urls: https://httpwg.org/specs/rfc9110.html#uri
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/allow/index.md
+++ b/files/en-us/web/http/headers/allow/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Header
   - Response header
   - Reference
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-7.4.1
+spec-urls: https://httpwg.org/specs/rfc9110.html#field.allow
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
-spec-urls: https://httpwg.org/specs/rfc7231.html#header.max-forwards
+spec-urls: https://httpwg.org/specs/rfc9110.html#field.max-forwards
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Request header
   - header
-spec-urls: https://httpwg.org/specs/rfc7235.html#header.proxy-authorization
+spec-urls: https://httpwg.org/specs/rfc9110.html#field.proxy-authorization
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -7,7 +7,7 @@ tags:
   - Informational
   - Reference
   - WebSockets
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.2.2
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.101
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/202/index.md
+++ b/files/en-us/web/http/status/202/index.md
@@ -6,7 +6,7 @@ tags:
   - Reference
   - Status code
   - Success response
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.3.3
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.202
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/203/index.md
+++ b/files/en-us/web/http/status/203/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Status code
   - Successful response
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.3.4
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.203
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/205/index.md
+++ b/files/en-us/web/http/status/205/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.3.6
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.205
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/300/index.md
+++ b/files/en-us/web/http/status/300/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.4.1
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.300
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/400/index.md
+++ b/files/en-us/web/http/status/400/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.1
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.400
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/402/index.md
+++ b/files/en-us/web/http/status/402/index.md
@@ -6,7 +6,7 @@ tags:
   - Client error
   - HTTP
   - Status code
-spec-urls: https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.2
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.402
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/en-us/web/http/status/405/index.md
+++ b/files/en-us/web/http/status/405/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.5
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.405
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/408/index.md
+++ b/files/en-us/web/http/status/408/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.7
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.408
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/411/index.md
+++ b/files/en-us/web/http/status/411/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.10
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.411
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/413/index.md
+++ b/files/en-us/web/http/status/413/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.11
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.413
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/414/index.md
+++ b/files/en-us/web/http/status/414/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.12
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.414
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/415/index.md
+++ b/files/en-us/web/http/status/415/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.13
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.415
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/417/index.md
+++ b/files/en-us/web/http/status/417/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.14
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.417
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/426/index.md
+++ b/files/en-us/web/http/status/426/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.5.15
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.426
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/429/index.md
+++ b/files/en-us/web/http/status/429/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-4
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.429
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/429/index.md
+++ b/files/en-us/web/http/status/429/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP Status Code
   - Reference
   - Status code
-spec-urls: https://httpwg.org/specs/rfc9110.html#status.429
+spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-4
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/505/index.md
+++ b/files/en-us/web/http/status/505/index.md
@@ -6,7 +6,7 @@ tags:
   - Reference
   - Server error
   - Status code
-spec-urls: https://httpwg.org/specs/rfc7231.html#section-6.6.6
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.505
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/511/index.md
+++ b/files/en-us/web/http/status/511/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Server error
   - Status code
-spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-6
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.511
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/511/index.md
+++ b/files/en-us/web/http/status/511/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - Server error
   - Status code
-spec-urls: https://httpwg.org/specs/rfc9110.html#status.511
+spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-6
 ---
 {{HTTPSidebar}}
 


### PR DESCRIPTION
After spending some time thinking about it more, I figured out some ways to automate the updates for most of these.