### PR TITLE
chore: set prettier to ignore code blocks

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "bracketSameLine": true
+  "bracketSameLine": true,
+  "embeddedLanguageFormatting": "off"
 }


### PR DESCRIPTION
Was trying to see if some of the code block languages could be skipped like `bad-example`, but I found this option as a temporary workaround.
With this, only 1100 files are changes currently running accross the entire repo vs 7K with it set to "auto".
Long term it would be good to opt back in with a custom parser that could help skip some of the blocks