### PR TITLE
Fix typo introduced in #19177

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -20,7 +20,7 @@ The **`filter()`** method creates a [shallow copy](/en-US/docs/Glossary/Shallow_
 
 ## Syntax
 
-```js-nolints
+```js-nolint
 // Arrow function
 filter((element) => { /* … */ } )
 filter((element, index) => { /* … */ } )


### PR DESCRIPTION
`js-nolints` -> `js-nolint`  (Introduced in #19177)