### PR TITLE
Add redirects to mmultiscripts and semantics pages

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12297,7 +12297,11 @@
 /en-US/docs/Web/Manifest/dir	/en-US/docs/Web/Manifest
 /en-US/docs/Web/Manifest/iarc_rating_id	/en-US/docs/Web/Manifest
 /en-US/docs/Web/Manifest/lang	/en-US/docs/Web/Manifest
+/en-US/docs/Web/MathML/Element/annotation	/en-US/docs/Web/MathML/Element/semantics
+/en-US/docs/Web/MathML/Element/annotation-xml	/en-US/docs/Web/MathML/Element/semantics
 /en-US/docs/Web/MathML/Element/menclosed	/en-US/docs/Web/MathML/Element/menclose
+/en-US/docs/Web/MathML/Element/mprescripts	/en-US/docs/Web/MathML/Element/mmultiscripts
+/en-US/docs/Web/MathML/Element/none	/en-US/docs/Web/MathML/Element/mmultiscripts
 /en-US/docs/Web/MathML/Fonts/Test	/en-US/docs/Web/MathML/Fonts
 /en-US/docs/Web/MathML/Index	/en-US/docs/Web/MathML
 /en-US/docs/Web/Media/Formats/Guide_to_codecs_for_audio_on_the_web	/en-US/docs/Web/Media/Formats/Audio_codecs

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -20,6 +20,8 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 ### A
 
 - {{MathMLElement("maction")}} (Bound actions to sub-expressions)
+- {{MathMLElement("annotation")}} (Data annotations)
+- {{MathMLElement("annotation-xml")}} (XML annotations)
 
 ### E
 
@@ -42,6 +44,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 ### N
 
 - {{MathMLElement("mn")}} (Number)
+- {{MathMLElement("none")}} (empty scripts)
 
 ### O
 
@@ -52,6 +55,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 - {{MathMLElement("mpadded")}} (Space around content)
 - {{MathMLElement("mphantom")}} (Invisible content with reserved space)
+- {{MathMLElement("mprescripts")}} (delimiter for prescripts)
 
 ### R
 
@@ -61,6 +65,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 ### S
 
 - {{MathMLElement("ms")}} (String literal)
+- {{MathMLElement("semantics")}} (Container for semantic annotations)
 - {{MathMLElement("mspace")}} (Space)
 - {{MathMLElement("msqrt")}} (Square root without an index)
 - {{MathMLElement("mstyle")}} (Style change)
@@ -79,12 +84,6 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 - {{MathMLElement("munder")}} (Underscript)
 - {{MathMLElement("munderover")}} (Underscript-overscript pair)
-
-### Other elements
-
-- {{MathMLElement("semantics")}} (Container for semantic annotations)
-- [`<annotation>`](/en-US/docs/Web/MathML/Element/semantics#annotation) (Data annotations)
-- [`<annotation-xml>`](/en-US/docs/Web/MathML/Element/semantics#annotation-xml) (XML annotations)
 
 ## MathML elements by category
 
@@ -138,8 +137,8 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ## Semantic annotations
 
-- [`<annotation>`](/en-US/docs/Web/MathML/Element/semantics#annotation)
-- [`<annotation-xml>`](/en-US/docs/Web/MathML/Element/semantics#annotation-xml)
+- {{MathMLElement("annotation")}}
+- {{MathMLElement("annotation-xml")}}
 - {{MathMLElement("semantics")}}
 
 ## See also


### PR DESCRIPTION
### Description

Add redirects for `<annotation>`, `<annotation-xml>`, `<mprescripts>` and `<none>` elements using the commands:

````
$ yarn content add-redirect /en-US/docs/Web/MathML/Element/annotation /en-US/docs/Web/MathML/Element/semantics
$ yarn content add-redirect /en-US/docs/Web/MathML/Element/annotation-xml /en-US/docs/Web/MathML/Element/semantics
$ yarn content add-redirect /en-US/docs/Web/MathML/Element/none /en-US/docs/Web/MathML/Element/mmultiscripts
$ yarn content add-redirect /en-US/docs/Web/MathML/Element/mprescripts /en-US/docs/Web/MathML/Element/mmultiscripts
````

Also modify the MathML element page to place these elements in the alphabetical list and use MathMLElement macro when possible.

### Motivation

- `<annotation>` and `<annotation-xml>` elements are normally used as children of the `<semantics>` element and so documented on that element's article.
- `<mprescripts>` and `<none>` elements are normally used as children of the `<mmultiscripts>` element and so documented on that element's article.

It makes sense to have redirects for these elements so that users can easily access the documentation by editing the URL, and MDN pages can just use the MathMLElement macro normally to refer to these elements.

### Additional details

The spec also introduces `<annotation>`, `<annotation-xml>`, `<mprescripts>` and `<none>` in their parent element's section:

[1] https://w3c.github.io/mathml-core/#semantics-and-presentation
[2] https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts

This was discussed on matrix with @sideshowbarker 

### Related issues and pull requests

N/A