### PR TITLE
fix: qualify bad internal links

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -32,7 +32,7 @@ None.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an [array](Web/JavaScript/Reference/Global_Objects/array) of search engine objects. Each search engine object may contain the following properties:
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of search engine objects. Each search engine object may contain the following properties:
 
 - `name`
   - : `string`. The search engine's name.

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -49,7 +49,7 @@ The API defines {{domxref('PaintWorklet')}}, a {{domxref('worklet')}} that can b
 
 The following example creates a list of items with a background image that rotates between three different colors and three widths. In a supporting browser you will see something like the image below.
 
-![The width and color of the background image changes based on the custom properties](Guide/boxbg.png)
+![The width and color of the background image changes based on the custom properties](guide/boxbg.png)
 
 To achieve this we'll define two custom CSS properties, `--boxColor` and `--widthSubtractor`.
 

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
@@ -59,7 +59,7 @@ console.log(cssValue.getRectValue());
 This feature was originally defined in the [DOM Style Level 2](https://www.w3.org/TR/DOM-Level-2-Style/) specification, but has been dropped from any
 standardization effort since then.
 
-It has been superseded by a modern, but incompatible, [CSS Typed Object Model API](CSS_Typed_OM_API) that is now on the standard track.
+It has been superseded by a modern, but incompatible, [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) that is now on the standard track.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -48,7 +48,7 @@ It has been superseded by a modern, but incompatible, [CSS Typed Object Model AP
 This feature was originally defined in the [DOM Style Level 2](https://www.w3.org/TR/DOM-Level-2-Style/) specification, but has been dropped from any
 standardization effort since then.
 
-It has been superseded by a modern, but incompatible, [CSS Typed Object Model API](CSS_Typed_OM_API) that is now on the standard track.
+It has been superseded by a modern, but incompatible, [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) that is now on the standard track.
 
 ## See also
 

--- a/files/en-us/web/api/cssvaluelist/item/index.md
+++ b/files/en-us/web/api/cssvaluelist/item/index.md
@@ -25,8 +25,8 @@ this method returns `null`.
 >
 > To achieve your purpose, you can use:
 >
-> - the untyped [CSS Object Model](CSS_Object_Model), widely supported, or
-> - the modern [CSS Typed Object Model API](CSS_Typed_OM_API), less supported and considered experimental.
+> - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
+> - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
 ## Syntax
 

--- a/files/en-us/web/api/cssvaluelist/length/index.md
+++ b/files/en-us/web/api/cssvaluelist/length/index.md
@@ -25,8 +25,8 @@ in the list. The range of valid values of the indices is `0` to
 >
 > To achieve your purpose, you can use:
 >
-> - the untyped [CSS Object Model](CSS_Object_Model), widely supported, or
-> - the modern [CSS Typed Object Model API](CSS_Typed_OM_API), less supported and considered experimental.
+> - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
+> - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
 ## Value
 

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
@@ -30,7 +30,7 @@ A specific feature name must be specified.
 
 ### Return value
 
-An [Allow list](Web/HTTP/Feature_Policy/Using_Feature_Policy) for the
+An [Allow list](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy) for the
 specified feature.
 
 ## Errors

--- a/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -157,6 +157,6 @@ This processing is useful if you wish to examine the data that a drag is holding
 ## See also
 
 - [HTML Drag and Drop API (Overview)](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
-- [Drag Operations](Web/Guide/HTML/Drag_operations)
+- [Drag Operations](/en-US/docs/Web/Guide/HTML/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
 - [HTML Living Standard: Drag and Drop](https://html.spec.whatwg.org/multipage/interaction.html#dnd)

--- a/files/en-us/web/api/permissions/index.md
+++ b/files/en-us/web/api/permissions/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Permissions
 ---
 {{APIRef("Permissions API")}}
 
-The Permissions interface of the [Permissions API](Permissions_API) provides the core Permission API functionality, such as methods for querying and revoking permissions
+The Permissions interface of the [Permissions API](/en-US/docs/Web/API/Permissions_API) provides the core Permission API functionality, such as methods for querying and revoking permissions
 
 ## Methods
 

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -13,7 +13,7 @@ browser-compat: api.PermissionStatus
 ---
 {{APIRef("Permissions API")}}
 
-The **`PermissionStatus`** interface of the [Permissions API](Permissions_API) provides the state of an object and an event handler for monitoring changes to said state.
+The **`PermissionStatus`** interface of the [Permissions API](/en-US/docs/Web/API/Permissions_API) provides the state of an object and an event handler for monitoring changes to said state.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -60,7 +60,7 @@ See [Options and constraints](#options_and_constraints), below, for more on both
 
 ### Example of a window allowing the user to select a display surface to capture
 
-[![Screenshot of Chrome's window for picking a source surface](chrome-screen-capture-window.png)](Chrome-Screen-Capture-Window.png)
+[![Screenshot of Chrome's window for picking a source surface](chrome-screen-capture-window.png)](chrome-screen-capture-window.png)
 
 You can then use the captured stream, `captureStream`, for anything that accepts a stream as input. The [examples](#examples) below show a few ways to make use of the stream.
 

--- a/files/en-us/web/api/svggraphicselement/copy_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.md
@@ -97,5 +97,5 @@ document.querySelector("text").addEventListener("copy", (evt) => {
 
 - Related events: [`cut`](/en-US/docs/Web/API/SVGGraphicsElement/cut_event), [`paste`](/en-US/docs/Web/API/SVGGraphicsElement/paste_event)
 - This event on HTML {{domxref("Element")}} targets: [`copy`](/en-US/docs/Web/API/Element/copy_event)
-- This event on {{domxref("Document")}} targets: [`copy`](Web/API/Document/v_event)
-- This event on {{domxref("Window")}} targets: [`copy`](Web/API/Window/copy_event)
+- This event on {{domxref("Document")}} targets: [`copy`](/en-US/docs/Web/API/Document/v_event)
+- This event on {{domxref("Window")}} targets: [`copy`](/en-US/docs/Web/API/Window/copy_event)

--- a/files/en-us/web/api/svggraphicselement/cut_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/cut_event/index.md
@@ -55,5 +55,5 @@ A {{domxref("ClipboardEvent")}}. Inherits from {{domxref("Event")}}.
 
 - Related events: [`copy`](/en-US/docs/Web/API/SVGGraphicsElement/copy_event), [`paste`](/en-US/docs/Web/API/SVGGraphicsElement/paste_event)
 - This event on HTML {{domxref("Element")}} targets: [`cut`](/en-US/docs/Web/API/Element/cut_event)
-- This event on {{domxref("Document")}} targets: [`cut`](Web/API/Document/cut_event)
-- This event on {{domxref("Window")}} targets: [`cut`](Web/API/Window/cut_event)
+- This event on {{domxref("Document")}} targets: [`cut`](/en-US/docs/Web/API/Document/cut_event)
+- This event on {{domxref("Window")}} targets: [`cut`](/en-US/docs/Web/API/Window/cut_event)

--- a/files/en-us/web/api/svggraphicselement/paste_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/paste_event/index.md
@@ -89,5 +89,5 @@ document.getElementById("element-to-paste-text").addEventListener("paste", (evt)
 
 - Related events: [`cut`](/en-US/docs/Web/API/SVGGraphicsElement/cut_event), [`copy`](/en-US/docs/Web/API/SVGGraphicsElement/copy_event)
 - This event on HTML {{domxref("Element")}} targets: [`paste`](/en-US/docs/Web/API/Element/paste_event)
-- This event on {{domxref("Document")}} targets: [`paste`](Web/API/Document/paste_event)
-- This event on {{domxref("Window")}} targets: [`paste`](Web/API/Window/paste_event)
+- This event on {{domxref("Document")}} targets: [`paste`](/en-US/docs/Web/API/Document/paste_event)
+- This event on {{domxref("Window")}} targets: [`paste`](/en-US/docs/Web/API/Window/paste_event)

--- a/files/en-us/web/api/svgpreserveaspectratio/index.md
+++ b/files/en-us/web/api/svgpreserveaspectratio/index.md
@@ -285,7 +285,7 @@ An `SVGPreserveAspectRatio` object can be designated as read only, which means t
   </tbody>
 </table>
 
-**Exceptions on setting:** a [`DOMException`](DOMException) with code `NO_MODIFICATION_ALLOWED_ERR` is raised on an attempt to change the value of an attribute on a read only object.
+**Exceptions on setting:** a [`DOMException`](/en-US/docs/Web/API/DOMException) with code `NO_MODIFICATION_ALLOWED_ERR` is raised on an attempt to change the value of an attribute on a read only object.
 
 ## Methods
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -26,16 +26,16 @@ Before you get started, you'll want to make sure you've [installed node](https:/
 
 ### Table of Contents
 
-1. [Setup](Build_a_phone_with_peerjs/Setup)
-2. [Connect Peers](Build_a_phone_with_peerjs/Connect_peers)
+1. [Setup](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup)
+2. [Connect Peers](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers)
 
-    1. [Get Microphone Permission](Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission)
-    2. [Showing and hiding HTML](Build_a_phone_with_peerjs/Connect_peers/Show_hide_html)
-    3. [Create a Peer Connection](Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection)
-    4. [Creating a Call](Build_a_phone_with_peerjs/Connect_peers/Creating_a_call)
-    5. [Answer a Call](Build_a_phone_with_peerjs/Connect_peers/Answer_a_call)
-    6. [End a Call](Build_a_phone_with_peerjs/Connect_peers/End_a_call)
+    1. [Get Microphone Permission](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission)
+    2. [Showing and hiding HTML](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html)
+    3. [Create a Peer Connection](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection)
+    4. [Creating a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call)
+    5. [Answer a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call)
+    6. [End a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call)
 
-3. [Deployment and Further Reading](Build_a_phone_with_peerjs/Deployment_and_further_reading)
+3. [Deployment and Further Reading](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading)
 
 {{NextMenu("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup")}}

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -179,7 +179,7 @@ Network client hints allow a server to choose what information is sent based on 
 
 ## CORS
 
-_Learn more about CORS [here](CORS)._
+_Learn more about CORS [here](/en-US/docs/Glossary/CORS)._
 
 - {{HTTPHeader("Access-Control-Allow-Origin")}}
   - : Indicates whether the response can be shared.


### PR DESCRIPTION
Did a quick case sensitive search in VScode for `\]\([A-Z]+` to find some partial internal links that were missing the `/en-US/docs/Web` parts