### PR TITLE
Fix Object static methods' behavior for non-object argument

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -59,8 +59,7 @@ Object.isExtensible(frozen); // === false
 
 ### Non-object argument
 
-In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, it will return `false` without any errors if a non-object argument is passed.
+In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, it will return `false` without any errors if a non-object argument is passed, since primitives are, by definition, immutable.
 
 ```js
 Object.isExtensible(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -57,11 +57,10 @@ const frozen = Object.freeze({});
 Object.isExtensible(frozen); // === false
 ```
 
-### Non-object coercion
+### Non-object argument
 
 In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be treated as if
-it was a non-extensible ordinary object, return `false`.
+cause a {{jsxref("TypeError")}}. In ES2015, it will return `false` without any errors if a non-object argument is passed.
 
 ```js
 Object.isExtensible(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -125,8 +125,7 @@ Object.isSealed(frozen); // === true
 
 ### Non-object argument
 
-In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed.
+In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed, since primitives are, by definition, immutable.
 
 ```js
 Object.isFrozen(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -123,11 +123,10 @@ Object.isExtensible(frozen); // === false
 Object.isSealed(frozen); // === true
 ```
 
-### Non-object coercion
+### Non-object argument
 
 In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be treated as if
-it was a frozen ordinary object, return `true`.
+cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed.
 
 ```js
 Object.isFrozen(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -88,11 +88,10 @@ Object.isFrozen(s3); // === true
 // (only configurability matters for accessor properties)
 ```
 
-### Non-object coercion
+### Non-object argument
 
 In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be treated as if
-it was a sealed ordinary object, return `true`.
+cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed.
 
 ```js
 Object.isSealed(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -90,8 +90,7 @@ Object.isFrozen(s3); // === true
 
 ### Non-object argument
 
-In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed.
+In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, it will return `true` without any errors if a non-object argument is passed, since primitives are, by definition, immutable.
 
 ```js
 Object.isSealed(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -96,8 +96,7 @@ fixed.__proto__ = { oh: 'hai' };
 
 ### Non-object argument
 
-In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as it is without any errors.
+In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as-is without any errors, since primitives are already, by definition, immutable.
 
 ```js
 Object.preventExtensions(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -94,11 +94,10 @@ const fixed = Object.preventExtensions({});
 fixed.__proto__ = { oh: 'hai' };
 ```
 
-### Non-object coercion
+### Non-object argument
 
 In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be treated as if
-it was a non-extensible ordinary object, return it.
+cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as it is without any errors.
 
 ```js
 Object.preventExtensions(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
@@ -105,8 +105,7 @@ Object.defineProperty(obj, 'foo', {
 
 ### Non-object argument
 
-In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as it is without any errors.
+In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as-is without any errors, since primitives are already, by definition, immutable.
 
 ```js
 Object.seal(1);

--- a/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
@@ -103,11 +103,10 @@ Object.defineProperty(obj, 'foo', {
 }); // changes existing property value
 ```
 
-### Non-object coercion
+### Non-object argument
 
 In ES5, if the argument to this method is not an object (a primitive), then it will
-cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be treated as if
-it was a sealed ordinary object by returning it.
+cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be returned as it is without any errors.
 
 ```js
 Object.seal(1);


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
##### Replacing "Coercion" with "argument" :
According to specs, there is no coercion happens for the non-object argument it just returns it in es2015 or throws an error in es5

##### Removing "a non-object argument will be treated as if it was a non-extensible ordinary object, return it":
Also, according to specs, no special behavior happens to a non-extensible object.
