### PR TITLE
fix: quote l10n:priority

### DIFF
--- a/files/en-us/glossary/ajax/index.md
+++ b/files/en-us/glossary/ajax/index.md
@@ -6,7 +6,7 @@ tags:
   - CodingScripting
   - Glossary
   - Infrastructure
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 **Ajax**, which initially stood for Asynchronous {{Glossary("JavaScript")}} And {{Glossary("XML")}}, is a programming practice of building complex, dynamic webpages using a technology known as {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.

--- a/files/en-us/glossary/css/index.md
+++ b/files/en-us/glossary/css/index.md
@@ -6,7 +6,7 @@ tags:
   - CodingScripting
   - Glossary
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 **CSS** (Cascading Style Sheets) is a declarative language that controls how webpages look in the {{glossary("browser")}}.

--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -5,7 +5,7 @@ tags:
   - CodingScripting
   - Glossary
   - HTML
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 **HTML** (HyperText Markup Language) is a descriptive language that specifies webpage structure.

--- a/files/en-us/glossary/http/index.md
+++ b/files/en-us/glossary/http/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Infrastructure
   - Web Performance
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 The HyperText Transfer Protocol (**HTTP**) is the underlying network {{glossary("protocol")}} that enables transfer of hypermedia documents on the {{glossary("World Wide Web","Web")}}, typically between a browser and a server so that humans can read them. The current version of the HTTP specification is called {{glossary("HTTP_2", "HTTP/2")}}.

--- a/files/en-us/glossary/http_2/index.md
+++ b/files/en-us/glossary/http_2/index.md
@@ -7,7 +7,7 @@ tags:
   - Infrastructure
   - Reference
   - Web Performance
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 **HTTP/2** is a major revision of the [HTTP network protocol](/en-US/docs/Web/HTTP/Basics_of_HTTP).

--- a/files/en-us/glossary/javascript/index.md
+++ b/files/en-us/glossary/javascript/index.md
@@ -5,7 +5,7 @@ tags:
   - CodingScripting
   - Glossary
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 JavaScript (or "JS") is a programming language used most often for dynamic client-side scripts on webpages, but it is also often used on the {{Glossary("Server","server")}}-side, using a runtime such as [Node.js](https://nodejs.org/).

--- a/files/en-us/glossary/json/index.md
+++ b/files/en-us/glossary/json/index.md
@@ -6,7 +6,7 @@ tags:
   - Glossary
   - Intro
   - JSON
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 _JavaScript Object Notation_ (**JSON**) is a data-interchange format. Although not a strict subset, JSON closely resembles a subset of {{Glossary("JavaScript")}} syntax. Though many programming languages support JSON, it is especially useful for JavaScript-based apps, including websites and browser extensions.

--- a/files/en-us/glossary/svg/index.md
+++ b/files/en-us/glossary/svg/index.md
@@ -7,7 +7,7 @@ tags:
   - Glossary
   - Graphics
   - SVG
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 _Scalable Vector Graphics_ (**SVG**) is a 2D vector image format based on an {{Glossary("XML")}} syntax.

--- a/files/en-us/glossary/url/index.md
+++ b/files/en-us/glossary/url/index.md
@@ -4,7 +4,7 @@ slug: Glossary/URL
 tags:
   - Glossary
   - Infrastructure
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 **Uniform Resource Locator** (**URL**) is a text string that specifies where a resource (such as a web page, image, or video) can be found on the Internet.

--- a/files/en-us/glossary/xml/index.md
+++ b/files/en-us/glossary/xml/index.md
@@ -5,7 +5,7 @@ tags:
   - CodingScripting
   - Glossary
   - XML
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 eXtensible Markup Language (XML) is a generic markup language specified by the W3C. The information technology (IT) industry uses many languages based on XML as data-description languages.

--- a/files/en-us/learn/getting_started_with_the_web/css_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/css_basics/index.md
@@ -8,7 +8,7 @@ tags:
   - Learn
   - Styling
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/dealing_with_files/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/dealing_with_files/index.md
@@ -7,7 +7,7 @@ tags:
   - Files
   - Guide
   - HTML
-  - l10n:priority
+  - "l10n:priority"
   - theory
   - website
 ---

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -11,7 +11,7 @@ tags:
   - Learn
   - Server
   - TCP
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
@@ -8,7 +8,7 @@ tags:
   - HTML
   - Learn
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/Dealing_with_files", "Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/index.md
@@ -8,7 +8,7 @@ tags:
   - Guide
   - HTML
   - Index
-  - l10n:priority
+  - "l10n:priority"
   - publishing
   - theory
 ---

--- a/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -8,7 +8,7 @@ tags:
   - Setup
   - Tools
   - WebMechanics
-  - l10n:priority
+  - "l10n:priority"
   - text editor
 ---
 

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -7,7 +7,7 @@ tags:
   - JavaScript
   - Learn
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -9,7 +9,7 @@ tags:
   - Google App Engine
   - Learn
   - Web
-  - l10n:priority
+  - "l10n:priority"
   - publishing
   - web server
 ---

--- a/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
@@ -11,7 +11,7 @@ tags:
   - Fonts
   - Learn
   - Simple
-  - l10n:priority
+  - "l10n:priority"
   - step by step
 ---
 

--- a/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -12,7 +12,7 @@ tags:
   - Tutorial
   - build
   - invoke
-  - l10n:priority
+  - "l10n:priority"
   - parameters
 ---
 

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -12,7 +12,7 @@ tags:
   - conditions
   - else
   - if
-  - l10n:priority
+  - "l10n:priority"
   - ternary
 ---
 

--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -10,7 +10,7 @@ tags:
   - JavaScript
   - Learn
   - events
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Return_values","Learn/JavaScript/Building_blocks/Image_gallery", "Learn/JavaScript/Building_blocks")}}

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -15,7 +15,7 @@ tags:
   - Method
   - anonymous
   - invoke
-  - l10n:priority
+  - "l10n:priority"
   - parameters
 ---
 

--- a/files/en-us/learn/javascript/building_blocks/image_gallery/index.md
+++ b/files/en-us/learn/javascript/building_blocks/image_gallery/index.md
@@ -11,7 +11,7 @@ tags:
   - Learn
   - Loops
   - events
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}

--- a/files/en-us/learn/javascript/building_blocks/index.md
+++ b/files/en-us/learn/javascript/building_blocks/index.md
@@ -15,7 +15,7 @@ tags:
   - Loops
   - Module
   - events
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.md
@@ -13,7 +13,7 @@ tags:
   - break
   - continue
   - for
-  - l10n:priority
+  - "l10n:priority"
   - while
 ---
 

--- a/files/en-us/learn/javascript/building_blocks/return_values/index.md
+++ b/files/en-us/learn/javascript/building_blocks/return_values/index.md
@@ -11,7 +11,7 @@ tags:
   - Learn
   - Return
   - Return values
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Build_your_own_function","Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -13,7 +13,7 @@ tags:
   - Operators
   - Variables
   - events
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/What_is_JavaScript", "Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps")}}

--- a/files/en-us/learn/javascript/first_steps/arrays/index.md
+++ b/files/en-us/learn/javascript/first_steps/arrays/index.md
@@ -11,7 +11,7 @@ tags:
   - Learn
   - Pop
   - Push
-  - l10n:priority
+  - "l10n:priority"
   - shift
   - split
   - unshift

--- a/files/en-us/learn/javascript/first_steps/index.md
+++ b/files/en-us/learn/javascript/first_steps/index.md
@@ -14,7 +14,7 @@ tags:
   - Numbers
   - Operators
   - Variables
-  - l10n:priority
+  - "l10n:priority"
   - maths
   - strings
 ---

--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -12,7 +12,7 @@ tags:
   - Operators
   - augmented
   - increment
-  - l10n:priority
+  - "l10n:priority"
   - maths
   - modulo
 ---

--- a/files/en-us/learn/javascript/first_steps/silly_story_generator/index.md
+++ b/files/en-us/learn/javascript/first_steps/silly_story_generator/index.md
@@ -11,7 +11,7 @@ tags:
   - Numbers
   - Operators
   - Variables
-  - l10n:priority
+  - "l10n:priority"
   - strings
 ---
 

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -10,7 +10,7 @@ tags:
   - Join
   - Quotes
   - concatenation
-  - l10n:priority
+  - "l10n:priority"
   - strings
 ---
 

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
@@ -9,7 +9,7 @@ tags:
   - Learn
   - case
   - indexOf
-  - l10n:priority
+  - "l10n:priority"
   - length
   - lower
   - replace

--- a/files/en-us/learn/javascript/first_steps/variables/index.md
+++ b/files/en-us/learn/javascript/first_steps/variables/index.md
@@ -11,7 +11,7 @@ tags:
   - Variables
   - declaring
   - initializing
-  - l10n:priority
+  - "l10n:priority"
   - loose typing
   - strings
 ---

--- a/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
@@ -15,7 +15,7 @@ tags:
   - comments
   - external
   - inline
-  - l10n:priority
+  - "l10n:priority"
   - what
 ---
 

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
@@ -12,7 +12,7 @@ tags:
   - Learn
   - Tutorial
   - console.log
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps")}}

--- a/files/en-us/learn/javascript/index.md
+++ b/files/en-us/learn/javascript/index.md
@@ -9,7 +9,7 @@ tags:
   - Landing
   - Module
   - Topic
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -10,7 +10,7 @@ tags:
   - OOJS
   - Object-Oriented
   - Objects
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_building_practice", "", "Learn/JavaScript/Objects")}}

--- a/files/en-us/learn/javascript/objects/json/index.md
+++ b/files/en-us/learn/javascript/objects/json/index.md
@@ -15,7 +15,7 @@ tags:
   - Learn
   - Objects
   - Tutorial
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Classes_in_JavaScript", "Learn/JavaScript/Objects/Object_building_practice", "Learn/JavaScript/Objects")}}

--- a/files/en-us/learn/javascript/objects/object_building_practice/index.md
+++ b/files/en-us/learn/javascript/objects/object_building_practice/index.md
@@ -11,7 +11,7 @@ tags:
   - Learn
   - Objects
   - Tutorial
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects/Adding_bouncing_balls_features", "Learn/JavaScript/Objects")}}

--- a/files/en-us/web/css/index.md
+++ b/files/en-us/web/css/index.md
@@ -12,7 +12,7 @@ tags:
   - Style Sheets
   - Styles
   - Stylesheets
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -6,7 +6,7 @@ tags:
   - Guide
   - Overview
   - Reference
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/html/element/index.md
+++ b/files/en-us/web/html/element/index.md
@@ -7,7 +7,7 @@ tags:
   - HTML
   - Reference
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{HTMLSidebar("Elements")}}

