### PR TITLE
Deprecate RTCIceServer»credentialType & RTCIceCredentialType

### DIFF
--- a/files/en-us/web/api/rtciceserver/credentialtype/index.md
+++ b/files/en-us/web/api/rtciceserver/credentialtype/index.md
@@ -14,10 +14,12 @@ tags:
   - credentialType
   - credentials
   - password
+  - Deprecated
+  - Non-standard
 browser-compat: api.RTCIceServer.credentialType
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The {{domxref("RTCIceServer")}} dictionary's
 **`credentialType`** property is a string value which
@@ -69,7 +71,7 @@ const myPeerConnection = new RTCPeerConnection({
 
 ## Specifications
 
-{{Specifications}}
+This feature is not part of any current specification.
 
 ## Browser compatibility
 


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/commit/0cba163 (https://github.com/w3c/webrtc-pc/pull/2767) removed RTCIceServer»credentialType and RTCIceCredentialType from the WebRTC spec. Related BCD change: https://github.com/mdn/browser-compat-data/pull/17748.