### PR TITLE
fix: add missing extension for PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,23 @@
 <!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
 
-### Description
+## Description
 
 <!-- ✍️ Summarize your changes in one or two sentences -->
 
-### Motivation
+## Motivation
 
 <!-- ❓ Why are you making these changes and how do they help readers? -->
 
-### Additional details
+## Additional details
 
 <!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
 
-### Related issues and pull requests
+## Related issues and pull requests
 
 <!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
 <!-- 👉 Highlight related pull requests using "Relates to #123" -->
 <!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
 
-
 <!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
+
+<!-- markdownlint-disable-file MD041-->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

## Description

Add missing extension and fix minor Markdownlint issues now that it is parsed as MD

## Motivation

I don't always use these, but it looks like it was added some time ago, but isn't currently being picked up with the missing extension

## Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

## Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

<!-- markdownlint-disable-file MD041-->
