### PR TITLE
adapt "note box" due to a change in the interactive editor

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
@@ -26,7 +26,7 @@ In this task, we want you to help fill in the links on our Whales information pa
 - The second link should be turned into a link you can click to open up an email in the user's default mail application, with the recipient set as "whales\@example.com".
 - You'll get a bonus point if you also set it so that the subject line of the email is automatically filled in as "Question about Whales".
 
-> **Note:** The first link in the example has the `target="_blank"` attribute set on it, so that when you click on it, it opens the linked page in a new tab. This is not strictly best practice, but we've done it here so that the page doesn't open in the embedded `<iframe>`, getting rid of your example code in the process!
+> **Note:** The two links in the example have the `target="_blank"` attribute set on them. This is not strictly best practice, but we've done it here so that the links don't open in the embedded `<iframe>`, getting rid of your example code in the process!
 
 Try updating the live code below to recreate the finished example:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

before the merged pr in https://github.com/mdn/learning-area/pull/495 there was just one link with the `target="_blank"` attribute - now both of them have it (issue https://github.com/mdn/content/issues/20436)

i rewrote the sentence in the note box in plural and because the second `<a>` element is a mail anchor, i wrote "so that the links..." instead of "so that the page...".

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To make the content correct. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

i am always open for suggestions and improvements :)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to pr https://github.com/mdn/learning-area/pull/495 and issue https://github.com/mdn/content/issues/20436

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
