### PR TITLE
chore: remove orphan .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ["plugin:json/recommended"],
-};


### PR DESCRIPTION
The first pass for the JSON formatting used ESLint. This was switched to Prettier, but I didn't clean out that file while making the change.
ESLint might come back later, but there is no point keeping this around as-is