### PR TITLE
Fix: file paths with '(' and ')' getting ignored by markdownlint-cli2

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          files_to_lint="${{ steps.changed-files.outputs.all_changed_files }}"
+          files_to_lint='${{ steps.changed-files.outputs.all_changed_files }}'
+          echo "Before: $files_to_lint"
+          files_to_lint=$(echo $files_to_lint | sed -E 's/([()])/\\\1/g')
+          echo "After: $files_to_lint"
           yarn markdownlint-cli2 ${files_to_lint}

--- a/files/en-us/glossary/descriptor_(css)/index.md
+++ b/files/en-us/glossary/descriptor_(css)/index.md
@@ -9,6 +9,6 @@ tags:
 ---
 A **CSS descriptor** defines the characteristics of an [at-rule](/en-US/docs/Web/CSS/At-rule). At-rules may have one or multiple descriptors. Each descriptor has:
 
-- A name
+- A name 
 - A value, which holds the component values
 - An "!important" flag, which in its default state is unset

--- a/files/en-us/glossary/xhr_(xmlhttprequest)/index.md
+++ b/files/en-us/glossary/xhr_(xmlhttprequest)/index.md
@@ -11,7 +11,7 @@ tags:
 
 {{domxref("XMLHttpRequest")}} (XHR) is a {{Glossary("JavaScript")}} {{Glossary("API")}} to create {{Glossary("AJAX")}} requests. Its methods provide the ability to send network requests between the {{Glossary("browser")}} and a {{Glossary("server")}}.
 
-## See also
+## See also  
 
 - [XMLHttpRequest](https://en.wikipedia.org/wiki/XMLHttpRequest) on Wikipedia
 - [Synchronous vs. Asynchronous Communications](https://peoplesofttutorial.com/difference-between-synchronous-and-asynchronous-messaging/)


### PR DESCRIPTION
The markdownlint-cli2 can't locate file paths with `(` `)`.
```
> yarn markdownlint-cli2 'files/en-us/glossary/xhr_(xmlhttprequest)/index.md'
yarn run v1.22.19
$ /home/user/GitHub/mdn/content/node_modules/.bin/markdownlint-cli2 'files/en-us/glossary/xhr_(xmlhttprequest)/index.md'
markdownlint-cli2 v0.5.1 (markdownlint v0.26.2)
Finding: files/en-us/glossary/xhr_(xmlhttprequest)/index.md !node_modules
Linting: 0 file(s)
Summary: 0 error(s)
Done in 0.38s.
```

We have to escape the brackets for it to work:
```
> yarn markdownlint-cli2 'files/en-us/glossary/xhr_\(xmlhttprequest\)/index.md'
yarn run v1.22.19
$ /home/user/GitHub/mdn/content/node_modules/.bin/markdownlint-cli2 'files/en-us/glossary/xhr_\(xmlhttprequest\)/index.md'
markdownlint-cli2 v0.5.1 (markdownlint v0.26.2)
Finding: files/en-us/glossary/xhr_\(xmlhttprequest\)/index.md !node_modules
Linting: 1 file(s)
Summary: 1 error(s)
files/en-us/glossary/xhr_(xmlhttprequest)/index.md:14:12 search-replace Custom rule [trailing-spaces: Avoid trailing spaces] [Context: "column: 12 text:'  '"]
error Command failed with exit code 1.
```

This creates a problem in our workflow. Escaping the characters doesn't work work in our workflow because shell or yarn is unescaping the characters before passing the args to the linter. [the run](https://github.com/mdn/content/runs/8273787233?check_suite_focus=true)
```
Run echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
  echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
  files_to_lint='files/en-us/glossary/descriptor_(css)/index.md files/en-us/glossary/xhr_(xmlhttprequest)/index.md'
  echo "Before: $files_to_lint"
  files_to_lint=$(echo $files_to_lint | sed -E 's/([()])/\\\1/g')
  echo "After: $files_to_lint"
  yarn markdownlint-cli[2](https://github.com/mdn/content/runs/8273787233?check_suite_focus=true#step:6:2) ${files_to_lint}
  shell: /usr/bin/bash -e {0}

Before: files/en-us/glossary/descriptor_(css)/index.md files/en-us/glossary/xhr_(xmlhttprequest)/index.md
After: files/en-us/glossary/descriptor_\(css\)/index.md files/en-us/glossary/xhr_\(xmlhttprequest\)/index.md
yarn run v1.22.19
$ /home/runner/work/content/content/node_modules/.bin/markdownlint-cli2 'files/en-us/glossary/descriptor_(css)/index.md' 'files/en-us/glossary/xhr_(xmlhttprequest)/index.md'
markdownlint-cli2 v0.5.1 (markdownlint v0.26.2)
Finding: files/en-us/glossary/descriptor_(css)/index.md files/en-us/glossary/xhr_(xmlhttprequest)/index.md !node_modules
Linting: 0 file(s)
Summary: 0 error(s)
Done in 0.30s.
```