### PR TITLE
fix syntax error

### DIFF
--- a/files/en-us/web/api/event/eventphase/index.md
+++ b/files/en-us/web/api/event/eventphase/index.md
@@ -142,9 +142,9 @@ function onDivClick(e) {
 }
 
 function clearDivs() {
-  divs.forEach((div, i) => {
-    if (div.id !== 'divInfo') {
-      div.style.backgroundColor = i % 2 !== 0 ? '#f6eedb' : '#cceeff';
+  for (let i = 0; i < divs.length; i++) {
+    if (divs[i].id !== 'divInfo') {
+      divs[i].style.backgroundColor = i % 2 !== 0 ? '#f6eedb' : '#cceeff';
     }
   }
   divInfo.textContent = '';


### PR DESCRIPTION
[The live sample](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase#result) on eventPhase page throws a syntax error on line 149:
> Uncaught SyntaxError: missing ) after argument list

But the main issue is that the `divs` is an HTMLCollection (array like) and it doesn't have `forEach()` and `entries()` methods. So we have to resort to the old `for(;;)` loop.