### PR TITLE
Deemphasize IE notes in typeof, more descriptive headings

### DIFF
--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -9,10 +9,10 @@ tags:
   - Unary
 browser-compat: javascript.operators.typeof
 ---
+
 {{JSSidebar("Operators")}}
 
-The **`typeof`** operator returns a string indicating the type
-of the unevaluated operand.
+The **`typeof`** operator returns a string indicating the type of the operand's value.
 
 {{EmbedInteractiveExample("pages/js/expressions-typeof.html")}}
 
@@ -29,27 +29,21 @@ typeof operand
 
 ## Description
 
-The following table summarizes the possible return values of `typeof`. For
-more information about types and primitives, see also the [JavaScript data structure](/en-US/docs/Web/JavaScript/Data_structures) page.
+The following table summarizes the possible return values of `typeof`. For more information about types and primitives, see also the [JavaScript data structure](/en-US/docs/Web/JavaScript/Data_structures) page.
 
-| Type                                                                                     | Result                                 |
-| ---------------------------------------------------------------------------------------- | -------------------------------------- |
-| [Undefined](/en-US/docs/Glossary/undefined)                                              | `"undefined"`                          |
-| [Null](/en-US/docs/Glossary/Null)                                                        | `"object"` (see [below](#typeof_null)) |
-| [Boolean](/en-US/docs/Glossary/Boolean)                                                  | `"boolean"`                            |
-| [Number](/en-US/docs/Glossary/Number)                                                    | `"number"`                             |
-| [BigInt](/en-US/docs/Glossary/BigInt)                                                    | `"bigint"`                             |
-| [String](/en-US/docs/Glossary/String)                                                    | `"string"`                             |
-| [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)                     | `"symbol"`                             |
-| [Function](/en-US/docs/Glossary/Function) (implements [[Call]] in ECMA-262 terms; [classes](/en-US/docs/Web/JavaScript/Reference/Statements/class) are functions as well) | `"function"`                           |
-| Any other object                                                                         | `"object"`                             |
+| Type                                                                                                                                                                      | Result                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [Undefined](/en-US/docs/Glossary/undefined)                                                                                                                               | `"undefined"`                       |
+| [Null](/en-US/docs/Glossary/Null)                                                                                                                                         | `"object"` ([reason](#typeof_null)) |
+| [Boolean](/en-US/docs/Glossary/Boolean)                                                                                                                                   | `"boolean"`                         |
+| [Number](/en-US/docs/Glossary/Number)                                                                                                                                     | `"number"`                          |
+| [BigInt](/en-US/docs/Glossary/BigInt)                                                                                                                                     | `"bigint"`                          |
+| [String](/en-US/docs/Glossary/String)                                                                                                                                     | `"string"`                          |
+| [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)                                                                                                      | `"symbol"`                          |
+| [Function](/en-US/docs/Glossary/Function) (implements [[Call]] in ECMA-262 terms; [classes](/en-US/docs/Web/JavaScript/Reference/Statements/class) are functions as well) | `"function"`                        |
+| Any other object                                                                                                                                                          | `"object"`                          |
 
-> **Note:** ECMAScript 2019 and older permitted implementations to have
-> `typeof` return any implementation-defined string value for non-callable
-> non-standard exotic objects.
->
-> The only known browser to have actually taken advantage of this is old Internet
-> Explorer (see [below](#ie-specific_notes)).
+This list of values is exhaustive. No spec-compliant engines are reported to produce (or had historically produced) values other than those listed. The old Internet Explorer was the only browser known to [implement additional return values](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872), before the spec removed the behavior of `typeof` returning implementation-defined strings for non-callable non-standard exotic objects.
 
 ## Examples
 
@@ -57,95 +51,90 @@ more information about types and primitives, see also the [JavaScript data struc
 
 ```js
 // Numbers
-typeof 37 === 'number';
-typeof 3.14 === 'number';
-typeof 42 === 'number';
-typeof Math.LN2 === 'number';
-typeof Infinity === 'number';
-typeof NaN === 'number'; // Despite being "Not-A-Number"
-typeof Number('1') === 'number';      // Number tries to parse things into numbers
-typeof Number('shoe') === 'number';   // including values that cannot be type coerced to a number
+typeof 37 === "number";
+typeof 3.14 === "number";
+typeof 42 === "number";
+typeof Math.LN2 === "number";
+typeof Infinity === "number";
+typeof NaN === "number"; // Despite being "Not-A-Number"
+typeof Number("1") === "number"; // Number tries to parse things into numbers
+typeof Number("shoe") === "number"; // including values that cannot be type coerced to a number
 
-typeof 42n === 'bigint';
+typeof 42n === "bigint";
 
 // Strings
-typeof '' === 'string';
-typeof 'bla' === 'string';
-typeof `template literal` === 'string';
-typeof '1' === 'string'; // note that a number within a string is still typeof string
-typeof (typeof 1) === 'string'; // typeof always returns a string
-typeof String(1) === 'string'; // String converts anything into a string, safer than toString
+typeof "" === "string";
+typeof "bla" === "string";
+typeof `template literal` === "string";
+typeof "1" === "string"; // note that a number within a string is still typeof string
+typeof typeof 1 === "string"; // typeof always returns a string
+typeof String(1) === "string"; // String converts anything into a string, safer than toString
 
 // Booleans
-typeof true === 'boolean';
-typeof false === 'boolean';
-typeof Boolean(1) === 'boolean'; // Boolean() will convert values based on if they're truthy or falsy
-typeof !!(1) === 'boolean'; // two calls of the ! (logical NOT) operator are equivalent to Boolean()
+typeof true === "boolean";
+typeof false === "boolean";
+typeof Boolean(1) === "boolean"; // Boolean() will convert values based on if they're truthy or falsy
+typeof !!1 === "boolean"; // two calls of the ! (logical NOT) operator are equivalent to Boolean()
 
 // Symbols
-typeof Symbol() === 'symbol'
-typeof Symbol('foo') === 'symbol'
-typeof Symbol.iterator === 'symbol'
+typeof Symbol() === "symbol";
+typeof Symbol("foo") === "symbol";
+typeof Symbol.iterator === "symbol";
 
 // Undefined
-typeof undefined === 'undefined';
-typeof declaredButUndefinedVariable === 'undefined';
-typeof undeclaredVariable === 'undefined';
+typeof undefined === "undefined";
+typeof declaredButUndefinedVariable === "undefined";
+typeof undeclaredVariable === "undefined";
 
 // Objects
-typeof { a: 1 } === 'object';
+typeof { a: 1 } === "object";
 
 // use Array.isArray or Object.prototype.toString.call
 // to differentiate regular objects from arrays
-typeof [1, 2, 4] === 'object';
+typeof [1, 2, 4] === "object";
 
-typeof new Date() === 'object';
-typeof /regex/ === 'object'; // See Regular expressions section for historical results
+typeof new Date() === "object";
+typeof /regex/ === "object";
 
 // The following are confusing, dangerous, and wasteful. Avoid them.
-typeof new Boolean(true) === 'object';
-typeof new Number(1) === 'object';
-typeof new String('abc') === 'object';
+typeof new Boolean(true) === "object";
+typeof new Number(1) === "object";
+typeof new String("abc") === "object";
 
 // Functions
-typeof function () {} === 'function';
-typeof class C {} === 'function';
-typeof Math.sin === 'function';
+typeof function () {} === "function";
+typeof class C {} === "function";
+typeof Math.sin === "function";
 ```
 
 ### typeof null
 
 ```js
 // This stands since the beginning of JavaScript
-typeof null === 'object';
+typeof null === "object";
 ```
 
-In the first implementation of JavaScript, JavaScript values were represented as a type
-tag and a value. The type tag for objects was `0`. `null` was
-represented as the NULL pointer (`0x00` in most platforms). Consequently,
-`null` had `0` as type tag, hence the `typeof` return
-value `"object"`. ([reference](https://2ality.com/2013/10/typeof-null.html))
+In the first implementation of JavaScript, JavaScript values were represented as a type tag and a value. The type tag for objects was `0`. `null` was represented as the NULL pointer (`0x00` in most platforms). Consequently, `null` had `0` as type tag, hence the `typeof` return value `"object"`. ([reference](https://2ality.com/2013/10/typeof-null.html))
 
-A fix was proposed for ECMAScript (via an opt-in), but
-[was rejected](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null).
-It would have resulted in `typeof null === 'null'`.
+A fix was proposed for ECMAScript (via an opt-in), but [was rejected](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null). It would have resulted in `typeof null === "null"`.
 
 ### Using new operator
 
+All constructor functions called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) will return non-primitives (`"object"` or `"function"`). Most return objects, with the notable exception being [`Function`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function), which returns a function.
+
 ```js
-// All constructor functions, with the exception of the Function constructor, will always be typeof 'object'
-const str = new String('String');
+const str = new String("String");
 const num = new Number(100);
 
-typeof str; // It will return 'object'
-typeof num; // It will return 'object'
+typeof str; // "object"
+typeof num; // "object"
 
 const func = new Function();
 
-typeof func; // It will return 'function'
+typeof func; // "function"
 ```
 
-### Need for parentheses in Syntax
+### Need for parentheses in syntax
 
 The `typeof` operator has higher [precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) than binary operators like addition (`+`). Therefore, parentheses are needed to evaluate the type of an addition result.
 
@@ -153,57 +142,43 @@ The `typeof` operator has higher [precedence](/en-US/docs/Web/JavaScript/Referen
 // Parentheses can be used for determining the data type of expressions.
 const someData = 99;
 
-typeof someData + ' Wisen'; // 'number Wisen'
-typeof (someData + ' Wisen'); // 'string'
+typeof someData + " Wisen"; // "number Wisen"
+typeof (someData + " Wisen"); // "string"
 ```
 
-### Regular expressions
+### Interaction with undeclared and uninitialized variables
 
-Callable regular expressions were a non-standard addition in some browsers.
+`typeof` is generally always guaranteed to return a string for any operand it is supplied with. Even with undeclared identifiers, `typeof` will return `"undefined"` instead of throwing an error.
 
 ```js
-typeof /s/ === 'function'; // Chrome 1-12 Non-conform to ECMAScript 5.1
-typeof /s/ === 'object';   // Firefox 5+  Conform to ECMAScript 5.1
+typeof undeclaredVariable; // "undefined"
 ```
-
-### Errors
-
-`typeof` is generally always guaranteed to return a string
-for any operand it is supplied with. Even with undeclared identifiers, `typeof` will return `'undefined'` instead of throwing an error.
 
 However, using `typeof` on lexical declarations ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the line of declaration will throw a {{JSxRef("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
 
-```js
-typeof undeclaredVariable === 'undefined';
-
+```js example-bad
 typeof newLetVariable; // ReferenceError
 typeof newConstVariable; // ReferenceError
 typeof newClass; // ReferenceError
 
 let newLetVariable;
-const newConstVariable = 'hello';
-class newClass{}
+const newConstVariable = "hello";
+class newClass {}
 ```
 
-### Exceptions
+### Exceptional behavior of document.all
 
-All current browsers expose a non-standard host object [`document.all`](/en-US/docs/Web/API/Document/all)
-with type `undefined`.
+All current browsers expose a non-standard host object [`document.all`](/en-US/docs/Web/API/Document/all) with type `undefined`.
 
 ```js
-typeof document.all === 'undefined';
+typeof document.all === "undefined";
 ```
 
-Although the specification allows custom type tags for non-standard exotic objects, it
-requires those type tags to be different from the predefined ones. The case of
-`document.all` having type `'undefined'` is classified in the web
-standards as a "willful violation" of the original ECMA JavaScript standard.
+Although `document.all` is also [falsy](/en-US/docs/Glossary/Falsy) and [loosely equal](/en-US/docs/Web/JavaScript/Reference/Operators/Equality) to `undefined`, it is not [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined). The case of `document.all` having type `"undefined"` is classified in the web standards as a "willful violation" of the original ECMAScript standard for web compatibility.
 
 ### Custom method that gets a more specific type
 
-`typeof` is very useful, but it's not as versatile as might be required. For
-example, `typeof []` , is `'object'`, as well as
-`typeof new Date()`, `typeof /abc/`, etc.
+`typeof` is very useful, but it's not as versatile as might be required. For example, `typeof []` is `"object"`, as well as `typeof new Date()`, `typeof /abc/`, etc.
 
 For greater specificity in checking types, here we present a custom `type(value)` function, which mostly mimics the behavior of `typeof`, but for non-primitives (i.e. objects and functions), it returns a more granular type name where possible.
 
@@ -246,8 +221,7 @@ function type(value) {
 }
 ```
 
-For checking non-existent variables that would otherwise throw
-a {{JSxRef("ReferenceError")}}, use `typeof nonExistentVar === 'undefined'`.
+For checking potentially non-existent variables that would otherwise throw a {{JSxRef("ReferenceError")}}, use `typeof nonExistentVar === "undefined"` because this behavior cannot be mimicked with custom code.
 
 ## Specifications
 
@@ -256,22 +230,6 @@ a {{JSxRef("ReferenceError")}}, use `typeof nonExistentVar === 'undefined'`.
 ## Browser compatibility
 
 {{Compat}}
-
-### IE-specific notes
-
-On IE 6, 7, and 8 a lot of host objects are objects and not functions. For example:
-
-```js
-typeof alert === 'object'
-```
-
-Some non-standard IE properties return other values
-([tc39/ecma262#1440 (comment)](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872)):
-
-```js
-typeof window.external.AddSearchProvider === "unknown";
-typeof window.external.IsSearchProviderInstalled === "unknown";
-```
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Now that we don't even have IE in the compat table anymore (which I disagreed with in https://github.com/mdn/mdn-community/discussions/202), it makes even more sense to remove notes for _older_ IE.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
