### PR TITLE
docs(relnote): 19707 remove 'obsolete' admonition, add menuitem to 103 relnote as removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -2,11 +2,12 @@
 title: Firefox 103 for developers
 slug: Mozilla/Firefox/Releases/103
 tags:
-  - '103'
+  - "103"
   - Firefox
   - Mozilla
   - Release
 ---
+
 {{FirefoxSidebar}}
 
 This article provides information about the changes in Firefox 103 that will affect developers. Firefox 103 was released on July 26, 2022.
@@ -16,6 +17,9 @@ This article provides information about the changes in Firefox 103 that will aff
 ### HTML
 
 #### Removals
+
+- Support for the `<menuitem>` element has been removed along with the `dom.menuitem.enabled` preference.
+  For more details, see [Bug 1372276](https://bugzilla.mozilla.org/show_bug.cgi?id=1372276).
 
 ### MathML
 

--- a/files/en-us/web/html/global_attributes/contextmenu/index.md
+++ b/files/en-us/web/html/global_attributes/contextmenu/index.md
@@ -13,8 +13,6 @@ browser-compat: html.global_attributes.contextmenu
 
 {{HTMLSidebar("Global_attributes")}}{{Deprecated_Header}}{{Non-standard_header}}
 
-> **Warning:** The [contextmenu attribute is obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#attr-contextmenu) and will be removed from all browsers
-
 The **`contextmenu`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is the [**id**](/en-US/docs/Web/HTML/Global_attributes/id) of a {{HTMLElement("menu")}} to use as the contextual menu for this element.
 
 A _context menu_ is a menu that appears upon user interaction, such as a right-click. HTML now allows us to customize this menu. Here are some implementation examples, including nested menus.
@@ -33,22 +31,24 @@ A _context menu_ is a menu that appears upon user interaction, such as a right-c
   </menu>
   <ol>
     <li>
-      Anywhere in the example you can share the page on Twitter and
-      Facebook using the Share menu from your context menu.
+      Anywhere in the example you can share the page on Twitter and Facebook
+      using the Share menu from your context menu.
     </li>
     <li contextmenu="changeFont" id="fontSizing">
-      On this specific list element, you can change the size of the text
-      by using the "Increase/Decrease font" actions from your context menu
+      On this specific list element, you can change the size of the text by
+      using the "Increase/Decrease font" actions from your context menu
     </li>
     <menu type="context" id="changeFont">
       <menuitem label="Increase Font" onclick="incFont()"></menuitem>
       <menuitem label="Decrease Font" onclick="decFont()"></menuitem>
     </menu>
     <li contextmenu="ChangeImage" id="changeImage">
-      On the image below, you can fire the "Change Image" action
-      in your Context Menu.<br />
-      <img src="promobutton_mdn5.png"
-          contextmenu="ChangeImage" id="promoButton" />
+      On the image below, you can fire the "Change Image" action in your Context
+      Menu.<br />
+      <img
+        src="promobutton_mdn5.png"
+        contextmenu="ChangeImage"
+        id="promoButton" />
       <menu type="context" id="ChangeImage">
         <menuitem label="Change Image" onclick="changeImage()"></menuitem>
       </menu>
@@ -61,13 +61,17 @@ A _context menu_ is a menu that appears upon user interaction, such as a right-c
 
 ```js
 function shareViaTwitter() {
-  window.open("https://twitter.com/intent/tweet?text=" +
-      "Hurray! I am learning ContextMenu from MDN via Mozilla");
+  window.open(
+    "https://twitter.com/intent/tweet?text=" +
+      "Hurray! I am learning ContextMenu from MDN via Mozilla"
+  );
 }
 
 function shareViaFacebook() {
-  window.open("https://facebook.com/sharer/sharer.php?u=" +
-      "https://developer.mozilla.org/en/HTML/Element/Using_HTML_context_menus");
+  window.open(
+    "https://facebook.com/sharer/sharer.php?u=" +
+      "https://developer.mozilla.org/en/HTML/Element/Using_HTML_context_menus"
+  );
 }
 
 function incFont() {


### PR DESCRIPTION
__Description:__

This PR has the following changes:

* __Removed__ reference to "obsolete" as per the [Writing Guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#obsolete).
* __Added__ item to 103 relnotes that `<menuitem>` support has been removed along with the preference to enable this functionality.

__Todo:__

- [x] Clarify that removing "obsolete" reference is correct

__Related:__

See #19707 

