### PR TITLE
Add some docs about transient and sticky user activation

### DIFF
--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
-**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset during the frame's lifetime after it has been set initially (unlike {{Glossary("Transient activation")}}).
+**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset after it has been set initially (unlike {{Glossary("Transient activation")}}).
 
 See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _sticky activation_.
 

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -1,0 +1,16 @@
+---
+title: Sticky activation
+slug: Glossary/Sticky_activation
+tags:
+  - Sticky activation
+  - Glossary
+  - JavaScript
+---
+**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset during the frame's lifetime after it has been set initially (unlike {{Glossary("Transient activation")}}).
+
+See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _sticky activation_.
+
+## See also
+
+- [HTML Living Standard > Sticky activation](https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation)
+- {{Glossary("Transient activation")}}

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
-**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. 
+**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction.
 
 A page is considered "user activated" if a user is currently interacting with the page or has completed a touch, pointer, or keyboard interaction since page load. With sticky user activation, if activation is set it is not reset for the duration of the session (unlike {{Glossary("Transient activation")}}).
 

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -6,7 +6,9 @@ tags:
   - Glossary
   - JavaScript
 ---
-**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset after it has been set initially (unlike {{Glossary("Transient activation")}}).
+**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. 
+
+A page is considered "user activated" if a user is currently interacting with the page or has completed a touch, pointer, or keyboard interaction since page load. With sticky user activation, if activation is set it is not reset for the duration of the session (unlike {{Glossary("Transient activation")}}).
 
 See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _sticky activation_.
 

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -6,6 +6,7 @@ tags:
   - Glossary
   - JavaScript
 ---
+
 **Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction.
 
 A page is considered "user activated" if a user is currently interacting with the page or has completed a touch, pointer, or keyboard interaction since page load. With sticky user activation, if activation is set it is not reset for the duration of the session (unlike {{Glossary("Transient activation")}}).

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -11,13 +11,11 @@ tags:
 This state is sometimes used as a mechanism for ensuring that a web API can only function if triggered by user interaction.
 For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠—it must be triggered from a UI element's event handler.
 
-Examples of APIs that require _transient activation_ are:
+See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _transient activation_.
 
-- {{domxref("MediaDevices.selectAudioOutput()")}}
-
-> **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs.
+> **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs. See {{Glossary("Sticky activation")}} for a user activation that doesn't reset during the frame's lifetime after it has once been set.
 
 ## See also
 
-- {{domxref("MediaDevices.selectAudioOutput()")}}
 - [HTML Living Standard > Transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation)
+- {{Glossary("Sticky activation")}}

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -13,7 +13,7 @@ For example, scripts cannot arbitrarily launch a popup that requires _transient 
 
 See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _transient activation_.
 
-> **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs. See {{Glossary("Sticky activation")}} for a user activation that doesn't reset during the frame's lifetime after it has once been set.
+> **Note:** Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs. See {{Glossary("Sticky activation")}} for a user activation that doesn't reset after it has been set initially.
 
 ## See also
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -28,7 +28,7 @@ Example APIs that require transient activation:
 - [`beforeunload` event](/en-US/docs/Web/API/Window/beforeunload_event)
 - {{domxref("Clipboard.read()")}}
 - {{domxref("Clipboard.readText()")}}
-- {{domxref("Clipboard.writeText()")}} (requires activation in Safari and Firefox, but not in Chromium-based browsers)
+- {{domxref("Clipboard.writeText()")}}
 - {{domxref("Document.requestStorageAccess()")}}
 - {{domxref("Element.requestFullScreen()")}}
 - {{domxref("Element.requestPointerLock()")}}

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -7,7 +7,17 @@ To ensure applications are unable to abuse APIs that can create bad user experie
 
 A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load. Typically, this is a click on a button or some other user interaction with the UI.
 
