### PR TITLE
Fix legacy algorithm for <semantics> and remove obsolete attributes

### DIFF
--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -21,7 +21,7 @@ By default, only the first child of the `<semantics>` element is rendered while 
 >
 > - If no other rules apply: By default only the first child is rendered, which is supposed to be Presentation MathML.
 > - If the first child is a Presentation MathML element other than `<annotation>` or `<annotation-xml>`, render the first child.
-> - If no Presentation MathML is found, render the first `<annotation>` or `<annotation-xml>` child element of `<semantics>` without an `src` attribute, with the additional requirement for `<annotation-xml>` elements that the `encoding` attribute is equal to one of following values:
+> - If no Presentation MathML is found, render the first `<annotation>` or `<annotation-xml>` child element of `<semantics>` without a `src` attribute. For `<annotation-xml>` elements the `encoding` attribute must be equal to one of following values:
 >   - `"application/mathml-presentation+xml"`
 >   - `"MathML-Presentation"`
 >   - `"SVG1.1"`

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -21,15 +21,13 @@ By default, only the first child of the `<semantics>` element is rendered while 
 >
 > - If no other rules apply: By default only the first child is rendered, which is supposed to be Presentation MathML.
 > - If the first child is a Presentation MathML element other than `<annotation>` or `<annotation-xml>`, render the first child.
-> - If no Presentation MathML is found, render the first `<annotation>` or `<annotation-xml>` child element of `<semantics>`.
->  Beware that `<annotation-xml>` elements are only recognized, if the encoding attribute is set to one of the following:
->
-> - `"application/mathml-presentation+xml"`
-> - `"MathML-Presentation"`
-> - `"SVG1.1"`
-> - `"text/html"`
-> - `"image/svg+xml"`
-> - `"application/xml`".
+> - If no Presentation MathML is found, render the first `<annotation>` or `<annotation-xml>` child element of `<semantics>` without an `src` attribute, with the additional requirement for `<annotation-xml>` elements that the `encoding` attribute is equal to one of following values:
+>   - `"application/mathml-presentation+xml"`
+>   - `"MathML-Presentation"`
+>   - `"SVG1.1"`
+>   - `"text/html"`
+>   - `"image/svg+xml"`
+>   - `"application/xml`".
 >
 > Note that `"application/mathml+xml"` is _not_ mentioned here as it does not distinguish between Content or Presentation MathML.
 
@@ -37,15 +35,9 @@ By default, only the first child of the `<semantics>` element is rendered while 
 
 `<semantics>`, `<annotation>` and `<annotation-xml>` elements accept the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). Additionally, the following attributes can be set on the `<annotation>` and `<annotation-xml>` elements:
 
-- `definitionURL`
-  - : The location of the annotation key symbol.
 - `encoding`
   - : The encoding of the semantic information in the annotation (e.g. `"MathML-Content"`, `"MathML-Presentation"`, `"application/openmath+xml"`, `"image/png"`)
-- `cd`
-  - : The content dictionary that contains the annotation key symbol.
-- `name`
-  - : The name of the annotation key symbol.
-- `src`
+- `src` {{deprecated_inline}}
   - : The location of an external source for semantic information.
 
 ## Example


### PR DESCRIPTION
### Description

Update the note about the legacy algorithm implemented in WebKit and
Firefox, which actually skip the annotations that have an `src`
attribute [1] [2]. Also try to clarify that annotation-xml without
a known encoding are skipped too, as current text is not clear.

MathML Core only mentions `encoding` for non-global attributes
accepted on annotation/annotation-xml elements. So mark `src` as
deprecated and remove all the other attributes that were never
involved in browser implementations.

### Motivation

Cleanup obsolete information and fix mistake in legacy algo.

### Additional details

[1] https://github.com/WebKit/WebKit/blob/b7d555805988f56bc97e9ae21014a35a463b1987/Source/WebCore/mathml/MathMLSelectElement.cpp#L174
[2] https://searchfox.org/mozilla-central/rev/3f9dcc016dd96a0336d46f4a19aeabdd796ab9e9/layout/mathml/nsMathMLsemanticsFrame.cpp#63
[3] https://w3c.github.io/mathml-core/#semantics-and-presentation

### Related issues and pull requests

Compat data: https://github.com/mdn/browser-compat-data/pull/17702