### PR TITLE
Document deprecate MathML 1 style attributes on <mstyle>

### DIFF
--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -19,6 +19,16 @@ The MathML `<mstyle>` element is used to change the style of its children.
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
+- `background` {{deprecated_inline}}
+  - : Specifies a <a href="/en-US/docs/Web/CSS/background-color"><code>background-color</code></a>.
+- `color` {{deprecated_inline}}
+  - : Specifies a <a href="/en-US/docs/Web/CSS/color"><code>color</code></a>.
+- `fontsize` {{deprecated_inline}}
+  - : Specifies a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a>.
+- `fontstyle` {{deprecated_inline}}
+  - : Specifies a <a href="/en-US/docs/Web/CSS/font-style"><code>font-style</code></a>.
+- `fontweight` {{deprecated_inline}}
+  - : Specifies a <a href="/en-US/docs/Web/CSS/font-weight"><code>font-weight</code></a>.
 - `scriptminsize` {{deprecated_inline}}
   - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is `8pt`.
 - `scriptsizemultiplier` {{deprecated_inline}}

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -20,15 +20,15 @@ The MathML `<mstyle>` element is used to change the style of its children.
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `background` {{deprecated_inline}}
-  - : Uses <a href="/en-US/docs/Web/CSS/background-color"><code>background-color</code></a> instead.
+  - : Use <a href="/en-US/docs/Web/CSS/background-color"><code>background-color</code></a> instead.
 - `color` {{deprecated_inline}}
-  - : Uses <a href="/en-US/docs/Web/CSS/color"><code>color</code></a> instead.
+  - : Use <a href="/en-US/docs/Web/CSS/color"><code>color</code></a> instead.
 - `fontsize` {{deprecated_inline}}
-  - : Uses <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> instead.
+  - : Use <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> instead.
 - `fontstyle` {{deprecated_inline}}
-  - : Uses <a href="/en-US/docs/Web/CSS/font-style"><code>font-style</code></a> instead.
+  - : Use <a href="/en-US/docs/Web/CSS/font-style"><code>font-style</code></a> instead.
 - `fontweight` {{deprecated_inline}}
-  - : Uses <a href="/en-US/docs/Web/CSS/font-weight"><code>font-weight</code></a> instead.
+  - : Use <a href="/en-US/docs/Web/CSS/font-weight"><code>font-weight</code></a> instead.
 - `scriptminsize` {{deprecated_inline}}
   - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is `8pt`.
 - `scriptsizemultiplier` {{deprecated_inline}}

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -20,15 +20,15 @@ The MathML `<mstyle>` element is used to change the style of its children.
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `background` {{deprecated_inline}}
-  - : Specifies a <a href="/en-US/docs/Web/CSS/background-color"><code>background-color</code></a>.
+  - : Uses <a href="/en-US/docs/Web/CSS/background-color"><code>background-color</code></a> instead.
 - `color` {{deprecated_inline}}
-  - : Specifies a <a href="/en-US/docs/Web/CSS/color"><code>color</code></a>.
+  - : Uses <a href="/en-US/docs/Web/CSS/color"><code>color</code></a> instead.
 - `fontsize` {{deprecated_inline}}
-  - : Specifies a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a>.
+  - : Uses <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> instead.
 - `fontstyle` {{deprecated_inline}}
-  - : Specifies a <a href="/en-US/docs/Web/CSS/font-style"><code>font-style</code></a>.
+  - : Uses <a href="/en-US/docs/Web/CSS/font-style"><code>font-style</code></a> instead.
 - `fontweight` {{deprecated_inline}}
-  - : Specifies a <a href="/en-US/docs/Web/CSS/font-weight"><code>font-weight</code></a>.
+  - : Uses <a href="/en-US/docs/Web/CSS/font-weight"><code>font-weight</code></a> instead.
 - `scriptminsize` {{deprecated_inline}}
   - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is `8pt`.
 - `scriptsizemultiplier` {{deprecated_inline}}


### PR DESCRIPTION

### Description

These elements are already listed on [1] and are still implemented in WebKit.

### Motivation

List them on `<mstyle>` page too for completeness.

### Additional details

[1] https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute
[2] https://github.com/mdn/browser-compat-data/pull/17741
