### PR TITLE
fix(Workflow): auto fix cron job not creating a PR

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Lint markdown files
         run: |
-          yarn lint:md
+          yarn fix:md
 
       - name: Create PR with only fixable issues
         if: success()


### PR DESCRIPTION
We [deliberately added a lint error](https://github.com/mdn/content/pull/20500#pullrequestreview-1103080809) to test the cron job.
Today it ran but [did not create any PR](https://github.com/mdn/content/runs/8288424651?check_suite_focus=true). This is because current command didn't modify any files.

We need to use `yarn fix:md` in the workflow and not `yarn lint:md`.

cc/ @teoli2003 , @nschonni 