### PR TITLE
Tag syntax code blocks with js-nolint, part 12

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.md
@@ -22,7 +22,7 @@ source for pixels for subsequent calls to
 
 ## Syntax
 
-```js
+```js-nolint
 readBuffer(source)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.md
@@ -21,7 +21,7 @@ samples to be used.
 
 ## Syntax
 
-```js
+```js-nolint
 renderbufferStorageMultisample(target, samples, internalFormat, width, height)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -19,7 +19,7 @@ transform feedback operation.
 
 ## Syntax
 
-```js
+```js-nolint
 resumeTransformFeedback()
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
@@ -19,7 +19,7 @@ of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) set
 
 ## Syntax
 
-```js
+```js-nolint
 samplerParameteri(sampler, pname, param)
 samplerParameterf(sampler, pname, param)
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
@@ -18,7 +18,7 @@ texture image.
 
 ## Syntax
 
-```js
+```js-nolint
 texImage3D(target, level, internalformat, width, height, depth, border, format, type, offset)
 texImage3D(target, level, internalformat, width, height, depth, border, format, type, source)
 texImage3D(target, level, internalformat, width, height, depth, border, format, type, srcData)

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.md
@@ -19,7 +19,7 @@ two-dimensional texture storage.
 
 ## Syntax
 
-```js
+```js-nolint
 texStorage2D(target, levels, internalformat, width, height)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.md
@@ -19,7 +19,7 @@ three-dimensional texture or two-dimensional array texture.
 
 ## Syntax
 
-```js
+```js-nolint
 texStorage3D(target, levels, internalformat, width, height, depth)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
@@ -19,7 +19,7 @@ current texture.
 
 ## Syntax
 
-```js
+```js-nolint
 texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels)
 texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset)
 texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, srcData)

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
@@ -19,7 +19,7 @@ to record in {{domxref("WebGLTransformFeedback")}} buffers.
 
 ## Syntax
 
-```js
+```js-nolint
 transformFeedbackVaryings(program, varyings, bufferMode)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
@@ -24,7 +24,7 @@ uniform variables.
 
 ## Syntax
 
-```js
+```js-nolint
 uniform1ui(location, v0)
 uniform2ui(location, v0, v1)
 uniform3ui(location, v0, v1, v2)

--- a/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.md
@@ -19,7 +19,7 @@ for active uniform blocks.
 
 ## Syntax
 
-```js
+```js-nolint
 uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
@@ -23,7 +23,7 @@ values for uniform variables.
 
 ## Syntax
 
