### PR TITLE
Fixing a typo in a code example at https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint

### DIFF
--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -57,7 +57,7 @@ let output = document.getElementById("output");
 if (document.elementsFromPoint) {
   let elements = document.elementsFromPoint(30, 20);
   elements.forEach((elt, i) => {
-    output.textContent += element.localName;
+    output.textContent += elt.localName;
     if (i < elements.length - 1) {
       output.textContent += " < ";
     }


### PR DESCRIPTION
On the [https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint), there is a typo:
The demo does not work, the content stays what it's defined in html
When I ran the JS for it, I got ` Uncaught ReferenceError: element is not defined`
Here is the code I am talking about:
 ```
 let output = document.getElementById("output");
if (document.elementsFromPoint) {
  let elements = document.elementsFromPoint(30, 20);
  elements.forEach((elt, i) => {
    output.textContent += element.localName;  //element should be elt
    if (i < elements.length - 1) {
      output.textContent += " < ";
    }
  });
} else {
  output.innerHTML = "<span style=\"color: red;\">" +
     "Browser does not support <code>document.elementsFromPoint()</code>" +
     "</span>";
}
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Changing the unrefeferenced variable `element` to a defined variable `elt` inside a forEach loop, thus
making the code run expectedly

<!-- ❓ Why are you making these changes and how do they help readers? -->

The original code, as pasted in the beginning of this report, returns a ReferenceError and the demo does not work.

This is my first time filing a report like this, please be kind :)