### PR TITLE
fix: Add some missing parentheses for arrow functions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -13,6 +13,7 @@ tags:
   - XPCOM
   - page scripts
 ---
+
 {{AddonSidebar}}
 
 > **Note:** The techniques described in this section are only available in Firefox, and only from Firefox 49 onwards.
@@ -48,7 +49,7 @@ Let's take a simple example. Suppose a web page loads a script:
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
   </head>
   <body>
     <script src="main.js"></script>
@@ -146,10 +147,10 @@ Define a function in the content script's scope, then export it
 into the page script's scope.
 */
 function notify(message) {
-  browser.runtime.sendMessage({content: `Function call: ${message}`});
+  browser.runtime.sendMessage({ content: `Function call: ${message}` });
 }
 
-exportFunction(notify, window, {defineAs:'notify'});
+exportFunction(notify, window, { defineAs: "notify" });
 ```
 
 This defines a function `notify()`, which just sends its argument to the background script. It then exports the function to the page script's scope. Now the page script can call this function:
@@ -267,12 +268,12 @@ document.dispatchEvent(ev); // true, undefined, "unwrapped", "propC"
 A Promise cannot be cloned directly using `cloneInto`, as Promise is not supported by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). However, the desired result can be achieved using `window.Promise` instead of `Promise`, and then cloning the resolution value like this:
 
 ```js
