### PR TITLE
Fixed anchors in internal page links (take 2)

### DIFF
--- a/files/en-us/web/html/element/input/button/index.md
+++ b/files/en-us/web/html/element/input/button/index.md
@@ -35,8 +35,8 @@ browser-compat: html.elements.input.type_button
     <tr>
       <td><strong>Supported common attributes</strong></td>
       <td>
-        {{htmlattrxref("type", "input")}} and
-        {{htmlattrxref("value", "input")}}
+        <a href="/en-US/docs/Web/HTML/Element/input#type"><code>type</code></a> and
+        <a href="/en-US/docs/Web/HTML/Element/input#value"><code>value</code></a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description

I replaced all the anchors for internal links previously using `htmlattrxref` macro (specifically, the ones I missed last time).

### Motivation

Several internal links used the `htmlattrxref` macro, so their anchors were all broken. 

### Additional details

I replaced most of the links in #20068, but I missed a couple. 

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15725, https://github.com/mdn/content/pull/16660, https://github.com/mdn/content/pull/18361, https://github.com/mdn/content/pull/18923, https://github.com/mdn/content/pull/19199, https://github.com/mdn/content/pull/19613, https://github.com/mdn/content/pull/19893 and #20068.
