### PR TITLE
Fix a condition in code snippets

### DIFF
--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -200,7 +200,7 @@ The [web-push module](https://www.npmjs.com/package/web-push) is used to set the
 ```js
 const webPush = require('web-push');
 
-if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
+if (!process.env.VAPID_PUBLIC_KEY && !process.env.VAPID_PRIVATE_KEY) {
   console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
     "environment variables. You can use the following ones:");
   console.log(webPush.generateVAPIDKeys());


### PR DESCRIPTION
In this case
```
if (!process.env.VAPID_PUBLIC_KEY && !process.env.VAPID_PRIVATE_KEY) {
```
If the first condition is met, i.e. the public key is not set, we do not need to check if the private key is not set as well, as both of them are required

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Please see the above lines

### Motivation

To have a more accurate code examples

