### PR TITLE
WebXr: update BCD Info

### DIFF
--- a/files/en-us/web/api/xrcompositionlayer/blendtexturesourcealpha/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/blendtexturesourcealpha/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCompositionLayer.blendTextureSourceAlpha
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`blendTextureSourceAlpha`** property of the {{domxref("XRCompositionLayer")}} interface is a boolean enabling the layer's texture {{Glossary("Alpha", "alpha channel")}}.
 

--- a/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCompositionLayer.chromaticAberrationCorrection
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`chromaticAberrationCorrection`** property of the {{domxref("XRCompositionLayer")}} interface is a boolean enabling the layer's optical chromatic aberration correction.
 

--- a/files/en-us/web/api/xrcompositionlayer/destroy/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/destroy/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRCompositionLayer.destroy
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`destroy()`** method of the {{domxref("XRCompositionLayer")}} interface deletes the references to the underlying graphics library for the layer. It also sets the color textures and depth stencil texture arrays to an empty array.
 

--- a/files/en-us/web/api/xrcompositionlayer/layout/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/layout/index.md
@@ -11,10 +11,11 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 
 browser-compat: api.XRCompositionLayer.layout
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`layout`** property of the {{domxref("XRCompositionLayer")}} interface is the layout type of the layer.
 

--- a/files/en-us/web/api/xrcompositionlayer/miplevels/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/miplevels/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCompositionLayer.mipLevels
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`mipLevels`** property of the {{domxref("XRCompositionLayer")}} interface is a layer's number of mip levels in the color and texture data. See also [Mipmap](https://en.wikipedia.org/wiki/Mipmap) on Wikipedia.
 

--- a/files/en-us/web/api/xrcompositionlayer/needsredraw/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/needsredraw/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCompositionLayer.needsRedraw
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`needsRedraw`** property of the {{domxref("XRCompositionLayer")}} interface is a boolean signaling that the layer should be re-rendered in the next frame.
 

--- a/files/en-us/web/api/xrcubelayer/orientation/index.md
+++ b/files/en-us/web/api/xrcubelayer/orientation/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCubeLayer.orientation
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`orientation`** property of the {{domxref("XRCubeLayer")}} interface represents the orientation relative to the `space` property.
 

--- a/files/en-us/web/api/xrcubelayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcubelayer/redraw_event/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCubeLayer.redraw_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `redraw` event is sent to the `XRCubeLayer` object when the underlying resources of the layer are lost or when the XR Compositor can no longer reproject the layer. If this event is sent, authors should redraw the content of the layer in the next XR animation frame.
 

--- a/files/en-us/web/api/xrcubelayer/space/index.md
+++ b/files/en-us/web/api/xrcubelayer/space/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCubeLayer.space
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`space`** property of the {{domxref("XRCubeLayer")}} interface represents the layer's spatial relationship with the user's physical environment.
 

--- a/files/en-us/web/api/xrcylinderlayer/aspectratio/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/aspectratio/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.aspectRatio
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`aspectRatio`** property of the {{domxref("XRCylinderLayer")}} interface represents the ratio of the visible cylinder section. It is the ratio of the width of the visible section of the cylinder divided by its height. The width is calculated by multiplying the {{domxref("XRCylinderLayer.radius", "radius")}} with the {{domxref("XRCylinderLayer.centralAngle", "centralAngle")}}.
 

--- a/files/en-us/web/api/xrcylinderlayer/centralangle/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/centralangle/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.centralAngle
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`centralAngle`** property of the {{domxref("XRCylinderLayer")}} interface represents the angle in radians of the visible section of the cylinder.
 

--- a/files/en-us/web/api/xrcylinderlayer/radius/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/radius/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.radius
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`radius`** property of the {{domxref("XRCylinderLayer")}} interface represents the radius of the cylinder.
 

--- a/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.redraw_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `redraw` event is sent to the `XRCylinderLayer` object when the underlying resources of the layer are lost or when the XR Compositor can no longer reproject the layer. If this event is sent, authors should redraw the content of the layer in the next XR animation frame.
 

--- a/files/en-us/web/api/xrcylinderlayer/space/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/space/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.space
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`space`** property of the {{domxref("XRCylinderLayer")}} interface represents the layer's spatial relationship with the user's physical environment.
 

--- a/files/en-us/web/api/xrcylinderlayer/transform/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/transform/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRCylinderLayer.transform
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`transform`** property of the {{domxref("XRCylinderLayer")}} interface represents the offset and orientation relative to the layer's {{domxref("XRCylinderLayer.space", "space")}}.
 

