### PR TITLE
fix: MD001 Headings should only increment by 1

### DIFF
--- a/files/en-us/learn/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.md
@@ -272,7 +272,7 @@ There is one last `<input>` type that came to us in early HTML: the file input t
 
 To create a [file picker widget](/en-US/docs/Web/HTML/Element/input/file), you use the {{HTMLElement("input")}} element with its {{htmlattrxref("type","input")}} attribute set to `file`. The types of files that are accepted can be constrained using the {{htmlattrxref("accept","input")}} attribute. In addition, if you want to let the user pick more than one file, you can do so by adding the {{htmlattrxref("multiple","input")}} attribute.
 
-#### Example
+### Example
 
 In this example, a file picker is created that requests graphic image files. The user is allowed to select multiple files in this case.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -160,9 +160,9 @@ The blockquote can contain code blocks or other block elements.
 
 Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.
 
-#### Examples
+### Examples
 
-##### Note
+#### Note
 
 ```plain
 > **Note:** This is how you write a note.
@@ -185,7 +185,7 @@ This HTML will be rendered as a highlighted box, like:
 >
 > It can have multiple lines.
 
-##### Warnings
+#### Warnings
 
 ```plain
 > **Warning:** This is how you write a warning.
@@ -208,7 +208,7 @@ This HTML will be rendered as a highlighted box, like:
 >
 > It can have multiple paragraphs.
 
-##### Callouts
+#### Callouts
 
 ```plain
 > **Callout:** **This is how you write a callout.**
@@ -233,7 +233,7 @@ This HTML will be rendered as a highlighted box, like:
 >
 > It can have multiple paragraphs.
 
-##### Translated warning
+#### Translated warning
 
 For example, if we want to use "Warnung" for "Warning" in German, then in German pages we would write:
 
@@ -249,7 +249,7 @@ And this will produce:
 </div>
 ```
 
-##### Note containing a code block
+#### Note containing a code block
 
 This example contains a code block.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
@@ -488,10 +488,10 @@ You can also specify the desired API as the first argument to the macro as shown
 
 The macro calls generate the following tables (and corresponding set of notes):
 
-#### Compatibility table example
+### Compatibility table example
 
 {{Compat}}
 
-#### Specifications table examples
+### Specifications table examples
 
 {{Specifications}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -272,14 +272,14 @@ They can also be used to mark up a section on a page.
 The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macros/AvailableInWorkers.ejs) macro inserts a localized note box indicating that a feature is available in a [Web worker](/en-US/docs/Web/API/Web_Workers_API) context.
 You can use the argument `notservice` to indicate that a feature works in web workers except for service workers.
 
-##### Syntax
+#### Syntax
 
 ```plain
 \{{AvailableInWorkers}}
 \{{AvailableInWorkers("notservice")}}
 ```
 
