### PR TITLE
FF104 Add CSS Font Loading API in workers to Experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -811,6 +811,47 @@ This new API provides low-level support for performing computation and graphics 
   </tbody>
 </table>
 
+### CSS Font Loading API
+
+The [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) can now be used in worker threads.
+See {{bug(1072107)}}.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.font-loading-api.workers.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Audio Output API
 
 #### MediaDevices.selectAudioOutput()


### PR DESCRIPTION
Added experimental features entry for worker support addition of CSS Fonts Loading API that was added in FF104 https://bugzilla.mozilla.org/show_bug.cgi?id=1072107

Other docs work can be tracked in #18769