### PR TITLE
Update dot concatenation of Express Tutorial Part 3

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -374,14 +374,14 @@ query.exec((err, athletes) => {
 Above we've defined the query conditions in the `find()` method. We can also do this using a `where()` function, and we can chain all the parts of our query together using the dot operator (.) rather than adding them separately. The code fragment below is the same as our query above, with an additional condition for the age.
 
 ```js
-Athlete.
-  find().
-  where('sport').equals('Tennis').
-  where('age').gt(17).lt(50). // Additional where query
-  limit(5).
-  sort({ age: -1 }).
-  select('name age').
-  exec(callback); // where callback is the name of our callback function.
+Athlete
+  .find()
+  .where('sport').equals('Tennis')
+  .where('age').gt(17).lt(50) // Additional where query
+  .limit(5)
+  .sort({ age: -1 })
+  .select('name age')
+  .exec(callback); // where callback is the name of our callback function.
 ```
 
 The [find()](https://mongoosejs.com/docs/api.html#query_Query-find) method gets all matching records, but often you just want to get one match. The following methods query for a single record:


### PR DESCRIPTION
I think it improves reading as is more easy view what happens, if the dot is before the word. From line 451 to 453 is used the convention that I'm trying to add here. example change from "
  Athlete.
  find().
  where('sport').equals('Tennis')
"
to "
  Athlete
  .find()
  .where('sport').equals('Tennis')
".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