-##### Examples
+#### Examples
 
 {{AvailableInWorkers}}
 {{AvailableInWorkers("notservice")}}

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -85,7 +85,7 @@ For more information, see the [full bug list](https://bugzilla.mozilla.org/bugli
   - The `content` object (that offered `content.fetch`, `content.XMLHttpRequest`, and `content.WebSocket`) is removed from the content script execution environment.
 - Addition of the {{WebExtAPIRef("storage.StorageArea.onChanged")}} event that enables you to listen for changes in content in the `local` and `sync` storage areas ({{bug(1758475)}}).
 
-#### Removals
+### Removals
 
 ### Other
 

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -86,7 +86,7 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ## Changes for add-on developers
 
-#### Removals
+### Removals
 
 - Removed the ServiceWorker API in WebExtensions (`'serviceWorker' in navigator` now returns false when run inside an extension). ({{bug(1593931)}})
 

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -82,7 +82,7 @@ No notable changes.
 
 ## Changes for add-on developers
 
-#### Removals
+### Removals
 
 ### Other
 

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -55,7 +55,7 @@ This article provides information about the changes in Firefox 105 that will aff
 
 - Support for defining persistent scripts using {{WebExtAPIRef("scripting")}} has been added. A script is identified as persistent using the `persistAcrossSessions` property in {{WebExtAPIRef("scripting.RegisteredContentScript")}} ({{bug("1751436")}}).
 
-#### Removals
+### Removals
 
 ### Other
 

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -53,7 +53,7 @@ This article provides information about the changes in Firefox 106 that will aff
 
 ## Changes for add-on developers
 
-#### Removals
+### Removals
 
 ### Other
 

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -90,7 +90,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 
 The following example creates an otherwise non-semantic checkbox element using CSS and JavaScript to handle the checked or unchecked status of the element.
 
-#### HTML
+### HTML
 
 ```html
 <span role="checkbox" id="chkPref" aria-checked="false" onclick="changeCheckbox()" onKeyDown="changeCheckbox(event.keyCode)"
@@ -98,7 +98,7 @@ The following example creates an otherwise non-semantic checkbox element using C
 <label id="chk1-label" onclick="changeCheckbox()" onKeyDown="changeCheckbox(event.keyCode)">Remember my preferences</label>
 ```
 
-#### CSS
+### CSS
 
 ```css
 [role="checkbox"] {
@@ -118,7 +118,7 @@ The following example creates an otherwise non-semantic checkbox element using C
 }
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 function changeCheckbox(keyCode) {

--- a/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
@@ -33,7 +33,7 @@ Marking up a dialog element with the `dialog` role helps assistive technology id
 
 The sections below describe how these two requirements can be met.
 
-#### Labeling
+### Labeling
 
 Even though it is not required for the dialog itself to be able to receive focus, it still needs to be labeled. The label given to the dialog will provide contextual information for the interactive controls inside the dialog. In other words, the dialog's label acts like a grouping label for the controls inside it (similar to how a `<legend>` element provides a grouping label for the controls inside a `<fieldset>` element).
 
@@ -81,7 +81,7 @@ When the dialog is correctly labeled and focus is moved to an element (often an 
 
 ## Examples
 
-#### A dialog containing a form
+### A dialog containing a form
 
 ```html
  <div role="dialog" aria-labelledby="dialog1Title" aria-describedby="dialog1Desc">

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -159,7 +159,7 @@ When the user clicks on an option, hits <kbd>Space</kbd> when focused on an opti
 
 ## Examples
 
-#### Example 1: A single select listbox that uses [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)
+### Example 1: A single select listbox that uses [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)
 
 The snippet below shows how the listbox role is added directly into the HTML source code.
 
@@ -193,7 +193,7 @@ This could have more easily been handled with the native HTML {{HTMLElement('sel
 </select>
 ```
 
-#### More examples
+### More examples
 
 - [Scrollable Listbox Example](https://w3c.github.io/aria-practices/examples/listbox/listbox-scrollable.html): Single-select listbox that scrolls to reveal more options, similar to HTML {{HTMLElement('select')}} with `size` attribute greater than one.
 - [Collapsible Dropdown Listbox Example](https://w3c.github.io/aria-practices/examples/listbox/listbox-collapsible.html): Single-select collapsible listbox that expands when activated, similar to HTML {{HTMLElement('select')}} with the attribute `size="1"`.

--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -525,11 +525,11 @@ The `update` media feature is used to query the ability of the output device to 
 
 ## Developmental & Experimental Features
 
-#### MDN Navigator.doNotTrack
+### MDN Navigator.doNotTrack
 
 [From the documentation](/en-US/docs/Web/API/Navigator/doNotTrack): _"Returns the user's do-not-track setting. This is "1" if the user has requested not to be tracked by web sites, content, or advertising"_.
 
-#### Media Queries Level 5
+### Media Queries Level 5
 
 EnvironmentMQ (Planned in Media Queries Level 5)
 
@@ -538,7 +538,7 @@ EnvironmentMQ (Planned in Media Queries Level 5)
 - `environment-blending`
   - : From W3C's Draft document, Media Queries Level 5: _"The [`environment-blending`](https://drafts.csswg.org/mediaqueries-5/#descdef-media-environment-blending) media feature is used to query the characteristics of the user's display so the author can adjust the style of the document. An author might choose to adjust the visuals and/or layout of the page depending on the display technology to increase the appeal or improve legibility."_
 
-##### User Preference Media Features (Planned in Media Queries Level 5)
+#### User Preference Media Features (Planned in Media Queries Level 5)
 
 [User Preference Media Features](https://drafts.csswg.org/mediaqueries-5/#mf-user-preferences) in [W3C Editor's Draft Media Queries Level 5](https://drafts.csswg.org/mediaqueries-5/) are especially promising in providing user control over media. Here are some highlights:
 
@@ -569,7 +569,7 @@ The Web Animations model is intended to provide the features necessary for expre
 
 ## See also
 
-#### MDN
+### MDN
 
 - [Accessibility: What users can do to browse more safely](/en-US/docs/Web/Accessibility/Accessibility:_What_users_can_to_to_browse_safely)
 - [Accessibility: Understanding color and luminance](/en-US/docs/Web/Accessibility/Understanding_Colors_and_Luminance)
@@ -584,46 +584,46 @@ The Web Animations model is intended to provide the features necessary for expre
 - [WebGL: 2D and 3D graphics for the web](/en-US/docs/Web/API/WebGL_API)
 - [WebVR API](/en-US/docs/Web/API/WebVR_API)
 
-#### Color
+### Color
 
 - [Color Tutorial: describing color](https://colortutorial.design/) Tom Jewett
 - [Formula to Determine Brightness of RGB color](https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color) Stack Exchange Discussion Thread
 - [How the Color Red Influences Our Behavior](https://www.scientificamerican.com/article/how-the-color-red-influences-our-behavior/) Scientific American By Susana Martinez-Conde, Stephen L. Macknik on November 1, 2014
 
-#### Discussions
+### Discussions
 
 - [Problems with WCAG 2.0 Flash Definition #553](https://github.com/w3c/wcag/issues/553)
 - [WCAG 2.1 Understanding 2.3.1 - missing/vague dimension definitions #585](https://github.com/w3c/wcag/issues/585)
 
-#### Epilepsy and Seizures
+### Epilepsy and Seizures
 
 - [Shedding Light on Photosensitivity, One of Epilepsy's Most Complex Conditions](https://www.epilepsy.com/stories/shedding-light-photosensitivity-one-epilepsys-most-complex-conditions-0) Epilepsy Foundation: _"Certain individuals are born with special sensitivity to flashing lights or contrasting visual patterns, such as stripes, grids and checkerboards. Because of this condition, their brain will produce seizure-like discharges when exposed to this type of visual stimulation."_
 - [Gamma oscillations and photosensitive epilepsy](https://www.sciencedirect.com/science/article/pii/S0960982217304062?via%3Dihub) Current Biology [Volume 27, Issue 9](https://www.sciencedirect.com/journal/current-biology/vol/27/issue/9), 8 May 2017, Pages R336-R338: _"Certain [visual images](https://www.sciencedirect.com/topics/biochemistry-genetics-and-molecular-biology/retina-image), even in the absence of motion or flicker, can trigger seizures in patients with photosensitive epilepsy."_
 - [Photosensitive Seizures. Cedars-Sinai](https://www.cedars-sinai.org/health-library/diseases-and-conditions/p/photosensitive-seizures.html) "_Photosensitive seizures are triggered by flashing or flickering lights. These seizures can also be triggered by certain patterns such as stripes._"
 - [Photic-and pattern-induced seizures: expert consensus of the Epilepsy Foundation of America Working Group](https://pubmed.ncbi.nlm.nih.gov/16146438/) Eplepsia 2005 Sept, 46(9):1423-5 PubMed.gov NCBI [Harding G](https://pubmed.ncbi.nlm.nih.gov/?term=Harding%20G%5BAuthor%5D&cauthor=true&cauthor_uid=16146438), [Wilkins AJ](https://pubmed.ncbi.nlm.nih.gov/?term=Wilkins%20AJ%5BAuthor%5D&cauthor=true&cauthor_uid=16146438), [Erba G](https://pubmed.ncbi.nlm.nih.gov/?term=Erba%20G%5BAuthor%5D&cauthor=true&cauthor_uid=16146438), [Barkley GL](https://pubmed.ncbi.nlm.nih.gov/?term=Barkley%20GL%5BAuthor%5D&cauthor=true&cauthor_uid=16146438), [Fisher RS](https://pubmed.ncbi.nlm.nih.gov/?term=Fisher%20RS%5BAuthor%5D&cauthor=true&cauthor_uid=16146438); [Epilepsy Foundation of America Working Group](https://pubmed.ncbi.nlm.nih.gov/?term=Epilepsy%20Foundation%20of%20America%20Working%20Group%5BCorporate%20Author%5D).
 
-#### GPII
+### GPII
 
 - [Accessibility Master List](https://ds.gpii.net/learn/accessibility-masterlist) Gregg Vanderheiden Ph.D. Editor
 
-#### Harding
+### Harding
 
 Along with the PEAT tool, is generally recognized to be one of the two "gold standards" for analyzing flashes.
 
 - [Harding Flash and Pattern Analyzer](https://www.hardingfpa.com)
 
-#### ISO
+### ISO
 
 - [IEC 61966-2-2:2003(en)](https://www.iso.org/obp/ui/#iso:std:iec:61966:-2-2:ed-1:v1:en) Multimedia systems and equipment — Colour measurement and management — Part 2-2: Colour management — Extended RGB color space — scRGB
 
-#### Photosensitive Epilepsy Analysis Tool
+### Photosensitive Epilepsy Analysis Tool
 
 Along with the Harding tool, is generally recognized to be one of the two "gold standards" for analyzing flashes.
 
 - [Trace Research and Development Center](https://trace.umd.edu/peat/)
 - [Using PEAT To Create Seizureless Web Animations](https://www.useragentman.com/blog/2017/04/02/using-peat-to-create-seizureless-web-animations/)
 
-#### W3C
+### W3C
 
 - [CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/)
 - [Personalization Semantics Explainer 1.0](https://www.w3.org/TR/personalization-semantics-1.0/). Working Draft

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -417,7 +417,7 @@ Within the W3 AGWG there is active discussion and investigation regarding the WC
 
 ## Additional Resources
 
-#### MDN
+### MDN
 
 - [Accessibility](/en-US/docs/Web/Accessibility)
 - [Accessibility learning path](/en-US/docs/Learn/Accessibility)
@@ -425,7 +425,7 @@ Within the W3 AGWG there is active discussion and investigation regarding the WC
 - [`<color>`](/en-US/docs/Web/CSS/color_value)
 - [Web accessibility for seizures and physical reactions](/en-US/docs/Web/Accessibility/Seizure_disorders)
 
-#### W3C Issues and Discussions
+### W3C Issues and Discussions
 
 - [The Visual Contrast Research Group](https://www.w3.org/WAI/GL/task-forces/silver/wiki/Visual_Contrast_of_Text_Subgroup) for WCAG 3.
 - [Light and dark text](https://github.com/w3c/silver/issues/261) & WCAG 3.0 contrast (Silver thread #261)
@@ -433,7 +433,7 @@ Within the W3 AGWG there is active discussion and investigation regarding the WC
 - [Luminance / Luma confusion](https://github.com/w3c/wcag/issues/236) thread #236
 - [Non-sRGB color spaces](https://github.com/w3c/wcag/issues/360), outdated sRGB threshold thread #360
 
-#### W3C Standards and Guidelines
+### W3C Standards and Guidelines
 
 - [The latest draft of the new WCAG 3 standards](https://www.w3.org/TR/wcag-3.0/)
 - [Ensuring that a contrast ratio of 3:1 is provided for icons](https://www.w3.org/WAI/WCAG21/Techniques/general/G207)
@@ -441,6 +441,6 @@ Within the W3 AGWG there is active discussion and investigation regarding the WC
 - [CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/)
 - [CSS Color Module Level 4](https://drafts.csswg.org/css-color-4/)
 
-### Page Source
+## Page Source
 
 This page is based largely on the white paper on color and contrast by Andrew Somers, which is being developed for the W3 and Accessibility Guidelines Working Group, used herein by permission. Andrew Somers is an invited expert of the W3 and the AGWG, the author of the WCAG 3 Visual Contrast specifications, and the inventor of the APCA.

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontkerning/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontkerning/index.md
@@ -37,13 +37,13 @@ Allowed values are:
 
 In this example we display the text "AVA Ta We" using each of the supported values of the `textRendering` property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700" height="140"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -62,7 +62,7 @@ ctx.fontKerning = 'none';
 ctx.fillText(`AVA Ta We (${ctx.fontKerning})`, 5, 110);
 ```
 
-#### Result
+### Result
 
 Note that the the last string has font kerning disabled, so adjacent characters are evenly spread.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
@@ -29,13 +29,13 @@ The property can be used to get or set the font stretch value.
 In this example we display the text "Hello World" using each of the supported values of the `fontStretch` property.
 The stretch value is also displayed for each case by reading the property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700" height="310"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -82,7 +82,7 @@ ctx.fontStretch = 'ultra-expanded';
 ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 290);
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 700, 300) }}
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontvariantcaps/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontvariantcaps/index.md
@@ -49,13 +49,13 @@ Note that there are accessibility concerns with some of these, which are outline
 In this example we display the text "Hello World" using each of the supported values of the `fontVariantCaps` property.
 The value is also displayed for each case by reading the property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700" height="220"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -90,7 +90,7 @@ ctx.fontVariantCaps = 'titling-caps';
 ctx.fillText(`Hello world (${ctx.fontVariantCaps})`, 5, 200);
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 700, 230) }}
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
@@ -60,14 +60,14 @@ We then apply the retrieved matrix directly to the second canvas context by pass
 `DOMMatrix` object directly to `setTransform()`, and draw a circle
 on it.
 
