### PR TITLE
docs(CSP): clarification of frame-src v frame-ancestors

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -20,7 +20,7 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`frame-ancestors`** d
 Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options")}}`: deny` (which is also supported in older browsers).
 
 > **Note:** **`frame-ancestors`** allows you to specify what parent source may embed a page.
-> This differs from **`frame-src`** which allows you to specify where iframes in a page may be loaded from.
+> This differs from **`frame-src`**, which allows you to specify where iframes in a page may be loaded from.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -76,7 +76,7 @@ Content-Security-Policy: frame-ancestors <source> <source>;
   - : A scheme such as `http:` or `https:`. The colon is required and scheme should not be quoted. You can also specify data schemes (not recommended).
 
     - `data:` Allows [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary `data:` URLs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
+    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Capture_and_Streams_API) to be used as a content source.
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
     - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'CSP: frame-ancestors'
+title: "CSP: frame-ancestors"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
 tags:
   - Ancestors
@@ -18,6 +18,9 @@ browser-compat: http.headers.Content-Security-Policy.frame-ancestors
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`frame-ancestors`** directive specifies valid parents that may embed a page using {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("object")}}, {{HTMLElement("embed")}}, or {{HTMLElement("applet")}}.
 
 Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options")}}`: deny` (which is also supported in older browsers).
+
+> **Note:** **`frame-ancestors`** allows you to specify what parent source may embed a page.
+> This differs from **`frame-src`** which allows you to specify where iframes in a page may be loaded from.
 
 <table class="properties">
   <tbody>
@@ -102,3 +105,4 @@ Content-Security-Policy: frame-ancestors 'self' https://www.example.org;
 
 - {{HTTPHeader("Content-Security-Policy")}}
 - {{HTTPHeader("X-Frame-Options")}}
+- {{CSP("frame-src")}} CSP

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -22,7 +22,7 @@ browsing contexts loading using elements such as {{HTMLElement("frame")}} and
 {{HTMLElement("iframe")}}.
 
 > **Note:** **`frame-src`** allows you to specify where iframes in a page may be loaded from.
-> This differs from **`frame-ancestors`** which allows you to specify what parent source may embed a page.
+> This differs from **`frame-ancestors`**, which allows you to specify what parent source may embed a page.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'CSP: frame-src'
+title: "CSP: frame-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-src
 tags:
   - CSP
@@ -20,6 +20,9 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`frame-src`** directive specifies valid sources for nested
 browsing contexts loading using elements such as {{HTMLElement("frame")}} and
 {{HTMLElement("iframe")}}.
+
+> **Note:** **`frame-src`** allows you to specify where iframes in a page may be loaded from.
+> This differs from **`frame-ancestors`** which allows you to specify what parent source may embed a page.
 
 <table class="properties">
   <tbody>
@@ -85,3 +88,4 @@ The following {{HTMLElement("iframe")}} is blocked and won't load:
 
 - {{HTTPHeader("Content-Security-Policy")}}
 - {{HTMLElement("frame")}} and {{HTMLElement("iframe")}}
+- {{CSP("frame-ancestors")}}


### PR DESCRIPTION
This PR is a minor clarification that fixes #19938
