### PR TITLE
docs: Web Worker APIs doc in bullet list format

### DIFF
--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -48,7 +48,7 @@ Some of the functions (a subset) that are common to all workers and to the main 
 - {{domxref("btoa", "btoa()")}}
 - {{domxref("clearInterval", "clearInterval()")}}
 - {{domxref("clearTimeout()")}}
-- {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}
+- {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}}
 - {{domxref("setInterval()")}}
 - {{domxref("setTimeout()")}}
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -44,12 +44,13 @@ Workers run in a different global context than the current {{DOMxRef("window")}}
 
 Some of the functions (a subset) that are common to all workers and to the main thread (from `WindowOrWorkerGlobalScope`) are:
 
-* {{domxref("atob", "atob()")}}
-* {{domxref("btoa", "btoa()")}}
-* {{domxref("clearInterval", "clearInterval()")}}
-* {{domxref("clearTimeout()")}}
-* {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}
-* {{domxref("setInterval()")}}, {{domxref("setTimeout()")}}
+- {{domxref("atob", "atob()")}}
+- {{domxref("btoa", "btoa()")}}
+- {{domxref("clearInterval", "clearInterval()")}}
+- {{domxref("clearTimeout()")}}
+- {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}
+- {{domxref("setInterval()")}}
+- {{domxref("setTimeout()")}}
 
 The following functions are **only** available to workers:
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -81,12 +81,13 @@ The following Web APIs are available to workers:
 - {{domxref("IndexedDB_API", "IndexedDB")}}
 - [Network Information API](/en-US/docs/Web/API/Network_Information_API)
 - {{domxref("Notifications_API", "Notifications API")}}
-- {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}
-- {{domxref("PerformanceEntry")}}
-- {{domxref("PerformanceMeasure")}}
-- {{domxref("PerformanceMark")}}
-- {{domxref("PerformanceObserver")}}
-- {{domxref("PerformanceResourceTiming")}})
+- {{domxref("Performance_API","Performance API")}}, including:
+    - {{domxref("Performance")}}
+    - {{domxref("PerformanceEntry")}}
+    - {{domxref("PerformanceMeasure")}}
+    - {{domxref("PerformanceMark")}}
+    - {{domxref("PerformanceObserver")}}
+    - {{domxref("PerformanceResourceTiming")}}
 - {{jsxref("Promise")}}
 - [Server-sent events](/en-US/docs/Web/API/Server-sent_events)
 - {{domxref("ServiceWorkerRegistration")}}

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -70,9 +70,7 @@ The following Web APIs are available to workers:
 - {{domxref("Console API", "Console API")}}
 - [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) (e.g. {{domxref("Crypto")}})
 - {{domxref("CustomEvent")}}
-- {{domxref("Encoding_API", "Encoding API")}}
-- ({{domxref("TextEncoder")}}
-- {{domxref("TextDecoder")}}, etc.)
+- {{domxref("Encoding_API", "Encoding API")}} (e.g. ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}})
 - {{domxref("Fetch_API", "Fetch API")}}
 - {{domxref("FileReader")}}
 - {{domxref("FileReaderSync")}} (only works in workers!)

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -70,7 +70,7 @@ The following Web APIs are available to workers:
 - {{domxref("Console API", "Console API")}}
 - [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) (e.g. {{domxref("Crypto")}})
 - {{domxref("CustomEvent")}}
-- {{domxref("Encoding_API", "Encoding API")}} (e.g. ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}})
+- {{domxref("Encoding_API", "Encoding API")}} (e.g. {{domxref("TextEncoder")}}, {{domxref("TextDecoder")}})
 - {{domxref("Fetch_API", "Fetch API")}}
 - {{domxref("FileReader")}}
 - {{domxref("FileReaderSync")}} (only works in workers!)

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -53,9 +53,46 @@ The following functions are **only** available to workers:
 
 > **Note:** If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
 
-The following Web APIs are available to workers: {{domxref("Barcode_Detection_API","Barcode Detection API")}}, {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}, {{domxref("Cache", "Cache API")}}, {{domxref("Channel_Messaging_API", "Channel Messaging API")}}, {{domxref("Console API", "Console API")}}, [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) ({{domxref("Crypto")}}), {{domxref("CustomEvent")}}, {{domxref("Encoding_API", "Encoding API")}} ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}}, etc.), {{domxref("Fetch_API", "Fetch API")}}, {{domxref("FileReader")}}, {{domxref("FileReaderSync")}} (only works in workers!), {{domxref("FormData")}}, {{domxref("ImageData")}}, {{domxref("IndexedDB_API", "IndexedDB")}}, [Network Information API](/en-US/docs/Web/API/Network_Information_API), {{domxref("Notifications_API", "Notifications API")}}, {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}, {{domxref("PerformanceEntry")}}, {{domxref("PerformanceMeasure")}}, {{domxref("PerformanceMark")}}, {{domxref("PerformanceObserver")}}, {{domxref("PerformanceResourceTiming")}}), {{jsxref("Promise")}}, [Server-sent events](/en-US/docs/Web/API/Server-sent_events), {{domxref("ServiceWorkerRegistration")}}, {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }}), [WebGL](/en-US/docs/Web/API/WebGL_API) with {{domxref("OffscreenCanvas")}}, {{domxref("WebSocket")}}, {{domxref("XMLHttpRequest")}}.
+The following Web APIs are available to workers:
 
