### PR TITLE
Tag syntax code blocks with js-nolint, part 11

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -22,7 +22,7 @@ interpreted as a point in the local coordinate system of the element.
 
 ## Syntax
 
-```js
+```js-nolint
 isPointInFill(point)
 ```
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -23,7 +23,7 @@ the element.
 
 ## Syntax
 
-```js
+```js-nolint
 isPointInStroke(point)
 ```
 

--- a/files/en-us/web/api/svggraphicselement/getbbox/index.md
+++ b/files/en-us/web/api/svggraphicselement/getbbox/index.md
@@ -29,7 +29,7 @@ geometry attributes on all the elements contained in the target element).
 
 ## Syntax
 
-```js
+```js-nolint
 getBBox()
 getBBox(options)
 ```

--- a/files/en-us/web/api/svgimageelement/decode/index.md
+++ b/files/en-us/web/api/svgimageelement/decode/index.md
@@ -25,7 +25,7 @@ for use.
 
 ## Syntax
 
-```js
+```js-nolint
 decode()
 ```
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.md
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.md
@@ -17,7 +17,7 @@ The **`setOrientToAngle()`** method of the {{domxref("SVGMarkerElement")}} inter
 
 ## Syntax
 
-```js
+```js-nolint
 setOrientToAngle(angle)
 ```
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.md
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.md
@@ -17,7 +17,7 @@ The **`setOrientToAuto()`** method of the {{domxref("SVGMarkerElement")}} interf
 
 ## Syntax
 
-```js
+```js-nolint
 setOrientToAuto()
 ```
 

--- a/files/en-us/web/api/svgpoint/index.md
+++ b/files/en-us/web/api/svgpoint/index.md
@@ -22,7 +22,7 @@ An `SVGPoint` represents a 2D or 3D point in the SVG coordinate system.
 ## Syntax
 
 ```js-nolint
-retObject = SVGSVGElement.createSVGPoint()
+createSVGPoint()
 ```
 
 ### Value

--- a/files/en-us/web/api/svgpoint/index.md
+++ b/files/en-us/web/api/svgpoint/index.md
@@ -21,7 +21,7 @@ An `SVGPoint` represents a 2D or 3D point in the SVG coordinate system.
 
 ## Syntax
 
-```js
+```js-nolint
 retObject = SVGSVGElement.createSVGPoint()
 ```
 

--- a/files/en-us/web/api/svgpointlist/appenditem/index.md
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.md
@@ -17,7 +17,7 @@ The **`appendItem()`** method of the {{domxref("SVGPointList")}} interface adds 
 
 ## Syntax
 
-```js
+```js-nolint
 appendItem(obj)
 ```
 

--- a/files/en-us/web/api/svgpointlist/clear/index.md
+++ b/files/en-us/web/api/svgpointlist/clear/index.md
@@ -17,7 +17,7 @@ The **`clear()`** method of the {{domxref("SVGPointList")}} interface removes al
 
 ## Syntax
 
-```js
+```js-nolint
 clear()
 ```
 

--- a/files/en-us/web/api/svgpointlist/getitem/index.md
+++ b/files/en-us/web/api/svgpointlist/getitem/index.md
@@ -17,7 +17,7 @@ The **`getItem()`** method of the {{domxref("SVGPointList")}} interface gets one
 
 ## Syntax
 
-```js
+```js-nolint
 getItem(index)
 ```
 

--- a/files/en-us/web/api/svgpointlist/initialize/index.md
+++ b/files/en-us/web/api/svgpointlist/initialize/index.md
@@ -17,7 +17,7 @@ The **`initialize()`** method of the {{domxref("SVGPointList")}} interface clear
 
 ## Syntax
 
-```js
+```js-nolint
 initialize(obj)
 ```
 

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.md
@@ -17,7 +17,7 @@ The **`insertItemBefore()`** method of the {{domxref("SVGPointList")}} interface
 
 ## Syntax
 
-```js
+```js-nolint
 insertItemBefore(obj, index)
 ```
 

--- a/files/en-us/web/api/svgpointlist/removeitem/index.md
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.md
@@ -17,7 +17,7 @@ The **`removeItem()`** method of the {{domxref("SVGPointList")}} interface remov
 
 ## Syntax
 
-```js
+```js-nolint
 removeItem(index)
 ```
 

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.md
@@ -17,7 +17,7 @@ The **`replaceItem()`** method of the {{domxref("SVGPointList")}} interface repl
 
 ## Syntax
 
-```js
+```js-nolint
 replaceItem(obj, index)
 ```
 