--- a/files/en-us/web/html/index.md
+++ b/files/en-us/web/html/index.md
@@ -5,7 +5,7 @@ tags:
   - HTML
   - Landing
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{HTMLSidebar}}

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -12,7 +12,7 @@ tags:
   - Same-origin policy
   - Security
   - XMLHttpRequest
-  - l10n:priority
+  - "l10n:priority"
 browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -8,7 +8,7 @@ tags:
   - TCP/IP
   - Web
   - Web Development
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/overview/index.md
+++ b/files/en-us/web/http/overview/index.md
@@ -6,7 +6,7 @@ tags:
   - HTTP
   - Overview
   - WebMechanics
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -10,7 +10,7 @@ tags:
   - JavaScript
   - Logic
   - control
-  - l10n:priority
+  - "l10n:priority"
   - statements
 ---
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - JavaScript
   - Operators
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -6,7 +6,7 @@ tags:
   - Functions
   - Guide
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_Operators")}}

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Grammar_and_types
 tags:
   - Guide
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Introduction", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}

--- a/files/en-us/web/javascript/guide/index.md
+++ b/files/en-us/web/javascript/guide/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide
 tags:
   - Guide
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Indexed_collections
 tags:
   - Guide
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}

--- a/files/en-us/web/javascript/guide/introduction/index.md
+++ b/files/en-us/web/javascript/guide/introduction/index.md
@@ -6,7 +6,7 @@ tags:
   - Guide
   - Introduction
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}

