### PR TITLE
Improve clarity on `.has` Map method

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -281,32 +281,24 @@ console.log(contacts.size) // 1
   - : Removes all key-value pairs from the `Map` object.
 - {{jsxref("Map.prototype.delete()")}}
   - : Returns `true` if an element in the `Map` object existed and has been
-    removed, or `false` if the element does not exist. `Map.prototype.has(key)`
+    removed, or `false` if the element does not exist. `map.has(key)`
     will return `false` afterwards.
 - {{jsxref("Map.prototype.get()")}}
-  - : Returns the value associated to the `key`, or `undefined` if there is
-    none.
+  - : Returns the value associated to the passed key, or `undefined` if there is none.
 - {{jsxref("Map.prototype.has()")}}
-  - : Returns a boolean indicating whether a value has been associated with a passed `key` in the `Map` object or not.
+  - : Returns a boolean indicating whether a value has been associated with the passed key in the `Map` object or not.
 - {{jsxref("Map.prototype.set()")}}
-  - : Sets the `value` for the `key` in the `Map` object. Returns the `Map`
-    object.
+  - : Sets the value for the passed key in the `Map` object. Returns the `Map` object.
 - {{jsxref("Map/@@iterator", "Map.prototype[@@iterator]()")}}
-  - : Returns a new Iterator object that contains **an array of `[key, value]`**
-    for each element in the `Map` object in insertion order.
+  - : Returns a new Iterator object that contains a two-member array of `[key, value]` for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.keys()")}}
-  - : Returns a new Iterator object that contains the **keys** for each element
-    in the `Map` object in insertion order.
+  - : Returns a new Iterator object that contains the keys for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.values()")}}
-  - : Returns a new Iterator object that contains the **values** for each
-    element in the `Map` object in insertion order.
+  - : Returns a new Iterator object that contains the values for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.entries()")}}
-  - : Returns a new Iterator object that contains **an array of `[key, value]`**
-    for each element in the `Map` object in insertion order.
+  - : Returns a new Iterator object that contains a two-member array of `[key, value]` for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.forEach()")}}
-  - : Calls `callbackFn` once for each key-value pair present in the `Map`
-    object, in insertion order. If a `thisArg` parameter is provided to
-    `forEach`, it will be used as the `this` value for each callback.
+  - : Calls `callbackFn` once for each key-value pair present in the `Map` object, in insertion order. If a `thisArg` parameter is provided to `forEach`, it will be used as the `this` value for each callback.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -287,7 +287,7 @@ console.log(contacts.size) // 1
   - : Returns the value associated to the `key`, or `undefined` if there is
     none.
 - {{jsxref("Map.prototype.has()")}}
-  - : Returns a boolean asserting whether a value has been associated to the
+  - : Returns a boolean asserting whether a value has been associated to a passed
     `key` in the `Map` object or not.
 - {{jsxref("Map.prototype.set()")}}
   - : Sets the `value` for the `key` in the `Map` object. Returns the `Map`

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -287,8 +287,7 @@ console.log(contacts.size) // 1
   - : Returns the value associated to the `key`, or `undefined` if there is
     none.
 - {{jsxref("Map.prototype.has()")}}
-  - : Returns a boolean asserting whether a value has been associated to a passed
-    `key` in the `Map` object or not.
+  - : Returns a boolean indicating whether a value has been associated with a passed `key` in the `Map` object or not.
 - {{jsxref("Map.prototype.set()")}}
   - : Sets the `value` for the `key` in the `Map` object. Returns the `Map`
     object.


### PR DESCRIPTION
### Description

Since there are no props seen inside the list item "header" `Map.prototype.has()`, it is more clear to allude to the fact that you will pass a `key`.

### Motivation

I have been trying use Maps more, and when reading through the basic methods, I caught myself asking, "do we pass the key"? This small change can help avoid that for others :)