### PR TITLE
fix the max-age description

### DIFF
--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -554,8 +554,8 @@ Some commonly-used cache-header values are shown below.
 
 ```
 36 cache-control max-age=0
-37 cache-control max-age=2592000
-38 cache-control max-age=604800
+37 cache-control max-age=604800
+38 cache-control max-age=2592000
 39 cache-control no-cache
 40 cache-control no-store
 41 cache-control public, max-age=31536000
@@ -574,7 +574,7 @@ The `public` value has the effect of making the response storable even if the `A
 > **Note:** The `public` directive should only be used if there is a need to store the response when the `Authorization` header is set.
 > It is not required otherwise, because a response will be stored in the shared cache as long as `max-age` is given.
 
-So if the response is personalized with basic authentication, the presence of `public` may cause problems. If you are concerned about that, you can choose the second-longest value, `37` (1 month).
+So if the response is personalized with basic authentication, the presence of `public` may cause problems. If you are concerned about that, you can choose the second-longest value, `38` (1 month).
 
 ```http
 # response for bundle.v123.js


### PR DESCRIPTION
### Description

fix the max-age description

See line 566, and for easier to read, the order should be `one week`, `one month` and `one year`. Change the line order of `max-age` to match it.
