### PR TITLE
Mention dynamic property accessors

### DIFF
--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -19,8 +19,8 @@ object's properties by using the dot notation or the bracket notation.
 ## Syntax
 
 ```js
-object.property
-object['property']
+object.propertyName
+object[expression]
 ```
 
 ## Description
@@ -39,7 +39,7 @@ notation_.
 
 ### Dot notation
 
-In the `object.property` syntax, the `property` must be a valid JavaScript [identifier](/en-US/docs/Glossary/Identifier). (In the ECMAScript standard, the names of properties are technically "IdentifierNames", not "Identifiers", so reserved words can be used but are not recommended). For example, `object.$1` is valid, while `object.1` is not.
+In the `object.propertyName` syntax, the `propertyName` must be a valid JavaScript [identifier](/en-US/docs/Glossary/Identifier). (In the ECMAScript standard, the names of properties are technically "IdentifierNames", not "Identifiers", so reserved words can be used but are not recommended). For example, `object.$1` is valid, while `object.1` is not.
 
 ```js
 const variable = object.propertyName;
@@ -75,7 +75,7 @@ method call, so that the dot is not interpreted as a decimal point.
 77
 .toExponential()
 // or
-;(77).toExponential()
+(77).toExponential()
 // or
 77..toExponential()
 // or
@@ -85,7 +85,7 @@ method call, so that the dot is not interpreted as a decimal point.
 
 ### Bracket notation
 
-In the `object[propertyName]` syntax, the `propertyName` is just a string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). So, it can be any string, including `'1foo'`, `'!bar!'`, or even `' '` (a space).
+In the `object[expression]` syntax, the `expression` is just a string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) that represents the propertyName, or any other expressions that evaluate to the propertyName. So, it can be any string, including `'1foo'`, `'!bar!'`, or even `' '` (a space).
 
 ```js
 const variable = object[propertyName];
@@ -102,6 +102,17 @@ A space before bracket notation is allowed.
 
 ```js
 document ['createElement']('pre')
+```
+Passing expressions that evaluate to propertyName will do the same thing as directly passing the propertyName
+
+```js
+let key ="name"
+let getKey = ()=>"name"
+let Obj = {name:"John"}
+
+Obj["name"];   //returns "John" 
+Obj[key];      //evaluates to Obj["name"], and returns "John"
+Obj[getKey()]; // evaluates to Obj["name"], and returns "John"
 ```
 
 ### Property names

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -11,8 +11,7 @@ browser-compat: javascript.operators.property_accessors
 
 {{jsSidebar("Operators")}}
 
-**Property accessors** provide access to an
-object's properties by using the dot notation or the bracket notation.
+**Property accessors** provide access to an object's properties by using the dot notation or the bracket notation.
 
 {{EmbedInteractiveExample("pages/js/expressions-propertyaccessors.html", "taller")}}
 
@@ -25,21 +24,13 @@ object[expression]
 
 ## Description
 
-One can think of an object as an _associative array_ (a.k.a. _map_,
-_dictionary_, _hash_, _lookup table_). The _keys_ in this
-array are the names of the object's properties.
+One can think of an object as an _associative array_ (a.k.a. _map_, _dictionary_, _hash_, _lookup table_). The _keys_ in this array are the names of the object's properties.
 
-It's typical when speaking of an object's properties to make a distinction between
-properties and methods. However, the property/method distinction is little more than a
-convention. A method is a property that can be called (for example, if it has a
-reference to a {{jsxref("Function")}} instance as its value).
-
-There are two ways to access properties: _dot notation_ and _bracket
-notation_.
+There are two ways to access properties: _dot notation_ and _bracket notation_.
 
 ### Dot notation
 
-In the `object.propertyName` syntax, the `propertyName` must be a valid JavaScript [identifier](/en-US/docs/Glossary/Identifier). (In the ECMAScript standard, the names of properties are technically "IdentifierNames", not "Identifiers", so reserved words can be used but are not recommended). For example, `object.$1` is valid, while `object.1` is not.
+In the `object.propertyName` syntax, the `propertyName` must be a valid JavaScript [identifier](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) which can also be a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords). For example, `object.$1` is valid, while `object.1` is not.
 
 ```js
 const variable = object.propertyName;
@@ -48,44 +39,41 @@ object.propertyName = value;
 
 ```js
 const object = {};
-object.$1 = 'foo';
-console.log(object.$1);  // 'foo'
+object.$1 = "foo";
+console.log(object.$1); // 'foo'
 ```
 
 ```js example-bad
 const object = {};
-object.1 = 'bar';        // SyntaxError
-console.log(object.1);   // SyntaxError
+object.1 = 'bar'; // SyntaxError
+console.log(object.1); // SyntaxError
 ```
 
-Here, the method named `createElement` is retrieved from
-`document` and is called.
+Here, the method named `createElement` is retrieved from `document` and is called.
 
 ```js
-document.createElement('pre')
+document.createElement("pre");
 ```
 
-If you use a method for a numeric literal, and the numeric literal has no exponent and
-no decimal point, you should leave [white-space(s)](/en-US/docs/Glossary/Whitespace) before the dot preceding the
-method call, so that the dot is not interpreted as a decimal point.
+If you use a method for a numeric literal, and the numeric literal has no exponent and no decimal point, you should leave [white-space(s)](/en-US/docs/Glossary/Whitespace) before the dot preceding the method call, so that the dot is not interpreted as a decimal point.
 
 ```js