--- a/files/en-us/web/api/xrequirectlayer/centralhorizontalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/centralhorizontalangle/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.centralHorizontalAngle
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`centralHorizontalAngle`** property of the {{domxref("XREquirectLayer")}} interface represents the central horizontal angle in radians for the sphere.
 

--- a/files/en-us/web/api/xrequirectlayer/lowerverticalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/lowerverticalangle/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.lowerVerticalAngle
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`lowerVerticalAngle`** property of the {{domxref("XREquirectLayer")}} interface represents the lower vertical angle in radians for the sphere.
 

--- a/files/en-us/web/api/xrequirectlayer/radius/index.md
+++ b/files/en-us/web/api/xrequirectlayer/radius/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.radius
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`radius`** property of the {{domxref("XREquirectLayer")}} interface represents the radius of the sphere.
 

--- a/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.redraw_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `redraw` event is sent to the `XREquirectLayer` object when the underlying resources of the layer are lost or when the XR Compositor can no longer reproject the layer. If this event is sent, authors should redraw the content of the layer in the next XR animation frame.
 

--- a/files/en-us/web/api/xrequirectlayer/space/index.md
+++ b/files/en-us/web/api/xrequirectlayer/space/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.space
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`space`** property of the {{domxref("XREquirectLayer")}} interface represents the layer's spatial relationship with the user's physical environment.
 

--- a/files/en-us/web/api/xrequirectlayer/transform/index.md
+++ b/files/en-us/web/api/xrequirectlayer/transform/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.transform
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`transform`** property of the {{domxref("XREquirectLayer")}} interface represents the offset and orientation relative to the layer's {{domxref("XREquirectLayer.space", "space")}}.
 

--- a/files/en-us/web/api/xrequirectlayer/upperverticalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/upperverticalangle/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XREquirectLayer.upperVerticalAngle
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`upperVerticalAngle`** property of the {{domxref("XREquirectLayer")}} interface represents the upper vertical angle in radians for the sphere.
 

--- a/files/en-us/web/api/xrlayerevent/layer/index.md
+++ b/files/en-us/web/api/xrlayerevent/layer/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRLayerEvent.layer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`layer`** property of the {{domxref("XRLayerEvent")}} interface is a reference to the {{domxref("XRLayer")}} which generated the event.
 

--- a/files/en-us/web/api/xrlayerevent/xrlayerevent/index.md
+++ b/files/en-us/web/api/xrlayerevent/xrlayerevent/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRLayerEvent.XRLayerEvent
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRLayerEvent`** constructor creates and returns a new {{domxref("XRLayerEvent")}} object. These events relate to a change of state of an {{domxref("XRLayer")}} object.
 

--- a/files/en-us/web/api/xrmediabinding/createcylinderlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createcylinderlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRMediaBinding.createCylinderLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createCylinderLayer()`** method of the {{domxref("XRMediaBinding")}} interface returns an {{domxref("XRCylinderLayer")}} object which is a layer that takes up a curved rectangular space in the virtual environment.
 

--- a/files/en-us/web/api/xrmediabinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createequirectlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRMediaBinding.createEquirectLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createEquirectLayer()`** method of the {{domxref("XRMediaBinding")}} interface returns an {{domxref("XREquirectLayer")}} object which is a layer that maps an equirectangular coded data onto the inside of a sphere.
 

--- a/files/en-us/web/api/xrmediabinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createquadlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRMediaBinding.createQuadLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createQuadLayer()`** method of the {{domxref("XRMediaBinding")}} interface returns an {{domxref("XRQuadLayer")}} object which is a layer that takes up a flat rectangular space in the virtual environment.
 

--- a/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
+++ b/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - WebXR
   - XR
+  - Experimental
 browser-compat: api.XRMediaBinding.XRMediaBinding
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRMediaBinding()`** constructor creates and returns a new {{domxref("XRMediaBinding")}} object.
 

--- a/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRProjectionLayer.fixedFoveation
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`fixedFoveation`** property of the {{domxref("XRProjectionLayer")}} interface is a number indicating the amount of foveation used by the XR compositor for the layer. Fixed Foveated Rendering (FFR) renders the edges of the eye textures at a lower resolution than the center and reduces the GPU load.
 

--- a/files/en-us/web/api/xrprojectionlayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/ignoredepthvalues/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRProjectionLayer.ignoreDepthValues
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`ignoreDepthValues`** property of the {{domxref("XRProjectionLayer")}} interface is a boolean indicating if the XR compositor is not making use of depth buffer values when rendering the layer.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for WebXr

Pulling files that require only the experimental header.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.