### PR TITLE
fix: update XmlHttpRequest withCredentials documentation

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -17,11 +17,11 @@ browser-compat: api.XMLHttpRequest.withCredentials
 
 {{APIRef('XMLHttpRequest')}}
 
-The **`XMLHttpRequest.withCredentials`** property is a boolean value that indicates whether or not cross-site `Access-Control` requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting `withCredentials` has no effect on same-site requests.
+The **`XMLHttpRequest.withCredentials`** property is a boolean value that indicates whether or not cross-site `Access-Control` requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting `withCredentials` has no effect on same-origin requests.
 
 In addition, this flag is also used to indicate when cookies are to be ignored in the response. The default is `false`. `XMLHttpRequest` responses from a different domain cannot set cookie values for their own domain unless `withCredentials` is set to `true` before making the request. The third-party cookies obtained by setting `withCredentials` to true will still honor same-origin policy and hence can not be accessed by the requesting script through [document.cookie](/en-US/docs/Web/API/Document/cookie) or from response headers.
 
-> **Note:** This never affects same-site requests.
+> **Note:** This never affects same-origin requests.
 
 > **Note:** `XMLHttpRequest` responses from a different domain _cannot_ set cookie values for their own domain unless `withCredentials` is set to `true` before making the request, regardless of `Access-Control-` header values.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Updates documentation on the [XmlHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) page to accurately reflect spec behavior in regards to same-site/same-origin.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Help users understand the correct use of `withCredentials` in `same-origin` context instead of `same-site`

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[whatwg spec details](https://xhr.spec.whatwg.org/#ref-for-dom-xmlhttprequest-withcredentials%E2%91%A0)
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #20441
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
