### PR TITLE
Added limitation for new Date("2010, 09")

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -32,7 +32,9 @@ new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds)
 Date()
 ```
 
-> **Note:** `Date()` can be called with or without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new), but with different effects. See [Return value](#return_value).
+> **Note:** 
+> 1. `Date()` can be called with or without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new), but with different effects. See [Return value](#return_value).
+> 2. `new Date(year, monthIndex)` formats only works with individual arguments, will work limited when string with comma seperated values are passed i.e) `new Date("2010, 09")` will not work in browsers like Mozilla Firefox. 
 
 ### Parameters
 


### PR DESCRIPTION
There is a limitation while Date constructor created with string parameters, if we pass individual values it works fine in all the browsers, but when we pass string with comma separated values, it only works in few browsers.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
There is a limitation while Date constructor created with string parameters,
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Providing notifications to the readers while creating Date constructor with string arguments, which behaves differently for each browser.
<!-- ❓ Why are you making these changes and how do they help readers? -->


### Additional details
There is a limitation while Date constructor created with string parameters, if we pass individual values it works fine in all the browsers, but when we pass string with comma separated values, it only works in few browsers.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Changes won't resolve the Java Script Date constructor issue but it provides notes to the users, there is a limitation when they pass date formats as string with comma separated values.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