-#### HTML
+### HTML
 
 ```html
 <canvas width="240"></canvas>
 <canvas width="240"></canvas>
 ```
 
-#### CSS
+### CSS
 
 ```css
 canvas {
@@ -75,7 +75,7 @@ canvas {
 }
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvases = document.querySelectorAll('canvas');
@@ -94,7 +94,7 @@ ctx2.arc(50, 50, 50, 0, 2 * Math.PI);
 ctx2.fill();
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', "100%", 180) }}
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/letterspacing/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/letterspacing/index.md
@@ -30,13 +30,13 @@ The property value will remain unchanged if set to an invalid/unparsable value.
 In this example we display the text "Hello World" three times, using the `letterSpacing` property to modify the letter spacing in each case.
 The spacing is also displayed for each case, using the value of the property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -56,7 +56,7 @@ ctx.letterSpacing = '20px';
 ctx.fillText(`Hello world (${ctx.letterSpacing})`, 10, 140);
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 700, 180) }}
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textrendering/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textrendering/index.md
@@ -43,13 +43,13 @@ The property can be used to get or set the value.
 In this example we display the text "Hello World" using each of the supported values of the `textRendering` property.
 The value is also displayed for each case by reading the property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700" height="220"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -72,7 +72,7 @@ ctx.textRendering = 'geometricPrecision';
 ctx.fillText(`Hello world (${ctx.textRendering})`, 5, 110);
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 700, 230) }}
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
@@ -30,13 +30,13 @@ The property value will remain unchanged if set to an invalid/unparsable value.
 In this example we display the text "Hello World" three times, using the `wordSpacing` property to modify the spacing in each case.
 The spacing is also displayed for each case, using the value of the property.
 
-#### HTML
+### HTML
 
 ```html
 <canvas id="canvas" width="700"></canvas>
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 const canvas = document.getElementById('canvas');
@@ -56,7 +56,7 @@ ctx.wordSpacing = '30px';
 ctx.fillText(`Hello world (${ctx.wordSpacing})`, 10, 140);
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 700, 180) }}
 

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -41,7 +41,7 @@ None ({{jsxref("undefined")}}).
 
 This example shows the use of the `clear()` method.
 
