### PR TITLE
fix(workflow): auto fix cron job run link

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -47,4 +47,4 @@ jobs:
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             Auto-fix was run, but additional issues found.
-            Please review the run log: https://github.com/mdn/content/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true#step:5:1
+            Please review the run log: https://github.com/mdn/content/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
The workflow is creating a broken link to it's run when there are unfixable errors:
> Auto-fix was run, but additional issues found.
Please review the run log: [https://github.com/mdn/content/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true#step:5:1](https://github.com/mdn/content/actions/runs/$%7BGITHUB_RUN_ID%7D?check_suite_focus=true#step:5:1)


The environment variable `${GITHUB_RUN_ID}` is not getting evaluated as it's part of the body string and not a shell command.
For example refer before fix PR: https://github.com/OnkarRuikar/content/pull/4

We need to use [expression](https://docs.github.com/en/actions/learn-github-actions/expressions) `${{ github.run_id }}` instead.
After fix demo PR: https://github.com/OnkarRuikar/content/pull/7