### PR TITLE
Tag `example-bad` blocks with js-nolint

### DIFF
--- a/files/en-us/glossary/function/index.md
+++ b/files/en-us/glossary/function/index.md
@@ -91,7 +91,7 @@ Function expressions, named or anonymous, can be called immediately.
 
 Declared functions can't be called immediately this way, because IIFEs must be function _expressions_.
 
-```js example-bad
+```js-nolint example-bad
 function foo() {
   console.log('Hello Foo');
 }();

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -21,7 +21,7 @@ In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Referenc
 
 A {{glossary("function")}} creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
 
-```js example-bad
+```js-nolint example-bad
 function exampleFunction() {
   const x = "declared inside function"; // x can only be used in exampleFunction
   console.log("Inside function");
@@ -56,7 +56,7 @@ Blocks only scope `let` and `const` declarations, but not `var` declarations.
 console.log(x); // 1
 ```
 
-```js example-bad
+```js-nolint example-bad
 {
   const x = 1;
 }

--- a/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.md
+++ b/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.md
@@ -199,15 +199,15 @@ document.querySelector('h1').appendChild(myWordmark);
 
 Now try entering the following incorrect versions of the code and see what you get.
 
-```js example-bad
+```js-nolint example-bad
 alert('hello!);
 ```
 
-```js example-bad
+```js-nolint example-bad
 document.cheeseSelector('html').style.backgroundColor = 'purple';
 ```
 
-```js example-bad
+```js-nolint example-bad
 const myWordmark = document.createElement('img');
 myBanana.setAttribute('src','https://blog.mozilla.org/press/wp-content/themes/OneMozilla/img/mozilla-wordmark.png');
 document.querySelector('h1').appendChild(myWordmark);

--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -304,7 +304,7 @@ We can even use a `try...catch` block for error handling, exactly as we would if
 
 Note though that async functions always return a promise, so you can't do something like:
 
-```js example-bad
+```js-nolint example-bad
 async function fetchProducts() {
   try {
     const response = await fetch('https://mdn.github.io/learning-area/javascript/apis/fetching-data/can-store/products.json');

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -86,7 +86,7 @@ However, you need to be careful here — in this case, the second block of code 
 
 As a final point, while not recommended, you may sometimes see `if...else` statements written without the curly braces:
 
-```js example-bad
+```js-nolint example-bad
 if (condition) /* code to run if condition is true */
 else /* run some other code instead */
 ```
@@ -266,7 +266,7 @@ if ((x === 5 || y > 3 || z <= 10) && (loggedIn || userName === 'Steve')) {
 
 A common mistake when using the logical OR operator in conditional statements is to try to state the variable whose value you are checking once, and then give a list of values it could be to return true, separated by `||` (OR) operators. For example:
 
-```js example-bad
+```js-nolint example-bad
 if (x === 5 || 7 || 10 || 20) {
   // run my code
 }

--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -263,7 +263,7 @@ guessCount++;
 
 Let's try playing with these in your console. For a start, note that you can't apply these directly to a number, which might seem strange, but we are assigning a variable a new updated value, not operating on the value itself. The following will return an error:
 
-```js example-bad
+```js-nolint example-bad
 3++;
 ```
 

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -57,7 +57,7 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 
 2. If you don't do this, or miss one of the quotes, you'll get an error. Try entering the following lines:
 
-   ```js example-bad
+   ```js-nolint example-bad
    const badString1 = This is a test;
    const badString2 = 'This is a test;
    const badString3 = This is a test';
@@ -87,7 +87,7 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 
 2. There is very little difference between the two, and which you use is down to personal preference. You should choose one and stick to it, however; differently quoted code can be confusing, especially if you use two different quotes on the same string! The following will return an error:
 
-   ```js example-bad
+   ```js-nolint example-bad
    const badQuotes = 'What on earth?";
    ```
 
@@ -102,7 +102,7 @@ Strings are dealt with similarly to numbers at first glance, but when you dig de
 
 4. However, you can't include the same quote mark inside the string if it's being used to contain them. The following will error, as it confuses the browser as to where the string ends:
 
-   ```js example-bad
+   ```js-nolint example-bad
    const bigmouth = 'I've got no right to take my place…';
    ```
 

--- a/files/en-us/learn/javascript/first_steps/variables/index.md
+++ b/files/en-us/learn/javascript/first_steps/variables/index.md
@@ -77,7 +77,7 @@ To understand why this is so useful, let's think about how we'd write this examp
 <h3 id="heading_B"></h3>
 ```
 
-```js example-bad
+```js-nolint example-bad
 const buttonB = document.querySelector('#button_B');
 const headingB = document.querySelector('#heading_B');
 
@@ -193,7 +193,7 @@ var myName = 'Bob';
 
 But the following would throw an error on the second line:
 
-```js example-bad
+```js-nolint example-bad
 let myName = 'Chris';
 let myName = 'Bob';
 ```
@@ -384,7 +384,7 @@ let count;
 
 If you try to do this using `const` you will see an error:
 
-```js example-bad
+```js-nolint example-bad
 const count;
 ```
 
@@ -397,7 +397,7 @@ count = 2;
 
 If you try to do this using `const` you will see an error:
 
-```js example-bad
+```js-nolint example-bad
 const count = 1;
 count = 2;
 ```

--- a/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
@@ -304,7 +304,7 @@ This works great, but what if we wanted to put our JavaScript in an external fil
 Note that sometimes you'll come across bits of actual JavaScript code living inside HTML.
 It might look something like this:
 
-```js example-bad
+```js-nolint example-bad
 function createParagraph() {
   const para = document.createElement('p');
   para.textContent = 'You clicked the button!';

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
@@ -198,7 +198,7 @@ const userGuess = Number(guessField.value);
 
 to
 
-```js example-bad
+```js-nolint example-bad
 const userGuess === Number(guessField.value);
 ```
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -123,7 +123,7 @@ For example:
 const greeting = "I'm a good example";
 ```
 
-```js example-bad
+```js-nolint example-bad
 const greeting = "I'm a bad example";
 ```
 ````
@@ -134,7 +134,7 @@ These will be rendered as:
 const greeting = "I'm a good example";
 ```
 
-```js example-bad
+```js-nolint example-bad
 const greeting = "I'm a bad example";
 ```
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
@@ -86,7 +86,7 @@ if (condition) {
 
 For example, this is not great:
 
-```js example-bad
+```js-nolint example-bad
 let tommyCat = 'Said Tommy the Cat as he reeled back to clear whatever foreign matter may have nestled its way into his mighty throat. Many a fat alley rat had met its demise while staring point blank down the cavernous barrel of this awesome prowling machine.';
 ```
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -45,7 +45,7 @@ const visitedCities = [];
 
 Don't do this while creating arrays:
 
-```js example-bad
+```js-nolint example-bad
 const visitedCities = new Array(length);
 ```
 
@@ -65,7 +65,7 @@ pets.push("cat");
 
 Don't add items to the array like this:
 
-```js example-bad
+```js-nolint example-bad
 pets[pets.length] = "cat";
 ```
 
@@ -95,7 +95,7 @@ Comments are critical to writing good code examples. They clarify the intent of 
 
   On the other hand, restating the code in prose is not a good use of comments:
 
-  ```js example-bad
+  ```js-nolint example-bad
   let total = 0;
 
   // For loop from 1 to 4
@@ -113,7 +113,7 @@ Comments are critical to writing good code examples. They clarify the intent of 
 
   Don't write:
 
-  ```js example-bad
+  ```js-nolint example-bad
   closeConnection(); // Closing the connection
   ```
 
@@ -155,7 +155,7 @@ In general, use single-line comments to comment code. Writers must mark each lin
 
   Don't write:
 
-  ```js example-bad
+  ```js-nolint example-bad
   function exampleFunc(fruitBasket) {
     // Logs: ['banana', 'mango', 'orange']
     console.log(fruitBasket);
@@ -185,7 +185,7 @@ Short comments are usually better, so try to keep them in one line of 60–80 ch
 
 Don't use `/* … */`:
 
-```js example-bad
+```js-nolint example-bad
 /* This is an example of a multi-line comment.
   The imaginary function that follows has some unusual
   limitations that I want to call out.
@@ -210,7 +210,7 @@ function exampleFunc() {
 
 Don't use ellipses (…) like this:
 
-```js example-bad
+```js-nolint example-bad
 function exampleFunc() {
   …
 }
@@ -244,7 +244,7 @@ function sayHello() {
 
 Don't use function names like these:
 
-```js example-bad
+```js-nolint example-bad
 function SayHello() {
   console.log("Hello!");
 }
@@ -268,7 +268,7 @@ function doIt() {
 
   This is not a good way to define a function:
 
-  ```js example-bad
+  ```js-nolint example-bad
   let sum = function (a, b) {
     return a + b;
   };
@@ -285,7 +285,7 @@ function doIt() {
 
   Instead of this:
 
-  ```js example-bad
+  ```js-nolint example-bad
   const array1 = [1, 2, 3, 4];
   const sum = array1.reduce(function (a, b) {
     return a + b;
@@ -302,7 +302,7 @@ function doIt() {
 
   Don't do:
 
-  ```js example-bad
+  ```js-nolint example-bad
   const x = () => {
     // …
   };
@@ -316,7 +316,7 @@ function doIt() {
 
   And not:
 
-  ```js example-bad
+  ```js-nolint example-bad
   arr.map((e) => {
     return e.id;
   });
@@ -350,7 +350,7 @@ When [loops](/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code) are requ
 
   Do not use `for (;;)` — not only do you have to add an extra index, `i`, but you also have to track the length of the array. This can be error-prone for beginners.
 
-  ```js example-bad
+  ```js-nolint example-bad
   const dogs = ["Rex", "Lassie"];
   for (let i = 0; i < dogs.length; i++) {
     console.log(dogs[i]);
@@ -372,7 +372,7 @@ When [loops](/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code) are requ
 
   The example below does not follow the recommended guidelines for the initialization (it implicitly creates a global variable and will fail in strict mode):
 
-  ```js example-bad
+  ```js-nolint example-bad
   const cats = ["Athena", "Luna"];
   for (i of cats) {
     console.log(i);
@@ -390,7 +390,7 @@ When [loops](/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code) are requ
 
   Do not write:
 
-  ```js example-bad
+  ```js-nolint example-bad
   const gerbils = ["Zoé", "Chloé"];
   for (let i = 0; i < gerbils.length; i++) {
     console.log(`Gerbil #${i}: ${gerbils[i]}`);
@@ -420,7 +420,7 @@ if (test) {
 
 Do not write:
 
-```js example-bad
+```js-nolint example-bad
 if (test) {
   // Perform something if test is true
   // …
@@ -443,7 +443,7 @@ for (const car of storedCars) {
 
 Don't write:
 
-```js example-bad
+```js-nolint example-bad
 for (const car of storedCars) car.paint("red");
 ```
 
@@ -468,7 +468,7 @@ Switch statements can be a little tricky.
 
   If you add a `break` statement, it will be unreachable. Do not write:
 
-  ```js example-bad
+  ```js-nolint example-bad
   switch (species) {
     case "chicken":
       return farm.shed;
@@ -554,7 +554,7 @@ const object = {};
 
 Don't create a general object like this:
 
-```js example-bad
+```js-nolint example-bad
 const object = new Object();
 ```
 
@@ -603,7 +603,7 @@ const obj = {
 
 Instead of:
 
-```js example-bad
+```js-nolint example-bad
 const obj = {
   foo: function () {
     // …
@@ -627,7 +627,7 @@ const obj = {
 
   Don't write:
 
-  ```js example-bad
+  ```js-nolint example-bad
   function createObject(name, age) {
     return { name: name, age: age };
   }
@@ -647,7 +647,7 @@ const x = condition ? 1 : 2;
 
 Do not write:
 
-```js example-bad
+```js-nolint example-bad
 let x;
 if (condition) {
   x = 1;
@@ -671,7 +671,7 @@ age !== 25;
 
 Don't use the loose equality and inequality operators, as shown below:
 
-```js example-bad
+```js-nolint example-bad
 name == "Chris";
 age != 25;
 ```
@@ -699,7 +699,7 @@ For inserting values into strings, use [template literals](/en-US/docs/Web/JavaS
 
   Don't concatenate strings like this:
 
-  ```js example-bad
+  ```js-nolint example-bad
   const name = "Chris";
   console.log("Hi! I'm" + name + "!"); // Hi! I'mChris!
   ```
@@ -727,7 +727,7 @@ Good variable names are essential to understanding code.
 
   Don't name variables like this:
 
-  ```js example-bad
+  ```js-nolint example-bad
   const thisIsaveryLONGVariableThatRecordsPlayerscore345654 = 0;
   const s = d / t;
   ```
@@ -755,14 +755,14 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
 - The example below uses `let` where it should be `const`. The code will work, but we want to avoid this usage in MDN Web Docs code examples.
 
-  ```js example-bad
+  ```js-nolint example-bad
   let name = "Chris";
   console.log(myName);
   ```
 
 - The example below uses `const` for a variable that gets reassigned. The reassignment will throw an error.
 
-  ```js example-bad
+  ```js-nolint example-bad
   const age = 40;
   age++;
   console.log("Happy birthday!");
@@ -770,7 +770,7 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
 - The example below uses `var`, polluting the global scope:
 
-  ```js example-bad
+  ```js-nolint example-bad
   var age = 40;
   var name = "Chris";
   ```
@@ -786,7 +786,7 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
   Do not declare multiple variables in one line, separating them with commas or using chain declaration. Avoid declaring variables like this:
 
-  ```js example-bad
+  ```js-nolint example-bad
   let var1, var2;
   let var3 = var4 = "Apapou"; // var4 is implicitly created as a global variable; fails in strict mode
   ```
@@ -809,7 +809,7 @@ class Person {
 
 Don't write:
 
-```js example-bad
+```js-nolint example-bad
 class Person {
   #name;
   #birthYear;
@@ -835,7 +835,7 @@ const context = new AudioContext();
 
 Avoid the added complexity of prefixes. Don't write:
 
-```js example-bad
+```js-nolint example-bad
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 const context = new AudioContext();
 ```
@@ -865,7 +865,7 @@ Here is a non-exhaustive list of Web APIs to avoid and what to replace them with
 
   Don't use `innerHTML` to insert _pure text_ into DOM nodes.
 
-  ```js example-bad
+  ```js-nolint example-bad
   const text = "Hello to all you good people";
   const para = document.createElement("p");
   para.innerHTML = text;

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -91,7 +91,7 @@ Events have three functions:
 
     > **Note:** If you pass an async function to `addListener()`, the listener will return a Promise for every message it receives, preventing other listeners from responding:
     >
-    > ```js example-bad
+    > ```js-nolint example-bad
     > // don't do this
     > browser.runtime.onMessage.addListener(
     >   async (data, sender) => {

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -448,7 +448,7 @@ For a complete working example of this, [visit the demo page on GitHub](https://
 >
 > To give a trivial example, suppose the content script code that receives the message does something like this:
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > // content-script.js
 >
 > window.addEventListener("message", (event) => {
@@ -528,7 +528,7 @@ The same applies to [`setTimeout()`](/en-US/docs/Web/API/setTimeout), [`setInter
 >
 > The page's environment is controlled by potentially malicious web pages, which can redefine objects you interact with to behave in unexpected ways:
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > // page.js redefines console.log
 >
 > let original = console.log;
@@ -538,7 +538,7 @@ The same applies to [`setTimeout()`](/en-US/docs/Web/API/setTimeout), [`setInter
 > }
 > ```
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > // content-script.js calls the redefined version
 >
 > window.eval('console.log(false)');

--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -40,7 +40,7 @@ This approach is safe because the use of `.textContent` automatically escapes an
 
 However, beware, you can use native methods that aren't safe. Take the following code:
 
-```js example-bad
+```js-nolint example-bad
 let data = JSON.parse(responseText);
 addonElement.innerHTML = `<div class='${data.className}'>Your favorite color is now ${data.color}</div>`;
 ```

--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -79,7 +79,7 @@ For security reasons, [CSP](/en-US/docs/Web/HTTP/CSP) nonces from non-script
 sources, such as CSS selectors, and `.getAttribute("nonce")` calls are
 hidden.
 
-```js example-bad
+```js-nolint example-bad
 let nonce =  script.getAttribute('nonce');
 // returns empty string
 ```

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -91,7 +91,7 @@ format should be allowed.
 
 For example:
 
-```js example-bad
+```js-nolint example-bad
 const clearKeyOptions = [
   {
     initDataTypes: ['keyids', 'webm'],

--- a/files/en-us/web/api/node/appendchild/index.md
+++ b/files/en-us/web/api/node/appendchild/index.md
@@ -59,7 +59,7 @@ const paragraph = document.body.appendChild(document.createElement('p'));
 
 On the other hand, you cannot use `appendChild()` in a [fluent API](https://en.wikipedia.org/wiki/Fluent_interface) fashion (like JQuery).
 
-```js example-bad
+```js-nolint example-bad
 // This doesn't append three paragraphs:
 // the three elements will be nested instead of siblings
 document.body

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -80,7 +80,7 @@ To call a function repeatedly (e.g., every _N_ milliseconds), consider using
 
 If `setTimeout()` is called with [_delay_](#delay) value that's not a number, implicit [type coercion](/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number. For example, the following code incorrectly uses the string `"1000"` for the _delay_ value, rather than the number `1000` – but it nevertheless works, because when the code runs, the string is coerced into the number `1000`, and so the code executes 1 second later.
 
-```js example-bad
+```js-nolint example-bad
 setTimeout(() => {
   console.log("Delayed for 1 second.");
 }, "1000")
@@ -88,7 +88,7 @@ setTimeout(() => {
 
 But in many cases, the implicit type coercion can lead to unexpected and surprising results. For example, when the following code runs, the string `"1 second"` ultimately gets coerced into the number `0` — and so, the code executes immediately, with zero delay.
 
-```js example-bad
+```js-nolint example-bad
 setTimeout(() => {
   console.log("Delayed for 1 second.");
 }, "1 second")
@@ -219,7 +219,7 @@ setTimeout(myBoundMethod, 1.5*1000, "1"); // prints "one" after 1.5 seconds
 Passing a string instead of a function to `setTimeout()` has the same problems as using
 [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval).
 
-```js example-bad
+```js-nolint example-bad
 // Don't do this
 setTimeout("console.log('Hello World!');", 500);
 ```

--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
@@ -220,7 +220,7 @@ In the past, the {{domxref("RTCPeerConnection.negotiationneeded_event", "negotia
 
 Consider this {{domxref("RTCPeerConnection.negotiationneeded_event", "onnegotiationneeded")}} event handler:
 
-```js example-bad
+```js-nolint example-bad
 pc.onnegotiationneeded = async () => {
   try {
     await pc.setLocalDescription(await pc.createOffer());
@@ -269,7 +269,7 @@ Doing so returns the local peer to the `stable` {{domxref("RTCPeerConnection.sig
 
 Using the previous API to implement incoming negotiation messages during perfect negotiation would look something like this:
 
-```js example-bad
+```js-nolint example-bad
 signaler.onmessage = async ({data: { description, candidate }}) => {
   try {
     if (description) {
@@ -377,7 +377,7 @@ The techniques previously used to trigger an [ICE restart](/en-US/docs/Web/API/W
 
 In the past, if you encountered an ICE error and needed to restart negotiation, you might have done something like this:
 
-```js example-bad
+```js-nolint example-bad
 pc.onnegotiationneeded = async (options) => {
   await pc.setLocalDescription(await pc.createOffer(options));
   signaler.send({ description: pc.localDescription });

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -221,7 +221,7 @@ for (const link of links) {
 
 If the newly opened browsing context does not share the same [origin](/en-US/docs/Glossary/Origin), the opening script will not be able to interact (reading or writing) with the browsing context's content.
 
-```js example-bad
+```js-nolint example-bad
 // Script from example.com
 const otherOriginContext = window.open("https://example.org");
 // example.com and example.org are not the same origin

--- a/files/en-us/web/html/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/global_attributes/nonce/index.md
@@ -62,7 +62,7 @@ Content-Security-Policy: script-src 'nonce-8IBTHwOdqNKAWeKl7plt8g=='
 
 For security reasons, the `nonce` content attribute is hidden (an empty string will be returned).
 
-```js example-bad
+```js-nolint example-bad
 script.getAttribute('nonce'); // returns empty string
 ```
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -139,7 +139,7 @@ if (condition) {
 
 In general it's good practice to not have an `if...else` with an assignment like `x = y` as a condition:
 
-```js example-bad
+```js-nolint example-bad
 if (x = y) {
   /* statements here */
 }

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -792,7 +792,7 @@ const d = 8n >>> 2n; // TypeError: BigInts have no unsigned right shift, use >> 
 
 BigInts and numbers are not mutually replaceable — you cannot mix them in calculations.
 
-```js example-bad
+```js-nolint example-bad
 const a = 1n + 2; // TypeError: Cannot mix BigInt and other types
 ```
 

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -177,7 +177,7 @@ The scope of a function is the function in which it is declared (or the entire p
 >
 > This means that function hoisting only works with function _declarations_—not with function _expressions_.
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > console.log(square); // ReferenceError: Cannot access 'square' before initialization
 > const square = function (n) {
 >   return n * n;
@@ -519,7 +519,7 @@ getCode();    // Returns the apiCode
 >
 > If an enclosed function defines a variable with the same name as a variable in the outer scope, then there is no way to refer to the variable in the outer scope again. (The inner scope variable "overrides" the outer one, until the program exits the inner scope. It can be thought of as a [name conflict](#name_conflicts).)
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > const createPet = function (name) {  // The outer function defines a variable called "name".
 >   return {
 >     setName(name) {    // The enclosed function also defines a variable called "name".

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -47,7 +47,7 @@ The syntax of **comments** is the same as in C++ and in many other languages:
 
 You can't nest block comments. This often happens when you accidentally include a `*/` sequence in your comment, which will terminate the comment.
 
-```js example-bad
+```js-nolint example-bad
 /* You can't, however, /* nest comments */ SyntaxError */
 ```
 
@@ -249,7 +249,7 @@ In the following example, the variable name `baz` is hoisted — due to [variabl
 
 Thus, the `baz()` call below throws a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) with _"baz is not a function"_, because the function assigned to `baz` isn't hoisted — while the `console.log(baz)` call doesn't throw a [`ReferenceError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError) but instead logs [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined), because the _variable_ `baz` is still hoisted even though the function assigned to it isn't. (But the value of `baz` is undefined, since nothing has yet been assigned to it).
 
-```js example-bad
+```js-nolint example-bad
 // Doesn't throw ReferenceError
 console.log(baz) // undefined
 
@@ -286,7 +286,7 @@ The scope rules for constants are the same as those for `let` block-scope variab
 
 You cannot declare a constant with the same name as a function or variable in the same scope. For example:
 
-```js example-bad
+```js-nolint example-bad
 // THIS WILL CAUSE AN ERROR
 function f() {};
 const f = 5;
@@ -569,7 +569,7 @@ Object property names can be any string, including the empty string. If the prop
 
 Property names that are not valid identifiers cannot be accessed as a dot (`.`) property.
 
-```js example-bad
+```js-nolint example-bad
 const unusualPropertyNames = {
   '': 'An empty string',
   '!': 'Bang!'

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -581,7 +581,7 @@ Some JavaScript objects, such as the [`NodeList`](/en-US/docs/Web/API/NodeList) 
 
 Array methods cannot be called directly on array-like objects.
 
-```js example-bad
+```js-nolint example-bad
 function printArguments() {
   arguments.forEach((item) => { // TypeError: arguments.forEach is not a function
     console.log(item);

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -206,7 +206,7 @@ Avoid infinite loops. Make sure the condition in a loop eventually becomes
 following `while` loop execute forever because the condition never becomes
 `false`:
 
-```js example-bad
+```js-nolint example-bad
 // Infinite loops are bad!
 while (true) {
   console.log('Hello, world!');

--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -352,7 +352,7 @@ console.log(red.getRed()); // 255
 
 Accessing private fields outside the class is an early syntax error. The language can guard against this because `#privateField` is a special syntax, so it can do some static analysis and find all usage of private fields before even evaluating the code.
 
-```js example-bad
+```js-nolint example-bad
 console.log(red.#values); // SyntaxError: Private field '#values' must be declared in an enclosing class
 ```
 
@@ -661,7 +661,7 @@ console.log(ColorWithAlpha.isValid(255, 0, 0, -1)); // false
 
 Derived classes don't have access to the parent class's private fields — this is another key aspect to JavaScript private fields being "hard private". Private fields are scoped to the class body itself and do not grant access to _any_ outside code.
 
-```js example-bad
+```js-nolint example-bad
 class ColorWithAlpha extends Color {
   log() {
     console.log(this.#values); // SyntaxError: Private field '#values' must be declared in an enclosing class

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -114,7 +114,7 @@ doSomething()
 
 **Important:** Always return results, otherwise callbacks won't catch the result of a previous promise (with arrow functions, `() => x` is short for `() => { return x; }`). If the previous handler started a promise but did not return it, there's no way to track its settlement anymore, and the promise is said to be "floating".
 
-```js example-bad
+```js-nolint example-bad
 doSomething()
   .then((url) => {
     // I forgot to return this
@@ -130,7 +130,7 @@ doSomething()
 
 This may be worse if you have race conditions — if the promise from the last handler is not returned, the next `then` handler will be called early, and any value it reads may be incomplete.
 
-```js example-bad
+```js-nolint example-bad
 const listOfIngredients = [];
 
 doSomething()
@@ -441,7 +441,7 @@ The inner neutralizing `catch` statement only catches failures from `doSomething
 
 Here are some common mistakes to watch out for when composing promise chains. Several of these mistakes manifest in the following example:
 
-```js example-bad
+```js-nolint example-bad
 // Bad example! Spot 3 mistakes!
 
 doSomething()

--- a/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
+++ b/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
@@ -18,7 +18,7 @@ Private class features deliver truly private fields and methods, with that priva
 
 To understand how private fields work, let's first consider a class that has only public fields, but uses the constructor to encapsulate data—a somewhat common technique, even if it is a bit of a hack. The following class creates a basic count that accepts a starting number, allows that number to be increased or decreased, and can be reset to the original starting value or any other value.
 
-```js example-bad
+```js-nolint example-bad
 class PublicCounter {
   constructor(start = 0) {
     let _count = start;
@@ -68,7 +68,7 @@ Having declared the private fields, they act as we saw in the public example. Th
 
 You **cannot** read a private value directly from code outside the class object. Consider:
 
-```js example-bad
+```js-nolint example-bad
 const score = new PrivateCounter(); // #count and #init are now both 0
 console.log(score.#count);
   // output:
@@ -79,7 +79,7 @@ If you wish to read private data from outside a class, you must first invent a m
 
 What are the other restrictions around private fields? For one, you can't refer to a private field you didn't previously define. You might be used to inventing new fields on the fly in JavaScript, but that just won't fly with private fields.
 
-```js example-bad
+```js-nolint example-bad
 class BadIdea {
   constructor(arg) {
     this.#init = arg;  // syntax error occurs here
@@ -90,7 +90,7 @@ class BadIdea {
 
 You can't define the same name twice in a single class, and you can't delete private fields.
 
-```js example-bad
+```js-nolint example-bad
 class BadIdeas {
   #firstName;
   #firstName; // syntax error occurs here
@@ -113,7 +113,7 @@ const planet = {
 
 If you try to include a private class feature when doing this, an error will be thrown.
 
-```js example-bad
+```js-nolint example-bad
 const planet = {
   name: 'Terra',
   radiusKm: 6371,

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -321,7 +321,7 @@ const obj = new Derived();
 
 You may also see some legacy code using [`Object.create`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create). However, because this re-assigns the `prototype` property, it's a bad practice, for the reasons previously described here.
 
-```js example-bad
+```js-nolint example-bad
 function Base() {}
 function Derived() {}
 // Re-assigns `Derived.prototype` to a new object

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -170,7 +170,7 @@ console.log(Pi); // 3.14
 
 A variable declared with `const` cannot be reassigned.
 
-```js example-bad
+```js-nolint example-bad
 const Pi = 3.14;
 Pi = 1; // will throw an error because you cannot change a constant variable.
 ```

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -41,7 +41,7 @@ class Rectangle {
 An important difference between **function declarations** and **class declarations** is that while functions can be called in code that appears before they are defined, classes must be defined before they can be constructed.
 Code like the following will throw a {{jsxref("ReferenceError")}}:
 
-```js example-bad
+```js-nolint example-bad
 const p = new Rectangle(); // ReferenceError
 
 class Rectangle {}

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -61,7 +61,7 @@ It is also a syntax error to refer to private fields
 that were not declared before they were called, or to attempt to remove
 declared fields with `delete`.
 
-```js example-bad
+```js-nolint example-bad
 class ClassWithPrivateField {
   #privateField;
 

--- a/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
@@ -32,7 +32,7 @@ The argument of {{jsxref("Array.prototype.sort()")}} is expected to be either {{
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 [1, 3, 2].sort(5);  // TypeError
 
 const cmp = { asc: (x, y) => x >= y, dsc: (x, y) => x <= y };

--- a/files/en-us/web/javascript/reference/errors/bad_octal/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_octal/index.md
@@ -42,7 +42,7 @@ for more information.
 
 ### Invalid octal numbers
 
-```js example-bad
+```js-nolint example-bad
 08;
 09;
 // SyntaxError: 08 is not a legal ECMA-262 octal constant

--- a/files/en-us/web/javascript/reference/errors/bad_radix/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_radix/index.md
@@ -51,7 +51,7 @@ The most common radixes:
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 (42).toString(0);
 (42).toString(1);
 (42).toString(37);

--- a/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -67,7 +67,7 @@ Here is an example showing use of only correct flags.
 
 Below is an example showing the use of some invalid flags `b`, `a` and `r`:
 
-```js example-bad
+```js-nolint example-bad
 /foo/bar;
 
 // SyntaxError: invalid regular expression flag "b"
@@ -75,7 +75,7 @@ Below is an example showing the use of some invalid flags `b`, `a` and `r`:
 
 The code below is incorrect, because `W`, `e` and `b` are not valid flags.
 
-```js example-bad
+```js-nolint example-bad
 const obj = {
   url: /docs/Web,
 };

--- a/files/en-us/web/javascript/reference/errors/bad_return_or_yield/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_return_or_yield/index.md
@@ -41,7 +41,7 @@ execution and specify a value to be returned to the function caller.
 
 ### Missing curly brackets
 
-```js example-bad
+```js-nolint example-bad
 function cheer(score) {
   if (score === 147)
     return 'Maximum!';

--- a/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
@@ -32,7 +32,7 @@ The divisor of a [division](/en-US/docs/Web/JavaScript/Reference/Operators/Divis
 
 ### Division by 0n
 
-```js example-bad
+```js-nolint example-bad
 const a = 1n;
 const b = 0n;
 const quotient = a / b;

--- a/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
@@ -32,7 +32,7 @@ The exponent of an [exponentiation](/en-US/docs/Web/JavaScript/Reference/Operato
 
 ### Using a negative BigInt as exponent
 
-```js example-bad
+```js-nolint example-bad
 const a = 1n;
 const b = -1n;
 const c = a ** b;

--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -49,7 +49,7 @@ force the `this` argument to the expected object.
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 const mySet = new Set;
 ['bar', 'baz'].forEach(mySet.add);
 // mySet.add is a function, but "mySet" is not captured as this.

--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -42,7 +42,7 @@ Note also that this issue does not occur for variables declared using `var`, bec
 In this case, the variable `foo` is accessed before it is declared.
 At this point is has not been initialized with a value, so accessing the variable throws a reference error.
 
-```js example-bad
+```js-nolint example-bad
 function test() {
   // Accessing the 'const' variable foo before it's declared
   console.log(foo);       // ReferenceError: foo is not initialized

--- a/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
@@ -39,7 +39,7 @@ that an object variant of a {{jsxref("String")}} or a {{jsxref("Number")}} is ex
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 const foo = "my string";

--- a/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
@@ -31,7 +31,7 @@ When using the [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 const a = BigInt(1.5);
 // RangeError: The number 1.5 cannot be converted to a BigInt because it is not an integer
 const b = BigInt(NaN);

--- a/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
@@ -36,7 +36,7 @@ The error can also happen if the [unsigned right shift operator (`>>>`)](/en-US/
 
 ### Mixing numbers and BigInts in operations
 
-```js example-bad
+```js-nolint example-bad
 const sum = 1n + 1;
 // TypeError: can't convert BigInt to number
 ```
@@ -50,7 +50,7 @@ const sum2 = Number(1n) + 1;
 
 ### Using unsigned right shift on BigInts
 
-```js example-bad
+```js-nolint example-bad
 const a = 4n >>> 2n;
 // TypeError: can't convert BigInt to number
 ```

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -34,7 +34,7 @@ Some operations, like [`BigInt.asIntN`](/en-US/docs/Web/JavaScript/Reference/Glo
 
 ### Using BigInt() on invalid values
 
-```js example-bad
+```js-nolint example-bad
 const a = BigInt(null);
 // TypeError: can't convert null to BigInt
 const b = BigInt(undefined);
@@ -54,7 +54,7 @@ const d = BigInt(Symbol("1").description);
 
 ### Passing a number to a function expecting a BigInt
 
-```js example-bad
+```js-nolint example-bad
 const a = BigInt.asIntN(4, 8);
 // TypeError: can't convert 8 to BigInt
 const b = new BigInt64Array(3).fill(3);

--- a/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
@@ -44,7 +44,7 @@ attempting to add new properties to a non-extensible object throws a
 `TypeError`. In sloppy mode, the addition of the "x" property is silently
 ignored.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 const obj = {};
@@ -58,7 +58,7 @@ In both, [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) and
 sloppy mode, a call to {{jsxref("Object.defineProperty()")}} throws when adding a new
 property to a non-extensible object.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { };
 Object.preventExtensions(obj);
 

--- a/files/en-us/web/javascript/reference/errors/cant_delete/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_delete/index.md
@@ -42,20 +42,20 @@ non-strict code, the operation returns `false`.
 Non-configurable properties are not super common, but they can be created using
 {{jsxref("Object.defineProperty()")}} or {{jsxref("Object.freeze()")}}.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const obj = Object.freeze({name: 'Elsa', score: 157});
 delete obj.score;  // TypeError
 ```
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const obj = {};
 Object.defineProperty(obj, 'foo', {value: 2, configurable: false});
 delete obj.foo;  // TypeError
 ```
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const frozenArray = Object.freeze([0, 1, 2]);
 frozenArray.pop();  // TypeError
@@ -64,7 +64,7 @@ frozenArray.pop();  // TypeError
 There are also a few non-configurable properties built into JavaScript. Maybe you tried
 to delete a mathematical constant.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 delete Math.PI;  // TypeError
 ```

--- a/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
@@ -41,7 +41,7 @@ Usually, properties in an object created by an
 The {{jsxref("Object.defineProperty()")}} creates non-configurable properties if you
 haven't specified them as configurable.
 
-```js example-bad
+```js-nolint example-bad
 const obj = Object.create({});
 Object.defineProperty(obj, "foo", {value: "bar"});
 

--- a/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
@@ -34,7 +34,7 @@ The [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operato
 
 However, the precedence _between_ `??` and `&&`/`||` is intentionally undefined, because the short circuiting behavior of logical operators can make the expression's evaluation counter-intuitive. Therefore, the following combinations are all syntax errors, because the language doesn't know how to parenthesize the operands:
 
-```js example-bad
+```js-nolint example-bad
 a ?? b || c
 a || b ?? c
 a ?? b && c
@@ -52,7 +52,7 @@ a ?? (b && c)
 
 When migrating legacy code that uses `||` and `&&` for guarding against `null` or `undefined`, you may often convert it partially:
 
-```js example-bad
+```js-nolint example-bad
 function getId(user, fallback) {
   // Previously: user && user.id || fallback
   return user && user.id ?? fallback; // SyntaxError: cannot use `??` unparenthesized within `||` and `&&` expressions

--- a/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
@@ -45,7 +45,7 @@ circularReference.myself = circularReference;
 
 {{jsxref("JSON.stringify()")}} will fail
 
-```js example-bad
+```js-nolint example-bad
 JSON.stringify(circularReference);
 // TypeError: cyclic object value
 ```

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -42,7 +42,7 @@ This error only happens in [strict mode code](/en-US/docs/Web/JavaScript/Referen
 
 Attempting to delete a plain variable, doesn't work in JavaScript and it throws an error in strict mode:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 var x;

--- a/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -42,7 +42,7 @@ non-standard, hard to optimize and potentially a performance-harmful feature.
 [`arguments.callee.caller`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
 are deprecated (see the reference articles for more information).
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 function myFunc() {
@@ -62,7 +62,7 @@ myFunc();
 {{jsxref("Function.prototype.arguments")}} is deprecated (see the reference article for more
 information).
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 function f(n) { g(n - 1); }

--- a/files/en-us/web/javascript/reference/errors/deprecated_expression_closures/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_expression_closures/index.md
@@ -37,7 +37,7 @@ scripts using it will throw a {{jsxref("SyntaxError")}} in newer versions of Fir
 Expression closures omit curly braces or return statements from function declarations
 or from method definitions in objects.
 
-```js example-bad
+```js-nolint example-bad
 var x = function () 1;
 
 var obj = {
@@ -70,7 +70,7 @@ const x = () => 1;
 
 Expression closures can also be found with getter and setter, like this:
 
-```js example-bad
+```js-nolint example-bad
 var obj = {
   get x() 1,
   set x(v) this.v = v

--- a/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
@@ -41,7 +41,7 @@ letter "O" (`0o` or `0O`).
 
 ### "0"-prefixed octal literals
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 03;
@@ -51,7 +51,7 @@ letter "O" (`0o` or `0O`).
 
 ### Octal escape sequences
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 "\251";

--- a/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -40,7 +40,7 @@ The source map specification changed the syntax due to a conflict with IE whenev
 
 Syntax with the "@" sign is deprecated.
 
-```js example-bad
+```js-nolint example-bad
 //@ sourceMappingURL=http://example.com/path/to/your/sourcemap.map
 ```
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_string_generics/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_string_generics/index.md
@@ -57,7 +57,7 @@ applied to any object.
 
 ### Deprecated syntax
 
-```js example-bad
+```js-nolint example-bad
 const num = 15;
 String.replace(num, /5/, '2');
 ```

--- a/files/en-us/web/javascript/reference/errors/deprecated_tolocaleformat/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_tolocaleformat/index.md
@@ -37,7 +37,7 @@ Firefox 58+**.
 The `Date.prototype.toLocaleFormat()` method is deprecated and will be
 removed (no cross-browser support, available in Firefox only).
 
-```js example-bad
+```js-nolint example-bad
 const today = new Date();
 const date = today.toLocaleFormat("%A, %e. %B %Y");
 
@@ -94,7 +94,7 @@ dates.forEach((date) => console.log(dateFormatter.format(date)));
 
 The {{jsxref("Date")}} object offers several methods to build a custom date string.
 
-```js example-bad
+```js-nolint example-bad
 new Date().toLocaleFormat("%Y%m%d");
 // "20170310"
 ```

--- a/files/en-us/web/javascript/reference/errors/equal_as_assign/index.md
+++ b/files/en-us/web/javascript/reference/errors/equal_as_assign/index.md
@@ -40,7 +40,7 @@ It is advisable to not use simple assignments in a conditional expression (such 
 because the assignment can be confused with equality when glancing over the code. For
 example, do not use the following code:
 
-```js example-bad
+```js-nolint example-bad
 if (x = y) {
   // do the right thing
 }

--- a/files/en-us/web/javascript/reference/errors/getter_only/index.md
+++ b/files/en-us/web/javascript/reference/errors/getter_only/index.md
@@ -42,7 +42,7 @@ It doesn't specify a [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set
 property to `30`. For more details see also the
 {{jsxref("Object.defineProperty()")}} page.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 function Archiver() {

--- a/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
+++ b/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
@@ -39,7 +39,7 @@ line of a file, or accidentally forgetting the quotation marks around a DOM iden
 
 For each case, there might be something slightly wrong. For example
 
-```js example-bad
+```js-nolint example-bad
 document.querySelector(#some-element)
 ```
 
@@ -51,7 +51,7 @@ document.querySelector("#some-element")
 
 ### Outside of a class
 
-```js example-bad
+```js-nolint example-bad
 class ClassWithPrivateField {
   #privateField
 

--- a/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
@@ -40,7 +40,7 @@ They can't start with a digit! Only subsequent characters can be digits (0-9).
 
 Variable names can't start with numbers in JavaScript. The following fails:
 
-```js example-bad
+```js-nolint example-bad
 const 1life = 'foo';
 // SyntaxError: identifier starts immediately after numeric literal
 

--- a/files/en-us/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/en-us/web/javascript/reference/errors/illegal_character/index.md
@@ -40,7 +40,7 @@ Some characters look similar, but will cause the parser to fail interpreting you
 Famous examples of this are quotes, the minus or semicolon
 ([greek question mark (U+37e)](https://en.wikipedia.org/wiki/Question_mark#Greek_question_mark) looks same).
 
-```js example-bad
+```js-nolint example-bad
 “This looks like a string”;  // SyntaxError: illegal character
                              // “ and ” are not " but look like this
 
@@ -65,7 +65,7 @@ Some editors and IDEs will notify you or at least use a slightly different highl
 
 It's easy to forget a character here or there.
 
-```js example-bad
+```js-nolint example-bad
 const colors = ['#000', #333', '#666'];
 // SyntaxError: illegal character
 ```
@@ -81,7 +81,7 @@ const colors = ['#000', '#333', '#666'];
 When copy pasting code from external sources, there might be invalid characters. Watch
 out!
 
-```js example-bad
+```js-nolint example-bad
 const foo = 'bar';​
 // SyntaxError: illegal character
 ```

--- a/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -40,7 +40,7 @@ You can't search in strings, or in numbers, or other primitive types.
 Unlike in other programming languages (e.g. Python), you can't search in strings using
 the [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in).
 
-```js example-bad
+```js-nolint example-bad
 "Hello" in "Hello World";
 // TypeError: cannot use 'in' operator to search for 'Hello' in 'Hello World'
 ```
@@ -57,7 +57,7 @@ Instead you will need to use {{jsxref("String.prototype.includes()")}}, for exam
 Make sure the object you are inspecting isn't actually [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
 {{jsxref("undefined")}}.
 
-```js example-bad
+```js-nolint example-bad
 const foo = null;
 "bar" in foo;
 // TypeError: cannot use 'in' operator to search for 'bar' in 'foo' (Chrome)

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -52,7 +52,7 @@ using it as argument of the constructor.
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 new Array(Math.pow(2, 40))
 new Array(-1)
 new ArrayBuffer(Math.pow(2, 32)) // 32-bit system

--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -37,7 +37,7 @@ While a single `=` sign assigns a value to a variable, the `==` or `===` operato
 
 ### Typical invalid assignments
 
-```js example-bad
+```js-nolint example-bad
 if (Math.PI + 1 = 3 || Math.PI + 1 = 4) {
   console.log('no way!');
 }

--- a/files/en-us/web/javascript/reference/errors/invalid_bigint_syntax/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_bigint_syntax/index.md
@@ -32,7 +32,7 @@ When using the [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 const a = BigInt("1.5");
 const b = BigInt("1n");
 const c = BigInt.asIntN(4, "8n");

--- a/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
@@ -40,7 +40,7 @@ keyword.
 
 Assigning a value to the same constant name in the same block-scope will throw.
 
-```js example-bad
+```js-nolint example-bad
 const COLUMNS = 80;
 
 // …
@@ -100,7 +100,7 @@ identifier cannot be reassigned. For instance, in case the content is an object,
 means the object itself can still be altered. This means that you can't mutate the value
 stored in a variable:
 
-```js example-bad
+```js-nolint example-bad
 const obj = {foo: 'bar'};
 obj = {foo: 'baz'}; // TypeError: invalid assignment to const `obj'
 ```

--- a/files/en-us/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_date/index.md
@@ -39,7 +39,7 @@ strings usually return {{jsxref("NaN")}}. However, depending on the implementati
 non–conforming ISO format strings, may also throw `RangeError: invalid date`,
 like the following cases in Firefox:
 
-```js example-bad
+```js-nolint example-bad
 new Date('foo-bar 2014');
 new Date('2014-25-23').toISOString();
 new Date('foo-bar 2014').toString();
@@ -47,7 +47,7 @@ new Date('foo-bar 2014').toString();
 
 This, however, returns {{jsxref("NaN")}} in Firefox:
 
-```js example-bad
+```js-nolint example-bad
 Date.parse('foo-bar 2014'); // NaN
 ```
 

--- a/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -40,7 +40,7 @@ In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), however, a `
 
 This example throws a `SyntaxError`:
 
-```js example-bad
+```js-nolint example-bad
 const obj = { a: 1, b: 2, c: 3 };
 
 for (const i = 0 in obj) {

--- a/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -33,7 +33,7 @@ The head of a [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...o
 
 ### Invalid for-of loop
 
-```js example-bad
+```js-nolint example-bad
 const iterable = [10, 20, 30];
 
 for (const value = 50 of iterable) {

--- a/files/en-us/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
@@ -40,7 +40,7 @@ i.e. an object which has a `prototype` property and is callable. It can also be 
 
 ### instanceof vs typeof
 
-```js example-bad
+```js-nolint example-bad
 "test" instanceof ""; // TypeError: invalid 'instanceof' operand ""
 42 instanceof 0;      // TypeError: invalid 'instanceof' operand 0
 

--- a/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
+++ b/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
@@ -42,7 +42,7 @@ an object implementing the [iterable protocol](/en-US/docs/Web/JavaScript/Refere
 
 ### Array destructuring a non-iterable
 
-```js example-bad
+```js-nolint example-bad
 const myobj = { arrayOrObjProp1: {}, arrayOrObjProp2: [42] };
 
 const { arrayOrObjProp1: [value1], arrayOrObjProp2: [value2] } = myobj; // TypeError: object is not iterable
@@ -59,7 +59,7 @@ the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
 Therefore, you cannot use [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement)
 to iterate over the properties of an object.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { France: 'Paris', England: 'London' };
 for (const p of obj) { // TypeError: obj is not iterable
   // …
@@ -108,7 +108,7 @@ for (const [country, capital] of map.entries()) {
 [Generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#generators)
 are functions you call to produce an iterable object.
 
-```js example-bad
+```js-nolint example-bad
 function* generate(a, b) {
   yield a;
   yield b;
@@ -141,7 +141,7 @@ Custom iterables can be created by implementing the
 {{jsxref("Symbol.iterator")}} method. You must be certain that your iterator method
 returns an object which is an iterator, which is to say it must have a next method.
 
-```js example-bad
+```js-nolint example-bad
 const myEmptyIterable = {
   [Symbol.iterator]() {
     return []; // [] is iterable, but it is not an iterator — it has no next method.

--- a/files/en-us/web/javascript/reference/errors/json_bad_parse/index.md
+++ b/files/en-us/web/javascript/reference/errors/json_bad_parse/index.md
@@ -65,7 +65,7 @@ and will throw this error if incorrect syntax was encountered.
 
 Both lines will throw a SyntaxError:
 
-```js example-bad
+```js-nolint example-bad
 JSON.parse('[1, 2, 3, 4,]');
 JSON.parse('{"foo": 1,}');
 // SyntaxError JSON.parse: unexpected character
@@ -83,7 +83,7 @@ JSON.parse('{"foo": 1}');
 
 You cannot use single-quotes around properties, like 'foo'.
 
-```js example-bad
+```js-nolint example-bad
 JSON.parse("{'foo': 1}");
 // SyntaxError: JSON.parse: expected property name or '}'
 // at line 1 column 2 of the JSON data
@@ -100,7 +100,7 @@ JSON.parse('{"foo": 1}');
 You cannot use leading zeros, like 01, and decimal points must be followed by at least
 one digit.
 
-```js example-bad
+```js-nolint example-bad
 JSON.parse('{"foo": 01}');
 // SyntaxError: JSON.parse: expected ',' or '}' after property value
 // in object at line 1 column 2 of the JSON data

--- a/files/en-us/web/javascript/reference/errors/malformed_formal_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/malformed_formal_parameter/index.md
@@ -49,7 +49,7 @@ Firefox engineers are huge fans of 19th-century Gothic horror novels.
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 const f = Function('x y', 'return x + y;');
 // SyntaxError (missing a comma)
 

--- a/files/en-us/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/en-us/web/javascript/reference/errors/malformed_uri/index.md
@@ -41,7 +41,7 @@ escape sequences representing the UTF-8 encoding of the character. An
 {{jsxref("URIError")}} will be thrown if there is an attempt to encode a surrogate which
 is not part of a high-low pair, for example:
 
-```js example-bad
+```js-nolint example-bad
 encodeURI('\uD800');
 // "URIError: malformed URI sequence"
 
@@ -61,7 +61,7 @@ encodeURI('\uD800\uDFFF');
 Decoding replaces each escape sequence in the encoded URI component with the character
 that it represents. If there isn't such a character, an error will be thrown:
 
-```js example-bad
+```js-nolint example-bad
 decodeURIComponent('%E0%A4%A');
 // "URIError: malformed URI sequence"
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
@@ -34,7 +34,7 @@ closing bracket (`]`) or a comma (`,`) missing.
 
 ### Incomplete array initializer
 
-```js example-bad
+```js-nolint example-bad
 const list = [1, 2,
 
 const instruments = [

--- a/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -44,7 +44,7 @@ const obj = { propertyKey: 'value' };
 This code fails, as the equal sign can't be used this way in this object initializer
 syntax.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { propertyKey = 'value' };
 // SyntaxError: missing : after property id
 ```
@@ -66,7 +66,7 @@ obj['propertyKey'] = 'value';
 If you create a property key from an expression, you need to use square brackets.
 Otherwise the property name can't be computed:
 
-```js example-bad
+```js-nolint example-bad
 const obj = { 'b'+'ar': 'foo' };
 // SyntaxError: missing : after property id
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
@@ -36,7 +36,7 @@ a bit nicer might also help you to see through the jungle.
 
 Oftentimes, there is a missing curly bracket in your function code:
 
-```js example-bad
+```js-nolint example-bad
 const charge = function () {
   if (sunny) {
     useSolarCells();
@@ -60,7 +60,7 @@ const charge = function () {
 It can be more obscure when using [IIFE](/en-US/docs/Glossary/IIFE), [Closures](/en-US/docs/Web/JavaScript/Closures), or other constructs that use
 a lot of different parenthesis and curly brackets, for example.
 
-```js example-bad
+```js-nolint example-bad
 (function () { if (true) { return false; } );
 ```
 

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -39,7 +39,7 @@ also help you to see through the jungle.
 
 Oftentimes, there is a missing comma in your object initializer code:
 
-```js example-bad
+```js-nolint example-bad
 const obj = {
   a: 1,
   b: { myProp: 2 }

--- a/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -46,7 +46,7 @@ identifier is part of the code.
 Function parameters must be identifiers when setting up a function. All these function
 declarations fail, as they are providing values for their parameters:
 
-```js example-bad
+```js-nolint example-bad
 function square(3) {
   return number * number;
 };

--- a/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
@@ -43,7 +43,7 @@ changed later).
 Unlike `var` or `let`, you must specify a value for a
 `const` declaration. This throws:
 
-```js example-bad
+```js-nolint example-bad
 const COLUMNS;
 // SyntaxError: missing = in const declaration
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -42,7 +42,7 @@ case. Please see the examples below.
 in JavaScript use either the dot (.) or square brackets (`[]`), but not both.
 Square brackets allow computed property access.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { foo: { bar: "baz", bar2: "baz2" } };
 const i = 2;
 
@@ -71,7 +71,7 @@ obj.foo[`bar${i}`]; // "baz2"
 If you are coming from another programming language (like [PHP](/en-US/docs/Glossary/PHP)), it is also easy to mix up the dot operator
 (`.`) and the concatenation operator (`+`).
 
-```js example-bad
+```js-nolint example-bad
 console.log("Hello" . "world");
 
 // SyntaxError: missing name after . operator

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -36,7 +36,7 @@ Because there is no "+" operator to concatenate the string, JavaScript expects t
 argument for the `log` function to be just `"PI: "`. In that case,
 it should be terminated by a closing parenthesis.
 
-```js example-bad
+```js-nolint example-bad
 console.log('PI: ' Math.PI);
 // SyntaxError: missing ) after argument list
 ```
@@ -57,7 +57,7 @@ console.log('PI: ', Math.PI);
 
 ### Unterminated strings
 
-```js example-bad
+```js-nolint example-bad
 console.log('"Java" + "Script" = \"' + 'Java' + 'Script\");
 // SyntaxError: missing ) after argument list
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
@@ -47,7 +47,7 @@ if (condition) {
 
 It might just be an oversight, carefully check all you parenthesis in your code.
 
-```js example-bad
+```js-nolint example-bad
 if (Math.PI < 3 {
   console.log("wait what?");
 }
@@ -68,7 +68,7 @@ if (Math.PI < 3) {
 If you are coming from another programming language, it is also easy to add keywords
 that don't mean the same or have no meaning at all in JavaScript.
 
-```js example-bad
+```js-nolint example-bad
 if (done is true) {
  console.log("we are done!");
 }

--- a/files/en-us/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -45,7 +45,7 @@ many parenthesis somewhere. Carefully check the syntax when this error is thrown
 This error can occur easily when not escaping strings properly and the JavaScript
 engine is expecting the end of your string already. For example:
 
-```js example-bad
+```js-nolint example-bad
 const foo = 'Tom's bar';
 // SyntaxError: missing ; before statement
 ```
@@ -63,7 +63,7 @@ const foo = 'Tom\'s bar';
 You **cannot** declare properties of an object or array with a
 `var` declaration.
 
-```js example-bad
+```js-nolint example-bad
 const obj = {};
 const obj.foo = 'hi'; // SyntaxError missing ; before statement
 
@@ -86,7 +86,7 @@ array[0] = 'there';
 If you come from another programming language, it is also common to use keywords that
 don't mean the same or have no meaning at all in JavaScript:
 
-```js example-bad
+```js-nolint example-bad
 def print(info) {
   console.log(info);
 } // SyntaxError missing ; before statement

--- a/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -38,7 +38,7 @@ There is an error with how a function is called. More arguments need to be provi
 The {{jsxref("Object.create()")}} method requires at least one argument and the
 {{jsxref("Object.setPrototypeOf()")}} method requires at least two arguments:
 
-```js example-bad
+```js-nolint example-bad
 const obj = Object.create();
 // TypeError: Object.create requires at least 1 argument, but only 0 were passed
 

--- a/files/en-us/web/javascript/reference/errors/negative_repetition_count/index.md
+++ b/files/en-us/web/javascript/reference/errors/negative_repetition_count/index.md
@@ -37,7 +37,7 @@ number. The range of allowed values can be described like this: \[0, +∞).
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 'abc'.repeat(-1); // RangeError
 ```
 

--- a/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
@@ -43,7 +43,7 @@ When methods like {{jsxref("Object.create()")}} or
 used, the optional descriptor parameter expects a property descriptor object. Providing
 no object (like just a number), will throw an error:
 
-```js example-bad
+```js-nolint example-bad
 Object.defineProperty({}, 'key', 1);
 // TypeError: 1 is not a non-null object
 
@@ -62,7 +62,7 @@ Object.defineProperty({}, 'key', { value: 'foo', writable: false });
 {{jsxref("WeakMap")}} and {{jsxref("WeakSet")}} objects store object keys. You can't
 use other types as keys.
 
-```js example-bad
+```js-nolint example-bad
 const ws = new WeakSet();
 ws.add('foo');
 // TypeError: "foo" is not a non-null object

--- a/files/en-us/web/javascript/reference/errors/no_properties/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_properties/index.md
@@ -36,7 +36,7 @@ access.
 
 ### null and undefined have no properties
 
-```js example-bad
+```js-nolint example-bad
 null.foo;
 // TypeError: null has no properties
 

--- a/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
@@ -35,7 +35,7 @@ When declaring multiple variables at the same time, make sure that the previous 
 
 ### Missing a variable name
 
-```js example-bad
+```js-nolint example-bad
 const = "foo";
 ```
 
@@ -50,7 +50,7 @@ const description = "foo";
 There are a few variable names that are [reserved keywords](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords).
 You can't use these. Sorry :(
 
-```js example-bad
+```js-nolint example-bad
 const debugger = "whoop";
 // SyntaxError: missing variable name
 ```
@@ -61,7 +61,7 @@ Pay special attention to commas when declaring multiple variables.
 Is there an excess comma, or did you use commas instead of semicolons?
 Did you remember to assign values for all your `const` variables?
 
-```js example-bad
+```js-nolint example-bad
 let x, y = "foo",
 const z, = "foo"
 
@@ -86,7 +86,7 @@ const second = document.getElementById('two');
 {{jsxref("Array")}} literals in JavaScript need square brackets around the values.
 This won't work:
 
-```js example-bad
+```js-nolint example-bad
 const arr = 1,2,3,4,5;
 // SyntaxError: missing variable name
 ```

--- a/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.md
+++ b/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.md
@@ -48,7 +48,7 @@ are configurable. However, for example, when using
 The {{jsxref("Object.defineProperty()")}} creates non-configurable properties by
 default if you haven't specified them as configurable.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 const arr = [];
 Object.defineProperty(arr, 0, { value: 0 });
@@ -74,7 +74,7 @@ arr.length = 1;
 The {{jsxref("Object.seal()")}} function marks all existing elements as
 non-configurable.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 const arr = [1, 2, 3];
 Object.seal(arr);

--- a/files/en-us/web/javascript/reference/errors/not_a_codepoint/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_codepoint/index.md
@@ -40,7 +40,7 @@ Unicode codespace; that is, the range of integers from `0` to
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 String.fromCodePoint('_');      // RangeError
 String.fromCodePoint(Infinity); // RangeError
 String.fromCodePoint(-1);       // RangeError

--- a/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
@@ -43,7 +43,7 @@ are not a constructor: {{jsxref("Math")}}, {{jsxref("JSON")}}, {{jsxref("Symbol"
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 const Car = 1;
 new Car();
 // TypeError: Car is not a constructor
@@ -85,7 +85,7 @@ When returning an immediately-resolved or immediately-rejected Promise, you do n
 
 This is not legal (the [`Promise` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) is not being called correctly) and will throw a `TypeError: this is not a constructor` exception:
 
-```js example-bad
+```js-nolint example-bad
 const fn = () => {
   return new Promise.resolve(true);
 }

--- a/files/en-us/web/javascript/reference/errors/not_a_function/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_function/index.md
@@ -52,7 +52,7 @@ provide a function in order to have these methods working properly:
 
 In this case, which happens way too often, there is a typo in the method name:
 
-```js example-bad
+```js-nolint example-bad
 const x = document.getElementByID('foo');
 // TypeError: document.getElementByID is not a function
 ```
@@ -69,7 +69,7 @@ For certain methods, you have to provide a (callback) function and it will work 
 specific objects only. In this example, {{jsxref("Array.prototype.map()")}} is used,
 which will work with {{jsxref("Array")}} objects only.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { a: 13, b: 37, c: 42 };
 
 obj.map(function (num) {
@@ -96,7 +96,7 @@ numbers.map(function (num) {
 Sometimes when making a class, you may have a property and a function with the same
 name. Upon calling the function, the compiler thinks that the function ceases to exist.
 
-```js example-bad
+```js-nolint example-bad
 function Dog() {
   this.age = 11;
   this.color = "black";
@@ -138,7 +138,7 @@ In math, you can write 2 × (3 + 5) as 2\*(3 + 5) or just 2(3 + 5).
 
 Using the latter will throw an error:
 
-```js example-bad
+```js-nolint example-bad
 const sixteen = 2(3 + 5);
 console.log(`2 x (3 + 5) is ${sixteen}`);
 // Uncaught TypeError: 2 is not a function

--- a/files/en-us/web/javascript/reference/errors/not_defined/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_defined/index.md
@@ -37,7 +37,7 @@ declared, or you need to make sure it is available in your current script or [sc
 
 ### Variable not declared
 
-```js example-bad
+```js-nolint example-bad
 foo.substring(1); // ReferenceError: foo is not defined
 ```
 
@@ -56,7 +56,7 @@ inside a [function](/en-US/docs/Web/JavaScript/Reference/Functions) cannot be
 accessed from anywhere outside the function, because the variable is defined only in the
 scope of the function
 
-```js example-bad
+```js-nolint example-bad
 function numbers() {
   const num1 = 2;
   const num2 = 3;

--- a/files/en-us/web/javascript/reference/errors/precision_range/index.md
+++ b/files/en-us/web/javascript/reference/errors/precision_range/index.md
@@ -39,7 +39,7 @@ There was an out of range precision argument in one of these methods:
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 77.1234.toExponential(-1);  // RangeError
 77.1234.toExponential(101); // RangeError
 

--- a/files/en-us/web/javascript/reference/errors/read-only/index.md
+++ b/files/en-us/web/javascript/reference/errors/read-only/index.md
@@ -41,7 +41,7 @@ non-strict code, the assignment is silently ignored.
 Read-only properties are not super common, but they can be created using
 {{jsxref("Object.defineProperty()")}} or {{jsxref("Object.freeze()")}}.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const obj = Object.freeze({ name: 'Elsa', score: 157 });
 obj.score = 0;  // TypeError
@@ -58,7 +58,7 @@ frozenArray[0]++;  // TypeError
 There are also a few read-only properties built into JavaScript. Maybe you tried to
 redefine a mathematical constant.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 Math.PI = 4;  // TypeError
 ```
@@ -68,7 +68,7 @@ Sorry, you can't do that.
 The global variable `undefined` is also read-only, so you can't silence the
 infamous "undefined is not a function" error by doing this:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 undefined = function() {};  // TypeError: "undefined" is read-only
 ```

--- a/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
@@ -39,7 +39,7 @@ allowed in JavaScript.
 
 In this case, the variable "arg" redeclares the argument.
 
-```js example-bad
+```js-nolint example-bad
 function f(arg) {
   let arg = 'foo';
 }

--- a/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
@@ -47,7 +47,7 @@ This problem appears frequently when combined with a filter
 which will remove all elements of the list. Thus leaving none to be used as the initial
 value.
 
-```js example-bad
+```js-nolint example-bad
 const ints = [0, -1, -2, -3, -4, -5];
 ints.filter((x) => x > 0)       // removes all elements
   .reduce((x, y) => x + y)    // no more elements to use for the initial value.
@@ -56,7 +56,7 @@ ints.filter((x) => x > 0)       // removes all elements
 Similarly, the same issue can happen if there is a typo in a selector, or an unexpected
 number of elements in a list:
 
-```js example-bad
+```js-nolint example-bad
 const names = document.getElementsByClassName("names");
 const name_list = Array.prototype.reduce.call(names, (acc, name) => acc + ", " + name);
 ```

--- a/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
+++ b/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
@@ -50,14 +50,14 @@ The following are only reserved when they are found in strict mode code:
 
 The `enum` identifier is generally reserved.
 
-```js example-bad
+```js-nolint example-bad
 const enum = { RED: 0, GREEN: 1, BLUE: 2 };
 // SyntaxError: enum is a reserved identifier
 ```
 
 In strict mode code, more identifiers are reserved.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 const package = ["potatoes", "rice", "fries"];
 // SyntaxError: package is a reserved identifier

--- a/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -43,7 +43,7 @@ differ in JavaScript engines. In Firefox (SpiderMonkey) the maximum string size 
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 'abc'.repeat(Infinity); // RangeError
 'a'.repeat(2**30);      // RangeError
 ```

--- a/files/en-us/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/en-us/web/javascript/reference/errors/stmt_after_return/index.md
@@ -53,7 +53,7 @@ Warnings will not be shown for semicolon-less returns if these statements follow
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 function f() {
   let x = 3;
   x += 4;

--- a/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -49,7 +49,7 @@ the ECMAScript specification.
 In this case, the function `sum` has default parameters `a=1` and
 `b=2`:
 
-```js example-bad
+```js-nolint example-bad
 function sum(a = 1, b = 2) {
   // SyntaxError: "use strict" not allowed in function with default parameter
   'use strict';
@@ -72,7 +72,7 @@ function sum(a = 1, b = 2) {
 
 A function expression can use yet another workaround:
 
-```js example-bad
+```js-nolint example-bad
 const sum = function sum([a, b]) {
   // SyntaxError: "use strict" not allowed in function with destructuring parameter
   'use strict';
@@ -96,7 +96,7 @@ const sum = (function() {
 If an arrow function needs to access the `this` variable, you can use the
 arrow function as the enclosing function:
 
-```js example-bad
+```js-nolint example-bad
 const callback = (...args) => {
   // SyntaxError: "use strict" not allowed in function with rest parameter
   'use strict';

--- a/files/en-us/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/en-us/web/javascript/reference/errors/too_much_recursion/index.md
@@ -52,7 +52,7 @@ loop(0);
 
 Setting this condition to an extremely high value, won't work:
 
-```js example-bad
+```js-nolint example-bad
 function loop(x) {
   if (x >= 1000000000000)
     return;
@@ -67,7 +67,7 @@ loop(0);
 This recursive function is missing a base case. As there is no exit condition, the
 function will call itself infinitely.
 
-```js example-bad
+```js-nolint example-bad
 function loop(x) {
   // The base case is missing
   loop(x + 1); // Recursive call
@@ -80,7 +80,7 @@ loop(0);
 
 ### Class error: too much recursion
 
-```js example-bad
+```js-nolint example-bad
 class Person {
   constructor() {}
   set name(name) {
@@ -99,7 +99,7 @@ In this example when the setter is triggered, it is told to do the same thing ag
 
 This issue also appears if the same variable is used in the getter.
 
-```js example-bad
+```js-nolint example-bad
 class Person {
   get name() {
     return this.name; // Recursive call

--- a/files/en-us/web/javascript/reference/errors/undeclared_var/index.md
+++ b/files/en-us/web/javascript/reference/errors/undeclared_var/index.md
@@ -51,7 +51,7 @@ In non-strict code, they are silently ignored.
 
 In this case, the variable "bar" is an undeclared variable.
 
-```js example-bad
+```js-nolint example-bad
 function foo() {
   'use strict';
   bar = true;

--- a/files/en-us/web/javascript/reference/errors/undefined_prop/index.md
+++ b/files/en-us/web/javascript/reference/errors/undefined_prop/index.md
@@ -38,7 +38,7 @@ ways to access properties; see the {{jsxref("Operators/Property_Accessors", "pro
 In this case, the property `bar` is an undefined property, so a
 `ReferenceError` will occur.
 
-```js example-bad
+```js-nolint example-bad
 const foo = {};
 foo.bar; // ReferenceError: reference to undefined property "bar"
 ```

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -39,7 +39,7 @@ be a simple typo.
 
 For example, when chaining expressions, trailing commas are not allowed.
 
-```js example-bad
+```js-nolint example-bad
 for (let i = 0; i < 5,; ++i) {
   console.log(i);
 }
@@ -58,7 +58,7 @@ for (let i = 0; i < 5; ++i) {
 
 Sometimes, you leave out brackets around `if` statements:
 
-```js example-bad
+```js-nolint example-bad
 function round(n, upperBound, lowerBound) {
   if (n > upperBound) || (n < lowerBound) { // Not enough brackets here!
     throw new Error(`Number ${n} is more than ${upperBound} or less than ${lowerBound}`);

--- a/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
@@ -42,7 +42,7 @@ Also, certain methods, such as {{jsxref("Object.create()")}} or
 
 ### Invalid cases
 
-```js example-bad
+```js-nolint example-bad
 // undefined and null cases on which the substring method won't work
 const foo = undefined;
 foo.substring(1); // TypeError: foo is undefined

--- a/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -38,7 +38,7 @@ You'll need to check how functions are defined and if you need to provide a name
 A _[function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function)_ (or _function declaration_) requires a name.
 This won't work:
 
-```js example-bad
+```js-nolint example-bad
 function () {
   return 'Hello world';
 }
@@ -66,7 +66,7 @@ If your function is intended to be an [IIFE](https://en.wikipedia.org/wiki/Immed
 If you are using function [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label), you will still need to provide a function name after the `function` keyword.
 This doesn't work:
 
-```js example-bad
+```js-nolint example-bad
 function Greeter() {
   german: function () {
     return "Moin";
@@ -111,7 +111,7 @@ const greeter = {
 Also, check your syntax when using callbacks.
 Brackets and commas can quickly get confusing.
 
-```js example-bad
+```js-nolint example-bad
 promise.then(
   function () {
     console.log("success");

--- a/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
@@ -27,7 +27,7 @@ SyntaxError: Unexpected token '**'. Ambiguous unary expression in the left hand 
 
 You likely wrote something like this:
 
-```js example-bad
+```js-nolint example-bad
 -a ** b
 ```
 
@@ -40,7 +40,7 @@ Whether it should be evaluated as `(-a) ** b` or `-(a ** b)` is ambiguous. In ma
 
 Other unary operators cannot be the left-hand side of exponentiation either.
 
-```js example-bad
+```js-nolint example-bad
 await a ** b
 !a ** b
 +a ** b
@@ -51,7 +51,7 @@ await a ** b
 
 When writing complex math expressions involving exponentiation, you may write something like this:
 
-```js example-bad
+```js-nolint example-bad
 function taylorSin(x) {
   return (n) => -1 ** n * x ** (2 * n + 1) / factorial(2 * n + 1);
   // SyntaxError: unparenthesized unary expression can't appear on the left-hand side of '**'

--- a/files/en-us/web/javascript/reference/errors/unterminated_string_literal/index.md
+++ b/files/en-us/web/javascript/reference/errors/unterminated_string_literal/index.md
@@ -45,7 +45,7 @@ To fix this error, check if:
 
 You can't split a string across multiple lines like this in JavaScript:
 
-```js example-bad
+```js-nolint example-bad
 const longString = 'This is a very long string which needs
                     to wrap across multiple lines because
                     otherwise my code is unreadable.';

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -454,7 +454,7 @@ const func2 = (x, y) => { return x + y; };
 Keep in mind that returning object literals using the concise body syntax
 `(params) => {object:literal}` will not work as expected.
 
-```js example-bad
+```js-nolint example-bad
 const func = () => { foo: 1 };
 // Calling func() returns undefined!
 
@@ -478,7 +478,7 @@ const func = () => ({ foo: 1 });
 
 An arrow function cannot contain a line break between its parameters and its arrow.
 
-```js example-bad
+```js-nolint example-bad
 const func = (a, b, c)
   => 1;
 // SyntaxError: Unexpected token '=>'
@@ -516,7 +516,7 @@ special parsing rules that interact differently with
 [operator precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
 compared to regular functions.
 
-```js example-bad
+```js-nolint example-bad
 let callback;
 
 callback = callback || () => {};

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -81,7 +81,7 @@ This means that earlier parameters can be referred to in the initializers of lat
 
 For example, the following function will throw a `ReferenceError` when invoked, because the default parameter value does not have access to the child scope of the function body:
 
-```js example-bad
+```js-nolint example-bad
 function f(a = go()) {
   function go() {
     return ":P";
@@ -93,7 +93,7 @@ f(); // ReferenceError: go is not defined
 
 This function will print the value of the _parameter_ `a`, because the variable `var a` is hoisted only to the top of the scope created for the function body, not the parent scope created for the parameter list, so its value is not visible to `b`.
 
-```js example-bad
+```js-nolint example-bad
 function f(a, b = () => console.log(a)) {
   var a = 1;
   b();

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -51,7 +51,7 @@ Note the following when working with the `get` syntax:
   for more information);
 - It must not appear in an object literal with another `get` e.g. the following is forbidden
 
-  ```js example-bad
+  ```js-nolint example-bad
   {
     get x() { }, get x() { }
   }
@@ -59,7 +59,7 @@ Note the following when working with the `get` syntax:
 
 - It must not appear with a data entry for the same property e.g. the following is forbidden
 
-  ```js example-bad
+  ```js-nolint example-bad
   {
     x: /* … */, get x() { /* … */ }
   }

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -152,7 +152,7 @@ const obj4 = {
 Methods cannot be constructors! They will throw a {{jsxref("TypeError")}} if you try to
 instantiate them.
 
-```js example-bad
+```js-nolint example-bad
 const objA = {
   method() {}
 }

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -47,14 +47,14 @@ myFun("one", "two", "three", "four", "five", "six");
 
 A function definition can have only one `...`_restParam_.
 
-```js example-bad
+```js-nolint example-bad
 foo(...one, ...wrong, ...wrong)
 ```
 
 The rest parameter must be the last parameter in the function
 definition.
 
-```js example-bad
+```js-nolint example-bad
 foo(...wrong, arg2, arg3)
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -568,7 +568,7 @@ Results in
 
 Array elements are object properties in the same way that `toString` is a property (to be specific, however, `toString()` is a method). Nevertheless, trying to access an element of an array as follows throws a syntax error because the property name is not valid:
 
-```js example-bad
+```js-nolint example-bad
 console.log(arr.0); // a syntax error
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -168,7 +168,7 @@ dates, so the output text will flow properly when concatenated with other text.
 For this reason, you cannot expect to be able to compare the results of
 `toLocaleString()` to a static value:
 
-```js example-bad
+```js-nolint example-bad
 "1/1/2019, 01:00:00" === new Date("2019-01-01T01:00:00Z").toLocaleString("en-US");
 // true in Firefox and others
 // false in IE and Edge

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -141,7 +141,7 @@ Indirect eval can be seen as if the code is evaluated within a separate `<script
 
 In strict mode, declaring a variable named `eval` or re-assigning `eval` is a {{jsxref("SyntaxError")}}.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 const eval = 1; // SyntaxError: Unexpected eval or arguments in strict mode

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -70,7 +70,7 @@ new BoundBase(3, 4); // true, [1, 2, 3, 4]
 
 However, because a bound function does not have the [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property, it cannot be used as a base class for [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends).
 
-```js example-bad
+```js-nolint example-bad
 class Derived extends class {}.bind(null) {}
 // TypeError: Class extends value does not have valid prototype property undefined
 ```

--- a/files/en-us/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/tostring/index.md
@@ -41,7 +41,7 @@ The `toString()` method will throw a {{jsxref("TypeError")}} exception
 ("Function.prototype.toString called on incompatible object"), if its
 `this` value object is not a `Function` object.
 
-```js example-bad
+```js-nolint example-bad
 Function.prototype.toString.call('foo'); // throws TypeError
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/internalerror/index.md
@@ -61,7 +61,7 @@ loop(0);
 
 Setting this condition to an extremely high value, may not work:
 
-```js example-bad
+```js-nolint example-bad
 function loop(x) {
   if (x >= 1000000000000)
     return;

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -80,7 +80,7 @@ text will flow properly when concatenated with other text.
 For this reason you cannot expect to be able to compare the results of
 `format()` to a static value:
 
-```js example-bad
+```js-nolint example-bad
 let d = new Date("2019-01-01T00:00:00.000000Z");
 let formattedDate = Intl.DateTimeFormat(undefined, {
   year: 'numeric',

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/index.md
@@ -40,7 +40,7 @@ The **`Intl.Segmenter`** object enables locale-sensitive text segmentation, enab
 
 If we were to use [`String.prototype.split(" ")`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) to segment a text in words, we would not get the correct result if the locale of the text does not use whitespaces between words (which is the case for Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.).
 
-```js example-bad
+```js-nolint example-bad
 const str = "吾輩は猫である。名前はたぬき。";
 console.table(str.split(" "));
 // ['吾輩は猫である。名前はたぬき。']

--- a/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
@@ -97,7 +97,7 @@ JSON.parse('{"1": 1, "2": 2, "3": {"4": 4, "5": {"6": 6}}}', (key, value) => {
 
 ### JSON.parse() does not allow trailing commas
 
-```js example-bad
+```js-nolint example-bad
 // both will throw a SyntaxError
 JSON.parse('[1, 2, 3, 4, ]');
 JSON.parse('{"foo" : 1, }');
@@ -105,7 +105,7 @@ JSON.parse('{"foo" : 1, }');
 
 ### JSON.parse() does not allow single quotes
 
-```js example-bad
+```js-nolint example-bad
 // will throw a SyntaxError
 JSON.parse("{'foo': 1}");
 ```

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -310,7 +310,7 @@ JSON.stringify([obj]);
 
 Since the [JSON format](https://www.json.org/) doesn't support object references (although an [IETF draft exists](https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03)), a {{JSxRef("TypeError")}} will be thrown if one attempts to encode an object with circular references.
 
-```js example-bad
+```js-nolint example-bad
 const circularReference = {};
 circularReference.myself = circularReference;
 

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -227,7 +227,7 @@ considerable confusion.
 
 Therefore, this appears to work in a way:
 
-```js example-bad
+```js-nolint example-bad
 const wrongMap = new Map();
 wrongMap['bla'] = 'blaa';
 wrongMap['bla2'] = 'blaaa2';
@@ -239,7 +239,7 @@ But that way of setting a property does not interact with the Map data
 structure. It uses the feature of the generic object. The value of 'bla' is not
 stored in the Map for queries. Other operations on the data fail:
 
-```js example-bad
+```js-nolint example-bad
 wrongMap.has('bla')    // false
 wrongMap.delete('bla') // false
 console.log(wrongMap)  // Map { bla: 'blaa', bla2: 'blaaa2' }

--- a/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -161,7 +161,7 @@ Promise.resolve(thenable)
 
 > **Warning:** Do not call `Promise.resolve()` on a thenable that resolves to itself. That leads to infinite recursion, because it attempts to flatten an infinitely-nested promise.
 
-```js example-bad
+```js-nolint example-bad
 const thenable = {
   then(onFulfilled, onRejected) {
     onFulfilled(thenable);

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -76,7 +76,7 @@ console.log(new p(1).value); // "called: 1"
 
 The following code violates the invariant.
 
-```js example-bad
+```js-nolint example-bad
 const p = new Proxy(function () {}, {
   construct(target, argumentsList, newTarget) {
     return 1;
@@ -88,7 +88,7 @@ new p(); // TypeError is thrown
 
 The following code improperly initializes the proxy. The `target` in Proxy initialization must itself be a valid constructor for the {{jsxref("Operators/new", "new")}} operator.
 
-```js example-bad
+```js-nolint example-bad
 const p = new Proxy({}, {
   construct(target, argumentsList, newTarget) {
     return {};

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -79,7 +79,7 @@ console.log(Object.getOwnPropertyDescriptor(p, 'a').value); // "called: a"
 
 The following code violates an invariant.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { a: 10 };
 Object.preventExtensions(obj);
 const p = new Proxy(obj, {

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -99,7 +99,7 @@ console.log(
 
 ### Two kinds of exceptions
 
-```js example-bad
+```js-nolint example-bad
 const obj = {};
 const p = new Proxy(obj, {
   getPrototypeOf(target) {

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -83,7 +83,7 @@ console.log('a' in p); // "called: a"
 
 The following code violates an invariant.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { a: 10 };
 Object.preventExtensions(obj);
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -77,7 +77,7 @@ console.log(Object.isExtensible(p)); // "called"
 
 The following code violates the invariant.
 
-```js example-bad
+```js-nolint example-bad
 const p = new Proxy({}, {
   isExtensible(target) {
     return false;

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -84,7 +84,7 @@ console.log(Object.getOwnPropertyNames(p)); // "called"
 
 The following code violates an invariant.
 
-```js example-bad
+```js-nolint example-bad
 const obj = {};
 Object.defineProperty(obj, 'a', {
   configurable: false,

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -75,7 +75,7 @@ console.log(Object.preventExtensions(p)); // "called"
 
 The following code violates the invariant.
 
-```js example-bad
+```js-nolint example-bad
 const p = new Proxy({}, {
   preventExtensions(target) {
     return true;

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -69,7 +69,7 @@ See also [Planned changes to shared memory](/en-US/docs/Web/JavaScript/Reference
 
 `SharedArrayBuffer` objects must be constructed with the {{jsxref("Operators/new", "new")}} operator. Calling `SharedArrayBuffer()` as a function without using `new` will throw a {{jsxref("TypeError")}}.
 
-```js example-bad
+```js-nolint example-bad
 const sab = SharedArrayBuffer(1024);
 // TypeError: calling a builtin SharedArrayBuffer constructor
 // without new is forbidden

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
@@ -50,7 +50,7 @@ initialized to 0.
 {{jsxref("Operators/new", "new")}} operator. Calling a `SharedArrayBuffer`
 constructor as a function without `new` will throw a {{jsxref("TypeError")}}.
 
-```js example-bad
+```js-nolint example-bad
 const sab = SharedArrayBuffer(1024);
 // TypeError: calling a builtin SharedArrayBuffer constructor
 // without new is forbidden

--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -178,7 +178,7 @@ Given `styleHyphenFormat('borderTop')`, this returns `'border-top'`.
 
 Because we want to further transform the _result_ of the match before the final substitution is made, we must use a function. This forces the evaluation of the match prior to the [`toLowerCase()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) method. If we had tried to do this using the match without a function, the {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}} would have no effect.
 
-```js example-bad
+```js-nolint example-bad
 const newString = propertyName.replace(/[A-Z]/g, '-' + '$&'.toLowerCase());  // won't work
 ```
 
@@ -211,7 +211,7 @@ console.log("abcd".replace(/(bc)/, (match, p1, offset) => `${match} (${offset}) 
 
 However, this replacer would be hard to generalize if we want it to work with any regex pattern. The replacer is _variadic_ — the number of arguments it receives depends on the number of capturing groups present. We can use [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), but it would also collect `offset`, `string`, etc. into the array. The fact that `groups` may or may not be passed depending on the identity of the regex would also make it hard to generically know which argument corresponds to the `offset`.
 
-```js example-bad
+```js-nolint example-bad
 function addOffset(match, ...args) {
   const offset = args.at(-2);
   return `${match} (${offset}) `;

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -87,7 +87,7 @@ For more information about how regex properties (especially the [sticky](/en-US/
 
 When using a regular expression search value, it must be global. This won't work:
 
-```js example-bad
+```js-nolint example-bad
 'aabbcc'.replaceAll(/b/, '.');
 // TypeError: replaceAll must be called with a global RegExp
 ```

--- a/files/en-us/web/javascript/reference/global_objects/string/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/string/index.md
@@ -61,7 +61,7 @@ that's why you rarely want to use the String constructor at all.
 
 `String()` is the only case where a symbol can be converted to a string without throwing, because it's very explicit.
 
-```js example-bad
+```js-nolint example-bad
 const sym = Symbol("example");
 `${sym}`; // TypeError: Cannot convert a Symbol value to a string
 "" + sym; // TypeError: Cannot convert a Symbol value to a string

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -74,7 +74,7 @@ console.log(...someObj); // 'a', 'b'
 
 If an iterable's `@@iterator` method does not return an iterator object, then it is a non-well-formed iterable. Using it as such is likely to result in runtime exceptions or buggy behavior:
 
-```js example-bad
+```js-nolint example-bad
 const nonWellFormedIterable = {};
 nonWellFormedIterable[Symbol.iterator] = () => 1;
 [...nonWellFormedIterable] // TypeError: [Symbol.iterator]() returned a non-object value

--- a/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -89,7 +89,7 @@ with (character) {
 
 To preserve backward compatibility, you decided to add an `@@unscopables` property when adding more properties to `character`. You may naïvely do it like:
 
-```js example-bad
+```js-nolint example-bad
 const character = {
   name: "Yoda",
   toString: function () {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -281,7 +281,7 @@ underlying `ArrayBuffer` could be mutated through another
 `TypedArray` view of the buffer. This would mean that the object
 would never genuinely be frozen.
 
-```js example-bad
+```js-nolint example-bad
 const i8 = Int8Array.of(1, 2, 3);
 Object.freeze(i8);
 // TypeError: Cannot freeze array buffer views with elements
@@ -294,7 +294,7 @@ When constructing a `TypedArray` as a view onto an
 element size; in other words, the offset must be a multiple of
 `BYTES_PER_ELEMENT`.
 
-```js example-bad
+```js-nolint example-bad
 const i32 = new Int32Array(new ArrayBuffer(4), 1);
 // RangeError: start offset of Int32Array should be a multiple of 4
 ```
@@ -309,7 +309,7 @@ Like the `byteOffset` parameter, the `byteLength` property of an
 `ArrayBuffer` passed to a `TypedArray`'s constructor
 must be a multiple of the constructor's `BYTES_PER_ELEMENT`.
 
-```js example-bad
+```js-nolint example-bad
 const i32 = new Int32Array(new ArrayBuffer(3));
 // RangeError: byte length of Int32Array should be a multiple of 4
 ```

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -39,7 +39,7 @@ a value was not {{jsxref("Statements/return", "returned")}}.
 
 > **Note:** While you can use `undefined` as an {{Glossary("identifier")}} (variable name) in any scope other than the global scope (because `undefined` is not a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words)), doing so is a very bad idea that will make your code difficult to maintain and debug.
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > //  DON'T DO THIS
 >
 > //  logs "foo string"

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
@@ -65,7 +65,7 @@ Every call to `grow` will detach any references to the old `buffer`, even for `g
 Detachment means that the {{jsxref("ArrayBuffer")}}'s `byteLength` becomes zero, and it no longer has bytes accessible to JavaScript.
 Accessing the `buffer` property after calling `grow`, will yield an `ArrayBuffer` with the correct length.
 
-```js example-bad
+```js-nolint example-bad
 const memory = new WebAssembly.Memory({
   initial: 1
 });

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -241,7 +241,7 @@ If an iterable's `@@iterator` method doesn't return an iterator object, then it'
 
 Using one is likely to result in runtime errors or buggy behavior:
 
-```js example-bad
+```js-nolint example-bad
 const nonWellFormedIterable = {};
 nonWellFormedIterable[Symbol.iterator] = () => 1;
 [...nonWellFormedIterable]; // TypeError: [Symbol.iterator]() returned a non-object value

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -154,7 +154,7 @@ console.log(\u4f60\u597d); // Hello
 
 Not all places accept the full range of identifiers. Certain syntaxes, such as function declarations, function expressions, and variable declarations require using identifiers names that are not [reserved words](#reserved_words).
 
-```js example-bad
+```js-nolint example-bad
 function import() {} // Illegal: import is a reserved word.
 ```
 
@@ -175,7 +175,7 @@ Some keywords are _reserved_, meaning that cannot be used as an identifier for v
 
 Identifiers are always compared by _string value_, so escape sequences are interpreted. For example, this is still a syntax error:
 
-```js example-bad
+```js-nolint example-bad
 const els\u{65} = 1;
 // `els\u{65}` encodes the same identifier as `else`
 ```
@@ -371,7 +371,7 @@ The [BigInt](/en-US/docs/Web/JavaScript/Data_structures#bigint_type) type is a n
 
 Note that legacy octal numbers with just a leading zero won't work for `BigInt`:
 
-```js example-bad
+```js-nolint example-bad
 0755n
 // SyntaxError: invalid BigInt syntax
 ```
@@ -408,7 +408,7 @@ To improve readability for numeric literals, underscores (`_`, `U+005F`) can be 
 
 Note these limitations:
 
-```js example-bad
+```js-nolint example-bad
 // More than one underscore in a row is not allowed
 100__000; // SyntaxError
 
@@ -599,7 +599,7 @@ a + b;
 
 Note that ASI would only be triggered if a line break separates tokens that would otherwise produce invalid syntax. If the next token can be parsed as part of a valid structure, semicolons would not be inserted. For example:
 
-```js example-bad
+```js-nolint example-bad
 const a = 1
 (1).toString()
 
@@ -609,7 +609,7 @@ const b = 1
 
 Because `()` can be seen as a function call, it would usually not trigger ASI. Similarly, `[]` may be a member access. The code above is equivalent to:
 
-```js example-bad
+```js-nolint example-bad
 const a = 1(1).toString()
 
 const b = 1[1, 2, 3].forEach(console.log)
@@ -619,7 +619,7 @@ Therefore, you would get errors like "1 is not a function" and "Cannot read prop
 
 Within classes, class fields and generator methods can be a pitfall as well.
 
-```js example-bad
+```js-nolint example-bad
 class A {
   a = 1
   *gen() {}
@@ -628,7 +628,7 @@ class A {
 
 It is seen as:
 
-```js example-bad
+```js-nolint example-bad
 class A {
   a = 1 * gen() {}
 }

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -51,7 +51,7 @@ delete object[property]
 
 The `delete` operator has the same [precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) as other unary operators like [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof). Therefore, it accepts any expression formed by higher-precedence operators. However, the following forms lead to early syntax errors in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode):
 
-```js example-bad
+```js-nolint example-bad
 delete identifier;
 delete object.#privateProperty;
 ```
@@ -60,7 +60,7 @@ Because [classes](/en-US/docs/Web/JavaScript/Reference/Classes) are automaticall
 
 While other expressions are accepted, they don't lead to meaningful behaviors:
 
-```js example-bad
+```js-nolint example-bad
 delete console.log(1);
 // Logs 1, returns true, but nothing deleted
 ```

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -119,7 +119,7 @@ const obj = { a: 1, b: 2 };
 
 Note that the equivalent _binding pattern_ of the code above is not valid syntax:
 
-```js example-bad
+```js-nolint example-bad
 const numbers = [];
 const obj = { a: 1, b: 2 };
 const { a: numbers[0], b: numbers[1] } = obj;
@@ -162,7 +162,7 @@ console.log(others2); // [2, 3]
 
 The rest property must be the last in the pattern, and must not have a trailing comma.
 
-```js example-bad
+```js-nolint example-bad
 const [a, ...b,] = [1, 2, 3];
 
 // SyntaxError: rest element may not have a trailing comma
@@ -290,7 +290,7 @@ console.log(a, b, c, d, e, f); // 1 2 3 4 5 6
 
 On the other hand, object destructuring can only have an identifier as the rest property.
 
-```js example-bad
+```js-nolint example-bad
 const { a, ...{ b } } = { a: 1, b: 2 };
 // SyntaxError: `...` must be followed by an identifier in declaration contexts
 
@@ -332,7 +332,7 @@ console.log(a, b); // [1, 2] [3, 4]
 
 Non-iterables cannot be destructured as arrays.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { 0: "a", 1: "b", length: 2 };
 const [a, b] = obj;
 // TypeError: obj is not iterable

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -75,7 +75,7 @@ It also generally avoids the need for dealing with error handling just to access
 
 However, the `in` operator still requires the private property to be declared beforehand in the enclosing class — otherwise, it would throw a {{jsxref("SyntaxError")}} ("Private field '#x' must be declared in an enclosing class"), the same one as when you try to access an undeclared private property.
 
-```js example-bad
+```js-nolint example-bad
 class C {
   foo() {
     #x in this;
@@ -168,7 +168,7 @@ const empties = new Array(3).fill(undefined);
 
 The `in` operator returns `true` for properties in the prototype chain. This may be undesirable if you are using objects to store arbitrary key-value pairs.
 
-```js example-bad
+```js-nolint example-bad
 const ages = { alice: 18, bob: 27 };
 
 function hasPerson(name) {

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -217,7 +217,7 @@ if (!(mycar instanceof Car)) {
 
 This is really different from:
 
-```js example-bad
+```js-nolint example-bad
 if (!mycar instanceof Car) {
   // unreachable code
 }

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -46,7 +46,7 @@ x && (x = y);
 
 And not equivalent to the following which would always perform an assignment:
 
-```js example-bad
+```js-nolint example-bad
 x = x && y;
 ```
 

--- a/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.md
@@ -48,7 +48,7 @@ x ?? (x = y);
 
 And not equivalent to the following which would always perform an assignment:
 
-```js example-bad
+```js-nolint example-bad
 x = x ?? y;
 ```
 

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -49,7 +49,7 @@ x || (x = y);
 
 And not equivalent to the following which would always perform an assignment:
 
-```js example-bad
+```js-nolint example-bad
 x = x || y;
 ```
 

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
@@ -129,7 +129,7 @@ It is not possible to combine both the AND (`&&`) and OR operators
 [`SyntaxError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError)
 will be thrown in such cases.
 
-```js example-bad
+```js-nolint example-bad
 null || undefined ?? "foo"; // raises a SyntaxError
 true || undefined ?? "foo"; // raises a SyntaxError
 ```

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -77,7 +77,7 @@ a OP2 OP1 b
 
 Then the binary operator `OP2` must have lower precedence than the unary operator `OP1` for it to be grouped as `a OP2 (OP1 b)`. For example, the following is invalid:
 
-```js example-bad
+```js-nolint example-bad
 function* foo() {
   a + yield 1;
 }
@@ -93,7 +93,7 @@ OP1 OP2 a
 
 Then the unary operator closer to the operand, `OP2`, must have higher precedence than `OP1` for it to be grouped as `OP1 (OP2 a)`. It's possible to get it the other way and end up with `(OP1 OP2) a`:
 
-```js example-bad
+```js-nolint example-bad
 async function* foo() {
   await yield 1;
 }
@@ -103,7 +103,7 @@ Because [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) has high
 
 For postfix unary operators (namely, `++` and `--`), the same rules apply. Luckily, both operators have higher precedence than any binary operator, so the grouping is always what you would expect. Moreover, because `++` evaluates to a _value_, not a _reference_, you can't chain multiple increments together either, as you may do in C.
 
-```js example-bad
+```js-nolint example-bad
 let a = 1;
 a++++; // SyntaxError: Invalid left-hand side in postfix operation.
 ```

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -129,7 +129,7 @@ const arrayItem = arr?.[42];
 
 It is invalid to try to assign to the result of an optional chaining expression:
 
-```js example-bad
+```js-nolint example-bad
 const object = {};
 object?.property = 1; // Uncaught SyntaxError: Invalid left-hand side in assignment
 ```

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -43,7 +43,7 @@ object.$1 = "foo";
 console.log(object.$1); // 'foo'
 ```
 
-```js example-bad
+```js-nolint example-bad
 const object = {};
 object.1 = 'bar'; // SyntaxError
 console.log(object.1); // SyntaxError

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -38,7 +38,7 @@ Although the syntax looks the same, they come with slightly different semantics.
 
 Only [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) objects, like {{jsxref("Array")}}, can be spread in array and function parameters. Many objects are not iterable, including all [plain objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) that lack a [`Symbol.iterator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator) method:
 
-```js example-bad
+```js-nolint example-bad
 const obj = { key1: 'value1' };
 const array = [...obj]; // TypeError: obj is not iterable
 ```
@@ -124,7 +124,7 @@ arr2.push(4);
 
 > **Note:** Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays. The same is true with {{jsxref("Object.assign()")}} — no native operation in JavaScript does a deep clone.
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > const a = [[1], [2], [3]];
 > const b = [...a];
 >

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -31,7 +31,7 @@ The `super` keyword can be used in two ways: as a "function call" (`super(...arg
 
 > **Note:** `super` is a keyword and these are special syntactic constructs. `super` is not a variable that points to the prototype object. Attempting to read `super` itself is a {{jsxref("SyntaxError")}}.
 >
-> ```js example-bad
+> ```js-nolint example-bad
 > const child = {
 >   myParent() {
 >     console.log(super); // SyntaxError: 'super' keyword unexpected here
@@ -125,7 +125,7 @@ class Extended extends Base {
 
 Note that instance fields are set on the instance instead of the constructor's `prototype`, so you can't use `super` to access the instance field of a superclass.
 
-```js example-bad
+```js-nolint example-bad
 class Base {
   baseField = 10;
 }
@@ -269,7 +269,7 @@ console.log(Object.hasOwn(b, "x")); // true
 
 This means that while methods that _get_ `super.prop` are usually not susceptible to changes in the `this` context, those that _set_ `super.prop` are.
 
-```js example-bad
+```js-nolint example-bad
 /* Reusing same declarations as above */
 
 const b2 = new B();

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -156,7 +156,7 @@ typeof undeclaredVariable; // "undefined"
 
 However, using `typeof` on lexical declarations ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the line of declaration will throw a {{JSxRef("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
 
-```js example-bad
+```js-nolint example-bad
 typeof newLetVariable; // ReferenceError
 typeof newConstVariable; // ReferenceError
 typeof newClass; // ReferenceError

--- a/files/en-us/web/javascript/reference/statements/break/index.md
+++ b/files/en-us/web/javascript/reference/statements/break/index.md
@@ -110,7 +110,7 @@ generates a `SyntaxError` because its `break` statement is within
 `block1` but references `block2`. A `break` statement
 must always be nested within any label it references.
 
-```js example-bad
+```js-nolint example-bad
 block1: {
   console.log('1');
   break block2; // SyntaxError: label not found
@@ -127,7 +127,7 @@ block2: {
 `break` statements within functions that are nested within a loop, or labeled
 block that the `break` statements are intended to break out of.
 
-```js example-bad
+```js-nolint example-bad
 function testBreak(x) {
   let i = 0;
 
@@ -146,7 +146,7 @@ function testBreak(x) {
 testBreak(1); // SyntaxError: Illegal break statement
 ```
 
-```js example-bad
+```js-nolint example-bad
 block_1: {
   console.log('1');
   (function () {

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -71,7 +71,7 @@ class FilledRectangle extends Rectangle {
 
 Re-declaring a class using the class declaration throws a {{jsxref("SyntaxError")}}.
 
-```js example-bad
+```js-nolint example-bad
 class Foo {};
 class Foo {}; // Uncaught SyntaxError: Identifier 'Foo' has already been declared
 ```
@@ -79,7 +79,7 @@ class Foo {}; // Uncaught SyntaxError: Identifier 'Foo' has already been declare
 The same error is thrown when a class has been defined before using the class
 expression.
 
-```js example-bad
+```js-nolint example-bad
 let Foo = class {};
 class Foo {}; // Uncaught SyntaxError: Identifier 'Foo' has already been declared
 ```

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -61,7 +61,7 @@ A constant cannot share its name with a function or a variable in the same scope
 
 Unlike `var`, `const` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
 
-```js example-bad
+```js-nolint example-bad
 if (true) const a = 1; // SyntaxError: Unexpected token 'const'
 ```
 
@@ -116,7 +116,7 @@ console.log('my favorite number is ' + MY_FAV);
 
 ### const needs to be initialized
 
-```js example-bad
+```js-nolint example-bad
 // throws an error
 // Uncaught SyntaxError: Missing initializer in const declaration
 
@@ -127,7 +127,7 @@ const FOO;
 
 `const` also works on objects and arrays. Attempting to overwrite the object throws an error "Assignment to constant variable".
 
-```js example-bad
+```js-nolint example-bad
 const MY_OBJECT = { key: 'value' };
 MY_OBJECT = { OTHER_KEY: 'value' };
 ```
@@ -142,7 +142,7 @@ You would need to use [`Object.freeze()`](/en-US/docs/Web/JavaScript/Reference/G
 
 The same applies to arrays. Assigning a new array to the variable throws an error "Assignment to constant variable".
 
-```js example-bad
+```js-nolint example-bad
 const MY_ARRAY = [];
 MY_ARRAY = ['B'];
 ```

--- a/files/en-us/web/javascript/reference/statements/empty/index.md
+++ b/files/en-us/web/javascript/reference/statements/empty/index.md
@@ -54,7 +54,7 @@ not really obvious to distinguish from a normal semicolon.
 
 In the following example, the usage is probably not intentional:
 
-```js example-bad
+```js-nolint example-bad
 if (condition);      // Caution, this "if" does nothing!
   killTheUniverse()  // So this always gets executed!!!
 ```

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -206,7 +206,7 @@ import { a } from "./barrel.js";
 
 The following is syntactically invalid despite its import equivalent:
 
-```js example-bad
+```js-nolint example-bad
 export DefaultExport from 'bar.js'; // Invalid
 ```
 

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -61,7 +61,7 @@ You can use [destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destr
 
 However, a special rule forbids using `async` as the variable name. This is invalid syntax:
 
-```js example-bad
+```js-nolint example-bad
 let async;
 for (async of [1, 2, 3]); // SyntaxError: The left-hand side of a for-of loop may not be 'async'.
 ```
@@ -301,7 +301,7 @@ for (const value of iterator) {
 
 Generators implement the [`return()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return) method, which causes the generator function to early return when the loop exits. This makes generators not reusable between loops.
 
-```js example-bad
+```js-nolint example-bad
 function* source() {
   yield 1;
   yield 2;

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -58,7 +58,7 @@ for (let i = 0; i < 9; i++) {
 
 The initialization block accepts both expressions and variable declarations. However, expressions cannot use the [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) operator unparenthesized, because that is ambiguous with a [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop.
 
-```js example-bad
+```js-nolint example-bad
 for (let i = "start" in window ? window.start : 0; i < 9; i++) {
   console.log(i);
 }

--- a/files/en-us/web/javascript/reference/statements/if...else/index.md
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.md
@@ -79,7 +79,7 @@ if (condition) {
 
 Not using blocks may lead to confusing behavior, especially if the code is hand-formatted. For example:
 
-```js example-bad
+```js-nolint example-bad
 function checkValue(a, b) {
   if (a === 1)
     if (b === 2)
@@ -154,7 +154,7 @@ if (x > 50) {
 
 You should almost never have an `if...else` with an assignment like `x = y` as a condition:
 
-```js example-bad
+```js-nolint example-bad
 if (x = y) {
   /* do something */
 }

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -115,7 +115,7 @@ else
 
 If you use a declaration instead of a statement, it would be a {{jsxref("SyntaxError")}}. For example, a [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) declaration is not a statement, so you can't use it in its bare form as the body of an `if` statement.
 
-```js example-bad
+```js-nolint example-bad
 if (condition)
   let i = 0; // SyntaxError: Lexical declaration cannot appear in a single-statement context
 ```
@@ -131,7 +131,7 @@ You can see declarations as "binding identifiers to values", and statements as "
 
 As another example, [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label) can only be attached to statements.
 
-```js example-bad
+```js-nolint example-bad
 label: const a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
 ```
 

--- a/files/en-us/web/javascript/reference/statements/label/index.md
+++ b/files/en-us/web/javascript/reference/statements/label/index.md
@@ -166,7 +166,7 @@ L: function F() {}
 In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) code,
 however, this will throw a {{jsxref("SyntaxError")}}:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 L: function F() {}
 // SyntaxError: functions cannot be labelled
@@ -175,7 +175,7 @@ L: function F() {}
 [Generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*)
 can neither be labeled in strict code, nor in non-strict code:
 
-```js example-bad
+```js-nolint example-bad
 L: function* F() {}
 // SyntaxError: generator functions cannot be labelled
 ```

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -52,7 +52,7 @@ Many issues with `let` variables can be avoided by declaring them at the top of 
 
 Unlike `var`, `let` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
 
-```js example-bad
+```js-nolint example-bad
 if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
 ```
 
@@ -98,7 +98,7 @@ console.log(this.y); // undefined
 
 Redeclaring the same variable within the same function or block scope raises a {{jsxref("SyntaxError")}}.
 
-```js example-bad
+```js-nolint example-bad
 if (x) {
   let foo;
   let foo; // SyntaxError thrown.
@@ -107,7 +107,7 @@ if (x) {
 
 You may encounter errors in {{jsxref("Statements/switch", "switch")}} statements because there is only one block.
 
-```js example-bad
+```js-nolint example-bad
 let x = 1;
 switch(x) {
   case 0:
@@ -148,7 +148,7 @@ If no initial value was specified with the variable declaration, it will be init
 This differs from {{jsxref("Statements/var", "var", "var_hoisting")}} variables, which will return a value of `undefined` if they are accessed before they are declared.
 The code below demonstrates the different result when `let` and `var` are accessed in code before the line in which they are declared.
 
-```js example-bad
+```js-nolint example-bad
 { // TDZ starts at beginning of scope
   console.log(bar); // undefined
   console.log(foo); // ReferenceError
@@ -176,7 +176,7 @@ For example, the code below works because, even though the function that uses th
 
 Using the `typeof` operator for a `let` variable in its TDZ will throw a {{jsxref("ReferenceError")}}:
 
-```js example-bad
+```js-nolint example-bad
 // results in a 'ReferenceError'
 console.log(typeof i);
 let i = 10;
@@ -193,7 +193,7 @@ console.log(typeof undeclaredVariable);
 
 The following code results in a `ReferenceError` at the line shown:
 
-```js example-bad
+```js-nolint example-bad
 function test() {
   var foo = 33;
   if (foo) {
@@ -213,7 +213,7 @@ So, the identifier `n.a` is resolved to the property '`a`' of the '`n`' object l
 
 This is still in the temporal dead zone as its declaration statement has not been reached and terminated.
 
-```js example-bad
+```js-nolint example-bad
 function go(n) {
   // n here is defined!
   console.log(n); // Object {a: [1,2,3]}
@@ -250,7 +250,7 @@ console.log(b); // 2
 However, this combination of **`var`** and **`let`** declaration below is a {{jsxref("SyntaxError")}} due to **`var`** being hoisted to the top of the block.
 This results in an implicit re-declaration of the variable.
 
-```js example-bad
+```js-nolint example-bad
 let x = 1;
 
 {

--- a/files/en-us/web/javascript/reference/statements/return/index.md
+++ b/files/en-us/web/javascript/reference/statements/return/index.md
@@ -58,7 +58,7 @@ The `return` statement is affected by
 [automatic semicolon insertion (ASI)](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion).
 No line terminator is allowed between the `return` keyword and the expression.
 
-```js example-bad
+```js-nolint example-bad
 return
 a + b;
 ```

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -96,7 +96,7 @@ You can use other control-flow statements to replace `break`, such as a [`return
 
 The `case` and `default` clauses are like [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label): they indicate possible places that control flow may jump to. However, they don't create lexical [scopes](/en-US/docs/Glossary/Scope) themselves (neither do they automatically break out — as demonstrated above). For example:
 
-```js example-bad
+```js-nolint example-bad
 const action = 'say_hello';
 switch (action) {
   case 'say_hello':

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -46,7 +46,7 @@ The `try` statement always starts with a `try` block. Then, a `catch` block, a `
 
 Unlike other constructs such as [`if`](/en-US/docs/Web/JavaScript/Reference/Statements/if...else) or [`for`](/en-US/docs/Web/JavaScript/Reference/Statements/for), the `try`, `catch`, and `finally` blocks must be _blocks_, instead of single statements.
 
-```js example-bad
+```js-nolint example-bad
 try doSomething(); // SyntaxError
 catch (e) console.log(e);
 ```

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -93,7 +93,7 @@ straightforward property of the global object. JavaScript has automatic memory
 management, and it would make no sense to be able to use the `delete`
 operator on a global variable.
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 var x = 1;
 Object.hasOwn(globalThis, 'x'); // true

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -71,7 +71,7 @@ In some cases, it can make sense to use an assignment as a condition — but whe
 
 Consider the following example, which iterates over a document's comments, logging them to the console.
 
-```js example-bad
+```js-nolint example-bad
 const iterator = document.createNodeIterator(
   document,
   NodeFilter.SHOW_COMMENT,
@@ -84,7 +84,7 @@ while (currentNode = iterator.nextNode()) {
 
 That's not completely a good-practice example, due to the following line specifically:
 
-```js example-bad
+```js-nolint example-bad
 while (currentNode = iterator.nextNode()) {
 ```
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -125,7 +125,7 @@ delete Object.prototype; // throws a TypeError
 
 Fourth, strict mode requires that function parameter names be unique. In normal code the last duplicated argument hides previous identically-named arguments. Those previous arguments remain available through `arguments[i]`, so they're not completely inaccessible. Still, this hiding makes little sense and is probably undesirable (it might hide a typo, for example), so in strict mode duplicate argument names are a syntax error:
 
-```js example-bad
+```js-nolint example-bad
 function sum(a, a, c) { // !!! syntax error
   'use strict';
   return a + a + c; // wrong if this code ran
@@ -140,7 +140,7 @@ const a = 0o10;
 
 Novice developers sometimes believe a leading zero prefix has no semantic meaning, so they might use it as an alignment device — but this changes the number's meaning! A leading zero syntax for the octal is rarely useful and can be mistakenly used, so strict mode makes it a syntax error:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const sum = 015 + // !!! syntax error
             197 +
@@ -175,7 +175,7 @@ Strict mode simplifies how variable names map to particular variable definitions
 
 First, strict mode prohibits [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with). The problem with `with` is that any name inside the block might map either to a property of the object passed to it, or to a variable in surrounding (or even global) scope, at runtime; it's impossible to know which beforehand. Strict mode makes `with` a syntax error, so there's no chance for a name in a `with` to refer to an unknown location at runtime:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 const x = 17;
 with (obj) { // !!! syntax error
@@ -227,7 +227,7 @@ Thus names in strict mode `eval` code behave identically to names in strict mode
 
 Third, strict mode forbids deleting plain names. `delete name` in strict mode is a syntax error:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 
 var x;
@@ -242,7 +242,7 @@ Strict mode makes `arguments` and `eval` less bizarrely magical. Both involve a 
 
 First, the names `eval` and `arguments` can't be bound or assigned in language syntax. All these attempts to do so are syntax errors:
 
-```js example-bad
+```js-nolint example-bad
 'use strict';
 eval = 17;
 arguments++;

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -116,7 +116,7 @@ In certain cases, nesting a template is the easiest (and perhaps more readable) 
 
 For example, without template literals, if you wanted to return a certain value based on a particular condition, you could do something like the following:
 
-```js example-bad
+```js-nolint example-bad
 let classes = "header";
 classes += isLargeScreen()
   ? ""
@@ -127,7 +127,7 @@ classes += isLargeScreen()
 
 With a template literal but without nesting, you could do this:
 
-```js example-bad
+```js-nolint example-bad
 const classes = `header ${
   isLargeScreen() ? "" : item.isCollapsed ? "icon-expander" : "icon-collapser"
 }`;
@@ -196,14 +196,14 @@ console.log(`Hello``World`); // TypeError: "Hello" is not a function
 
 The only exception is optional chaining, which will throw a syntax error.
 
-```js example-bad
+```js-nolint example-bad
 console.log?.`Hello`; // SyntaxError: Invalid tagged template on optional chain
 console?.log`Hello`; // SyntaxError: Invalid tagged template on optional chain
 ```
 
 Note that these two expressions are still parsable. This means they would not be subject to [automatic semicolon insertion](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion), which will only insert semicolons to fix code that's otherwise unparsable.
 
-```js example-bad
+```js-nolint example-bad
 // Still a syntax error
 const a = console?.log
 `Hello`
@@ -349,7 +349,7 @@ latex`\unicode`;
 
 Note that the escape-sequence restriction is only dropped from _tagged_ templates, but not from _untagged_ template literals:
 
-```js example-bad
+```js-nolint example-bad
 const bad = `bad escape sequence: \unicode`;
 ```
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.md
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.md
@@ -129,7 +129,7 @@ Math.max(10, 20,);
 
 Function parameter definitions or function invocations only containing a comma will throw a {{jsxref("SyntaxError")}}. Furthermore, when using [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), trailing commas are not allowed:
 
-```js example-bad
+```js-nolint example-bad
 function f(,) {} // SyntaxError: missing formal parameter
 (,) => {};       // SyntaxError: expected expression, got ','
 f(,)             // SyntaxError: expected expression, got ','
@@ -156,7 +156,7 @@ const { p, q, } = o;
 
 Again, when using a rest element, a {{jsxref("SyntaxError")}} will be thrown:
 
-```js example-bad
+```js-nolint example-bad
 const [a, ...b,] = [1, 2, 3];
 // SyntaxError: rest element may not have a trailing comma
 ```
@@ -167,7 +167,7 @@ As JSON is based on a very restricted subset of JavaScript syntax, **trailing co
 
 Both lines will throw a `SyntaxError`:
 
-```js example-bad
+```js-nolint example-bad
 JSON.parse("[1, 2, 3, 4, ]");
 JSON.parse('{"foo" : 1, }');
 // SyntaxError JSON.parse: unexpected character


### PR DESCRIPTION
Adding to https://github.com/mdn/content/pull/19177

- Updating syntax code blocks with the new tag. Refer: https://github.com/mdn/yari/pull/7017