-There are two types of user activation window states: sticky and transient.
+More precisely, an _activation triggering input event_ is an event which:
+
+- has the [`isTrusted`](/en-US/docs/Web/API/Event/isTrusted) attribute set to `true`, and
+- is an event of the following types:
+  - [`keydown`](/en-US/docs/Web/API/Element/keydown_event) (except for the <kbd>Esc</kbd> key nor a shortcut key reserved by the user agent)
+  - [`mousedown`](/en-US/docs/Web/API/Element/mousedown_event)
+  - [`pointerdown`](/en-US/docs/Web/API/Element/pointerdown_event) (if `pointerType` is "mouse")
+  - [`pointerup`](/en-US/docs/Web/API/Element/pointerup_event) (if `pointerType` is not "mouse")
+  - [`touchend`](/en-US/docs/Web/API/Element/touchend_event)
+
+If an activation has been triggered, the user agent differentiates between two types of user activation window states: sticky and transient.
 
 ## Transient activation
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -18,6 +18,7 @@ Example APIs that require transient activation:
 - [`beforeunload` event](/en-US/docs/Web/API/Window/beforeunload_event)
 - {{domxref("Clipboard.read()")}}
 - {{domxref("Clipboard.readText()")}}
+- {{domxref("Clipboard.writeText()")}} (requires activation in Safari and Firefox, but not in Chromium-based browsers)
 - {{domxref("Document.requestStorageAccess()")}}
 - {{domxref("Element.requestFullScreen()")}}
 - {{domxref("Element.requestPointerLock()")}}

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -45,7 +45,7 @@ Example APIs that require transient activation:
 
 ## Sticky activation
 
-{{Glossary("Sticky activation")}} is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset during the frame's lifetime after it has been set initially (unlike transient activation).
+{{Glossary("Sticky activation")}} is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset after it has been set initially (unlike transient activation).
 
 Examples APIs that require sticky activation:
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -9,7 +9,7 @@ A user activation either implies that the user is currently interacting with the
 
 There are two types of user activation, sticky and transient.
 
-## Transient activation 
+## Transient activation
 
 {{Glossary("Transient activation")}} is a window state that indicates a user has recently pressed a button, moved a mouse, used a menu, or performed some other user interaction. Transient activation expires after a timeout (if not renewed by further interaction) and may also be consumed by some APIs (like {{domxref("Window.open()")}}).
 
@@ -43,7 +43,7 @@ Example APIs that require transient activation:
 - `Window.queryLocalFonts()`
 - {{domxref("XRSystem.requestSession()")}}
 
-## Sticky activation 
+## Sticky activation
 
 {{Glossary("Sticky activation")}} is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset during the frame's lifetime after it has been set initially (unlike transient activation).
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -1,0 +1,62 @@
+---
+title: Features gated by user activation
+slug: Web/Security/User_activation
+---
+
+Browsers gate access to sensitive APIs like popups, fullscreen, or vibration APIs behind user activation to prevent malicious scripts from abusing these features. This page lists web platform features available only after user activation.
+
+A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load. Typically, this is a click on a button or some other user interaction with the UI.
+
+There are two types of user activation, sticky and transient.
+
+## Transient activation 
+
+{{Glossary("Transient activation")}} is a window state that indicates a user has recently pressed a button, moved a mouse, used a menu, or performed some other user interaction. Transient activation expires after a timeout (if not renewed by further interaction) and may also be consumed by some APIs (like {{domxref("Window.open()")}}).
+
+Example APIs that require transient activation:
+
+- [`beforeunload` event](/en-US/docs/Web/API/Window/beforeunload_event)
+- {{domxref("Clipboard.read()")}}
+- {{domxref("Clipboard.readText()")}}
+- {{domxref("Document.requestStorageAccess()")}}
+- {{domxref("Element.requestFullScreen()")}}
+- {{domxref("Element.requestPointerLock()")}}
+- `GPUAdapter.requestAdapterInfo()`
+- {{domxref("HID.requestDevice()")}}
+- {{domxref("HTMLVideoElement.requestPictureInPicture()")}}
+- {{domxref("IdleDetector.requestPermission()")}}
+- {{domxref("MediaDevices.selectAudioOutput()")}}
+- `MediaStreamTrack.sendCaptureAction()`
+- `MediaDevices.getViewportMedia()`
+- {{domxref("MediaDevices.getDisplayMedia()")}}
+- {{domxref("Navigator.share()")}}
+- {{domxref("PaymentRequest.show()")}}
+- {{domxref("PresentationREquest.start()")}}
+- {{domxref("RemotePlayback.prompt()")}}
+- {{domxref("USB.requestDevice()")}}
+- {{domxref("Keyboard.lock()")}}
+- {{domxref("Window.open()")}}
+- {{domxref("Window.showOpenFilePicker()")}}
+- {{domxref("Window.showSaveFilePicker()")}}
+- {{domxref("Window.showDirectoryPicker()")}}
+- `Window.getScreenDetails()`
+- `Window.queryLocalFonts()`
+- {{domxref("XRSystem.requestSession()")}}
+
+## Sticky activation 
+
+{{Glossary("Sticky activation")}} is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset during the frame's lifetime after it has been set initially (unlike transient activation).
+
+Examples APIs that require sticky activation:
+
+- {{domxref("Navigator.vibrate()")}}
+- `navigator.getAutoplayPolicy()`
+- `navigator.virtualKeyboard.show()`
+
+## See also
+
+- {{Glossary("Transient activation")}}
+- {{Glossary("Sticky activation")}}
+- [Features restricted to secure contexts](/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts)
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -3,11 +3,11 @@ title: Features gated by user activation
 slug: Web/Security/User_activation
 ---
 
