### PR TITLE
Fixing typo in Operators explanation

### DIFF
--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -251,7 +251,7 @@ The double-equals and triple-equals also have their inequality counterparts: `!=
 JavaScript also has [bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators#bitwise_shift_operators) and [logical operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators). Notably, logical operators don't work with boolean values only — they work by the "truthiness" of the value.
 
 ```js
-const a = 0 && "Hello"; // "Hello" because 0 is "falsy"
+const a = 0 && "Hello"; // 0 because 0 is "falsy"
 const b = "Hello" || "world"; // "Hello" because both "Hello" and "world" are "truthy"
 ```
 


### PR DESCRIPTION
The result on line no. 254 as shown in the comment is wrong. The correct value should be 0

Original:
```js
const a = 0 && "Hello"; // "Hello" because 0 is "falsy"
```

Proposed:
```js
const a = 0 && "Hello"; // 0 because 0 is "falsy"
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fixing the typo in Bitwise Operators example

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The result as shown in the example is incorrect.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
