### PR TITLE
CSS: remove redundant properties and fix typos

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
@@ -109,14 +109,13 @@ body {
 }
 ```
 
-The CSS in `src/styles.css` apply to the entire application, however, these styles don't effect everything on the page.
+The CSS in `src/styles.css` apply to the entire application, however, these styles don't affect everything on the page.
 The next step is to add styles that apply specifically to the `AppComponent`.
 
 In `app.component.css`, add the following styles:
 
 ```css
 body {
-  color: #4d4d4d;
   background-color: #f5f5f5;
   color: #4d4d4d;
 }

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
@@ -45,7 +45,7 @@ In the last article we completed the development of our app, finished organizing
   </tbody>
 </table>
 
-Using stores we will create an `Alert` component that shows notifications on screen, which can receive messages from any component. In this case, the `Alert` component is independent from the rest — it is not a parent or child of any other — so the messages don't fit into the component hierarchy.
+Using stores we will create an `Alert` component that shows notifications on screen, which can receive messages from any component. In this case, the `Alert` component is independent of the rest — it is not a parent or child of any other — so the messages don't fit into the component hierarchy.
 
 We will also see how to develop our own custom store to persist the todo information to [web storage](/en-US/docs/Web/API/Web_Storage_API), allowing our to-dos to persist over page reloads.
 
@@ -83,7 +83,7 @@ To code along with us using the REPL, start at
 
 We have already seen how our components can communicate with each other using props, two-way data binding, and events. In all these cases we were dealing with communication between parent and child components.
 
-But not all application state belongs inside your application's component hierarchy. For example, information about the logged in user, or whether the dark theme is selected or not.
+But not all application state belongs inside your application's component hierarchy. For example, information about the logged-in user, or whether the dark theme is selected or not.
 
 Sometimes, your app state will need to be accessed by multiple components that are not hierarchically related, or by a regular JavaScript module.
 
@@ -99,7 +99,7 @@ Svelte also provides a very intuitive way to integrate stores into its reactivit
 
 To show how to work with stores, we will create an `Alert` component. These kinds of widgets might also be known as popup notifications, toast, or notification bubbles.
 
-Our `Alert` component will displayed by the `App` component, but any component can send notifications to it. Whenever a notification arrives, the `Alert` component will be in charge of displaying it on screen.
+Our `Alert` component will be displayed by the `App` component, but any component can send notifications to it. Whenever a notification arrives, the `Alert` component will be in charge of displaying it on screen.
 
 ### Creating a store
 
@@ -114,7 +114,7 @@ Let's start by creating a writable store. Any component will be able to write to
     export const alert = writable('Welcome to the to-do list app!')
     ```
 
-> **Note:** Stores can be defined and used outside of Svelte components, so you can organize them in any way you please.
+> **Note:** Stores can be defined and used outside Svelte components, so you can organize them in any way you please.
 
 In the above code we import the `writable()` function from `svelte/store` and use it to create a new store called `alert` with an initial value of "Welcome to the to-do list app!". We then `export` the store.
 
@@ -156,7 +156,6 @@ Let's now create our `Alert` component and see how we can read values from the s
       border-radius: 0.2rem;
       background-color: #565656;
       color: #fff;
-      font-size: 0.875rem;
       font-weight: 700;
       padding: 0.5rem 1.4rem;
       font-size: 1.5rem;
@@ -259,7 +258,7 @@ Behind the scenes Svelte has generated the code to declare the local variable `$
 
 The end result of this nifty trick is that you can access global stores just as easily as using reactive local variables.
 
-This is a perfect example of how Svelte puts the compiler in charge of better developer ergonomics, not only saving us from typing boiler plate, but also generating less error-prone code.
+This is a perfect example of how Svelte puts the compiler in charge of better developer ergonomics, not only saving us from typing boilerplate, but also generating less error-prone code.
 
 ## Writing to our store
 
@@ -334,13 +333,13 @@ As soon as we execute `$alert = …`, Svelte will run `alert.set()`. Our `Alert`
 
 We could do the same within any component or `.js` file.
 
-> **Note:** Outside of Svelte components you cannot use the `$store` syntax. That's because the Svelte compiler won't touch anything outside of Svelte components. In that case you'll have to rely on the `store.subscribe()` and `store.set()` methods.
+> **Note:** Outside Svelte components you cannot use the `$store` syntax. That's because the Svelte compiler won't touch anything outside Svelte components. In that case you'll have to rely on the `store.subscribe()` and `store.set()` methods.
 
 ## Improving our Alert component
 
 It's a bit annoying having to click on the alert to get rid of it. It would be better if the notification just disappeared after a couple of seconds.
 
-Lets see how to do that. We'll specify a prop with the milliseconds to wait before clearing the notification, and we'll define a timeout to remove the alert. We'll also take care of clearing the timeout when the `Alert` component is unmounted to prevent memory leaks.
+Let's see how to do that. We'll specify a prop with the milliseconds to wait before clearing the notification, and we'll define a timeout to remove the alert. We'll also take care of clearing the timeout when the `Alert` component is unmounted to prevent memory leaks.
 
 1. Update the `<script>` section of your `Alert.svelte` component like so:
 

--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.md
@@ -165,7 +165,6 @@ button.switch span {
 label.switch {
   font: 16px "Open Sans", "Arial", sans-serif;
   line-height: 20px;
-  user-select: none;
   vertical-align: middle;
   user-select: none;
 }

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -98,12 +98,12 @@ Viewport-percentage lengths define `<length>` values in percentage relative to t
     For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svw`, `lvw`, and `dvw`.
     `vw` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vmax`
-  - : Represents in percentage the larger of `vw` and `vh`.
+  - : Represents in percentage the largest of `vw` and `vh`.
 
     For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmax`, `lvmax`, and `dvmax`.
     `vmax` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vmin`
-  - : Represents in percentage the smaller of `vw` and `vh`.
+  - : Represents in percentage the smallest of `vw` and `vh`.
 
     For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmin`, `lvmin`, and `dvmin`.
     `vmin` represents the viewport-percentage length unit based on the browser default viewport size.
@@ -196,7 +196,6 @@ html {
 
 .result {
   height: 20px;
-  background-color: #999;
   box-shadow: inset 3px 3px 5px rgba(255,255,255,0.5),
               inset -3px -3px 5px rgba(0,0,0,0.5);
   background-color: orange;


### PR DESCRIPTION
Main goal of the PR is to remove properties that have been specified multiple times in the same rule.
Also fixes some typos.