### PR TITLE
link-correction MediaElementAudioSourceNode()

### DIFF
--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
@@ -41,7 +41,7 @@ new MediaElementAudioSourceNode(context, options)
       - : A string describing the meaning of the channels. This
         interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
         The possible values are `"speakers"` or `"discrete"`. (See
-        {{domxref("AudioNode.channelCountMode")}} for more information including default
+        {{domxref("AudioNode.channelInterpretation")}} for more information including default
         values.)
 
 ### Return value


### PR DESCRIPTION
#### Summary

Correction of DOM-ref link for MediaElementAudioSourceNode constructor options parameters	

channelInterpretation:

AudioNode.channelCountMode
to
AudioNode.channelInterpretation

https://developer.mozilla.org/en-US/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode#syntax

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
