### PR TITLE
Remove "unloaded" from visibilityState values on Page Visibility API

### DIFF
--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -134,12 +134,6 @@ The Page Visibility API adds the following properties to the {{domxref("Document
 
         > **Note:** Not all browsers support prerendering.
 
-    - `unloaded`
-
-      - : The page is in the process of being unloaded from memory.
-
-        > **Note:** Not all browsers support the `unloaded` value.
-
 ## Events added to the Document interface
 
 The Page Visibility API adds the following events to the {{domxref("Document")}} interface:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Remove the `"unloaded"` value from the list of possible visibility states on Page Visibility API

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Not listed on the browser compatibility table, the [Document.visibilityState reference](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState), nor in the [current HTML Standard](https://html.spec.whatwg.org/#the-document-object).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://html.spec.whatwg.org/#the-document-object

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #20283

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