-let promise = new window.Promise(resolve => {
+const promise = new window.Promise((resolve) => {
   // if just a primitive, then cloneInto is not needed:
   // resolve("string is a primitive");
 
   // if not a primitive, such as an object, then the value must be cloned
-  let result = { exampleKey: "exampleValue" };
+  const result = { exampleKey: "exampleValue" };
   resolve(cloneInto(result, window));
 });
 // now the promise can be passed to the web page

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -8,6 +8,7 @@ tags:
   - Intermediate
   - Tutorial
 ---
+
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
 
 Until now we haven't looked at the actual pixels of our canvas. With the `ImageData` object you can directly read and write a data array to manipulate pixel data. We will also look into how image smoothing (anti-aliasing) can be controlled and how to save images from your canvas.
@@ -30,7 +31,7 @@ The {{jsxref("Uint8ClampedArray")}} contains `height` × `width` × 4 bytes of d
 For example, to read the blue component's value from the pixel at column 200, row 50 in the image, you would do the following:
 
 ```js
-blueComponent = imageData.data[((50 * (imageData.width * 4)) + (200 * 4)) + 2];
+const blueComponent = imageData.data[50 * (imageData.width * 4) + 200 * 4 + 2];
 ```
 
 If given a set of coordinates (X and Y), you may end up doing something like this:
@@ -92,17 +93,16 @@ In this example we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRe
 
 ```js
 const img = new Image();
-img.crossOrigin = 'anonymous';
-img.src = './assets/rhino.jpg';
-const canvas = document.getElementById('canvas');
-const ctx = canvas.getContext('2d');
-img.addEventListener('load', () => {
+img.crossOrigin = "anonymous";
+img.src = "./assets/rhino.jpg";
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
+img.addEventListener("load", () => {
   ctx.drawImage(img, 0, 0);
-  img.style.display = 'none';
+  img.style.display = "none";
 });
-const hoveredColor = document.getElementById('hovered-color');
-const selectedColor = document.getElementById('selected-color');
-
+const hoveredColor = document.getElementById("hovered-color");
+const selectedColor = document.getElementById("selected-color");
 
 function pick(event, destination) {
   const bounding = canvas.getBoundingClientRect();
@@ -118,8 +118,8 @@ function pick(event, destination) {
   return rgba;
 }
 
-canvas.addEventListener('mousemove', event => pick(event, hoveredColor));
-canvas.addEventListener('click', event => pick(event, selectedColor));
+canvas.addEventListener("mousemove", (event) => pick(event, hoveredColor));
+canvas.addEventListener("click", (event) => pick(event, selectedColor));
 ```
 
 The code's usage is demonstrated in the following live example:
@@ -150,57 +150,57 @@ In this example we iterate over all pixels to change their values, then we put t
 
 ```js
 const img = new Image();
-img.crossOrigin = 'anonymous';
-img.src = './assets/rhino.jpg';
+img.crossOrigin = "anonymous";
+img.src = "./assets/rhino.jpg";
 
-const canvas = document.getElementById('canvas');
-const ctx = canvas.getContext('2d');
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
 
 img.onload = () => {
-    ctx.drawImage(img, 0, 0);
+  ctx.drawImage(img, 0, 0);
 };
 
 const original = () => {
-    ctx.drawImage(img, 0, 0);
+  ctx.drawImage(img, 0, 0);
 };
 
 const invert = () => {
-    ctx.drawImage(img, 0, 0);
-    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    const data = imageData.data;
-    for (let i = 0; i < data.length; i += 4) {
-        data[i]     = 255 - data[i];     // red
-        data[i + 1] = 255 - data[i + 1]; // green
-        data[i + 2] = 255 - data[i + 2]; // blue
-    }
-    ctx.putImageData(imageData, 0, 0);
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255 - data[i]; // red
+    data[i + 1] = 255 - data[i + 1]; // green
+    data[i + 2] = 255 - data[i + 2]; // blue
+  }
+  ctx.putImageData(imageData, 0, 0);
 };
 
 const grayscale = () => {
-    ctx.drawImage(img, 0, 0);
-    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    const data = imageData.data;
-    for (let i = 0; i < data.length; i += 4) {
-        const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
-        data[i]     = avg; // red
-        data[i + 1] = avg; // green
-        data[i + 2] = avg; // blue
-    }
-    ctx.putImageData(imageData, 0, 0);
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
+    data[i] = avg; // red
+    data[i + 1] = avg; // green
+    data[i + 2] = avg; // blue
+  }
+  ctx.putImageData(imageData, 0, 0);
 };
 
-const inputs = document.querySelectorAll('[name=color]');
+const inputs = document.querySelectorAll("[name=color]");
 for (const input of inputs) {
-    input.addEventListener("change", (evt) => {
-        switch (evt.target.value) {
-            case "inverted":
-                return invert();
-            case "grayscale":
-                return grayscale();
-            default:
-                return original();
-        }
-    });
+  input.addEventListener("change", (evt) => {
+    switch (evt.target.value) {
+      case "inverted":
+        return invert();
+      case "grayscale":
+        return grayscale();
+      default:
+        return original();
+    }
+  });
 }
 ```
 
@@ -227,24 +227,28 @@ Zoom example:
 
 ```js
 const img = new Image();
-img.crossOrigin = 'anonymous';
-img.src = './assets/rhino.jpg';
+img.crossOrigin = "anonymous";
+img.src = "./assets/rhino.jpg";
 img.onload = () => {
   draw(this);
 };
 
 function draw(img) {
-  const canvas = document.getElementById('canvas');
-  const ctx = canvas.getContext('2d');
+  const canvas = document.getElementById("canvas");
+  const ctx = canvas.getContext("2d");
   ctx.drawImage(img, 0, 0);
 
-  const smoothedZoomCtx = document.getElementById('smoothed-zoom').getContext('2d');
+  const smoothedZoomCtx = document
+    .getElementById("smoothed-zoom")
+    .getContext("2d");
   smoothedZoomCtx.imageSmoothingEnabled = true;
   smoothedZoomCtx.mozImageSmoothingEnabled = true;
   smoothedZoomCtx.webkitImageSmoothingEnabled = true;
   smoothedZoomCtx.msImageSmoothingEnabled = true;
 
-  const pixelatedZoomCtx = document.getElementById('pixelated-zoom').getContext('2d');
+  const pixelatedZoomCtx = document
+    .getElementById("pixelated-zoom")
+    .getContext("2d");
   pixelatedZoomCtx.imageSmoothingEnabled = false;
   pixelatedZoomCtx.mozImageSmoothingEnabled = false;
   pixelatedZoomCtx.webkitImageSmoothingEnabled = false;
@@ -259,7 +263,7 @@ function draw(img) {
         200, 200);
   };
 
-  canvas.addEventListener('mousemove', (event) => {
+  canvas.addEventListener("mousemove", (event) => {
     const x = event.layerX;
     const y = event.layerY;
     zoom(smoothedZoomCtx, x, y);

--- a/files/en-us/web/api/element/beforexrselect_event/index.md
+++ b/files/en-us/web/api/element/beforexrselect_event/index.md
@@ -1,14 +1,15 @@
 ---
-title: 'beforexrselect event'
+title: "beforexrselect event"
 slug: Web/API/Element/beforexrselect_event
 page-type: web-api-event
 tags:
-   - API
-   - Event
-   - Reference
-   - Experimental
+  - API
+  - Event
+  - Reference
+  - Experimental
 browser-compat: api.Element.beforexrselect_event
 ---
+
 {{APIRef}}{{SeeCompatTable}}
 
 The **`beforexrselect`** event is fired before WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) are dispatched. It can be used to suppress XR world input events while the user is interacting with a DOM overlay UI.
@@ -20,9 +21,9 @@ This event [bubbles](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_b
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('beforexrselect', event => { });
+addEventListener("beforexrselect", (event) => {});
 
-onbeforexrselect = event => { };
+onbeforexrselect = (event) => {};
 ```
 
 ## Event type
@@ -51,8 +52,9 @@ The **`beforexrselect`** event is a global event and available to the following 
 To suppress WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}), an application can listen for the `beforexrselect` event. The event bubbles, so a call to {{domxref("Event/preventDefault", "preventDefault()")}} on the DOM overlay element will prevent any WebXR select events within this container allowing interaction with the DOM element and avoiding duplicate event input to the XR world.
 
 ```js
-document.getElementById('xr-overlay').addEventListener(
-  'beforexrselect', (ev) => ev.preventDefault());
+document
+  .getElementById("xr-overlay")
+  .addEventListener("beforexrselect", (ev) => ev.preventDefault());
 ```
 
 ## Specifications

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -8,6 +8,7 @@ tags:
   - MIME
   - XMLHttpRequest
 ---
