### PR TITLE
Fix constructor parameter names

### DIFF
--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
@@ -28,12 +28,12 @@ specified object.
 ## Syntax
 
 ```js-nolint
-new RTCSessionDescription(rtcSessionDescriptionInit)
+new RTCSessionDescription(options)
 ```
 
 ### Values
 
-- `rtcSessionDescriptionInit` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object providing the default values for the session description; the object
     conforms to the `RTCSessionDescriptionInit` dictionary. That dictionary has

--- a/files/en-us/web/api/taskcontroller/taskcontroller/index.md
+++ b/files/en-us/web/api/taskcontroller/taskcontroller/index.md
@@ -20,12 +20,12 @@ If no priority is set, the signal priority defaults to [`user-visible`](/en-US/d
 
 ```js-nolint
 new TaskController()
-new TaskController(init)
+new TaskController(options)
 ```
 
 ### Parameters
 
-- `init` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object with the following properties:
 

--- a/files/en-us/web/api/text/text/index.md
+++ b/files/en-us/web/api/text/text/index.md
@@ -17,16 +17,16 @@ with the optional string given in parameter as its textual content.
 
 ```js-nolint
 new Text()
-new Text(aString)
+new Text(string)
 ```
 
 ### Parameters
 
-- `aString` {{optional_inline}}
+- `string` {{optional_inline}}
 
 ### Return value
 
-A new {{domxref("Text")}} object containing `aString`, or the empty string if no parameter was given.
+A new {{domxref("Text")}} object with the content of the `string` parameter, or the empty string if no parameter was given.
 
 ## Example
 

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -22,12 +22,12 @@ new {{domxref("URLSearchParams")}} object.
 
 ```js-nolint
 new URLSearchParams()
-new URLSearchParams(init)
+new URLSearchParams(options)
 ```
 
 ### Parameters
 
-- `init` {{optional_inline}}
+- `options` {{optional_inline}}
   - : One of:
     - A string, which will be parsed from `application/x-www-form-urlencoded` format. A leading `'?'` character is ignored.
     - A literal sequence of name-value string pairs, or any object — such as a {{domxref("FormData")}} object — with an [iterator](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#iterators) that produces a sequence of string pairs. Note that {{domxref("File")}} entries will be serialized as `[object File]` rather than as their filename (as they would in an `application/x-www-form-urlencoded` form).

--- a/files/en-us/web/api/videocolorspace/videocolorspace/index.md
+++ b/files/en-us/web/api/videocolorspace/videocolorspace/index.md
@@ -19,15 +19,15 @@ The **`VideoColorSpace()`** constructor creates a new {{domxref("VideoColorSpace
 
 ```js-nolint
 new VideoColorSpace()
-new VideoColorSpace(init)
+new VideoColorSpace(options)
 ```
 
 ### Parameters
 
 All values default to `null` when they are not present.
 
-- `init` {{optional_inline}}
-  - : A dictionary object containing the following:
+- `options` {{optional_inline}}
+  - : An object containing the following:
     - `primaries` {{optional_inline}}
       - : One of the following strings:
         - `"bt709"`
@@ -52,12 +52,12 @@ All values default to `null` when they are not present.
 The following example creates a new `VideoColorSpace` object with {{domxref("VideoColorSpace.primaries")}} set to `"bt709"`, and {{domxref("VideoColorSpace.primaries")}} set to `true`.
 
 ```js
-let options = {
+const options = {
   primaries: "bt709",
   fullRange: true
 }
 
-let colorSpace = new VideoColorSpace(options);
+const colorSpace = new VideoColorSpace(options);
 console.log(colorSpace);
 ```
 

--- a/files/en-us/web/api/videodecoder/videodecoder/index.md
+++ b/files/en-us/web/api/videodecoder/videodecoder/index.md
@@ -18,13 +18,13 @@ The **`VideoDecoder()`** constructor creates a new {{domxref("VideoDecoder")}} o
 ## Syntax
 
 ```js-nolint
-new VideoDecoder(init)
+new VideoDecoder(options)
 ```
 
 ### Parameters
 
-- `init`
-  - : A dictionary object containing two callbacks.
+- `options`
+  - : An object containing two callbacks.
     - `output`
       - : A callback which takes a {{domxref("VideoFrame")}} object as its only argument.
     - `error`

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -18,12 +18,12 @@ The **`VideoEncoder()`** constructor creates a new {{domxref("VideoEncoder")}} o
 ## Syntax
 
 ```js-nolint
-new VideoEncoder(init)
+new VideoEncoder(options)
 ```
 
 ### Parameters
 
-- `init`
+- `options`
   - : An object containing two required callbacks.
     - `output`
       - : A callback which takes an {{domxref("EncodedVideoChunk")}} object as the first argument, and an optional metadata object as the second. The metadata object has three members:

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -19,8 +19,8 @@ The **`VideoFrame()`** constructor creates a new {{domxref("VideoFrame")}} objec
 
 ```js-nolint
 new VideoFrame(image)
-new VideoFrame(image, init)
-new VideoFrame(data, init)
+new VideoFrame(image, options)
+new VideoFrame(data, options)
 ```
 
 ### Parameters
@@ -35,8 +35,8 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
     an {{domxref("ImageBitmap")}},
     an {{domxref("OffscreenCanvas")}},
     or another {{domxref("VideoFrame")}}.
-- `init` {{Optional_Inline}}
-  - : A dictionary object containing the following:
+- `options` {{Optional_Inline}}
+  - : An object containing the following:
     - `duration` {{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
     - `timestamp`
@@ -46,7 +46,7 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
         - `"keep"`: Indicates that the user agent should preserve alpha channel data.
         - `"discard"`: Indicates that the user agent should ignore or remove alpha channel data.
     - `visibleRect` {{Optional_Inline}}
-      - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
+      - : An object representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
         - `y`
@@ -64,8 +64,8 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
 
 - `data`
   - : An {{jsxref("ArrayBuffer")}} containing the data for the new `VideoFrame`.
-- `init`
-  - : A dictionary object containing the following:
+- `options`
+  - : An object containing the following:
     - `format`
       - : A string representing the video pixel format. One of the following strings, which are fully described on the page for the {{domxref("VideoFrame.format","format")}} property:
         - `"I420"`
@@ -93,7 +93,7 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
             Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
     - `visibleRect` {{Optional_Inline}}
-      - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
+      - : An object representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
         - `y`
@@ -107,7 +107,7 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
     - `displayHeight` {{Optional_Inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
     - `colorSpace`
-      - : A dictionary representing the color space of the `VideoFrame`, containing the following:
+      - : An object representing the color space of the `VideoFrame`, containing the following:
         - `primaries`
           - : A string representing the video color primaries, described on the page for the {{domxref("VideoColorSpace.primaries")}} property.
         - `transfer`

--- a/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
@@ -20,12 +20,12 @@ The **`createEquirectLayer()`** method of the {{domxref("XRWebGLBinding")}} inte
 ## Syntax
 
 ```js-nolint
-createEquirectLayer(init)
+createEquirectLayer(options)
 ```
 
 ### Parameters
 
-- `init`
+- `options`
   - : An object to configure the {{domxref("XREquirectLayer")}}. It must have the `space`, `viewPixelHeight`, and `viewPixelWidth` properties. `init` has the following properties:
     - `centralHorizontalAngle` {{optional_inline}}
       - : A number indicating the central horizontal angle in radians of the sphere. Default value: `6.28318` (2π).

--- a/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
@@ -20,12 +20,12 @@ The **`createQuadLayer()`** method of the {{domxref("XRWebGLBinding")}} interfac
 ## Syntax
 
 ```js-nolint
-createQuadLayer(init)
+createQuadLayer(options)
 ```
 
 ### Parameters
 
-- `init`
+- `options`
   - : An object to configure the {{domxref("XRQuadLayer")}}. It must have the `space`, `viewPixelHeight`, and `viewPixelWidth` properties. `init` has the following properties:
     - `colorFormat` {{optional_inline}}
       - : A {{domxref("GLenum")}} defining the data type of the color texture data. Possible values:
@@ -58,10 +58,10 @@ createQuadLayer(init)
         - `gl.DEPTH_COMPONENT24`
         - `gl.DEPTH24_STENCIL24`
           The default value is `gl.DEPTH_COMPONENT`.
-    - `height`
-      - : Optional. A number specifying the height of the layer in meters. The default value is `1.0`.
-    - `isStatic`
-      - : Optional. A boolean that, if true, indicates you can only draw to this layer when {{domxref("XRCompositionLayer.needsRedraw", "needsRedraw")}} is `true`. The default value is `false`.
+    - `height` {{optional_inline}}
+      - : A number specifying the height of the layer in meters. The default value is `1.0`.
+    - `isStatic` {{optional_inline}}
+      - : A boolean that, if true, indicates you can only draw to this layer when {{domxref("XRCompositionLayer.needsRedraw", "needsRedraw")}} is `true`. The default value is `false`.
     - `layout` {{optional_inline}}
       - : A string indicating the layout of the layer. Possible values:
         - `default`

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -35,7 +35,7 @@ new XRWebGLBinding(session, context)
 
 ### Return value
 
-A newly-created {{domxref("XRWebGLBinding")}}.
+A new {{domxref("XRWebGLBinding")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
@@ -35,7 +35,7 @@ WebXR device and the WebGL graphics layer used to render the 3D scene.
 
 ```js-nolint
 new XRWebGLLayer(session, context)
-new XRWebGLLayer(session, context, layerInit)
+new XRWebGLLayer(session, context, options)
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ new XRWebGLLayer(session, context, layerInit)
   - : A {{domxref("WebGLRenderingContext")}} or {{domxref("WebGL2RenderingContext")}}
     identifying the WebGL drawing context to use for rendering the scene for the specified
     WebXR session.
-- `layerInit` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object providing configuration options for the new `XRWebGLLayer`. The available options
     are:


### PR DESCRIPTION
We prefer to use _options_ rather than _init_ or some derivated as used in the spec. This fixes the few occurrences that we missed.