### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -79,7 +79,7 @@ The following table shows the state of `result` after running this script:
 | `[2]`     | `"Jumps"`                                                          |
 | `index`   | `4`                                                                |
 | `indices` | `[[4, 25], [10, 15], [20, 25]]`<br />`groups: { color: [10, 15 ]}` |
-| `input`   | `4`                                                                |
+| `input`   | `"The Quick Brown Fox Jumps Over The Lazy Dog"`                    |
 | `groups`  | `{ color: "brown" }`                                               |
 
 In addition, `re.lastIndex` will be set to `25`, due to this regex being global.


### PR DESCRIPTION
In the table that shows expected values for `result`, `input` shows 4 (which is incorrect). `input` should have the original string that was matched against, which in this case is "The Quick Brown Fox Jumps Over The Lazy Dog"

#### Summary
In the table that shows expected values for `result`, `input` shows 4 (which is incorrect). `input` should have the original string that was matched against, which in this case is "The Quick Brown Fox Jumps Over The Lazy Dog"

#### Motivation
The docs currently show an incorrect value for this example, which may be confusing for someone who is learning.


#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
