### PR TITLE
Configure Prettier to add trailing commas everywhere

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "bracketSameLine": true
+  "bracketSameLine": true,
+  "trailingComma": "all"
 }


### PR DESCRIPTION
Little by little, we are _manually_ running Prettier on more parts of MDN (Games/, Related/, and soon WebAssembly/) in preparation for its activation in workflows and/or pre-commit hooks (When this will happen is something we don't know yet 😄 and – don't worry – there will be a discussion ahead of it.)

Prettier, by design, has very few configuration options – Prettier is opinionated. Nevertheless, we have already decided on changing one from the default (the position of the final `>` of a multiline tag).

It has been proposed [there](https://github.com/mdn/content/pull/20405#discussion_r966071078) to add a second one:

Trailing commas are not mandatory in JavaScript and have not been accepted everywhere in the past. By default, Prettier adds them where they are legal in ES5. Prettier provides an option to allow them where they are legal in ES2017. [More info about the config option](https://prettier.io/docs/en/options.html#trailing-commas)

Considering that:
- it adds more consistency to our code,
- we allow and recommend writing examples with ES6+ features on MDN,
- I've been told (not found the first-hand source) that this would likely be the new default in Prettier v3,

I think this is a good idea.

What do you think? 

cc/ @OnkarRuikar @nschonni (I can't add you to the Reviewers list as we hit the max)

[This is a check for consensus: approve and/or add a thumb-up if you agree; add a thumb-down _and_ explain why if you disagree]