+
 The `responseType` property of the XMLHttpRequest object can be set to change the expected response type from the server. Possible values are the empty string (default), `"arraybuffer"`, `"blob"`, `"document"`, `"json"`, and `"text"`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This is `null` if the request is not complete or was not successful.
 
 This example reads an image as a binary file and creates an 8-bit unsigned integer array from the raw bytes. Note that this will not decode the image and read the pixels. You will need a [png decoding library](https://github.com/foliojs/png.js) for that.
@@ -21,9 +22,9 @@ req.onload = (event) => {
   const arrayBuffer = req.response; // Note: not req.responseText
   if (arrayBuffer) {
     const byteArray = new Uint8Array(arrayBuffer);
-    byteArray.forEach((element, index)) => {
+    byteArray.forEach((element, index) => {
       // do something with each byte in the array
-    }
+    });
   }
 };
 
@@ -47,25 +48,24 @@ oReq.send();
 
 ## Receiving binary data in older browsers
 
-The `load_binary_resource()` function shown below loads binary data from the specified URL, returning it to the caller.
+The `loadBinaryResource()` function shown below loads binary data from the specified URL, returning it to the caller.
 
 ```js
-function load_binary_resource(url) {
+function loadBinaryResource(url) {
   const req = new XMLHttpRequest();
-  req.open('GET', url, false);
+  req.open("GET", url, false);
 
-  //XHR binary charset opt by Marcus Granado 2006 [http://mgran.blogspot.com]
-  req.overrideMimeType('text/plain; charset=x-user-defined');
+  // XHR binary charset opt by Marcus Granado 2006 [http://mgran.blogspot.com]
+  req.overrideMimeType("text/plain; charset=x-user-defined");
   req.send(null);
-  if (req.status !== 200) return '';
-  return req.responseText;
+  return req.status === 200 ? req.responseText : "";
 }
 ```
 
 The magic happens in line 5, which overrides the MIME type, forcing the browser to treat it as plain text, using a user-defined character set. This tells the browser not to parse it, and to let the bytes pass through unprocessed.
 
 ```js
-const filestream = load_binary_resource(url);
+const filestream = loadBinaryResource(url);
 const abyte = filestream.charCodeAt(x) & 0xff; // throw away high-order byte (f7)
 ```
 
@@ -86,7 +86,7 @@ req.onload = (event) => {
   // Uploaded
 };
 
-const blob = new Blob(['abc123'], { type: 'text/plain' });
+const blob = new Blob(["abc123"], { type: "text/plain" });
 
 req.send(blob);
 ```
@@ -96,10 +96,10 @@ req.send(blob);
 You can send JavaScript typed arrays as binary data as well.
 
 ```js
-// Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
+// Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0)
 const array = new Uint8Array(512).map((v, i) => i);
 
-const xhr = new XMLHttpRequest;
+const xhr = new XMLHttpRequest();
 xhr.open("POST", url, false);
 xhr.send(array);
 ```

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -134,7 +134,7 @@ const c = {};
 const o = { a, b, c };
 
 // In other words,
-console.log((o.a === {a}.a)) // true
+console.log(o.a === { a }.a); // true
 ```
 
 #### Duplicate property names
@@ -146,7 +146,7 @@ const a = { x: 1, x: 2 };
 console.log(a); // {x: 2}
 ```
 
-In ECMAScript 5 strict mode code, duplicate property names were considered a {{jsxref("SyntaxError")}}.  With the introduction of computed property names making duplication possible at runtime, ECMAScript 2015 has removed this restriction.
+In ECMAScript 5 strict mode code, duplicate property names were considered a {{jsxref("SyntaxError")}}. With the introduction of computed property names making duplication possible at runtime, ECMAScript 2015 has removed this restriction.
 
 ```js
 function haveES2015DuplicatePropertySemantics() {
@@ -172,7 +172,7 @@ const o = {
   property: function (parameters) {},
   get property() {},
   set property(value) {},
-}
+};
 ```
 
 A shorthand notation is available, so that the keyword `function` is no longer necessary.
@@ -181,7 +181,7 @@ A shorthand notation is available, so that the keyword `function` is no longer n
 // Shorthand method names
 const o = {
   property(parameters) {},
-}
+};
 ```
 
 There is also a way to concisely define generator methods.
@@ -262,7 +262,7 @@ const mergedObj = { ...obj1, ...obj2 };
 
 ### Prototype setter
 
-A property definition of the form `__proto__: value` or `"__proto__": value` does not create a property with the name `__proto__`.  Instead, if the provided value is an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), it points the `[[Prototype]]` of the created object to that value.  (If the value is not an object or `null`, the object is not changed.)
+A property definition of the form `__proto__: value` or `"__proto__": value` does not create a property with the name `__proto__`. Instead, if the provided value is an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), it points the `[[Prototype]]` of the created object to that value. (If the value is not an object or `null`, the object is not changed.)
 
 ```js
 const obj1 = {};


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add some missing () for arrow functions, removes one extra `)`. Partly autoformatted for consistent style (indent, spaces, quotes).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
