### PR TITLE
Small typo fixes for `Glossary/Speed_index`

### DIFF
--- a/files/en-us/glossary/speed_index/index.md
+++ b/files/en-us/glossary/speed_index/index.md
@@ -8,11 +8,11 @@ tags:
   - Web Performance
 ---
 
-**Speed Index** (SI) is a page load performance metric that shows you how quickly the contents of a page are visibly populated. It is the average time at which visible parts of the page are displayed. Expressed in milliseconds, and dependent on the size of the viewport, the lower the score, the better.
+**Speed Index** (SI) is a page load performance metric that shows you how quickly the contents of a page are visibly populated. It is the average time at which visible parts of the page are displayed. Expressed in milliseconds and dependent on the size of the viewport, the lower the score, the better.
 
 ![Calculation of SpeedIndex](speedindex.png)
 
-The calculation calculates what percent of the page is visually complete at every 100ms interval until the page is visually complete. The overall score, the above the fold metric, is a sum of the individual 10 times per second intervals of the percent of the screen that is not-visually complete**.**
+The calculation calculates what percent of the page is visually complete at every 100ms interval until the page is visually complete. The overall score, the above the fold metric, is a sum of the individual 10 times per second intervals of the percent of the screen that is not visually complete.
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description/Motivation

- Remove unnecessary asterisks around a period `.`
- Small punctuation corrections (I think? 😅)

I may have missed other "errors", but I would be happy to add other fixes/improvements :)