### PR TITLE
WebXr: update BCD Info

### DIFF
--- a/files/en-us/web/api/xrprojectionlayer/texturearraylength/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/texturearraylength/index.md
@@ -12,9 +12,10 @@ tags:
   - WebXR Device API
   - XR
   - NeedsExample
+  - Experimental
 browser-compat: api.XRProjectionLayer.textureArrayLength
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`textureArrayLength`** property of the {{domxref("XRProjectionLayer")}} interface indicates layer's layer count for array textures when using `texture-array` as the `textureType`.
 

--- a/files/en-us/web/api/xrprojectionlayer/textureheight/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/textureheight/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRProjectionLayer.textureHeight
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`textureHeight`** property of the {{domxref("XRProjectionLayer")}} interface indicates the height in pixels of the color textures of this layer.
 

--- a/files/en-us/web/api/xrprojectionlayer/texturewidth/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/texturewidth/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRProjectionLayer.textureWidth
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`textureWidth`** property of the {{domxref("XRProjectionLayer")}} interface indicates the width in pixels of the color textures of this layer.
 

--- a/files/en-us/web/api/xrquadlayer/height/index.md
+++ b/files/en-us/web/api/xrquadlayer/height/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRQuadLayer.height
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`height`** property of the {{domxref("XRQuadLayer")}} interface represents the height of the layer in meters.
 

--- a/files/en-us/web/api/xrquadlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrquadlayer/redraw_event/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRQuadLayer.redraw_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `redraw` event is sent to the `XRQuadLayer` object when the underlying resources of the layer are lost or when the XR Compositor can no longer reproject the layer. If this event is sent, authors should redraw the content of the layer in the next XR animation frame.
 

--- a/files/en-us/web/api/xrquadlayer/space/index.md
+++ b/files/en-us/web/api/xrquadlayer/space/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRQuadLayer.space
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`space`** property of the {{domxref("XRQuadLayer")}} interface represents the layer's spatial relationship with the user's physical environment.
 

--- a/files/en-us/web/api/xrquadlayer/transform/index.md
+++ b/files/en-us/web/api/xrquadlayer/transform/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRQuadLayer.transform
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`transform`** property of the {{domxref("XRQuadLayer")}} interface represents the offset and orientation relative to the layer's {{domxref("XRQuadLayer.space", "space")}}.
 

--- a/files/en-us/web/api/xrquadlayer/width/index.md
+++ b/files/en-us/web/api/xrquadlayer/width/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRQuadLayer.width
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`width`** property of the {{domxref("XRQuadLayer")}} interface represents the width of the layer in meters.
 

--- a/files/en-us/web/api/xrrenderstate/layers/index.md
+++ b/files/en-us/web/api/xrrenderstate/layers/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRRenderState.layers
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`layers`** property of the {{domxref("XRRenderState")}} interface is an ordered array containing {{domxref("XRLayer")}} objects that are displayed by the XR compositor.
 

--- a/files/en-us/web/api/xrsubimage/viewport/index.md
+++ b/files/en-us/web/api/xrsubimage/viewport/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRSubImage.viewport
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`viewport`** property of the {{domxref("XRSubImage")}} interface represents the {{domxref("XRViewport")}} that is used when rendering the sub image.
 

--- a/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.createCubeLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createCubeLayer()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRCubeLayer")}} object, which is a layer that renders directly from a [cubemap](https://en.wikipedia.org/wiki/Cube_mapping), and projects it onto the inside faces of a cube.
 

--- a/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.createCylinderLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createCylinderLayer()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRCylinderLayer")}} object, which is a layer that takes up a curved rectangular space in the virtual environment.
 

--- a/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.createEquirectLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createEquirectLayer()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XREquirectLayer")}} object, which is a layer that maps [equirectangular](https://en.wikipedia.org/wiki/Equirectangular_projection) coded data onto the inside of a sphere.
 

--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.createProjectionLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createProjectionLayer()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRProjectionLayer")}} object which is a layer that fills the entire view of the observer and is refreshed close to the device's native frame rate.
 

--- a/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.createQuadLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createQuadLayer()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRQuadLayer")}} object which is a layer that takes up a flat rectangular space in the virtual environment.
 

--- a/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.getSubImage
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getSubImage()`** method of the {{domxref("XRWebGLBinding")}} interface returns a {{domxref("XRWebGLSubImage")}} object representing the WebGL texture to render.
 

--- a/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.getViewSubImage
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getViewSubImage()`** method of the {{domxref("XRWebGLBinding")}} interface returns a {{domxref("XRWebGLSubImage")}} object representing the WebGL texture to render for a view.
 

