### PR TITLE
Bump engine requirement from 12.0.0 to 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16.0.0 || >=18.0.0"
   },
   "scripts": {
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",


### PR DESCRIPTION
Current configuration says the repo supports node version `>=12.0.0`. But now none of the dependency supports node version below `12.13.0`.
If a contributor, with older node installed, tries to run the scripts may face errors.

Here are the current engine requirements using [ls-engines](https://www.npmjs.com/package/ls-engines) tool:
```bash
> ls-engines
`node_modules` found; loading tree from disk...
┌────────┬─────────────────────────────────────────────────────────────────┐
│ engine │ Currently available latest release of each valid major version: │
├────────┼─────────────────────────────────────────────────────────────────┤
│ node   │ v18.8.0, v17.9.1, v16.17.0                                      │
└────────┴─────────────────────────────────────────────────────────────────┘

┌───────────────────────┬───────────────────────────┐
│ package engines:      │ dependency graph engines: │
├───────────────────────┼───────────────────────────┤
│ "engines": {          │ "engines": {              │
│   "node": ">= 12.0.0" │   "node": ">= 16"         │
│ }                     │ }                         │
└───────────────────────┴───────────────────────────┘


┌────────┬─────────────────┬─────────────────┬──────────────────────────┐
│ engine │ current version │ valid (package) │ valid (dependency graph) │
├────────┼─────────────────┼─────────────────┼──────────────────────────┤
│ node   │ v16.15.0        │ yes!            │ yes!                     │
└────────┴─────────────────┴─────────────────┴──────────────────────────┘

Your “engines” field allows more node versions than your dependency graph does.

┌─────────────────────────────┬─────────────────────────────────────────┐
│ Conflicting dependencies    │ engines.node                            │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @mdn/yari                   │ ^16.0.0 || >=18.0.0                     │
├─────────────────────────────┼─────────────────────────────────────────┤
│ css-tree                    │ ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/arborist            │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/fs                  │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/git                 │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/map-workspaces      │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/metavuln-calculator │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/move-file           │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/node-gyp            │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/package-json        │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/promise-spawn       │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/query               │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ @npmcli/run-script          │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ are-we-there-yet            │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ bin-links                   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-normalize-package-bin   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ cacache                     │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ cmd-shim                    │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ gauge                       │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ get-dep-tree                │ >= 16 || ^14.15 || ^12.13               │
├─────────────────────────────┼─────────────────────────────────────────┤
│ ignore-walk                 │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ image-size                  │ >=14.0.0                                │
├─────────────────────────────┼─────────────────────────────────────────┤
│ ini                         │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ ls-engines                  │ >= 18 || ^16 || ^14.15 || ^12.22        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ make-fetch-happen           │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ markdownlint                │ >=14                                    │
├─────────────────────────────┼─────────────────────────────────────────┤
│ markdownlint-cli            │ >=14                                    │
├─────────────────────────────┼─────────────────────────────────────────┤
│ commander                   │ ^12.20.0 || >=14                        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ minipass-fetch              │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ node-gyp                    │ ^12.22 || ^14.13 || >=16                │
├─────────────────────────────┼─────────────────────────────────────────┤
│ nopt                        │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-install-checks          │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-package-arg             │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ hosted-git-info             │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-packlist                │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-bundled                 │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-normalize-package-bin   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-pick-manifest           │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-normalize-package-bin   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-registry-fetch          │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npmlog                      │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ pacote                      │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ parse-conflict-json         │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ proc-log                    │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ read-cmd-shim               │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ read-package-json           │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ hosted-git-info             │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ normalize-package-data      │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ npm-normalize-package-bin   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ ssri                        │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ treeverse                   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ unique-filename             │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ unique-slug                 │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ validate-npm-package-name   │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
├─────────────────────────────┼─────────────────────────────────────────┤
│ write-file-atomic           │ ^12.13.0 || ^14.15.0 || >=16.0.0        │
└─────────────────────────────┴─────────────────────────────────────────┘


If you want to narrow your support, you can run `ls-engines --save`, or manually add the following to your `package.json`:
"engines": {
  "node": ">= 16"
}
```

So, we can safely update the engine support to `>=16.0.0`.

cc/ @caugner @teoli2003 @nschonni 