-Workers can also spawn other workers, so these APIs are also available: {{domxref("Worker")}}, {{domxref("WorkerGlobalScope")}}, {{domxref("WorkerLocation")}}, {{domxref("WorkerNavigator")}}.
+- {{domxref("Barcode_Detection_API","Barcode Detection API")}}
+- {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}
+- {{domxref("Cache", "Cache API")}}
+- {{domxref("Channel_Messaging_API", "Channel Messaging API")}}
+- {{domxref("Console API", "Console API")}}
+- [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) (e.g. {{domxref("Crypto")}})
+- {{domxref("CustomEvent")}}
+- {{domxref("Encoding_API", "Encoding API")}}
+- ({{domxref("TextEncoder")}}
+- {{domxref("TextDecoder")}}, etc.)
+- {{domxref("Fetch_API", "Fetch API")}}
+- {{domxref("FileReader")}}
+- {{domxref("FileReaderSync")}} (only works in workers!)
+- {{domxref("FormData")}}
+- {{domxref("ImageData")}}
+- {{domxref("IndexedDB_API", "IndexedDB")}}
+- [Network Information API](/en-US/docs/Web/API/Network_Information_API)
+- {{domxref("Notifications_API", "Notifications API")}}
+- {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}
+- {{domxref("PerformanceEntry")}}
+- {{domxref("PerformanceMeasure")}}
+- {{domxref("PerformanceMark")}}
+- {{domxref("PerformanceObserver")}}
+- {{domxref("PerformanceResourceTiming")}})
+- {{jsxref("Promise")}}
+- [Server-sent events](/en-US/docs/Web/API/Server-sent_events)
+- {{domxref("ServiceWorkerRegistration")}}
+- {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }})
+- [WebGL](/en-US/docs/Web/API/WebGL_API) with {{domxref("OffscreenCanvas")}}
+- {{domxref("WebSocket")}}
+- {{domxref("XMLHttpRequest")}}
+
+Workers can also spawn other workers, so these APIs are also available:
+
+- {{domxref("Worker")}}
+- {{domxref("WorkerGlobalScope")}}
+- {{domxref("WorkerLocation")}}
+- {{domxref("WorkerNavigator")}}.
 
 ## Web Worker interfaces
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -42,7 +42,14 @@ Workers run in a different global context than the current {{DOMxRef("window")}}
 - {{domxref("SharedWorkerGlobalScope")}} for shared workers
 - {{domxref("ServiceWorkerGlobalScope")}} for [service workers](/en-US/docs/Web/API/Service_Worker_API)
 
-Some of the functions (a subset) that are common to all workers and to the main thread (from `WindowOrWorkerGlobalScope`) are: {{domxref("atob", "atob()")}}, {{domxref("btoa", "btoa()")}}, {{domxref("clearInterval", "clearInterval()")}}, {{domxref("clearTimeout()")}}, {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}}, {{domxref("setInterval()")}}, {{domxref("setTimeout()")}}.
+Some of the functions (a subset) that are common to all workers and to the main thread (from `WindowOrWorkerGlobalScope`) are:
+
+* {{domxref("atob", "atob()")}}
+* {{domxref("btoa", "btoa()")}}
+* {{domxref("clearInterval", "clearInterval()")}}
+* {{domxref("clearTimeout()")}}
+* {{domxref("Window.dump()", "dump()")}} {{non-standard_inline}
+* {{domxref("setInterval()")}}, {{domxref("setTimeout()")}}
 
 The following functions are **only** available to workers:
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -82,12 +82,12 @@ The following Web APIs are available to workers:
 - [Network Information API](/en-US/docs/Web/API/Network_Information_API)
 - {{domxref("Notifications_API", "Notifications API")}}
 - {{domxref("Performance_API","Performance API")}}, including:
-    - {{domxref("Performance")}}
-    - {{domxref("PerformanceEntry")}}
-    - {{domxref("PerformanceMeasure")}}
-    - {{domxref("PerformanceMark")}}
-    - {{domxref("PerformanceObserver")}}
-    - {{domxref("PerformanceResourceTiming")}}
+  - {{domxref("Performance")}}
+  - {{domxref("PerformanceEntry")}}
+  - {{domxref("PerformanceMeasure")}}
+  - {{domxref("PerformanceMark")}}
+  - {{domxref("PerformanceObserver")}}
+  - {{domxref("PerformanceResourceTiming")}}
 - {{jsxref("Promise")}}
 - [Server-sent events](/en-US/docs/Web/API/Server-sent_events)
 - {{domxref("ServiceWorkerRegistration")}}

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -101,7 +101,7 @@ Workers can also spawn other workers, so these APIs are also available:
 - {{domxref("Worker")}}
 - {{domxref("WorkerGlobalScope")}}
 - {{domxref("WorkerLocation")}}
-- {{domxref("WorkerNavigator")}}.
+- {{domxref("WorkerNavigator")}}
 
 ## Web Worker interfaces
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -91,7 +91,7 @@ The following Web APIs are available to workers:
 - {{jsxref("Promise")}}
 - [Server-sent events](/en-US/docs/Web/API/Server-sent_events)
 - {{domxref("ServiceWorkerRegistration")}}
-- {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }})
+- {{domxref("URL_API","URL API")}} (e.g. {{domxref("URL")}})
 - [WebGL](/en-US/docs/Web/API/WebGL_API) with {{domxref("OffscreenCanvas")}}
 - {{domxref("WebSocket")}}
 - {{domxref("XMLHttpRequest")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Re-layout the <https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API#worker_global_contexts_and_functions> and <https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API#supported_web_apis> section in bullet point format.

### Motivation

As the list of APIs becomes very long, it becomes harder for readers to look for supported APIs and for writers to maintain this list. So I would like to rewrite them in bullet list format.