### PR TITLE
chore: fix function naming according to JS guidelines

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
 browser-compat: api.CanvasRenderingContext2D.reset
 ---
+
 {{APIRef}}
 
 The **`CanvasRenderingContext2D.reset()`** method of the Canvas 2D API resets the rendering context to its default state, allowing it to be reused for drawing something else without having to explicitly reset all the properties.
@@ -20,7 +21,7 @@ This includes the current [transformation](/en-US/docs/Web/API/CanvasRenderingCo
 ## Syntax
 
 ```js
-reset()
+reset();
 ```
 
 ### Parameters
@@ -38,7 +39,9 @@ This example shows how we can use `reset()` to completely clear the context befo
 First we define a button and a canvas.
 
 ```css
-#toggle-reset { display:block; }
+#toggle-reset {
+  display: block;
+}
 ```
 
 ```html
@@ -51,10 +54,10 @@ It then defines functions that can use the context to draw a rectangle and a cir
 
 ```js
 // Get the 2d context
-const canvas = document.getElementById('my-house');
-const ctx = canvas.getContext('2d');
+const canvas = document.getElementById("my-house");
+const ctx = canvas.getContext("2d");
 
-function DrawRect() {
+function drawRect() {
   // Set line width
   ctx.lineWidth = 10;
 
@@ -62,11 +65,11 @@ function DrawRect() {
   ctx.strokeRect(50, 50, 150, 100);
 
   // Create filled text
-  ctx.font = '50px serif';
-  ctx.fillText('Rect!', 70, 110);
+  ctx.font = "50px serif";
+  ctx.fillText("Rect!", 70, 110);
 }
 
-function DrawCircle() {
+function drawCircle() {
   // Set line width
   ctx.lineWidth = 5;
 
@@ -76,8 +79,8 @@ function DrawCircle() {
   ctx.stroke();
 
   // Create filled text
-  ctx.font = '25px sans-serif';
-  ctx.fillText('Circle!', 265, 100);
+  ctx.font = "25px sans-serif";
+  ctx.fillText("Circle!", 265, 100);
 }
 ```
 
@@ -86,18 +89,18 @@ The button toggles drawing the circle and rectangle.
 Note how `reset()` is called before drawing to clear the context.
 
 ```js
-DrawRect();
+drawRect();
 
 // Toggle between circle and rectangle using button
 let toggle = true;
-const mybutton = document.getElementById('toggle-reset');
+const mybutton = document.getElementById("toggle-reset");
 
 mybutton.addEventListener("click", () => {
   ctx.reset(); // Clear the context!
   if (toggle) {
-    DrawCircle();
+    drawCircle();
   } else {
-    DrawRect();
+    drawRect();
   }
   toggle = !toggle;
 });

--- a/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
@@ -21,7 +21,7 @@ This includes the current [transformation](/en-US/docs/Web/API/CanvasRenderingCo
 ## Syntax
 
 ```js
-reset();
+reset()
 ```
 
 ### Parameters


### PR DESCRIPTION
__Summary:__

This is a minor cleanup PR after recent changes landed that conflict with our JS guidelines.
