### PR TITLE
fix the difference between Object methods, and Reflect methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -42,7 +42,7 @@ A {{jsxref("TypeError")}}, if `target` is not an {{jsxref("Object")}}.
 
 The `Reflect.isExtensible` method allows you determine if an object is
 extensible (whether it can have new properties added to it). It is the same method as
-{{jsxref("Object.isExtensible()")}}.
+{{jsxref("Object.isExtensible()")}}, but with some [differences](#difference_to_object.isextensible).
 
 ## Examples
 
@@ -72,15 +72,14 @@ Reflect.isExtensible(frozen)  // === false
 
 If the `target` argument to this method is not an object (a
 primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.isExtensible()")}}, a non-object first argument will be coerced to an
-object at first.
+{{jsxref("Object.isExtensible()")}}, a non-object `target` will return false without any errors.
 
 ```js
 Reflect.isExtensible(1)
 // TypeError: 1 is not an object
 
-Object.isExtensible(1)
-// false
+Object.isExtensible(1);
+// false                         
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -12,10 +12,7 @@ browser-compat: javascript.builtins.Reflect.isExtensible
 ---
 {{JSRef}}
 
-The static
-**`Reflect.isExtensible()`** method determines if an object is
-extensible (whether it can have new properties added to it). It is similar to
-{{jsxref("Object.isExtensible()")}}, but with some [differences](#difference_to_object.isextensible).
+The static **`Reflect.isExtensible()`** method determines if an object is extensible (whether it can have new properties added to it). It is similar to {{jsxref("Object.isExtensible()")}}, but with [some differences](#difference_with_object.isextensible).
 
 {{EmbedInteractiveExample("pages/js/reflect-isextensible.html", "taller")}}
 
@@ -37,12 +34,6 @@ A {{jsxref("Boolean")}} indicating whether or not the target is extensible.
 ### Exceptions
 
 A {{jsxref("TypeError")}}, if `target` is not an {{jsxref("Object")}}.
-
-## Description
-
-The `Reflect.isExtensible` method allows you determine if an object is
-extensible (whether it can have new properties added to it). It is the same method as
-{{jsxref("Object.isExtensible()")}}, but with some [differences](#difference_to_object.isextensible).
 
 ## Examples
 
@@ -68,18 +59,16 @@ const frozen = Object.freeze({});
 Reflect.isExtensible(frozen)  // === false
 ```
 
-### Difference to Object.isExtensible()
+### Difference with Object.isExtensible()
 
-If the `target` argument to this method is not an object (a
-primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.isExtensible()")}}, a non-object `target` will return false without any errors.
+If the `target` argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. With {{jsxref("Object.isExtensible()")}}, a non-object `target` will return false without any errors.
 
 ```js
 Reflect.isExtensible(1)
 // TypeError: 1 is not an object
 
-Object.isExtensible(1);
-// false                         
+Object.isExtensible(1)
+// false
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -42,7 +42,7 @@ A {{jsxref("TypeError")}}, if `target` is not an {{jsxref("Object")}}.
 
 The `Reflect.isExtensible` method allows you determine if an object is
 extensible (whether it can have new properties added to it). It is the same method as
-{{jsxref("Object.isExtensible()")}}.
+{{jsxref("Object.isExtensible()")}}, but with some [differences](#difference_to_object.isextensible).
 
 ## Examples
 
@@ -72,15 +72,18 @@ Reflect.isExtensible(frozen)  // === false
 
 If the `target` argument to this method is not an object (a
 primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.isExtensible()")}}, a non-object first argument will be coerced to an
-object at first.
+{{jsxref("Object.isExtensible()")}}, a non-object `target` will throw a {{jsxref("TypeError")}} in ES5,
+but in ES2015 it will return false without any errors, since primitives are already, by definition, immutable.
 
 ```js
 Reflect.isExtensible(1)
 // TypeError: 1 is not an object
 
-Object.isExtensible(1)
-// false
+Object.isExtensible(1);
+// TypeError: 1 is not an object (ES5 code)
+
+Object.isExtensible(1);
+// false                         (ES2015 code)
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -67,15 +67,18 @@ Reflect.isExtensible(empty)  // === false
 
 If the `target` argument to this method is not an object (a
 primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.preventExtensions()")}}, a non-object `target`
-will be coerced to an object.
+{{jsxref("Object.preventExtensions()")}}, a non-object `target` will throw a {{jsxref("TypeError")}} in ES5, 
+but in ES2015 it will be returned as-is without any errors, since primitives are already, by definition, immutable.
 
 ```js
 Reflect.preventExtensions(1);
 // TypeError: 1 is not an object
 
 Object.preventExtensions(1);
-// 1
+// TypeError: 1 is not an object (ES5 code)
+
+Object.preventExtensions(1);
+// 1                             (ES2015 code)
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -12,11 +12,7 @@ browser-compat: javascript.builtins.Reflect.preventExtensions
 ---
 {{JSRef}}
 
-The static
-**`Reflect.preventExtensions()`** method prevents new
-properties from ever being added to an object (i.e., prevents future extensions to the
-object). It is similar to {{jsxref("Object.preventExtensions()")}}, but with
-some [differences](#difference_from_object.preventextensions).
+The static **`Reflect.preventExtensions()`** method prevents new properties from ever being added to an object (i.e., prevents future extensions to the object). It is similar to {{jsxref("Object.preventExtensions()")}}, but with [ somedifferences](#difference_with_object.preventextensions).
 
 {{EmbedInteractiveExample("pages/js/reflect-preventextensions.html")}}
 
@@ -33,20 +29,11 @@ Reflect.preventExtensions(target)
 
 ### Return value
 
-A {{jsxref("Boolean")}} indicating whether or not the target was successfully set to
-prevent extensions.
+A {{jsxref("Boolean")}} indicating whether or not the target was successfully set to prevent extensions.
 
 ### Exceptions
 
-A {{jsxref("TypeError")}}, if `target` is not an
-{{jsxref("Object")}}.
-
-## Description
-
-The `Reflect.preventExtensions()` method allows you to prevent new
-properties from ever being added to an object (i.e., prevents future extensions to the
-object). It is similar to {{jsxref("Object.preventExtensions()")}}, but with
-some [differences](#difference_from_object.preventextensions).
+A {{jsxref("TypeError")}}, if `target` is not an {{jsxref("Object")}}.
 
 ## Examples
 
@@ -64,17 +51,15 @@ Reflect.preventExtensions(empty);
 Reflect.isExtensible(empty)  // === false
 ```
 
-### Difference from Object.preventExtensions()
+### Difference with Object.preventExtensions()
 
-If the `target` argument to this method is not an object (a
-primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.preventExtensions()")}}, a non-object `target` will be returned as-is without any errors.
+If the `target` argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. With {{jsxref("Object.preventExtensions()")}}, a non-object `target` will be returned as-is without any errors.
 
 ```js
-Reflect.preventExtensions(1);
+Reflect.preventExtensions(1)
 // TypeError: 1 is not an object
 
-Object.preventExtensions(1);
+Object.preventExtensions(1)
 // 1
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -67,8 +67,7 @@ Reflect.isExtensible(empty)  // === false
 
 If the `target` argument to this method is not an object (a
 primitive), then it will cause a {{jsxref("TypeError")}}. With
-{{jsxref("Object.preventExtensions()")}}, a non-object `target`
-will be coerced to an object.
+{{jsxref("Object.preventExtensions()")}}, a non-object `target` will be returned as-is without any errors.
 
 ```js
 Reflect.preventExtensions(1);


### PR DESCRIPTION
#### Summary
since Object.isExtinsible() and Object.preventExtensions() behvior is different from specs, so we should modify this.

check this: #20221

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
