### PR TITLE
Properly illustrate re-adding constructor property

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -319,7 +319,7 @@ const obj = new Derived();
 // obj ---> Derived.prototype ---> Base.prototype ---> Object.prototype ---> null
 ```
 
-You may also see some legacy code using [`Object.create`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create). However, because this re-assigns the `prototype` property, it's a bad practice, for the reasons previously described here.
+You may also see some legacy code using {{jsxref("Object.create()")}} to build the inheritance chain. However, because this reassigns the `prototype` property and removes the [`constructor`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) property, it can be more error-prone, while performance gains may not be apparent if the constructors haven't created any instances yet.
 
 ```js example-bad
 function Base() {}

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -291,7 +291,7 @@ Child.prototype.getOffsetByInitialPosition = function () {
 console.log(new Child(1, 1).getOffsetByInitialPosition()); // { offsetX: -1, offsetY: -1 }
 ```
 
-Again, using `Object.setPrototypeOf()` may have adverse performance effects, so make sure it happens immediately after the constructor declaration and before any instances are created to avoid objects being "tainted".
+Again, using `Object.setPrototypeOf()` may have adverse performance effects, so make sure it happens immediately after the constructor declaration and before any instances are created — to avoid objects being "tainted".
 
 > **Note:** Manually updating or setting the constructor can lead to different and sometimes confusing consequences. To prevent this, just define the role of `constructor` in each specific case. In most cases, `constructor` is not used and reassigning it is not necessary.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -201,7 +201,7 @@ CreatedConstructor.prototype.create = function () {
 new CreatedConstructor().create().create(); // still works without re-creating constructor property
 ```
 
-`Object.setPrototypeOf()` comes with its potential performance downsides because all previously created objects involved in the prototype chain have to be re-compiled, but if the above initialization code happens before `Parent` or `CreatedConstructor` are constructed, the effect should be minimal.
+`Object.setPrototypeOf()` comes with its potential performance downsides because all previously created objects involved in the prototype chain have to be re-compiled; but if the above initialization code happens before `Parent` or `CreatedConstructor` are constructed, the effect should be minimal.
 
 Let's consider one more involved case.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -13,27 +13,39 @@ browser-compat: javascript.builtins.Object.constructor
 
 The **`constructor`** property returns a reference to the {{jsxref("Object")}} constructor function that created the instance object. Note that the value of this property is a reference to _the function itself_, not a string containing the function's name.
 
-The value is only read-only for primitive values such as `1`, `true`, and `"test"`.
+> **Note:** This is a property of JavaScript objects. For the `constructor` method in classes, see [its own reference page](/en-US/docs/Web/JavaScript/Reference/Classes/constructor).
+
+{{js_property_attributes(1, 0, 1)}}
 
 ## Description
 
-Any object (with the exception of objects created with `Object.create(null)`) will have a `constructor` property on its `[[Prototype]]`. Objects created without the explicit use of a constructor function (such as object literals and array literals) will have a `constructor` property that points to the Fundamental Object constructor type for that object.
+Any object (with the exception of [`null` prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype)) will have a `constructor` property on its `[[Prototype]]`. Objects created with literals will also have a `constructor` property that points to the constructor type for that object — for example, array literals create {{jsxref("Array")}} objects, and [object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) create plain objects.
 
 ```js
-let o = {}
-o.constructor === Object // true
+const o1 = {};
+o1.constructor === Object; // true
 
-let o = new Object
-o.constructor === Object // true
+const o2 = new Object();
+o2.constructor === Object; // true
 
-let a = []
-a.constructor === Array // true
+const a1 = [];
+a1.constructor === Array; // true
 
-let a = new Array
-a.constructor === Array // true
+const a2 = new Array();
+a2.constructor === Array; // true
 
-let n = new Number(3)
-n.constructor === Number // true
+const n = 3;
+n.constructor === Number; // true
+```
+
+Note that `constructor` usually comes from the constructor's [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property. If you have a longer prototype chain, you can usually expect every object in the chain to have a `constructor` property.
+
+```js
+const o = new TypeError(); // Inheritance: TypeError -> Error -> Object
+const proto = Object.getPrototypeOf;
+proto(o).constructor === TypeError; // true
+proto(proto(o)).constructor === Error; // true
+proto(proto(proto(o))).constructor === Object; // true
 ```
 
 ## Examples
@@ -47,7 +59,7 @@ function Tree(name) {
   this.name = name;
 }
 
-const theTree = new Tree('Redwood');
+const theTree = new Tree("Redwood");
 console.log(`theTree.constructor is ${theTree.constructor}`);
 ```
 
@@ -59,20 +71,20 @@ theTree.constructor is function Tree(name) {
 }
 ```
 
-### Assigning the `constructor` property to an object
+### Assigning the constructor property to an object
 
 One can assign the `constructor` property of non-primitives.
 
 ```js
 const arr = [];
-arr.constructor = String
-arr.constructor === String // true
-arr instanceof String // false
-arr instanceof Array // true
+arr.constructor = String;
+arr.constructor === String; // true
+arr instanceof String; // false
+arr instanceof Array; // true
 
 const foo = new Foo();
-foo.constructor = 'bar'
-foo.constructor === 'bar' // true
+foo.constructor = "bar";
+foo.constructor === "bar"; // true
 
 // etc.
 ```
@@ -81,11 +93,11 @@ This does not overwrite the old `constructor` property — it was originally pre
 
 ```js
 const arr = [];
-Object.hasOwn(arr, "constructor") // false
-Object.hasOwn(Object.getPrototypeOf(arr), "constructor") // true
+Object.hasOwn(arr, "constructor"); // false
+Object.hasOwn(Object.getPrototypeOf(arr), "constructor"); // true
 
 arr.constructor = String;
-Object.hasOwn(arr, "constructor") // true — the instance property shadows the one on its prototype
+Object.hasOwn(arr, "constructor"); // true — the instance property shadows the one on its prototype
 ```
 
 But even when `Object.getPrototypeOf(a).constructor` is re-assigned, it won't change other behaviors of the object. For example, the behavior of `instanceof` is controlled by [`Symbol.hasInstance`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance), not `constructor`:
@@ -93,21 +105,23 @@ But even when `Object.getPrototypeOf(a).constructor` is re-assigned, it won't ch
 ```js
 const arr = [];
 arr.constructor = String;
-arr instanceof String // false
-arr instanceof Array // true
+arr instanceof String; // false
+arr instanceof Array; // true
 ```
 
 There is nothing protecting the `constructor` property from being re-assigned or shadowed, so using it to detect the type of a variable should usually be avoided in favor of less fragile ways like `instanceof` and [`Symbol.toStringTag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) for objects, or [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) for primitives.
 
-### Changing the `constructor` of a constructor function's `prototype`
+### Changing the constructor of a constructor function's prototype
 
-Every function constructor will have a `prototype` property, which will become the instance's `[[Prototype]]` when called via the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. `ConstructorFunction.prototype.constructor` will therefore become a property on the instance's `[[Prototype]]`, as previously demonstrated.
+Every constructor has a [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property, which will become the instance's `[[Prototype]]` when called via the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. `ConstructorFunction.prototype.constructor` will therefore become a property on the instance's `[[Prototype]]`, as previously demonstrated.
 
 However, if `ConstructorFunction.prototype` is re-assigned, the `constructor` property will be lost. For example, the following is a common way to create an inheritance pattern:
 
 ```js
-function Parent() { /* … */ }
-Parent.prototype.parentMethod = function parentMethod() {}
+function Parent() {
+  // …
+}
+Parent.prototype.parentMethod = function () {};
 
 function Child() {
   Parent.call(this); // Make sure everything is initialized properly
@@ -116,17 +130,23 @@ function Child() {
 Child.prototype = Object.create(Parent.prototype);
 ```
 
-The `constructor` of instances of `Child` will be `Parent` due to `Child.prototype` being re-assigned. Ensuring that `Child.prototype.constructor` always points to `Child` itself is crucial when you are using `constructor` to access the original class from an instance. Take the following case: the object has the `create()` method to create itself.
+The `constructor` of instances of `Child` will be `Parent` due to `Child.prototype` being re-assigned.
+
+This is usually not a big deal — the language almost never reads the `constructor` property of an object. The only exception is when using [`@@species`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species) to create new instances of a class, but such cases are rare, and you should be using the [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends) syntax to subclass builtins anyway.
+
+However, ensuring that `Child.prototype.constructor` always points to `Child` itself is crucial when some caller is using `constructor` to access the original class from an instance. Take the following case: the object has the `create()` method to create itself.
 
 ```js
-function Parent() { /* … */ }
+function Parent() {
+  // …
+}
 function CreatedConstructor() {
   Parent.call(this);
 }
 
 CreatedConstructor.prototype = Object.create(Parent.prototype);
 
-CreatedConstructor.prototype.create = function create() {
+CreatedConstructor.prototype.create = function () {
   return new this.constructor();
 };
 
@@ -136,34 +156,52 @@ new CreatedConstructor().create().create(); // TypeError: new CreatedConstructor
 In the example above, an exception is thrown, since the `constructor` links to `Parent`. To avoid this, just assign the necessary constructor you are going to use.
 
 ```js
-function Parent() { /* … */ }
-function CreatedConstructor() { /* … */ }
+function Parent() {
+  // …
+}
+function CreatedConstructor() {
+  // …
+}
 
-CreatedConstructor.prototype = Object.create(Parent.prototype);
-// Return original constructor to Child
-CreatedConstructor.prototype.constructor = CreatedConstructor;
+CreatedConstructor.prototype = Object.create(Parent.prototype, {
+  // Return original constructor to Child
+  constructor: {
+    value: CreatedConstructor,
+    enumerable: false, // Make it non-enumerable, so it won't appear in `for...in` loop
+    writable: true,
+    configurable: true,
+  },
+});
 
-CreatedConstructor.prototype.create = function create() {
+CreatedConstructor.prototype.create = function () {
   return new this.constructor();
 };
 
 new CreatedConstructor().create().create(); // it's pretty fine
 ```
 
-However, even better, do not re-assign `ConstructorFunction.prototype` — instead, use [`Object.setPrototypeOf`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) to manipulate the prototype chain.
+Note that when manually adding the `constructor` property, it's crucial to make the property [non-enumerable](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties), so `constructor` won't be visited in [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loops — as it normally isn't.
+
+If the code above looks like too much boilerplate, you may also consider using [`Object.setPrototypeOf()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) to manipulate the prototype chain.
 
 ```js
-function Parent() { /* … */ }
-function CreatedConstructor() { /* … */ }
+function Parent() {
+  // …
+}
+function CreatedConstructor() {
+  // …
+}
 
 Object.setPrototypeOf(CreatedConstructor.prototype, Parent.prototype);
 
-CreatedConstructor.prototype.create = function create() {
+CreatedConstructor.prototype.create = function () {
   return new this.constructor();
 };
 
 new CreatedConstructor().create().create(); // still works without re-creating constructor property
 ```
+
+`Object.setPrototypeOf()` comes with its potential performance downsides because all previously created objects involved in the prototype chain have to be re-compiled, but if the above initialization code happens before `Parent` or `CreatedConstructor` are constructed, the effect should be minimal.
 
 Let's consider one more involved case.
 
@@ -171,7 +209,7 @@ Let's consider one more involved case.
 function ParentWithStatic() {}
 
 ParentWithStatic.startPosition = { x: 0, y: 0 }; // Static member property
-ParentWithStatic.getStartPosition = function getStartPosition() {
+ParentWithStatic.getStartPosition = function () {
   return this.startPosition;
 };
 
@@ -179,10 +217,17 @@ function Child(x, y) {
   this.position = { x, y };
 }
 
-Child.prototype = Object.create(ParentWithStatic.prototype);
-Child.prototype.constructor = Child;
+Child.prototype = Object.create(ParentWithStatic.prototype, {
+  // Return original constructor to Child
+  constructor: {
+    value: Child,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
 
-Child.prototype.getOffsetByInitialPosition = function getOffsetByInitialPosition() {
+Child.prototype.getOffsetByInitialPosition = function () {
   const position = this.position;
   // Using this.constructor, in hope that getStartPosition exists as a static method
   const startPosition = this.constructor.getStartPosition();
@@ -202,9 +247,16 @@ For this example to work properly, we can reassign the `Parent`'s static propert
 
 ```js
 // …
-Child = Object.assign(Child, ParentWithStatic); // Notice that we assign it before we create() a prototype below
-Child.prototype = Object.create(ParentWithStatic.prototype);
-Child.prototype.constructor = Child;
+Object.assign(Child, ParentWithStatic); // Notice that we assign it before we create() a prototype below
+Child.prototype = Object.create(ParentWithStatic.prototype, {
+  // Return original constructor to Child
+  constructor: {
+    value: Child,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
 // …
 ```
 
@@ -214,7 +266,7 @@ But even better, we can make the constructor functions themselves extend each ot
 function ParentWithStatic() {}
 
 ParentWithStatic.startPosition = { x: 0, y: 0 }; // Static member property
-ParentWithStatic.getStartPosition = function getStartPosition() {
+ParentWithStatic.getStartPosition = function () {
   return this.startPosition;
 };
 
@@ -226,7 +278,7 @@ function Child(x, y) {
 Object.setPrototypeOf(Child.prototype, ParentWithStatic.prototype);
 Object.setPrototypeOf(Child, ParentWithStatic);
 
-Child.prototype.getOffsetByInitialPosition = function getOffsetByInitialPosition() {
+Child.prototype.getOffsetByInitialPosition = function () {
   const position = this.position;
   const startPosition = this.constructor.getStartPosition();
 
@@ -238,6 +290,8 @@ Child.prototype.getOffsetByInitialPosition = function getOffsetByInitialPosition
 
 console.log(new Child(1, 1).getOffsetByInitialPosition()); // { offsetX: -1, offsetY: -1 }
 ```
+
+Again, using `Object.setPrototypeOf()` may have adverse performance effects, so make sure it happens immediately after the constructor declaration and before any instances are created to avoid objects being "tainted".
 
 > **Note:** Manually updating or setting the constructor can lead to different and sometimes confusing consequences. To prevent this, just define the role of `constructor` in each specific case. In most cases, `constructor` is not used and reassigning it is not necessary.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -5,7 +5,7 @@ tags:
   - ECMAScript 5
   - JavaScript
   - Method
-  - 'Null'
+  - "Null"
   - Object
   - Reference
   - Polyfill
@@ -14,8 +14,7 @@ browser-compat: javascript.builtins.Object.create
 
 {{JSRef}}
 
-The **`Object.create()`** method creates a new object, using an
-existing object as the prototype of the newly created object.
+The **`Object.create()`** method creates a new object, using an existing object as the prototype of the newly created object.
 
 {{EmbedInteractiveExample("pages/js/object-create.html", "taller")}}
 
@@ -31,11 +30,7 @@ Object.create(proto, propertiesObject)
 - `proto`
   - : The object which should be the prototype of the newly-created object.
 - `propertiesObject` {{Optional_inline}}
-  - : If specified and not {{jsxref("undefined")}}, an object whose enumerable own
-    properties (that is, those properties defined upon itself and _not_ enumerable
-    properties along its prototype chain) specify property descriptors to be added to the
-    newly-created object, with the corresponding property names. These properties
-    correspond to the second argument of {{jsxref("Object.defineProperties()")}}.
+  - : If specified and not {{jsxref("undefined")}}, an object whose [enumerable own properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) specify property descriptors to be added to the newly-created object, with the corresponding property names. These properties correspond to the second argument of {{jsxref("Object.defineProperties()")}}.
 
 ### Return value
 
@@ -43,21 +38,19 @@ A new object with the specified prototype object and properties.
 
 ### Exceptions
 
-The `proto` parameter has to be either
+- {{jsxref("TypeError")}}
+  - : Thrown if `proto` is neither [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) nor an {{jsxref("Object")}}.
 
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
-- an {{jsxref("Object")}} excluding [primitive wrapper objects](/en-US/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript).
+## Examples
 
-If `proto` is neither of these a {{jsxref("TypeError")}} is thrown.
-
-## Object with `null` prototype
+### Object with null prototype
 
 A new object with `null` prototype can behave in unexpected ways, because it doesn't inherit any object methods from `Object.prototype`. This is especially true when debugging, since common object-property converting/detecting utility functions may generate errors, or lose information (especially if using silent error-traps that ignore errors).
 
 For example, the lack of [`Object.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) often makes debugging intractable:
 
 ```js
-const normalObj = {};   // create a normal object
+const normalObj = {}; // create a normal object
 const nullProtoObj = Object.create(null); // create an object with "null" prototype
 
 console.log(`normalObj is: ${normalObj}`); // shows "normalObj is: [object Object]"
@@ -70,14 +63,14 @@ alert(nullProtoObj); // throws error: Cannot convert object to primitive value
 Other methods will fail as well.
 
 ```js
-normalObj.valueOf() // shows {}
-nullProtoObj.valueOf() // throws error: nullProtoObj.valueOf is not a function
+normalObj.valueOf(); // shows {}
+nullProtoObj.valueOf(); // throws error: nullProtoObj.valueOf is not a function
 
-normalObj.hasOwnProperty("p") // shows "true"
-nullProtoObj.hasOwnProperty("p") // throws error: nullProtoObj.hasOwnProperty is not a function
+normalObj.hasOwnProperty("p"); // shows "true"
+nullProtoObj.hasOwnProperty("p"); // throws error: nullProtoObj.hasOwnProperty is not a function
 
-normalObj.constructor // shows "Object() { [native code] }"
-nullProtoObj.constructor // shows "undefined"
+normalObj.constructor; // shows "Object() { [native code] }"
+nullProtoObj.constructor; // shows "undefined"
 ```
 
 We can add the `toString` method back to the null-prototype object by simply assigning it one:
@@ -104,8 +97,8 @@ function getAge(name) {
   return ages[name];
 }
 
-hasPerson("hasOwnProperty") // true
-getAge("toString") // [Function: toString]
+hasPerson("hasOwnProperty"); // true
+getAge("toString"); // [Function: toString]
 ```
 
 Using a null-prototype object removes this hazard without introducing too much complexity to the `hasPerson` and `getAge` functions:
@@ -116,8 +109,8 @@ const ages = Object.create(null, {
   bob: { value: 27, enumerable: true },
 });
 
-hasPerson("hasOwnProperty") // false
-getAge("toString") // undefined
+hasPerson("hasOwnProperty"); // false
+getAge("toString"); // undefined
 ```
 
 In such case, the addition of any method should be done cautiously, as they can be confused with the other key-value pairs stored as data.
@@ -136,12 +129,9 @@ if (user.authenticated) {
 }
 ```
 
-## Examples
+### Classical inheritance with Object.create()
 
-### Classical inheritance with `Object.create()`
-
-Below is an example of how to use `Object.create()` to achieve classical
-inheritance. This is for a single inheritance, which is all that JavaScript supports.
+Below is an example of how to use `Object.create()` to achieve classical inheritance. This is for a single inheritance, which is all that JavaScript supports.
 
 ```js
 // Shape - superclass
@@ -151,10 +141,10 @@ function Shape() {
 }
 
 // superclass method
-Shape.prototype.move = function(x, y) {
+Shape.prototype.move = function (x, y) {
   this.x += x;
   this.y += y;
-  console.info('Shape moved.');
+  console.info("Shape moved.");
 };
 
 // Rectangle - subclass
@@ -163,19 +153,26 @@ function Rectangle() {
 }
 
 // subclass extends superclass
-Rectangle.prototype = Object.create(Shape.prototype);
-
-//If you don't set Rectangle.prototype.constructor to Rectangle,
-//it will take the prototype.constructor of Shape (parent).
-//To avoid that, we set the prototype.constructor to Rectangle (child).
-Rectangle.prototype.constructor = Rectangle;
+Rectangle.prototype = Object.create(Shape.prototype, {
+  // If you don't set Rectangle.prototype.constructor to Rectangle,
+  // it will take the prototype.constructor of Shape (parent).
+  // To avoid that, we set the prototype.constructor to Rectangle (child).
+  constructor: {
+    value: Rectangle,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
 
 const rect = new Rectangle();
 
-console.log('Is rect an instance of Rectangle?', rect instanceof Rectangle); // true
-console.log('Is rect an instance of Shape?', rect instanceof Shape); // true
+console.log("Is rect an instance of Rectangle?", rect instanceof Rectangle); // true
+console.log("Is rect an instance of Shape?", rect instanceof Shape); // true
 rect.move(1, 1); // Outputs, 'Shape moved.'
 ```
+
+Note that there are caveats to watch out for using `create()`, such as re-adding the [`constructor`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) property to ensure proper semantics. Although `Object.create()` is believed to have better performance than mutating the prototype with {{jsxref("Object.setPrototypeOf()")}}, the difference is in fact negligible if no instances have been created and property accesses haven't been optimized yet. In modern code, the [class](/en-US/docs/Web/JavaScript/Reference/Classes) syntax should be preferred in any case.
 
 ### Using propertiesObject argument with Object.create()
 
@@ -197,16 +194,18 @@ o = Object.create(Object.prototype, {
   foo: {
     writable: true,
     configurable: true,
-    value: 'hello'
+    value: "hello",
   },
   // bar is a getter-and-setter (accessor) property
   bar: {
     configurable: false,
-    get() { return 10; },
+    get() {
+      return 10;
+    },
     set(value) {
-      console.log('Setting `o.bar` to', value);
-    }
-  }
+      console.log("Setting `o.bar` to", value);
+    },
+  },
 });
 
 function Constructor() {}
@@ -237,14 +236,17 @@ delete o.p;
 // false
 
 // to specify a property with the same attributes as in an initializer
-o2 = Object.create({}, {
-  p: {
-    value: 42,
-    writable: true,
-    enumerable: true,
-    configurable: true
-  }
-});
+o2 = Object.create(
+  {},
+  {
+    p: {
+      value: 42,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    },
+  },
+);
 // This is not equivalent to:
 // o2 = Object.create({ p: 42 })
 // which will create an object with prototype { p: 42 }

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -57,7 +57,7 @@ Object.setPrototypeOf(Object.prototype, {}); // TypeError: Immutable prototype o
 
 ## Examples
 
-### Pseudoclassical inheritance using Object.setPrototypeOf
+### Pseudoclassical inheritance using Object.setPrototypeOf()
 
 Inheritance in JS using classes.
 
@@ -88,23 +88,25 @@ Object.setPrototypeOf(SuperHero.prototype, Human.prototype);
 
 Human.prototype.speak = function () {
   return `${this.name} says hello.`;
-}
+};
 
 SuperHero.prototype.fly = function () {
   return `${this.name} is flying.`;
-}
+};
 
-const superMan = new SuperHero('Clark Kent', 1);
+const superMan = new SuperHero("Clark Kent", 1);
 
 console.log(superMan.fly());
-console.log(superMan.speak())
+console.log(superMan.speak());
 ```
 
 The similarity between classical inheritance (with classes) and pseudoclassical inheritance (with constructors' `prototype` property) as done above is mentioned in [Inheritance chains](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains).
 
-In the example below, which also uses classes, `SuperHero` is made to inherit from `Human` without using `extends` by using `setPrototypeOf` instead.
+Since function constructors' [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property is writable, you can reassign it to a new object created with [`Object.create()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#classical_inheritance_with_object.create) to achieve the same inheritance chain as well. There are caveats to watch out when using `create()`, such as remembering to re-add the [`constructor`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) property.
 
-> **Warning:** It is not advisable to use `setPrototypeOf` instead of `extends` due to performance and readability reasons.
+In the example below, which also uses classes, `SuperHero` is made to inherit from `Human` without using `extends` by using `setPrototypeOf()` instead.
+
+> **Warning:** It is not advisable to use `setPrototypeOf()` instead of `extends` due to performance and readability reasons.
 
 ```js
 class Human {}
@@ -119,7 +121,7 @@ Object.setPrototypeOf(SuperHero, Human);
 const superMan = new SuperHero();
 ```
 
-Subclassing without extends is mentioned in [ES-6 subclassing](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/).
+Subclassing without `extends` is mentioned in [ES-6 subclassing](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/).
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Closes https://github.com/mdn/content/pull/18880

The important part is realizing that the performance degradation only happens after property accesses have already happened, which is not the case during constructor definition. The point about ergonomics still stands, but I decided to (1) properly illustrate how `Object.create()` should work and (2) explicitly point out the performance trade-offs.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
