### PR TITLE
Align for...in syntax and page structure with for...of

### DIFF
--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -135,7 +135,7 @@ The {{jsxref("RegExp/compile", "compile()")}} method is deprecated. Construct a 
 
 The [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) statement is deprecated and unavailable in strict mode.
 
-Initializers in `var` declarations of [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loops headers are deprecated and produce syntax errors in strict mode. They are silently ignored in non-strict mode.
+Initializers in `var` declarations of [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loops headers are deprecated and produce [syntax errors](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer) in strict mode. They are silently ignored in non-strict mode.
 
 ## Obsolete features
 

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -10,83 +10,69 @@ browser-compat: javascript.statements.for_in
 
 {{jsSidebar("Statements")}}
 
-The **`for...in` statement** iterates over all
-[enumerable properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
-of an object that are keyed by strings
-(ignoring ones keyed by [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)),
-including inherited enumerable properties.
+The **`for...in` statement** iterates over all [enumerable string properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) of an object (ignoring properties keyed by [symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)), including inherited enumerable properties.
 
 {{EmbedInteractiveExample("pages/js/statement-forin.html")}}
 
 ## Syntax
 
 ```js
-for (const variable in object) {
+for (variable in object)
   statement
-}
 ```
 
+### Parameters
+
 - `variable`
-  - : A different property name is assigned to `variable` on each iteration.
+  - : Receives a string property name on each iteration. May be either a declaration with [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), or [`var`](/en-US/docs/Web/JavaScript/Reference/Statements/var), or an [assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment) target (e.g. a previously declared variable or an object property).
 - `object`
-  - : Object whose non-Symbol enumerable properties are iterated over.
+  - : Object whose non-symbol enumerable properties are iterated over.
+- `statement`
+  - : A statement to be executed on every iteration. May reference `variable`. You can use a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block) to execute multiple statements.
 
 ## Description
 
 The loop will iterate over all enumerable properties of the object itself and those the object inherits from its prototype chain (properties of nearer prototypes take precedence over those of prototypes further away from the object in its prototype chain).
 
-A `for...in` loop only iterates over enumerable, non-Symbol properties. Objects created from built–in constructors like `Array` and `Object` have inherited non–enumerable properties from `Array.prototype` and `Object.prototype`, such as {{jsxref("Array")}}'s {{jsxref("Array/indexOf", "indexOf()")}} method or {{jsxref("Object")}}'s {{jsxref("Object/toString", "toString()")}} method, which will not be visited in the `for...in` loop.
+A `for...in` loop only iterates over enumerable, non-symbol properties. Objects created from built–in constructors like `Array` and `Object` have inherited non–enumerable properties from `Array.prototype` and `Object.prototype`, such as {{jsxref("Array")}}'s {{jsxref("Array/indexOf", "indexOf()")}} method or {{jsxref("Object")}}'s {{jsxref("Object/toString", "toString()")}} method, which will not be visited in the `for...in` loop.
 
 The traversal order, as of modern ECMAScript specification, is well-defined and consistent across implementations. Within each component of the prototype chain, all non-negative integer keys (those that can be array indices) will be traversed first in ascending order by value, then other string keys in ascending chronological order of property creation.
 
+The `variable` part of `for...in` accepts anything that can come before the `=` operator. You can use {{jsxref("Statements/const", "const")}} to declare the variable as long as it's not reassigned within the loop body (it can change between iterations, because those are two separate variables). Otherwise, you can use {{jsxref("Statements/let", "let")}}. You can use [destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) or an object property like `for (x.y in iterable)` as well.
+
+A [legacy syntax](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#statements) allows `var` declarations of the loop variable to have an initializer. This throws a [syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer) in strict mode and is ignored in non–strict mode.
+
 ### Deleted, added, or modified properties
 
-If a property is modified in one iteration and then visited at a later time, its value
-in the loop is its value at that later time. A property that is deleted before it has
-been visited will not be visited later. Properties added to the object over which
-iteration is occurring may either be visited or omitted from iteration.
+If a property is modified in one iteration and then visited at a later time, its value in the loop is its value at that later time. A property that is deleted before it has been visited will not be visited later. Properties added to the object over which iteration is occurring may either be visited or omitted from iteration.
 
-In general, it is best not to add, modify, or remove properties from the object during
-iteration, other than the property currently being visited. There is no guarantee
-whether an added property will be visited, whether a modified property (other than the
-current one) will be visited before or after it is modified, or whether a deleted
-property will be visited before it is deleted.
+In general, it is best not to add, modify, or remove properties from the object during iteration, other than the property currently being visited. There is no guarantee whether an added property will be visited, whether a modified property (other than the current one) will be visited before or after it is modified, or whether a deleted property will be visited before it is deleted.
 
 ### Array iteration and for...in
 
-Array indexes are just enumerable properties with integer names and are otherwise identical to general object properties. The `for...in` loop will traverse all integer keys before traversing other keys, and in strictly increasing order, making the behavior of `for...in` close to normal array iteration. However, the `for...in` loop will return all enumerable properties, including those with non–integer names and those that are inherited. Unlike `for...of`, `for...in` uses property enumeration instead of the array's iterator. In sparse arrays, `for...of` will visit the empty slots, but `for...in` will not.
+Array indexes are just enumerable properties with integer names and are otherwise identical to general object properties. The `for...in` loop will traverse all integer keys before traversing other keys, and in strictly increasing order, making the behavior of `for...in` close to normal array iteration. However, the `for...in` loop will return all enumerable properties, including those with non–integer names and those that are inherited. Unlike `for...of`, `for...in` uses property enumeration instead of the array's iterator. In [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays), `for...of` will visit the empty slots, but `for...in` will not.
 
 It is better to use a {{jsxref("Statements/for", "for")}} loop with a numeric index, {{jsxref("Array.prototype.forEach()")}}, or the {{jsxref("Statements/for...of", "for...of")}} loop, because they will return the index as a number instead of a string, and also avoid non-index properties.
 
 ### Iterating over own properties only
 
-If you only want to consider properties attached to the object itself, and not its
-prototypes, you can use one of the following techniques:
+If you only want to consider properties attached to the object itself, and not its prototypes, you can use one of the following techniques:
 
 - {{jsxref("Object.keys", "Object.keys(myObject)")}}
 - {{jsxref("Object.getOwnPropertyNames", "Object.getOwnPropertyNames(myObject)")}}
 
 `Object.keys` will return a list of enumerable own string properties, while `Object.getOwnPropertyNames` will also contain non-enumerable ones.
 
-## Why Use for...in?
-
-Many JavaScript style guides and linters recommend against the use of `for...in`, because it iterates over the entire prototype chain which is rarely what one wants, and may be a confusion with the more widely-used `for...of` loop. In what cases would `for...in` be useful at all?
-
-It may be most practically used for debugging purposes, being an easy way to check the
-properties of an object (by outputting to the console or otherwise). Although arrays are
-often more practical for storing data, in situations where a key-value pair is preferred
-for working with data (with properties acting as the "key"), there may be instances
-where you want to check if any of those keys hold a particular value.
+Many JavaScript style guides and linters recommend against the use of `for...in`, because it iterates over the entire prototype chain which is rarely what one wants, and may be a confusion with the more widely-used `for...of` loop. `for...in` is most practically used for debugging purposes, being an easy way to check the properties of an object (by outputting to the console or otherwise). In situations where objects are used as ad-hoc key-value pairs, `for...in` allows you check if any of those keys hold a particular value.
 
 ## Examples
 
 ### Using for...in
 
-The `for...in` loop below iterates over all of the object's enumerable,
-non-Symbol properties and logs a string of the property names and their values.
+The `for...in` loop below iterates over all of the object's enumerable, non-symbol properties and logs a string of the property names and their values.
 
 ```js
-const obj = {a: 1, b: 2, c: 3};
+const obj = { a: 1, b: 2, c: 3 };
 
 for (const prop in obj) {
   console.log(`obj.${prop} = ${obj[prop]}`);
@@ -100,15 +86,13 @@ for (const prop in obj) {
 
 ### Iterating own properties
 
-The following function illustrates the use of
-{{jsxref("Object.hasOwn", "Object.hasOwn()")}}: the inherited
-properties are not displayed.
+The following function illustrates the use of {{jsxref("Object.hasOwn", "Object.hasOwn()")}}: the inherited properties are not displayed.
 
 ```js
-const triangle = {a: 1, b: 2, c: 3};
+const triangle = { a: 1, b: 2, c: 3 };
 
 function ColoredTriangle() {
-  this.color = 'red';
+  this.color = "red";
 }
 
 ColoredTriangle.prototype = triangle;
@@ -133,32 +117,10 @@ for (const prop in obj) {
 
 {{Compat}}
 
-### Compatibility: Initializer expressions in strict mode
-
-Prior to Firefox 40, it was possible to use an initializer expression
-(`i=0`) in a `for...in` loop:
-
-```js example-bad
-const obj = { a: 1, b: 2, c: 3 };
-for (var i = 0 in obj) {
-  console.log(obj[i]);
-}
-// 1
-// 2
-// 3
-```
-
-This nonstandard behavior is now ignored in version 40 and later, and will present a {{jsxref("SyntaxError")}} ("[for-in loop head declarations may not have initializers](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer)") error in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) ([bug 748550](https://bugzilla.mozilla.org/show_bug.cgi?id=748550) and [bug 1164741](https://bugzilla.mozilla.org/show_bug.cgi?id=1164741)).
-
-Other engines such as v8 (Chrome), Chakra (IE/Edge), and JSC (WebKit/Safari) are
-investigating whether to remove the nonstandard behavior as well.
-
 ## See also
 
-- {{jsxref("Statements/for...of", "for...of")}} – a similar statement that iterates
-  over the property _values_
+- {{jsxref("Statements/for...of", "for...of")}}
 - {{jsxref("Statements/for", "for")}}
-- [Iterators and Generator functions](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) (usable with `for...of` syntax)
 - [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)
 - {{jsxref("Object.getOwnPropertyNames()")}}
 - {{jsxref("Object.hasOwn()")}}

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -13,54 +13,39 @@ browser-compat: javascript.statements.for
 
 {{jsSidebar("Statements")}}
 
-The **for statement** creates a loop that consists of three optional
-expressions, enclosed in parentheses and separated by semicolons, followed by a
-statement (usually a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block)) to
-be executed in the loop.
+The **for statement** creates a loop that consists of three optional expressions, enclosed in parentheses and separated by semicolons, followed by a statement (usually a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block)) to be executed in the loop.
 
 {{EmbedInteractiveExample("pages/js/statement-for.html")}}
 
 ## Syntax
 
 ```js
-for ([initialization]; [condition]; [final-expression])
+for (initialization; condition; afterthought)
   statement
 ```
 
-- `initialization`
+- `initialization` {{optional_inline}}
 
-  - : An expression (including assignment expressions) or variable declaration evaluated
-    once before the loop begins. Typically used to initialize a counter variable. This
-    expression may optionally declare new variables with `var` or
-    `let` keywords. Variables declared with `var` are not local to
-    the loop, i.e. they are in the same scope the `for` loop is in. Variables
-    declared with `let` are local to the statement.
+  - : An expression (including [assignment expressions](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment)) or variable declaration evaluated once before the loop begins. Typically used to initialize a counter variable. This expression may optionally declare new variables with `var` or `let` keywords. Variables declared with `var` are not local to the loop, i.e. they are in the same scope the `for` loop is in. Variables declared with `let` are local to the statement.
 
     The result of this expression is discarded.
 
-- `condition`
+- `condition` {{optional_inline}}
+
   - : An expression to be evaluated before each loop iteration. If this expression [evaluates to true](/en-US/docs/Glossary/Truthy), `statement` is executed. If the expression [evaluates to false](/en-US/docs/Glossary/Falsy), execution exits the loop and goes to the first statement after the `for` construct.
 
     This conditional test is optional. If omitted, the condition always evaluates to true.
-- `final-expression`
-  - : An expression to be evaluated at the end of each loop iteration. This occurs before
-    the next evaluation of `condition`. Generally used to update or
-    increment the counter variable.
+
+- `afterthought` {{optional_inline}}
+  - : An expression to be evaluated at the end of each loop iteration. This occurs before the next evaluation of `condition`. Generally used to update or increment the counter variable.
 - `statement`
-  - : A statement that is executed as long as the condition evaluates to true. To execute
-    multiple statements within the loop, use a {{jsxref("Statements/block", "block", "",
-    0)}} statement (`{ /* ... */ }`) to group those statements. To execute no
-    statement within the loop, use an {{jsxref("Statements/empty", "empty", "", 0)}}
-    statement (`;`).
+  - : A statement that is executed as long as the condition evaluates to true. You can use a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block) to execute multiple statements. To execute no statement within the loop, use an [empty statement](/en-US/docs/Web/JavaScript/Reference/Statements/Empty) (`;`).
 
 ## Examples
 
 ### Using for
 
-The following `for` statement starts by declaring the variable
-`i` and initializing it to `0`. It checks that `i` is
-less than nine, performs the two succeeding statements, and increments `i` by
-1 after each pass through the loop.
+The following `for` statement starts by declaring the variable `i` and initializing it to `0`. It checks that `i` is less than nine, performs the two succeeding statements, and increments `i` by 1 after each pass through the loop.
 
 ```js
 for (let i = 0; i < 9; i++) {
@@ -69,12 +54,32 @@ for (let i = 0; i < 9; i++) {
 }
 ```
 
+### Initialization block syntax
+
+The initialization block accepts both expressions and variable declarations. However, expressions cannot use the [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) operator unparenthesized, because that is ambiguous with a [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop.
+
+```js example-bad
+for (let i = "start" in window ? window.start : 0; i < 9; i++) {
+  console.log(i);
+}
+// SyntaxError: 'for-in' loop variable declaration may not have an initializer.
+```
+
+```js example-good
+// Parenthesize the whole initializer
+for (let i = ("start" in window ? window.start : 0); i < 9; i++) {
+  console.log(i);
+}
+
+// Parenthesize the `in` expression
+for (let i = ("start" in window) ? window.start : 0; i < 9; i++) {
+  console.log(i);
+}
+```
+
 ### Optional for expressions
 
-All three expressions in the head of the `for` loop are optional.
-
-For example, in the `initialization` block it is not required to
-initialize variables:
+All three expressions in the head of the `for` loop are optional. For example, it is not required to use the `initialization` block to initialize variables:
 
 ```js
 let i = 0;
@@ -84,23 +89,17 @@ for (; i < 9; i++) {
 }
 ```
 
-Like the `initialization` block, the
-`condition` block is also optional. If you are omitting this
-expression, you must make sure to break the loop in the body in order to not create an
-infinite loop.
+Like the `initialization` block, the `condition` part is also optional. If you are omitting this expression, you must make sure to break the loop in the body in order to not create an infinite loop.
 
 ```js
-for (let i = 0;; i++) {
+for (let i = 0; ; i++) {
   console.log(i);
   if (i > 3) break;
   // more statements
 }
 ```
 
-You can also omit all three blocks. Again, make sure to use a
-{{jsxref("Statements/break", "break")}} statement to end the loop and also modify
-(increase) a variable, so that the condition for the break statement is true at some
-point.
+You can also omit all three expressions. Again, make sure to use a {{jsxref("Statements/break", "break")}} statement to end the loop and also modify (increase) a variable, so that the condition for the break statement is true at some point.
 
 ```js
 let i = 0;
@@ -135,7 +134,7 @@ for (let i = 0; i < 3; i++) {
 }
 ```
 
-…it logs `0`, `1`, and `2`, as expected. However, if the variable is defined in the upper scope:
+It logs `0`, `1`, and `2`, as expected. However, if the variable is defined in the upper scope:
 
 ```js
 let i = 0;
@@ -146,7 +145,7 @@ for (; i < 3; i++) {
 }
 ```
 
-…it logs `3`, `3`, and `3`. The reason is that each `setTimeout` creates a new closure that closes over the `i` variable, but if the `i` is not scoped to the loop body, all closures will reference the same variable when they eventually get called — and due to the asynchronous nature of [`setTimeout`](/en-US/docs/Web/API/setTimeout), it will happen after the loop has already exited, causing the value of `i` in all queued callbacks' bodies to have the value of `3`.
+It logs `3`, `3`, and `3`. The reason is that each `setTimeout` creates a new closure that closes over the `i` variable, but if the `i` is not scoped to the loop body, all closures will reference the same variable when they eventually get called — and due to the asynchronous nature of [`setTimeout`](/en-US/docs/Web/API/setTimeout), it will happen after the loop has already exited, causing the value of `i` in all queued callbacks' bodies to have the value of `3`.
 
 This also happens if you use a `var` statement as the initialization, because variables declared with `var` are only function-scoped, but not lexically scoped (i.e. they can't be scoped to the loop body).
 
@@ -159,31 +158,30 @@ for (var i = 0; i < 3; i++) {
 // Logs 3, 3, 3
 ```
 
-The scoping effect of the initialization block can be understood as if the declaration happens within the loop body, but just happens to be accessible within the `condition` and `final-expression` parts.
+The scoping effect of the initialization block can be understood as if the declaration happens within the loop body, but just happens to be accessible within the `condition` and `afterthought` parts.
 
 ### Using for without a statement
 
-The following `for` cycle calculates the offset position of a node in the
-`final-expression` section, and therefore it does not require the
-use of a `statement` section, a semicolon is used instead.
+The following `for` cycle calculates the offset position of a node in the `afterthought` section, and therefore it does not require the use of a `statement` section, a semicolon is used instead.
 
 ```js
 function showOffsetPos(id) {
   let left = 0;
   let top = 0;
   for (
-    let itNode = document.getElementById(id); /* initialization */
-    itNode; /* condition */
-    left += itNode.offsetLeft, top += itNode.offsetTop, itNode = itNode.offsetParent /* final-expression */
-  ); /* semicolon */
+    let itNode = document.getElementById(id); // initialization
+    itNode; // condition
+    left += itNode.offsetLeft,
+      top += itNode.offsetTop,
+      itNode = itNode.offsetParent // afterthought
+  ); // semicolon
 
-  console.log(`Offset position of '${id}' element:\n left: ${left}px;\n top: ${top}px;`);
-
+  console.log(
+    `Offset position of '${id}' element:\n left: ${left}px;\n top: ${top}px;`,
+  );
 }
 
-/* Example call: */
-
-showOffsetPos('content');
+showOffsetPos("content");
 
 // Output:
 // "Offset position of "content" element:
@@ -191,13 +189,11 @@ showOffsetPos('content');
 // top: 153px;"
 ```
 
-> **Note:** This is one of the few cases in JavaScript where
-> **the semicolon is mandatory**. Indeed, without the semicolon the line that
-> follows the cycle declaration will be considered a statement.
+Note that the semicolon after the `for` statement is mandatory, because it stands as an [empty statement](/en-US/docs/Web/JavaScript/Reference/Statements/Empty). Otherwise, the `for` statement acquires the following `console.log` line as its `statement` section, which makes the `log` execute multiple times.
 
 ### Using for with two iterating variables
 
-You can create two counters that are updated simultaneously in a for loop using the [comma operator](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator).
+You can create two counters that are updated simultaneously in a for loop using the [comma operator](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator). Multiple `let` and `var` declarations can also be joined with commas.
 
 ```js
 const arr = [1, 2, 3, 4, 5, 6];
@@ -219,7 +215,7 @@ for (let l = 0, r = arr.length - 1; l < r; l++, r--) {
 
 ## See also
 
-- {{jsxref("Statements/empty", "empty statement", "", 0)}}
+- [empty statement](/en-US/docs/Web/JavaScript/Reference/Statements/Empty)
 - {{jsxref("Statements/break", "break")}}
 - {{jsxref("Statements/continue", "continue")}}
 - {{jsxref("Statements/while", "while")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

After #19901, the `for...of` page no longer shows `const` in its syntax box, but uses prose to define it. It's later ported to #20112. This syncs `for...in` with both.

This also removed a mention of "planning to remove the syntax" because it's standardized and not planned anymore.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
