### PR TITLE
Link MathML tutorial from the MathML and Learn pages.

### DIFF
--- a/files/en-us/learn/index.md
+++ b/files/en-us/learn/index.md
@@ -59,6 +59,8 @@ The following is a list of all the topics we cover in the MDN learning area.
   - : Accessibility is the practice of making web content available to as many people as possible regardless of disability, device, locale, or other differentiating factors. This topic gives you all you need to know.
 - [Web Performance — making websites fast and responsive](/en-US/docs/Learn/Performance)
   - : Web performance is the art of making sure web applications download fast and are responsive to user interaction, regardless of a user's bandwidth, screen size, network, or device capabilities.
+- [MathML](/en-US/docs/Learn/MathML)
+  - : MathML is the language that we can use to write mathematical formulas in web pages using fractions, scripts, radicals, matrices, integrals, series, etc.  This topic covers MathML.
 - [Tools and testing](/en-US/docs/Learn/Tools_and_testing)
   - : This topic covers the tools developers use to facilitate their work, such as cross-browser testing tools, linters, formatters, transformation tools, version control systems, deployment tools, and client-side JavaScript frameworks.
 - [Server-side website programming](/en-US/docs/Learn/Server-side)

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -29,6 +29,8 @@ Below you will find links to documentation, examples, and tools to work with Mat
   - : MathML samples and examples to help you understand how it works.
 - [Authoring MathML](/en-US/docs/Web/MathML/Authoring)
   - : Suggestions and tips for writing MathML, including suggested MathML editors and how to integrate their output into Web content.
+- [MathML tutorial](/en-US/docs/Learn/MathML)
+  - : A gentle introduction to MathML.
 
 ## Getting help from the community
 


### PR DESCRIPTION
### Description

Link MathML tutorial from the MathML and Learn pages.

### Motivation

Make the tutorial accessible.

### Additional details

N/A

### Related issues and pull requests

Follow-up of
https://github.com/mdn/content/pull/19467
https://github.com/mdn/yari/pull/6953
