### PR TITLE
Sync getOutputTimestamp example with webaudio-examples repo

### DIFF
--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -63,30 +63,33 @@ outputs the `contextTime` and `performanceTime`.
 You can see full code of this [example at output-timestamp](https://github.com/mdn/webaudio-examples/blob/master/output-timestamp/index.html) ([see it live also](https://mdn.github.io/webaudio-examples/output-timestamp/)).
 
 ```js
-play.addEventListener('click', () => {
+// Press the play button
+playBtn.addEventListener("click", () => {
+  // We can create the audioCtx as there has been some user action
   if (!audioCtx) {
-    audioCtx = new window.AudioContext();
+    audioCtx = new AudioContext();
   }
-
+  source = new AudioBufferSourceNode(audioCtx);
   getData();
   source.start(0);
-  play.setAttribute('disabled', 'disabled');
-
+  playBtn.disabled = true;
+  stopBtn.disabled = false;
   rAF = requestAnimationFrame(outputTimestamps);
 });
 
-stop.addEventListener('click', () => {
+// Press the stop button
+stopBtn.addEventListener("click", () => {
   source.stop(0);
-  play.removeAttribute('disabled');
+  playBtn.disabled = false;
+  stopBtn.disabled = true;
   cancelAnimationFrame(rAF);
 });
 
-// function to output timestamps
-
+// Helper function to output timestamps
 function outputTimestamps() {
-  let ts = audioCtx.getOutputTimestamp()
-  console.log(`Context time: ${ts.contextTime} | Performance time: ${ts.performanceTime}`);
-  rAF = requestAnimationFrame(outputTimestamps);
+  const ts = audioCtx.getOutputTimestamp();
+  output.textContent = `Context time: ${ts.contextTime} | Performance time: ${ts.performanceTime}`;
+  rAF = requestAnimationFrame(outputTimestamps); // Reregister itself
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This copies the code from https://github.com/mdn/webaudio-examples/blob/master/output-timestamp/index.html so that the example is in sync with it. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
