### PR TITLE
Encourage use of AbortController

### DIFF
--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -46,7 +46,7 @@ The `fetch` specification differs from `jQuery.ajax()` in three main ways:
 
 ### Aborting a fetch
 
-[Most browsers](https://caniuse.com/abortcontroller) have support for the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces (aka The Abort API) since 2019, which allow operations like Fetch and XHR to be aborted if they have not already completed. See the interface pages for more details.
+To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
 
 ## Fetch Interfaces
 

--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -46,7 +46,7 @@ The `fetch` specification differs from `jQuery.ajax()` in three main ways:
 
 ### Aborting a fetch
 
-Browsers have started to add experimental support for the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces (aka The Abort API), which allow operations like Fetch and XHR to be aborted if they have not already completed. See the interface pages for more details.
+[Most browsers](https://caniuse.com/abortcontroller) have support for the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces (aka The Abort API) since 2019, which allow operations like Fetch and XHR to be aborted if they have not already completed. See the interface pages for more details.
 
 ## Fetch Interfaces
 


### PR DESCRIPTION
With IE being officially dead, all major browsers support the AbortController API since around 2019, with Safari 12.1 being the latest to adopt in March 2019.

### Motivation

Encourage developers to use widely available APIs.
