### PR TITLE
Edit parseFloat() behavior with Infinity and trailing spaces.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -49,7 +49,7 @@ number.
 - Leading spaces in the argument are ignored.
 - If the argument's first character can't be converted to a number (it's not any of
   the above characters), `parseFloat` returns {{jsxref("NaN")}}.
-- `Infinity` or `-Infinity` is returned if `Infinity` or `-Infinity` is used as an argument. Note that trailing characters will be ignored.
+- `Infinity` or `-Infinity` is returned if `"Infinity"` or `"-Infinity"` is used as an argument.
 - For numbers outside the `-1.7976931348623158e+308 - 1.7976931348623158e+308` range `-Infinity` or `Infinity` is returned.
 - `parseFloat` converts {{jsxref("BigInt")}} syntax to {{jsxref("Number", "Numbers")}}, losing precision. This happens because the trailing `n`
   character is discarded.

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -46,10 +46,10 @@ number.
   ignoring the invalid character and characters following it.
 - A _second_ decimal point also stops parsing (characters up to that point
   will still be parsed).
-- Leading and trailing spaces in the argument are ignored.
+- Leading spaces in the argument are ignored.
 - If the argument's first character can't be converted to a number (it's not any of
   the above characters), `parseFloat` returns {{jsxref("NaN")}}.
-- `parseFloat` can also parse and return {{jsxref("Infinity")}} if the string starts with "Infinity" preceded by none or more white spaces.
+- `Infinity` or `-Infinity` is returned if `Infinity` or `-Infinity` is used as an argument. Note that trailing characters will be ignored.
 - For numbers outside the `-1.7976931348623158e+308 - 1.7976931348623158e+308` range `-Infinity` or `Infinity` is returned.
 - `parseFloat` converts {{jsxref("BigInt")}} syntax to {{jsxref("Number", "Numbers")}}, losing precision. This happens because the trailing `n`
   character is discarded.

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -49,7 +49,7 @@ number.
 - Leading spaces in the argument are ignored.
 - If the argument's first character can't be converted to a number (it's not any of
   the above characters), `parseFloat` returns {{jsxref("NaN")}}.
-- `Infinity` or `-Infinity` is returned if `"Infinity"` or `"-Infinity"` is used as an argument.
+- `parseFloat()` can also parse and return {{jsxref("Infinity")}} or `-Infinity` if the string starts with `"Infinity"` or `"-Infinity"` preceded by none or more white spaces.
 - For numbers outside the `-1.7976931348623158e+308 - 1.7976931348623158e+308` range `-Infinity` or `Infinity` is returned.
 - `parseFloat` converts {{jsxref("BigInt")}} syntax to {{jsxref("Number", "Numbers")}}, losing precision. This happens because the trailing `n`
   character is discarded.


### PR DESCRIPTION
### Description

Removed the leading spaces before Infinity. This is explained earlier.
Removed trailing spaces being ignored. This is also explained earlier.

### Motivation

Some of the behavior with Infinity and trailing spaces can be explained by the first rule. This is to avoid redundancy.

### Related issues and pull requests

https://github.com/mdn/content/pull/16596

#### Metadata

- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
