### PR TITLE
Fix not iterable property in grouping example of the reduce page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -240,7 +240,7 @@ function groupBy(objectArray, property) {
   return objectArray.reduce((acc, obj) => {
     const key = obj[property];
 
-    return { ...acc, [key]: [...acc[key], obj] };
+    return { ...acc, [key]: [...(acc[key] || []), obj] };
   }, {});
 }
 


### PR DESCRIPTION
### Description

Resolved `acc[key] is not iterable` issue by providing a default value in case the `acc` variable is `undefined`.

### Motivation

As I was trying to use the code example from the reduce page, I ran into an error. Then I copied the code snippet, ran it, and found the same issue. 

This small change will fix the issue with the example code.

### Additional details

### Related issues and pull requests

Fixes #20631 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
