### PR TITLE
Recommend against EPSILON for equality tests, align related pages

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -14,24 +14,70 @@ browser-compat: javascript.builtins.Number.EPSILON
 
 The **`Number.EPSILON`** property represents the difference between 1 and the smallest floating point number greater than 1.
 
-You do not have to create a {{jsxref("Number")}} object to access this static property (use `Number.EPSILON`).
+Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use it as `Number.EPSILON`, rather than as a property of a number value.
 
 {{EmbedInteractiveExample("pages/js/number-epsilon.html")}}{{js_property_attributes(0, 0, 0)}}
 
 ## Description
 
-The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>.
+The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, and the lowest bit has a significance of 2<sup>-52</sup>.
+
+Note that the absolute accuracy of floating numbers decreases as the number gets larger, because the exponent grows while the significand's accuracy stays the same. {{jsxref("Number.MIN_VALUE")}} is the smallest representable positive number, which is much smaller than `Number.EPSILON`.
 
 ## Examples
 
 ### Testing equality
 
+Because floating point numbers are represented in binary, not decimal, they are not always exact. For example, `0.1 + 0.2` is not exactly equal to `0.3`:
+
 ```js
-x = 0.2;
-y = 0.3;
-z = 0.1;
-equal = (Math.abs(x - y + z) < Number.EPSILON);
+console.log(0.1 + 0.2); // 0.30000000000000004
+console.log(0.1 + 0.2 === 0.3); // false
 ```
+
+For this cause, it is often advised that **floating point numbers should never be compared with `===`**. Instead, we can deem two numbers as equal if they are _close enough_ to each other. The `Number.EPSILON` constant is usually a reasonable threshold for errors if the arithmetic is around the magnitude of `1`, because `EPSILON`, in essence, specifies how accurate the number "1" is.
+
+```js
+function equal(x, y) {
+  return Math.abs(x - y) < Number.EPSILON;
+}
+
+const x = 0.2;
+const y = 0.3;
+const z = 0.1;
+console.log(equal(x + z, y)); // true
+```
+
+However, `Number.EPSILON` is inappropriate for any arithmetic with a larger range. If your data is on the 10<sup>3</sup> order of magnitude, the decimal part will have a much smaller accuracy than `Number.EPSILON`:
+
+```js
+function equal(x, y) {
+  return Math.abs(x - y) < Number.EPSILON;
+}
+
+const x = 1000.1;
+const y = 1000.2;
+const z = 2000.3;
+console.log(x + y); // 2000.3000000000002; error of 10^-13 instead of 10^-16
+console.log(equal(x + y, z)); // false
+```
+
+In this case, you should use a larger tolerance, such as `2000 * Number.EPSILON`, since the numbers we are comparing have the magnitude of about `2000`:
+
+```js
+function equal(x, y, tolerance = Number.EPSILON) {
+  return Math.abs(x - y) < tolerance;
+}
+
+const x = 1000.1;
+const y = 1000.2;
+const z = 2000.3;
+console.log(equal(x + y, z, 2000 * Number.EPSILON)); // true
+```
+
+Besides magnitude, it's important to also consider the _accuracy_ of your input. For example, if the numbers are collected from a form input, and the input value can only be adjusted by steps of `0.1`, it usually makes sense to allow a much larger tolerance, such as `0.01`, since the data only has a precision of `0.1`.
+
+> **Note:** Important takeaway: do not blindly use `Number.EPSILON` as a threshold for equality testing. Use a threshold that is appropriate for the magnitude and accuracy of the numbers you are comparing.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -77,7 +77,7 @@ console.log(equal(x + y, z, 2000 * Number.EPSILON)); // true
 
 In addition to magnitude, it is important to consider the _accuracy_ of your input. For example, if the numbers are collected from a form input and the input value can only be adjusted by steps of `0.1` (i.e. [`<input type="number" step="0.1">`](/en-US/docs/Web/HTML/Attributes/step)), it usually makes sense to allow a much larger tolerance, such as `0.01`, since the data only has a precision of `0.1`.
 
-> **Note:** Important takeaway: do not blindly use `Number.EPSILON` as a threshold for equality testing. Use a threshold that is appropriate for the magnitude and accuracy of the numbers you are comparing.
+> **Note:** Important takeaway: do not simply use `Number.EPSILON` as a threshold for equality testing. Use a threshold that is appropriate for the magnitude and accuracy of the numbers you are comparing.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -62,7 +62,7 @@ console.log(x + y); // 2000.3000000000002; error of 10^-13 instead of 10^-16
 console.log(equal(x + y, z)); // false
 ```
 
-In this case, you should use a larger tolerance, such as `2000 * Number.EPSILON`, since the numbers we are comparing have the magnitude of about `2000`:
+In this case, a larger tolerance is required. As the numbers compared have a magnitude of approximately `2000`, a multiplier such as `2000 * Number.EPSILON` creates enough tolerance for this instance.
 
 ```js
 function equal(x, y, tolerance = Number.EPSILON) {

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -18,9 +18,9 @@ The **`Number.EPSILON`** property represents the difference between 1 and the sm
 
 ## Description
 
-The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), and the lowest bit has a significance of 2<sup>-52</sup>.
+The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 52 bits to represent the [mantissa](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), and the lowest bit has a significance of 2<sup>-52</sup>.
 
-Note that the absolute accuracy of floating numbers decreases as the number gets larger, because the exponent grows while the significand's accuracy stays the same. {{jsxref("Number.MIN_VALUE")}} is the smallest representable positive number, which is much smaller than `Number.EPSILON`.
+Note that the absolute accuracy of floating numbers decreases as the number gets larger, because the exponent grows while the mantissa's accuracy stays the same. {{jsxref("Number.MIN_VALUE")}} is the smallest representable positive number, which is much smaller than `Number.EPSILON`.
 
 Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use it as `Number.EPSILON`, rather than as a property of a number value.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -14,8 +14,6 @@ browser-compat: javascript.builtins.Number.EPSILON
 
 The **`Number.EPSILON`** property represents the difference between 1 and the smallest floating point number greater than 1.
 
-Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use it as `Number.EPSILON`, rather than as a property of a number value.
-
 {{EmbedInteractiveExample("pages/js/number-epsilon.html")}}{{js_property_attributes(0, 0, 0)}}
 
 ## Description
@@ -23,6 +21,8 @@ Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use i
 The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), and the lowest bit has a significance of 2<sup>-52</sup>.
 
 Note that the absolute accuracy of floating numbers decreases as the number gets larger, because the exponent grows while the significand's accuracy stays the same. {{jsxref("Number.MIN_VALUE")}} is the smallest representable positive number, which is much smaller than `Number.EPSILON`.
+
+Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use it as `Number.EPSILON`, rather than as a property of a number value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -35,7 +35,7 @@ console.log(0.1 + 0.2); // 0.30000000000000004
 console.log(0.1 + 0.2 === 0.3); // false
 ```
 
-For this cause, it is often advised that **floating point numbers should never be compared with `===`**. Instead, we can deem two numbers as equal if they are _close enough_ to each other. The `Number.EPSILON` constant is usually a reasonable threshold for errors if the arithmetic is around the magnitude of `1`, because `EPSILON`, in essence, specifies how accurate the number "1" is.
+For this reason, it is often advised that **floating point numbers should never be compared with `===`**. Instead, we can deem two numbers as equal if they are _close enough_ to each other. The `Number.EPSILON` constant is usually a reasonable threshold for errors if the arithmetic is around the magnitude of `1`, because `EPSILON`, in essence, specifies how accurate the number "1" is.
 
 ```js
 function equal(x, y) {

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -75,7 +75,7 @@ const z = 2000.3;
 console.log(equal(x + y, z, 2000 * Number.EPSILON)); // true
 ```
 
-Besides magnitude, it's important to also consider the _accuracy_ of your input. For example, if the numbers are collected from a form input, and the input value can only be adjusted by steps of `0.1`, it usually makes sense to allow a much larger tolerance, such as `0.01`, since the data only has a precision of `0.1`.
+In addition to magnitude, it is important to consider the _accuracy_ of your input. For example, if the numbers are collected from a form input and the input value can only be adjusted by steps of `0.1` (i.e. [`<input type="number" step="0.1">`](/en-US/docs/Web/HTML/Attributes/step)), it usually makes sense to allow a much larger tolerance, such as `0.01`, since the data only has a precision of `0.1`.
 
 > **Note:** Important takeaway: do not blindly use `Number.EPSILON` as a threshold for equality testing. Use a threshold that is appropriate for the magnitude and accuracy of the numbers you are comparing.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -48,7 +48,7 @@ const z = 0.1;
 console.log(equal(x + z, y)); // true
 ```
 
-However, `Number.EPSILON` is inappropriate for any arithmetic with a larger range. If your data is on the 10<sup>3</sup> order of magnitude, the decimal part will have a much smaller accuracy than `Number.EPSILON`:
+However, `Number.EPSILON` is inappropriate for any arithmetic operating on a larger magnitude. If your data is on the 10<sup>3</sup> order of magnitude, the decimal part will have a much smaller accuracy than `Number.EPSILON`:
 
 ```js
 function equal(x, y) {

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -20,7 +20,7 @@ Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use i
 
 ## Description
 
-The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, and the lowest bit has a significance of 2<sup>-52</sup>.
+The `EPSILON` property has a value of approximately `2.2204460492503130808472633361816E-16`, or 2<sup>-52</sup>. This is the smallest value that can be added to 1 to get a distinct number, because [double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), and the lowest bit has a significance of 2<sup>-52</sup>.
 
 Note that the absolute accuracy of floating numbers decreases as the number gets larger, because the exponent grows while the significand's accuracy stays the same. {{jsxref("Number.MIN_VALUE")}} is the smallest representable positive number, which is much smaller than `Number.EPSILON`.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -16,33 +16,47 @@ browser-compat: javascript.builtins.Number
 
 The `Number` constructor contains constants and methods for working with numbers. Values of other types can be converted to numbers using the `Number()` function.
 
-The JavaScript `Number` type is a [double-precision 64-bit binary format IEEE 754](https://en.wikipedia.org/wiki/Floating-point_arithmetic) value, like `double` in Java or C#. This means it can represent fractional values, but there are some limits to what it can store. A `Number` only keeps about 17 decimal places of precision; arithmetic is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding). The largest value a `Number` can hold is about 1.8E308. Values higher than that are replaced with the special `Number` constant {{jsxref("Infinity")}}.
-
-A number literal like `37` in JavaScript code is a floating-point value, not an integer. There is no separate integer type in common everyday use. (JavaScript now has a {{jsxref("BigInt")}} type, but it was not designed to replace Number for everyday uses. `37` is still a `Number`, not a BigInt.)
-
-`Number` may also be expressed in literal forms like `0b101`, `0o13`, `0x0A`. Learn more on numeric [lexical grammar here](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals).
-
 ## Description
+
+Numbers are most commonly expressed in literal forms like `0b101`, `0o13`, `0x0A`. The [lexical grammar](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals) contains a more detailed reference.
+
+```js
+123; // one-hundred twenty-three
+123.0; // same
+123 === 123.0; // true
+```
+
+A number literal like `37` in JavaScript code is a floating-point value, not an integer. There is no separate integer type in common everyday use. (JavaScript also has a {{jsxref("BigInt")}} type, but it's not designed to replace Number for everyday uses. `37` is still a number, not a BigInt.)
 
 When used as a function, `Number(value)` converts a string or other value to the Number type. If the value can't be converted, it returns {{jsxref("NaN")}}.
 
-### Literal syntax
-
 ```js
-123    // one-hundred twenty-three
-123.0  // same
-123 === 123.0  // true
+Number("123"); // returns the number 123
+Number("123") === 123; // true
+
+Number("unicorn"); // NaN
+Number(undefined); // NaN
 ```
 
-### Function syntax
+### Number encoding
 
-```js
-Number('123')  // returns the number 123
-Number('123') === 123  // true
+The JavaScript `Number` type is a [double-precision 64-bit binary format IEEE 754](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) value, like `double` in Java or C#. This means it can represent fractional values, but there are some limits to the stored number's magnitude and precision. Very briefly, a IEEE 754 double-precision number uses 64 bits to represent 3 parts:
 
-Number("unicorn")  // NaN
-Number(undefined)  // NaN
-```
+- 1 bit for the _sign_ (positive or negative)
+- 11 bits for the _exponent_ (-1022 to 1023)
+- 52 bits for the _significand_ (representing a number between 1 and 2)
+
+The significand (also called _mantissa_) is the part of the number representing the actual value (significant digits). The exponent is the power of 2 that the significand should be multiplied by. Thinking about it as scientific notation:
+
+<math display="block"><semantics><mrow><mtext>Number</mtext><mo>=</mo><mo stretchy="false">(</mo><mrow><mo>−</mo><mn>1</mn></mrow><msup><mo stretchy="false">)</mo><mtext>sign</mtext></msup><mo>⋅</mo><mtext>significand</mtext><mo>⋅</mo><msup><mn>2</mn><mtext>exponent</mtext></msup></mrow><annotation encoding="TeX">\text{Number} = ({-1})^{\text{sign}} \cdot \text{significand} \cdot 2^{\text{exponent}}</annotation></semantics></math>
+
+The significand is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the significand's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 decimal places; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
+
+The largest value a number can hold is 2<sup>1024</sup> - 1 (with the exponent being 1023 and the significand being 1.1111… in base 2), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
+
+Integers can only be represented without loss of precision in the range -2<sup>53</sup> + 1 to 2<sup>53</sup> - 1, inclusive (obtainable via {{jsxref("Number.MIN_SAFE_INTEGER")}} and {{jsxref("Number.MAX_SAFE_INTEGER")}}), because the significand can only hold 53 bits (including the leading 1).
+
+More details on this are described in the [ECMAScript standard](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type).
 
 ## Constructor
 
@@ -111,20 +125,20 @@ When `Number` is called as a constructor (with `new`), it creates a {{jsxref("Nu
 The following example uses the `Number` object's properties to assign values to several numeric variables:
 
 ```js
-const biggestNum     = Number.MAX_VALUE
-const smallestNum    = Number.MIN_VALUE
-const infiniteNum    = Number.POSITIVE_INFINITY
-const negInfiniteNum = Number.NEGATIVE_INFINITY
-const notANum        = Number.NaN
+const biggestNum = Number.MAX_VALUE;
+const smallestNum = Number.MIN_VALUE;
+const infiniteNum = Number.POSITIVE_INFINITY;
+const negInfiniteNum = Number.NEGATIVE_INFINITY;
+const notANum = Number.NaN;
 ```
 
 ### Integer range for Number
 
-The following example shows the minimum and maximum integer values that can be represented as `Number` object. (More details on this are described in the ECMAScript standard, chapter _[6.1.6 The Number Type](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type)._)
+The following example shows the minimum and maximum integer values that can be represented as `Number` object.
 
 ```js
-const biggestInt  = Number.MAX_SAFE_INTEGER  //  (2**53 - 1) =>  9007199254740991
-const smallestInt = Number.MIN_SAFE_INTEGER  // -(2**53 - 1) => -9007199254740991
+const biggestInt = Number.MAX_SAFE_INTEGER; //  (2**53 - 1) =>  9007199254740991
+const smallestInt = Number.MIN_SAFE_INTEGER; // -(2**53 - 1) => -9007199254740991
 ```
 
 When parsing data that has been serialized to JSON, integer values falling outside of this range can be expected to become corrupted when JSON parser coerces them to `Number` type.
@@ -133,12 +147,12 @@ A possible workaround is to use {{jsxref("String")}} instead.
 
 Larger numbers can be represented using the {{jsxref("BigInt")}} type.
 
-### Using Number to convert a Date object
+### Using Number() to convert a Date object
 
 The following example converts the {{jsxref("Date")}} object to a numerical value using `Number` as a function:
 
 ```js
-const d = new Date('December 17, 1995 03:24:00');
+const d = new Date("December 17, 1995 03:24:00");
 console.log(Number(d));
 ```
 
@@ -147,19 +161,19 @@ This logs `819199440000`.
 ### Convert numeric strings and null to numbers
 
 ```js
-Number('123')     // 123
-Number('123') === 123 // true
-Number('12.3')    // 12.3
-Number('12.00')   // 12
-Number('123e-1')  // 12.3
-Number('')        // 0
-Number(null)      // 0
-Number('0x11')    // 17
-Number('0b11')    // 3
-Number('0o11')    // 9
-Number('foo')     // NaN
-Number('100a')    // NaN
-Number('-Infinity') // -Infinity
+Number("123"); // 123
+Number("123") === 123; // true
+Number("12.3"); // 12.3
+Number("12.00"); // 12
+Number("123e-1"); // 12.3
+Number(""); // 0
+Number(null); // 0
+Number("0x11"); // 17
+Number("0b11"); // 3
+Number("0o11"); // 9
+Number("foo"); // NaN
+Number("100a"); // NaN
+Number("-Infinity"); // -Infinity
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -44,17 +44,17 @@ The JavaScript `Number` type is a [double-precision 64-bit binary format IEEE 75
 
 - 1 bit for the _sign_ (positive or negative)
 - 11 bits for the _exponent_ (-1022 to 1023)
-- 52 bits for the _significand_ (representing a number between 1 and 2)
+- 52 bits for the _mantissa_ (representing a number between 0 and 1)
 
-The significand (also called _mantissa_) is the part of the number representing the actual value (significant digits). The exponent is the power of 2 that the significand should be multiplied by. Thinking about it as scientific notation:
+The mantissa (also called _significand_) is the part of the number representing the actual value (significant digits). The exponent is the power of 2 that the mantissa should be multiplied by. Thinking about it as scientific notation:
 
-<math display="block"><semantics><mrow><mtext>Number</mtext><mo>=</mo><mo stretchy="false">(</mo><mrow><mo>−</mo><mn>1</mn></mrow><msup><mo stretchy="false">)</mo><mtext>sign</mtext></msup><mo>⋅</mo><mtext>significand</mtext><mo>⋅</mo><msup><mn>2</mn><mtext>exponent</mtext></msup></mrow><annotation encoding="TeX">\text{Number} = ({-1})^{\text{sign}} \cdot \text{significand} \cdot 2^{\text{exponent}}</annotation></semantics></math>
+<math display="block"><semantics><mrow><mtext>Number</mtext><mo>=</mo><mo stretchy="false">(</mo><mrow><mo>−</mo><mn>1</mn></mrow><msup><mo stretchy="false">)</mo><mtext>sign</mtext></msup><mo>⋅</mo><mo stretchy="false">(</mo><mn>1</mn><mo>+</mo><mtext>mantissa</mtext><mo stretchy="false">)</mo><mo>⋅</mo><msup><mn>2</mn><mtext>exponent</mtext></msup></mrow><annotation encoding="TeX">\text{Number} = ({-1})^{\text{sign}} \cdot (1 + \text{mantissa}) \cdot 2^{\text{exponent}}</annotation></semantics></math>
 
-The significand is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the significand's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 decimal places; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
+The mantissa is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the mantissa's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 decimal places; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
 
-The largest value a number can hold is 2<sup>1024</sup> - 1 (with the exponent being 1023 and the significand being 1.1111… in base 2), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
+The largest value a number can hold is 2<sup>1024</sup> - 1 (with the exponent being 1023 and the mantissa being 0.1111… in base 2), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
 
-Integers can only be represented without loss of precision in the range -2<sup>53</sup> + 1 to 2<sup>53</sup> - 1, inclusive (obtainable via {{jsxref("Number.MIN_SAFE_INTEGER")}} and {{jsxref("Number.MAX_SAFE_INTEGER")}}), because the significand can only hold 53 bits (including the leading 1).
+Integers can only be represented without loss of precision in the range -2<sup>53</sup> + 1 to 2<sup>53</sup> - 1, inclusive (obtainable via {{jsxref("Number.MIN_SAFE_INTEGER")}} and {{jsxref("Number.MAX_SAFE_INTEGER")}}), because the mantissa can only hold 53 bits (including the leading 1).
 
 More details on this are described in the [ECMAScript standard](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type).
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -12,10 +12,7 @@ browser-compat: javascript.builtins.Number.isFinite
 
 {{JSRef}}
 
-The **`Number.isFinite()`** method
-determines whether the passed value is a finite number — that is, it checks that the
-type of a given value is {{jsxref("Number")}}, and the number is neither positive
-{{jsxref("Infinity")}}, negative `Infinity`, nor {{jsxref("NaN")}}.
+The **`Number.isFinite()`** method determines whether the passed value is a finite number — that is, it checks that a given value is a number, and the number is neither positive {{jsxref("Infinity")}}, negative `Infinity`, nor {{jsxref("NaN")}}.
 
 {{EmbedInteractiveExample("pages/js/number-isfinite.html")}}
 
@@ -34,28 +31,28 @@ Number.isFinite(value)
 
 The boolean value `true` if the given value is a finite number. Otherwise `false`.
 
-## Description
-
-In comparison to the global {{jsxref("isFinite", "isFinite()")}} function, this method
-doesn't first convert the parameter to a number. This means only values of the type
-number _and_ are finite return `true`.
-
 ## Examples
 
-### Using isFinite
+### Using isFinite()
 
 ```js
-Number.isFinite(Infinity);  // false
-Number.isFinite(NaN);       // false
+Number.isFinite(Infinity); // false
+Number.isFinite(NaN); // false
 Number.isFinite(-Infinity); // false
 
-Number.isFinite(0);         // true
-Number.isFinite(2e64);      // true
+Number.isFinite(0); // true
+Number.isFinite(2e64); // true
+```
 
-Number.isFinite('0');       // false, would've been true with
-                            // global isFinite('0')
-Number.isFinite(null);      // false, would've been true with
-                            // global isFinite(null)
+### Difference between Number.isFinite() and global isFinite()
+
+In comparison to the global {{jsxref("isFinite", "isFinite()")}} function, this method doesn't first convert the parameter to a number. This means only values of the type number _and_ are finite return `true`, and non-numbers always return `false`.
+
+```js
+isFinite('0'); // true; coerced to number 0
+Number.isFinite("0"); // false
+isFinite(null); // true; coerced to number 0
+Number.isFinite(null); // false
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Number.isInteger
 
 {{JSRef}}
 
-The **`Number.isInteger()`** method determines whether the
-passed value is an integer.
+The **`Number.isInteger()`** method determines whether the passed value is an integer.
 
 {{EmbedInteractiveExample("pages/js/number-isinteger.html")}}
 
@@ -34,10 +33,7 @@ The boolean value `true` if the given value is an integer. Otherwise `false`.
 
 ## Description
 
-If the target value is an integer, return `true`, otherwise return
-`false`. If the value is {{jsxref("NaN")}} or {{jsxref("Infinity")}}, return
-`false`. The method will also return `true` for floating point
-numbers that can be represented as integer. It will always return `false` if the value is not a number (`typeof value !== "number"`).
+If the target value is an integer, return `true`, otherwise return `false`. If the value is {{jsxref("NaN")}} or {{jsxref("Infinity")}}, return `false`. The method will also return `true` for floating point numbers that can be represented as integer. It will always return `false` if the value is not a number.
 
 Note that some number literals, while looking like non-integers, actually represent integers — due to the precision limit of ECMAScript floating-point number encoding (IEEE-754). For example, `5.0000000000000001` only differs from `5` by `1e-16`, which is too small to be represented. (For reference, [`Number.EPSILON`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON) stores the distance between 1 and the next representable floating-point number greater than 1, and that is about `2.22e-16`.) Therefore, `5.0000000000000001` will be represented with the same encoding as `5`, thus making `Number.isInteger(5.0000000000000001)` return `true`.
 
@@ -48,23 +44,23 @@ In a similar sense, numbers around the magnitude of [`Number.MAX_SAFE_INTEGER`](
 ### Using isInteger
 
 ```js
-Number.isInteger(0);         // true
-Number.isInteger(1);         // true
-Number.isInteger(-100000);   // true
+Number.isInteger(0); // true
+Number.isInteger(1); // true
+Number.isInteger(-100000); // true
 Number.isInteger(99999999999999999999999); // true
 
-Number.isInteger(0.1);       // false
-Number.isInteger(Math.PI);   // false
+Number.isInteger(0.1); // false
+Number.isInteger(Math.PI); // false
 
-Number.isInteger(NaN);       // false
-Number.isInteger(Infinity);  // false
+Number.isInteger(NaN); // false
+Number.isInteger(Infinity); // false
 Number.isInteger(-Infinity); // false
-Number.isInteger('10');      // false
-Number.isInteger(true);      // false
-Number.isInteger(false);     // false
-Number.isInteger([1]);       // false
+Number.isInteger("10"); // false
+Number.isInteger(true); // false
+Number.isInteger(false); // false
+Number.isInteger([1]); // false
 
-Number.isInteger(5.0);       // true
+Number.isInteger(5.0); // true
 Number.isInteger(5.000000000000001); // false
 Number.isInteger(5.0000000000000001); // true, because of loss of precision
 Number.isInteger(4500000000000000.1); // true, because of loss of precision

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -32,48 +32,57 @@ Number.isNaN(value)
 
 ### Return value
 
-**true** if the given value is {{jsxref("NaN")}} and its type is
-{{jsxref("Number")}}; otherwise, **false**.
+The boolean value `false` if the given value is a number with value {{jsxref("NaN")}}. Otherwise, `false`.
 
 ## Description
 
-Due to both equality operators, [`==`](/en-US/docs/Web/JavaScript/Reference/Operators/Equality) and [`===`](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality),
-evaluating to `false` when checking if {{jsxref("NaN")}} _is_
-{{jsxref("NaN")}}, the function `Number.isNaN()` has become necessary. This
-situation is unlike all other possible value comparisons in JavaScript.
+Due to both equality operators, [`==`](/en-US/docs/Web/JavaScript/Reference/Operators/Equality) and [`===`](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality), evaluating to `false` when checking if {{jsxref("NaN")}} _is_ {{jsxref("NaN")}}, the function `Number.isNaN()` has become necessary. This situation is unlike all other possible value comparisons in JavaScript.
 
 Since `x !== x` is only true for `NaN` among all possible JavaScript values, `Number.isNaN(x)` can also be replaced with a test for `x !== x`, despite the latter being less readable.
 
-In comparison to the global {{jsxref("isNaN", "isNaN()")}} function,
-`Number.isNaN()` doesn't suffer the problem of forcefully converting the
-parameter to a number. This means it is now safe to pass values that would normally
-convert to {{jsxref("NaN")}}, but aren't actually the same value as {{jsxref("NaN")}}.
-This also means that only values of the type number, that are also {{jsxref("NaN")}},
-return `true`.
+In comparison to the global {{jsxref("isNaN", "isNaN()")}} function, `Number.isNaN()` doesn't suffer the problem of forcefully converting the parameter to a number. This means it is now safe to pass values that would normally convert to {{jsxref("NaN")}}, but aren't actually the same value as {{jsxref("NaN")}}. This also means that only values of the type number, that are also {{jsxref("NaN")}}, return `true`.
 
 ## Examples
 
-### Using isNaN
+### Using isNaN()
 
 ```js
-Number.isNaN(NaN);        // true
+Number.isNaN(NaN); // true
 Number.isNaN(Number.NaN); // true
-Number.isNaN(0 / 0);      // true
+Number.isNaN(0 / 0); // true
+Number.isNaN(37); // false
+```
 
-// e.g. these would have been true with global isNaN()
-Number.isNaN('NaN');      // false
-Number.isNaN(undefined);  // false
-Number.isNaN({});         // false
-Number.isNaN('blabla');   // false
+### Difference between Number.isNaN() and global isNaN()
 
-// These all return false
+`Number.isNaN()` doesn't attempt to convert the parameter to a number, so non-numbers always return `false`. The following are all `false`:
+
+```js
+Number.isNaN("NaN");
+Number.isNaN(undefined);
+Number.isNaN({});
+Number.isNaN("blabla");
 Number.isNaN(true);
 Number.isNaN(null);
-Number.isNaN(37);
-Number.isNaN('37');
-Number.isNaN('37.37');
-Number.isNaN('');
-Number.isNaN(' ');
+Number.isNaN("37");
+Number.isNaN("37.37");
+Number.isNaN("");
+Number.isNaN(" ");
+```
+
+The global {{jsxref("isNaN", "isNaN()")}} coerces its parameter to a number:
+
+```js
+isNaN("NaN"); // true
+isNaN(undefined); // true
+isNaN({}); // true
+isNaN("blabla"); // true
+isNaN(true); // false, this is coerced to 1
+isNaN(null); // false, this is coerced to 0
+isNaN("37"); // false, this is coerced to 37
+isNaN("37.37"); // false, this is coerced to 37.37
+isNaN(""); // false, this is coerced to 0
+isNaN(" "); // false, this is coerced to 0
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -40,7 +40,7 @@ Due to both equality operators, [`==`](/en-US/docs/Web/JavaScript/Reference/Oper
 
 Since `x !== x` is only true for `NaN` among all possible JavaScript values, `Number.isNaN(x)` can also be replaced with a test for `x !== x`, despite the latter being less readable.
 
-In comparison to the global {{jsxref("isNaN", "isNaN()")}} function, `Number.isNaN()` doesn't suffer the problem of forcefully converting the parameter to a number. This means it is now safe to pass values that would normally convert to {{jsxref("NaN")}}, but aren't actually the same value as {{jsxref("NaN")}}. This also means that only values of the type number, that are also {{jsxref("NaN")}}, return `true`.
+As opposed to the global {{jsxref("isNaN", "isNaN()")}} function, the `Number.isNaN()` method doesn't force-convert the parameter to a number. This makes it safe to pass values that would normally convert to {{jsxref("NaN")}} but aren't actually the same value as {{jsxref("NaN")}}. This also means that only values of the Number type that are also {{jsxref("NaN")}} return `true`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -32,7 +32,7 @@ Number.isNaN(value)
 
 ### Return value
 
-The boolean value `false` if the given value is a number with value {{jsxref("NaN")}}. Otherwise, `false`.
+The boolean value `true` if the given value is a number with value {{jsxref("NaN")}}. Otherwise, `false`.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Number.isSafeInteger
 
 {{JSRef}}
 
-The **`Number.isSafeInteger()`** method determines whether the
-provided value is a number that is a _safe integer_.
+The **`Number.isSafeInteger()`** method determines whether the provided value is a number that is a _safe integer_.
 
 {{EmbedInteractiveExample("pages/js/number-issafeinteger.html")}}
 
@@ -30,46 +29,34 @@ Number.isSafeInteger(testValue)
 
 ### Return value
 
-The boolean value `true` if the given value is a number that is a
-safe integer. Otherwise `false`.
+The boolean value `true` if the given value is a number that is a safe integer. Otherwise `false`.
 
 ## Description
 
-A safe integer is an integer that
+The safe integers consist of all integers from -(2<sup>53</sup> - 1) inclusive to 2<sup>53</sup> - 1 inclusive (±9,007,199,254,740,991). A safe integer is an integer that:
 
 - can be exactly represented as an IEEE-754 double precision number, and
-- whose IEEE-754 representation cannot be the result of rounding any other integer to
-  fit the IEEE-754 representation.
+- whose IEEE-754 representation cannot be the result of rounding any other integer to fit the IEEE-754 representation.
 
-For example, 2<sup>53</sup> - 1 is a safe integer: it can be exactly
-represented, and no other integer rounds to it under any IEEE-754 rounding mode. In
-contrast, 2<sup>53</sup> is _not_ a safe integer: it can be exactly
-represented in IEEE-754, but the integer 2<sup>53</sup> + 1 can't be
-directly represented in IEEE-754 but instead rounds to 2<sup>53</sup> under
-round-to-nearest and round-to-zero rounding. The safe integers consist of all integers
-from -(2<sup>53</sup> - 1) inclusive to 2<sup>53</sup> - 1
-inclusive (±9,007,199,254,740,991).
+For example, 2<sup>53</sup> - 1 is a safe integer: it can be exactly represented, and no other integer rounds to it under any IEEE-754 rounding mode. In contrast, 2<sup>53</sup> is _not_ a safe integer: it can be exactly represented in IEEE-754, but the integer 2<sup>53</sup> + 1 can't be directly represented in IEEE-754 but instead rounds to 2<sup>53</sup> under round-to-nearest and round-to-zero rounding.
 
-Handling values larger or smaller than \~9 quadrillion with full precision requires
-using an [arbitrary precision arithmetic library](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic).
-See [What Every Programmer Needs to Know about Floating Point Arithmetic](https://floating-point-gui.de/) for more
-information on floating point representations of numbers.
+Handling values larger or smaller than \~9 quadrillion with full precision requires using an [arbitrary precision arithmetic library](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). See [What Every Programmer Needs to Know about Floating Point Arithmetic](https://floating-point-gui.de/) for more information on floating point representations of numbers.
 
 For larger integers, consider using the {{jsxref("BigInt")}} type.
 
 ## Examples
 
-### Using isSafeInteger
+### Using isSafeInteger()
 
 ```js
-Number.isSafeInteger(3);                    // true
-Number.isSafeInteger(Math.pow(2, 53));      // false
-Number.isSafeInteger(Math.pow(2, 53) - 1);  // true
-Number.isSafeInteger(NaN);                  // false
-Number.isSafeInteger(Infinity);             // false
-Number.isSafeInteger('3');                  // false
-Number.isSafeInteger(3.1);                  // false
-Number.isSafeInteger(3.0);                  // true
+Number.isSafeInteger(3); // true
+Number.isSafeInteger(2 ** 53); // false
+Number.isSafeInteger(2 ** 53 - 1); // true
+Number.isSafeInteger(NaN); // false
+Number.isSafeInteger(Infinity); // false
+Number.isSafeInteger("3"); // false
+Number.isSafeInteger(3.1); // false
+Number.isSafeInteger(3.0); // true
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -33,7 +33,7 @@ The boolean value `true` if the given value is a number that is a safe integer. 
 
 ## Description
 
-The safe integers consist of all integers from -(2<sup>53</sup> - 1) inclusive to 2<sup>53</sup> - 1 inclusive (±9,007,199,254,740,991). A safe integer is an integer that:
+The safe integers consist of all integers from -(2<sup>53</sup> - 1) to 2<sup>53</sup> - 1, inclusive (±9,007,199,254,740,991). A safe integer is an integer that:
 
 - can be exactly represented as an IEEE-754 double precision number, and
 - whose IEEE-754 representation cannot be the result of rounding any other integer to fit the IEEE-754 representation.

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -20,11 +20,9 @@ For larger integers, consider using {{jsxref("BigInt")}}.
 
 ## Description
 
-The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991 or \~9 quadrillion). The reasoning behind that number is that JavaScript uses [double-precision floating-point format numbers](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) as specified in [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point) and can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1.
+The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991 or \~9 quadrillion).
 
-Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
-
-This field does not exist in old browsers. Using it without checking its existence, such as `Math.max(Number.MAX_SAFE_INTEGER, 2)`, will yield undesired results such as NaN.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 
@@ -36,12 +34,12 @@ Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you alw
 Number.MAX_SAFE_INTEGER; // 9007199254740991
 ```
 
-### Numbers higher than safe integer
+### Relationship between MAX_SAFE_INTEGER and EPSILON
 
-This returns 2 because in floating points, the value is actually the decimal trailing "1" except for in subnormal precision cases such as zero.
+{{jsxref("Number.EPSILON")}} is 2<sup>-52</sup>, while `MAX_SAFE_INTEGER` is 2<sup>53</sup> – 1 — both of them are derived from the width of the significand, which is 53 bits (with the highest bit always being 1). Multiplying them will give a value very close — but not equal — to 2.
 
 ```js
-Number.MAX_SAFE_INTEGER * Number.EPSILON; // 2
+Number.MAX_SAFE_INTEGER * Number.EPSILON; // 1.9999999999999998
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -22,7 +22,7 @@ For larger integers, consider using {{jsxref("BigInt")}}.
 
 The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991, or \~9 quadrillion).
 
-[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 52 bits to represent the [mantissa](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a number value.
 
@@ -36,7 +36,7 @@ Number.MAX_SAFE_INTEGER; // 9007199254740991
 
 ### Relationship between MAX_SAFE_INTEGER and EPSILON
 
-{{jsxref("Number.EPSILON")}} is 2<sup>-52</sup>, while `MAX_SAFE_INTEGER` is 2<sup>53</sup> – 1 — both of them are derived from the width of the significand, which is 53 bits (with the highest bit always being 1). Multiplying them will give a value very close — but not equal — to 2.
+{{jsxref("Number.EPSILON")}} is 2<sup>-52</sup>, while `MAX_SAFE_INTEGER` is 2<sup>53</sup> – 1 — both of them are derived from the width of the mantissa, which is 53 bits (with the highest bit always being 1). Multiplying them will give a value very close — but not equal — to 2.
 
 ```js
 Number.MAX_SAFE_INTEGER * Number.EPSILON; // 1.9999999999999998

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -22,7 +22,7 @@ For larger integers, consider using {{jsxref("BigInt")}}.
 
 The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991, or \~9 quadrillion).
 
-[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -20,7 +20,7 @@ For larger integers, consider using {{jsxref("BigInt")}}.
 
 ## Description
 
-The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991 or \~9 quadrillion).
+The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991, or \~9 quadrillion).
 
 [Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -22,7 +22,7 @@ For larger integers, consider using {{jsxref("BigInt")}}.
 
 The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254,740,991, or \~9 quadrillion).
 
-[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -24,7 +24,7 @@ The `MAX_SAFE_INTEGER` constant has a value of `9007199254740991` (9,007,199,254
 
 [Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. "Safe" in this context refers to the ability to represent integers exactly and to compare them correctly. For example, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
-Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a number value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
@@ -19,7 +19,7 @@ The **`Number.MAX_VALUE`** property represents the maximum numeric value represe
 
 The `MAX_VALUE` property has a value of approximately `1.7976931348623157E+308`, or 2<sup>1024</sup> - 1. Values larger than `MAX_VALUE` are represented as {{jsxref("Infinity")}} and will lose their actual value.
 
-Because `MAX_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_VALUE`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `MAX_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_VALUE`, rather than as a property of a number value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
@@ -17,7 +17,7 @@ The **`Number.MAX_VALUE`** property represents the maximum numeric value represe
 
 ## Description
 
-The `MAX_VALUE` property has a value of approximately `1.79E+308`, or 1.7976931348623157 × 10<sup>308</sup>. Values larger than `MAX_VALUE` are represented as {{jsxref("Infinity")}}.
+The `MAX_VALUE` property has a value of approximately `1.7976931348623157E+308`, or 2<sup>1024</sup> - 1. Values larger than `MAX_VALUE` are represented as {{jsxref("Infinity")}} and will lose their actual value.
 
 Because `MAX_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_VALUE`, rather than as a property of a {{jsxref("Number")}} object you created.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -22,7 +22,7 @@ To represent integers smaller than this, consider using {{jsxref("BigInt")}}.
 
 The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991, or about -9 quadrillion).
 
-[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -20,7 +20,7 @@ To represent integers smaller than this, consider using {{jsxref("BigInt")}}.
 
 ## Description
 
-The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991 or about -9 quadrillion).
+The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991, or about -9 quadrillion).
 
 [Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -20,7 +20,9 @@ To represent integers smaller than this, consider using {{jsxref("BigInt")}}.
 
 ## Description
 
-The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991 or about -9 quadrillion). The reasoning behind that number is that JavaScript uses [double-precision floating-point format numbers](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) as specified in [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point) and can only safely represent numbers between -(2<sup>53</sup> - 1) and 2<sup>53</sup> - 1. See {{jsxref("Number.isSafeInteger()")}} for more information.
+The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991 or about -9 quadrillion).
+
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the significand, so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 
@@ -29,8 +31,8 @@ Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you alw
 ### Using MIN_SAFE_INTEGER
 
 ```js
-Number.MIN_SAFE_INTEGER // -9007199254740991
--(Math.pow(2, 53) - 1)  // -9007199254740991
+Number.MIN_SAFE_INTEGER; // -9007199254740991
+-(2 ** 53 - 1); // -9007199254740991
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -22,7 +22,7 @@ To represent integers smaller than this, consider using {{jsxref("BigInt")}}.
 
 The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,254,740,991, or about -9 quadrillion).
 
-[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
+[Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 52 bits  to represent the [mantissa](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
 Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_SAFE_INTEGER`, rather than as a property of a number value.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -24,7 +24,7 @@ The `MIN_SAFE_INTEGER` constant has a value of `-9007199254740991` (-9,007,199,2
 
 [Double precision floating point format](https://en.wikipedia.org/wiki/Double_precision_floating-point_format) only has 53 bits (with the highest bit always being 1) to represent the [significand](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding), so it can only safely represent integers between -(2<sup>53</sup> – 1) and 2<sup>53</sup> – 1. Safe in this context refers to the ability to represent integers exactly and to correctly compare them. For example, `Number.MIN_SAFE_INTEGER - 1 === Number.MIN_SAFE_INTEGER - 2` will evaluate to true, which is mathematically incorrect. See {{jsxref("Number.isSafeInteger()")}} for more information.
 
-Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `MIN_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_SAFE_INTEGER`, rather than as a property of a number value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_value/index.md
@@ -20,7 +20,7 @@ The **`Number.MIN_VALUE`** property represents the smallest positive numeric val
 
 In practice, its precise value in mainstream engines like V8 (used by Chrome, Edge, Node.js), SpiderMonkey (used by Firefox), and JavaScriptCore (used by Safari) is 2<sup>-1074</sup>, or `5E-324`.
 
-Because `MIN_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_VALUE`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `MIN_VALUE` is a static property of {{jsxref("Number")}}, you always use it as `Number.MIN_VALUE`, rather than as a property of a number value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -32,9 +32,9 @@ This value behaves slightly differently than mathematical infinity:
 - `NEGATIVE_INFINITY`, divided by either `NEGATIVE_INFINITY` or {{jsxref("Number.POSITIVE_INFINITY", "POSITIVE_INFINITY")}}, is {{jsxref("NaN")}}.
 - `x > Number.NEGATIVE_INFINITY` is true for any number _x_ that isn't `NEGATIVE_INFINITY`.
 
-You might use the `Number.NEGATIVE_INFINITY` property to indicate an error condition that returns a finite number in case of success. Note, however, that {{jsxref("isFinite")}} would be more appropriate in such a case.
+You might use the `Number.NEGATIVE_INFINITY` property to indicate an error condition that returns a finite number in case of success. Note, however, that {{jsxref("NaN")}} would be more appropriate in such a case.
 
-Because `NEGATIVE_INFINITY` is a static property of {{jsxref("Number")}}, you always use it as `Number.NEGATIVE_INFINITY`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `NEGATIVE_INFINITY` is a static property of {{jsxref("Number")}}, you always use it as `Number.NEGATIVE_INFINITY`, rather than as a property of a number value.
 
 ## Examples
 
@@ -43,7 +43,7 @@ Because `NEGATIVE_INFINITY` is a static property of {{jsxref("Number")}}, you al
 In the following example, the variable `smallNumber` is assigned a value that is smaller than the minimum value. When the {{jsxref("Statements/if...else", "if")}} statement executes, `smallNumber` has the value `-Infinity`, so `smallNumber` is set to a more manageable value before continuing.
 
 ```js
-let smallNumber = (-Number.MAX_VALUE) * 2;
+let smallNumber = -Number.MAX_VALUE * 2;
 
 if (smallNumber === Number.NEGATIVE_INFINITY) {
   smallNumber = returnFinite();

--- a/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.md
@@ -32,9 +32,9 @@ This value behaves slightly differently than mathematical infinity:
 - `POSITIVE_INFINITY`, divided by either {{jsxref("Number.NEGATIVE_INFINITY", "NEGATIVE_INFINITY")}} or `POSITIVE_INFINITY`, is {{jsxref("NaN")}}.
 - `Number.POSITIVE_INFINITY > x` is true for any number _x_ that isn't `POSITIVE_INFINITY`.
 
-You might use the `Number.POSITIVE_INFINITY` property to indicate an error condition that returns a finite number in case of success. Note, however, that {{jsxref("isFinite")}} would be more appropriate in such a case.
+You might use the `Number.POSITIVE_INFINITY` property to indicate an error condition that returns a finite number in case of success. Note, however, that {{jsxref("NaN")}} would be more appropriate in such a case.
 
-Because `POSITIVE_INFINITY` is a static property of {{jsxref("Number")}}, you always use it as `Number.POSITIVE_INFINITY`, rather than as a property of a {{jsxref("Number")}} object you created.
+Because `POSITIVE_INFINITY` is a static property of {{jsxref("Number")}}, you always use it as `Number.POSITIVE_INFINITY`, rather than as a property of a number value.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Number.EPSILON` is very inappropriate for equality testing because it has no context of magnitude or precision. See: https://stackoverflow.com/questions/51019475/what-are-the-possible-usage-scenarios-for-number-epsilon

I've also done some edits to the related pages about floating point representations to make them more aligned.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
