### PR TITLE
style: run prettier on code writing guidelines

### DIFF
--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
@@ -147,13 +147,13 @@ In a stylesheet that contains [media query](/en-US/docs/Web/CSS/Media_Queries/Us
 
   ```css example-good
   .editorial-summary {
-    ...
+    // ...
   }
   ```
 
   ```css example-bad
   #editorial-summary {
-    ...
+    // ...
   }
   ```
 
@@ -172,12 +172,14 @@ In a stylesheet that contains [media query](/en-US/docs/Web/CSS/Media_Queries/Us
 
   Not this: <!--I thought this is the preferred style-->
 
+<!-- prettier-ignore-start -->
   ```css example-bad
   h1, h2, h3 {
     font-family: sans-serif;
     text-align: center;
   }
   ```
+<!-- prettier-ignore-end -->
 
 ## Space after function parameters
 
@@ -208,9 +210,11 @@ p {
 }
 ```
 
+<!-- prettier-ignore-start -->
 ```css example-bad
 p { color: white; background-color: black; padding: 1rem; }
 ```
+<!-- prettier-ignore-end -->
 
 ## Value to turn off properties
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
@@ -147,13 +147,13 @@ In a stylesheet that contains [media query](/en-US/docs/Web/CSS/Media_Queries/Us
 
   ```css example-good
   .editorial-summary {
-    // ...
+    /* ... */
   }
   ```
 
   ```css example-bad
   #editorial-summary {
-    // ...
+    /* ... */
   }
   ```
 
@@ -172,14 +172,12 @@ In a stylesheet that contains [media query](/en-US/docs/Web/CSS/Media_Queries/Us
 
   Not this: <!--I thought this is the preferred style-->
 
-<!-- prettier-ignore-start -->
   ```css example-bad
   h1, h2, h3 {
     font-family: sans-serif;
     text-align: center;
   }
   ```
-<!-- prettier-ignore-end -->
 
 ## Space after function parameters
 
@@ -210,11 +208,9 @@ p {
 }
 ```
 
-<!-- prettier-ignore-start -->
 ```css example-bad
 p { color: white; background-color: black; padding: 1rem; }
 ```
-<!-- prettier-ignore-end -->
 
 ## Value to turn off properties
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -101,11 +101,9 @@ Use lowercase for all element names and attribute names/values because it looks 
 <p class="nice">This looks nice and neat</p>
 ```
 
-<!-- prettier-ignore-start -->
 ```html example-bad
 <P CLASS="WHOA-THERE">Why is my markup shouting?</P>
 ```
-<!-- prettier-ignore-end -->
 
 ## Class and ID names
 
@@ -127,11 +125,9 @@ Use double quotes for HTML, not single quotes, like so:
 <p class="important">Yes</p>
 ```
 
-<!-- prettier-ignore-start -->
 ```html example-bad
 <p class='important'>Nope</p>
 ```
-<!-- prettier-ignore-end -->
 
 ## Entity references
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -38,7 +38,7 @@ You should use the HTML5 doctype. It is short, easy to remember, and backwards c
 Set the document language using the {{htmlattrxref('lang')}} attribute on your {{htmlelement("html")}} element:
 
 ```html example-good
-<html lang="en-US">
+<html lang="en-US"></html>
 ```
 
 This is good for accessibility and search engines, helps with localizing content, and reminds people to use best practices.
@@ -48,7 +48,7 @@ This is good for accessibility and search engines, helps with localizing content
 You should also define your document's characterset like so:
 
 ```html example-good
-<meta charset="utf-8">
+<meta charset="utf-8" />
 ```
 
 Use UTF-8 unless you have a very good reason not to; it will cover all character needs pretty much regardless of what language you are using in your document. In addition, you should always specify the characterset as early as possible within your HTML's {{HTMLElement("head")}} block (within the first kilobyte), as it protects against a rather [nasty Internet Explorer security vulnerability](https://docs.microsoft.com/troubleshoot/developer/browsers/development-website/wrong-character-set-for-html-page).
@@ -58,7 +58,7 @@ Use UTF-8 unless you have a very good reason not to; it will cover all character
 Finally, you should always add the viewport meta tag into your HTML {{HTMLElement("head")}} to give the code example a better chance of working on mobile devices. You should include at least the following in your document, which can be modified later on as the need arises:
 
 ```html example-good
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=device-width" />
 ```
 
 See [Using the viewport meta tag to control layout on mobile browsers](/en-US/docs/Web/HTML/Viewport_meta_tag) for further details.
@@ -68,7 +68,7 @@ See [Using the viewport meta tag to control layout on mobile browsers](/en-US/do
 You should put all attribute values in double quotes. It is tempting to omit quotes since HTML5 allows this, but markup is neater and easier to read if you do include them. For example, this is better:
 
 ```html example-good
-<img src="images/logo.jpg" alt="A circular globe icon" class="no-border">
+<img src="images/logo.jpg" alt="A circular globe icon" class="no-border" />
 ```
 
 …than this:
@@ -101,9 +101,11 @@ Use lowercase for all element names and attribute names/values because it looks 
 <p class="nice">This looks nice and neat</p>
 ```
 
+<!-- prettier-ignore-start -->
 ```html example-bad
 <P CLASS="WHOA-THERE">Why is my markup shouting?</P>
 ```
+<!-- prettier-ignore-end -->
 
 ## Class and ID names
 
@@ -125,9 +127,11 @@ Use double quotes for HTML, not single quotes, like so:
 <p class="important">Yes</p>
 ```
 
+<!-- prettier-ignore-start -->
 ```html example-bad
 <p class='important'>Nope</p>
 ```
+<!-- prettier-ignore-end -->
 
 ## Entity references
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
@@ -61,7 +61,7 @@ These guidelines for formatting code examples for MDN Web Docs are also good pra
 ```js example-good
 function myFunc() {
   if (thingy) {
-    console.log('Yup, that worked.');
+    console.log("Yup, that worked.");
   }
 }
 ```
@@ -72,9 +72,9 @@ Add a space between a control statement or loop keyword and its opening parenthe
 
 ```js example-good
 if (condition) {
- /* handle the condition */
+  /* handle the condition */
 } else {
- /* handle the "else" case */
+  /* handle the "else" case */
 }
 ```
 
@@ -87,16 +87,18 @@ if (condition) {
 For example, this is not great:
 
 ```js example-bad
-let tommyCat = 'Said Tommy the Cat as he reeled back to clear whatever foreign matter may have nestled its way into his mighty throat. Many a fat alley rat had met its demise while staring point blank down the cavernous barrel of this awesome prowling machine.';
+let tommyCat =
+  "Said Tommy the Cat as he reeled back to clear whatever foreign matter may have nestled its way into his mighty throat. Many a fat alley rat had met its demise while staring point blank down the cavernous barrel of this awesome prowling machine.";
 ```
 
 This is better, but somewhat awkward:
 
 ```js
-const tommyCat = 'Said Tommy the Cat as he reeled back to clear whatever foreign '
-+ 'matter may have nestled its way into his mighty throat. Many a fat alley rat '
-+ 'had met its demise while staring point blank down the cavernous barrel of '
-+ 'this awesome prowling machine.';
+const tommyCat =
+  "Said Tommy the Cat as he reeled back to clear whatever foreign " +
+  "matter may have nestled its way into his mighty throat. Many a fat alley rat " +
+  "had met its demise while staring point blank down the cavernous barrel of " +
+  "this awesome prowling machine.";
 ```
 
 Even better is to use a template literal:
@@ -109,14 +111,18 @@ const tommyCat = `Said Tommy the Cat as he reeled back to clear whatever foreign
 ```
 
 ```js example-good
-if (obj.CONDITION || obj.OTHER_CONDITION || obj.SOME_OTHER_CONDITION
-       || obj.YET_ANOTHER_CONDITION ) {
+if (
+  obj.CONDITION ||
+  obj.OTHER_CONDITION ||
+  obj.SOME_OTHER_CONDITION ||
+  obj.YET_ANOTHER_CONDITION
+) {
   /* something */
 }
 
-const toolkitProfileService =
-  Components.classes["@mozilla.org/toolkit/profile-service;1"]
-    .createInstance(Components.interfaces.nsIToolkitProfileService);
+const toolkitProfileService = Components.classes[
+  "@mozilla.org/toolkit/profile-service;1"
+].createInstance(Components.interfaces.nsIToolkitProfileService);
 ```
 
 ### Code block height
@@ -181,28 +187,28 @@ To get this rendering, use "code fences" to demarcate the code block, followed b
 
 ```js
 function myFunc() {
-  console.log('Hello!');
-};
+  console.log("Hello!");
+}
 ```
 
 To represent the code block as a good or bad example, add `example-good` or `example-bad` after the language string, like so:
 
 ````plain
 ```html example-good
-<p class="brush: js example-good">
+<p class="brush: js example-good"></p>
 ```
 
 ```html example-bad
-<p class="brush: js example-bad">
+<p class="brush: js example-bad"></p>
 ```
 ````
 
 These will be rendered as:
 
 ```html example-good
-<p class="brush: js example-good">
+<p class="brush: js example-good"></p>
 ```
 
 ```html example-bad
-<p class="brush: js example-bad">
+<p class="brush: js example-bad"></p>
 ```

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -786,12 +786,10 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
   Do not declare multiple variables in one line, separating them with commas or using chain declaration. Avoid declaring variables like this:
 
-<!-- prettier-ignore-start -->
   ```js example-bad
   let var1, var2;
   let var3 = var4 = "Apapou"; // var4 is implicitly created as a global variable; fails in strict mode
   ```
-<!-- prettier-ignore-end -->
 
 ### Type coercion
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -223,7 +223,7 @@ When writing code, you usually omit parameters you don't need. But in some code 
 To do so, use `/* … */` in the parameter list. This is an exception to the rule to only use single-line comments (`//`).
 
 ```js
-array.forEach((value, /* index, array */) => {
+array.forEach((value /* , index, array */) => {
   // …
 });
 ```
@@ -786,10 +786,12 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
   Do not declare multiple variables in one line, separating them with commas or using chain declaration. Avoid declaring variables like this:
 
+<!-- prettier-ignore-start -->
   ```js example-bad
   let var1, var2;
   let var3 = var4 = "Apapou"; // var4 is implicitly created as a global variable; fails in strict mode
   ```
+<!-- prettier-ignore-end -->
 
 ### Type coercion
 


### PR DESCRIPTION
Tried a small change to see how prettier will treat the style guide. Had to use some ignores, but I don't like that it didn't like the ignore directives being indented around the code fences