-```js
+```js-nolint
 uniformMatrix2fv(location, transpose, data)
 uniformMatrix2fv(location, transpose, data, srcOffset)
 uniformMatrix2fv(location, transpose, data, srcOffset, srcLength)

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
@@ -26,7 +26,7 @@ with {{domxref("WebGL2RenderingContext.drawArraysInstanced()",
 
 ## Syntax
 
-```js
+```js-nolint
 vertexAttribDivisor(index, divisor)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.md
@@ -19,7 +19,7 @@ values for generic vertex attributes.
 
 ## Syntax
 
-```js
+```js-nolint
 vertexAttribI4i(index, v0, v1, v2, v3)
 vertexAttribI4ui(index, v0, v1, v2, v3)
 vertexAttribI4iv(index, value)

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.md
@@ -19,7 +19,7 @@ formats and locations of vertex attributes in a vertex attributes array.
 
 ## Syntax
 
-```js
+```js-nolint
 vertexAttribIPointer(index, size, type, stride, offset)
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
@@ -21,7 +21,7 @@ multiple GL contexts.
 
 ## Syntax
 
-```js
+```js-nolint
 waitSync(sync, flags, timeout)
 ```
 

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
@@ -20,7 +20,7 @@ by the implementation.
 
 ## Syntax
 
-```js
+```js-nolint
 getSupportedProfiles()
 ```
 

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
@@ -19,7 +19,7 @@ you to debug a translated shader.
 
 ## Syntax
 
-```js
+```js-nolint
 getTranslatedShaderSource(shader)
 ```
 

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
@@ -24,7 +24,7 @@ This method is part of the {{domxref("WEBGL_draw_buffers")}} extension.
 
 ## Syntax
 
-```js
+```js-nolint
 drawBuffersWEBGL(buffers)
 ```
 

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -22,7 +22,7 @@ called.
 
 ## Syntax
 
-```js
+```js-nolint
 loseContext()
 ```
 

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -18,7 +18,7 @@ restoring the context of a {{domxref("WebGLRenderingContext")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 restoreContext()
 ```
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -22,7 +22,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 void ext.multiDrawArraysInstancedWEBGL(mode,
     firstsList, firstsOffset,
     countsList, countsOffset,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -23,7 +23,7 @@ method.
 ## Syntax
 
 ```js-nolint
-void ext.multiDrawArraysInstancedWEBGL(mode,
+multiDrawArraysInstancedWEBGL(mode,
     firstsList, firstsOffset,
     countsList, countsOffset,
     instanceCountsList, instanceCountsOffset,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
@@ -22,7 +22,7 @@ method.
 ## Syntax
 
 ```js-nolint
-void ext.multiDrawArraysWEBGL(mode,
+multiDrawArraysWEBGL(mode,
     firstsList, firstsOffset,
     countsList, countsOffset,
     drawCount);

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
@@ -21,7 +21,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 void ext.multiDrawArraysWEBGL(mode,
     firstsList, firstsOffset,
     countsList, countsOffset,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
@@ -23,7 +23,7 @@ method.
 ## Syntax
 
 ```js-nolint
-void ext.multiDrawElementsInstancedWEBGL(mode,
+multiDrawElementsInstancedWEBGL(mode,
     countsList, countsOffset,
     type,
     firstsList, firstsOffset,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
@@ -22,7 +22,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 void ext.multiDrawElementsInstancedWEBGL(mode,
     countsList, countsOffset,
     type,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
@@ -22,7 +22,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 void ext.multiDrawElementsWEBGL(mode,
     countsList, countsOffset,
     type,

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
@@ -23,7 +23,7 @@ method.
 ## Syntax
 
 ```js-nolint
-void ext.multiDrawElementsWEBGL(mode,
+multiDrawElementsWEBGL(mode,
     countsList, countsOffset,
     type,
     firstsList, firstsOffset,

--- a/files/en-us/web/api/webglrenderingcontext/activetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/activetexture/index.md
@@ -19,7 +19,7 @@ make active.
 
 ## Syntax
 
-```js
+```js-nolint
 activeTexture(texture)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
@@ -15,8 +15,8 @@ vertex {{domxref("WebGLShader")}} to a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
-void gl.attachShader(program, shader);
+```js-nolint
+void gl.attachShader(program, shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
@@ -16,7 +16,7 @@ vertex {{domxref("WebGLShader")}} to a {{domxref("WebGLProgram")}}.
 ## Syntax
 
 ```js-nolint
-void gl.attachShader(program, shader)
+attachShader(program, shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.md
@@ -19,7 +19,7 @@ to an attribute variable.
 
 ## Syntax
 
-```js
+```js-nolint
 bindAttribLocation(program, index, name)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.bindBuffer()`** method of the [WebGL API](/en-US/do
 
 ## Syntax
 
-```js
+```js-nolint
 bindBuffer(target, buffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.bindFramebuffer()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 bindFramebuffer(target, framebuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
@@ -20,7 +20,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) binds a given
 
 ## Syntax
 
-```js
+```js-nolint
 bindRenderbuffer(target, renderbuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
@@ -19,7 +19,7 @@ The **`WebGLRenderingContext.bindTexture()`** method of the [WebGL API](/en-US/d
 
 ## Syntax
 
-```js
+```js-nolint
 bindTexture(target, texture)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/blendcolor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendcolor/index.md
@@ -18,7 +18,7 @@ destination blending factors.
 
 ## Syntax
 
-```js
+```js-nolint
 blendColor(red, green, blue, alpha)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/blendequation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendequation/index.md
@@ -22,7 +22,7 @@ The blend equation determines how a new pixel is combined with a pixel already i
 
 ## Syntax
 
-```js
+```js-nolint
 blendEquation(mode)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.md
@@ -22,7 +22,7 @@ The blend equation determines how a new pixel is combined with a pixel already i
 
 ## Syntax
 
-```js
+```js-nolint
 blendEquationSeparate(modeRGB, modeAlpha)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.md
@@ -18,7 +18,7 @@ blending pixel arithmetic.
 
 ## Syntax
 
-```js
+```js-nolint
 blendFunc(sfactor, dfactor)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.md
@@ -19,7 +19,7 @@ for blending pixel arithmetic for RGB and alpha components separately.
 
 ## Syntax
 
-```js
+```js-nolint
 blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
@@ -20,7 +20,7 @@ buffer object's data store.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL1
 bufferData(target, usage)
 bufferData(target, size, usage)

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
@@ -20,7 +20,7 @@ object's data store.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL1
 bufferSubData(target, offset)
 bufferSubData(target, offset, srcData)

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -20,8 +20,8 @@ object.
 
 ## Syntax
 
-```js
-gl.canvas;
+```js-nolint
+gl.canvas
 ```
 
 ### Return value

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
@@ -19,7 +19,7 @@ status of the {{domxref("WebGLFramebuffer")}} object.
 
 ## Syntax
 
-```js
+```js-nolint
 checkFramebufferStatus(target)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.md
@@ -24,7 +24,7 @@ method.
 
 ## Syntax
 
-```js
+```js-nolint
 clear(mask)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/clearcolor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clearcolor/index.md
@@ -22,7 +22,7 @@ between 0 and 1.
 
 ## Syntax
 
-```js
+```js-nolint
 clearColor(red, green, blue, alpha)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/cleardepth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/cleardepth/index.md
@@ -22,7 +22,7 @@ between 0 and 1.
 
 ## Syntax
 
-```js
+```js-nolint
 clearDepth(depth)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/clearstencil/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clearstencil/index.md
@@ -21,7 +21,7 @@ This specifies what stencil value to use when calling the
 
 ## Syntax
 
-```js
+```js-nolint
 clearStencil(s)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/colormask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/colormask/index.md
@@ -18,7 +18,7 @@ enable or to disable when drawing or rendering to a {{domxref("WebGLFramebuffer"
 
 ## Syntax
 
-```js
+```js-nolint
 colorMask(red, green, blue, alpha)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -21,7 +21,7 @@ context is not directly fixed to a specific canvas.
 
 ## Syntax
 
-```js
+```js-nolint
 commit()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
@@ -18,7 +18,7 @@ data so that it can be used by a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 compileShader(shader)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -27,7 +27,7 @@ using these methods.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL 1:
 compressedTexImage2D(target, level, internalformat, width, height, border)
 compressedTexImage2D(target, level, internalformat, width, height, border, pixels)

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
@@ -24,7 +24,7 @@ using this method or a {{domxref("WebGL2RenderingContext")}} must be used.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL 1:
 compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, srcData)
 

--- a/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.md
@@ -20,7 +20,7 @@ The **`WebGLRenderingContext.copyTexImage2D()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 copyTexImage2D(target, level, internalformat, x, y, width, height, border)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.md
@@ -20,7 +20,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) copies pixels from the current
 
 ## Syntax
 
-```js
+```js-nolint
 copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.createBuffer()`** method of the [WebGL API](/en-US/
 
 ## Syntax
 
-```js
+```js-nolint
 createBuffer()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -19,7 +19,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) creates and initializes a
 
 ## Syntax
 
-```js
+```js-nolint
 createFramebuffer()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
@@ -19,7 +19,7 @@ The **`WebGLRenderingContext.createProgram()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 createProgram()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -19,7 +19,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) creates and initializes a
 
 ## Syntax
 
-```js
+```js-nolint
 createRenderbuffer()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.md
@@ -22,7 +22,7 @@ method **`createShader()`** of the [WebGL API](/en-US/docs/Web/API/WebGL_API) cr
 
 ## Syntax
 
-```js
+```js-nolint
 createShader(type)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
@@ -20,7 +20,7 @@ The **`WebGLRenderingContext.createTexture()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 createTexture()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/cullface/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/cullface/index.md
@@ -18,7 +18,7 @@ and/or back-facing polygons can be culled.
 
 ## Syntax
 
-```js
+```js-nolint
 cullFace(mode)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
@@ -19,7 +19,7 @@ deleted. Normally you don't need to call this method yourself, when the buffer o
 
 ## Syntax
 
-```js
+```js-nolint
 deleteBuffer(buffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
@@ -20,7 +20,7 @@ has already been deleted.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteFramebuffer(framebuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
@@ -20,7 +20,7 @@ been deleted.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteProgram(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
@@ -20,7 +20,7 @@ has already been deleted.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteRenderbuffer(renderbuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteshader/index.md
@@ -21,7 +21,7 @@ is destroyed by the garbage collector.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteShader(shader)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
@@ -21,7 +21,7 @@ been deleted.
 
 ## Syntax
 
-```js
+```js-nolint
 deleteTexture(texture)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/depthfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthfunc/index.md
@@ -18,7 +18,7 @@ incoming pixel depth to the current depth buffer value.
 
 ## Syntax
 
-```js
+```js-nolint
 depthFunc(func)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/depthmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthmask/index.md
@@ -18,7 +18,7 @@ buffer is enabled or disabled.
 
 ## Syntax
 
-```js
+```js-nolint
 depthMask(flag)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/depthrange/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthrange/index.md
@@ -18,7 +18,7 @@ from normalized device coordinates to window or viewport coordinates.
 
 ## Syntax
 
-```js
+```js-nolint
 depthRange(zNear, zFar)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
@@ -16,7 +16,7 @@ attached {{domxref("WebGLShader")}} from a {{domxref("WebGLProgram")}}.
 ## Syntax
 
 ```js-nolint
-void gl.detachShader(program, shader)
+detachShader(program, shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
@@ -15,8 +15,8 @@ attached {{domxref("WebGLShader")}} from a {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
-void gl.detachShader(program, shader);
+```js-nolint
+void gl.detachShader(program, shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.md
@@ -18,7 +18,7 @@ capabilities for this context.
 
 ## Syntax
 
-```js
+```js-nolint
 disable(capability)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.md
@@ -19,7 +19,7 @@ vertex attribute array off at a given index position.
 
 ## Syntax
 
-```js
+```js-nolint
 disableVertexAttribArray(index)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.drawArrays()`** method of the [WebGL API](/en-US/do
 
 ## Syntax
 
-```js
+```js-nolint
 drawArrays(mode, first, count)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.drawElements()`** method of the [WebGL API](/en-US/
 
 ## Syntax
 
-```js
+```js-nolint
 drawElements(mode, count, type, offset)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.md
@@ -18,7 +18,7 @@ for this context.
 
 ## Syntax
 
-```js
+```js-nolint
 enable(cap)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -44,7 +44,7 @@ access the attribute, including {{domxref("WebGLRenderingContext.vertexAttribPoi
 
 ## Syntax
 
-```js
+```js-nolint
 enableVertexAttribArray(index)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/finish/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/finish/index.md
@@ -18,7 +18,7 @@ previously called commands are finished.
 
 ## Syntax
 
-```js
+```js-nolint
 finish()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/flush/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/flush/index.md
@@ -18,7 +18,7 @@ causing all commands to be executed as quickly as possible.
 
 ## Syntax
 
-```js
+```js-nolint
 flush()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.md
@@ -19,7 +19,7 @@ method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) attaches a
 
 ## Syntax
 
-```js
+```js-nolint
 framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.md
@@ -19,7 +19,7 @@ of the [WebGL API](/en-US/docs/Web/API/WebGL_API) attaches a texture to a
 
 ## Syntax
 
-```js
+```js-nolint
 framebufferTexture2D(target, attachment, textarget, texture, level)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/frontface/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/frontface/index.md
@@ -18,7 +18,7 @@ front- or back-facing by setting a winding orientation.
 
 ## Syntax
 
-```js
+```js-nolint
 frontFace(mode)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
@@ -25,7 +25,7 @@ resolution until a 1x1 dimension texture image is created.
 
 ## Syntax
 
-```js
+```js-nolint
 generateMipmap(target)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
@@ -21,7 +21,7 @@ generic library creation.
 
 ## Syntax
 
-```js
+```js-nolint
 getActiveAttrib(program, index)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
@@ -21,7 +21,7 @@ generic library creation.
 
 ## Syntax
 
-```js
+```js-nolint
 getActiveUniform(program, index)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
@@ -19,7 +19,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) returns a list of
 
 ## Syntax
 
-```js
+```js-nolint
 getAttachedShaders(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.md
@@ -19,7 +19,7 @@ attribute variable in a given {{domxref("WebGLProgram")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 getAttribLocation(program, name)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.md
@@ -19,7 +19,7 @@ buffer.
 
 ## Syntax
 
-```js
+```js-nolint
 getBufferParameter(target, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -19,7 +19,7 @@ parameters. Might return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators
 
 ## Syntax
 
-```js
+```js-nolint
 getContextAttributes()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/geterror/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/geterror/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.getError()`** method of the [WebGL API](/en-US/docs
 
 ## Syntax
 
-```js
+```js-nolint
 getError()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.getExtension()`** method enables a
 
 ## Syntax
 
-```js
+```js-nolint
 getExtension(name)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
@@ -20,7 +20,7 @@ about a framebuffer's attachment.
 
 ## Syntax
 
-```js
+```js-nolint
 getFramebufferAttachmentParameter(target, attachment, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
@@ -18,7 +18,7 @@ parameter name.
 
 ## Syntax
 
-```js
+```js-nolint
 getParameter(pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
@@ -19,7 +19,7 @@ occurred during failed linking or validation of `WebGLProgram` objects.
 
 ## Syntax
 
-```js
+```js-nolint
 getProgramInfoLog(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
@@ -20,7 +20,7 @@ given program.
 
 ## Syntax
 
-```js
+```js-nolint
 getProgramParameter(program, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
@@ -19,7 +19,7 @@ about the renderbuffer.
 
 ## Syntax
 
-```js
+```js-nolint
 getRenderbufferParameter(target, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
@@ -19,7 +19,7 @@ compile information.
 
 ## Syntax
 
-```js
+```js-nolint
 getShaderInfoLog(shader)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
@@ -19,7 +19,7 @@ given shader.
 
 ## Syntax
 
-```js
+```js-nolint
 getShaderParameter(shader, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
@@ -21,7 +21,7 @@ the specified shader numeric format.
 
 ## Syntax
 
-```js
+```js-nolint
 getShaderPrecisionFormat(shaderType, precisionType)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
@@ -19,7 +19,7 @@ The **`WebGLRenderingContext.getShaderSource()`** method of the
 
 ## Syntax
 
-```js
+```js-nolint
 getShaderSource(shader)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -19,7 +19,7 @@ extensions.
 
 ## Syntax
 
-```js
+```js-nolint
 getSupportedExtensions()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -20,7 +20,7 @@ given texture.
 
 ## Syntax
 
-```js
+```js-nolint
 getTexParameter(target, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
@@ -18,7 +18,7 @@ variable at a given location.
 
 ## Syntax
 
-```js
+```js-nolint
 getUniform(program, location)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -46,7 +46,7 @@ The uniform itself is declared in the shader program using GLSL.
 
 ## Syntax
 
-```js
+```js-nolint
 getUniformLocation(program, name)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
@@ -19,7 +19,7 @@ attribute at a given position.
 
 ## Syntax
 
-```js
+```js-nolint
 getVertexAttrib(index, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
@@ -19,7 +19,7 @@ specified vertex attribute.
 
 ## Syntax
 
-```js
+```js-nolint
 getVertexAttribOffset(index, pname)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/hint/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/hint/index.md
@@ -18,7 +18,7 @@ behaviors. The interpretation of these hints depend on the implementation.
 
 ## Syntax
 
-```js
+```js-nolint
 hint(target, mode)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLBuffer")}} is valid and `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isBuffer(buffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
@@ -23,7 +23,7 @@ must be re-established before rendering can resume.
 
 ## Syntax
 
-```js
+```js-nolint
 isContextLost()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
@@ -21,7 +21,7 @@ By default, all capabilities except `gl.DITHER` are
 
 ## Syntax
 
-```js
+```js-nolint
 isEnabled(cap)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
@@ -19,7 +19,7 @@ passed {{domxref("WebGLFramebuffer")}} is valid and `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isFramebuffer(framebuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLProgram")}} is valid, `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isProgram(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
@@ -19,7 +19,7 @@ passed {{domxref("WebGLRenderbuffer")}} is valid and `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isRenderbuffer(renderbuffer)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLShader")}} is valid, `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isShader(shader)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLTexture")}} is valid and `false` otherwise.
 
 ## Syntax
 
-```js
+```js-nolint
 isTexture(texture)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -27,7 +27,7 @@ lines.
 
 ## Syntax
 
-```js
+```js-nolint
 lineWidth(width)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
@@ -20,7 +20,7 @@ program's fragment and vertex shaders.
 
 ## Syntax
 
-```js
+```js-nolint
 linkProgram(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.md
@@ -41,7 +41,7 @@ standard 2D display but can then be transitioned to a 3D immersion system.
 
 ## Syntax
 
-```js
+```js-nolint
 makeXRCompatible()
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.pixelStorei()`** method of the [WebGL API](/en-US/d
 
 ## Syntax
 
-```js
+```js-nolint
 pixelStorei(pname, param)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
@@ -22,7 +22,7 @@ into the depth buffer.
 
 ## Syntax
 
-```js
+```js-nolint
 polygonOffset(factor, units)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
@@ -18,7 +18,7 @@ specified rectangle of the current color framebuffer into a {{jsxref("TypedArray
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL1:
 readPixels(x, y, width, height, format, type, pixels)
 

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
@@ -19,7 +19,7 @@ renderbuffer object's data store.
 
 ## Syntax
 
-```js
+```js-nolint
 renderbufferStorage(target, internalFormat, width, height)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
@@ -19,7 +19,7 @@ parameters for anti-aliasing effects.
 
 ## Syntax
 
-```js
+```js-nolint
 sampleCoverage(value, invert)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.md
@@ -18,7 +18,7 @@ the drawing to a specified rectangle.
 
 ## Syntax
 
-```js
+```js-nolint
 scissor(x, y, width, height)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.shaderSource()`** method of the [WebGL API](/en-US/
 
 ## Syntax
 
-```js
+```js-nolint
 shaderSource(shader, source)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
@@ -21,7 +21,7 @@ multipass rendering to achieve special effects.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilFunc(func, ref, mask)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
@@ -22,7 +22,7 @@ multipass rendering to achieve special effects.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilFuncSeparate(face, func, ref, mask)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
@@ -21,7 +21,7 @@ back stencil writemasks to different values.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilMask(mask)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
@@ -22,7 +22,7 @@ and back stencil writemasks to one value at the same time.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilMaskSeparate(face, mask)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
@@ -18,7 +18,7 @@ stencil test actions.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilOp(fail, zfail, zpass)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
@@ -19,7 +19,7 @@ back-facing stencil test actions.
 
 ## Syntax
 
-```js
+```js-nolint
 stencilOpSeparate(face, fail, zfail, zpass)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -19,7 +19,7 @@ image.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL1
 texImage2D(target, level, internalformat, width, height, border, format, type)
 texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels a TypedArray or a DataView

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
@@ -21,7 +21,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) set texture parameters.
 
 ## Syntax
 
-```js
+```js-nolint
 texParameterf(target, pname, param)
 texParameteri(target, pname, param)
 ```

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -20,7 +20,7 @@ current texture.
 
 ## Syntax
 
-```js
+```js-nolint
 // WebGL1
 texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels) // pixels is a TypedArray or a DataView
 texSubImage2D(target, level, xoffset, yoffset, format, type, pixels)

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -26,7 +26,7 @@ object, when they are once again initialized to 0.
 
 ## Syntax
 
-```js
+```js-nolint
 uniform1f(location, v0)
 uniform1fv(location, value)
 uniform1i(location, v0)

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -32,7 +32,7 @@ expected to have 4, 9 or 16 floats.
 
 ## Syntax
 
-```js
+```js-nolint
 uniformMatrix2fv(location, transpose, value)
 uniformMatrix3fv(location, transpose, value)
 uniformMatrix4fv(location, transpose, value)

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
@@ -18,7 +18,7 @@ The **`WebGLRenderingContext.useProgram()`** method of the [WebGL API](/en-US/do
 
 ## Syntax
 
-```js
+```js-nolint
 useProgram(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
@@ -20,7 +20,7 @@ used in the current WebGL state.
 
 ## Syntax
 
-```js
+```js-nolint
 validateProgram(program)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -19,7 +19,7 @@ values for generic vertex attributes.
 
 ## Syntax
 
-```js
+```js-nolint
 vertexAttrib1f(index, v0)
 vertexAttrib2f(index, v0, v1)
 vertexAttrib3f(index, v0, v1, v2)

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -21,7 +21,7 @@ buffer object and specifies its layout.
 
 ## Syntax
 
-```js
+```js-nolint
 vertexAttribPointer(index, size, type, normalized, stride, offset)
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.md
@@ -19,7 +19,7 @@ coordinates.
 
 ## Syntax
 
-```js
+```js-nolint
 viewport(x, y, width, height)
 ```
 

--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -21,7 +21,7 @@ already `CLOSED`, this method does nothing.
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 close(code)
 close(code, reason)

--- a/files/en-us/web/api/websocket/send/index.md
+++ b/files/en-us/web/api/websocket/send/index.md
@@ -22,7 +22,7 @@ The browser will throw an exception if you call `send()` when the connection is 
 
 ## Syntax
 
-```js
+```js-nolint
 send(data)
 ```
 

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -18,7 +18,7 @@ The **`WebSocket()`** constructor returns a new
 
 ## Syntax
 
-```js
+```js-nolint
 new WebSocket(url)
 new WebSocket(url, protocols)
 ```

--- a/files/en-us/web/api/wheelevent/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/wheelevent/index.md
@@ -20,7 +20,7 @@ The **`WheelEvent()`** constructor returns a new {{domxref("WheelEvent")}} objec
 
 ## Syntax
 
-```js
+```js-nolint
 new WheelEvent(type)
 new WheelEvent(type, options)
 ```

--- a/files/en-us/web/api/window/alert/index.md
+++ b/files/en-us/web/api/window/alert/index.md
@@ -20,7 +20,7 @@ Under some conditions — for example, when the user switches tabs — the brows
 
 ## Syntax
 
-```js
+```js-nolint
 alert()
 alert(message)
 ```

--- a/files/en-us/web/api/window/back/index.md
+++ b/files/en-us/web/api/window/back/index.md
@@ -24,7 +24,7 @@ Firefox-specific method and was removed in Firefox 31.
 
 ## Syntax
 
-```js
+```js-nolint
 back()
 ```
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -16,7 +16,7 @@ Shifts focus away from the window.
 
 ## Syntax
 
-```js
+```js-nolint
 blur()
 ```
 

--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -21,7 +21,7 @@ animation frame request previously scheduled through a call to
 
 ## Syntax
 
-```js
+```js-nolint
 cancelAnimationFrame(requestID)
 ```
 

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -23,7 +23,7 @@ previously scheduled with {{domxref("window.requestIdleCallback()")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 cancelIdleCallback(handle)
 ```
 

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -17,7 +17,7 @@ capture all events of the specified type.
 
 ## Syntax
 
-```js
+```js-nolint
 captureEvents(eventType)
 ```
 

--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -22,7 +22,7 @@ This method clears the action specified by {{DOMxRef("window.setImmediate")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 clearImmediate(immediateID)
 ```
 

--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -28,7 +28,7 @@ objects returned by
 
 ## Syntax
 
-```js
+```js-nolint
 close()
 ```
 

--- a/files/en-us/web/api/window/confirm/index.md
+++ b/files/en-us/web/api/window/confirm/index.md
@@ -20,7 +20,7 @@ Under some conditions — for example, when the user switches tabs — the brows
 
 ## Syntax
 
-```js
+```js-nolint
 confirm(message)
 ```
 

--- a/files/en-us/web/api/window/content/index.md
+++ b/files/en-us/web/api/window/content/index.md
@@ -16,8 +16,8 @@ In unprivileged content (webpages), `content` is normally equivalent to [top](/e
 
 ### Syntax
 
-```js
-const windowObject = window.content;
+```js-nolint
+const windowObject = window.content
 ```
 
 ### Example

--- a/files/en-us/web/api/window/dump/index.md
+++ b/files/en-us/web/api/window/dump/index.md
@@ -19,7 +19,7 @@ Output from `dump()` is _not_ sent to the browser's developer tools console. To 
 
 ## Syntax
 
-```js
+```js-nolint
 dump(message)
 ```
 

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -24,7 +24,7 @@ The **`Window.find()`** method finds a string in a window sequentially.
 
 ## Syntax
 
-```js
+```js-nolint
 find(aString, aCaseSensitive, aBackwards, aWrapAround, aWholeWord, aSearchInFrames, aShowDialog)
 ```
 

--- a/files/en-us/web/api/window/focus/index.md
+++ b/files/en-us/web/api/window/focus/index.md
@@ -17,7 +17,7 @@ Makes a request to bring the window to the front. It may fail due to user settin
 
 ## Syntax
 
-```js
+```js-nolint
 focus()
 ```
 

--- a/files/en-us/web/api/window/forward/index.md
+++ b/files/en-us/web/api/window/forward/index.md
@@ -22,7 +22,7 @@ Moves the window one document forward in history. This was a Firefox-specific me
 
 ## Syntax
 
-```js
+```js-nolint
 forward()
 ```
 

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -24,7 +24,7 @@ indexing with CSS property names.
 
 ## Syntax
 
-```js
+```js-nolint
 getComputedStyle(element)
 getComputedStyle(element, pseudoElt)
 ```

--- a/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
@@ -19,7 +19,7 @@ styles are taken into account.
 
 ## Syntax
 
-```js
+```js-nolint
 getDefaultComputedStyle(element)
 getDefaultComputedStyle(element, pseudoElt)
 ```

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -21,7 +21,7 @@ the current position of the caret.
 
 ## Syntax
 
-```js
+```js-nolint
 getSelection()
 ```
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -24,7 +24,7 @@ media query.
 
 ## Syntax
 
-```js
+```js-nolint
 matchMedia(mediaQueryString)
 ```
 

--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -22,7 +22,7 @@ interface moves the current window by a specified amount.
 
 ## Syntax
 
-```js
+```js-nolint
 moveBy(deltaX, deltaY)
 ```
 

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -22,7 +22,7 @@ interface moves the current window to the specified coordinates.
 
 ## Syntax
 
-```js
+```js-nolint
 moveTo(x, y)
 ```
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -18,7 +18,7 @@ The **`open()`** method of the [`Window`](/en-US/docs/Web/API/Window) interface 
 
 ## Syntax
 
-```js
+```js-nolint
 open()
 open(url)
 open(url, target)

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -32,7 +32,7 @@ receiving window is then free to [handle this event](/en-US/docs/Web/Events/Even
 
 ## Syntax
 
-```js
+```js-nolint
 postMessage(message, targetOrigin)
 postMessage(message, targetOrigin, transfer)
 ```

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -21,7 +21,7 @@ This method will block while the print dialog is open.
 
 ## Syntax
 
-```js
+```js-nolint
 print()
 ```
 

--- a/files/en-us/web/api/window/prompt/index.md
+++ b/files/en-us/web/api/window/prompt/index.md
@@ -21,7 +21,7 @@ Under some conditions — for example, when the user switches tabs — the brows
 
 ## Syntax
 
-```js
+```js-nolint
 prompt()
 prompt(message)
 prompt(message, defaultValue)

--- a/files/en-us/web/api/window/releaseevents/index.md
+++ b/files/en-us/web/api/window/releaseevents/index.md
@@ -20,7 +20,7 @@ Releases the window from trapping events of a specific type.
 
 ## Syntax
 
-```js
+```js-nolint
 releaseEvents(eventType)
 ```
 

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -56,7 +56,7 @@ timestamp is a decimal number, in milliseconds, but with a minimal precision of 
 
 ## Syntax
 
-```js
+```js-nolint
 requestAnimationFrame(callback)
 ```
 

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -27,7 +27,7 @@ use. The returned {{domxref("FileSystem")}} is then available for use with the o
 
 ## Syntax
 
-```js
+```js-nolint
 requestFileSystem(type, size, successCallback)
 requestFileSystem(type, size, successCallback, errorCallback)
 ```

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -33,7 +33,7 @@ loop.
 
 ## Syntax
 
-```js
+```js-nolint
 requestIdleCallback(callback)
 requestIdleCallback(callback, options)
 ```

--- a/files/en-us/web/api/window/resizeby/index.md
+++ b/files/en-us/web/api/window/resizeby/index.md
@@ -19,7 +19,7 @@ by a specified amount.
 
 ## Syntax
 
-```js
+```js-nolint
 resizeBy(xDelta, yDelta)
 ```
 

--- a/files/en-us/web/api/window/resizeto/index.md
+++ b/files/en-us/web/api/window/resizeto/index.md
@@ -18,7 +18,7 @@ window.
 
 ## Syntax
 
-```js
+```js-nolint
 resizeTo(width, height)
 ```
 

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -17,7 +17,7 @@ window by the given amount.
 
 ## Syntax
 
-```js
+```js-nolint
 scrollBy(x-coord, y-coord)
 scrollBy(options)
 ```

--- a/files/en-us/web/api/window/scrollbylines/index.md
+++ b/files/en-us/web/api/window/scrollbylines/index.md
@@ -19,7 +19,7 @@ the specified number of lines.
 
 ## Syntax
 
-```js
+```js-nolint
 scrollByLines(lines)
 ```
 

--- a/files/en-us/web/api/window/scrollbypages/index.md
+++ b/files/en-us/web/api/window/scrollbypages/index.md
@@ -21,7 +21,7 @@ document by the specified number of pages.
 
 ## Syntax
 
-```js
+```js-nolint
 scrollByPages(pages)
 ```
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -18,7 +18,7 @@ coordinates in the document.
 
 ## Syntax
 
-```js
+```js-nolint
 scrollTo(x-coord, y-coord)
 scrollTo(options)
 ```

--- a/files/en-us/web/api/window/setimmediate/index.md
+++ b/files/en-us/web/api/window/setimmediate/index.md
@@ -26,7 +26,7 @@ updates.
 
 ## Syntax
 
-```js
+```js-nolint
 setImmediate(func)
 setImmediate(func, param0)
 setImmediate(func, param0, param1)

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -21,8 +21,8 @@ select a directory.
 
 ## Syntax
 
-```js
-const FileSystemDirectoryHandle = window.showDirectoryPicker();
+```js-nolint
+const FileSystemDirectoryHandle = window.showDirectoryPicker()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -22,7 +22,7 @@ select a directory.
 ## Syntax
 
 ```js-nolint
-const FileSystemDirectoryHandle = window.showDirectoryPicker()
+window.showDirectoryPicker()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -22,7 +22,7 @@ select a directory.
 ## Syntax
 
 ```js-nolint
-window.showDirectoryPicker()
+showDirectoryPicker()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/showmodaldialog/index.md
+++ b/files/en-us/web/api/window/showmodaldialog/index.md
@@ -23,7 +23,7 @@ created and displayed a modal dialog box containing a specified HTML document.
 
 ## Syntax
 
-```js
+```js-nolint
 showModalDialog(uri)
 showModalDialog(uri, arguments)
 showModalDialog(uri, arguments, options)

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -20,7 +20,7 @@ or multiple files and returns a handle for the file(s).
 
 ## Syntax
 
-```js
+```js-nolint
 showOpenFilePicker()
 ```
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -21,7 +21,7 @@ Either by selecting an existing file, or entering a name for a new file.
 
 ## Syntax
 
-```js
+```js-nolint
 showSaveFilePicker()
 ```
 

--- a/files/en-us/web/api/window/sizetocontent/index.md
+++ b/files/en-us/web/api/window/sizetocontent/index.md
@@ -24,7 +24,7 @@ being too small for the user to interact with.
 
 ## Syntax
 
-```js
+```js-nolint
 sizeToContent()
 ```
 

--- a/files/en-us/web/api/window/stop/index.md
+++ b/files/en-us/web/api/window/stop/index.md
@@ -24,7 +24,7 @@ objects.
 
 ## Syntax
 
-```js
+```js-nolint
 stop()
 ```
 

--- a/files/en-us/web/api/window/updatecommands/index.md
+++ b/files/en-us/web/api/window/updatecommands/index.md
@@ -23,7 +23,7 @@ Updates the state of commands of the current chrome window (UI).
 
 ## Syntax
 
-```js
+```js-nolint
 updateCommands("sCommandName")
 ```
 

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -30,7 +30,7 @@ non-standard and _should not be used_.
 
 ## Syntax
 
-```js
+```js-nolint
 convertPointFromNodeToPage(node, nodePoint)
 ```
 

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
@@ -29,7 +29,7 @@ system of the specified DOM {{domxref("Node")}}.
 
 ## Syntax
 
-```js
+```js-nolint
 convertPointFromPageToNode(node, pagePoint)
 ```
 

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -22,7 +22,7 @@ interface gives user input focus to the current client and returns a
 
 ## Syntax
 
-```js
+```js-nolint
 focus()
 ```
 

--- a/files/en-us/web/api/windowclient/navigate/index.md
+++ b/files/en-us/web/api/windowclient/navigate/index.md
@@ -21,7 +21,7 @@ interface loads a specified URL into a controlled client page then returns a
 
 ## Syntax
 
-```js
+```js-nolint
 navigate(url)
 ```
 

--- a/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
@@ -19,7 +19,7 @@ This only applies to Progressive Web Apps installed on desktop operating systems
 
 ## Syntax
 
-```js
+```js-nolint
 getTitlebarAreaRect()
 ```
 

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -17,7 +17,7 @@ The **`WindowControlsOverlayGeometryChangeEvent()`** constructor returns a newly
 
 ## Syntax
 
-```js
+```js-nolint
 new WindowControlsOverlayGeometryChangeEvent(type, options)
 ```
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -23,7 +23,7 @@ The `Worker` can send back information to the thread that spawned it using the {
 
 ## Syntax
 
-```js
+```js-nolint
 postMessage(message)
 postMessage(message, transfer)
 ```

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -18,7 +18,7 @@ The **`terminate()`** method of the {{domxref("Worker")}} interface immediately 
 
 ## Syntax
 
-```js
+```js-nolint
 terminate()
 ```
 

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -19,7 +19,7 @@ The **`Worker()`** constructor creates a {{domxref("Worker")}} object that execu
 
 ## Syntax
 
-```js
+```js-nolint
 new Worker(aURL)
 new Worker(aURL, options)
 ```

--- a/files/en-us/web/api/workerglobalscope/dump/index.md
+++ b/files/en-us/web/api/workerglobalscope/dump/index.md
@@ -22,7 +22,7 @@ Output from `dump()` is _not_ sent to the browser's developer tools console. To 
 
 ## Syntax
 
-```js
+```js-nolint
 dump(message)
 ```
 

--- a/files/en-us/web/api/workerglobalscope/importscripts/index.md
+++ b/files/en-us/web/api/workerglobalscope/importscripts/index.md
@@ -18,7 +18,7 @@ The **`importScripts()`** method of the {{domxref("WorkerGlobalScope")}} interfa
 
 ## Syntax
 
-```js
+```js-nolint
 importScripts(path0)
 importScripts(path0, path1)
 importScripts(path0, path1, /* … ,*/ pathN)

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -17,7 +17,7 @@ The **`toString()`** {{Glossary("stringifier")}} method of a {{domxref("WorkerLo
 
 ## Syntax
 
-```js
+```js-nolint
 toString()
 ```
 

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -24,7 +24,7 @@ adds it to the current `Worklet`.
 
 ## Syntax
 
-```js
+```js-nolint
 addModule(moduleURL)
 addModule(moduleURL, options)
 ```

--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -18,7 +18,7 @@ The **`abort()`** method of the {{domxref("WritableStream")}} interface aborts t
 
 ## Syntax
 
-```js
+```js-nolint
 abort(reason)
 ```
 

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -19,7 +19,7 @@ While the stream is locked, no other writer can be acquired until this one is re
 
 ## Syntax
 
-```js
+```js-nolint
 getWriter()
 ```
 


### PR DESCRIPTION
Adding to https://github.com/mdn/content/pull/19177

- Updating syntax code blocks with the new tag. Refer: https://github.com/mdn/yari/pull/7017
