### PR TITLE
Make first-paint glossary more precise

### DIFF
--- a/files/en-us/glossary/first_paint/index.md
+++ b/files/en-us/glossary/first_paint/index.md
@@ -7,7 +7,7 @@ tags:
   - Performance
   - Web Performance
 ---
-**First Paint**, part of the [Paint Timing API](/en-US/docs/Web/API/Paint_Timing_API), is the time between navigation and when the browser renders the first pixels to the screen, rendering anything that is visually different from what was on the screen prior to navigation. It answers the question "Is it happening?"
+**First Paint**, part of the [Paint Timing API](/en-US/docs/Web/API/Paint_Timing_API), is the time between navigation and when the browser renders the first pixels to the screen, rendering anything that is visually different from the default [background color](en-US/docs/Web/CSS/background-color) of the [body](/en-US/docs/Web/API/Document/body). It answers the question "Is it happening?"
 
 ## See also
 


### PR DESCRIPTION
First paint is measured from the first time something other than the body background color is painted, not from the first time something other than the previous page is painted.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
