### PR TITLE
quaternion unit: XRReferenceSpace minor edit

### DIFF
--- a/files/en-us/web/api/xrreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/index.md
@@ -83,7 +83,7 @@ To move or rotate the user's view of the world, you need to change the `XRRefere
 
 ```js
 let offsetTransform = new XRRigidTransform({x: 2, y: 0, z: 1},
-                                           {x: 0, y: 1, z: 0, w: 1});
+                                           {x: 0, y: 0, z: 0, w: 1});
 xrReferenceSpace = xrReferenceSpace.getOffsetReferenceSpace(offsetTransform);
 ```
 


### PR DESCRIPTION
The quaternion used in the example is not valid nor it is not a unit quaternion.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
