### PR TITLE
Run Prettier on CSS code fences, part 17

### DIFF
--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -75,14 +75,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {
   width: 150px;
   height: 100px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 ```
@@ -112,7 +112,7 @@ To float the box, add the {{cssxref("float")}} and {{cssxref("margin-right")}} p
   width: 150px;
   height: 100px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 ```
@@ -133,7 +133,7 @@ Add a class of `special` to the first paragraph of text, the one immediately fol
 
 ```css
 .special {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -158,7 +158,7 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {
@@ -167,12 +167,12 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 
 .special {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -211,7 +211,7 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {
@@ -220,12 +220,12 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 
 .special {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -263,7 +263,7 @@ In your CSS, add the following rule for the `.wrapper` class and then reload the
 
 ```css
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -290,11 +290,11 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -305,7 +305,7 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 ```
@@ -347,11 +347,11 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
 }
@@ -362,7 +362,7 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 
@@ -383,7 +383,7 @@ Remove the clearfix CSS you added in the last section; instead add `overflow: au
 
 ```css
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
   overflow: auto;
@@ -407,11 +407,11 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
   overflow: auto;
@@ -423,7 +423,7 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 ```
@@ -438,7 +438,7 @@ The modern way of solving this problem is to use the value `flow-root` of the `d
 
 ```css
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
   display: flow-root;
@@ -462,11 +462,11 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .wrapper {
-  background-color: rgb(79,185,227);
+  background-color: rgb(79, 185, 227);
   padding: 10px;
   color: #fff;
   display: flow-root;
@@ -478,7 +478,7 @@ body {
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  background-color: rgb(207,232,220);
+  background-color: rgb(207, 232, 220);
   padding: 1em;
 }
 ```

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -68,7 +68,7 @@ To define a grid we use the `grid` value of the {{cssxref("display")}} property.
 
 ```css
 .container {
-    display: grid;
+  display: grid;
 }
 ```
 
@@ -78,8 +78,8 @@ To see something that looks more grid-like, we'll need to add some columns to th
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: 200px 200px 200px;
+  display: grid;
+  grid-template-columns: 200px 200px 200px;
 }
 ```
 
@@ -90,14 +90,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container > div {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 ```
 
@@ -123,8 +123,8 @@ Change your track listing to the following definition, creating three `1fr` trac
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
 }
 ```
 
@@ -132,8 +132,8 @@ You should now see that you have flexible tracks. The `fr` unit distributes spac
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
 }
 ```
 
@@ -144,14 +144,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container > div {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 ```
 
@@ -177,9 +177,9 @@ To create gaps between tracks we use the properties {{cssxref("column-gap")}} fo
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
-    gap: 20px;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 20px;
 }
 ```
 
@@ -190,14 +190,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container > div {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 ```
 
@@ -219,10 +219,10 @@ body {
 >
 > ```css
 > .container {
->     display: grid;
->     grid-template-columns: 2fr 1fr 1fr;
->     grid-gap: 20px;
->     gap: 20px;
+>   display: grid;
+>   grid-template-columns: 2fr 1fr 1fr;
+>   grid-gap: 20px;
+>   gap: 20px;
 > }
 > ```
 
@@ -233,9 +233,9 @@ Change your track listing to the following:
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
 }
 ```
 
@@ -252,14 +252,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container > div {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 ```
 
@@ -294,10 +294,10 @@ The {{cssxref("minmax", "minmax()")}} function lets us set a minimum and maximum
 
 ```css
 .container {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: minmax(100px, auto);
-    gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: minmax(100px, auto);
+  gap: 20px;
 }
 ```
 
@@ -314,14 +314,14 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container > div {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 ```
 
@@ -395,25 +395,25 @@ footer {
 ```
 
 ```css hidden
-  body {
-    width: 90%;
-    max-width: 900px;
-    margin: 2em auto;
-    font: .9em/1.2 Arial, Helvetica, sans-serif;
+body {
+  width: 90%;
+  max-width: 900px;
+  margin: 2em auto;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container {
-    display: grid;
-    grid-template-columns: 1fr 3fr;
-    gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  gap: 20px;
 }
 
 header,
 footer {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 
 aside {
@@ -452,9 +452,9 @@ Remove the line-based positioning from the last example (or re-download the file
 .container {
   display: grid;
   grid-template-areas:
-      "header header"
-      "sidebar content"
-      "footer footer";
+    "header header"
+    "sidebar content"
+    "footer footer";
   grid-template-columns: 1fr 3fr;
   gap: 20px;
 }
@@ -483,15 +483,15 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 header,
 footer {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 
 aside {
@@ -560,12 +560,12 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 2em auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif;
+  font: 0.9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .container {
   display: grid;
-  grid-template-columns: repeat(12, minmax(0,1fr));
+  grid-template-columns: repeat(12, minmax(0, 1fr));
   gap: 20px;
 }
 
@@ -573,8 +573,8 @@ header,
 footer {
   border-radius: 5px;
   padding: 10px;
-  background-color: rgb(207,232,220);
-  border: 2px solid rgb(79,185,227);
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
 }
 
 aside {

--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -110,11 +110,13 @@ The HTML markup below gives us a containing element with a class of `wrapper`, i
 However, if we add `display: flex` to the parent, the three items now arrange themselves into columns. This is due to them becoming _flex items_ and being affected by some initial values that flexbox sets on the flex container. They are displayed in a row because the property {{cssxref("flex-direction")}} of the parent element has an initial value of `row`. They all appear to stretch in height because the property {{cssxref("align-items")}} of their parent element has an initial value of `stretch`. This means that the items stretch to the height of the flex container, which in this case is defined by the tallest item. The items all line up at the start of the container, leaving any extra space at the end of the row.
 
 ```css hidden
-* {box-sizing: border-box;}
+* {
+  box-sizing: border-box;
+}
 .wrapper > div {
-    border-radius: 5px;
-    background-color: rgb(207,232,220);
-    padding: 1em;
+  border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  padding: 1em;
 }
 ```
 
@@ -142,22 +144,22 @@ As a simple example, we can add the {{cssxref("flex")}} property to all of our c
 
 ```css hidden
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 .wrapper > div {
-    border-radius: 5px;
-    background-color: rgb(207,232,220);
-    padding: 1em;
+  border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  padding: 1em;
 }
 ```
 
 ```css
 .wrapper {
-    display: flex;
+  display: flex;
 }
 
 .wrapper > div {
-    flex: 1;
+  flex: 1;
 }
 ```
 
@@ -183,22 +185,22 @@ Similar to flexbox, we enable Grid Layout with its specific display value — `d
 
 ```css hidden
 * {
-    box-sizing: border-box;
-  }
+  box-sizing: border-box;
+}
 
 .wrapper > div {
-    border-radius: 5px;
-    background-color: rgb(207,232,220);
-    padding: 1em;
+  border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  padding: 1em;
 }
 ```
 
 ```css
 .wrapper {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 100px 100px;
-    gap: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 100px 100px;
+  gap: 10px;
 }
 ```
 
@@ -221,37 +223,37 @@ Once you have a grid, you can explicitly place your items on it, rather than rel
 
 ```css hidden
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .wrapper > div {
-    border-radius: 5px;
-    background-color: rgb(207,232,220);
-    padding: 1em;
+  border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  padding: 1em;
 }
 ```
 
 ```css
 .wrapper {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 100px 100px;
-    gap: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 100px 100px;
+  gap: 10px;
 }
 
 .box1 {
-    grid-column: 2 / 4;
-    grid-row: 1;
+  grid-column: 2 / 4;
+  grid-row: 1;
 }
 
 .box2 {
-    grid-column: 1;
-    grid-row: 1 / 3;
+  grid-column: 1;
+  grid-row: 1 / 3;
 }
 
 .box3 {
-    grid-row: 2;
-    grid-column: 3;
+  grid-row: 2;
+  grid-column: 3;
 }
 ```
 
@@ -284,21 +286,21 @@ In the example below, we float a `<div>` left and give it a {{cssxref("margin")}
 
 ```css hidden
 body {
-    width: 90%;
-    max-width: 900px;
-    margin: 0 auto;
+  width: 90%;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 p {
-    line-height: 2;
-    word-spacing: 0.1rem;
+  line-height: 2;
+  word-spacing: 0.1rem;
 }
 
 .box {
-    background-color: rgb(207,232,220);
-    border: 2px solid rgb(79,185,227);
-    padding: 10px;
-    border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+  padding: 10px;
+  border-radius: 5px;
 }
 ```
 
@@ -312,10 +314,10 @@ p {
 
 ```css
 .box {
-    float: left;
-    width: 150px;
-    height: 150px;
-    margin-right: 30px;
+  float: left;
+  width: 150px;
+  height: 150px;
+  margin-right: 30px;
 }
 ```
 
@@ -358,11 +360,11 @@ body {
 }
 
 p {
-    background-color: rgb(207,232,220);
-    border: 2px solid rgb(79,185,227);
-    padding: 10px;
-    margin: 10px;
-    border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+  padding: 10px;
+  margin: 10px;
+  border-radius: 5px;
 }
 ```
 
@@ -401,19 +403,19 @@ body {
 }
 
 p {
-    background-color: rgb(207,232,220);
-    border: 2px solid rgb(79,185,227);
-    padding: 10px;
-    margin: 10px;
-    border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+  padding: 10px;
+  margin: 10px;
+  border-radius: 5px;
 }
 ```
 
 ```css hidden
 .positioned {
   position: relative;
-  background: rgba(255,84,104,.3);
-  border: 2px solid rgb(255,84,104);
+  background: rgba(255, 84, 104, 0.3);
+  border: 2px solid rgb(255, 84, 104);
   top: 30px;
   left: 30px;
 }
@@ -452,18 +454,18 @@ body {
 }
 
 p {
-    background-color: rgb(207,232,220);
-    border: 2px solid rgb(79,185,227);
-    padding: 10px;
-    margin: 10px;
-    border-radius: 5px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+  padding: 10px;
+  margin: 10px;
+  border-radius: 5px;
 }
 ```
 
 ```css hidden
 .positioned {
-    background: rgba(255,84,104,.3);
-    border: 2px solid rgb(255,84,104);
+  background: rgba(255, 84, 104, 0.3);
+  border: 2px solid rgb(255, 84, 104);
 }
 ```
 
@@ -499,24 +501,24 @@ et a urna. Ut id ornare felis, eget fermentum sapien.</p>
 
 ```css hidden
 body {
-    width: 500px;
-    margin: 0 auto;
+  width: 500px;
+  margin: 0 auto;
 }
 
 .positioned {
-    background: rgba(255,84,104,.3);
-    border: 2px solid rgb(255,84,104);
-    padding: 10px;
-    margin: 10px;
-    border-radius: 5px;
+  background: rgba(255, 84, 104, 0.3);
+  border: 2px solid rgb(255, 84, 104);
+  padding: 10px;
+  margin: 10px;
+  border-radius: 5px;
 }
 ```
 
 ```css
 .positioned {
-    position: fixed;
-    top: 30px;
-    left: 30px;
+  position: fixed;
+  top: 30px;
+  left: 30px;
 }
 ```
 
@@ -545,8 +547,8 @@ body {
 }
 
 .positioned {
-  background: rgba(255,84,104,.3);
-  border: 2px solid rgb(255,84,104);
+  background: rgba(255, 84, 104, 0.3);
+  border: 2px solid rgb(255, 84, 104);
   padding: 10px;
   margin: 10px;
   border-radius: 5px;
@@ -611,7 +613,8 @@ form div {
   display: table-row;
 }
 
-form label, form input {
+form label,
+form input {
   display: table-cell;
   margin-bottom: 10px;
 }
@@ -678,12 +681,15 @@ In the below example, we start with a block of HTML inside a containing `<div>` 
 We're using a `column-width` of 200 pixels on that container, causing the browser to create as many 200 pixel columns as will fit. Whatever space is left between the columns will be shared.
 
 ```css hidden
-body { max-width: 800px; margin: 0 auto; }
+body {
+  max-width: 800px;
+  margin: 0 auto;
+}
 ```
 
 ```css
 .container {
-    column-width: 200px;
+  column-width: 200px;
 }
 ```
 

--- a/files/en-us/learn/css/css_layout/legacy_layout_methods/index.md
+++ b/files/en-us/learn/css/css_layout/legacy_layout_methods/index.md
@@ -331,24 +331,24 @@ Anyway, back to our grids! Any column that spans more than one column of our gri
 
 ```css
 .col.span4 {
-  width: calc((6.25%*4) + (2.08333333%*3));
+  width: calc((6.25% * 4) + (2.08333333% * 3));
 }
 ```
 
 Try replacing your bottom block of rules with the following, then reload it in the browser to see if you get the same result:
 
 ```css
-.col.span2 { width: calc((6.25%*2) + 2.08333333%); }
-.col.span3 { width: calc((6.25%*3) + (2.08333333%*2)); }
-.col.span4 { width: calc((6.25%*4) + (2.08333333%*3)); }
-.col.span5 { width: calc((6.25%*5) + (2.08333333%*4)); }
-.col.span6 { width: calc((6.25%*6) + (2.08333333%*5)); }
-.col.span7 { width: calc((6.25%*7) + (2.08333333%*6)); }
-.col.span8 { width: calc((6.25%*8) + (2.08333333%*7)); }
-.col.span9 { width: calc((6.25%*9) + (2.08333333%*8)); }
-.col.span10 { width: calc((6.25%*10) + (2.08333333%*9)); }
-.col.span11 { width: calc((6.25%*11) + (2.08333333%*10)); }
-.col.span12 { width: calc((6.25%*12) + (2.08333333%*11)); }
+.col.span2 { width: calc((6.25% * 2) + 2.08333333%); }
+.col.span3 { width: calc((6.25% * 3) + (2.08333333%*2)); }
+.col.span4 { width: calc((6.25% * 4) + (2.08333333%*3)); }
+.col.span5 { width: calc((6.25% * 5) + (2.08333333%*4)); }
+.col.span6 { width: calc((6.25% * 6) + (2.08333333%*5)); }
+.col.span7 { width: calc((6.25% * 7) + (2.08333333%*6)); }
+.col.span8 { width: calc((6.25% * 8) + (2.08333333%*7)); }
+.col.span9 { width: calc((6.25% * 9) + (2.08333333%*8)); }
+.col.span10 { width: calc((6.25% * 10) + (2.08333333%*9)); }
+.col.span11 { width: calc((6.25% * 11) + (2.08333333%*10)); }
+.col.span12 { width: calc((6.25% * 12) + (2.08333333%*11)); }
 ```
 
 > **Note:** You can see our finished version in [fluid-grid-calc.html](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/fluid-grid-calc.html) (also [see it live](https://mdn.github.io/learning-area/css/css-layout/grids/fluid-grid-calc.html)).
@@ -363,7 +363,7 @@ These are not the only approach. You could instead decide on your grid and then 
 
 ```css
 .content {
-  width: calc((6.25%*8) + (2.08333333%*7));
+  width: calc((6.25% * 8) + (2.08333333% * 7));
 }
 ```
 
@@ -381,7 +381,7 @@ Let's create a class in our CSS that will offset a container element by one colu
 
 ```css
 .offset-by-one {
-  margin-left: calc(6.25% + (2.08333333%*2));
+  margin-left: calc(6.25% + (2.08333333% * 2));
 }
 ```
 
@@ -447,7 +447,7 @@ body {
   margin-bottom: 1em;
   width: 6.25%;
   flex: 1 1 auto;
-  background: rgb(255,150,150);
+  background: rgb(255, 150, 150);
 }
 ```
 
@@ -567,7 +567,9 @@ Try saving your HTML file and loading it in your browser to see the effect.
 If you look in the skeleton.css file you can see how this works. For example, Skeleton has the following defined to style elements with "three columns" classes added to them.
 
 ```css
-.three.columns { width: 22%; }
+.three.columns {
+  width: 22%;
+}
 ```
 
 All Skeleton (or any other grid framework) is doing is setting up predefined classes that you can use by adding them to your markup. It's exactly the same as if you did the work of calculating these percentages yourself.

--- a/files/en-us/learn/css/css_layout/media_queries/index.md
+++ b/files/en-us/learn/css/css_layout/media_queries/index.md
@@ -65,9 +65,9 @@ The following media query will only set the body to 12pt if the page is printed.
 
 ```css
 @media print {
-    body {
-        font-size: 12pt;
-    }
+  body {
+    font-size: 12pt;
+  }
 }
 ```
 
@@ -89,9 +89,9 @@ These features are used to create layouts that respond to different screen sizes
 
 ```css
 @media screen and (width: 600px) {
-    body {
-        color: red;
-    }
+  body {
+    color: red;
+  }
 }
 ```
 
@@ -101,9 +101,9 @@ The `width` (and `height`) media features can be used as ranges, and therefore b
 
 ```css
 @media screen and (max-width: 600px) {
-    body {
-        color: blue;
-    }
+  body {
+    color: blue;
+  }
 }
 ```
 
@@ -119,9 +119,9 @@ One well-supported media feature is `orientation`, which allows us to test for p
 
 ```css
 @media (orientation: landscape) {
-    body {
-        color: rebeccapurple;
-    }
+  body {
+    color: rebeccapurple;
+  }
 }
 ```
 
@@ -135,9 +135,9 @@ As part of the Level 4 specification, the `hover` media feature was introduced. 
 
 ```css
 @media (hover: hover) {
-    body {
-        color: rebeccapurple;
-    }
+  body {
+    color: rebeccapurple;
+  }
 }
 ```
 
@@ -159,9 +159,9 @@ To combine media features you can use `and` in much the same way as we have used
 
 ```css
 @media screen and (min-width: 600px) and (orientation: landscape) {
-    body {
-        color: blue;
-    }
+  body {
+    color: blue;
+  }
 }
 ```
 
@@ -173,9 +173,9 @@ If you have a set of queries, any of which could match, then you can comma separ
 
 ```css
 @media screen and (min-width: 600px), screen and (orientation: landscape) {
-    body {
-        color: blue;
-    }
+  body {
+    color: blue;
+  }
 }
 ```
 
@@ -187,9 +187,9 @@ You can negate an entire media query by using the `not` operator. This reverses 
 
 ```css
 @media not all and (orientation: landscape) {
-    body {
-        color: blue;
-    }
+  body {
+    color: blue;
+  }
 }
 ```
 
@@ -219,54 +219,54 @@ Our starting point is an HTML document with some CSS applied to add background c
 
 ```css
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {
-    width: 90%;
-    margin: 2em auto;
-    font: 1em/1.3 Arial, Helvetica, sans-serif;
+  width: 90%;
+  margin: 2em auto;
+  font: 1em/1.3 Arial, Helvetica, sans-serif;
 }
 
 a:link,
 a:visited {
-    color: #333;
+  color: #333;
 }
 
 nav ul,
 aside ul {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
 nav a:link,
 nav a:visited {
-    background-color: rgba(207, 232, 220, 0.2);
-    border: 2px solid rgb(79, 185, 227);
-    text-decoration: none;
-    display: block;
-    padding: 10px;
-    color: #333;
-    font-weight: bold;
+  background-color: rgba(207, 232, 220, 0.2);
+  border: 2px solid rgb(79, 185, 227);
+  text-decoration: none;
+  display: block;
+  padding: 10px;
+  color: #333;
+  font-weight: bold;
 }
 
 nav a:hover {
-    background-color: rgba(207, 232, 220, 0.7);
+  background-color: rgba(207, 232, 220, 0.7);
 }
 
 .related {
-    background-color: rgba(79, 185, 227, 0.3);
-    border: 1px solid rgb(79, 185, 227);
-    padding: 10px;
+  background-color: rgba(79, 185, 227, 0.3);
+  border: 1px solid rgb(79, 185, 227);
+  padding: 10px;
 }
 
 .sidebar {
-    background-color: rgba(207, 232, 220, 0.5);
-    padding: 10px;
+  background-color: rgba(207, 232, 220, 0.5);
+  padding: 10px;
 }
 
 article {
-    margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 ```
 
@@ -327,19 +327,19 @@ From this point, start to drag the Responsive Design Mode view wider until you c
 
 ```css
 @media screen and (min-width: 40em) {
-    article {
-        display: grid;
-        grid-template-columns: 3fr 1fr;
-        column-gap: 20px;
-    }
+  article {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    column-gap: 20px;
+  }
 
-    nav ul {
-        display: flex;
-    }
+  nav ul {
+    display: flex;
+  }
 
-    nav li {
-        flex: 1;
-    }
+  nav li {
+    flex: 1;
+  }
 }
 ```
 
@@ -353,20 +353,20 @@ Let's continue to expand the width until we feel there is enough room for the si
 
 ```css
 @media screen and (min-width: 70em) {
-    main {
-        display: grid;
-        grid-template-columns: 3fr 1fr;
-        column-gap: 20px;
-    }
+  main {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    column-gap: 20px;
+  }
 
-    article {
-        margin-bottom: 0;
-    }
+  article {
+    margin-bottom: 0;
+  }
 
-    footer {
-        border-top: 1px solid #ccc;
-        margin-top: 2em;
-    }
+  footer {
+    border-top: 1px solid #ccc;
+    margin-top: 2em;
+  }
 }
 ```
 
@@ -423,17 +423,17 @@ This could be achieved using the following:
 
 ```css
 .grid {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 20px;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
 .grid li {
-    border: 1px solid #666;
-    padding: 10px;
+  border: 1px solid #666;
+  padding: 10px;
 }
 ```
 

--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.md
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.md
@@ -44,24 +44,24 @@ This is something that is both very simple and very fun. The {{cssxref("border-r
 ```css
 .fancy {
   /* Within a circle, centered text looks prettier. */
-  text-align : center;
+  text-align: center;
 
   /* Let's avoid our text touching the border. As
      our text will still flow in a square, it looks
      nicer that way, giving the feeling that it's a "real"
      circle. */
-  padding : 1em;
+  padding: 1em;
 
   /* The border will make the circle visible.
      You could also use a background, as
      backgrounds are clipped by border radius */
-  border : 0.5em solid black;
+  border: 0.5em solid black;
 
   /* Let's make sure we have a square.
      If it's not a square, we'll get an
      ellipsis rather than a circle */
-  width  : 4em;
-  height : 4em;
+  width: 4em;
+  height: 4em;
 
   /* and let's turn the square into a circle */
   border-radius: 100%;
@@ -89,14 +89,14 @@ Okay, let's have fun with backgrounds:
 
 ```css
 .fancy {
-  padding : 1em;
+  padding: 1em;
   width: 100%;
   height: 200px;
   box-sizing: border-box;
 
   /* At the bottom of our background stack,
      let's have a misty grey solid color */
-  background-color: #E4E4D9;
+  background-color: #e4e4d9;
 
   /* We stack linear gradients on top of each
      other to create our color strip effect.
@@ -140,16 +140,16 @@ Let's have an example by turning our box into a cloud:
 
   /* Same trick as previously used to make circles */
   box-sizing: border-box;
-  width     : 150px;
-  height    : 150px;
-  padding   : 80px 1em 0 1em;
+  width: 150px;
+  height: 150px;
+  padding: 80px 1em 0 1em;
 
   /* We make room for the "ears" of our cloud */
-  margin    : 0 100px;
+  margin: 0 100px;
 
   position: relative;
 
-  background-color: #A4C9CF;
+  background-color: #a4c9cf;
 
   /* Well, actually we are not making a full circle
      as we want the bottom of our cloud to be flat.
@@ -165,28 +165,28 @@ Let's have an example by turning our box into a cloud:
   /* This is required to be allowed to display the
      pseudo-elements, event if the value is an empty
      string */
-  content: '';
+  content: "";
 
   /* We position our pseudo-elements on the left and
      right sides of the box, but always at the bottom */
   position: absolute;
-  bottom  : 0;
+  bottom: 0;
 
   /* This makes sure our pseudo-elements will be below
      the box content whatever happens. */
-  z-index : -1;
+  z-index: -1;
 
-  background-color: #A4C9CF;
+  background-color: #a4c9cf;
   border-radius: 100%;
 }
 
 .fancy::before {
   /* This is the size of the clouds left ear */
-  width  : 125px;
-  height : 125px;
+  width: 125px;
+  height: 125px;
 
   /* We slightly move it to the left */
-  left    : -80px;
+  left: -80px;
 
   /* To make sure that the bottom of the cloud
      remains flat, we must make the bottom right
@@ -196,11 +196,11 @@ Let's have an example by turning our box into a cloud:
 
 .fancy::after {
   /* This is the size of the clouds left ear */
-  width  : 100px;
-  height : 100px;
+  width: 100px;
+  height: 100px;
 
   /* We slightly move it to the right */
-  right   : -60px;
+  right: -60px;
 
   /* To make sure that the bottom of the cloud
      remains flat, we must make the bottom left
@@ -231,46 +231,46 @@ So here comes our style:
 ```css
 blockquote {
   min-height: 5em;
-  padding   : 1em 4em;
-  font      : 1em/150% sans-serif;
-  position  : relative;
+  padding: 1em 4em;
+  font: 1em/150% sans-serif;
+  position: relative;
   background-color: lightgoldenrodyellow;
 }
 
 blockquote::before,
 blockquote::after {
   position: absolute;
-  height  : 3rem;
-  font    : 6rem/100% Georgia, "Times New Roman", Times, serif;
+  height: 3rem;
+  font: 6rem/100% Georgia, "Times New Roman", Times, serif;
 }
 
 blockquote::before {
-  content: '“';
-  top    : 0.3rem;
-  left   : 0.9rem;
+  content: "“";
+  top: 0.3rem;
+  left: 0.9rem;
 }
 
 blockquote::after {
-  content: '”';
-  bottom : 0.3rem;
-  right  : 0.8rem;
+  content: "”";
+  bottom: 0.3rem;
+  right: 0.8rem;
 }
 
 blockquote:lang(fr)::before {
-  content: '«';
-  top    : -1.5rem;
-  left   : 0.5rem;
+  content: "«";
+  top: -1.5rem;
+  left: 0.5rem;
 }
 
 blockquote:lang(fr)::after {
-  content: '»';
-  bottom : 2.6rem;
-  right  : 0.5rem
+  content: "»";
+  bottom: 2.6rem;
+  right: 0.5rem;
 }
 
 blockquote i {
-  display   : block;
-  font-size : 0.8em;
+  display: block;
+  font-size: 0.8em;
   margin-top: 1rem;
   text-align: right;
 }
@@ -291,7 +291,7 @@ Let's create some partial drop shadow effect. The {{cssxref("box-shadow")}} prop
 ```css
 .fancy {
   position: relative;
-  background-color: #FFC;
+  background-color: #ffc;
   padding: 2rem;
   text-align: center;
   max-width: 200px;
@@ -300,12 +300,12 @@ Let's create some partial drop shadow effect. The {{cssxref("box-shadow")}} prop
 .fancy::before {
   content: "";
 
-  position : absolute;
-  z-index  : -1;
-  bottom   : 15px;
-  right    : 5px;
-  width    : 50%;
-  top      : 80%;
+  position: absolute;
+  z-index: -1;
+  bottom: 15px;
+  right: 5px;
+  width: 50%;
+  top: 80%;
   max-width: 200px;
 
   box-shadow: 0px 13px 10px black;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
@@ -35,7 +35,7 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -46,8 +46,8 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -60,84 +60,84 @@ This is the first example of code that explains [how to build a custom form widg
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 
@@ -171,7 +171,7 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -182,8 +182,8 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -196,84 +196,84 @@ This is the first example of code that explains [how to build a custom form widg
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 
@@ -307,7 +307,7 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -318,8 +318,8 @@ This is the first example of code that explains [how to build a custom form widg
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -332,84 +332,84 @@ This is the first example of code that explains [how to build a custom form widg
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0, 0, 0, .45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFF;
+  color: #fff;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_2/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_2/index.md
@@ -40,10 +40,10 @@ This is the second example that explain [how to build custom form widgets](/en-U
 ```css
 .widget select,
 .no-widget .select {
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 
 /* --------------- */
@@ -52,7 +52,7 @@ This is the second example that explain [how to build custom form widgets](/en-U
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -63,8 +63,8 @@ This is the second example that explain [how to build custom form widgets](/en-U
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -77,84 +77,84 @@ This is the second example that explain [how to build custom form widgets](/en-U
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 
@@ -205,10 +205,10 @@ window.addEventListener("load", () => {
 ```css
 .widget select,
 .no-widget .select {
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
@@ -40,10 +40,10 @@ This is the third example that explain [how to build custom form widgets](/en-US
 ```css
 .widget select,
 .no-widget .select {
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 
 /* --------------- */
@@ -52,7 +52,7 @@ This is the third example that explain [how to build custom form widgets](/en-US
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -63,8 +63,8 @@ This is the third example that explain [how to build custom form widgets](/en-US
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -77,84 +77,84 @@ This is the third example that explain [how to build custom form widgets](/en-US
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -44,10 +44,10 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 ```css
 .widget select,
 .no-widget .select {
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 
 /* --------------- */
@@ -56,7 +56,7 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -67,8 +67,8 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -81,84 +81,84 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -40,10 +40,10 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 ```css
 .widget select,
 .no-widget .select {
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 
 /* --------------- */
@@ -52,7 +52,7 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 
 .select {
   position: relative;
-  display : inline-block;
+  display: inline-block;
 }
 
 .select.active,
@@ -63,8 +63,8 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 
 .select .optList {
   position: absolute;
-  top     : 100%;
-  left    : 0;
+  top: 100%;
+  left: 0;
 }
 
 .select .optList.hidden {
@@ -77,84 +77,84 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 /* ------------ */
 
 .select {
-  font-size   : 0.625em; /* 10px */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* 10px */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
+  width: 10em; /* 100px */
 
-  border        : 0.2em solid #000; /* 2px */
-  border-radius : 0.4em; /* 4px */
+  border: 0.2em solid #000; /* 2px */
+  border-radius: 0.4em; /* 4px */
 
-  box-shadow : 0 0.1em 0.2em rgba(0,0,0,.45); /* 0 1px 2px */
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45); /* 0 1px 2px */
 
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
 
-  white-space   : nowrap;
-  text-overflow : ellipsis;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
 }
 
 .select:after {
-  content : "▼";
+  content: "▼";
   position: absolute;
-  z-index : 1;
-  height  : 100%;
-  width   : 2em; /* 20px */
-  top     : 0;
-  right   : 0;
+  z-index: 1;
+  height: 100%;
+  width: 2em; /* 20px */
+  top: 0;
+  right: 0;
 
-  padding-top : .1em;
+  padding-top: 0.1em;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  text-align : center;
+  text-align: center;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
+  background-color: #000;
+  color: #fff;
 }
 
 .select .optList {
-  z-index : 2;
+  z-index: 2;
 
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
   background: #f0f0f0;
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  min-width : 100%;
+  min-width: 100%;
   max-height: 10em; /* 100px */
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .select .option {
-  padding: .2em .3em;
+  padding: 0.2em 0.3em;
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -131,7 +131,7 @@ The required styles are those necessary to handle the three states of our contro
   position: relative;
 
   /* This will make our control become part of the text flow and sizable at the same time */
-  display : inline-block;
+  display: inline-block;
 }
 ```
 
@@ -156,9 +156,9 @@ Now, let's handle the list of options:
 .select .optList {
   /* This will make sure our list of options will be displayed below the value
      and out of the HTML flow */
-  position : absolute;
-  top      : 100%;
-  left     : 0;
+  position: absolute;
+  top: 100%;
+  left: 0;
 }
 ```
 
@@ -183,31 +183,31 @@ So now that we have the basic functionality in place, the fun can start. The fol
 .select {
   /* The computations are made assuming 1em equals 16px which is the default value in most browsers.
      If you are lost with px to em conversion, try http://riddle.pl/emcalc/ */
-  font-size   : 0.625em; /* this (10px) is the new font size context for em value in this context */
-  font-family : Verdana, Arial, sans-serif;
+  font-size: 0.625em; /* this (10px) is the new font size context for em value in this context */
+  font-family: Verdana, Arial, sans-serif;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
   /* We need extra room for the down arrow we will add */
-  padding : .1em 2.5em .2em .5em;
-  width   : 10em; /* 100px */
+  padding: 0.1em 2.5em 0.2em 0.5em;
+  width: 10em; /* 100px */
 
-  border        : .2em solid #000;
-  border-radius : .4em;
-  box-shadow    : 0 .1em .2em rgba(0,0,0,.45);
+  border: 0.2em solid #000;
+  border-radius: 0.4em;
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45);
 
   /* The first declaration is for browsers that do not support linear gradients. */
-  background : #F0F0F0;
-  background : linear-gradient(0deg, #E3E3E3, #fcfcfc 50%, #f0f0f0);
+  background: #f0f0f0;
+  background: linear-gradient(0deg, #e3e3e3, #fcfcfc 50%, #f0f0f0);
 }
 
 .select .value {
   /* Because the value can be wider than our control, we have to make sure it will not
      change the control's width. If the content overflows, we display an ellipsis */
-  display  : inline-block;
-  width    : 100%;
-  overflow : hidden;
-  white-space : nowrap;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   vertical-align: top;
 }
@@ -217,24 +217,24 @@ We don't need an extra element to design the down arrow; instead, we're using th
 
 ```css
 .select:after {
-  content : "▼"; /* We use the unicode character U+25BC; make sure to set a charset meta tag */
+  content: "▼"; /* We use the unicode character U+25BC; make sure to set a charset meta tag */
   position: absolute;
-  z-index : 1; /* This will be important to keep the arrow from overlapping the list of options */
-  top     : 0;
-  right   : 0;
+  z-index: 1; /* This will be important to keep the arrow from overlapping the list of options */
+  top: 0;
+  right: 0;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
-  height  : 100%;
-  width   : 2em;
-  padding-top : .1em;
+  height: 100%;
+  width: 2em;
+  padding-top: 0.1em;
 
-  border-left  : .2em solid #000;
-  border-radius: 0 .1em .1em 0;
+  border-left: 0.2em solid #000;
+  border-radius: 0 0.1em 0.1em 0;
 
-  background-color : #000;
-  color : #FFF;
-  text-align : center;
+  background-color: #000;
+  color: #fff;
+  text-align: center;
 }
 ```
 
@@ -242,18 +242,18 @@ Next, let's style the list of options:
 
 ```css
 .select .optList {
-  z-index : 2; /* We explicitly said the list of options will always be on top of the down arrow */
+  z-index: 2; /* We explicitly said the list of options will always be on top of the down arrow */
 
   /* this will reset the default style of the ul element */
   list-style: none;
-  margin : 0;
+  margin: 0;
   padding: 0;
 
-  box-sizing : border-box;
+  box-sizing: border-box;
 
   /* If the values are smaller than the control, the list of options
      will be as wide as the control itself */
-  min-width : 100%;
+  min-width: 100%;
 
   /* In case the list is too long, its content will overflow vertically
      (which will add a vertical scrollbar automatically) but never horizontally
@@ -263,11 +263,11 @@ Next, let's style the list of options:
   overflow-y: auto;
   overflow-x: hidden;
 
-  border: .2em solid #000;
-  border-top-width : .1em;
-  border-radius: 0 0 .4em .4em;
+  border: 0.2em solid #000;
+  border-top-width: 0.1em;
+  border-radius: 0 0 0.4em 0.4em;
 
-  box-shadow: 0 .2em .4em rgba(0,0,0,.4);
+  box-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.4);
   background: #f0f0f0;
 }
 ```
@@ -276,12 +276,12 @@ For the options, we need to add a `highlight` class to be able to identify the v
 
 ```css
 .select .option {
-  padding: .2em .3em; /* 2px 3px */
+  padding: 0.2em 0.3em; /* 2px 3px */
 }
 
 .select .highlight {
   background: #000;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 ```
 
@@ -378,10 +378,10 @@ Second, we need two new classes to let us hide the unneeded element: we visually
      - either we have set the body class to "widget" and thus we hide the actual {{HTMLElement("select")}} element
      - or we have not changed the body class, therefore the body class is still "no-widget",
        so the elements whose class is "select" must be hidden */
-  position : absolute;
-  left     : -5000em;
-  height   : 0;
-  overflow : hidden;
+  position: absolute;
+  left: -5000em;
+  height: 0;
+  overflow: hidden;
 }
 ```
 
@@ -785,7 +785,7 @@ We'll do a little styling of the radio button list (not the legend/fieldset) to 
   padding: 0;
   display: flex;
 }
-.styledSelect [type=radio] {
+.styledSelect [type="radio"] {
   position: absolute;
   left: -100vw;
   top: -100vh;
@@ -801,12 +801,12 @@ We'll do a little styling of the radio button list (not the legend/fieldset) to 
   overflow: hidden;
 }
 .styledSelect:not(:focus-within) input:checked + label {
-  border: .2em solid #000;
-  border-radius: .4em;
-  box-shadow: 0 .1em .2em rgba(0,0,0,.45);
+  border: 0.2em solid #000;
+  border-radius: 0.4em;
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45);
 }
 .styledSelect:not(:focus-within) input:checked + label::after {
-  content : "▼";
+  content: "▼";
   background: black;
   float: right;
   color: white;
@@ -814,9 +814,9 @@ We'll do a little styling of the radio button list (not the legend/fieldset) to 
   margin: 0 -4px 0 4px;
 }
 .styledSelect:focus-within {
-  border: .2em solid #000;
-  border-radius: .4em;
-  box-shadow: 0 .1em .2em rgba(0,0,0,.45);
+  border: 0.2em solid #000;
+  border-radius: 0.4em;
+  box-shadow: 0 0.1em 0.2em rgba(0, 0, 0, 0.45);
 }
 .styledSelect:focus-within input:checked + label {
   background-color: #333;

--- a/files/en-us/learn/forms/styling_web_forms/index.md
+++ b/files/en-us/learn/forms/styling_web_forms/index.md
@@ -101,7 +101,10 @@ We'll walk through an example at the end of this article to give you some more i
 CSS font and text features can be used easily with any widget (and yes, you can use {{cssxref("@font-face")}} with form widgets). However, browser behavior is often inconsistent. By default, some widgets do not inherit {{cssxref("font-family")}} and {{cssxref("font-size")}} from their parents. Many browsers use the system default appearance instead. To make your forms' appearance consistent with the rest of your content, you can add the following rules to your stylesheet:
 
 ```css
-button, input, select, textarea {
+button,
+input,
+select,
+textarea {
   font-family: inherit;
   font-size: 100%;
 }
@@ -124,8 +127,11 @@ All text fields have complete support for every property related to the CSS box 
 **This is because each widget has their own rules for border, padding and margin.** To give the same size to several different widgets, you can use the {{cssxref("box-sizing")}} property along with some consistent values for other properties:
 
 ```css
-input, textarea, select, button {
-  width : 150px;
+input,
+textarea,
+select,
+button {
+  width: 150px;
   padding: 0;
   margin: 0;
   box-sizing: border-box;
@@ -228,42 +234,42 @@ First, we prepare by defining our {{cssxref("@font-face")}} rules, and all the b
 
 ```css
 @font-face {
-    font-family: 'handwriting';
-    src: url('fonts/journal-webfont.woff2') format('woff2'),
-         url('fonts/journal-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
+  font-family: "handwriting";
+  src: url("fonts/journal-webfont.woff2") format("woff2"), url("fonts/journal-webfont.woff")
+      format("woff");
+  font-weight: normal;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'typewriter';
-    src: url('fonts/momt___-webfont.woff2') format('woff2'),
-         url('fonts/momt___-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
+  font-family: "typewriter";
+  src: url("fonts/momt___-webfont.woff2") format("woff2"), url("fonts/momt___-webfont.woff")
+      format("woff");
+  font-weight: normal;
+  font-style: normal;
 }
 
 body {
-  font  : 1.3rem sans-serif;
-  padding : 0.5em;
-  margin  : 0;
-  background : #222;
+  font: 1.3rem sans-serif;
+  padding: 0.5em;
+  margin: 0;
+  background: #222;
 }
 
 form {
-  position : relative;
-  width  : 740px;
-  height : 498px;
-  margin : 0 auto;
+  position: relative;
+  width: 740px;
+  height: 498px;
+  margin: 0 auto;
   padding: 1em;
   box-sizing: border-box;
-  background : #FFF url(background.jpg);
+  background: #fff url(background.jpg);
 
   /* we create our grid */
-  display  : grid;
-  grid-gap : 20px;
-  grid-template-columns : repeat(2, 1fr);
-  grid-template-rows    : 10em 1em 1em 1em;
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 10em 1em 1em 1em;
 }
 ```
 
@@ -271,16 +277,17 @@ Notice that we've used some [CSS Grid](/en-US/docs/Web/CSS/CSS_Grid_Layout) and 
 
 ```css
 h1 {
-  font : 1em "typewriter", monospace;
-  align-self : end;
+  font: 1em "typewriter", monospace;
+  align-self: end;
 }
 
 #message {
-   grid-row: 1 / 5;
+  grid-row: 1 / 5;
 }
 
-#from, #reply {
-   display: flex;
+#from,
+#reply {
+  display: flex;
 }
 ```
 
@@ -290,28 +297,30 @@ Now we can start working on the form elements themselves. First, let's ensure th
 
 ```css
 label {
-  font : .8em "typewriter", sans-serif;
+  font: 0.8em "typewriter", sans-serif;
 }
 ```
 
 The text fields require some common rules. In other words, we remove their {{cssxref("border","borders")}} and {{cssxref("background","backgrounds")}}, and redefine their {{cssxref("padding")}} and {{cssxref("margin")}}:
 
 ```css
-input, textarea {
-  font    : 1.4em/1.5em "handwriting", cursive, sans-serif;
-  border  : none;
-  padding : 0 10px;
-  margin  : 0;
-  width   : 80%;
-  background : none;
+input,
+textarea {
+  font: 1.4em/1.5em "handwriting", cursive, sans-serif;
+  border: none;
+  padding: 0 10px;
+  margin: 0;
+  width: 80%;
+  background: none;
 }
 ```
 
 When one of these fields gains focus, we highlight them with a light grey, transparent, background (it is always important to have focus style, for usability and keyboard accessibility):
 
 ```css
-input:focus, textarea:focus {
-  background   : rgba(0,0,0,.1);
+input:focus,
+textarea:focus {
+  background: rgba(0, 0, 0, 0.1);
   border-radius: 5px;
 }
 ```
@@ -324,12 +333,12 @@ Now that our text fields are complete, we need to adjust the display of the sing
 
 ```css
 textarea {
-  display : block;
+  display: block;
 
-  padding : 10px;
-  margin  : 10px 0 0 -10px;
-  width   : 100%;
-  height  : 90%;
+  padding: 10px;
+  margin: 10px 0 0 -10px;
+  width: 100%;
+  height: 90%;
 
   border-right: 1px solid;
 
@@ -344,24 +353,24 @@ The {{HTMLElement("button")}} element is really convenient to style with CSS; yo
 
 ```css
 button {
-  padding      : 5px;
-  font         : bold .6em sans-serif;
-  border       : 2px solid #333;
+  padding: 5px;
+  font: bold 0.6em sans-serif;
+  border: 2px solid #333;
   border-radius: 5px;
-  background   : none;
-  cursor       : pointer;
-  transform    : rotate(-1.5deg);
+  background: none;
+  cursor: pointer;
+  transform: rotate(-1.5deg);
 }
 
 button:after {
-  content      : " >>>";
+  content: " >>>";
 }
 
 button:hover,
 button:focus {
-  outline     : none;
-  background  : #000;
-  color       : #FFF;
+  outline: none;
+  background: #000;
+  color: #fff;
 }
 ```
 


### PR DESCRIPTION
Adding to #20633

The PR focuses only on CSS code fences.

This is probably the last one for CSS fences. :partying_face: 

***

**Note:** I have not linted code where perfectly aligned comments/values would be ruined by the Prettier. For example,
```
.multiple {
  box-shadow: 1px 1px 1px black,
              2px 2px 1px black,
              3px 3px 1px red,
              4px 4px 1px red,
              5px 5px 1px black,
              6px 6px 1px black;
}
```
May be we need to add `css-nolint` for such code fences. `css-nolint` isn't there in yari yet.