-Browsers gate access to sensitive APIs like popups, fullscreen, or vibration APIs behind user activation to prevent malicious scripts from abusing these features. This page lists web platform features available only after user activation.
+To ensure applications are unable to abuse APIs that can create bad user experience when the behavior is not desired, some APIs can only be used when the user is in an "active interaction" state, meaning the user is currently interacting with the web page, or has interacted with the page at least once. Browsers limit access to sensitive APIs like popups, fullscreen, or vibration APIs to active user interactions to prevent malicious scripts from abusing these features. This page lists web platform features available only after user activation.
 
 A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load. Typically, this is a click on a button or some other user interaction with the UI.
 
-There are two types of user activation, sticky and transient.
+There are two types of user activation window states: sticky and transient.
 
 ## Transient activation
 
@@ -31,7 +31,7 @@ Example APIs that require transient activation:
 - {{domxref("MediaDevices.getDisplayMedia()")}}
 - {{domxref("Navigator.share()")}}
 - {{domxref("PaymentRequest.show()")}}
-- {{domxref("PresentationREquest.start()")}}
+- {{domxref("PresentationRequest.start()")}}
 - {{domxref("RemotePlayback.prompt()")}}
 - {{domxref("USB.requestDevice()")}}
 - {{domxref("Keyboard.lock()")}}

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -34,6 +34,7 @@ Example APIs that require transient activation:
 - {{domxref("Element.requestPointerLock()")}}
 - `GPUAdapter.requestAdapterInfo()`
 - {{domxref("HID.requestDevice()")}}
+- {{domxref("HTMLInputElement.showPicker()")}}
 - {{domxref("HTMLVideoElement.requestPictureInPicture()")}}
 - {{domxref("IdleDetector.requestPermission()")}}
 - {{domxref("MediaDevices.selectAudioOutput()")}}


### PR DESCRIPTION
### Description

Expands the docs a bit to tell more about transient and sticky user activation.

### Motivation

I was motivated by this request: https://github.com/openwebdocs/project/issues/73

### Additional details

Here's the spec: https://html.spec.whatwg.org/multipage/interaction.html#tracking-user-activation

Dom has a great tool to search in specs, so I used that to find APIs that use user activation.
https://dontcallmedom.github.io/webdex/t.html#Transient%20activation%40%40html%25%25dfn
https://dontcallmedom.github.io/webdex/s.html#Sticky%20activation%40%40html%25%25dfn