### PR TITLE
Provide sidebars to WebDriver pages

### DIFF
--- a/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
+++ b/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
@@ -7,6 +7,9 @@ tags:
   - capabilities
   - acceptInsecureCerts
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}
+
 The **`acceptInsecureCerts` capability** communicates whether expired or invalid [TLS certificates](/en-US/docs/Glossary/TLS) are checked when [navigating](/en-US/docs/Web/WebDriver/Commands/NavigateTo). When the capability is false, an [insecure certificate](/en-US/docs/Web/WebDriver/Errors/InsecureCertificate) error will be returned as navigation encounters domains with certificate problems. Otherwise, self-signed or otherwise invalid certificates will be implicitly trusted by the browser on navigation. The capability has effect for the lifetime of the session.
 
 ## Example

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -8,6 +8,9 @@ tags:
   - Extension capabilities
   - firefoxOptions
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}
+
 The **`moz:firefoxOptions` capability** is a namespaced set of
 capabilities specific to [Firefox](https://www.mozilla.org/en-US/firefox/). It is used to control the
 behavior of Firefox and can be used as a member of

--- a/files/en-us/web/webdriver/capabilities/index.md
+++ b/files/en-us/web/webdriver/capabilities/index.md
@@ -6,6 +6,9 @@ tags:
   - WebDriver
   - capabilities
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}
+
 WebDriver **_capabilities_** are used to communicate the features supported by a [session](/en-US/docs/Web/WebDriver). A client may also use capabilities to define which features it requires the driver to satisfy when [creating a new session](/en-US/docs/Web/WebDriver/Commands/NewSession).
 
 When a WebDriver session is created it returns a set of capabilities describing the negotiated, effective capabilities of the session. Some of the capabilities included in this set are [standard and shared between all browsers](#list-of-capabilities), but the set may also contain [browser-specific capabilities](#vendor-specific-capabilities) and these are always prefixed.
@@ -154,5 +157,3 @@ But because there is only one `firstMatch` arm, and we know that session creatio
 
 - [New Session](/en-US/docs/Web/WebDriver/Commands/NewSession) command
 - [Delete Session](/en-US/docs/Web/WebDriver/Commands/NewSession) command
-
-{{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.md
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.md
@@ -7,6 +7,9 @@ tags:
   - capabilities
   - webSocketUrl
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}
+
 With the `webSocketUrl` capability set to `true` a WebSocket server will be started in the browser, supporting bidirectional communication by using the [WebDriver BiDi protocol](https://w3c.github.io/webdriver-bidi/).
 When the [New Session](/en-US/docs/Web/WebDriver/Commands/NewSession) request has the `webSocketUrl` capability set to `true`, and the session starts successfully, the value of the `capabilities` field in the response will have a `webSocketUrl` property set to the URL of the WebSocket server.
 

--- a/files/en-us/web/webdriver/commands/closewindow/index.md
+++ b/files/en-us/web/webdriver/commands/closewindow/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.CloseWindow
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Close Window_ [command](/en-US/docs/Web/WebDriver/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API closes the current top-level browsing context (window or tab) and returns with the list of currently open [`WebWindow`](/en-US/docs/Web/WebDriver/WebWindow)s. If it is the last window that is being closed, the WebDriver session will implicitly be deleted. Subsequent commands after the session is ended will therefore cause [invalid session ID](/en-US/docs/Web/WebDriver/Errors/InvalidSessionID) errors.
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/getelementattribute/index.md
+++ b/files/en-us/web/webdriver/commands/getelementattribute/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetElementAttribute
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Element Attribute_ [command](/en-US/docs/Web/WebDriver/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the attribute of the referenced [web element](/en-US/docs/Web/WebDriver/WebElement). If for example the element is an {{HTMLElement("img")}}, the returned attribute is `"//TODO"`, which is equivalent to calling {{domxref("Element.getAttribute")}} on the element. For XML/XHTML documents it may be cased differently.
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/getelementproperty/index.md
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetElementProperty
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Element Property_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the property of the referenced [web element](/en-US/docs/Web/WebDriver/WebElement). Given `<input value=foo>` where the user changes the value to `bar`, the returned property is `bar` rather than the initial value `foo`. This is equivalent to calling {{domxref("Element.getProperty")}} on the element.
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/getelementtagname/index.md
+++ b/files/en-us/web/webdriver/commands/getelementtagname/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetElementTagName
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Element Tag Name_ [command](/en-US/docs/Web/WebDriver/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the tag name of the referenced [web element](/en-US/docs/Web/WebDriver/WebElement). If for example the element is an {{HTMLElement("img")}}, the returned tag name is `"IMG"`, which is equivalent to calling {{domxref("Element.tagName")}} on the element. For XML/XHTML documents it may be cased differently.
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/gettimeouts/index.md
+++ b/files/en-us/web/webdriver/commands/gettimeouts/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetTimeouts
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Timeouts_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the timeouts associated with the current session. The [session timeout](/en-US/docs/Web/WebDriver/Timeouts) durations control such behavior as timeouts on [script injection](/en-US/docs/Web/WebDriver/Timeouts#script), [document navigation](/en-US/docs/Web/WebDriver/Timeouts#pageload), and [element retrieval](/en-US/docs/Web/WebDriver/Timeouts#implicit).
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/getwindowhandles/index.md
+++ b/files/en-us/web/webdriver/commands/getwindowhandles/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetWindowHandles
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Window Handles_ [command](/en-US/docs/Web/WebDriver/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns a list of all [`WebWindow`](/en-US/docs/Web/WebDriver/WebWindow)s. Each tab or window, depending on whether you are using a tabbed browser, is associated by a _window handle_ that is used as a reference when [switching to the window](/en-US/docs/Web/WebDriver/Commands/SwitchToWindow).
 
 In order to determine whether or not a particular interaction with the browser opens a new window, one can obtain the set of window handles before the interaction is performed and compare it with the set after the action is performed.

--- a/files/en-us/web/webdriver/commands/getwindowrect/index.md
+++ b/files/en-us/web/webdriver/commands/getwindowrect/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.GetWindowRect
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Get Window Rect_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the size and position of the given [`WebElement`](/en-US/docs/Web/WebDriver/WebElement). Many [WebDriver clients](/en-US/docs/Web/WebDriver/Clients) present separate API methods for getting an element's location and dimensions, but as an optimization they both use this primitive.
 
 The command operates on the currently selected window, and returns size and position of the operating system window. The returned [`WindowRect`](/en-US/docs/Web/WebDriver/WindowRect) can be used as input for the [Set Window Rect](/en-US/docs/Web/WebDriver/SetWindowRect) command, which is for manipulating a window's position and dimensions.

--- a/files/en-us/web/webdriver/commands/index.md
+++ b/files/en-us/web/webdriver/commands/index.md
@@ -8,6 +8,9 @@ tags:
   - commands
 browser-compat: webdriver.commands
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}
+
 The following is a list of the available WebDriver commands.
 
 {{SubpagesWithSummaries}}
@@ -15,5 +18,3 @@ The following is a list of the available WebDriver commands.
 ## Browser compatibility
 
 {{Compat}}
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}

--- a/files/en-us/web/webdriver/commands/new_window/index.md
+++ b/files/en-us/web/webdriver/commands/new_window/index.md
@@ -3,6 +3,9 @@ title: New Window
 slug: Web/WebDriver/Commands/New_Window
 browser-compat: webdriver.commands.NewWindow
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _New Window_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API opens a new top-level browsing context of type _window_ or _tab_, and returns with a dictionary containing the _handle_ of the new [WebWindow](/en-US/docs/Web/WebDriver/WebWindow) and its created _type_. If the requested _type_ cannot be created by the browser, the alternative type will be tried to create.
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/settimeouts/index.md
+++ b/files/en-us/web/webdriver/commands/settimeouts/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.SetTimeouts
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
+
 The _Set Timeouts_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets the timeouts associated with the current session. The [session timeout](/en-US/docs/Web/WebDriver/Timeouts) durations control such behavior as timeouts on [script injection](/en-US/docs/Web/WebDriver/Timeouts#script), [document navigation](/en-US/docs/Web/WebDriver/Timeouts#pageload), and [element retrieval](/en-US/docs/Web/WebDriver/Timeouts#implicit).
 
 ## Syntax

--- a/files/en-us/web/webdriver/commands/setwindowrect/index.md
+++ b/files/en-us/web/webdriver/commands/setwindowrect/index.md
@@ -8,6 +8,9 @@ tags:
   - WebDriver
 browser-compat: webdriver.commands.SetWindowRect
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/commands")}}
+
 The _Set Window Rect_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API alters the size and position of the operating system window associated with the current [`window`](/en-US/docs/Web/API/Window). The command acts as the setter of [Get Window Rect](/en-US/docs/Web/WebDriver/Commands/GetWindowRect), which return object you can pass directly as this command's payload.
 
 Certain subsets of devices do not support setting the window dimensions or its position. On these configurations the command will return an [unsupported operating](/en-US/docs/Web/WebDriver/Errors/UnsupportedOperation) error. To avoid running into situations where calling this might error it is possible to call it conditionally on whether the [`setWindowRect` capability](/en-US/docs/Web/WebDriver/Capabilities/setWindowRect) is set to true for the session.
@@ -94,5 +97,3 @@ The response payload is a [`WindowRect`](/en-US/docs/Web/WebDriver/WebWindow)[:]
   - [Get Window Handle](/en-US/docs/Web/WebDriver/Commands/GetWindowHandle)
   - [Get Window Handles](/en-US/docs/Web/WebDriver/Commands/GetWindowHandles)
   - [Close Window](/en-US/docs/Web/WebDriver/Commands/CloseWindow)
-
-{{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/errors/index.md
+++ b/files/en-us/web/webdriver/errors/index.md
@@ -8,6 +8,9 @@ tags:
   - Web
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages}}
+
 Any WebDriver [command](/en-US/docs/Web/WebDriver/Commands) that is sent to might plausibly receive an error [response](/en-US/docs/Web/WebDriver/Response). An error is represented by an [HTTP response](/en-US/docs/Web/HTTP) with an [HTTP status code](/en-US/docs/Web/HTTP/Status) in the 4xx or 5xx range, and a JSON payload holding details of the error.
 
 ## Payload
@@ -94,5 +97,3 @@ In most [clients](/en-US/docs/Web/WebDriver/Clients) the error would be represen
 
 - [WebDriver responses](/en-US/docs/Web/WebDriver/Response)
 - [WebDriver commands](/en-US/docs/Web/WebDriver/Commands)
-
-{{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/errors/insecurecertificate/index.md
+++ b/files/en-us/web/webdriver/errors/insecurecertificate/index.md
@@ -7,6 +7,9 @@ tags:
   - WebDriver
   - insecure certificate
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **insecure certificate** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when the remotely controlled browser hits a certificate warning of any kind. This is usually the result of [navigating](/en-US/docs/Web/WebDriver/Commands/NavigateTo) to a website with an expired or invalid [TLS certificate](/en-US/docs/Glossary/TLS). Examples of invalid certificates include self-signed, revoked, and cryptographically insecure certificates.
 
 Web browsers prevent and block traffic to domains with broken certificates since the communication with the server would be compromised. It is strongly recommended to fix the certificate situation instead of disabling certificate checks, even in test environments.

--- a/files/en-us/web/webdriver/errors/invalidargument/index.md
+++ b/files/en-us/web/webdriver/errors/invalidargument/index.md
@@ -7,6 +7,9 @@ tags:
   - WebDriver
   - invalid argument
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **invalid argument** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when the arguments passed to a [command](/en-US/docs/Web/WebDriver/Commands) are either invalid or malformed.
 
 Invalid argument errors can be likened to [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)s in [JavaScript](/en-US/docs/Web/JavaScript), in that they can occur for a great many APIs when the input value is not of the expected type or malformed in some way. See the type- and bounds constraints for each [WebDriver command](/en-US/docs/Web/WebDriver/Commands).

--- a/files/en-us/web/webdriver/errors/invalidcookiedomain/index.md
+++ b/files/en-us/web/webdriver/errors/invalidcookiedomain/index.md
@@ -7,6 +7,9 @@ tags:
   - WebDriver
   - invalid cookie domain
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **invalid cookie domain** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when an illegal attempt was made to set a [cookie](/en-US/docs/Glossary/Cookie) under a different [domain](/en-US/docs/Glossary/Domain) than that of the current document.
 
 In WebDriver it is not permissible to set cookies for other domains than the domain of the [current browsing context](/en-US/docs/Glossary/Browsing_context)'s [document](/en-US/docs/Web/API/Document)'s domain.

--- a/files/en-us/web/webdriver/errors/invalidselector/index.md
+++ b/files/en-us/web/webdriver/errors/invalidselector/index.md
@@ -7,6 +7,9 @@ tags:
   - WebDriver
   - invalid selector
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **invalid selector** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when an element retrieval command is used with an unknown [web element](/en-US/docs/Web/WebDriver/WebElement) selector strategy.
 
 The available selector strategies are [CSS](/en-US/docs/Web/WebDriver/WebElement#css-selector), [link text](/en-US/docs/Web/WebDriver/WebElement#link-text-selector), [partial link text](/en-US/docs/Web/WebDriver/WebElement#partial-link-text-selector), [tag name](/en-US/docs/Web/WebDriver/WebElement#tag-name-selector), and [XPath](/en-US/docs/Web/WebDriver/WebElement#tag-name-selector). Any other selector strategy is rejected with this error.

--- a/files/en-us/web/webdriver/errors/invalidsessionid/index.md
+++ b/files/en-us/web/webdriver/errors/invalidsessionid/index.md
@@ -7,6 +7,9 @@ tags:
   - WebDriver
   - invalid session id
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **invalid session ID** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when the server does not recognize the unique session identifier. This happens if the [session has been deleted](/en-US/docs/Web/WebDriver/Commands/DeleteSession) or if the session ID is invalid.
 
 ## Example

--- a/files/en-us/web/webdriver/errors/javascripterror/index.md
+++ b/files/en-us/web/webdriver/errors/javascripterror/index.md
@@ -7,6 +7,9 @@ tags:
   - Reference
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **JavaScript** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when a script the supplied by the user fails to execute.
 
 The underlying cause of the execution error is often supplied in the error message, along with a stacktrace provided by the JavaScript engine in the browser.

--- a/files/en-us/web/webdriver/errors/scripttimeout/index.md
+++ b/files/en-us/web/webdriver/errors/scripttimeout/index.md
@@ -7,6 +7,9 @@ tags:
   - Script timeout
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **script timeout** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when a script the user has provided did not complete before the session's [script timeout](/en-US/docs/Web/WebDriver/Capabilities#script-timeout) duration expired.
 
 The script timeout duration is a configurable capability, which means you can change how long it will take before the driver interrupts an injected script. The driver will by default wait 30 seconds before interrupting the script and returning with a script timeout error, but this can be both extended, limited, and be set to indefinite.

--- a/files/en-us/web/webdriver/errors/staleelementreference/index.md
+++ b/files/en-us/web/webdriver/errors/staleelementreference/index.md
@@ -7,6 +7,9 @@ tags:
   - Stale element reference
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **stale element reference** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs because the referenced [web element](/en-US/docs/Web/WebDriver/WebElement) is no longer attached to the [DOM](/en-US/docs/Glossary/DOM).
 
 Every DOM element is represented in WebDriver by a unique identifying reference, known as a _[web element](/en-US/docs/Web/WebDriver/WebElement)_.

--- a/files/en-us/web/webdriver/errors/unknowncommand/index.md
+++ b/files/en-us/web/webdriver/errors/unknowncommand/index.md
@@ -7,6 +7,9 @@ tags:
   - Unknown command
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **unknown command** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when the driver does not recognize the command/HTTP endpoint.
 
 ## Examples

--- a/files/en-us/web/webdriver/errors/unknownerror/index.md
+++ b/files/en-us/web/webdriver/errors/unknownerror/index.md
@@ -7,6 +7,9 @@ tags:
   - Unknown error
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **unknown element** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when an unspecified error occurs in the driver whilst processing a [command](/en-US/docs/Web/WebDriver/Commands).
 
 An unknown error will usually be specific to a particular driver, so it's a good idea to read the error message, if any, for an indication of what happened.

--- a/files/en-us/web/webdriver/errors/unknownmethod/index.md
+++ b/files/en-us/web/webdriver/errors/unknownmethod/index.md
@@ -7,6 +7,9 @@ tags:
   - Unknown method
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}
+
 The **unknown method** error is a [WebDriver error](/en-US/docs/Web/WebDriver/Errors) that occurs when the driver does not recognize the [HTTP request method](/en-US/docs/Web/HTTP/Methods) used for the endpoint.
 
 WebDriver provides a largely REST-ish API and not all endpoints in this API has `GET`, `POST`, and `DELETE` methods. This error occurs when you try to call an endpoint with an HTTP request method it does not support.

--- a/files/en-us/web/webdriver/index.md
+++ b/files/en-us/web/webdriver/index.md
@@ -10,6 +10,9 @@ tags:
   - Web
   - WebDriver
 ---
+
+{{QuickLinksWithSubpages}}
+
 WebDriver is a remote control interface that enables introspection and control of user agents. It provides a platform- and language-neutral wire protocol as a way for out-of-process programs to remotely instruct the behavior of web browsers.
 
 To have the ability to write instruction sets that can be run interchangeably in many browsers on different platforms is critical to deliver a consistent experience to users. With the new wave of developments on the web platform, the increase diversity in devices and demands for real interoperability between the technologies, WebDriver provides tooling for [cross-browser testing](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Introduction).
@@ -87,5 +90,3 @@ This might produce output akin to this:
 
 - [Cross browser testing](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing)
 - [Selenium documentation](https://www.selenium.dev/documentation/)
-
-{{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/timeouts/index.md
+++ b/files/en-us/web/webdriver/timeouts/index.md
@@ -5,6 +5,9 @@ tags:
   - WebDriver
   - timeouts
 ---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}
+
 Associated with a [WebDriver](/en-US/docs/Web/WebDriver) session are various timeout definitions that control behavior for [script injection](#script), [document navigation](#pageload), and [element retrieval](#implicit).
 
 You will find the _[timeouts object](#payload)_ used in a few different contexts. It can be used as configuration when [creating a new session](/en-US/docs/Web/WebDriver/Commands/NewSession) through [capabilities](/en-US/docs/Web/WebDriver/Capabilities), it is returned as part of the matched, effective capabilities after the session has been created, and it is used as input and output for the [Set Timeouts](/en-US/docs/Web/WebDriver/Commands/SetTimeouts) and [Get Timeouts](/en-US/docs/Web/WebDriver/Commands/GetTimeouts) commands.


### PR DESCRIPTION
Uses `{{QuickLinksWithSubpages(...)}}` macro to generate sidebar links.

:notebook: There is also a `{{ListSubpagesForSidebar(...)}}` macro. But root pages were already using `QuickLinksWithSubpages`  so I used the same throughout. 