### PR TITLE
Improve sentence clarity

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -188,7 +188,7 @@ The amount of specificity a selector has is measured using three different value
 
 > **Note:** The universal selector ([`*`](/en-US/docs/Web/CSS/Universal_selectors)), combinators (`+`, `>`, `~`, ' '), and specificity adjustment selector ([`:where()`](/en-US/docs/Web/CSS/:where)) have no effect on specificity.
 
-The negation ([`:not()`](/en-US/docs/Web/CSS/:not)) and the matches-any ([`:is()`](/en-US/docs/Web/CSS/:is)) pseudo-classes themselves don't have effect on specificity, but their parameters do. The specificity each contributes to the specificity algorithm is the specificity of the selector in parameter that has the greatest weight.
+The negation ([`:not()`](/en-US/docs/Web/CSS/:not)) and the matches-any ([`:is()`](/en-US/docs/Web/CSS/:is)) pseudo-classes themselves don't have effect on specificity, but their parameters do. The specificity that each contributes to the specificity algorithm is the specificity of the selector in the parameter that has the greatest weight.
 
 The following table shows a few isolated examples to get you in the mood. Try going through these, and make sure you understand why they have the specificity that we have given them. We've not covered selectors in detail yet, but you can find details of each selector on the MDN [selectors reference](/en-US/docs/Web/CSS/CSS_Selectors).
 


### PR DESCRIPTION
I edited a sentence which i found difficult to understand by adding a "that" and "the" to make it clearer.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I tried to improve the clarity of a sentence by adding "that" and "the" 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I am non native english speaker and I had dificulty the meaning of the sentence even after several re-reads. So, I looked around the MDN Web Docs for clarification. I was inspired by the style guide so I made the edit myself.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The Microsoft style guide, which is referenced by the MDN Web Docs, recommemds adding the and that to sentences to improve clarity.  https://docs.microsoft.com/en-us/style-guide/global-communications/writing-tips?source=recommendations

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