--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -5,7 +5,7 @@ tags:
   - Guide
   - Intermediate
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Using_promises", "Web/JavaScript/Guide/Meta_programming")}}

--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -6,7 +6,7 @@ tags:
   - Guide
   - JavaScript
   - Map
-  - l10n:priority
+  - "l10n:priority"
   - set
 ---
 

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -6,7 +6,7 @@ tags:
   - JavaScript
   - Loop
   - Syntax
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -7,7 +7,7 @@ tags:
   - JavaScript
   - Proxy
   - Reflect
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Iterators_and_Generators", "Web/JavaScript/Guide/Modules")}}

--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.md
@@ -13,7 +13,7 @@ tags:
   - Math
   - Numbers
   - Numeric
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Expressions_and_Operators", "Web/JavaScript/Guide/Text_formatting")}}

--- a/files/en-us/web/javascript/guide/text_formatting/index.md
+++ b/files/en-us/web/javascript/guide/text_formatting/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Text_formatting
 tags:
   - Guide
   - JavaScript
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Numbers_and_dates", "Web/JavaScript/Guide/Regular_Expressions")}}

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -8,7 +8,7 @@ tags:
   - Promise
   - Promises
   - asynchronous
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Using_Classes", "Web/JavaScript/Guide/Iterators_and_Generators")}}

--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -8,7 +8,7 @@ tags:
   - Guide
   - JavaScript
   - Object
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Keyed_collections", "Web/JavaScript/Guide/Using_Classes")}}

--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -6,7 +6,7 @@ tags:
   - Landing
   - Landing page
   - Learn
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{JsSidebar}}

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -11,7 +11,7 @@ tags:
   - Landing page
   - Reference
   - es
-  - l10n:priority
+  - "l10n:priority"
   - programming
 ---
 

--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -8,7 +8,7 @@ tags:
   - SVG
   - SVG Reference
   - Vector Graphics
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 SVG drawings and images are created using a wide array of elements which are dedicated to the construction, drawing, and layout of vector images and diagrams. Here you'll find reference documentation for each of the SVG elements.

--- a/files/en-us/web/svg/index.md
+++ b/files/en-us/web/svg/index.md
@@ -13,7 +13,7 @@ tags:
   - Scalable Images
   - Vector Graphics
   - Web
-  - l10n:priority
+  - "l10n:priority"
 ---
 
 {{SVGRef}}


### PR DESCRIPTION
Althout this doesn't trip up the YAML parser because there is no space after `:` to make it an entity, the quoted form is used directly in the README.md.
Since these might just be going way in the future, feel free to close