### PR TITLE
adjust CODEOWNERS to reduce unnecessary reviews for core-dev team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 # DEFAULT OWNERS
 # ----------------------------------------------------------------------------
-*    @mdn/core-dev
+*    @mdn/core-yari-content
 
 # ----------------------------------------------------------------------------
 # DEFAULT ENGLISH CONTENT OWNER(S)
@@ -71,7 +71,7 @@
 # ----------------------------------------------------------------------------
 /.github/     @mdn/core-dev
 /*            @mdn/core-dev
-/*.md         @mdn/core-dev @mdn/core-yari-content
+/*.md         @mdn/core-yari-content
 # These are @schalkneethling because the auto-merge GHA workflow uses my PAT and will assign me.
 # If we add another reviewer, the auto-merge will cease to be automatic.
 /package.json @schalkneethling


### PR DESCRIPTION
For discussion: we're currently getting pinged for a lot of reviews which don't seem necessary - indeed, most PRs where core-dev is auto-assigned as a reviewer end up being merged without our review.

I've updated the default assignee for all file changes to the core-yari-content team - this seems more appropriate - and limited the core-dev reviews to only files changed in the immediate root of the repo (excluding markdown files) and in the `.github` folder - even this may be a bit broad, but we can refine more in the future.

Is this alright? Are there any files elsewhere we need to review before merging which may break the build?