### PR TITLE
Use present tense in "Applying CSS to the DOM" section

### DIFF
--- a/files/en-us/learn/css/first_steps/how_css_works/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.md
@@ -101,7 +101,7 @@ p {margin:0;}
 
 ## Applying CSS to the DOM
 
-Let's say we added some CSS to our document, to style it. Again, the HTML is as follows:
+Let's say we add some CSS to our document, to style it. Again, the HTML is as follows:
 
 ```html
 <p>
@@ -121,7 +121,7 @@ span {
 }
 ```
 
-The browser will parse the HTML and create a DOM from it, then parse the CSS. Since the only rule available in the CSS has a `span` selector, the browser will be able to sort the CSS very quickly! It will apply that rule to each one of the three `<span>`s, then paint the final visual representation to the screen.
+The browser parses the HTML and creates a DOM from it. Next, it parses the CSS. Since the only rule available in the CSS has a `span` selector, the browser sorts the CSS very quickly! It applies that rule to each one of the three `<span>`s, then paints the final visual representation to the screen.
 
 The updated output is as follows:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"Applying CSS to the DOM" section uses future tense when in-fact, it should use present tense for consistency with the whole page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
