### PR TITLE
ci: Use custom Markdownlint in PR runs

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          yarn markdownlint ${{ steps.changed-files.outputs.all_changed_files }}
+          yarn markdownlint -r markdownlint-rule-search-replace ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
The PR specific CI didn't call the new custom rules