### PR TITLE
fix Object.freeze() description to match specs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -40,7 +40,7 @@ The object that was passed to the function.
 
 ## Description
 
-Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`, unless they are of accessor descriptor flavor it only sets `configurable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
+Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors'](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) `configurable` to `false` — and for data properties, `writable` to `false` as well. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
 
 For data properties of a frozen object, their values cannot be changed since the writable and
 configurable attributes are set to false. Accessor properties (getters and setters) work the same (and still give the illusion that you are changing the value).Note that values

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -43,7 +43,7 @@ The object that was passed to the function.
 Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors'](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) `configurable` to `false` — and for data properties, `writable` to `false` as well. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
 
 For data properties of a frozen object, their values cannot be changed since the writable and
-configurable attributes are set to false. Accessor properties (getters and setters) work the same (and still give the illusion that you are changing the value).Note that values
+configurable attributes are set to false. Accessor properties (getters and setters) work the same — the property value returned by the getter may still change, and the setter can still be called without throwing errors when setting the property. Note that values
 that are objects can still be modified, unless they are also frozen. As an object, an
 array can be frozen; after doing so, its elements cannot be altered and no elements can
 be added to or removed from the array.

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Object.freeze
 ---
 {{JSRef}}
 
-The **`Object.freeze()`** method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
+The **`Object.freeze()`** method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed unless its descriptor is accessor descriptor and has a setter inside, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
 
 Freezing an object is the highest integrity level that JavaScript provides.
 
@@ -40,11 +40,10 @@ The object that was passed to the function.
 
 ## Description
 
-Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
+Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`, unless they are of accessor descriptor flavor it only sets `configurable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
 
 For data properties of a frozen object, their values cannot be changed since the writable and
-configurable attributes are set to false. Accessor properties (getters and setters) work
-the same (and still give the illusion that you are changing the value). Note that values
+configurable attributes are set to false. Accessor properties (getters and setters) behaves differently as only configurable is set to false, so its values can be modified if there is a setter for it. Note that values
 that are objects can still be modified, unless they are also frozen. As an object, an
 array can be frozen; after doing so, its elements cannot be altered and no elements can
 be added to or removed from the array.

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -40,11 +40,10 @@ The object that was passed to the function.
 
 ## Description
 
-Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
+Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`, unless they are accessor descriptor it only sets `configurable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
 
 For data properties of a frozen object, their values cannot be changed since the writable and
-configurable attributes are set to false. Accessor properties (getters and setters) work
-the same (and still give the illusion that you are changing the value). Note that values
+configurable attributes are set to false. Accessor properties (getters and setters) behaves differently as only configurable is set to false, so its values can be modified if there is a setter for it. Note that values
 that are objects can still be modified, unless they are also frozen. As an object, an
 array can be frozen; after doing so, its elements cannot be altered and no elements can
 be added to or removed from the array.

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Object.freeze
 ---
 {{JSRef}}
 
-The **`Object.freeze()`** method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed unless its descriptor is accessor descriptor and has a setter inside, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
+The **`Object.freeze()`** method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
 
 Freezing an object is the highest integrity level that JavaScript provides.
 
@@ -43,7 +43,7 @@ The object that was passed to the function.
 Freezing an object is equivalent to [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and then changing all existing [properties' descriptors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) to `configurable: false, writable: false`, unless they are of accessor descriptor flavor it only sets `configurable: false`. Nothing can be added to or removed from the properties set of a frozen object. Any attempt to do so will fail, either silently or by throwing a {{jsxref("TypeError")}} exception (most commonly, but not exclusively, when in {{jsxref("Strict_mode", "strict mode", "", 1)}}).
 
 For data properties of a frozen object, their values cannot be changed since the writable and
-configurable attributes are set to false. Accessor properties (getters and setters) behave differently as only configurable is set to false, so their values can be modified if there is a setter for it. Note that values
+configurable attributes are set to false. Accessor properties (getters and setters) work the same (and still give the illusion that you are changing the value).Note that values
 that are objects can still be modified, unless they are also frozen. As an object, an
 array can be frozen; after doing so, its elements cannot be altered and no elements can
 be added to or removed from the array.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Object.freeze() behaves differently according to to object descriptor type.
it will modify only accessor descriptor configurable value while modifying data descriptor writable, and configurable.
this is somehow not expected behavior but this is how specs say.

