### PR TITLE
Fix a bug in `pr-check_markdownlint` workflow

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -34,4 +34,5 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          yarn markdownlint-cli2 ${{ steps.changed-files.outputs.all_changed_files }}
+          files_to_lint="${{ steps.changed-files.outputs.all_changed_files }}"
+          yarn markdownlint-cli2 ${files_to_lint}


### PR DESCRIPTION
The workflow executes the commands as shell script in a temporary file. And it complains about special characters like `(` in command line. Refer: https://github.com/mdn/content/runs/8263501927?check_suite_focus=true

> yarn markdownlint-cli2 files/en-us/glossary/deep_copy/index.md files/en-us/glossary/shallow_copy/index.md files/en-us/glossary/sloppy_mode/index.md files/en-us/glossary/tcp_handshake/index.md files/en-us/glossary/tcp_slow_start/index.md files/en-us/glossary/xhr_(xmlhttprequest)/index.md

> /home/runner/work/_temp/72d1278d-b185-4e35-9cdc-fb918c36742f.sh: line 2: syntax error near unexpected token `('
Error: Process completed with exit code 2.

