### PR TITLE
Fix a typo

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -65,7 +65,7 @@ Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with
 
    ```html
    <h2 id="attr" class="article-title">13 ARIA attributes you need to know</h2>
-   <p>There are over 50 ARIA states and properties, but 13 of them stand out &helip;
+   <p>There are over 50 ARIA states and properties, but 13 of them stand out…
      <a href="13.html" id="rm13" aria-labelledby="rm13 attr">read more</a>
    </p>
    ```


### PR DESCRIPTION
The character entity references has a typo.