-#### HTML
+### HTML
 
 ```html
  <div>
@@ -51,7 +51,7 @@ This example shows the use of the `clear()` method.
  <div id="target" ondrop="dropHandler(event);" ondragover="dragoverHandler(event);">Drop Zone</div>
 ```
 
-#### CSS
+### CSS
 
 ```css
   div {
@@ -67,7 +67,7 @@ This example shows the use of the `clear()` method.
   }
 ```
 
-#### JavaScript
+### JavaScript
 
 ```js
 function dragstartHandler(ev) {
@@ -121,7 +121,7 @@ function dragendHandler(ev) {
 }
 ```
 
-#### Result
+### Result
 
 {{EmbedLiveSample('Examples', 400, 300)}}
 

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -24,7 +24,7 @@ The `DirectoryEntrySync` interface represents a directory in a file system. It i
 
 If you want to create subdirectories, you have to create each child directory in sequence. If you try to create a directory using a full path that includes parent directories that do not exist yet, you get an error. So create the hierarchy by recursively adding a new path after creating the parent directory.
 
-#### Example
+### Example
 
 The `getFile()` method returns a `FileEntrySync`, which represents a file in the file system. The following creates an empty file called `logs.txt` in the root directory.
 

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -20,7 +20,7 @@ The `DirectoryReaderSync` interface lets you read the entries in a directory.
 
 Before you call the only method in this interface, [`readEntries()`](#readentries), create the [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync) object. But DirectoryEntrySync (as well as [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync)) is not a data type that you can pass between a calling app and Web Worker thread. It's not a big deal, because you don't really need to have the main app and the worker thread see the same JavaScript object; you just need them to access the same files. You can do that by passing a list of `filesystem:` URLs—which are just strings—instead of a list of entries. You can also use the `filesystem:` URL to look up the entry with `resolveLocalFileSystemURL()`. That gets you back to a DirectoryEntrySync (as well as FileEntrySync) object.
 
-#### Example
+### Example
 
 In the following code snippet from [HTML5Rocks (web.dev)](https://web.dev/filesystem-sync/), we create Web Workers and pass data from it to the main app.
 
@@ -94,10 +94,6 @@ self.onmessage = (e) => {
   }
 };
 ```
-
-## Method overview
-
-- <a href="#createreader()" title="#readEntries">readEntries()</a>
 
 ## Method
 

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -379,7 +379,7 @@ The reason for the [syntax](#syntax) of the `document.cookie`
 accessor property is due to the client-server nature of cookies, which differs from
 other client-client storage methods (like, for instance, [localStorage](/en-US/docs/Web/API/Web_Storage_API)):
 
-#### The server tells the client to store a cookie
+### The server tells the client to store a cookie
 
 ```bash
 HTTP/1.0 200 OK
@@ -390,7 +390,7 @@ Set-Cookie: cookie_name2=cookie_value2; expires=Sun, 16 Jul 3567 06:23:41 GMT
 [content of the page here]
 ```
 
-#### The client sends back to the server its cookies previously stored
+### The client sends back to the server its cookies previously stored
 
 ```bash
 GET /sample_page.html HTTP/1.1

--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -95,12 +95,12 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
 Though similar to {{domxref("Element/mouseover_event", "mouseover")}}, `mouseenter` differs in that it doesn't [bubble](/en-US/docs/Web/API/Event/bubbles) and it isn't sent to any descendants when the pointer is moved from one of its descendants' physical space to its own physical space.
 
-#### Behavior of `mouseenter` events:
+### Behavior of `mouseenter` events:
 
 ![](mouseenter.png)
 One `mouseenter` event is sent to each element of the hierarchy when entering them. Here 4 events are sent to the four elements of the hierarchy when the pointer reaches the text.
 
-#### Behavior of `mouseover` events:
+### Behavior of `mouseover` events:
 
 ![](mouseover.png)
 A single `mouseover` event is sent to the deepest element of the DOM tree, then it bubbles up the hierarchy until it is canceled by a handler or reaches the root.

--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -91,13 +91,13 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 - {{domxref("MouseEvent.y")}} {{ReadOnlyInline}}
   - : Alias for {{domxref("MouseEvent.clientY")}}
 
-#### Behavior of `mouseleave` events:
+### Behavior of `mouseleave` events:
 
 ![](mouseleave.png)
 
 One `mouseleave` event is sent to each element of the hierarchy when leaving them. Here four events are sent to the four elements of the hierarchy when the pointer moves from the text to an area outside of the most outer div represented here.
 
-#### Behavior of `mouseout` events:
+### Behavior of `mouseout` events:
 
 ![](mouseout.png)
 

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -77,15 +77,15 @@ Returns a File that represents the current state of the file that this `FileEntr
 void file ();
 ```
 
-##### Parameter
+#### Parameter
 
 None.
 
-##### Returns
+#### Returns
 
 A `File` object.
 
-##### Exceptions
+#### Exceptions
 
 This method can raise a [DOMException](/en-US/docs/Web/API/DOMException) with the following codes:
 

--- a/files/en-us/web/api/formdata/set/index.md
+++ b/files/en-us/web/api/formdata/set/index.md
@@ -25,7 +25,7 @@ set(name, value)
 set(name, value, filename)
 ```
 
-#### Parameters
+### Parameters
 
 - `name`
   - : The name of the field whose data is contained in `value`.

--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -311,7 +311,7 @@ The {{domxref("EventSource")}} interface represents the source which sent or is 
 
 In this example, an {{HTMLElement("input")}} element's {{domxref("HTMLElement/input_event", "input")}} event is monitored in order to update the state of a form's "submit" button based on whether or not a given field currently has a value.
 
-#### JavaScript
+### JavaScript
 
 ```js
 const nameField = document.getElementById("userName");
@@ -341,7 +341,7 @@ Then {{domxref("EventTarget.addEventListener", "addEventListener()")}} is called
 
 With this in place, the "Send" button is always enabled whenever the user name input field has a value, and disabled when it's empty.
 
-#### HTML
+### HTML
 
 The HTML for the form looks like this:
 
@@ -360,7 +360,7 @@ The HTML for the form looks like this:
 </form>
 ```
 
-#### Result
+### Result
 
 {{EmbedLiveSample("Examples", 640, 300)}}
 

--- a/files/en-us/web/api/htmlimageelement/align/index.md
+++ b/files/en-us/web/api/htmlimageelement/align/index.md
@@ -36,7 +36,7 @@ content attribute.
 A string specifying one of the following strings which set the
 alignment mode for the image.
 
-#### Baseline alignment
+### Baseline alignment
 
 These three values specify the alignment of the element relative to the text baseline.
 These should be replaced by using the CSS {{cssxref("vertical-align")}} property.
@@ -52,7 +52,7 @@ These should be replaced by using the CSS {{cssxref("vertical-align")}} property
 It may be worth noting that {{cssxref("vertical-align")}} offers several additional
 options for its value; you may wish to consider these when changing your code to use it.
 
-#### Floating images horizontally
+### Floating images horizontally
 
 The `left` and `right` properties don't affect the
 baseline-relative alignment. Instead, they cause the image to "float" to the left or

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -36,7 +36,7 @@ comprised of a media condition, then at least one whitespace character, then the
 **source size value** to use for the image when the media condition
 evaluates to `true`.
 
-#### Media conditions
+### Media conditions
 
 Each source size descriptor consists of a media condition as defined by the media
 queries standard. Because a source size descriptor is used to specify the width to use
@@ -45,7 +45,7 @@ necessarily) based entirely on width information. See
 {{SectionOnPage("/en-US/docs/Web/CSS/Media_Queries/Using_media_queries", "Syntax")}} for
 details on how to construct a media condition.
 
-#### Source size values
+### Source size values
 
 The source size value is a [CSS length](/en-US/docs/Web/CSS/length). It may
 be specified using font-relative units (such as `em` or `ex`),

--- a/files/en-us/web/api/keyboardevent/metakey/index.md
+++ b/files/en-us/web/api/keyboardevent/metakey/index.md
@@ -42,7 +42,7 @@ function ismetaKey(e) {
 }
 ```
 
-#### Result
+### Result
 
 {{ EmbedLiveSample('Examples', 400, 90) }}
 

--- a/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
@@ -303,7 +303,7 @@ h3 {
 }
 ```
 
-#### Defaults and variables
+### Defaults and variables
 
 First we have the default constraint sets, as strings. These strings are presented in editable {{HTMLElement("textarea")}}s, but this is the initial configuration of the stream.
 
@@ -360,7 +360,7 @@ videoConstraintEditor.value = videoDefaultConstraintString;
 audioConstraintEditor.value = audioDefaultConstraintString;
 ```
 
-#### Updating the settings display
+### Updating the settings display
 
 To the right of each of the constraint set editors is a second text box which we use to display the current configuration of the track's configurable properties. This display is updated by the function `getCurrentSettings()`, which gets the current settings for the audio and video tracks and inserts the corresponding code into the tracks' settings display boxes by setting their {{htmlattrxref("value", "textarea")}}.
 
@@ -378,7 +378,7 @@ function getCurrentSettings() {
 
 This gets called after the stream first starts up, as well as any time we've applied updated constraints, as you'll see below.
 
-#### Building the track constraint set objects
+### Building the track constraint set objects
 
 The `buildConstraints()` function builds the {{domxref("MediaTrackConstraints")}} objects for the audio and video tracks using the code in the two tracks' constraint set edit boxes.
 
@@ -395,7 +395,7 @@ function buildConstraints() {
 
 This uses {{jsxref("JSON.parse()")}} to parse the code in each editor into an object. If either call to JSON.parse() throws an exception, `handleError()` is called to output the error message to the log.
 
-#### Configuring and starting the stream
+### Configuring and starting the stream
 
 The `startVideo()` method handles setting up and starting the video stream.
 
@@ -453,7 +453,7 @@ document.getElementById("startButton").addEventListener(
 );
 ```
 
-#### Applying constraint set updates
+### Applying constraint set updates
 
 Next, we set up an event listener for the "Apply Constraints" button. If it's clicked and there's not already media in use, we call `startVideo()`, and let that function handle starting the stream with the specified settings in place. Otherwise, we follow these steps to apply the updated constraints to the already-active stream:
 
@@ -496,7 +496,7 @@ document.getElementById("applyButton").addEventListener(
 );
 ```
 
-#### Handling the stop button
+### Handling the stop button
 
 Then we set up the handler for the stop button.
 
@@ -517,7 +517,7 @@ document.getElementById("stopButton").addEventListener("click", () => {
 
 This stops the active tracks, sets the `videoTrack` and `audioTrack` variables to `null` so we know they're gone, and removes the stream from the {{HTMLElement("video")}} element by setting {{domxref("HTMLMediaElement.srcObject")}} to `null`.
 
-#### Simple tab support in the editor
+### Simple tab support in the editor
 
 This code adds simple support for tabs to the {{HTMLElement("textarea")}} elements by making the tab key insert two space characters when either constraint edit box is focused.
 
@@ -541,7 +541,7 @@ videoConstraintEditor.addEventListener("keydown", keyDownHandler, false);
 audioConstraintEditor.addEventListener("keydown", keyDownHandler, false);
 ```
 
-#### Show constrainable properties the browser supports
+### Show constrainable properties the browser supports
 
 The last significant piece of the puzzle: code that displays, for the user's reference, a list of the constrainable properties which their browser supports. Each property is a link to its documentation on MDN for the user's convenience. See the {{SectionOnPage("/en-US/docs/Web/API/MediaDevices/getSupportedConstraints", "Example")}} for details on how this code works.
 
@@ -559,7 +559,7 @@ for (const constraint in supportedConstraints) {
 }
 ```
 
-#### Error handling
+### Error handling
 
 We also have some simple error handling code; `handleError()` is called to handle promises which fail, and the `log()` function appends the error message to a special logging {{HTMLElement("div")}} box under the video.
 

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -156,7 +156,7 @@ const audioList = document.getElementById("audioList");
 const videoList = document.getElementById("videoList");
 ```
 
-#### Getting and drawing the device list
+### Getting and drawing the device list
 
 Now let's take a look at `updateDeviceList()` itself. This method is called
 any time we want to fetch the current list of media devices and then update the
@@ -212,7 +212,7 @@ parentheses, it's appended to the appropriate list by calling
 {{domxref("Node.appendChild", "appendChild()")}} on either `audioList` or
 `videoList`, as appropriate based on the device type.
 
-#### Handling device list changes
+### Handling device list changes
 
 We call `updateDeviceList()` in two places. The first is in the
 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} promise's fulfillment

--- a/files/en-us/web/api/mediaerror/code/index.md
+++ b/files/en-us/web/api/mediaerror/code/index.md
@@ -27,7 +27,7 @@ string with specific diagnostic information, see {{domxref("MediaError.message")
 A numeric value indicating the general type of error which occurred. The possible
 values are described below, in [Media error code constants](#media_error_code_constants).
 
-#### Media error code constants
+### Media error code constants
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -47,7 +47,7 @@ to determine if cross-origin requests lead to valid responses, and which propert
     - `websocket`
       - : A special mode used only when establishing a [WebSocket](/en-US/docs/Web/API/WebSockets_API) connection.
 
-#### Default mode
+### Default mode
 
 Requests can be initiated in a variety of ways, and the mode for a request depends on
 the particular means by which it was initiated.

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
@@ -35,7 +35,7 @@ uniquely identifies a single ongoing ICE interaction, including for any communic
 with the {{Glossary("STUN")}} server. The string may be up to 256 characters long, and
 has no default value.
 
-#### Randomization
+### Randomization
 
 At least 24 bits of the text in the `ufrag` are required to be randomly
 selected by the ICE layer at the beginning of the ICE session. The specifics for which

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -117,7 +117,7 @@ const style = document.querySelector("#circle_style_id");
 
 This example demonstrates how to get and set the properties of a style element, which in this case was specified in an SVG definition.
 
-#### HTML
+### HTML
 
 The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element, along with an HTML [`<button>`](/en-US/docs/Web/HTML/Element/button) element that will be used to enable and disable the style, and an HTML [`<textarea>`](/en-US/docs/Web/HTML/Element/button) element for logging the property values.
 
@@ -139,7 +139,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Eleme
 Note that above we have set the `media` attribute on the `style` tag.
 We have not set `type` as it is deprecated, or `disabled` because there is no such attribute (only the property on the element).
 
-#### JavaScript
+### JavaScript
 
 The code below gets the `style` element (an `SVGStyleElement`) using its id.
 
@@ -189,7 +189,7 @@ button.addEventListener('click', () => {
    });
 ```
 
-#### Result
+### Result
 
 The result is shown below.
 Toggle the button to enable and disable the SVG style element.

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -27,7 +27,7 @@ The value is initialized with the string specified in the corresponding style's 
 
 This example demonstrates programmatically getting and setting the media property on a style that was defined in an SVG definition.
 
-#### HTML
+### HTML
 
 The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that is conditional on the media query `"all and (min-width: 600px)"`.
 We also define a `button` that will be used to display the current style and change the style.
@@ -39,7 +39,7 @@ We also define a `button` that will be used to display the current style and cha
 </svg>
 ```
 
-#### JavaScript
+### JavaScript
 
 The code below gets the `style` element (an `SVGStyleElement`) using its id.
 
@@ -76,7 +76,7 @@ button.addEventListener('click', () => {
    });
 ```
 
-#### Result
+### Result
 
 The result is shown below.
 The button text shows the value of the media attribute originally applied to the SVG style along with the width of the current frame (since the code is run in a frame).

--- a/files/en-us/web/api/svgstyleelement/sheet/index.md
+++ b/files/en-us/web/api/svgstyleelement/sheet/index.md
@@ -22,7 +22,7 @@ A {{domxref("CSSStyleSheet")}}, or `null` if the element has no associated style
 
 This example demonstrates how to get the CSS sheet associated with an element.
 
-#### HTML
+### HTML
 
 The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle).
 
@@ -33,7 +33,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Eleme
 </svg>
 ```
 
-#### JavaScript
+### JavaScript
 
 The code below creates a `style` element (an `SVGStyleElement`) and adds it to the SVG.
 
@@ -55,7 +55,7 @@ const log = document.getElementById("log")
 log.value = `${style.sheet} with rules[0].cssText:\n ${style.sheet.rules[0].cssText}`;
 ```
 
-#### Result
+### Result
 
 The result is shown below.
 On success, the log shows the `CSSStyleSheet` object applied to the SVG circle.

--- a/files/en-us/web/api/svgstyleelement/title/index.md
+++ b/files/en-us/web/api/svgstyleelement/title/index.md
@@ -25,7 +25,7 @@ The value is initialized with the string specified in the corresponding style's 
 
 This example demonstrates programmatically getting and setting the `title` property on a style that was defined in an SVG definition.
 
-#### HTML
+### HTML
 
 The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that has a `title`.
 We also define a text area for logging the current title.
@@ -42,7 +42,7 @@ We also define a text area for logging the current title.
 </svg>
 ```
 
-#### JavaScript
+### JavaScript
 
 The code below gets the `style` element (an `SVGStyleElement`) using its tag name, logs the title, then changes and logs the title again.
 
@@ -56,7 +56,7 @@ style.title = "Altered Title";
 log.value += `New title: ${style.title}`;
 ```
 
-#### Result
+### Result
 
 The text in the log below shows that the title initially reflects the matching attribute on the `<style>` element, but can then be changed to another value.
 

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -1112,7 +1112,7 @@ Keys used when using an Input Method Editor (IME) to input text which can't read
 
 Some keys are common across multiple languages, while others exist only on keyboards targeting specific languages. In addition, not all keyboards have all of these keys.
 
-#### Common IME keys
+### Common IME keys
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/window/opendialog/index.md
+++ b/files/en-us/web/api/window/opendialog/index.md
@@ -62,7 +62,7 @@ const win = openDialog("http://example.tld/zzz.xul", "dlg", "", "pizza", 6.98);
 
 ## Notes
 
-#### New features
+### New features
 
 `all` - Initially activates (or deactivates `("all=no")`) all
 chrome (except the behavior flags `chrome`, `dialog` and
@@ -71,7 +71,7 @@ all chrome except the menubar.) This feature is explicitly ignored by
 {{domxref("window.open()")}}. `window.openDialog()` finds it useful because
 of its different default assumptions.
 
-#### Default behavior
+### Default behavior
 
 The `chrome` and `dialog` features are always assumed on, unless
 explicitly turned off ("`chrome=no`"). `openDialog()` treats the
@@ -84,7 +84,7 @@ zero-length string, or contains only one or more of the behavior features
 creation code is not given specific instructions, but is instead allowed to select the
 chrome that best fits a dialog on that operating system.
 
-#### Passing extra parameters to the dialog
+### Passing extra parameters to the dialog
 
 To pass extra parameters into the dialog, you can supply them after the
 `windowFeatures` parameter:
@@ -107,7 +107,7 @@ const price = window.arguments[1];
 Note that you can access this property from within anywhere in the dialog code.
 ([Another example](/en-US/docs/Mozilla/Add-ons/Code_snippets/Dialogs_and_Prompts#passing_arguments_and_displaying_a_dialog)).
 
-#### Returning values from the dialog
+### Returning values from the dialog
 
 Since {{domxref("window.close()")}} erases all properties associated with the dialog
 window (i.e. the variables specified in the JavaScript code which gets loaded from the

--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -56,7 +56,7 @@ The `all` property is specified as one of the CSS global keyword values. Note th
 
 In this example, the CSS file contains styling for the {{HTMLElement("blockquote")}} element in addition to some styling for the parent `<body>` element. Various outputs in the Results subsection demonstrate how the styling of the `<blockquote>` element is affected when different values are applied to the `all` property inside the `blockquote` rule.
 
-#### HTML
+### HTML
 
 ```html
 <blockquote id="quote">
@@ -65,7 +65,7 @@ In this example, the CSS file contains styling for the {{HTMLElement("blockquote
 Phasellus eget velit sagittis.
 ```
 
-#### CSS
+### CSS
 
 ```css
 body {
@@ -82,7 +82,7 @@ blockquote {
 }
 ```
 
-#### Results
+### Results
 
 #### A. No `all` property
 

--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -172,7 +172,7 @@ According to the specification you can either supply just the 4-character featur
 }
 ```
 
-#### More on font-feature-settings codes
+### More on font-feature-settings codes
 
 - ['The Complete CSS Demo for OpenType Features'](https://sparanoid.com/lab/opentype-features/) (can't vouch for the truth of the name, but it's pretty big)
 - [A list of OpenType features on Wikipedia](https://en.wikipedia.org/wiki/List_of_typographic_features)

--- a/files/en-us/web/css/gradient/index.md
+++ b/files/en-us/web/css/gradient/index.md
@@ -23,19 +23,19 @@ A CSS gradient has [no intrinsic dimensions](/en-US/docs/Web/CSS/image#descripti
 
 The `<gradient>` data type is defined with one of the function types listed below.
 
-#### Linear gradient
+### Linear gradient
 
 Linear gradients transition colors progressively along an imaginary line. They are generated with the {{cssxref("gradient/linear-gradient", "linear-gradient()")}} function.
 
-#### Radial gradient
+### Radial gradient
 
 Radial gradients transition colors progressively from a center point (origin). They are generated with the {{cssxref("gradient/radial-gradient", "radial-gradient()")}} function.
 
-#### Repeating gradient
+### Repeating gradient
 
 Repeating gradients duplicate a gradient as much as necessary to fill a given area. They are generated with the {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}} and {{cssxref("gradient/repeating-radial-gradient", "repeating-radial-gradient()")}} functions.
 
-#### Conic gradient
+### Conic gradient
 
 Conic gradients transition colors progressively around a circle. They are generated with the {{cssxref("gradient/conic-gradient", "conic-gradient()")}} function.
 

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -45,7 +45,7 @@ This example shows two identical blocks of text that have {{cssxref("hyphens")}}
 The first block has the value of the hyphen changed to the equals symbol ("`=`").
 The second block has no hyphenate-character set, which is equivalent to `hyphenate-character: auto` for user agents that support this property.
 
-#### HTML
+### HTML
 
 ```html
 <dl>
@@ -56,7 +56,7 @@ The second block has no hyphenate-character set, which is equivalent to `hyphena
 </dl>
 ```
 
-#### CSS
+### CSS
 
 ```css
 dd {
@@ -71,7 +71,7 @@ dd#string {
 }
 ```
 
-#### Result
+### Result
 
 {{EmbedLiveSample("Examples", "100%", 350)}}
 

--- a/files/en-us/web/css/named-color/index.md
+++ b/files/en-us/web/css/named-color/index.md
@@ -818,7 +818,7 @@ Although various colors not in the specification (mostly adapted from the X11 co
   </tbody>
 </table>
 
-##### transparent
+#### transparent
 
 The `transparent` keyword represents a fully transparent color. This makes the background behind the colored item completely visible. Technically, `transparent` is a shortcut for `rgba(0,0,0,0)`.
 
@@ -826,7 +826,7 @@ To prevent unexpected behavior, such as in a {{cssxref("gradient")}}, the curren
 
 The `transparent` keyword wasn't a true color in CSS Level 2 (Revision 1). It was a special keyword that could be used instead of a regular `<color>` value on two CSS properties: {{Cssxref("background")}} and {{Cssxref("border")}}. It was essentially added to allow developers to override an inherited solid color. With the advent of alpha channels in CSS Colors Level 3, `transparent` was redefined as a true color. It can now be used wherever a `<color>` value can be used.
 
-#### CSS Level 4 values
+### CSS Level 4 values
 
 [CSS Colors Level 4](https://drafts.csswg.org/css-color-4/) added the `rebeccapurple` keyword [to honor web pioneer Eric Meyer](https://codepen.io/trezy/post/honoring-a-great-man).
 

--- a/files/en-us/web/css/shape/index.md
+++ b/files/en-us/web/css/shape/index.md
@@ -28,7 +28,7 @@ The `<shape>` data type is specified using the `rect()` function, which produces
 rect(top, right, bottom, left)
 ```
 
-#### Values
+### Values
 
 ![A graph showing top, right, bottom, and left, as described below. These define the rectangle's shape. The upper left corner is defined by the top and left values. The bottom right corner is defined by the bottom and right values.](rect.png)
 

--- a/files/en-us/web/guide/printing/index.md
+++ b/files/en-us/web/guide/printing/index.md
@@ -35,7 +35,7 @@ Browsers send {{domxref("Window/beforeprint_event", "beforeprint")}} and {{domxr
 
 Here are some common examples.
 
-#### Open and automatically close a popup window when finished
+### Open and automatically close a popup window when finished
 
 If you want to be able to automatically close a [popup window](/en-US/docs/Web/API/Window/open) (for example, the printer-friendly version of a document) after the user prints its contents, you can use code like this:
 

--- a/files/en-us/web/html/element/abbr/index.md
+++ b/files/en-us/web/html/element/abbr/index.md
@@ -192,7 +192,7 @@ Spelling out the acronym or abbreviation in full the first time it is used on a 
 
 Only include a `title` if expanding the abbreviation or acronym in the text is not possible.  Having a difference between the announced word or phrase and what is displayed on the screen, especially if it's technical jargon the reader may not be familiar with, can be jarring.
 
-#### Example
+### Example
 
 ```html
 <p>JavaScript Object Notation (<abbr>JSON</abbr>) is a lightweight data-interchange format.</p>

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -385,7 +385,7 @@ Promise.resolve()
 console.log(1); // 1, 2, 3, 4
 ```
 
-#### Task queues vs microtasks
+### Task queues vs microtasks
 
 Promise callbacks are handled as a [Microtask](/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide) whereas [`setTimeout()`](/en-US/docs/Web/API/setTimeout) callbacks are handled as Task queues.
 

--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -106,7 +106,7 @@ For {{SVGElement('radialGradient')}}, `cx` defines the x-axis coordinate of the 
   </tbody>
 </table>
 
-#### Example
+### Example
 
 ```css hidden
 html,body,svg { height:100% }

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -130,7 +130,7 @@ For {{SVGElement('radialGradient')}}, `cy` defines the y-axis coordinate of the 
   </tbody>
 </table>
 
-#### Example
+### Example
 
 ```css hidden
 html,body,svg { height:100% }

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -42,7 +42,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 
 ## Example
 
-#### SVG
+### SVG
 
 ```html
 <svg width="230" height="120" xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +56,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 </svg>
 ```
 
-#### Result
+### Result
 
 {{EmbedLiveSample("Example",235,150)}}
 

--- a/files/en-us/web/svg/tutorial/positions/index.md
+++ b/files/en-us/web/svg/tutorial/positions/index.md
@@ -23,7 +23,7 @@ For all elements, SVG uses a coordinate system or **grid** system similar to the
 
 Note that this is slightly different than the way you're taught to graph as a kid (y axis is flipped). However, this is the same way elements in HTML are positioned (By default, LTR documents are considered not the RTL documents which position X from right-to-left).
 
-#### Example:
+### Example
 
 The element
 

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -137,23 +137,23 @@ Map of environment variable name to environment variable value, both of which mu
 
 Starting with geckodriver 0.26.0 additional capabilities exist if Firefox or an application embedding [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView) has to be controlled on Android:
 
-##### `androidPackage` (string, required)
+#### `androidPackage` (string, required)
 
 The package name of Firefox, e.g. `org.mozilla.firefox`,
 `org.mozilla.firefox_beta,` or `org.mozilla.fennec` depending on the release
 channel, or the package name of the application embedding GeckoView, e.g. `org.mozilla.geckoview_example`.
 
-##### `androidActivity` (string, optional)
+#### `androidActivity` (string, optional)
 
 The fully qualified class name of the activity to be launched, e.g. `.GeckoViewActivity`. If not
 specified, the package's default activity will be used.
 
-##### `androidDeviceSerial` (string, optional)
+#### `androidDeviceSerial` (string, optional)
 
 The serial number of the device on which to launch the application. If not specified and multiple devices are
 attached, an error will be returned.
 
-##### `androidIntentArguments` (array of strings, optional)
+#### `androidIntentArguments` (array of strings, optional)
 
 Arguments to launch the intent with. Under the hood, geckodriver uses [Android am](https://developer.android.com/studio/command-line/adb#am) to start the Android application
 under test. The given intent arguments are appended to the `am start` command. See Android's [specification for intent arguments](https://developer.android.com/studio/command-line/adb#IntentSpec) for
@@ -184,7 +184,7 @@ For example, to specify a boolean extra that can be processed with [android.cont
 
 A JSON Object that may have any of these fields:
 
-##### `level` (string)
+#### `level` (string)
 
 Set the level of verbosity of geckodriver and Firefox. Available levels are `trace`, `debug`,
 `config`, `info`, `warn`, `error`, and `fatal`. If left

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -14,7 +14,7 @@ This article provides some XPath code snippets — simple examples of how to a f
 
 The following custom utility function can be used to evaluate XPath expressions on given XML nodes. The first argument is a DOM node or Document object, while the second is a string defining an XPath expression.
 
-##### Example: Defining a custom node-specific `evaluateXPath()` utility function
+#### Example: Defining a custom node-specific `evaluateXPath()` utility function
 
 ```js
 // Evaluate an XPath expression aExpression against a given DOM node
@@ -97,7 +97,7 @@ console.log(results.length);
 
 The following is a simple utility function to get (ordered) XPath results into an array, regardless of whether there is a special need for namespace resolvers, etc. It avoids the more complex syntax of [`document.evaluate()`](/en-US/docs/Web/API/Document/evaluate) for cases when it is not required as well as the need to use the special iterators on [`XPathResult`](/en-US/docs/Web/API/XPathResult) (by returning an array instead).
 
-##### Example: Defining a simple `docEvaluateArray()` utility function
+#### Example: Defining a simple `docEvaluateArray()` utility function
 
 ```js
 // Example usage:
@@ -123,7 +123,7 @@ function docEvaluateArray (expr, doc, context, resolver) {
 
 The following function allows one to pass an element and an XML document to find a unique string XPath expression leading back to that element.
 
-##### Example: Defining a `getXPathForElement()` utility function
+#### Example: Defining a `getXPathForElement()` utility function
 
 ```js
 function getXPathForElement(el, xml) {


### PR DESCRIPTION
Cleaned up all but the ones that are inside the `**Callout**:` blockquotes.
These are the remaining ones
```
files/en-us/learn/accessibility/index.md:37 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/index.md:36 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
files/en-us/learn/tools_and_testing/github/index.md:30 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.md:26 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
files/en-us/web/css/index.md:36 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]        
files/en-us/web/html/index.md:34 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]   
```