-77 .toExponential()
+77 .toExponential();
 // or
 77
-.toExponential()
+.toExponential();
 // or
-(77).toExponential()
+(77).toExponential();
 // or
-77..toExponential()
+77..toExponential();
 // or
-77.0.toExponential()
+77.0.toExponential();
 // because 77. === 77.0, no ambiguity
 ```
 
 ### Bracket notation
 
-In the `object[expression]` syntax, the `expression` is just a string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) that represents the propertyName, or any other expressions that evaluate to the propertyName. So, it can be any string, including `'1foo'`, `'!bar!'`, or even `' '` (a space).
+In the `object[expression]` syntax, the `expression` should evaluate to a string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) that represents the property's name. So, it can be any string literal, for example, including `'1foo'`, `'!bar!'`, or even `' '` (a space).
 
 ```js
 const variable = object[propertyName];
@@ -95,77 +83,69 @@ object[propertyName] = value;
 This does the exact same thing as the previous example.
 
 ```js
-document['createElement']('pre')
+document["createElement"]("pre");
 ```
 
 A space before bracket notation is allowed.
 
 ```js
-document ['createElement']('pre')
+document ["createElement"]("pre");
 ```
-Passing expressions that evaluate to propertyName will do the same thing as directly passing the propertyName
+
+Passing expressions that evaluate to property name will do the same thing as directly passing the property name.
 
 ```js
-let key ="name"
-let getKey = ()=>"name"
-let Obj = {name:"John"}
+const key = "name";
+const getKey = () => "name";
+const Obj = { name: "John" };
 
-Obj["name"];   //returns "John" 
-Obj[key];      //evaluates to Obj["name"], and returns "John"
+Obj["name"]; // returns "John"
+Obj[key]; // evaluates to Obj["name"], and returns "John"
 Obj[getKey()]; // evaluates to Obj["name"], and returns "John"
 ```
 
 ### Property names
 
-Property names are string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Any
-other value, including a number, is coerced to a string. This outputs
-`'value'`, since `1` is coerced into `'1'`.
+Property names are string or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). Any other value, including a number, is coerced to a string. This outputs `'value'`, since `1` is coerced into `'1'`.
 
 ```js
 const object = {};
-object['1'] = 'value';
+object["1"] = "value";
 console.log(object[1]);
 ```
 
-This also outputs `'value'`, since both `foo` and
-`bar` are converted to the same string.
+This also outputs `'value'`, since both `foo` and `bar` are converted to the same string.
 
 ```js
 const foo = { uniqueProp: 1 };
 const bar = { uniqueProp: 2 };
 const object = {};
-object[foo] = 'value';
+object[foo] = "value";
 console.log(object[bar]);
 ```
 
 ### Method binding
 
-A method is not bound to the object that it is a method of. Specifically,
-`this` is not fixed in a method. Put another way, `this` does not
-necessarily refer to the object containing a method. Instead, `this` is
-"passed" by the function call.
-See [method binding](/en-US/docs/Web/JavaScript/Reference/Operators/this#method_binding).
+It's typical when speaking of an object's properties to make a distinction between properties and methods. However, the property/method distinction is little more than a convention. A method is a property that can be called (for example, if it has a reference to a {{jsxref("Function")}} instance as its value).
+
+A method is not bound to the object that it is a property of. Specifically, `this` is not fixed in a method and does not necessarily refer to the object containing the method. Instead, `this` is "passed" by the function call. See [method binding](/en-US/docs/Web/JavaScript/Reference/Operators/this#method_binding).
 
 ## Examples
 
 ### Bracket notation vs. eval()
 
-JavaScript novices often make the mistake of using {{jsxref("Global_Objects/eval", "eval()")}} where
-the bracket notation can be used instead.
+JavaScript novices often make the mistake of using {{jsxref("Global_Objects/eval", "eval()")}} where the bracket notation can be used instead.
 
 For example, the following syntax is often seen in many scripts.
 
 ```js
-x = eval(`document.forms.form_name.elements.${strFormControl}.value`);
+const x = eval(`document.forms.form_name.elements.${strFormControl}.value`);
 ```
 
-`eval()` is slow and should be avoided whenever possible. Also,
-`strFormControl` would have to hold an identifier, which is not required for
-names and `id`s of form controls. It is better to use bracket notation
-instead:
+`eval()` is slow and should be avoided whenever possible. Also, `strFormControl` would have to hold an identifier, which is not required for names and `id`s of form controls. It is better to use bracket notation instead:
 
 ```js
-x = document.forms['form_name'].elements[strFormControl].value;
+const x = document.forms.form_name.elements[strFormControl].value;
 ```
 
 ## Specifications


### PR DESCRIPTION

### Description
As bracket notation can accept any expression according to specs, then we need to mention that on this page. We also need to make a convention of naming the syntax all over the docs to be consistent, will it be object.propertyName or object.property?, will it be object[property] or object[propertName] or object["propertyName"], or object[expression] - which is preferred to match the specs, and cover all cases-,  as I've seen different conventions all over the docs and I think sticking with one will be better and consistent.