### PR TITLE
HTML: remove deprecated <style type='text/css'> attribute

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
@@ -93,7 +93,7 @@ In this example:
 <HTML>
 <head>
 <title>Order query Firefox 1.5 Example</title>
-<style>
+<style type="text/css">
 body, p {
   font-family: Verdana, sans-serif;
   font-size: 12px;

--- a/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
@@ -93,7 +93,7 @@ In this example:
 <HTML>
 <head>
 <title>Order query Firefox 1.5 Example</title>
-<style type="text/css">
+<style>
 body, p {
   font-family: Verdana, sans-serif;
   font-size: 12px;

--- a/files/en-us/web/api/xsltprocessor/generating_html/index.md
+++ b/files/en-us/web/api/xsltprocessor/generating_html/index.md
@@ -55,7 +55,7 @@ A template matching the root node of the XML document is created and used to cre
       <xsl:value-of select="/myNS:Article/myNS:Title"/>
     </title>
 
-    <style type="text/css">
+    <style>
       .myBox {margin:10px 155px 0 50px; border: 1px dotted #639ACE; padding:0 5px 0 5px;}
     </style>
 
@@ -135,7 +135,7 @@ The final XSLT stylesheet looks as follows:
           <xsl:value-of select="/myNS:Article/myNS:Title"/>
         </title>
 
-        <style type="text/css">
+        <style>
           .myBox {margin:10px 155px 0 50px; border: 1px dotted #639ACE; padding:0 5px 0 5px;}
         </style>
 

--- a/files/en-us/web/svg/attribute/class/index.md
+++ b/files/en-us/web/svg/attribute/class/index.md
@@ -63,7 +63,7 @@ You can use this class to style SVG content using CSS.
       viewPort="0 0 120 120"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg">
-      <style type="text/css">
+      <style>
         <![CDATA[
             rect.rectClass {
                 stroke: #000066;

--- a/files/en-us/web/svg/attribute/id/index.md
+++ b/files/en-us/web/svg/attribute/id/index.md
@@ -17,7 +17,7 @@ You can use this attribute with any SVG element.
 
 ```html
 <svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
-  <style type="text/css">
+  <style>
     <![CDATA[
       #smallRect {
         stroke: #000066;

--- a/files/en-us/web/svg/namespaces_crash_course/example/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/example/index.md
@@ -18,7 +18,7 @@ This is done completely in W3C Standards–XHTML, SVG, and JavaScript–no Flash
   xmlns:svg="http://www.w3.org/2000/svg">
   <head>
   <title>A swarm of motes</title>
-  <style type='text/css'>
+  <style>
   <![CDATA[
     label, input
     {

--- a/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
+++ b/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
@@ -114,7 +114,7 @@ Or it can be moved to a special style section that you include. Instead of shovi
 <?xml version="1.0" standalone="no"?>
 <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" version="1.1">
   <defs>
-    <style type="text/css"><![CDATA[
+    <style><![CDATA[
        #MyRect {
          stroke: black;
          fill: red;

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -32,7 +32,7 @@ Linear gradients change along a straight line. To insert one, you create a {{SVG
         <stop offset="50%" stop-color="black" stop-opacity="0"/>
         <stop offset="100%" stop-color="blue"/>
       </linearGradient>
-      <style type="text/css"><![CDATA[
+      <style><![CDATA[
         #rect1 { fill: url(#Gradient1); }
         .stop1 { stop-color: red; }
         .stop2 { stop-color: black; stop-opacity: 0; }

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -79,7 +79,7 @@ You can use `@font-face` to reference remote (and not so remote) fonts:
   <!-- and so on -->
 </font>
 
-<style type="text/css">
+<style>
 @font-face {
   font-family: "Super Sans";
   src: url(#Super_Sans);

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.md
@@ -44,7 +44,7 @@ The basic example will load an XML file and apply a XSL transformation on it. Th
           <xsl:value-of select="/myNS:Article/myNS:Title"/>
         </title>
 
-        <style type="text/css">
+        <style>
           .myBox {margin:10px 155px 0 50px; border: 1px dotted #639ACE; padding:0 5px 0 5px;}
         </style>
 


### PR DESCRIPTION
The `type` attribute [is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#deprecated_attributes) on the `<style>` tag.
It defaults to `text/css`.

The PR removes remaining occurrences in the repo.