--- a/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
+++ b/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLBinding.nativeProjectionScaleFactor
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`nativeProjectionScaleFactor`** property of the {{domxref("XRWebGLBinding")}} interface represents the scaling factor by which the projection layer's resolution is multiplied by to get the native resolution of the WebXR device's frame buffer.
 

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.md
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.md
@@ -22,9 +22,10 @@ tags:
   - appearance
   - augmented
   - rendering
+  - Experimental
 browser-compat: api.XRWebGLLayer.antialias
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRWebGLLayer")}} property
 **`antialias`** is a Boolean value which is `true`

--- a/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
@@ -11,10 +11,11 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 
 browser-compat: api.XRWebGLLayer.fixedFoveation
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`fixedFoveation`** property of the {{domxref("XRWebGLLayer")}} interface is a number indicating the amount of foveation used by the XR compositor. Fixed Foveated Rendering (FFR) renders the edges of the eye textures at a lower resolution than the center and reduces the GPU load.
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -19,9 +19,10 @@ tags:
   - XRWebGLLayer
   - augmented
   - framebuffer
+  - Experimental
 browser-compat: api.XRWebGLLayer.framebuffer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRWebGLLayer")}} property
 **`framebuffer`** is an opaque {{domxref("WebGLFramebuffer")}}

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
@@ -22,9 +22,10 @@ tags:
   - framebufferHeight
   - height
   - size
+  - Experimental
 browser-compat: api.XRWebGLLayer.framebufferHeight
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRWebGLLayer")}} property
 **`framebufferHeight`** indicates the height of the

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - framebufferWidth
   - width
+  - Experimental
 browser-compat: api.XRWebGLLayer.framebufferWidth
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRWebGLLayer")}} property
 **`framebufferWidth`** specifies the width of the framebuffer,

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.md
@@ -24,9 +24,10 @@ tags:
   - getNativeFramebufferScaleFactor
   - native
   - resolution
+  - Experimental
 browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The static method
 **`XRWebGLLayer.getNativeFramebufferScaleFactor()`** returns a

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -20,9 +20,10 @@ tags:
   - augmented
   - getViewport
   - viewport
+  - Experimental
 browser-compat: api.XRWebGLLayer.getViewport
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRWebGLLayer")}} interface's
 **`getViewport()`** method returns the

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
@@ -20,9 +20,10 @@ tags:
   - XRWebGLLayer
   - augmented
   - ignoreDepthValues
+  - Experimental
 browser-compat: api.XRWebGLLayer.ignoreDepthValues
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRWebGLLayer")}} property
 **`ignoreDepthValues`** is a Boolean value which is

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
@@ -21,9 +21,10 @@ tags:
   - XRWebGLLayer
   - augmented
   - new
+  - Experimental
 browser-compat: api.XRWebGLLayer.XRWebGLLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) **`XRWebGLLayer()`** constructor creates and
 returns a new {{domxref("XRWebGLLayer")}} object, providing the linkage between the

--- a/files/en-us/web/api/xrwebglsubimage/colortexture/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/colortexture/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLSubImage.colorTexture
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`colorTexture`** property of the {{domxref("XRWebGLSubImage")}} interface represents the color {{domxref("WebGLTexture")}} object for the {{domxref("XRCompositionLayer")}} to render.
 

--- a/files/en-us/web/api/xrwebglsubimage/depthstenciltexture/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/depthstenciltexture/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLSubImage.depthStencilTexture
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`depthStencilTexture`** property of the {{domxref("XRWebGLSubImage")}} interface represents the depth/stencil {{domxref("WebGLTexture")}} object for the {{domxref("XRCompositionLayer")}} to render.
 

--- a/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLSubImage.imageIndex
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`imageIndex`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 

--- a/files/en-us/web/api/xrwebglsubimage/textureheight/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/textureheight/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLSubImage.textureHeight
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`textureHeight`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the height in pixels of the GL attachment.
 

--- a/files/en-us/web/api/xrwebglsubimage/texturewidth/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/texturewidth/index.md
@@ -11,9 +11,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.XRWebGLSubImage.textureWidth
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`textureWidth`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the width in pixels of the GL attachment.
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -7,9 +7,10 @@ tags:
   - CSS Property
   - Reference
   - recipe:css-property
+  - Experimental
 browser-compat: css.properties.animation-composition
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies the {{Glossary("composite operation")}} to use when multiple animations affect the same property simultaneously.
 


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for WebXR

Pulling files that require only the experimental header.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.