### PR TITLE
Tag syntax code blocks with js-nolint, part 7

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -21,7 +21,7 @@ the child entry as the last array item.
 ## Syntax
 
 ```js-nolint
-const pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant)
+resolve(possibleDescendant)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -20,8 +20,8 @@ the child entry as the last array item.
 
 ## Syntax
 
-```js
-const pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant);
+```js-nolint
+const pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -22,7 +22,7 @@ object.
 ## Syntax
 
 ```js-nolint
-FileSystemDirectoryHandle.values()
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -21,8 +21,8 @@ object.
 
 ## Syntax
 
-```js
-FileSystemDirectoryHandle.values();
+```js-nolint
+FileSystemDirectoryHandle.values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
@@ -24,7 +24,7 @@ Generally, they are either {{domxref("FileSystemFileEntry")}} objects, which rep
 
 ## Syntax
 
-```js
+```js-nolint
 readEntries(successCallback)
 readEntries(successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/filesystementry/copyto/index.md
+++ b/files/en-us/web/api/filesystementry/copyto/index.md
@@ -31,7 +31,7 @@ typical restrictions on what you can do:
 
 ## Syntax
 
-```js
+```js-nolint
 copyTo(newParent)
 copyTo(newParent, newName)
 copyTo(newParent, newName, successCallback)

--- a/files/en-us/web/api/filesystementry/getmetadata/index.md
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.md
@@ -24,7 +24,7 @@ its modification date and time and its size.
 
 ## Syntax
 
-```js
+```js-nolint
 getMetadata(successCallback)
 getMetadata(successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/filesystementry/getparent/index.md
+++ b/files/en-us/web/api/filesystementry/getparent/index.md
@@ -21,7 +21,7 @@ The {{domxref("FileSystemEntry")}} interface's method
 
 ## Syntax
 
-```js
+```js-nolint
 getParent(successCallback, errorCallback)
 getParent(successCallback)
 ```

--- a/files/en-us/web/api/filesystementry/moveto/index.md
+++ b/files/en-us/web/api/filesystementry/moveto/index.md
@@ -37,7 +37,7 @@ restrictions on what you can do:
 
 ## Syntax
 
-```js
+```js-nolint
 moveTo(newParent, newName)
 moveTo(newParent, newName, successCallback)
 moveTo(newParent, newName, successCallback, errorCallback)

--- a/files/en-us/web/api/filesystementry/remove/index.md
+++ b/files/en-us/web/api/filesystementry/remove/index.md
@@ -29,7 +29,7 @@ instead.
 
 ## Syntax
 
-```js
+```js-nolint
 remove(successCallback)
 remove(successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/filesystementry/tourl/index.md
+++ b/files/en-us/web/api/filesystementry/tourl/index.md
@@ -25,7 +25,7 @@ the value of `src` and `href` attributes.
 
 ## Syntax
 
-```js
+```js-nolint
 toURL()
 toURL(mimeType)
 ```

--- a/files/en-us/web/api/filesystemfileentry/createwriter/index.md
+++ b/files/en-us/web/api/filesystemfileentry/createwriter/index.md
@@ -23,7 +23,7 @@ which can be used to write data into the file represented by the directory entry
 
 ## Syntax
 
-```js
+```js-nolint
 createWriter(successCallback)
 createWriter(successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/filesystemfileentry/file/index.md
+++ b/files/en-us/web/api/filesystemfileentry/file/index.md
@@ -22,7 +22,7 @@ the directory entry.
 
 ## Syntax
 
-```js
+```js-nolint
 file(successCallback)
 file(successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -27,8 +27,8 @@ the temporary file when the writable filestream is closed.
 
 ## Syntax
 
-```js
-const fileStreamPromise = FileSystemFileHandle.createWritable();
+```js-nolint
+const fileStreamPromise = FileSystemFileHandle.createWritable()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -28,7 +28,7 @@ the temporary file when the writable filestream is closed.
 ## Syntax
 
 ```js-nolint
-const fileStreamPromise = FileSystemFileHandle.createWritable()
+createWritable()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -25,7 +25,7 @@ If the file on disk changes or is removed after this method is called, the retur
 ## Syntax
 
 ```js-nolint
-const filePromise = FileSystemFileHandle.getFile()
+getFile()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -24,8 +24,8 @@ If the file on disk changes or is removed after this method is called, the retur
 
 ## Syntax
 
-```js
-const filePromise = FileSystemFileHandle.getFile();
+```js-nolint
+const filePromise = FileSystemFileHandle.getFile()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -19,7 +19,7 @@ The **`isSameEntry()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 isSameEntry(fileSystemHandle)
 ```
 

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -21,7 +21,7 @@ current handle.
 ## Syntax
 
 ```js-nolint
-queryPermission(FileSystemHandlePermissionDescriptor)
+queryPermission(fileSystemHandlePermissionDescriptor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -20,7 +20,7 @@ current handle.
 
 ## Syntax
 
-```js
+```js-nolint
 queryPermission(FileSystemHandlePermissionDescriptor)
 ```
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -21,7 +21,7 @@ file handle.
 ## Syntax
 
 ```js-nolint
-requestPermission(FileSystemHandlePermissionDescriptor)
+requestPermission(fileSystemHandlePermissionDescriptor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -20,7 +20,7 @@ file handle.
 
 ## Syntax
 
-```js
+```js-nolint
 requestPermission(FileSystemHandlePermissionDescriptor)
 ```
 

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -22,7 +22,7 @@ offset to the position (in bytes) specified when calling the method.
 ## Syntax
 
 ```js-nolint
-FileSystemWritableStream.seek(position).then(/* … */)
+seek(position)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -21,8 +21,8 @@ offset to the position (in bytes) specified when calling the method.
 
 ## Syntax
 
-```js
-FileSystemWritableStream.seek(position).then(/* … */);
+```js-nolint
+FileSystemWritableStream.seek(position).then(/* … */)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -32,7 +32,7 @@ Changes are typically written to a temporary file instead.
 ## Syntax
 
 ```js-nolint
-FileSystemWritableFileStream.truncate().then(/* … */)
+truncate()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -31,8 +31,8 @@ Changes are typically written to a temporary file instead.
 
 ## Syntax
 
-```js
-FileSystemWritableFileStream.truncate().then(/* … */);
+```js-nolint
+FileSystemWritableFileStream.truncate().then(/* … */)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -27,7 +27,7 @@ file contains.
 
 ## Syntax
 
-```js
+```js-nolint
 write(data)
 ```
 

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -20,7 +20,7 @@ set to the other target.
 
 ## Syntax
 
-```js
+```js-nolint
 new FocusEvent(type)
 new FocusEvent(type, options)
 ```

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -20,7 +20,7 @@ The **`FontFace()`** constructor creates a new
 
 ## Syntax
 
-```js
+```js-nolint
 new FontFace(family, source)
 new FontFace(family, source, descriptors)
 ```

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -22,7 +22,7 @@ If the `source` for the font face was specified as binary data, or the font {{do
 
 ## Syntax
 
-```js
+```js-nolint
 load()
 ```
 

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -17,7 +17,7 @@ The **`add()`** method of the {{domxref("FontFaceSet")}} interface adds a new fo
 
 ## Syntax
 
-```js
+```js-nolint
 add(font)
 ```
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -19,7 +19,7 @@ fonts in the given font list have been loaded and are available.
 
 ## Syntax
 
-```js
+```js-nolint
 check(font)
 check(font, text)
 ```

--- a/files/en-us/web/api/fontfaceset/clear/index.md
+++ b/files/en-us/web/api/fontfaceset/clear/index.md
@@ -17,7 +17,7 @@ The **`clear()`** method of the {{domxref("FontFaceSet")}} interface removes all
 
 ## Syntax
 
-```js
+```js-nolint
 clear()
 ```
 

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -17,7 +17,7 @@ The **`delete()`** method of the {{domxref("FontFaceSet")}} interface removes a 
 
 ## Syntax
 
-```js
+```js-nolint
 delete(font)
 ```
 

--- a/files/en-us/web/api/fontfaceset/entries/index.md
+++ b/files/en-us/web/api/fontfaceset/entries/index.md
@@ -17,7 +17,7 @@ The **`entries()`** method of the {{domxref("FontFaceSet")}} interface returns a
 
 ## Syntax
 
-```js
+```js-nolint
 entries()
 ```
 

--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -17,7 +17,7 @@ The **`forEach()`** method of the {{domxref("FontFaceSet")}} interface executes 
 
 ## Syntax
 
-```js
+```js-nolint
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 ```

--- a/files/en-us/web/api/fontfaceset/has/index.md
+++ b/files/en-us/web/api/fontfaceset/has/index.md
@@ -17,7 +17,7 @@ The **`has()`** method of the {{domxref("FontFaceSet")}} interface returns a {{j
 
 ## Syntax
 
-```js
+```js-nolint
 has(value)
 ```
 

--- a/files/en-us/web/api/fontfaceset/keys/index.md
+++ b/files/en-us/web/api/fontfaceset/keys/index.md
@@ -17,7 +17,7 @@ The **`keys()`** method of the {{domxref("FontFaceSet")}} interface is an alias 
 
 ## Syntax
 
-```js
+```js-nolint
 keys()
 ```
 

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -19,7 +19,7 @@ given in parameters to be loaded.
 
 ## Syntax
 
-```js
+```js-nolint
 load(font)
 load(font, text)
 ```

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -17,7 +17,7 @@ The **`values()`** method of the {{domxref("FontFaceSet")}} interface returns a 
 
 ## Syntax
 
-```js
+```js-nolint
 values()
 ```
 

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.md
@@ -21,7 +21,7 @@ The **`FontFaceSetLoadEvent()`** constructor creates a new
 
 ## Syntax
 
-```js
+```js-nolint
 new FontFaceSetLoadEvent(type)
 new FontFaceSetLoadEvent(type, options)
 ```

--- a/files/en-us/web/api/formdata/append/index.md
+++ b/files/en-us/web/api/formdata/append/index.md
@@ -21,7 +21,7 @@ The difference between {{domxref("FormData.set", "set()")}} and `append()` is th
 
 ## Syntax
 
-```js
+```js-nolint
 append(name, value)
 append(name, value, filename)
 ```

--- a/files/en-us/web/api/formdata/delete/index.md
+++ b/files/en-us/web/api/formdata/delete/index.md
@@ -19,7 +19,7 @@ The **`delete()`** method of the {{domxref("FormData")}} interface deletes a key
 
 ## Syntax
 
-```js
+```js-nolint
 delete(name)
 ```
 

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -20,7 +20,7 @@ The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaSc
 
 ## Syntax
 
-```js
+```js-nolint
 entries()
 ```
 

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -19,7 +19,7 @@ The **`FormData()`** constructor creates a new {{domxref("FormData")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 new FormData()
 new FormData(form)
 ```

--- a/files/en-us/web/api/formdata/get/index.md
+++ b/files/en-us/web/api/formdata/get/index.md
@@ -22,7 +22,7 @@ object. If you expect multiple values and want all of them, use the
 
 ## Syntax
 
-```js
+```js-nolint
 get(name)
 ```
 

--- a/files/en-us/web/api/formdata/getall/index.md
+++ b/files/en-us/web/api/formdata/getall/index.md
@@ -19,7 +19,7 @@ The **`getAll()`** method of the {{domxref("FormData")}} interface returns all t
 
 ## Syntax
 
-```js
+```js-nolint
 getAll(name)
 ```
 

--- a/files/en-us/web/api/formdata/has/index.md
+++ b/files/en-us/web/api/formdata/has/index.md
@@ -19,7 +19,7 @@ The **`has()`** method of the {{domxref("FormData")}} interface returns whether 
 
 ## Syntax
 
-```js
+```js-nolint
 has(name)
 ```
 

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -20,7 +20,7 @@ The **`FormData.keys()`** method returns an [iterator](/en-US/docs/Web/JavaScrip
 
 ## Syntax
 
-```js
+```js-nolint
 keys()
 ```
 

--- a/files/en-us/web/api/formdata/set/index.md
+++ b/files/en-us/web/api/formdata/set/index.md
@@ -21,7 +21,7 @@ The difference between `set()` and {{domxref("FormData.append", "append()")}} is
 
 ## Syntax
 
-```js
+```js-nolint
 set(name, value)
 set(name, value, filename)
 ```

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -20,7 +20,7 @@ The **`FormData.values()`** method returns an [iterator](/en-US/docs/Web/JavaScr
 
 ## Syntax
 
-```js
+```js-nolint
 values()
 ```
 

--- a/files/en-us/web/api/formdataevent/formdataevent/index.md
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.md
@@ -17,7 +17,7 @@ The **`FormDataEvent()`** constructor creates a new {{domxref("FormDataEvent")}}
 
 ## Syntax
 
-```js
+```js-nolint
 new FormDataEvent(type, formEventInit)
 ```
 

--- a/files/en-us/web/api/gainnode/gainnode/index.md
+++ b/files/en-us/web/api/gainnode/gainnode/index.md
@@ -21,7 +21,7 @@ change in volume.
 
 ## Syntax
 
-```js
+```js-nolint
 new GainNode(context, options)
 ```
 

--- a/files/en-us/web/api/gamepadevent/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/gamepadevent/index.md
@@ -17,7 +17,7 @@ The **`GamepadEvent()`** constructor creates a new {{domxref("GamepadEvent")}} o
 
 ## Syntax
 
-```js
+```js-nolint
 new GamepadEvent(type, options)
 ```
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -21,7 +21,7 @@ The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interf
 
 ## Syntax
 
-```js
+```js-nolint
 playEffect(type, params)
 ```
 

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -19,7 +19,7 @@ The **`pulse()`** method of the {{domxref("GamepadHapticActuator")}} interface m
 
 ## Syntax
 
-```js
+```js-nolint
 pulse(value, duration)
 ```
 

--- a/files/en-us/web/api/geolocation/clearwatch/index.md
+++ b/files/en-us/web/api/geolocation/clearwatch/index.md
@@ -21,7 +21,7 @@ location/error monitoring handlers previously installed using
 
 ## Syntax
 
-```js
+```js-nolint
 clearWatch(id)
 ```
 

--- a/files/en-us/web/api/geolocation/getcurrentposition/index.md
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.md
@@ -21,7 +21,7 @@ the current position of the device.
 
 ## Syntax
 
-```js
+```js-nolint
 getCurrentPosition(success)
 getCurrentPosition(success, error)
 getCurrentPosition(success, error, options)

--- a/files/en-us/web/api/geolocation/watchposition/index.md
+++ b/files/en-us/web/api/geolocation/watchposition/index.md
@@ -19,7 +19,7 @@ You can also, optionally, specify an error handling callback function.
 
 ## Syntax
 
-```js
+```js-nolint
 watchPosition(success)
 watchPosition(success, error)
 watchPosition(success, error, options)

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.md
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.md
@@ -23,7 +23,7 @@ provides on each reading the gravity applied to the device along all three axes.
 
 ## Syntax
 
-```js
+```js-nolint
 new GravitySensor()
 new GravitySensor(options)
 ```

--- a/files/en-us/web/api/gyroscope/gyroscope/index.md
+++ b/files/en-us/web/api/gyroscope/gyroscope/index.md
@@ -26,7 +26,7 @@ a user. The {{httpheader('Feature-Policy')}} HTTP header article contains implem
 
 ## Syntax
 
-```js
+```js-nolint
 new Gyroscope()
 new Gyroscope(options)
 ```

--- a/files/en-us/web/api/headers/append/index.md
+++ b/files/en-us/web/api/headers/append/index.md
@@ -29,7 +29,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 
 ## Syntax
 
-```js
+```js-nolint
 append(name, value)
 ```
 

--- a/files/en-us/web/api/headers/delete/index.md
+++ b/files/en-us/web/api/headers/delete/index.md
@@ -28,7 +28,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 
 ## Syntax
 
-```js
+```js-nolint
 delete(name)
 ```
 

--- a/files/en-us/web/api/headers/entries/index.md
+++ b/files/en-us/web/api/headers/entries/index.md
@@ -22,7 +22,7 @@ contained in this object. The both the key and value of each pairs are
 
 ## Syntax
 
-```js
+```js-nolint
 entries()
 ```
 

--- a/files/en-us/web/api/headers/foreach/index.md
+++ b/files/en-us/web/api/headers/foreach/index.md
@@ -17,7 +17,7 @@ The **`Headers.forEach()`** method executes a callback function once per each ke
 
 ## Syntax
 
-```js
+```js-nolint
 // Arrow function
 forEach((value, key) => { /* … */ })
 forEach((value, key, object) => { /* … */ })

--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -26,7 +26,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 
 ## Syntax
 
-```js
+```js-nolint
 get(name)
 ```
 

--- a/files/en-us/web/api/headers/has/index.md
+++ b/files/en-us/web/api/headers/has/index.md
@@ -23,7 +23,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 
 ## Syntax
 
-```js
+```js-nolint
 has(name)
 ```
 

--- a/files/en-us/web/api/headers/headers/index.md
+++ b/files/en-us/web/api/headers/headers/index.md
@@ -17,7 +17,7 @@ The **`Headers()`** constructor creates a new
 
 ## Syntax
 
-```js
+```js-nolint
 new Headers()
 new Headers(init)
 ```

--- a/files/en-us/web/api/headers/keys/index.md
+++ b/files/en-us/web/api/headers/keys/index.md
@@ -21,7 +21,7 @@ in this object. The keys are {{jsxref("String")}} objects.
 
 ## Syntax
 
-```js
+```js-nolint
 keys()
 ```
 

--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -29,7 +29,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 
 ## Syntax
 
-```js
+```js-nolint
 set(name, value)
 ```
 

--- a/files/en-us/web/api/headers/values/index.md
+++ b/files/en-us/web/api/headers/values/index.md
@@ -21,7 +21,7 @@ in this object. The values are {{jsxref("String")}} objects.
 
 ## Syntax
 
-```js
+```js-nolint
 values()
 ```
 

--- a/files/en-us/web/api/hid/getdevices/index.md
+++ b/files/en-us/web/api/hid/getdevices/index.md
@@ -18,7 +18,7 @@ The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of
 
 ## Syntax
 
-```js
+```js-nolint
 getDevices()
 ```
 

--- a/files/en-us/web/api/hid/requestdevice/index.md
+++ b/files/en-us/web/api/hid/requestdevice/index.md
@@ -20,7 +20,7 @@ The user agent will present a permission dialog including a list of connected de
 
 ## Syntax
 
-```js
+```js-nolint
 requestDevice(options)
 ```
 

--- a/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.md
+++ b/files/en-us/web/api/hidconnectionevent/hidconnectionevent/index.md
@@ -17,7 +17,7 @@ The **`HIDConnectionEvent()`** constructor creates a new {{domxref("HIDConnectio
 
 ## Syntax
 
-```js
+```js-nolint
 new HIDConnectionEvent(type, options)
 ```
 

--- a/files/en-us/web/api/hiddevice/close/index.md
+++ b/files/en-us/web/api/hiddevice/close/index.md
@@ -18,7 +18,7 @@ The **`close()`** method of the {{domxref("HIDDevice")}} interface closes the co
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/hiddevice/open/index.md
+++ b/files/en-us/web/api/hiddevice/open/index.md
@@ -20,7 +20,7 @@ The **`open()`** method of the {{domxref("HIDDevice")}} interface requests that 
 
 ## Syntax
 
-```js
+```js-nolint
 open()
 ```
 

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
@@ -20,7 +20,7 @@ The `reportId` for each of the report formats that this device supports can be r
 
 ## Syntax
 
-```js
+```js-nolint
 receiveFeatureReport(reportId)
 ```
 

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
@@ -20,7 +20,7 @@ The `reportId` for each of the report formats that this device supports can be r
 
 ## Syntax
 
-```js
+```js-nolint
 sendFeatureReport(reportId, data)
 ```
 

--- a/files/en-us/web/api/hiddevice/sendreport/index.md
+++ b/files/en-us/web/api/hiddevice/sendreport/index.md
@@ -20,7 +20,7 @@ The `reportId` for each of the report formats that this device supports can be r
 
 ## Syntax
 
-```js
+```js-nolint
 sendReport(reportId, data)
 ```
 

--- a/files/en-us/web/api/history/back/index.md
+++ b/files/en-us/web/api/history/back/index.md
@@ -27,7 +27,7 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 
 ## Syntax
 
-```js
+```js-nolint
 back()
 ```
 

--- a/files/en-us/web/api/history/forward/index.md
+++ b/files/en-us/web/api/history/forward/index.md
@@ -23,7 +23,7 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 
 ## Syntax
 
-```js
+```js-nolint
 forward()
 ```
 

--- a/files/en-us/web/api/history/go/index.md
+++ b/files/en-us/web/api/history/go/index.md
@@ -23,7 +23,7 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 
 ## Syntax
 
-```js
+```js-nolint
 go()
 go(delta)
 ```

--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -25,7 +25,7 @@ session history stack.
 
 ## Syntax
 
-```js
+```js-nolint
 pushState(state, unused)
 pushState(state, unused, url)
 ```

--- a/files/en-us/web/api/history/replacestate/index.md
+++ b/files/en-us/web/api/history/replacestate/index.md
@@ -22,7 +22,7 @@ to some user action.
 
 ## Syntax
 
-```js
+```js-nolint
 replaceState(stateObj, unused)
 replaceState(stateObj, unused, url)
 ```

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
@@ -23,7 +23,7 @@ This includes field of view information, and more.
 
 ## Syntax
 
-```js
+```js-nolint
 getEyeParameters(whichEye)
 ```
 

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
@@ -21,7 +21,7 @@ The **`setFieldOfView()`** method of the {{domxref("HMDVRDevice")}} interface ca
 
 ## Syntax
 
-```js
+```js-nolint
 setFieldOfView(leftFOV, rightFOV, zNear, zFar)
 ```
 

--- a/files/en-us/web/api/htmlanchorelement/tostring/index.md
+++ b/files/en-us/web/api/htmlanchorelement/tostring/index.md
@@ -18,7 +18,7 @@ version of {{domxref("HTMLAnchorElement.href")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/htmlareaelement/tostring/index.md
+++ b/files/en-us/web/api/htmlareaelement/tostring/index.md
@@ -18,7 +18,7 @@ version of {{domxref("HTMLAreaElement.href")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/htmlaudioelement/audio/index.md
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.md
@@ -24,7 +24,7 @@ offscreen to manage and play audio.
 
 ## Syntax
 
-```js
+```js-nolint
 new Audio()
 new Audio(url)
 ```

--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -23,7 +23,7 @@ which includes a {{domxref("CanvasCaptureMediaStreamTrack")}} containing a real-
 
 ## Syntax
 
-```js
+```js-nolint
 captureStream(frameRate)
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -25,7 +25,7 @@ different drawing context object on a given canvas element.
 
 ## Syntax
 
-```js
+```js-nolint
 getContext(contextType)
 getContext(contextType, contextAttributes)
 ```

--- a/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
@@ -21,7 +21,7 @@ canvas as image data. However, this non-standard and internal method has been re
 
 ## Syntax
 
-```js
+```js-nolint
 mozFetchAsStream(callback)
 mozFetchAsStream(callback, type)
 ```

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -24,7 +24,7 @@ The created image will have a resolution of 96dpi for file formats that support 
 
 ## Syntax
 
-```js
+```js-nolint
 toBlob(callback)
 toBlob(callback, type)
 toBlob(callback, type, quality)

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -25,7 +25,7 @@ The created image data will have a resolution of 96dpi for file formats that sup
 
 ## Syntax
 
-```js
+```js-nolint
 toDataURL()
 toDataURL(type)
 toDataURL(type, encoderOptions)

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -21,7 +21,7 @@ thread or on a worker.
 
 ## Syntax
 
-```js
+```js-nolint
 transferControlToOffscreen()
 ```
 

--- a/files/en-us/web/api/htmlcollection/item/index.md
+++ b/files/en-us/web/api/htmlcollection/item/index.md
@@ -24,7 +24,7 @@ returns the node located at the specified offset into the collection.
 
 ## Syntax
 
-```js
+```js-nolint
 item(index)
 ```
 

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -20,8 +20,8 @@ In JavaScript, using the array bracket syntax with a {{jsxref("String")}}, like 
 
 ## Syntax
 
-```js
-const item = collection.namedItem(key);
+```js-nolint
+const item = collection.namedItem(key)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -21,7 +21,7 @@ In JavaScript, using the array bracket syntax with a {{jsxref("String")}}, like 
 ## Syntax
 
 ```js-nolint
-const item = collection.namedItem(key)
+namedItem(key)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -20,7 +20,7 @@ argument, updating the `returnValue` of the dialog.
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 close(returnValue)
 ```

--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -20,7 +20,7 @@ outside of the dialog.
 
 ## Syntax
 
-```js
+```js-nolint
 show()
 ```
 

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -22,7 +22,7 @@ the content outside it is rendered inert.
 
 ## Syntax
 
-```js
+```js-nolint
 showModal()
 ```
 

--- a/files/en-us/web/api/htmlelement/accesskeylabel/index.md
+++ b/files/en-us/web/api/htmlelement/accesskeylabel/index.md
@@ -13,7 +13,7 @@ browser-assigned access key (if any); otherwise it returns an empty string.
 
 ## Syntax
 
-```js
+```js-nolint
 label = element.accessKeyLabel
 ```
 

--- a/files/en-us/web/api/htmlelement/attachinternals/index.md
+++ b/files/en-us/web/api/htmlelement/attachinternals/index.md
@@ -17,7 +17,7 @@ The **`HTMLElement.attachInternals()`** method returns an {{domxref("ElementInte
 
 ## Syntax
 
-```js
+```js-nolint
 attachInternals()
 ```
 

--- a/files/en-us/web/api/htmlelement/blur/index.md
+++ b/files/en-us/web/api/htmlelement/blur/index.md
@@ -17,8 +17,8 @@ The **`HTMLElement.blur()`** method removes keyboard focus from the current elem
 
 ## Syntax
 
-```js
-blur();
+```js-nolint
+blur()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlelement/click/index.md
+++ b/files/en-us/web/api/htmlelement/click/index.md
@@ -23,7 +23,7 @@ events.
 
 ## Syntax
 
-```js
+```js-nolint
 click()
 ```
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -25,7 +25,7 @@ Parameter options are provided to disable the default scrolling and force visibl
 
 ## Syntax
 
-```js
+```js-nolint
 focus()
 focus(options)
 ```

--- a/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
@@ -25,7 +25,7 @@ equivalent to `collection.namedItem("value")`.
 
 ## Syntax
 
-```js
+```js-nolint
 namedItem(str)
 // or collection[str]
 ```

--- a/files/en-us/web/api/htmlformelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlformelement/reportvalidity/index.md
@@ -21,7 +21,7 @@ each invalid child and validation problems are reported to the user.
 ## Syntax
 
 ```js-nolint
-HTMLFormElement.reportValidity()
+reportValidity()
 ```
 
 ### Return value

--- a/files/en-us/web/api/htmlformelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlformelement/reportvalidity/index.md
@@ -20,7 +20,7 @@ each invalid child and validation problems are reported to the user.
 
 ## Syntax
 
-```js
+```js-nolint
 HTMLFormElement.reportValidity()
 ```
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -23,7 +23,7 @@ that the form be submitted using a specific submit button.
 
 ## Syntax
 
-```js
+```js-nolint
 requestSubmit()
 requestSubmit(submitter)
 ```

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -30,7 +30,7 @@ whatever value the {{domxref("Element.setAttribute", "setAttribute()")}} call se
 
 ## Syntax
 
-```js
+```js-nolint
 reset()
 ```
 

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -35,7 +35,7 @@ submitted when you do it with original HTML form submit.
 
 ## Syntax
 
-```js
+```js-nolint
 submit()
 ```
 

--- a/files/en-us/web/api/htmliframeelement/src/index.md
+++ b/files/en-us/web/api/htmliframeelement/src/index.md
@@ -14,9 +14,9 @@ resource.
 
 ## Syntax
 
-```js
-refStr = iframeElt.src;
-iframeElt.src= refStr;
+```js-nolint
+refStr = iframeElt.src
+iframeElt.src= refStr
 ```
 
 ## Example

--- a/files/en-us/web/api/htmlimageelement/decode/index.md
+++ b/files/en-us/web/api/htmlimageelement/decode/index.md
@@ -34,7 +34,7 @@ a delay while the image loads.
 
 ## Syntax
 
-```js
+```js-nolint
 decode()
 ```
 

--- a/files/en-us/web/api/htmlimageelement/image/index.md
+++ b/files/en-us/web/api/htmlimageelement/image/index.md
@@ -26,7 +26,7 @@ equivalent to {{DOMxRef("Document.createElement()",
 
 ## Syntax
 
-```js
+```js-nolint
 new Image()
 new Image(width)
 new Image(width, height)

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -20,7 +20,7 @@ The **`HTMLInputElement.checkValidity()`** method returns a boolean value which 
 
 ## Syntax
 
-```js
+```js-nolint
 checkValidity()
 ```
 

--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -20,7 +20,7 @@ The **`reportValidity()`** method of the {{domxref('HTMLInputElement')}} interfa
 
 ## Syntax
 
-```js
+```js-nolint
 reportValidity()
 ```
 

--- a/files/en-us/web/api/htmlinputelement/select/index.md
+++ b/files/en-us/web/api/htmlinputelement/select/index.md
@@ -20,7 +20,7 @@ that includes a text field.
 
 ## Syntax
 
-```js
+```js-nolint
 select()
 ```
 

--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -20,7 +20,7 @@ The **`HTMLInputElement.setCustomValidity()`** method sets a custom validity mes
 
 ## Syntax
 
-```js
+```js-nolint
 setCustomValidity(message)
 ```
 

--- a/files/en-us/web/api/htmlinputelement/setrangetext/index.md
+++ b/files/en-us/web/api/htmlinputelement/setrangetext/index.md
@@ -21,7 +21,7 @@ a new string.
 
 ## Syntax
 
-```js
+```js-nolint
 setRangeText(replacement)
 setRangeText(replacement, start)
 setRangeText(replacement, start, end)

--- a/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
+++ b/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
@@ -38,7 +38,7 @@ method instead.
 
 ## Syntax
 
-```js
+```js-nolint
 setSelectionRange(selectionStart, selectionEnd)
 setSelectionRange(selectionStart, selectionEnd, selectionDirection)
 ```

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -24,7 +24,7 @@ More generally, this method should ideally display the picker for any input elem
 
 ## Syntax
 
-```js
+```js-nolint
 showPicker()
 ```
 

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -108,7 +108,7 @@ support the `step` attribute (see the list of supported input types above), or i
 
 ## Syntax
 
-```js
+```js-nolint
 stepDown()
 stepDown(stepDecrement)
 ```

--- a/files/en-us/web/api/htmlinputelement/stepup/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.md
@@ -120,7 +120,7 @@ table above), or if the step value is set to `any`, an
 
 ## Syntax
 
-```js
+```js-nolint
 stepUp()
 stepUp(stepIncrement)
 ```

--- a/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
@@ -31,7 +31,7 @@ The {{domxref("HTMLMediaElement")}} method **`canPlayType()`** reports how likel
 
 ## Syntax
 
-```js
+```js-nolint
 canPlayType(type)
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.md
@@ -27,7 +27,7 @@ This can be used, for example, as a source for a [WebRTC](/en-US/docs/Web/API/We
 
 ## Syntax
 
-```js
+```js-nolint
 captureStream()
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.md
@@ -23,7 +23,7 @@ media to the new time with precision tradeoff.
 
 ## Syntax
 
-```js
+```js-nolint
 fastSeek(time)
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/load/index.md
+++ b/files/en-us/web/api/htmlmediaelement/load/index.md
@@ -37,7 +37,7 @@ causing the changes to take effect.
 
 ## Syntax
 
-```js
+```js-nolint
 load()
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
@@ -16,8 +16,8 @@ The **`msClearEffects`** method of the [_HTMLMediaElement_](/en-US/docs/Web/API/
 
 ### Syntax
 
-```js
-HTMLMediaElement.msClearEffects();
+```js-nolint
+HTMLMediaElement.msClearEffects()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
@@ -17,7 +17,7 @@ The **`msClearEffects`** method of the [_HTMLMediaElement_](/en-US/docs/Web/API/
 ### Syntax
 
 ```js-nolint
-HTMLMediaElement.msClearEffects()
+msClearEffects()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
@@ -20,7 +20,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
+```js-nolint
 msInsertAudioEffect(activatableClassId, effectRequired)
 msInsertAudioEffect(activatableClassId, effectRequired, config)
 ```

--- a/files/en-us/web/api/htmlmediaelement/mssetmediaprotectionmanager/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mssetmediaprotectionmanager/index.md
@@ -19,9 +19,9 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
-msSetMediaProtectionManager();
-msSetMediaProtectionManager(mediaProtectionManager);
+```js-nolint
+msSetMediaProtectionManager()
+msSetMediaProtectionManager(mediaProtectionManager)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlmediaelement/pause/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause/index.md
@@ -19,7 +19,7 @@ of the media, if the media is already in a paused state this method will have no
 
 ## Syntax
 
-```js
+```js-nolint
 pause()
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -27,7 +27,7 @@ permission issues, result in the promise being rejected.
 
 ## Syntax
 
-```js
+```js-nolint
 play()
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -40,7 +40,7 @@ happens.
 
 ## Syntax
 
-```js
+```js-nolint
 seekToNextFrame()
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
@@ -23,7 +23,7 @@ playback.
 
 ## Syntax
 
-```js
+```js-nolint
 setMediaKeys(mediaKeys)
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
@@ -21,7 +21,7 @@ This only works when the application is authorized to use the specified device.
 
 ## Syntax
 
-```js
+```js-nolint
 setSinkId(sinkId)
 ```
 

--- a/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
@@ -22,7 +22,7 @@ is true, because object objects are never candidates for constraint validation.
 
 ## Syntax
 
-```js
+```js-nolint
 checkValidity()
 ```
 

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
@@ -21,7 +21,7 @@ element.
 
 ## Syntax
 
-```js
+```js-nolint
 setCustomValidity(errorMessage)
 ```
 

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -21,7 +21,7 @@ The **`Option()`** constructor creates a new
 
 ## Syntax
 
-```js
+```js-nolint
 new Option()
 new Option(text)
 new Option(text, value)

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -20,7 +20,7 @@ The method is expected to return `true` for classic and module scripts, which ar
 
 ## Syntax
 
-```js
+```js-nolint
 supports(type)
 ```
 

--- a/files/en-us/web/api/htmlselectelement/add/index.md
+++ b/files/en-us/web/api/htmlselectelement/add/index.md
@@ -18,7 +18,7 @@ collection of `option` elements for this `select` element.
 
 ## Syntax
 
-```js
+```js-nolint
 add(item)
 add(item, before)
 ```

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
@@ -21,7 +21,7 @@ element, and then returns `false`.
 
 ## Syntax
 
-```js
+```js-nolint
 checkValidity()
 ```
 

--- a/files/en-us/web/api/htmlselectelement/item/index.md
+++ b/files/en-us/web/api/htmlselectelement/item/index.md
@@ -24,7 +24,7 @@ In JavaScript, using the array bracket syntax with an `unsigned long`, like
 
 ## Syntax
 
-```js
+```js-nolint
 item(index)
 // or collection[index]
 ```

--- a/files/en-us/web/api/htmlselectelement/nameditem/index.md
+++ b/files/en-us/web/api/htmlselectelement/nameditem/index.md
@@ -22,7 +22,7 @@ In JavaScript, using `selectElt.namedItem('value')` is equivalent to `selectElt.
 
 ## Syntax
 
-```js
+```js-nolint
 namedItem(str)
 ```
 

--- a/files/en-us/web/api/htmlselectelement/remove/index.md
+++ b/files/en-us/web/api/htmlselectelement/remove/index.md
@@ -18,7 +18,7 @@ at the specified index from the options collection for this select element.
 
 ## Syntax
 
-```js
+```js-nolint
 remove(index)
 ```
 

--- a/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -21,7 +21,7 @@ error.
 
 ## Syntax
 
-```js
+```js-nolint
 setCustomValidity(string)
 ```
 

--- a/files/en-us/web/api/htmlslotelement/assign/index.md
+++ b/files/en-us/web/api/htmlslotelement/assign/index.md
@@ -22,7 +22,7 @@ Please note that you cannot mix declarative and imperative slot assignment. Ther
 
 ## Syntax
 
-```js
+```js-nolint
 assign(node1)
 assign(node1, node2)
 assign(node1, node2, /* … ,*/ nodeN)

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.md
@@ -23,7 +23,7 @@ If the `flatten` option is set to `true`, it returns a sequence of both the elem
 
 ## Syntax
 
-```js
+```js-nolint
 assignedElements()
 assignedElements(options)
 ```

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.md
@@ -20,7 +20,7 @@ If the `flatten` option is set to `true`, it returns a sequence of both the node
 
 ## Syntax
 
-```js
+```js-nolint
 assignedNodes()
 assignedNodes(options)
 ```

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -26,7 +26,7 @@ it, and then returns it.
 
 ## Syntax
 
-```js
+```js-nolint
 createCaption()
 ```
 

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -26,7 +26,7 @@ The **`createTBody()`** method of
 
 ## Syntax
 
-```js
+```js-nolint
 createTBody()
 ```
 

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -26,7 +26,7 @@ method creates it, and then returns it.
 
 ## Syntax
 
-```js
+```js-nolint
 createTFoot()
 ```
 

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -26,7 +26,7 @@ method creates it, and then returns it.
 
 ## Syntax
 
-```js
+```js-nolint
 createTHead()
 ```
 

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -21,7 +21,7 @@ nothing.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteCaption()
 ```
 

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -19,7 +19,7 @@ specific row ({{HtmlElement("tr")}}) from a given {{HtmlElement("table")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteRow(index)
 ```
 

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -19,7 +19,7 @@ The **`HTMLTableElement.deleteTFoot()`** method removes the
 
 ## Syntax
 
-```js
+```js-nolint
 deleteTFoot()
 ```
 

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -19,7 +19,7 @@ The **`HTMLTableElement.deleteTHead()`** removes the
 
 ## Syntax
 
-```js
+```js-nolint
 deleteTHead()
 ```
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -34,7 +34,7 @@ let row = specific_tbody.insertRow(index)
 
 ## Syntax
 
-```js
+```js-nolint
 insertRow()
 insertRow(index)
 ```

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -28,7 +28,7 @@ reference to the cell.
 
 ## Syntax
 
-```js
+```js-nolint
 insertCell()
 insertCell(index)
 ```

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -31,7 +31,7 @@ The data returned can be used to evaluate the quality of the video stream.
 
 ## Syntax
 
-```js
+```js-nolint
 getVideoPlaybackQuality()
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/msframestep/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msframestep/index.md
@@ -20,7 +20,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
+```js-nolint
 msFrameStep(forward)
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
@@ -20,7 +20,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
+```js-nolint
 msInsertVideoEffect(activatableClassId, effectRequired)
 msInsertVideoEffect(activatableClassId, effectRequired, config)
 ```

--- a/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
@@ -17,8 +17,8 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
-HTMLVideoElement.msSetVideoRectangle();
+```js-nolint
+HTMLVideoElement.msSetVideoRectangle()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
@@ -18,7 +18,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js-nolint
-HTMLVideoElement.msSetVideoRectangle()
+msSetVideoRectangle()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
@@ -18,7 +18,7 @@ This proprietary property is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js-nolint
-HTMLVideoElement.msStereo3DPackingMode(topbottom, sidebyside, none)
+msStereo3DPackingMode(topbottom, sidebyside, none)
 ```
 
 ## Value

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
@@ -17,8 +17,8 @@ This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
-HTMLVideoElement.msStereo3DPackingMode(topbottom, sidebyside, none);
+```js-nolint
+HTMLVideoElement.msStereo3DPackingMode(topbottom, sidebyside, none)
 ```
 
 ## Value

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
@@ -17,8 +17,8 @@ This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
 ## Syntax
 
-```js
-HTMLVideoElement.msStereo3DRenderMode(mono, stereo);
+```js-nolint
+HTMLVideoElement.msStereo3DRenderMode(mono, stereo)
 ```
 
 ## Value

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
@@ -18,7 +18,7 @@ This proprietary property is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js-nolint
-HTMLVideoElement.msStereo3DRenderMode(mono, stereo)
+msStereo3DRenderMode(mono, stereo)
 ```
 
 ## Value

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -29,7 +29,7 @@ video will receive a {{domxref("HTMLVideoElement.enterpictureinpicture_event",
 
 ## Syntax
 
-```js
+```js-nolint
 requestPictureInPicture()
 ```
 

--- a/files/en-us/web/api/idbcursor/advance/index.md
+++ b/files/en-us/web/api/idbcursor/advance/index.md
@@ -24,7 +24,7 @@ its position forward.
 
 ## Syntax
 
-```js
+```js-nolint
 advance(count)
 ```
 

--- a/files/en-us/web/api/idbcursor/continue/index.md
+++ b/files/en-us/web/api/idbcursor/continue/index.md
@@ -25,7 +25,7 @@ advances to the immediate next position, based on its direction.
 
 ## Syntax
 
-```js
+```js-nolint
 continue()
 continue(key)
 ```

--- a/files/en-us/web/api/idbcursor/continueprimarykey/index.md
+++ b/files/en-us/web/api/idbcursor/continueprimarykey/index.md
@@ -35,7 +35,7 @@ from an object store will throw an error.
 
 ## Syntax
 
-```js
+```js-nolint
 continuePrimaryKey(key, primaryKey)
 ```
 

--- a/files/en-us/web/api/idbcursor/delete/index.md
+++ b/files/en-us/web/api/idbcursor/delete/index.md
@@ -30,7 +30,7 @@ Be aware that you can't call `delete()` (or
 
 ## Syntax
 
-```js
+```js-nolint
 delete()
 ```
 

--- a/files/en-us/web/api/idbcursor/update/index.md
+++ b/files/en-us/web/api/idbcursor/update/index.md
@@ -30,7 +30,7 @@ Be aware that you can't call `update()` (or
 
 ## Syntax
 
-```js
+```js-nolint
 update(value)
 ```
 

--- a/files/en-us/web/api/idbdatabase/close/index.md
+++ b/files/en-us/web/api/idbdatabase/close/index.md
@@ -27,7 +27,7 @@ operation is pending.
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -30,7 +30,7 @@ transaction.
 
 ## Syntax
 
-```js
+```js-nolint
 createObjectStore(name)
 createObjectStore(name, options)
 ```

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
@@ -27,7 +27,7 @@ transaction.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteObjectStore(name)
 ```
 

--- a/files/en-us/web/api/idbdatabase/transaction/index.md
+++ b/files/en-us/web/api/idbdatabase/transaction/index.md
@@ -24,7 +24,7 @@ object store.
 
 ## Syntax
 
-```js
+```js-nolint
 transaction(storeNames)
 transaction(storeNames, mode)
 transaction(storeNames, mode, options)

--- a/files/en-us/web/api/idbfactory/cmp/index.md
+++ b/files/en-us/web/api/idbfactory/cmp/index.md
@@ -31,7 +31,7 @@ operations, such as storing and iterating.
 
 ## Syntax
 
-```js
+```js-nolint
 cmp(first, second)
 ```
 

--- a/files/en-us/web/api/idbfactory/databases/index.md
+++ b/files/en-us/web/api/idbfactory/databases/index.md
@@ -23,7 +23,7 @@ The **`databases`** method of the {{domxref("IDBFactory")}} interface returns a 
 
 ## Syntax
 
-```js
+```js-nolint
 databases()
 ```
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -34,7 +34,7 @@ particular database will get a [versionchange](/en-US/docs/Web/API/IDBDatabase/v
 
 ## Syntax
 
-```js
+```js-nolint
 // For the current standard:
 deleteDatabase(name)
 

--- a/files/en-us/web/api/idbfactory/open/index.md
+++ b/files/en-us/web/api/idbfactory/open/index.md
@@ -27,7 +27,7 @@ May trigger `upgradeneeded`, `blocked` or `versionchange` events.
 
 ## Syntax
 
-```js
+```js-nolint
 open(name)
 open(name, version)
 ```

--- a/files/en-us/web/api/idbfilehandle/abort/index.md
+++ b/files/en-us/web/api/idbfilehandle/abort/index.md
@@ -29,7 +29,7 @@ and all ongoing operations are canceled.
 
 ## Syntax
 
-```js
+```js-nolint
 abort()
 ```
 

--- a/files/en-us/web/api/idbfilehandle/append/index.md
+++ b/files/en-us/web/api/idbfilehandle/append/index.md
@@ -27,7 +27,7 @@ and actually sets the value of this property to `null`.
 
 ## Syntax
 
-```js
+```js-nolint
 append(data)
 ```
 

--- a/files/en-us/web/api/idbfilehandle/flush/index.md
+++ b/files/en-us/web/api/idbfilehandle/flush/index.md
@@ -29,7 +29,7 @@ To avoid that, it's possible to force a write onto the disk by calling the `flus
 
 ## Syntax
 
-```js
+```js-nolint
 flush()
 ```
 

--- a/files/en-us/web/api/idbfilehandle/getmetadata/index.md
+++ b/files/en-us/web/api/idbfilehandle/getmetadata/index.md
@@ -22,7 +22,7 @@ The **`getMetadata()`** method of the {{domxref("IDBFileHandle")}} allows retrie
 
 ## Syntax
 
-```js
+```js-nolint
 getMetaData()
 getMetaData(options)
 ```

--- a/files/en-us/web/api/idbfilehandle/readasarraybuffer/index.md
+++ b/files/en-us/web/api/idbfilehandle/readasarraybuffer/index.md
@@ -27,7 +27,7 @@ The reading operation starts at the position given by the
 
 ## Syntax
 
-```js
+```js-nolint
 readAsArrayBuffer(size)
 ```
 

--- a/files/en-us/web/api/idbfilehandle/readastext/index.md
+++ b/files/en-us/web/api/idbfilehandle/readastext/index.md
@@ -28,7 +28,7 @@ The reading operation starts at the position given by the
 
 ## Syntax
 
-```js
+```js-nolint
 readAsText(size)
 readAsText(size, encoding)
 ```

--- a/files/en-us/web/api/idbfilehandle/truncate/index.md
+++ b/files/en-us/web/api/idbfilehandle/truncate/index.md
@@ -30,7 +30,7 @@ at the index corresponding to the parameter and regardless of the value of
 
 ## Syntax
 
-```js
+```js-nolint
 truncate()
 truncate(start)
 ```

--- a/files/en-us/web/api/idbfilehandle/write/index.md
+++ b/files/en-us/web/api/idbfilehandle/write/index.md
@@ -26,7 +26,7 @@ that position by the number of written bytes.
 
 ## Syntax
 
-```js
+```js-nolint
 write(data)
 ```
 

--- a/files/en-us/web/api/idbindex/count/index.md
+++ b/files/en-us/web/api/idbindex/count/index.md
@@ -24,7 +24,7 @@ returns the number of records within a key range.
 
 ## Syntax
 
-```js
+```js-nolint
 count()
 count(key)
 ```

--- a/files/en-us/web/api/idbindex/get/index.md
+++ b/files/en-us/web/api/idbindex/get/index.md
@@ -29,7 +29,7 @@ with.
 
 ## Syntax
 
-```js
+```js-nolint
 get()
 get(key)
 ```

--- a/files/en-us/web/api/idbindex/getall/index.md
+++ b/files/en-us/web/api/idbindex/getall/index.md
@@ -27,7 +27,7 @@ use `getAll()`.
 
 ## Syntax
 
-```js
+```js-nolint
 getAll()
 getAll(query)
 getAll(query, count)

--- a/files/en-us/web/api/idbindex/getallkeys/index.md
+++ b/files/en-us/web/api/idbindex/getallkeys/index.md
@@ -19,7 +19,7 @@ setting them as the `result` of the request object.
 
 ## Syntax
 
-```js
+```js-nolint
 getAllKeys()
 getAllKeys(query)
 getAllKeys(query, count)

--- a/files/en-us/web/api/idbindex/getkey/index.md
+++ b/files/en-us/web/api/idbindex/getkey/index.md
@@ -28,7 +28,7 @@ Note that this doesn't return the whole record as {{domxref("IDBIndex.get")}} do
 
 ## Syntax
 
-```js
+```js-nolint
 getKey()
 getKey(key)
 ```

--- a/files/en-us/web/api/idbindex/opencursor/index.md
+++ b/files/en-us/web/api/idbindex/opencursor/index.md
@@ -30,7 +30,7 @@ If the key range is not specified or is null, then the range includes all the re
 
 ## Syntax
 
-```js
+```js-nolint
 openCursor()
 openCursor(range)
 openCursor(range, direction)

--- a/files/en-us/web/api/idbindex/openkeycursor/index.md
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.md
@@ -34,7 +34,7 @@ If the key range is not specified or is null, then the range includes all the ke
 
 ## Syntax
 
-```js
+```js-nolint
 openKeyCursor()
 openKeyCursor(range)
 openKeyCursor(range, direction)

--- a/files/en-us/web/api/idbkeyrange/bound/index.md
+++ b/files/en-us/web/api/idbkeyrange/bound/index.md
@@ -25,7 +25,7 @@ is, the bounds include the endpoint values). By default, the bounds are closed.
 
 ## Syntax
 
-```js
+```js-nolint
 bound(lower, upper)
 bound(lower, upper, lowerOpen)
 bound(lower, upper, lowerOpen, upperOpen)

--- a/files/en-us/web/api/idbkeyrange/includes/index.md
+++ b/files/en-us/web/api/idbkeyrange/includes/index.md
@@ -24,7 +24,7 @@ range.
 
 ## Syntax
 
-```js
+```js-nolint
 includes(key)
 ```
 

--- a/files/en-us/web/api/idbkeyrange/lowerbound/index.md
+++ b/files/en-us/web/api/idbkeyrange/lowerbound/index.md
@@ -24,7 +24,7 @@ By default, it includes the lower endpoint value and is closed.
 
 ## Syntax
 
-```js
+```js-nolint
 lowerBound(lower)
 lowerBound(lower, open)
 ```

--- a/files/en-us/web/api/idbkeyrange/only/index.md
+++ b/files/en-us/web/api/idbkeyrange/only/index.md
@@ -23,7 +23,7 @@ interface creates a new key range containing a single value.
 
 ## Syntax
 
-```js
+```js-nolint
 only(value)
 ```
 

--- a/files/en-us/web/api/idbkeyrange/upperbound/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperbound/index.md
@@ -24,7 +24,7 @@ it includes the upper endpoint value and is closed.
 
 ## Syntax
 
-```js
+```js-nolint
 upperBound(upper)
 upperBound(upper, open)
 ```

--- a/files/en-us/web/api/idbmutablefile/open/index.md
+++ b/files/en-us/web/api/idbmutablefile/open/index.md
@@ -24,7 +24,7 @@ that allows to safely write in the file.
 
 ## Syntax
 
-```js
+```js-nolint
 open(mode)
 ```
 

--- a/files/en-us/web/api/idbobjectstore/add/index.md
+++ b/files/en-us/web/api/idbobjectstore/add/index.md
@@ -33,7 +33,7 @@ object. For updating existing records, you should use the
 
 ## Syntax
 
-```js
+```js-nolint
 add(value)
 add(value, key)
 ```

--- a/files/en-us/web/api/idbobjectstore/clear/index.md
+++ b/files/en-us/web/api/idbobjectstore/clear/index.md
@@ -30,7 +30,7 @@ or {{domxref("IDBKeyRange")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 clear()
 ```
 

--- a/files/en-us/web/api/idbobjectstore/count/index.md
+++ b/files/en-us/web/api/idbobjectstore/count/index.md
@@ -26,7 +26,7 @@ of records in the store.
 
 ## Syntax
 
-```js
+```js-nolint
 count()
 count(query)
 ```

--- a/files/en-us/web/api/idbobjectstore/createindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.md
@@ -32,7 +32,7 @@ mode callback.
 
 ## Syntax
 
-```js
+```js-nolint
 createIndex(indexName, keyPath)
 createIndex(indexName, keyPath, objectParameters)
 ```

--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -28,7 +28,7 @@ record — without having to explicitly look up the record's key.
 
 ## Syntax
 
-```js
+```js-nolint
 delete(key)
 ```
 

--- a/files/en-us/web/api/idbobjectstore/deleteindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/deleteindex/index.md
@@ -28,7 +28,7 @@ mode callback. Note that this method synchronously modifies the
 
 ## Syntax
 
-```js
+```js-nolint
 deleteIndex(indexName)
 ```
 

--- a/files/en-us/web/api/idbobjectstore/get/index.md
+++ b/files/en-us/web/api/idbobjectstore/get/index.md
@@ -31,7 +31,7 @@ request object.
 
 ## Syntax
 
-```js
+```js-nolint
 get(key)
 ```
 

--- a/files/en-us/web/api/idbobjectstore/getall/index.md
+++ b/files/en-us/web/api/idbobjectstore/getall/index.md
@@ -38,7 +38,7 @@ To tell these situations apart, you either call
 
 ## Syntax
 
-```js
+```js-nolint
 getAll()
 getAll(query)
 getAll(query, count)

--- a/files/en-us/web/api/idbobjectstore/getallkeys/index.md
+++ b/files/en-us/web/api/idbobjectstore/getallkeys/index.md
@@ -33,7 +33,7 @@ method provides a cursor if the record exists, and no cursor if it does not.
 
 ## Syntax
 
-```js
+```js-nolint
 getAllKeys()
 getAllKeys(query)
 getAllKeys(query, count)

--- a/files/en-us/web/api/idbobjectstore/getkey/index.md
+++ b/files/en-us/web/api/idbobjectstore/getkey/index.md
@@ -26,7 +26,7 @@ result of the request object.
 
 ## Syntax
 
-```js
+```js-nolint
 getKey(key)
 ```
 


### PR DESCRIPTION
Adding to https://github.com/mdn/content/pull/19177

- Updating syntax code blocks with the new tag. Refer: https://github.com/mdn/yari/pull/7017
