### PR TITLE
Fix typo in project writing guidelines

### DIFF
--- a/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -38,7 +38,7 @@ The term **deprecated** on MDN Web Docs is used to mark an API or technology tha
 
 ## Obsolete
 
-On MDN Web Docs, the term **obsolete** was used to mark an API or technology that is not only no longer recommended but is also no longer implemented in browsers. The term was, however, confusing. It was similar to **deprecated** but it's distinction from **deprecated** was not very helpful.
+On MDN Web Docs, the term **obsolete** was used to mark an API or technology that is not only no longer recommended but is also no longer implemented in browsers. The term was, however, confusing. It was similar to **deprecated** but its distinction from **deprecated** was not very helpful.
 
 > **Note:** We do not use the term **obsolete** on MDN Web Docs anymore. If you come across any instances, they should be removed or replaced with the term **deprecated**.
 

--- a/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -38,7 +38,7 @@ The term **deprecated** on MDN Web Docs is used to mark an API or technology tha
 
 ## Obsolete
 
-On MDN Web Docs, the term **obsolete** was used to mark an API or technology that is not only no longer recommended but is also no longer implemented in browsers. The term was, however, confusing. It was similar to **deprecated** but it's distinction from **deprecated** ws not very helpful.
+On MDN Web Docs, the term **obsolete** was used to mark an API or technology that is not only no longer recommended but is also no longer implemented in browsers. The term was, however, confusing. It was similar to **deprecated** but it's distinction from **deprecated** was not very helpful.
 
 > **Note:** We do not use the term **obsolete** on MDN Web Docs anymore. If you come across any instances, they should be removed or replaced with the term **deprecated**.
 


### PR DESCRIPTION
- [x] Fixes a typo, bug, or other error

I had noticed a typo in https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete and changed 'ws' to 'was'

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