--- a/files/en-us/web/api/syncevent/syncevent/index.md
+++ b/files/en-us/web/api/syncevent/syncevent/index.md
@@ -19,7 +19,7 @@ The **`SyncEvent()`** constructor creates a new {{domxref("SyncEvent")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 new SyncEvent(type, options)
 ```
 

--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -21,7 +21,7 @@ The **`SyncManager.getTags`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 getTags()
 ```
 

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -21,7 +21,7 @@ The **`SyncManager.register`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 register()
 register(options)
 ```

--- a/files/en-us/web/api/taskcontroller/setpriority/index.md
+++ b/files/en-us/web/api/taskcontroller/setpriority/index.md
@@ -23,7 +23,7 @@ If the task is immutable, the function call is ignored.
 
 ## Syntax
 
-```js
+```js-nolint
 setPriority(priority)
 ```
 

--- a/files/en-us/web/api/taskcontroller/taskcontroller/index.md
+++ b/files/en-us/web/api/taskcontroller/taskcontroller/index.md
@@ -18,7 +18,7 @@ If no priority is set, the signal priority defaults to [`user-visible`](/en-US/d
 
 ## Syntax
 
-```js
+```js-nolint
 new TaskController()
 new TaskController(init)
 ```

--- a/files/en-us/web/api/taskprioritychangeevent/taskprioritychangeevent/index.md
+++ b/files/en-us/web/api/taskprioritychangeevent/taskprioritychangeevent/index.md
@@ -19,7 +19,7 @@ This object is created with a value indicating the [previous priority](/en-US/do
 
 ## Syntax
 
-```js
+```js-nolint
 new TaskPriorityChangeEvent(type, options)
 ```
 

--- a/files/en-us/web/api/text/splittext/index.md
+++ b/files/en-us/web/api/text/splittext/index.md
@@ -27,7 +27,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 newNode = textNode.splitText(offset)
 ```
 

--- a/files/en-us/web/api/text/text/index.md
+++ b/files/en-us/web/api/text/text/index.md
@@ -15,9 +15,9 @@ with the optional string given in parameter as its textual content.
 
 ## Syntax
 
-```js
-new Text();
-new Text(aString);
+```js-nolint
+new Text()
+new Text(aString)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/textdecoder/decode/index.md
+++ b/files/en-us/web/api/textdecoder/decode/index.md
@@ -18,7 +18,7 @@ specific method for that {{domxref("TextDecoder")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 decode()
 decode(buffer)
 decode(buffer, options)

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -20,7 +20,7 @@ If the value for _utfLabel_ is unknown, or is one of the two values leading to a
 
 ## Syntax
 
-```js
+```js-nolint
 new TextDecoder()
 new TextDecoder(utfLabel)
 new TextDecoder(utfLabel, options)

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
@@ -16,7 +16,7 @@ The **`TextDecoderStream()`** constructor creates a new {{domxref("TextDecoderSt
 
 ## Syntax
 
-```js
+```js-nolint
 new TextDecoderStream(label)
 new TextDecoderStream(label, options)
 ```

--- a/files/en-us/web/api/textencoder/encode/index.md
+++ b/files/en-us/web/api/textencoder/encode/index.md
@@ -21,7 +21,7 @@ for that {{domxref("TextEncoder")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 encode(string)
 ```
 

--- a/files/en-us/web/api/textencoder/encodeinto/index.md
+++ b/files/en-us/web/api/textencoder/encodeinto/index.md
@@ -22,7 +22,7 @@ heap.
 
 ## Syntax
 
-```js
+```js-nolint
 encodeInto(string, uint8Array)
 ```
 

--- a/files/en-us/web/api/textencoder/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/textencoder/index.md
@@ -18,7 +18,7 @@ The **`TextEncoder()`** constructor returns a newly created
 
 ## Syntax
 
-```js
+```js-nolint
 new TextEncoder()
 ```
 

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.md
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.md
@@ -16,7 +16,7 @@ The **`TextEncoderStream()`** constructor creates a new {{domxref("TextEncoderSt
 
 ## Syntax
 
-```js
+```js-nolint
 new TextEncoderStream()
 ```
 

--- a/files/en-us/web/api/texttrack/addcue/index.md
+++ b/files/en-us/web/api/texttrack/addcue/index.md
@@ -17,7 +17,7 @@ The **`addCue()`** method of the {{domxref("TextTrack")}} interface adds a new c
 
 ## Syntax
 
-```js
+```js-nolint
 addCue(cue)
 ```
 

--- a/files/en-us/web/api/texttrack/removecue/index.md
+++ b/files/en-us/web/api/texttrack/removecue/index.md
@@ -17,7 +17,7 @@ The **`removeCue()`** method of the {{domxref("TextTrack")}} interface removes a
 
 ## Syntax
 
-```js
+```js-nolint
 removeCue(cue)
 ```
 

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
@@ -19,7 +19,7 @@ The **`getCueById()`** method of the {{domxref("TextTrackCueList")}} interface r
 
 ## Syntax
 
-```js
+```js-nolint
 getCueById(id)
 ```
 

--- a/files/en-us/web/api/texttracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/texttracklist/gettrackbyid/index.md
@@ -31,7 +31,7 @@ string.
 
 ## Syntax
 
-```js
+```js-nolint
 getTrackById(id)
 ```
 

--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -18,7 +18,7 @@ The **`end()`** method of the {{domxref("TimeRanges")}} interface returns the ti
 
 ## Syntax
 
-```js
+```js-nolint
 end(index)
 ```
 

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -18,7 +18,7 @@ The **`start()`** method of the {{domxref("TimeRanges")}} interface returns the 
 
 ## Syntax
 
-```js
+```js-nolint
 start(index)
 ```
 

--- a/files/en-us/web/api/touch/touch/index.md
+++ b/files/en-us/web/api/touch/touch/index.md
@@ -16,7 +16,7 @@ The **`Touch()`** constructor creates a new {{domxref("Touch")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 new Touch(options)
 ```
 

--- a/files/en-us/web/api/touchevent/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/touchevent/index.md
@@ -21,7 +21,7 @@ The **`TouchEvent()`** constructor creates a new {{domxref("TouchEvent")}} objec
 
 ## Syntax
 
-```js
+```js-nolint
 new TouchEvent(type)
 new TouchEvent(type, options)
 ```

--- a/files/en-us/web/api/touchlist/item/index.md
+++ b/files/en-us/web/api/touchlist/item/index.md
@@ -21,7 +21,7 @@ object at the specified index in the {{ domxref("TouchList") }}.
 
 ## Syntax
 
-```js
+```js-nolint
 item(index)
 ```
 

--- a/files/en-us/web/api/trackevent/trackevent/index.md
+++ b/files/en-us/web/api/trackevent/trackevent/index.md
@@ -24,7 +24,7 @@ occurred on a list of tracks ({{domxref("AudioTrackList")}},
 
 ## Syntax
 
-```js
+```js-nolint
 new TrackEvent(type)
 new TrackEvent(type, options)
 ```

--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -16,7 +16,7 @@ The **`TransformStream()`** constructor creates a new {{domxref("TransformStream
 
 ## Syntax
 
-```js
+```js-nolint
 new TransformStream()
 new TransformStream(transformer)
 new TransformStream(transformer, writableStrategy)

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
@@ -19,7 +19,7 @@ For more information on readable streams and chunks see [Using Readable Streams]
 
 ## Syntax
 
-```js
+```js-nolint
 enqueue(chunk)
 ```
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
@@ -17,7 +17,7 @@ The **`error()`** method of the {{domxref("TransformStreamDefaultController")}} 
 
 ## Syntax
 
-```js
+```js-nolint
 error(reason)
 ```
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
@@ -17,7 +17,7 @@ The **`terminate()`** method of the {{domxref("TransformStreamDefaultController"
 
 ## Syntax
 
-```js
+```js-nolint
 terminate()
 ```
 

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.md
@@ -32,7 +32,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 initTransitionEvent(type, canBubble, cancelable, transitionName, elapsedTime)
 ```
 

--- a/files/en-us/web/api/transitionevent/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.md
@@ -19,7 +19,7 @@ The **`TransitionEvent()`** constructor returns a new {{domxref("TransitionEvent
 
 ## Syntax
 
-```js
+```js-nolint
 new TransitionEvent(type)
 new TransitionEvent(type, options)
 ```

--- a/files/en-us/web/api/treewalker/firstchild/index.md
+++ b/files/en-us/web/api/treewalker/firstchild/index.md
@@ -20,7 +20,7 @@ returns `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 firstChild()
 ```
 

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -20,7 +20,7 @@ returns `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 lastChild()
 ```
 

--- a/files/en-us/web/api/treewalker/nextnode/index.md
+++ b/files/en-us/web/api/treewalker/nextnode/index.md
@@ -20,7 +20,7 @@ returns `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 nextNode()
 ```
 

--- a/files/en-us/web/api/treewalker/nextsibling/index.md
+++ b/files/en-us/web/api/treewalker/nextsibling/index.md
@@ -19,7 +19,7 @@ is no such node, return `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 nextSibling()
 ```
 

--- a/files/en-us/web/api/treewalker/parentnode/index.md
+++ b/files/en-us/web/api/treewalker/parentnode/index.md
@@ -21,7 +21,7 @@ node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 parentNode()
 ```
 

--- a/files/en-us/web/api/treewalker/previousnode/index.md
+++ b/files/en-us/web/api/treewalker/previousnode/index.md
@@ -21,7 +21,7 @@ construction, returns `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 previousNode()
 ```
 

--- a/files/en-us/web/api/treewalker/previoussibling/index.md
+++ b/files/en-us/web/api/treewalker/previoussibling/index.md
@@ -21,7 +21,7 @@ there is no such node, return `null` and the current node is not changed.
 
 ## Syntax
 
-```js
+```js-nolint
 previousSibling()
 ```
 

--- a/files/en-us/web/api/trustedhtml/tojson/index.md
+++ b/files/en-us/web/api/trustedhtml/tojson/index.md
@@ -17,7 +17,7 @@ The **`toJSON()`** method of the {{domxref("TrustedHTML")}} interface returns a 
 
 ## Syntax
 
-```js
+```js-nolint
 toJSON()
 ```
 

--- a/files/en-us/web/api/trustedhtml/tostring/index.md
+++ b/files/en-us/web/api/trustedhtml/tostring/index.md
@@ -17,7 +17,7 @@ The **`toString()`** method of the {{domxref("TrustedHTML")}} interface returns 
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/trustedscript/tojson/index.md
+++ b/files/en-us/web/api/trustedscript/tojson/index.md
@@ -17,7 +17,7 @@ The **`toJSON()`** method of the {{domxref("TrustedScript")}} interface returns 
 
 ## Syntax
 
-```js
+```js-nolint
 toJSON()
 ```
 

--- a/files/en-us/web/api/trustedscript/tostring/index.md
+++ b/files/en-us/web/api/trustedscript/tostring/index.md
@@ -17,7 +17,7 @@ The **`toString()`** method of the {{domxref("TrustedScript")}} interface return
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/trustedscripturl/tojson/index.md
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.md
@@ -17,7 +17,7 @@ The **`toJSON()`** method of the {{domxref("TrustedScriptURL")}} interface retur
 
 ## Syntax
 
-```js
+```js-nolint
 toJSON()
 ```
 

--- a/files/en-us/web/api/trustedscripturl/tostring/index.md
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.md
@@ -17,7 +17,7 @@ The **`toString()`** method of the {{domxref("TrustedScriptURL")}} interface ret
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
@@ -17,7 +17,7 @@ The **`createHTML()`** method of the {{domxref("TrustedTypePolicy")}} interface 
 
 ## Syntax
 
-```js
+```js-nolint
 createHTML(input)
 createHTML(input, args)
 ```

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.md
@@ -17,7 +17,7 @@ The **`createScript()`** method of the {{domxref("TrustedTypePolicy")}} interfac
 
 ## Syntax
 
-```js
+```js-nolint
 createScript(input)
 createScript(input, args)
 ```

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
@@ -17,7 +17,7 @@ The **`createScriptURL()`** method of the {{domxref("TrustedTypePolicy")}} inter
 
 ## Syntax
 
-```js
+```js-nolint
 createScriptURL(input)
 createScriptURL(input, args)
 ```

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -25,7 +25,7 @@ In Chrome a policy with a name of "default" creates a special policy that will b
 
 ## Syntax
 
-```js
+```js-nolint
 createPolicy(policyName, policyOptions)
 ```
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -17,7 +17,7 @@ The **`getAttributeType()`** method of the {{domxref("TrustedTypePolicyFactory")
 
 ## Syntax
 
-```js
+```js-nolint
 getAttributeType(tagName, attribute)
 getAttributeType(tagName, attribute, elementNS)
 getAttributeType(tagName, attribute, elementNS, attrNS)

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -17,7 +17,7 @@ The **`getPropertyType()`** method of the {{domxref("TrustedTypePolicyFactory")}
 
 ## Syntax
 
-```js
+```js-nolint
 getPropertyType(tagName, property)
 getPropertyType(tagName, property, elementNS)
 ```

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
@@ -19,7 +19,7 @@ The **`isHTML()`** method of the {{domxref("TrustedTypePolicyFactory")}} interfa
 
 ## Syntax
 
-```js
+```js-nolint
 isHTML(value)
 ```
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
@@ -19,7 +19,7 @@ The **`isScript()`** method of the {{domxref("TrustedTypePolicyFactory")}} inter
 
 ## Syntax
 
-```js
+```js-nolint
 isScript(value)
 ```
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
@@ -19,7 +19,7 @@ The **`isScriptURL()`** method of the {{domxref("TrustedTypePolicyFactory")}} in
 
 ## Syntax
 
-```js
+```js-nolint
 isScriptURL(value)
 ```
 

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -28,7 +28,7 @@ dispatched, it doesn't do anything anymore.
 
 ## Syntax
 
-```js
+```js-nolint
 initUIEvent(type, canBubble, cancelable, view, detail)
 ```
 

--- a/files/en-us/web/api/uievent/uievent/index.md
+++ b/files/en-us/web/api/uievent/uievent/index.md
@@ -19,7 +19,7 @@ The **`UIEvent()`** constructor creates a new {{domxref("UIEvent")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 new UIEvent(type)
 new UIEvent(type, options)
 ```

--- a/files/en-us/web/api/url/createobjecturl/index.md
+++ b/files/en-us/web/api/url/createobjecturl/index.md
@@ -34,7 +34,7 @@ To release an object URL, call {{domxref("URL.revokeObjectURL", "revokeObjectURL
 
 ## Syntax
 
-```js
+```js-nolint
 createObjectURL(object)
 ```
 

--- a/files/en-us/web/api/url/revokeobjecturl/index.md
+++ b/files/en-us/web/api/url/revokeobjecturl/index.md
@@ -29,7 +29,7 @@ longer.
 
 ## Syntax
 
-```js
+```js-nolint
 revokeObjectURL(objectURL)
 ```
 

--- a/files/en-us/web/api/url/tojson/index.md
+++ b/files/en-us/web/api/url/tojson/index.md
@@ -23,7 +23,7 @@ although in practice it seems to have the same effect as
 
 ## Syntax
 
-```js
+```js-nolint
 toJSON()
 ```
 

--- a/files/en-us/web/api/url/tostring/index.md
+++ b/files/en-us/web/api/url/tostring/index.md
@@ -22,7 +22,7 @@ of {{domxref("URL.href")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -24,7 +24,7 @@ If the given base URL or the resulting URL are not valid URLs, the JavaScript
 
 ## Syntax
 
-```js
+```js-nolint
 new URL(url)
 new URL(url, base)
 ```

--- a/files/en-us/web/api/urlpattern/exec/index.md
+++ b/files/en-us/web/api/urlpattern/exec/index.md
@@ -24,7 +24,7 @@ pattern.
 
 ## Syntax
 
-```js
+```js-nolint
 exec(input)
 exec(input, baseURL)
 ```

--- a/files/en-us/web/api/urlpattern/test/index.md
+++ b/files/en-us/web/api/urlpattern/test/index.md
@@ -23,7 +23,7 @@ the current pattern.
 
 ## Syntax
 
-```js
+```js-nolint
 test(input)
 test(input, baseURL)
 ```

--- a/files/en-us/web/api/urlpattern/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/urlpattern/index.md
@@ -22,7 +22,7 @@ object representing the url pattern defined by the parameters.
 
 ## Syntax
 
-```js
+```js-nolint
 new URLPattern(input)
 new URLPattern(input, baseURL)
 ```

--- a/files/en-us/web/api/urlsearchparams/append/index.md
+++ b/files/en-us/web/api/urlsearchparams/append/index.md
@@ -23,7 +23,7 @@ appear in the parameter string multiple times for each value.
 
 ## Syntax
 
-```js
+```js-nolint
 append(name, value)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -21,7 +21,7 @@ list of all search parameters.
 
 ## Syntax
 
-```js
+```js-nolint
 delete(name)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -23,7 +23,7 @@ string objects.
 
 ## Syntax
 
-```js
+```js-nolint
 entries()
 ```
 

--- a/files/en-us/web/api/urlsearchparams/foreach/index.md
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.md
@@ -21,7 +21,7 @@ in this object via a callback function.
 
 ## Syntax
 
-```js
+```js-nolint
 forEach(callback)
 forEach(callback, thisArg)
 ```

--- a/files/en-us/web/api/urlsearchparams/get/index.md
+++ b/files/en-us/web/api/urlsearchparams/get/index.md
@@ -20,7 +20,7 @@ interface returns the first value associated to the given search parameter.
 
 ## Syntax
 
-```js
+```js-nolint
 get(name)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/getall/index.md
+++ b/files/en-us/web/api/urlsearchparams/getall/index.md
@@ -20,7 +20,7 @@ interface returns all the values associated with a given search parameter as an 
 
 ## Syntax
 
-```js
+```js-nolint
 getAll(name)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -21,7 +21,7 @@ specified name exists.
 
 ## Syntax
 
-```js
+```js-nolint
 has(name)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/keys/index.md
+++ b/files/en-us/web/api/urlsearchparams/keys/index.md
@@ -22,7 +22,7 @@ objects.
 
 ## Syntax
 
-```js
+```js-nolint
 keys()
 ```
 

--- a/files/en-us/web/api/urlsearchparams/set/index.md
+++ b/files/en-us/web/api/urlsearchparams/set/index.md
@@ -22,7 +22,7 @@ parameter doesn't exist, this method creates it.
 
 ## Syntax
 
-```js
+```js-nolint
 set(name, value)
 ```
 

--- a/files/en-us/web/api/urlsearchparams/sort/index.md
+++ b/files/en-us/web/api/urlsearchparams/sort/index.md
@@ -23,7 +23,7 @@ preserved).
 
 ## Syntax
 
-```js
+```js-nolint
 sort()
 ```
 

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -25,7 +25,7 @@ URL.
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -20,7 +20,7 @@ new {{domxref("URLSearchParams")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 new URLSearchParams()
 new URLSearchParams(init)
 ```

--- a/files/en-us/web/api/urlsearchparams/values/index.md
+++ b/files/en-us/web/api/urlsearchparams/values/index.md
@@ -23,7 +23,7 @@ objects.
 
 ## Syntax
 
-```js
+```js-nolint
 values()
 ```
 

--- a/files/en-us/web/api/usb/getdevices/index.md
+++ b/files/en-us/web/api/usb/getdevices/index.md
@@ -23,7 +23,7 @@ objects for paired attached devices. For information on pairing devices, see
 
 ## Syntax
 
-```js
+```js-nolint
 getDevices()
 ```
 

--- a/files/en-us/web/api/usb/requestdevice/index.md
+++ b/files/en-us/web/api/usb/requestdevice/index.md
@@ -23,7 +23,7 @@ triggers the user agent's pairing flow.
 
 ## Syntax
 
-```js
+```js-nolint
 requestDevice(filters)
 ```
 

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
@@ -23,7 +23,7 @@ the configuration on the provided USBDevice with the given configuration value.
 
 ## Syntax
 
-```js
+```js-nolint
 new USBConfiguration(device, configurationValue)
 ```
 

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
@@ -19,7 +19,7 @@ it is created by the browser in response to the connection and disconnection of 
 
 ## Syntax
 
-```js
+```js-nolint
 new USBConnectionEvent(type, options)
 ```
 

--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -23,7 +23,7 @@ the requested interface is claimed for exclusive access.
 
 ## Syntax
 
-```js
+```js-nolint
 claimInterface(interfaceNumber)
 ```
 

--- a/files/en-us/web/api/usbdevice/clearhalt/index.md
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.md
@@ -25,7 +25,7 @@ terminology) to clear that condition. See the for details.
 
 ## Syntax
 
-```js
+```js-nolint
 clearHalt(direction, endpointNumber)
 ```
 

--- a/files/en-us/web/api/usbdevice/close/index.md
+++ b/files/en-us/web/api/usbdevice/close/index.md
@@ -23,7 +23,7 @@ released and the device session has ended.
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/usbdevice/controltransferin/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.md
@@ -24,7 +24,7 @@ been received from the USB device.
 
 ## Syntax
 
-```js
+```js-nolint
 controlTransferIn(setup, length)
 ```
 

--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -24,7 +24,7 @@ transmitted to the USB device.
 
 ## Syntax
 
-```js
+```js-nolint
 controlTransferOut(setup, data)
 ```
 

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
@@ -24,7 +24,7 @@ transmitted received from the USB device.
 
 ## Syntax
 
-```js
+```js-nolint
 isochronousTransferIn(endpointNumber, packetLengths)
 ```
 

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
@@ -24,7 +24,7 @@ transmitted to the USB device.
 
 ## Syntax
 
-```js
+```js-nolint
 isochronousTransferOut(endpointNumber, data, packetLengths)
 ```
 

--- a/files/en-us/web/api/usbdevice/open/index.md
+++ b/files/en-us/web/api/usbdevice/open/index.md
@@ -23,7 +23,7 @@ started.
 
 ## Syntax
 
-```js
+```js-nolint
 open()
 ```
 

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.md
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.md
@@ -23,7 +23,7 @@ claimed interface is released from exclusive access.
 
 ## Syntax
 
-```js
+```js-nolint
 releaseInterface(interfaceNumber)
 ```
 

--- a/files/en-us/web/api/usbdevice/reset/index.md
+++ b/files/en-us/web/api/usbdevice/reset/index.md
@@ -23,7 +23,7 @@ app operations canceled and their promises rejected.
 
 ## Syntax
 
-```js
+```js-nolint
 reset()
 ```
 

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
@@ -23,7 +23,7 @@ the specified alternative endpoint is selected.
 
 ## Syntax
 
-```js
+```js-nolint
 selectAlternateInterface(interfaceNumber, alternateSetting)
 ```
 

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.md
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.md
@@ -23,7 +23,7 @@ the specified configuration is selected.
 
 ## Syntax
 
-```js
+```js-nolint
 selectConfiguration(configurationValue)
 ```
 

--- a/files/en-us/web/api/usbdevice/transferin/index.md
+++ b/files/en-us/web/api/usbdevice/transferin/index.md
@@ -24,7 +24,7 @@ device.
 
 ## Syntax
 
-```js
+```js-nolint
 transferIn(endpointNumber, length)
 ```
 

--- a/files/en-us/web/api/usbdevice/transferout/index.md
+++ b/files/en-us/web/api/usbdevice/transferout/index.md
@@ -24,7 +24,7 @@ device.
 
 ## Syntax
 
-```js
+```js-nolint
 transferOut(endpointNumber, data)
 ```
 

--- a/files/en-us/web/api/videocolorspace/tojson/index.md
+++ b/files/en-us/web/api/videocolorspace/tojson/index.md
@@ -17,7 +17,7 @@ The **`toJSON()`** method of the {{domxref("VideoColorSpace")}} interface is a _
 
 ## Syntax
 
-```js
+```js-nolint
 toJSON()
 ```
 

--- a/files/en-us/web/api/videocolorspace/videocolorspace/index.md
+++ b/files/en-us/web/api/videocolorspace/videocolorspace/index.md
@@ -17,7 +17,7 @@ The **`VideoColorSpace()`** constructor creates a new {{domxref("VideoColorSpace
 
 ## Syntax
 
-```js
+```js-nolint
 new VideoColorSpace()
 new VideoColorSpace(init)
 ```

--- a/files/en-us/web/api/videodecoder/close/index.md
+++ b/files/en-us/web/api/videodecoder/close/index.md
@@ -18,7 +18,7 @@ The **`close()`** method of the {{domxref("VideoDecoder")}} interface ends all p
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -18,7 +18,7 @@ The **`configure()`** method of the {{domxref("VideoDecoder")}} interface enqueu
 
 ## Syntax
 
-```js
+```js-nolint
 configure(config)
 ```
 

--- a/files/en-us/web/api/videodecoder/decode/index.md
+++ b/files/en-us/web/api/videodecoder/decode/index.md
@@ -18,7 +18,7 @@ The **`decode()`** method of the {{domxref("VideoDecoder")}} interface enqueues 
 
 ## Syntax
 
-```js
+```js-nolint
 decode(chunk)
 ```
 

--- a/files/en-us/web/api/videodecoder/flush/index.md
+++ b/files/en-us/web/api/videodecoder/flush/index.md
@@ -18,7 +18,7 @@ The **`flush()`** method of the {{domxref("VideoDecoder")}} interface returns a 
 
 ## Syntax
 
-```js
+```js-nolint
 flush()
 ```
 

--- a/files/en-us/web/api/videodecoder/reset/index.md
+++ b/files/en-us/web/api/videodecoder/reset/index.md
@@ -18,7 +18,7 @@ The **`reset()`** method of the {{domxref("VideoDecoder")}} interface resets all
 
 ## Syntax
 
-```js
+```js-nolint
 reset()
 ```
 

--- a/files/en-us/web/api/videodecoder/videodecoder/index.md
+++ b/files/en-us/web/api/videodecoder/videodecoder/index.md
@@ -17,7 +17,7 @@ The **`VideoDecoder()`** constructor creates a new {{domxref("VideoDecoder")}} o
 
 ## Syntax
 
-```js
+```js-nolint
 new VideoDecoder(init)
 ```
 

--- a/files/en-us/web/api/videoencoder/close/index.md
+++ b/files/en-us/web/api/videoencoder/close/index.md
@@ -18,7 +18,7 @@ The **`close()`** method of the {{domxref("VideoEncoder")}} interface ends all p
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -18,7 +18,7 @@ The **`configure()`** method of the {{domxref("VideoEncoder")}} interface enqueu
 
 ## Syntax
 
-```js
+```js-nolint
 configure(config)
 ```
 

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -18,7 +18,7 @@ The **`encode()`** method of the {{domxref("VideoEncoder")}} interface enqueues 
 
 ## Syntax
 
-```js
+```js-nolint
 encode(frame)
 encode(frame, options)
 ```

--- a/files/en-us/web/api/videoencoder/flush/index.md
+++ b/files/en-us/web/api/videoencoder/flush/index.md
@@ -18,7 +18,7 @@ The **`flush()`** method of the {{domxref("VideoEncoder")}} interface returns a 
 
 ## Syntax
 
-```js
+```js-nolint
 flush()
 ```
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -18,7 +18,7 @@ The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} i
 
 ## Syntax
 
-```js
+```js-nolint
 isConfigSupported(config)
 ```
 

--- a/files/en-us/web/api/videoencoder/reset/index.md
+++ b/files/en-us/web/api/videoencoder/reset/index.md
@@ -18,7 +18,7 @@ The **`reset()`** method of the {{domxref("VideoEncoder")}} interface resets all
 
 ## Syntax
 
-```js
+```js-nolint
 reset()
 ```
 

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -17,7 +17,7 @@ The **`VideoEncoder()`** constructor creates a new {{domxref("VideoEncoder")}} o
 
 ## Syntax
 
-```js
+```js-nolint
 new VideoEncoder(init)
 ```
 

--- a/files/en-us/web/api/videoframe/allocationsize/index.md
+++ b/files/en-us/web/api/videoframe/allocationsize/index.md
@@ -18,7 +18,7 @@ The **`allocationSize()`** method of the {{domxref("VideoFrame")}} interface ret
 
 ## Syntax
 
-```js
+```js-nolint
 allocationSize()
 allocationSize(options)
 ```

--- a/files/en-us/web/api/videoframe/clone/index.md
+++ b/files/en-us/web/api/videoframe/clone/index.md
@@ -18,7 +18,7 @@ The **`clone()`** method of the {{domxref("VideoFrame")}} interface creates a ne
 
 ## Syntax
 
-```js
+```js-nolint
 clone()
 ```
 

--- a/files/en-us/web/api/videoframe/close/index.md
+++ b/files/en-us/web/api/videoframe/close/index.md
@@ -18,7 +18,7 @@ The **`close()`** method of the {{domxref("VideoFrame")}} interface clears all s
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -18,7 +18,7 @@ The **`copyTo()`** method of the {{domxref("VideoFrame")}} interface copies the 
 
 ## Syntax
 
-```js
+```js-nolint
 copyTo(destination)
 copyTo(destination, options)
 ```

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -17,7 +17,7 @@ The **`VideoFrame()`** constructor creates a new {{domxref("VideoFrame")}} objec
 
 ## Syntax
 
-```js
+```js-nolint
 new VideoFrame(image)
 new VideoFrame(image, init)
 new VideoFrame(data, init)

--- a/files/en-us/web/api/videotracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/videotracklist/gettrackbyid/index.md
@@ -31,7 +31,7 @@ you know its ID string.
 
 ## Syntax
 
-```js
+```js-nolint
 getTrackById(id)
 ```
 

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
@@ -24,7 +24,7 @@ The **`cancelAnimationFrame()`** method of the {{domxref("VRDisplay")}} interfac
 
 ## Syntax
 
-```js
+```js-nolint
 cancelAnimationFrame(handle)
 ```
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.md
@@ -24,7 +24,7 @@ The **`exitPresent()`** method of the {{domxref("VRDisplay")}} interface stops t
 
 ## Syntax
 
-```js
+```js-nolint
 exitPresent()
 ```
 

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
@@ -25,7 +25,7 @@ The **`getEyeParameters()`** method of the {{domxref("VRDisplay")}} interface re
 
 ## Syntax
 
-```js
+```js-nolint
 getEyeParameters(whichEye)
 ```
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.md
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.md
@@ -26,7 +26,7 @@ This includes the {{domxref("VRPose")}} and view and projection matrices for the
 
 ## Syntax
 
-```js
+```js-nolint
 getFrameData(frameData)
 ```
 

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.md
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.md
@@ -25,7 +25,7 @@ The **`getImmediatePose()`** method of the {{domxref("VRDisplay")}} interface re
 
 ## Syntax
 
-```js
+```js-nolint
 getImmediatePose()
 ```
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.md
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.md
@@ -25,7 +25,7 @@ The **`getLayers()`** method of the {{domxref("VRDisplay")}} interface returns t
 
 ## Syntax
 
-```js
+```js-nolint
 getLayers()
 ```
 

--- a/files/en-us/web/api/vrdisplay/getpose/index.md
+++ b/files/en-us/web/api/vrdisplay/getpose/index.md
@@ -26,7 +26,7 @@ The **`getPose()`** method of the {{domxref("VRDisplay")}} interface returns a {
 
 ## Syntax
 
-```js
+```js-nolint
 getPose()
 ```
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
@@ -27,7 +27,7 @@ The **`requestAnimationFrame()`** method of the {{domxref("VRDisplay")}} interfa
 
 ## Syntax
 
-```js
+```js-nolint
 requestAnimationFrame(callback)
 ```
 

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.md
@@ -24,7 +24,7 @@ The **`requestPresent()`** method of the {{domxref("VRDisplay")}} interface star
 
 ## Syntax
 
-```js
+```js-nolint
 requestPresent(layers)
 ```
 

--- a/files/en-us/web/api/vrdisplay/resetpose/index.md
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.md
@@ -28,7 +28,7 @@ The VRDisplay's reported roll and pitch do not change when `resetPose()` is call
 
 ## Syntax
 
-```js
+```js-nolint
 resetPose()
 ```
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.md
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.md
@@ -26,7 +26,7 @@ The frame should subsequently be rendered using the {{domxref("VRPose")}} and ma
 
 ## Syntax
 
-```js
+```js-nolint
 submitFrame()
 ```
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
@@ -23,8 +23,8 @@ The **`VRDisplayEvent()`** constructor creates a {{domxref("VRDisplayEvent")}} o
 
 ## Syntax
 
-```js
-new VRDisplayEvent(type, options);
+```js-nolint
+new VRDisplayEvent(type, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrframedata/vrframedata/index.md
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.md
@@ -23,7 +23,7 @@ The **`VRFrameData()`** constructor creates a {{domxref("VRFrameData")}} object 
 
 ## Syntax
 
-```js
+```js-nolint
 new VRFrameData()
 ```
 

--- a/files/en-us/web/api/vttcue/getcueashtml/index.md
+++ b/files/en-us/web/api/vttcue/getcueashtml/index.md
@@ -17,7 +17,7 @@ The **`getCueAsHTML()`** method of the {{domxref("VTTCue")}} interface returns a
 
 ## Syntax
 
-```js
+```js-nolint
 getCueAsHTML()
 ```
 

--- a/files/en-us/web/api/vttcue/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/vttcue/index.md
@@ -23,7 +23,7 @@ The **`VTTCue()`** constructor creates and returns a new
 
 ## Syntax
 
-```js
+```js-nolint
 new VTTCue(startTime, endTime, text)
 ```
 

--- a/files/en-us/web/api/wakelock/request/index.md
+++ b/files/en-us/web/api/wakelock/request/index.md
@@ -21,7 +21,7 @@ locking.
 
 ## Syntax
 
-```js
+```js-nolint
 request(type)
 ```
 

--- a/files/en-us/web/api/wakelocksentinel/release/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release/index.md
@@ -23,7 +23,7 @@ once the sentinel has been successfully released.
 
 ## Syntax
 
-```js
+```js-nolint
 release()
 ```
 

--- a/files/en-us/web/api/wakelocksentinel/released/index.md
+++ b/files/en-us/web/api/wakelocksentinel/released/index.md
@@ -19,8 +19,8 @@ a {{domxref("WakeLockSentinel")}} has been released yet.
 
 ## Syntax
 
-```js
-const released = sentinel.released;
+```js-nolint
+const released = sentinel.released
 ```
 
 ### Value

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.md
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.md
@@ -22,7 +22,7 @@ represents a non-linear distorter.
 
 ## Syntax
 
-```js
+```js-nolint
 new WaveShaperNode(context, options)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.beginQuery()`** method of the [WebGL 2 API](/en-US
 
 ## Syntax
 
-```js
+```js-nolint
 beginQuery(target, query)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
@@ -19,7 +19,7 @@ feedback operation.
 
 ## Syntax
 
-```js
+```js-nolint
 beginTransformFeedback(primitiveMode)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
@@ -20,7 +20,7 @@ The **`WebGL2RenderingContext.bindBufferBase()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 bindBufferBase(target, index, buffer)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
@@ -20,7 +20,7 @@ the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) binds a range of a given
 
 ## Syntax
 
-```js
+```js-nolint
 bindBufferRange(target, index, buffer, offset, size)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLSampler")}} object to the texture unit at the passed inde
 
 ## Syntax
 
-```js
+```js-nolint
 bindSampler(unit, sampler)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
@@ -19,7 +19,7 @@ passed {{domxref("WebGLTransformFeedback")}} object to the current GL state.
 
 ## Syntax
 
-```js
+```js-nolint
 bindTransformFeedback(target, transformFeedback)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
@@ -19,7 +19,7 @@ passed {{domxref("WebGLVertexArrayObject")}} object to the buffer.
 
 ## Syntax
 
-```js
+```js-nolint
 bindVertexArray(vertexArray)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
@@ -20,7 +20,7 @@ using {{domxref("WebGLRenderingContext.bindFramebuffer()")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 blitFramebuffer(srcX0, srcY0, srcX1, srcY1,
                 dstX0, dstY0, dstX1, dstY1,
                 mask, filter)

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
@@ -19,7 +19,7 @@ currently bound framebuffer.
 
 ## Syntax
 
-```js
+```js-nolint
 clearBufferfv(buffer, drawbuffer, values)
 clearBufferfv(buffer, drawbuffer, values, srcOffset)
 

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
@@ -19,7 +19,7 @@ The **`WebGL2RenderingContext.clientWaitSync()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 clientWaitSync(sync, flags, timeout)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
@@ -19,7 +19,7 @@ three-dimensional sub-rectangle for a texture image in a compressed format.
 
 ## Syntax
 
-```js
+```js-nolint
 compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset)
 
 compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, srcData)

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
@@ -19,7 +19,7 @@ buffer to another buffer.
 
 ## Syntax
 
-```js
+```js-nolint
 copyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
@@ -19,7 +19,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) copies pixels from the current
 
 ## Syntax
 
-```js
+```js-nolint
 copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
@@ -19,7 +19,7 @@ information.
 
 ## Syntax
 
-```js
+```js-nolint
 createQuery()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
@@ -19,7 +19,7 @@ The **`WebGL2RenderingContext.createSampler()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 createSampler()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
@@ -19,7 +19,7 @@ initializes {{domxref("WebGLTransformFeedback")}} objects.
 
 ## Syntax
 
-```js
+```js-nolint
 createTransformFeedback()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
@@ -21,7 +21,7 @@ data.
 
 ## Syntax
 
-```js
+```js-nolint
 createVertexArray()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.deleteQuery()`** method of the [WebGL 2 API](/en-U
 
 ## Syntax
 
-```js
+```js-nolint
 deleteQuery(query)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
@@ -19,7 +19,7 @@ The **`WebGL2RenderingContext.deleteSampler()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 deleteSampler(sampler)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.deleteSync()`** method of the [WebGL 2 API](/en-US
 
 ## Syntax
 
-```js
+```js-nolint
 deleteSync(sync)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
@@ -19,7 +19,7 @@ method of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) deletes a given
 
 ## Syntax
 
-```js
+```js-nolint
 deleteTransformFeedback(transformFeedback)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
@@ -19,7 +19,7 @@ the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) deletes a given
 
 ## Syntax
 
-```js
+```js-nolint
 deleteVertexArray(vertexArray)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
@@ -24,7 +24,7 @@ method. In addition, it can execute multiple instances of the range of elements.
 
 ## Syntax
 
-```js
+```js-nolint
 drawArraysInstanced(mode, first, count, instanceCount)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -19,7 +19,7 @@ currently bound framebuffer or the drawingbuffer if no framebuffer is bound.
 
 ## Syntax
 
-```js
+```js-nolint
 drawBuffers(buffers)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
@@ -24,7 +24,7 @@ of elements.
 
 ## Syntax
 
-```js
+```js-nolint
 drawElementsInstanced(mode, count, type, offset, instanceCount)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
@@ -19,7 +19,7 @@ data in a given range.
 
 ## Syntax
 
-```js
+```js-nolint
 drawRangeElements(mode, start, end, count, type, offset)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
@@ -18,7 +18,7 @@ target.
 
 ## Syntax
 
-```js
+```js-nolint
 endQuery(target)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
@@ -19,7 +19,7 @@ operation.
 
 ## Syntax
 
-```js
+```js-nolint
 endTransformFeedback()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.fenceSync()`** method of the [WebGL 2 API](/en-US/
 
 ## Syntax
 
-```js
+```js-nolint
 fenceSync(condition, flags)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.md
@@ -22,7 +22,7 @@ but only a given single layer of the texture level is attached to the attachment
 
 ## Syntax
 
-```js
+```js-nolint
 framebufferTextureLayer(target, attachment, texture, level, layer)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
@@ -19,7 +19,7 @@ of the active uniform block at a given index within a {{domxref("WebGLProgram")}
 
 ## Syntax
 
-```js
+```js-nolint
 getActiveUniformBlockName(program, uniformBlockIndex)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -20,7 +20,7 @@ information about an active uniform block within a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 getActiveUniformBlockParameter(program, uniformBlockIndex, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
@@ -19,7 +19,7 @@ active uniforms within a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 getActiveUniforms(program, uniformIndices, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
@@ -20,7 +20,7 @@ binding point and writes them to an {{jsxref("ArrayBuffer")}} or
 
 ## Syntax
 
-```js
+```js-nolint
 getBufferSubData(target, srcByteOffset, dstData)
 getBufferSubData(target, srcByteOffset, dstData, dstOffset)
 getBufferSubData(target, srcByteOffset, dstData, dstOffset, length)

--- a/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.md
@@ -19,7 +19,7 @@ color numbers to user-defined varying out variables.
 
 ## Syntax
 
-```js
+```js-nolint
 getFragDataLocation(program, name)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
@@ -19,7 +19,7 @@ information about a given `target`.
 
 ## Syntax
 
-```js
+```js-nolint
 getIndexedParameter(target, index)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
@@ -19,7 +19,7 @@ information about implementation-dependent support for internal formats.
 
 ## Syntax
 
-```js
+```js-nolint
 getInternalformatParameter(target, internalformat, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.getQuery()`** method of the [WebGL 2 API](/en-US/d
 
 ## Syntax
 
-```js
+```js-nolint
 getQuery(target, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
@@ -19,7 +19,7 @@ information of a {{domxref("WebGLQuery")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 getQueryParameter(query, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
@@ -19,7 +19,7 @@ information of a {{domxref("WebGLSampler")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 getSamplerParameter(sampler, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
@@ -19,7 +19,7 @@ information of a {{domxref("WebGLSync")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 getSyncParameter(sync, pname)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.md
@@ -19,7 +19,7 @@ information about varying variables from {{domxref("WebGLTransformFeedback")}} b
 
 ## Syntax
 
-```js
+```js-nolint
 getTransformFeedbackVarying(program, index)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
@@ -19,7 +19,7 @@ a uniform block within a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 getUniformBlockIndex(program, uniformBlockName)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
@@ -19,7 +19,7 @@ number of uniforms within a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 getUniformIndices(program, uniformNames)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.md
@@ -19,7 +19,7 @@ of attachments in a framebuffer.
 
 ## Syntax
 
-```js
+```js-nolint
 invalidateFramebuffer(target, attachments)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.md
@@ -19,7 +19,7 @@ portions of the contents of attachments in a framebuffer.
 
 ## Syntax
 
-```js
+```js-nolint
 invalidateSubFramebuffer(target, attachments, x, y, width, height)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
@@ -18,7 +18,7 @@ passed object is a valid {{domxref("WebGLQuery")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 isQuery(query)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
@@ -18,7 +18,7 @@ passed object is a valid {{domxref("WebGLSampler")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 isSampler(sampler)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.md
@@ -18,7 +18,7 @@ passed object is a valid {{domxref("WebGLSync")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 isSync(sync)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
@@ -19,7 +19,7 @@ if the passed object is a valid {{domxref("WebGLTransformFeedback")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 isTransformFeedback(transformFeedback)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
@@ -19,7 +19,7 @@ passed object is a valid {{domxref("WebGLVertexArrayObject")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 isVertexArray(vertexArray)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
@@ -19,7 +19,7 @@ feedback operation.
 
 ## Syntax
 
-```js
+```js-nolint
 pauseTransformFeedback()
 ```
 


### PR DESCRIPTION
Adding to https://github.com/mdn/content/pull/19177

- Updating syntax code blocks with the new tag. Refer: https://github.com/mdn/yari/pull/7017
