### PR TITLE
Run Prettier on HTML code fences, part 16

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_routing/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_routing/index.md
@@ -169,7 +169,7 @@ In this file, change
 To
 
 ```hbs
-<TodoList @todos=\{{ @model.allTodos }}/>
+<TodoList @todos=\{{ @model.allTodos }} />
 ```
 
 ### The completed route model
@@ -206,7 +206,7 @@ In this file, change
 To
 
 ```hbs
-<TodoList @todos=\{{ @model.completedTodos }}/>
+<TodoList @todos=\{{ @model.completedTodos }} />
 ```
 
 ### The active route model
@@ -243,7 +243,7 @@ In this file, change
 To
 
 ```html
-<TodoList @todos=\{{ @model.activeTodos }}/>
+<TodoList @todos=\{{ @model.activeTodos }} />
 ```
 
 Note that, in each of the route model hooks, we are returning an object with a getter instead of a static object, or more just the static list of todos (for example, `this.todos.completed`). The reason for this is that we want the template to have a dynamic reference to the todo list, and if we returned the list directly, the data would never re-compute, which would result in the navigations appearing to fail / not actually filter. By having a getter defined in the return object from the model data, the todos are re-looked-up so that our changes to the todo list are represented in the rendered list.
@@ -263,9 +263,9 @@ Go back to `todomvc/app/components/footer.hbs`, and find the following bit of ma
 Update it to
 
 ```html
-<LinkTo @route='index'>All</LinkTo>
-<LinkTo @route='active'>Active</LinkTo>
-<LinkTo @route='completed'>Completed</LinkTo>
+<LinkTo @route="index">All</LinkTo>
+<LinkTo @route="active">Active</LinkTo>
+<LinkTo @route="completed">Completed</LinkTo>
 ```
 
 `<LinkTo>` is a built-in Ember component that handles all the state changes when navigating routes, as well as setting an "active" class on any link that matches the URL, in case there is a desire to style it differently from inactive links.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_structure_componentization/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_structure_componentization/index.md
@@ -75,8 +75,7 @@ However, we don't want this. Instead, we want it to contain the TodoMVC app stru
     class="new-todo"
     aria-label="What needs to be done?"
     placeholder="What needs to be done?"
-    autofocus
-  >
+    autofocus />
 </section>
 ```
 
@@ -95,11 +94,10 @@ It doesn't take too much effort to get our HTML looking like a fully-featured to
     class="new-todo"
     aria-label="What needs to be done?"
     placeholder="What needs to be done?"
-    autofocus
-  >
+    autofocus />
 
   <section class="main">
-    <input id="mark-all-complete" class="toggle-all" type="checkbox">
+    <input id="mark-all-complete" class="toggle-all" type="checkbox" />
     <label for="mark-all-complete">Mark all as complete</label>
 
     <ul class="todo-list">
@@ -108,17 +106,15 @@ It doesn't take too much effort to get our HTML looking like a fully-featured to
           <input
             aria-label="Toggle the completion of this todo"
             class="toggle"
-            type="checkbox"
-          >
+            type="checkbox" />
           <label>Buy Movie Tickets</label>
           <button
             type="button"
             class="destroy"
-            title="Remove this todo"
-          ></button>
+            title="Remove this todo"></button>
         </div>
 
-        <input autofocus class="edit" value="Todo Text">
+        <input autofocus class="edit" value="Todo Text" />
       </li>
 
       <li>
@@ -126,25 +122,21 @@ It doesn't take too much effort to get our HTML looking like a fully-featured to
           <input
             aria-label="Toggle the completion of this todo"
             class="toggle"
-            type="checkbox"
-          >
+            type="checkbox" />
           <label>Go to Movie</label>
           <button
             type="button"
             class="destroy"
-            title="Remove this todo"
-           ></button>
+            title="Remove this todo"></button>
         </div>
 
-        <input autofocus class="edit" value="Todo Text">
+        <input autofocus class="edit" value="Todo Text" />
       </li>
     </ul>
   </section>
 
   <footer class="footer">
-    <span class="todo-count">
-      <strong>0</strong> todos left
-    </span>
+    <span class="todo-count"> <strong>0</strong> todos left </span>
 
     <ul class="filters">
       <li>
@@ -154,9 +146,7 @@ It doesn't take too much effort to get our HTML looking like a fully-featured to
       </li>
     </ul>
 
-    <button type="button" class="clear-completed">
-      Clear Completed
-    </button>
+    <button type="button" class="clear-completed">Clear Completed</button>
   </footer>
 </section>
 ```
@@ -241,15 +231,14 @@ Now that we have all of our component structure files, we can cut and paste the 
      class="new-todo"
      aria-label="What needs to be done?"
      placeholder="What needs to be done?"
-     autofocus
-   >
+     autofocus />
    ```
 
 2. `todo-list.hbs` should be updated to contain this chunk of code:
 
    ```html
    <section class="main">
-     <input id="mark-all-complete" class="toggle-all" type="checkbox">
+     <input id="mark-all-complete" class="toggle-all" type="checkbox" />
      <label for="mark-all-complete">Mark all as complete</label>
 
      <ul class="todo-list">
@@ -269,17 +258,12 @@ Now that we have all of our component structure files, we can cut and paste the 
        <input
          aria-label="Toggle the completion of this todo"
          class="toggle"
-         type="checkbox"
-       >
+         type="checkbox" />
        <label>Buy Movie Tickets</label>
-       <button
-         type="button"
-         class="destroy"
-         title="Remove this todo"
-       ></button>
+       <button type="button" class="destroy" title="Remove this todo"></button>
      </div>
 
-     <input autofocus class="edit" value="Todo Text">
+     <input autofocus class="edit" value="Todo Text" />
    </li>
    ```
 
@@ -287,9 +271,7 @@ Now that we have all of our component structure files, we can cut and paste the 
 
    ```html
    <footer class="footer">
-     <span class="todo-count">
-       <strong>0</strong> todos left
-     </span>
+     <span class="todo-count"> <strong>0</strong> todos left </span>
 
      <ul class="filters">
        <li>
@@ -299,9 +281,7 @@ Now that we have all of our component structure files, we can cut and paste the 
        </li>
      </ul>
 
-     <button type="button" class="clear-completed">
-       Clear Completed
-     </button>
+     <button type="button" class="clear-completed">Clear Completed</button>
    </footer>
    ```
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -234,8 +234,7 @@ Further down, you can find our [`<ul>`](/en-US/docs/Web/HTML/Element/ul) element
 <ul
   role="list"
   className="todo-list stack-large stack-exception"
-  aria-labelledby="list-heading"
->
+  aria-labelledby="list-heading">…</ul>
 ```
 
 The `role` attribute helps assistive technology explain what kind of element a tag represents. A `<ul>` is treated like a list by default, but the styles we're about to add will break that functionality. This role will restore the "list" meaning to the `<ul>` element. If you want to learn more about why this is necessary, you can check out [Scott O'Hara's article, "Fixing Lists"](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html).

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_components/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_components/index.md
@@ -208,7 +208,7 @@ Using `bind`, we will tell Svelte that any changes made to the `filter` prop in 
 
    ```html
    <script>
-     export let filter = 'all'
+     export let filter = "all";
    </script>
    ```
 
@@ -260,11 +260,11 @@ Our `Todo` component will receive a single `todo` object as a prop. Let's declar
    ```html
    <ul role="list" class="todo-list stack-large" aria-labelledby="list-heading">
      {#each filterTodos(filter, todos) as todo (todo.id)}
-       <li class="todo">
-         <Todo {todo} />
-       </li>
+     <li class="todo">
+       <Todo {todo} />
+     </li>
      {:else}
-       <li>Nothing to do here!</li>
+     <li>Nothing to do here!</li>
      {/each}
    </ul>
    ```
@@ -387,11 +387,11 @@ The following gives you an idea of what the basic `if` block structure looks lik
 
 ```html
 <div class="stack-small">
-{#if editing}
+  {#if editing}
   <!-- markup for editing to-do: label, input text, Cancel and Save Button -->
-{:else}
+  {:else}
   <!-- markup for displaying to-do: checkbox, label, Edit and Delete Button -->
-{/if}
+  {/if}
 </div>
 ```
 
@@ -519,12 +519,10 @@ We also use `todo.id` to create unique ids for the new input controls and labels
 
    ```html
    {#each filterTodos(filter, todos) as todo (todo.id)}
-     <li class="todo">
-       <Todo {todo}
-         on:update={(e) => updateTodo(e.detail)}
-         on:remove={(e) => removeTodo(e.detail)}
-       />
-     </li>
+   <li class="todo">
+     <Todo {todo} on:update={(e) => updateTodo(e.detail)} on:remove={(e) =>
+     removeTodo(e.detail)} />
+   </li>
    ```
 
 4. Try your app again, and you should see that you can delete, add, edit, cancel editing of, and toggle completion status of to-dos. And our "x out of y items completed" status heading will now update appropriately when to-dos are completed.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_deployment_next/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_deployment_next/index.md
@@ -261,11 +261,11 @@ Let's have a go at doing this now.
    ```html
    <title>Svelte To-Do list</title>
 
-   <link rel='icon' type='image/png' href='favicon.png'>
-   <link rel='stylesheet' href='global.css'>
-   <link rel='stylesheet' href='build/bundle.css'>
+   <link rel="icon" type="image/png" href="favicon.png" />
+   <link rel="stylesheet" href="global.css" />
+   <link rel="stylesheet" href="build/bundle.css" />
 
-   <script defer src='build/bundle.js'></script>
+   <script defer src="build/bundle.js"></script>
    ```
 
    Do this now.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -201,7 +201,10 @@ With this in mind, let's have a look at the `src/App.svelte` file that came with
 
 <main>
   <h1>Hello {name}!</h1>
-  <p>Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn how to build Svelte apps.</p>
+  <p>
+    Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn
+    how to build Svelte apps.
+  </p>
 </main>
 
 <style>
@@ -246,7 +249,10 @@ In the markup section you can insert any HTML you like, and in addition you can 
 ```html
 <main>
   <h1>Hello {name}!</h1>
-  <p>Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn how to build Svelte apps.</p>
+  <p>
+    Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn
+    how to build Svelte apps.
+  </p>
 </main>
 ```
 
@@ -316,18 +322,21 @@ Try updating your `<script>` and markup sections like so:
   export let name;
 
   function toggleName() {
-    if (name === 'world') {
-      name = 'Svelte'
+    if (name === "world") {
+      name = "Svelte";
     } else {
-      name = 'world'
+      name = "world";
     }
   }
 </script>
 
 <main>
   <h1>Hello {name}!</h1>
-  <button on:click={toggleName}>Toggle name</button>
-  <p>Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn how to build Svelte apps.</p>
+  <button on:click="{toggleName}">Toggle name</button>
+  <p>
+    Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn
+    how to build Svelte apps.
+  </p>
 </main>
 ```
 
@@ -372,21 +381,20 @@ Finally the file `public/index.html` includes the generated `bundle.css` and `bu
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset='utf-8'>
-  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-  <title>Svelte app</title>
+    <title>Svelte app</title>
 
-  <link rel='icon' type='image/png' href='/favicon.png'>
-  <link rel='stylesheet' href='/global.css'>
-  <link rel='stylesheet' href='/build/bundle.css'>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="stylesheet" href="/global.css" />
+    <link rel="stylesheet" href="/build/bundle.css" />
 
-  <script defer src='/build/bundle.js'></script>
-</head>
+    <script defer src="/build/bundle.js"></script>
+  </head>
 
-<body>
-</body>
+  <body></body>
 </html>
 ```
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
@@ -104,17 +104,17 @@ Now we'll tackle the _Check All_ and _Remove Completed_ buttons. Let's create a 
 
    ```html
    <script>
-     import { createEventDispatcher } from 'svelte';
+     import { createEventDispatcher } from "svelte";
      const dispatch = createEventDispatcher();
 
      let completed = true;
 
      const checkAll = () => {
-       dispatch('checkAll', completed);
+       dispatch("checkAll", completed);
        completed = !completed;
-     }
+     };
 
-     const removeCompleted = () => dispatch('removeCompleted');
+     const removeCompleted = () => dispatch("removeCompleted");
    </script>
 
    <div class="btn-group">
@@ -503,7 +503,13 @@ Now we will take care of the `Todo` component's focus management details. First 
 3. And finally, bind `nameEl` to the `<input>` field by updating it like so:
 
    ```html
-   <input bind:value={name} bind:this={nameEl} type="text" id="todo-{todo.id}" autoComplete="off" class="todo-text" />
+   <input
+     bind:value={name}
+     bind:this={nameEl}
+     type="text"
+     id="todo-{todo.id}"
+     autocomplete="off"
+     class="todo-text" />
    ```
 
 4. However, when you try the updated app, you'll get an error along the lines of "TypeError: nameEl is undefined" in the console when you press a to-do's _Edit_ button.
@@ -591,8 +597,14 @@ In our immediate use case, we will define a function called `selectOnFocus()` th
 
    ```html
    <label for="todo-{todo.id}" class="todo-label">New name for '{todo.name}'</label>
-   <input bind:value={name} bind:this={nameEl} use:selectOnFocus type="text" id="todo-{todo.id}" autoComplete="off" class="todo-text"
-   />
+   <input
+     bind:value={name}
+     bind:this={nameEl}
+     use:selectOnFocus
+     type="text"
+     id="todo-{todo.id}"
+     autocomplete="off"
+     class="todo-text" />
    ```
 
 3. Let's try it out. Go to your app, press a to-do's _Edit_ button, then <kbd>Tab</kbd> to take focus away from the `<input>`. Now click on the `<input>`, and you'll see that the entire input text is selected.
@@ -637,9 +649,14 @@ To demonstrate our action's reusability, let's make use of it in `NewTodo.svelte
 2. Add the `use:selectOnFocus` directive to the `<input>`, like this:
 
    ```html
-   <input bind:value={name} bind:this={nameEl} use:selectOnFocus
-     type="text" id="todo-0" autoComplete="off" class="input input__lg"
-   />
+   <input
+     bind:value={name}
+     bind:this={nameEl}
+     use:selectOnFocus
+     type="text"
+     id="todo-0"
+     autocomplete="off"
+     class="input input__lg" />
    ```
 
 With a few lines of code we can add functionality to regular HTML elements in a very reusable and declarative way. It just takes an `import` and a short directive like `use:selectOnFocus` that clearly describes its purpose. And we can achieve this without the need to create a custom wrapper element like `TextInput`, `MyInput`, or similar. Moreover, you can add as many `use:action` directives as you want to an element.
@@ -659,7 +676,7 @@ In the previous section, while working with the `Todo` components, we had to dea
 2. And then in our markup we just need to add another `use:` directive:
 
    ```html
-   <input bind:value={name} use:selectOnFocus use:focusOnInit>
+   <input bind:value={name} use:selectOnFocus use:focusOnInit />
    ```
 
 3. Our `onEdit()` function can now be much simpler:
@@ -731,7 +748,9 @@ First we'll extract the status heading to its own component.
      $: completedTodos = todos.filter((todo) => todo.completed).length;
    </script>
 
-   <h2 id="list-heading">{completedTodos} out of {totalTodos} items completed</h2>
+   <h2 id="list-heading">
+     {completedTodos} out of {totalTodos} items completed
+   </h2>
    ```
 
 3. Import the file at the beginning of `Todos.svelte`, adding the following `import` statement below the others:
@@ -764,14 +783,15 @@ We've already seen that Svelte uses `export let varname = …` to [declare props
 
 ```html
 <script>
-  export let bar = 'optional default initial value'; // prop
+  export let bar = "optional default initial value"; // prop
   export let baz = undefined; // prop
   export let format = (n) => n.toFixed(2); // prop
 
   // these are readonly
-  export const thisIs = 'readonly'; // read-only export
+  export const thisIs = "readonly"; // read-only export
 
-  export function greet(name) { // read-only export
+  export function greet(name) {
+    // read-only export
     alert(`Hello, ${name}!`);
   }
 
@@ -792,12 +812,15 @@ With this in mind, let's go back to our use case. We'll create a function called
 
      let headingEl;
 
-     export function focus() { // shorter version: export const focus = () => headingEl.focus()
+     export function focus() {
+       // shorter version: export const focus = () => headingEl.focus()
        headingEl.focus();
      }
    </script>
 
-   <h2 id="list-heading" bind:this={headingEl} tabindex="-1">{completedTodos} out of {totalTodos} items completed</h2>
+   <h2 id="list-heading" bind:this={headingEl} tabindex="-1">
+     {completedTodos} out of {totalTodos} items completed
+   </h2>
    ```
 
    Note that we've added a `tabindex` attribute to the `<h2>` to allow the element to receive focus programmatically.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
@@ -213,14 +213,14 @@ This works, but you'll have to copy and paste all this code every time you want 
 
 ```html
 <script>
-  import myStore from './stores.js'
-  import { onDestroy } from 'svelte'
+  import myStore from "./stores.js";
+  import { onDestroy } from "svelte";
 
-  let myStoreContent = ''
+  let myStoreContent = "";
 
-  const unsubscribe = myStore.subscribe((value) => myStoreContent = value)
+  const unsubscribe = myStore.subscribe((value) => (myStoreContent = value));
 
-  onDestroy(unsubscribe)
+  onDestroy(unsubscribe);
 </script>
 
 {myStoreContent}
@@ -230,7 +230,7 @@ That's too much boilerplate for Svelte! Being a compiler, Svelte has more resour
 
 ```html
 <script>
-  import myStore from './stores.js'
+  import myStore from "./stores.js";
 </script>
 
 {$myStore}
@@ -443,17 +443,16 @@ So let's start by using a regular writable store to save our to-dos.
 
    ```html
    <script>
-     import Todos from './components/Todos.svelte'
-     import Alert from './components/Alert.svelte'
+     import Todos from "./components/Todos.svelte";
+     import Alert from "./components/Alert.svelte";
 
-     import { todos } from './stores.js'
+     import { todos } from "./stores.js";
 
      $todos = [
-       { id: 1, name: 'Create a Svelte starter app', completed: true },
-       { id: 2, name: 'Create your first component', completed: true },
-       { id: 3, name: 'Complete the rest of the tutorial', completed: false }
-     ]
-
+       { id: 1, name: "Create a Svelte starter app", completed: true },
+       { id: 2, name: "Create your first component", completed: true },
+       { id: 3, name: "Complete the rest of the tutorial", completed: false }
+     ];
    </script>
 
    <Alert />

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
@@ -123,7 +123,7 @@ Let's create a `Todos.svelte` component. This will contain our list of to-dos.
 
    ```html
    <script>
-     import Todos from './components/Todos.svelte'
+     import Todos from "./components/Todos.svelte";
    </script>
 
    <Todos />
@@ -152,16 +152,12 @@ For the moment we will start with a static markup representation of our app, so 
 ```html
 <!-- Todos.svelte -->
 <div class="todoapp stack-large">
-
   <!-- NewTodo -->
   <form>
     <h2 class="label-wrapper">
-      <label for="todo-0" class="label__lg">
-        What needs to be done?
-      </label>
+      <label for="todo-0" class="label__lg"> What needs to be done? </label>
     </h2>
-    <input type="text" id="todo-0" autocomplete="off"
-      class="input input__lg" />
+    <input type="text" id="todo-0" autocomplete="off" class="input input__lg" />
     <button type="submit" disabled="" class="btn btn__primary btn__lg">
       Add
     </button>
@@ -191,7 +187,6 @@ For the moment we will start with a static markup representation of our app, so 
 
   <!-- Todos -->
   <ul role="list" class="todo-list stack-large" aria-labelledby="list-heading">
-
     <!-- todo-1 (editing mode) -->
     <li class="todo">
       <div class="stack-small">
@@ -200,7 +195,11 @@ For the moment we will start with a static markup representation of our app, so 
             <label for="todo-1" class="todo-label">
               New name for 'Create a Svelte starter app'
             </label>
-            <input type="text" id="todo-1" autocomplete="off" class="todo-text" />
+            <input
+              type="text"
+              id="todo-1"
+              autocomplete="off"
+              class="todo-text" />
           </div>
           <div class="btn-group">
             <button class="btn todo-cancel" type="button">
@@ -220,7 +219,7 @@ For the moment we will start with a static markup representation of our app, so 
     <li class="todo">
       <div class="stack-small">
         <div class="c-cb">
-          <input type="checkbox" id="todo-2" checked/>
+          <input type="checkbox" id="todo-2" checked />
           <label for="todo-2" class="todo-label">
             Create your first component
           </label>
@@ -268,7 +267,6 @@ For the moment we will start with a static markup representation of our app, so 
     <button type="button" class="btn btn__primary">Check all</button>
     <button type="button" class="btn btn__primary">Remove completed</button>
   </div>
-
 </div>
 ```
 
@@ -307,7 +305,10 @@ The class `visually-hidden` has no effect yet, because we have not included any 
 Further down, you can find the following `<ul>` element:
 
 ```html
-<ul role="list" className="todo-list stack-large" aria-labelledby="list-heading">
+<ul
+  role="list"
+  className="todo-list stack-large"
+  aria-labelledby="list-heading">
 ```
 
 The `role` attribute helps assistive technology explain what kind of semantic value an element has — or what its purpose is. A `<ul>` is treated like a list by default, but the styles we're about to add will break that functionality. This role will restore the "list" meaning to the `<ul>` element. If you want to learn more about why this is necessary, you can check out Scott O'Hara's article "Fixing Lists".
@@ -327,7 +328,7 @@ For example, if we add an `<img>` element to our `todos.svelte` component withou
 ```html
 <h1>Svelte To-Do list</h1>
 
-<img height="32" width="88" src="https://www.w3.org/WAI/wcag2A">
+<img height="32" width="88" src="https://www.w3.org/WAI/wcag2A" />
 ```
 
 The compiler will issue the following warning:
@@ -352,7 +353,7 @@ You can tell Svelte to ignore this warning for the next block of markup with a [
 
 ```html
 <!-- svelte-ignore a11y-missing-attribute -->
-<img height="32" width="88" src="https://www.w3.org/WAI/wcag2A">
+<img height="32" width="88" src="https://www.w3.org/WAI/wcag2A" />
 ```
 
 > **Note:** With VSCode you can automatically add this ignore comment by clicking on the _Quick fix…_ link or pressing <kbd>Ctrl</kbd> + <kbd>.</kbd>.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
@@ -92,12 +92,12 @@ The state of our component will be represented by these three top-level variable
    ```html
    <script>
      let todos = [
-       { id: 1, name: 'Create a Svelte starter app', completed: true },
-       { id: 2, name: 'Create your first component', completed: true },
-       { id: 3, name: 'Complete the rest of the tutorial', completed: false }
-     ]
-     let totalTodos = todos.length
-     let completedTodos = todos.filter((todo) => todo.completed).length
+       { id: 1, name: "Create a Svelte starter app", completed: true },
+       { id: 2, name: "Create your first component", completed: true },
+       { id: 3, name: "Complete the rest of the tutorial", completed: false }
+     ];
+     let totalTodos = todos.length;
+     let completedTodos = todos.filter((todo) => todo.completed).length;
    </script>
    ```
 
@@ -144,26 +144,27 @@ Let's give it a try.
    <!-- To-dos -->
    <ul role="list" class="todo-list stack-large" aria-labelledby="list-heading">
      {#each todos as todo (todo.id)}
-       <li class="todo">
-         <div class="stack-small">
-           <div class="c-cb">
-             <input type="checkbox" id="todo-{todo.id}" checked={todo.completed}/>
-             <label for="todo-{todo.id}" class="todo-label">
-               {todo.name}
-             </label>
-           </div>
-           <div class="btn-group">
-             <button type="button" class="btn">
-               Edit <span class="visually-hidden">{todo.name}</span>
-             </button>
-             <button type="button" class="btn btn__danger">
-               Delete <span class="visually-hidden">{todo.name}</span>
-             </button>
-           </div>
+     <li class="todo">
+       <div class="stack-small">
+         <div class="c-cb">
+           <input
+             type="checkbox"
+             id="todo-{todo.id}"
+             checked={todo.completed} />
+           <label for="todo-{todo.id}" class="todo-label"> {todo.name} </label>
          </div>
-       </li>
+         <div class="btn-group">
+           <button type="button" class="btn">
+             Edit <span class="visually-hidden">{todo.name}</span>
+           </button>
+           <button type="button" class="btn btn__danger">
+             Delete <span class="visually-hidden">{todo.name}</span>
+           </button>
+         </div>
+       </div>
+     </li>
      {:else}
-       <li>Nothing to do here!</li>
+     <li>Nothing to do here!</li>
      {/each}
    </ul>
    ```
@@ -193,13 +194,13 @@ With a hardcoded list of to-dos, our `Todos` component is not very useful. To tu
 
    ```html
    <script>
-     import Todos from './components/Todos.svelte'
+     import Todos from "./components/Todos.svelte";
 
      let todos = [
-       { id: 1, name: 'Create a Svelte starter app', completed: true },
-       { id: 2, name: 'Create your first component', completed: true },
-       { id: 3, name: 'Complete the rest of the tutorial', completed: false }
-     ]
+       { id: 1, name: "Create a Svelte starter app", completed: true },
+       { id: 2, name: "Create your first component", completed: true },
+       { id: 3, name: "Complete the rest of the tutorial", completed: false }
+     ];
    </script>
 
    <Todos todos={todos} />
@@ -307,7 +308,12 @@ Now on to the next major task for this article — let's add some functionality 
    So, let's implement this. Update the `todo-0` input like so:
 
    ```html
-   <input bind:value={newTodoName} type="text" id="todo-0" autocomplete="off" class="input input__lg" />
+   <input
+     bind:value={newTodoName}
+     type="text"
+     id="todo-0"
+     autocomplete="off"
+     class="input input__lg" />
    ```
 
 3. An easy way to test that this works is to add a reactive statement to log the contents of `newTodoName`. Add this snippet at the end of the `<script>` section:

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_conditional_rendering/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_conditional_rendering/index.md
@@ -73,59 +73,59 @@ We can start by creating a separate component to handle the editing functionalit
   </form>
 </template>
 <script>
-export default {
-  props: {
-    label: {
-      type: String,
-      required: true
+  export default {
+    props: {
+      label: {
+        type: String,
+        required: true,
+      },
+      id: {
+        type: String,
+        required: true,
+      },
     },
-    id: {
-      type: String,
-      required: true
-    }
-  },
-  data() {
-    return {
-      newLabel: this.label
-    };
-  },
-  methods: {
-    onSubmit() {
-      if (this.newLabel && this.newLabel !== this.label) {
-        this.$emit("item-edited", this.newLabel);
-      }
+    data() {
+      return {
+        newLabel: this.label,
+      };
     },
-    onCancel() {
-      this.$emit("edit-cancelled");
-    }
-  }
-};
+    methods: {
+      onSubmit() {
+        if (this.newLabel && this.newLabel !== this.label) {
+          this.$emit("item-edited", this.newLabel);
+        }
+      },
+      onCancel() {
+        this.$emit("edit-cancelled");
+      },
+    },
+  };
 </script>
 <style scoped>
-.edit-label {
-  font-family: Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #0b0c0c;
-  display: block;
-  margin-bottom: 5px;
-}
-input {
-  display: inline-block;
-  margin-top: 0.4rem;
-  width: 100%;
-  min-height: 4.4rem;
-  padding: 0.4rem 0.8rem;
-  border: 2px solid #565656;
-}
-form {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-form > * {
-  flex: 0 0 100%;
-}
+  .edit-label {
+    font-family: Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color: #0b0c0c;
+    display: block;
+    margin-bottom: 5px;
+  }
+  input {
+    display: inline-block;
+    margin-top: 0.4rem;
+    width: 100%;
+    min-height: 4.4rem;
+    padding: 0.4rem 0.8rem;
+    border: 2px solid #565656;
+  }
+  form {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  form > * {
+    flex: 0 0 100%;
+  }
 </style>
 ```
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
@@ -242,7 +242,7 @@ If you navigate to the "local" address in a new browser tab (this should be some
 Let's make our first change to the app — we'll delete the Vue logo. Open the `App.vue` file, and delete the [`<img>`](/en-US/docs/Web/HTML/Element/img) element from the template section:
 
 ```html
-<img alt="Vue logo" src="./assets/logo.png">
+<img alt="Vue logo" src="./assets/logo.png" />
 ```
 
 If your server is still running, you should see the logo removed from the rendered site almost instantly. Let's also remove the `HelloWorld` component from our template.
@@ -250,7 +250,7 @@ If your server is still running, you should see the logo removed from the render
 First of all delete this line:
 
 ```html
-<HelloWorld msg="Welcome to Your Vue.js App"/>
+<HelloWorld msg="Welcome to Your Vue.js App" />
 ```
 
 If you save your `App.vue` file now, the rendered app will throw an error because we've registered the component but are not using it. We also need to remove the lines from inside the `<script>` element that import and register the component:

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.md
@@ -73,18 +73,13 @@ We now have an app that displays a list of to-do items. However, we can't update
    ```html
    <template>
      <form>
-       <label for="new-todo-input">
-         What needs to be done?
-       </label>
+       <label for="new-todo-input"> What needs to be done? </label>
        <input
          type="text"
          id="new-todo-input"
          name="new-todo"
-         autocomplete="off"
-       />
-       <button type="submit">
-         Add
-       </button>
+         autocomplete="off" />
+       <button type="submit">Add</button>
      </form>
    </template>
    ```
@@ -115,7 +110,10 @@ We now have an app that displays a list of to-do items. However, we can't update
        <to-do-form></to-do-form>
        <ul>
          <li v-for="item in ToDoItems" :key="item.id">
-           <to-do-item :label="item.label" :done="item.done" :id="item.id"></to-do-item>
+           <to-do-item
+             :label="item.label"
+             :done="item.done"
+             :id="item.id"></to-do-item>
          </li>
        </ul>
      </div>
@@ -151,7 +149,7 @@ To make a method available to the `ToDoForm` component, we need to add it to the
    We'll use the shorthand syntax here for consistency. Add the `submit` handler to your `<form>` element like so:
 
    ```html
-   <form @submit="onSubmit">
+   <form @submit="onSubmit">…</form>
    ```
 
 3. When you run this, the app still posts the data to the server, causing a refresh. Since we're doing all of our processing on the client, there's no server to handle the postback. We also lose all local state on page refresh. To prevent the browser from posting to the server, we need to stop the event's default action while bubbling up through the page ([`Event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault), in vanilla JavaScript). Vue has a special syntax called **event modifiers** that can handle this for us right in our template.
@@ -172,7 +170,7 @@ To make a method available to the `ToDoForm` component, we need to add it to the
    In this case, we need to use the `.prevent` modifier to stop the browser's default submit action. Add `.prevent` to the `@submit` handler in your template like so:
 
    ```html
-   <form @submit.prevent="onSubmit">
+   <form @submit.prevent="onSubmit">…</form>
    ```
 
 If you try submitting the form now, you'll notice that the page doesn't reload. If you open the console, you can see the results of the [`console.log()`](/en-US/docs/Web/API/console/log) we added inside our `onSubmit()` method.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_refs_focus_management/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_refs_focus_management/index.md
@@ -92,7 +92,11 @@ To use a ref in a component, you add a `ref` attribute to the element that you w
 So, let's attach a ref to our "Edit" button in `ToDoItem.vue`. Update it like this:
 
 ```html
-<button type="button" class="btn" ref="editButton" @click="toggleToItemEditForm">
+<button
+  type="button"
+  class="btn"
+  ref="editButton"
+  @click="toggleToItemEditForm">
   Edit
   <span class="visually-hidden">\{{label}}</span>
 </button>
@@ -183,7 +187,12 @@ Now that we've gone over the lifecycle methods, let's use one to trigger focus w
 In `ToDoItemEditForm.vue`, attach `ref="labelInput"` to the `<input>` element, like so:
 
 ```html
-<input :id="id" ref="labelInput" type="text" autocomplete="off" v-model.lazy.trim="newName" />
+<input
+  :id="id"
+  ref="labelInput"
+  type="text"
+  autocomplete="off"
+  v-model.lazy.trim="newName" />
 ```
 
 Next, add a `mounted()` property just inside your component object — **note that this should not be put inside the `methods` property, but rather at the same hierarchy level as `props`, `data()`, and `methods`.** Lifecycle methods are special methods that sit on their own, not alongside the user-defined methods. This should take no inputs. Note that you cannot use an arrow function here since we need access to `this` to access our `labelInput` ref.
@@ -218,7 +227,7 @@ First, we need to add a ref to our list heading. We also need to add a `tabindex
 Inside `App.vue`, update your `<h2>` as follows:
 
 ```html
- <h2 id="list-summary" ref="listSummary" tabindex="-1">\{{listSummary}}</h2>
+<h2 id="list-summary" ref="listSummary" tabindex="-1">\{{listSummary}}</h2>
 ```
 
 > **Note:** [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) is a really powerful tool for handling certain accessibility problems. However, it should be used with caution. Over-using `tabindex="-1"` can cause problems for all sorts of users, so only use it exactly where you need to. You should also almost never use `tabindex` > = `0`, as it can cause problems for users since it can make the DOM flow and the tab-order mismatch, and/or add non-interactive elements to the tab order. This can be confusing to users, especially those using screen readers and other assistive technology.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_rendering_lists/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_rendering_lists/index.md
@@ -138,7 +138,7 @@ To make sure that Vue can accurately compare the `key` attributes, they need to 
    ```html
    <ul>
      <li v-for="item in ToDoItems" :key="item.id">
-        <to-do-item :label="item.label" :done="item.done"></to-do-item>
+       <to-do-item :label="item.label" :done="item.done"></to-do-item>
      </li>
    </ul>
    ```
@@ -181,7 +181,10 @@ Now, over in your `App.vue` component, pass `item.id` as a prop to the `ToDoItem
     <h1>My To-Do List</h1>
     <ul>
       <li v-for="item in ToDoItems" :key="item.id">
-        <to-do-item :label="item.label" :done="item.done" :id="item.id"></to-do-item>
+        <to-do-item
+          :label="item.label"
+          :done="item.done"
+          :id="item.id"></to-do-item>
       </li>
     </ul>
   </div>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
@@ -316,11 +316,8 @@ Update your `ToDoForm` template so that it looks like this:
       name="new-todo"
       autocomplete="off"
       v-model.lazy.trim="label"
-      class="input__lg"
-    />
-    <button type="submit" class="btn btn__primary btn__lg">
-      Add
-    </button>
+      class="input__lg" />
+    <button type="submit" class="btn btn__primary btn__lg">Add</button>
   </form>
 </template>
 ```
@@ -330,7 +327,7 @@ Let's also add the `stack-large` class to the `<ul>` tag in our `App.vue` file. 
 Update it as follows:
 
 ```html
-<ul aria-labelledby="list-summary" class="stack-large">
+<ul aria-labelledby="list-summary" class="stack-large">…</ul>
 ```
 
 ## Adding scoped styles
@@ -340,8 +337,7 @@ The last component we want to style is our `ToDoItem` component. To keep the sty
 To use the `scoped` modifier, create a `<style>` element inside `ToDoItem.vue`, at the bottom of the file, and give it a `scoped` attribute:
 
 ```html
-<style scoped>
-</style>
+<style scoped>/* … */</style>
 ```
 
 Next, copy the following CSS into the newly created `<style>` element:

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
@@ -81,19 +81,20 @@ Semantic HTML (where the elements are used for their correct purpose) is accessi
 The most important quick win in semantic HTML is to use a structure of headings and paragraphs for your content; this is because screen reader users tend to use the headings of a document as signposts to find the content they need more quickly. If your content has no headings, all they will get is a huge wall of text with no signposts to find anything. Examples of bad and good HTML:
 
 ```html example-bad
-<font size="7">My heading</font>
-<br><br>
+<font size="7">My heading</font> <br /><br />
 This is the first section of my document.
-<br><br>
+<br /><br />
 I'll add another paragraph here too.
-<br><br>
+<br /><br />
 <font size="5">My subheading</font>
-<br><br>
-This is the first subsection of my document. I'd love people to be able to find this content!
-<br><br>
+<br /><br />
+This is the first subsection of my document. I'd love people to be able to find
+this content!
+<br /><br />
 <font size="5">My 2nd subheading</font>
-<br><br>
-This is the second subsection of my content. I think it is more interesting than the last one.
+<br /><br />
+This is the second subsection of my content. I think it is more interesting than
+the last one.
 ```
 
 ```html example-good
@@ -105,11 +106,17 @@ This is the second subsection of my content. I think it is more interesting than
 
 <h2>My subheading</h2>
 
-<p>This is the first subsection of my document. I'd love people to be able to find this content!</p>
+<p>
+  This is the first subsection of my document. I'd love people to be able to
+  find this content!
+</p>
 
 <h2>My 2nd subheading</h2>
 
-<p>This is the second subsection of my content. I think it is more interesting than the last one.</p>
+<p>
+  This is the second subsection of my content. I think it is more interesting
+  than the last one.
+</p>
 ```
 
 In addition, your content should make logical sense in its source order — you can always place it where you want using CSS later on, but you should get the source order right to start with.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
@@ -269,7 +269,7 @@ Let's have a look at how Modernizr works in terms of selectively applying CSS.
 2. Update your {{htmlelement("link")}} element in your HTML so it points to the correct CSS file (you should also update your {{htmlelement("title")}} element to something more suitable!):
 
    ```html
-   <link href="modernizr-css.css" rel="stylesheet">
+   <link href="modernizr-css.css" rel="stylesheet" />
    ```
 
 3. Above this `<link>` element, add a {{htmlelement("script")}} element to apply the Modernizr library to the page, as shown below. This needs to be applied to the page before any CSS (or JavaScript) that might make use of it.
@@ -281,14 +281,15 @@ Let's have a look at how Modernizr works in terms of selectively applying CSS.
 4. Now edit your opening `<html>` tag, so that it looks like this:
 
    ```html
-   <html class="no-js">
+   <html class="no-js">…</html>
    ```
 
 At this point, try loading your page, and you'll get an idea of how Modernizr works for CSS features. If you look at the DOM inspector of your browser's developer tools, you'll see that Modernizr has updated your `<html>` `class` value like so:
 
 ```html
-<html class="js no-htmlimports sizes flash transferables applicationcache blobconstructor
-blob-constructor cookies cors (and loads of more values)">
+<html
+  class="js no-htmlimports sizes flash transferables applicationcache blobconstructor
+blob-constructor cookies cors (and loads of more values)">…</html>
 ```
 
 It now contains a large number of classes that indicate the support status of different technology features. As an example, if the browser didn't support flexbox at all, `<html>` would be given a class name of `no-flexbox`. If it did support modern flexbox, it would get a class name of `flexbox`. If you search through the class list, you'll also see others relating to flexbox, like:

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -164,9 +164,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -175,10 +177,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -155,9 +155,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -166,10 +168,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -151,9 +151,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -162,10 +164,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -115,9 +115,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -126,10 +128,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -119,9 +119,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -130,10 +132,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
@@ -88,9 +88,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -99,10 +101,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Accessibility concerns

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -130,9 +130,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -141,10 +143,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Accessibility concerns

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -113,9 +113,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -124,10 +126,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Accessibility concerns

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -127,9 +127,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -138,10 +140,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Accessibility concerns

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -145,9 +145,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -156,10 +158,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -131,9 +131,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > ## Examples
 >
 > ### Using the fetch API
+>
 > Example of Fetch
 >
 > ### More examples
+>
 > Links to more examples on other pages
 > ```
 >
@@ -142,10 +144,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 > Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 > ```md
->  ## Examples
+> ## Examples
 >
->  For examples of this API, see [the page on fetch()](https://example.org).
->
+> For examples of this API, see [the page on fetch()](https://example.org).
 > ```
 
 ## Specifications

--- a/files/en-us/web/svg/element/metadata/index.md
+++ b/files/en-us/web/svg/element/metadata/index.md
@@ -34,29 +34,33 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
 ## Example
 
 ```html
-<svg width="400" viewBox="0 0 400 300"
-  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg
+  width="400"
+  viewBox="0 0 400 300"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
   <metadata>
-    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-             xmlns:connect="http://www.w3.org/1999/08/29-svg-connections-in-RDF#">
+    <rdf:RDF
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      xmlns:connect="http://www.w3.org/1999/08/29-svg-connections-in-RDF#">
       <rdf:Description about="#CableA">
-        <connect:ends rdf:resource="#socket1"/>
-        <connect:ends rdf:resource="#ComputerA"/>
+        <connect:ends rdf:resource="#socket1" />
+        <connect:ends rdf:resource="#ComputerA" />
       </rdf:Description>
       <rdf:Description about="#CableB">
-        <connect:ends rdf:resource="#socket2"/>
-        <connect:ends rdf:resource="#ComputerB"/>
+        <connect:ends rdf:resource="#socket2" />
+        <connect:ends rdf:resource="#ComputerB" />
       </rdf:Description>
       <rdf:Description about="#CableN">
-        <connect:ends rdf:resource="#socket5"/>
+        <connect:ends rdf:resource="#socket5" />
         <connect:ends>Everything</connect:ends>
       </rdf:Description>
       <rdf:Description about="#Hub">
-        <connect:ends rdf:resource="#socket1"/>
-        <connect:ends rdf:resource="#socket2"/>
-        <connect:ends rdf:resource="#socket3"/>
-        <connect:ends rdf:resource="#socket4"/>
-        <connect:ends rdf:resource="#socket5"/>
+        <connect:ends rdf:resource="#socket1" />
+        <connect:ends rdf:resource="#socket2" />
+        <connect:ends rdf:resource="#socket3" />
+        <connect:ends rdf:resource="#socket4" />
+        <connect:ends rdf:resource="#socket5" />
       </rdf:Description>
     </rdf:RDF>
   </metadata>
@@ -69,17 +73,21 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
       fill: white;
       stroke: black;
     }
-    text { fill: black; stroke: none; }
-    path { fill: none; }
+    text {
+      fill: black;
+      stroke: none;
+    }
+    path {
+      fill: none;
+    }
   </style>
 
   <!-- Define symbols used in the SVG -->
   <defs>
-
     <!-- hubPlug symbol. Used by hub symbol -->
     <symbol id="hubPlug">
       <desc>A 10BaseT/100baseTX socket</desc>
-      <path d="M0,10 h5 v-9 h12 v9 h5 v16 h-22 z"/>
+      <path d="M0,10 h5 v-9 h12 v9 h5 v16 h-22 z" />
     </symbol>
 
     <!-- hub symbol -->
@@ -87,29 +95,29 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
       <desc>A typical 10BaseT/100BaseTX network hub</desc>
       <text x="0" y="15">Hub</text>
       <g transform="translate(0 20)">
-        <rect width="253" height="84"/>
-        <rect width="229" height="44" x="12" y="10"/>
+        <rect width="253" height="84" />
+        <rect width="229" height="44" x="12" y="10" />
         <circle fill="red" cx="227" cy="71" r="7" />
         <!-- five groups each using the defined socket -->
         <g id="sock1et" transform="translate(25 20)">
           <title>Socket 1</title>
-          <use xlink:href="#hubPlug"/>
+          <use xlink:href="#hubPlug" />
         </g>
         <g id="socket2" transform="translate(70 20)">
           <title>Socket 2</title>
-          <use xlink:href="#hubPlug"/>
+          <use xlink:href="#hubPlug" />
         </g>
         <g id="socket3" transform="translate(115 20)">
           <title>Socket 3</title>
-          <use xlink:href="#hubPlug"/>
+          <use xlink:href="#hubPlug" />
         </g>
         <g id="socket4" transform="translate(160 20)">
           <title>Socket 4</title>
-          <use xlink:href="#hubPlug"/>
+          <use xlink:href="#hubPlug" />
         </g>
         <g id="socket5" transform="translate(205 20)">
           <title>Socket 5</title>
-          <use xlink:href="#hubPlug"/>
+          <use xlink:href="#hubPlug" />
         </g>
       </g>
     </symbol>
@@ -119,30 +127,32 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
       <desc>A common desktop PC</desc>
       <g id="monitorStand" transform="translate(40 121)">
         <title>Monitor stand</title>
-        <desc>One of those cool swivelling monitor stands that sit under the monitor</desc>
-        <path d="m0,0 S 10 10 40 12"/>
-        <path d="m80,0 S 70 10 40 12"/>
-        <path d="m0,20 L 10 10 S 40 12 70 10 L 80 20z"/>
+        <desc>
+          One of those cool swivelling monitor stands that sit under the monitor
+        </desc>
+        <path d="m0,0 S 10 10 40 12" />
+        <path d="m80,0 S 70 10 40 12" />
+        <path d="m0,20 L 10 10 S 40 12 70 10 L 80 20z" />
       </g>
       <g id="monitor">
         <title>Monitor</title>
         <desc>A very fancy monitor</desc>
-        <rect width="160" height="120"/>
-        <rect fill="lightgrey" width="138" height="95" x="11" y="12"/>
+        <rect width="160" height="120" />
+        <rect fill="lightgrey" width="138" height="95" x="11" y="12" />
       </g>
       <g id="processor" transform="translate(0 142)">
         <title>The computer</title>
         <desc>A desktop computer - broad flat box style</desc>
-        <rect width="160" height="60"/>
+        <rect width="160" height="60" />
         <g id="discDrive" transform="translate(70 8)">
           <title>disc drive</title>
           <desc>A built-in disc drive</desc>
-          <rect width="58" height="3" x="12" y="8"/>
-          <rect width="8" height="2" x="12" y="15"/>
+          <rect width="58" height="3" x="12" y="8" />
+          <rect width="8" height="2" x="12" y="15" />
         </g>
-        <circle cx="135" cy="40" r="5"/>
+        <circle cx="135" cy="40" r="5" />
       </g>
-     </symbol>
+    </symbol>
   </defs>
 
   <text x="0" y="15">Network</text>
@@ -150,40 +160,40 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
   <!-- Use the hub symbol. -->
   <g id="Hub" transform="translate(80 45)">
     <title>Hub</title>
-    <use xlink:href="#hub" transform="scale(0.75)"/>
+    <use xlink:href="#hub" transform="scale(0.75)" />
   </g>
 
   <!-- Use the computer symbol. -->
   <g id="ComputerA" transform="translate(20 170)">
     <title>Computer A</title>
-    <use xlink:href="#computer" transform="scale(0.5)"/>
+    <use xlink:href="#computer" transform="scale(0.5)" />
   </g>
 
   <!-- Use the same computer symbol. -->
   <g id="ComputerB" transform="translate(300 170)">
     <title>Computer B</title>
-    <use xlink:href="#computer" transform="scale(0.5)"/>
+    <use xlink:href="#computer" transform="scale(0.5)" />
   </g>
 
   <!-- Draw Cable A. -->
   <g id="CableA" transform="translate(107 88)">
     <title>Cable A</title>
     <desc>10BaseT twisted pair cable</desc>
-    <path d="M0,0c100,140 50,140 -8,160"/>
+    <path d="M0,0c100,140 50,140 -8,160" />
   </g>
 
   <!-- Draw Cable B. -->
   <g id="CableB" transform="translate(142 88)">
     <title>Cable B</title>
     <desc>10BaseT twisted pair cable</desc>
-    <path d="M0,0c100,180 110,160 159,160"/>
+    <path d="M0,0c100,180 110,160 159,160" />
   </g>
 
   <!-- Draw Cable N. -->
   <g id="CableN" transform="translate(242 88)">
-     <title>Cable N</title>
-     <desc>10BaseT twisted pair cable</desc>
-     <path d="M0,0c0,-70 20,-50 60,-50"/>
+    <title>Cable N</title>
+    <desc>10BaseT twisted pair cable</desc>
+    <path d="M0,0c0,-70 20,-50 60,-50" />
   </g>
 </svg>
 ```

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -22,27 +22,35 @@ Linear gradients change along a straight line. To insert one, you create a {{SVG
 ```html
 <svg width="120" height="240" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
-      <linearGradient id="Gradient1">
-        <stop class="stop1" offset="0%"/>
-        <stop class="stop2" offset="50%"/>
-        <stop class="stop3" offset="100%"/>
-      </linearGradient>
-      <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="50%" stop-color="black" stop-opacity="0"/>
-        <stop offset="100%" stop-color="blue"/>
-      </linearGradient>
-      <style><![CDATA[
-        #rect1 { fill: url(#Gradient1); }
-        .stop1 { stop-color: red; }
-        .stop2 { stop-color: black; stop-opacity: 0; }
-        .stop3 { stop-color: blue; }
-      ]]></style>
+    <linearGradient id="Gradient1">
+      <stop class="stop1" offset="0%" />
+      <stop class="stop2" offset="50%" />
+      <stop class="stop3" offset="100%" />
+    </linearGradient>
+    <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="50%" stop-color="black" stop-opacity="0" />
+      <stop offset="100%" stop-color="blue" />
+    </linearGradient>
+    <style>
+      <![CDATA[
+              #rect1 { fill: url(#Gradient1); }
+              .stop1 { stop-color: red; }
+              .stop2 { stop-color: black; stop-opacity: 0; }
+              .stop3 { stop-color: blue; }
+            ]]>
+    </style>
   </defs>
 
-  <rect id="rect1" x="10" y="10" rx="15" ry="15" width="100" height="100"/>
-  <rect x="10" y="120" rx="15" ry="15" width="100" height="100" fill="url(#Gradient2)"/>
-
+  <rect id="rect1" x="10" y="10" rx="15" ry="15" width="100" height="100" />
+  <rect
+    x="10"
+    y="120"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#Gradient2)" />
 </svg>
 ```
 
@@ -59,19 +67,25 @@ To use a gradient, we have to reference it from an object's `fill` or `stroke` a
 The `<linearGradient>` element also takes several other attributes, which specify the size and appearance of the gradient. The orientation of the gradient is controlled by two points, designated by the attributes `x1`, `x2`, `y1`, and `y2`. These attributes define a line along which the gradient travels. The gradient defaults to a horizontal orientation, but it can be rotated by changing these. Gradient2 in the above example is designed to create a vertical gradient.
 
 ```html
-<linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+<linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"></linearGradient>
 ```
 
 > **Note:** You can also use the `xlink:href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
 >
 > ```html
 > <linearGradient id="Gradient1">
->   <stop id="stop1" offset="0%"/>
->   <stop id="stop2" offset="50%"/>
->   <stop id="stop3" offset="100%"/>
+>   <stop id="stop1" offset="0%" />
+>   <stop id="stop2" offset="50%" />
+>   <stop id="stop3" offset="100%" />
 > </linearGradient>
-> <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"
->    xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Gradient1"/>
+> <linearGradient
+>   id="Gradient2"
+>   x1="0"
+>   x2="0"
+>   y1="0"
+>   y2="1"
+>   xmlns:xlink="http://www.w3.org/1999/xlink"
+>   xlink:href="#Gradient1" />
 > ```
 >
 > I've included the xlink namespace here directly on the node, although usually you would define it at the top of your document. More on that when we [talk about images](/en-US/docs/Web/SVG/Tutorial/Other_content_in_SVG).
@@ -86,19 +100,32 @@ Radial gradients are similar to linear ones but draw a gradient that radiates ou
 <?xml version="1.0" standalone="no"?>
 <svg width="120" height="240" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
-      <radialGradient id="RadialGradient1">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-      <radialGradient id="RadialGradient2" cx="0.25" cy="0.25" r="0.25">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
+    <radialGradient id="RadialGradient1">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
+    <radialGradient id="RadialGradient2" cx="0.25" cy="0.25" r="0.25">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
   </defs>
 
-  <rect x="10" y="10" rx="15" ry="15" width="100" height="100" fill="url(#RadialGradient1)"/>
-  <rect x="10" y="120" rx="15" ry="15" width="100" height="100" fill="url(#RadialGradient2)"/>
-
+  <rect
+    x="10"
+    y="10"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#RadialGradient1)" />
+  <rect
+    x="10"
+    y="120"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#RadialGradient2)" />
 </svg>
 ```
 
@@ -113,25 +140,40 @@ The second point is called the focal point and is defined by the `fx` and `fy` a
 ```html
 <?xml version="1.0" standalone="no"?>
 
-<svg width="120" height="120" version="1.1"
-  xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="120" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
-      <radialGradient id="Gradient"
-            cx="0.5" cy="0.5" r="0.5" fx="0.25" fy="0.25">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
+    <radialGradient id="Gradient" cx="0.5" cy="0.5" r="0.5" fx="0.25" fy="0.25">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
   </defs>
 
-  <rect x="10" y="10" rx="15" ry="15" width="100" height="100"
-        fill="url(#Gradient)" stroke="black" stroke-width="2"/>
+  <rect
+    x="10"
+    y="10"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#Gradient)"
+    stroke="black"
+    stroke-width="2" />
 
-  <circle cx="60" cy="60" r="50" fill="transparent" stroke="white" stroke-width="2"/>
-  <circle cx="35" cy="35" r="2" fill="white" stroke="white"/>
-  <circle cx="60" cy="60" r="2" fill="white" stroke="white"/>
-  <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">(fx,fy)</text>
-  <text x="63" y="63" fill="white" font-family="sans-serif" font-size="10pt">(cx,cy)</text>
-
+  <circle
+    cx="60"
+    cy="60"
+    r="50"
+    fill="transparent"
+    stroke="white"
+    stroke-width="2" />
+  <circle cx="35" cy="35" r="2" fill="white" stroke="white" />
+  <circle cx="60" cy="60" r="2" fill="white" stroke="white" />
+  <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">
+    (fx,fy)
+  </text>
+  <text x="63" y="63" fill="white" font-family="sans-serif" font-size="10pt">
+    (cx,cy)
+  </text>
 </svg>
 ```
 
@@ -148,34 +190,75 @@ Both linear and radial gradients also take a few other attributes to describe tr
 
 <svg width="220" height="220" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
-      <radialGradient id="GradientPad"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="pad">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-      <radialGradient id="GradientRepeat"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="repeat">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
-      <radialGradient id="GradientReflect"
-            cx="0.5" cy="0.5" r="0.4" fx="0.75" fy="0.75"
-            spreadMethod="reflect">
-        <stop offset="0%" stop-color="red"/>
-        <stop offset="100%" stop-color="blue"/>
-      </radialGradient>
+    <radialGradient
+      id="GradientPad"
+      cx="0.5"
+      cy="0.5"
+      r="0.4"
+      fx="0.75"
+      fy="0.75"
+      spreadMethod="pad">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
+    <radialGradient
+      id="GradientRepeat"
+      cx="0.5"
+      cy="0.5"
+      r="0.4"
+      fx="0.75"
+      fy="0.75"
+      spreadMethod="repeat">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
+    <radialGradient
+      id="GradientReflect"
+      cx="0.5"
+      cy="0.5"
+      r="0.4"
+      fx="0.75"
+      fy="0.75"
+      spreadMethod="reflect">
+      <stop offset="0%" stop-color="red" />
+      <stop offset="100%" stop-color="blue" />
+    </radialGradient>
   </defs>
 
-  <rect x="10" y="10" rx="15" ry="15" width="100" height="100" fill="url(#GradientPad)"/>
-  <rect x="10" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientRepeat)"/>
-  <rect x="120" y="120" rx="15" ry="15" width="100" height="100" fill="url(#GradientReflect)"/>
+  <rect
+    x="10"
+    y="10"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#GradientPad)" />
+  <rect
+    x="10"
+    y="120"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#GradientRepeat)" />
+  <rect
+    x="120"
+    y="120"
+    rx="15"
+    ry="15"
+    width="100"
+    height="100"
+    fill="url(#GradientReflect)" />
 
-  <text x="15" y="30" fill="white" font-family="sans-serif" font-size="12pt">Pad</text>
-  <text x="15" y="140" fill="white" font-family="sans-serif" font-size="12pt">Repeat</text>
-  <text x="125" y="140" fill="white" font-family="sans-serif" font-size="12pt">Reflect</text>
-
+  <text x="15" y="30" fill="white" font-family="sans-serif" font-size="12pt">
+    Pad
+  </text>
+  <text x="15" y="140" fill="white" font-family="sans-serif" font-size="12pt">
+    Repeat
+  </text>
+  <text x="125" y="140" fill="white" font-family="sans-serif" font-size="12pt">
+    Reflect
+  </text>
 </svg>
 ```
 
@@ -184,7 +267,14 @@ Both linear and radial gradients also take a few other attributes to describe tr
 Both gradients also have an attribute named `gradientUnits`, which describes the unit system you're going to use when you describe the size or orientation of the gradient. There are two possible values to use here: `userSpaceOnUse` or `objectBoundingBox`. `objectBoundingBox` is the default, so that's what has been shown so far. It essentially scales the gradient to the size of your object, so you only have to specify coordinates in values from zero to one, and they're scaled to the size of your object automatically for you. `userSpaceOnUse` essentially takes in absolute units. So you have to know where your object is, and place the gradient at the same place. The radialGradient above would be rewritten:
 
 ```html
-<radialGradient id="Gradient" cx="60" cy="60" r="50" fx="35" fy="35" gradientUnits="userSpaceOnUse">
+<radialGradient
+  id="Gradient"
+  cx="60"
+  cy="60"
+  r="50"
+  fx="35"
+  fy="35"
+  gradientUnits="userSpaceOnUse"></radialGradient>
 ```
 
 You can also then apply another transformation to the gradient by using the `gradientTransform` attribute, but since we haven't [introduced transforms](/en-US/docs/Web/SVG/Tutorial/Basic_Transformations) yet, I'll leave that for later.

--- a/files/en-us/web/svg/tutorial/positions/index.md
+++ b/files/en-us/web/svg/tutorial/positions/index.md
@@ -41,13 +41,13 @@ In the most basic case one pixel in an SVG document maps to one pixel on the out
 Without further specification, one user unit equals one screen unit. To explicitly change this behavior, there are several possibilities in SVG. We start with the `svg` root element:
 
 ```html
-<svg width="100" height="100">
+<svg width="100" height="100">…</svg>
 ```
 
 The above element defines a simple SVG canvas with 100x100px. One user unit equals one screen unit.
 
 ```html
-<svg width="200" height="200" viewBox="0 0 100 100">
+<svg width="200" height="200" viewBox="0 0 100 100">…</svg>
 ```
 
 The whole SVG canvas here is 200px by 200px in size. However, the `viewBox` attribute defines the portion of that canvas to display. These 200x200 pixels display an area that starts at user unit (0,0) and spans 100x100 user units to the right and to the bottom. This effectively zooms in on the 100x100 unit area and enlarges the image to double size.

--- a/files/en-us/web/svg/tutorial/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorial/svg_and_css/index.md
@@ -25,119 +25,133 @@ Below you'll create a simple demonstration that runs in your SVG-enabled browser
 Make a new SVG document as a plain text file, `doc8.svg`. Copy and paste the content from here, making sure that you scroll to get all of it:
 
 ```html
-<svg width="600px" height="600px" viewBox="-300 -300 600 600"
-    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-
-  <link rel="stylesheet"
-    href="style8.css" type="text/css"/>
+<svg
+  width="600px"
+  height="600px"
+  viewBox="-300 -300 600 600"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <link rel="stylesheet" href="style8.css" type="text/css" />
 
   <title>SVG demonstration</title>
   <desc>Mozilla CSS Getting Started - SVG demonstration</desc>
 
   <defs>
-    <radialGradient id="fade" cx="0" cy="0" r="200"
-        gradientUnits="userSpaceOnUse">
-      <stop id="fade-stop-1" offset="33%"/>
-      <stop id="fade-stop-2" offset="95%"/>
+    <radialGradient
+      id="fade"
+      cx="0"
+      cy="0"
+      r="200"
+      gradientUnits="userSpaceOnUse">
+      <stop id="fade-stop-1" offset="33%" />
+      <stop id="fade-stop-2" offset="95%" />
     </radialGradient>
   </defs>
 
   <text id="heading" x="-280" y="-270">SVG demonstration</text>
-  <text id="caption" x="-280" y="-250">Move your mouse pointer over the flower.</text>
+  <text id="caption" x="-280" y="-250">
+    Move your mouse pointer over the flower.
+  </text>
 
   <g id="flower">
-    <circle id="overlay" cx="0" cy="0" r="200" stroke="none" fill="url(#fade)"/>
+    <circle
+      id="overlay"
+      cx="0"
+      cy="0"
+      r="200"
+      stroke="none"
+      fill="url(#fade)" />
 
     <g id="outer-petals">
       <g class="quadrant">
         <g class="segment">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(18)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(36)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(54)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(72)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(90)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(108)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(126)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(144)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(162)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(180)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(198)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(216)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(234)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(252)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(270)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(288)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(306)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(324)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(342)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
     </g>
@@ -145,93 +159,93 @@ Make a new SVG document as a plain text file, `doc8.svg`. Copy and paste the con
     <g id="inner-petals" transform="rotate(9) scale(0.33)">
       <g class="quadrant">
         <g class="segment">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(18)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(36)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(54)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(72)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(90)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(108)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(126)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(144)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(162)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(180)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(198)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(216)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(234)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(252)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
 
       <g class="quadrant">
         <g class="segment" transform="rotate(270)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(288)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(306)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(324)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
         <g class="segment" transform="rotate(342)">
-          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+          <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+          <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
         </g>
       </g>
     </g>
@@ -383,8 +397,7 @@ Notes about this demonstration:
 - The SVG document links the stylesheet using the following HTML `<link>` tag:
 
   ```html
-  <link rel="stylesheet"
-    href="style8.css" type="text/css"/>
+  <link rel="stylesheet" href="style8.css" type="text/css" />
   ```
 
   It can also be linked with the `@import` rule inside a `<style>` tag:
@@ -410,47 +423,62 @@ The SVG structure shown above could be written much more concise by referencing 
 See below how the structure then looks like.
 
 ```html
-<svg width="600px" height="600px" viewBox="-300 -300 600 600"
-    xmlns="http://www.w3.org/2000/svg">
-
+<svg
+  width="600px"
+  height="600px"
+  viewBox="-300 -300 600 600"
+  xmlns="http://www.w3.org/2000/svg">
   <title>SVG demonstration</title>
   <desc>Mozilla CSS Getting Started - SVG demonstration</desc>
 
   <defs>
     <g id="segment" class="segment">
-      <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z"/>
-      <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10"/>
+      <path class="segment-fill" d="M0,0 v-200 a40,40 0 0,0 -62,10 z" />
+      <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
     </g>
     <g id="quadrant">
-      <use xlink:href="#segment"/>
-      <use xlink:href="#segment" transform="rotate(18)"/>
-      <use xlink:href="#segment" transform="rotate(36)"/>
-      <use xlink:href="#segment" transform="rotate(54)"/>
-      <use xlink:href="#segment" transform="rotate(72)"/>
+      <use xlink:href="#segment" />
+      <use xlink:href="#segment" transform="rotate(18)" />
+      <use xlink:href="#segment" transform="rotate(36)" />
+      <use xlink:href="#segment" transform="rotate(54)" />
+      <use xlink:href="#segment" transform="rotate(72)" />
     </g>
     <g id="petals">
-      <use xlink:href="#quadrant"/>
-      <use xlink:href="#quadrant" transform="rotate(90)"/>
-      <use xlink:href="#quadrant" transform="rotate(180)"/>
-      <use xlink:href="#quadrant" transform="rotate(270)"/>
+      <use xlink:href="#quadrant" />
+      <use xlink:href="#quadrant" transform="rotate(90)" />
+      <use xlink:href="#quadrant" transform="rotate(180)" />
+      <use xlink:href="#quadrant" transform="rotate(270)" />
     </g>
-    <radialGradient id="fade" cx="0" cy="0" r="200"
-        gradientUnits="userSpaceOnUse">
-      <stop id="fade-stop-1" offset="33%"/>
-      <stop id="fade-stop-2" offset="95%"/>
+    <radialGradient
+      id="fade"
+      cx="0"
+      cy="0"
+      r="200"
+      gradientUnits="userSpaceOnUse">
+      <stop id="fade-stop-1" offset="33%" />
+      <stop id="fade-stop-2" offset="95%" />
     </radialGradient>
   </defs>
 
   <text id="heading" x="-280" y="-270">SVG demonstration</text>
-  <text id="caption" x="-280" y="-250">Move your mouse pointer over the flower.</text>
+  <text id="caption" x="-280" y="-250">
+    Move your mouse pointer over the flower.
+  </text>
 
   <g id="flower">
-    <circle id="overlay" cx="0" cy="0" r="200" stroke="none" fill="url(#fade)"/>
-    <use id="outer-petals" xlink:href="#petals"/>
-    <use id="inner-petals" xlink:href="#petals"
-      transform="rotate(9) scale(0.33)"/>
+    <circle
+      id="overlay"
+      cx="0"
+      cy="0"
+      r="200"
+      stroke="none"
+      fill="url(#fade)" />
+    <use id="outer-petals" xlink:href="#petals" />
+    <use
+      id="inner-petals"
+      xlink:href="#petals"
+      transform="rotate(9) scale(0.33)" />
   </g>
-
 </svg>
 ```
 

--- a/files/en-us/web/svg/tutorial/svg_filters_tutorial/index.md
+++ b/files/en-us/web/svg/tutorial/svg_filters_tutorial/index.md
@@ -36,11 +36,11 @@ This above example will not produced the desired output. Instead we need to add 
 ```html
 <defs>
   <filter id="drop-shadow">
-    <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-    <feoffset in="blur" dx="4" dy="4" result="offsetBlur"/>
+    <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur" />
+    <feoffset in="blur" dx="4" dy="4" result="offsetBlur" />
     <feMerge>
-      <feMergeNode in="offsetBlur"/>
-      <feMergeNode in="SourceGraphic"/>
+      <feMergeNode in="offsetBlur" />
+      <feMergeNode in="SourceGraphic" />
     </feMerge>
   </filter>
 </defs>

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -42,9 +42,8 @@ There are some ingredients required for embedding a font in SVG. Let's show an e
     </font-face-src>
   </font-face>
   <missing-glyph><path d="M0,0h200v200h-200z" /></missing-glyph>
-  <glyph unicode="!" horiz-adv-x="300"
-    ><!-- Outline of exclamation point glyph --></glyph
-  >
+  <!-- Outline of exclamation point glyph -->
+  <glyph unicode="!" horiz-adv-x="300"></glyph>
   <glyph unicode="@"><!-- Outline of @ glyph --></glyph>
   <!-- more glyphs -->
 </font>

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -24,16 +24,27 @@ There are some ingredients required for embedding a font in SVG. Let's show an e
 
 ```html
 <font id="Font1" horiz-adv-x="1000">
-  <font-face font-family="Super Sans" font-weight="bold" font-style="normal"
-      units-per-em="1000" cap-height="600" x-height="400"
-      ascent="700" descent="300"
-      alphabetic="0" mathematical="350" ideographic="400" hanging="500">
+  <font-face
+    font-family="Super Sans"
+    font-weight="bold"
+    font-style="normal"
+    units-per-em="1000"
+    cap-height="600"
+    x-height="400"
+    ascent="700"
+    descent="300"
+    alphabetic="0"
+    mathematical="350"
+    ideographic="400"
+    hanging="500">
     <font-face-src>
-      <font-face-name name="Super Sans Bold"/>
+      <font-face-name name="Super Sans Bold" />
     </font-face-src>
   </font-face>
-  <missing-glyph><path d="M0,0h200v200h-200z"/></missing-glyph>
-  <glyph unicode="!" horiz-adv-x="300"><!-- Outline of exclamation point glyph --></glyph>
+  <missing-glyph><path d="M0,0h200v200h-200z" /></missing-glyph>
+  <glyph unicode="!" horiz-adv-x="300"
+    ><!-- Outline of exclamation point glyph --></glyph
+  >
   <glyph unicode="@"><!-- Outline of @ glyph --></glyph>
   <!-- more glyphs -->
 </font>
@@ -80,10 +91,10 @@ You can use `@font-face` to reference remote (and not so remote) fonts:
 </font>
 
 <style>
-@font-face {
-  font-family: "Super Sans";
-  src: url(#Super_Sans);
-}
+  @font-face {
+    font-family: "Super Sans";
+    src: url(#Super_Sans);
+  }
 </style>
 
 <text font-family="Super Sans">My text uses Super Sans</text>

--- a/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
+++ b/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
@@ -17,23 +17,22 @@ To include an inline SVG in an HTML file, paste the entire SVG file into the HTM
 ```html
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <title>SVG Demo</title>
-  <meta name="viewport" content="width=device-width">
-</head>
-<body>
-  <svg
-    viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" role="img">
-    <title>A gradient</title>
-    <linearGradient id="gradient">
-      <stop class="begin" offset="0%"/>
-      <stop class="end" offset="100%"/>
-    </linearGradient>
-    <rect x="0" y="0" width="100" height="100" style="fill:url(#gradient)" />
-    <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
-  </svg>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>SVG Demo</title>
+    <meta name="viewport" content="width=device-width" />
+  </head>
+  <body>
+    <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" role="img">
+      <title>A gradient</title>
+      <linearGradient id="gradient">
+        <stop class="begin" offset="0%" />
+        <stop class="end" offset="100%" />
+      </linearGradient>
+      <rect x="0" y="0" width="100" height="100" style="fill:url(#gradient)" />
+      <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
+    </svg>
+  </body>
 </html>
 ```
 
@@ -61,24 +60,62 @@ If the SVG can be labeled by visible text, reference that text with an [`aria-la
 
 ```html
 <svg viewBox="0 0 100 125" role="img" aria-labelledby="svgTitle svgDescription">
-   <title id="svgTitle">Manual</title>
-   <desc id="svgDescription">A non-descript twelve page booklet opened to the middle page</desc>
-   <defs>
-     <style>
-     rect {
-       fill:#cccccc;
-       stroke: #666;
-       transform-origin: top;
-     }
-     </style>
-   </defs>
+  <title id="svgTitle">Manual</title>
+  <desc id="svgDescription">
+    A non-descript twelve page booklet opened to the middle page
+  </desc>
+  <defs>
+    <style>
+      rect {
+        fill: #cccccc;
+        stroke: #666;
+        transform-origin: top;
+      }
+    </style>
+  </defs>
 
-   <rect width="36" height="60" x="13" y="18" ry="2" style="transform: skewy(24deg)"/>
-   <rect width="39" height="60" x="11" y="20" ry="2" style="transform: skewy(18deg)"/>
-   <rect width="42" height="90" x="8"  y="22" ry="2" style="transform: skewy(12deg)"/>
-   <rect width="36" height="60" x="50" y="18" ry="2" style="transform: skewy(-24deg)"/>
-   <rect width="39" height="60" x="50" y="20" ry="2"  style="transform: skewy(-18deg)" />
-   <rect width="42" height="90" x="50" y="22" ry="2" style="transform: skewy(-12deg)" />
+  <rect
+    width="36"
+    height="60"
+    x="13"
+    y="18"
+    ry="2"
+    style="transform: skewy(24deg)" />
+  <rect
+    width="39"
+    height="60"
+    x="11"
+    y="20"
+    ry="2"
+    style="transform: skewy(18deg)" />
+  <rect
+    width="42"
+    height="90"
+    x="8"
+    y="22"
+    ry="2"
+    style="transform: skewy(12deg)" />
+  <rect
+    width="36"
+    height="60"
+    x="50"
+    y="18"
+    ry="2"
+    style="transform: skewy(-24deg)" />
+  <rect
+    width="39"
+    height="60"
+    x="50"
+    y="20"
+    ry="2"
+    style="transform: skewy(-18deg)" />
+  <rect
+    width="42"
+    height="90"
+    x="50"
+    y="22"
+    ry="2"
+    style="transform: skewy(-12deg)" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/tutorial/texts/index.md
+++ b/files/en-us/web/svg/tutorial/texts/index.md
@@ -35,16 +35,19 @@ This element is used to mark up sub-portions of a larger text. It must be a chil
 
 ```html
 <svg width="350" height="60" xmlns="http://www.w3.org/2000/svg">
-<text>
-  This is <tspan font-weight="bold" fill="red">bold and red</tspan>
-</text>
+  <text>
+    This is
+    <tspan font-weight="bold" fill="red">bold and red</tspan>
+  </text>
 
-<style><![CDATA[
-  text{
-    dominant-baseline: hanging;
-    font: 28px Verdana, Helvetica, Arial, sans-serif;
-  }
-]]></style>
+  <style>
+    <![CDATA[
+      text{
+        dominant-baseline: hanging;
+        font: 28px Verdana, Helvetica, Arial, sans-serif;
+      }
+    ]]>
+  </style>
 </svg>
 ```
 
@@ -55,9 +58,11 @@ The `tspan` element has the following custom attributes:
 - `x`
   - : Set a new absolute `x` coordinate for the containing text. This overwrites the default current text position. The attribute may also contain a list of numbers, that are one by one applied to the single characters of the `tspan` element.
 - `dx`
+
   - : Start drawing the text with a horizontal offset `dx` from the default current position. Here, too, you may provide a list of values that are applied to consecutive characters, hence piling up the offset over time.
 
     Likewise, there are **`y`** and **`dy`** for vertical displacement.
+
 - `rotate`
   - : Rotate all characters by this degree. A list of numbers makes each character rotate to its respective value, with remaining characters rotating according to the last value.
 - `textLength`
@@ -69,19 +74,21 @@ This element fetches via its `xlink:href` attribute an arbitrary path and aligns
 
 ```html
 <svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
-<path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" />
-<text>
-  <textPath xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#my_path">
-    A curve.
-  </textPath>
-</text>
+  <path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" />
+  <text>
+    <textPath xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#my_path">
+      A curve.
+    </textPath>
+  </text>
 
-<style><![CDATA[
-  text{
-    dominant-baseline: hanging;
-    font: 28px Verdana, Helvetica, Arial, sans-serif;
-  }
-]]></style>
+  <style>
+    <![CDATA[
+      text{
+        dominant-baseline: hanging;
+        font: 28px Verdana, Helvetica, Arial, sans-serif;
+      }
+    ]]>
+  </style>
 </svg>
 ```
 

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -117,7 +117,9 @@ customElements.define('popup-info', PopUpInfo);
 It is now available to use on our page. Over in our HTML, we use it like so:
 
 ```html
-<popup-info img="img/alt.png" data-text="Your card validation code (CVC)
+<popup-info
+  img="img/alt.png"
+  data-text="Your card validation code (CVC)
   is an extra security feature — it is the last 3 or 4 numbers on the
   back of your card."></popup-info>
 ```
@@ -173,9 +175,7 @@ Using the built-in element in a web document also looks somewhat different:
 
 ```html
 <ul is="expanding-list">
-
-  ...
-
+  …
 </ul>
 ```
 

--- a/files/en-us/web/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/web_components/using_shadow_dom/index.md
@@ -21,14 +21,19 @@ This article assumes you are already familiar with the concept of the [DOM (Docu
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Simple DOM example</title>
   </head>
   <body>
-      <section>
-        <img src="dinosaur.png" alt="A red Tyrannosaurus Rex: A two legged dinosaur standing upright like a human, with small arms, and a large head with lots of sharp teeth.">
-        <p>Here we will add a link to the <a href="https://www.mozilla.org/">Mozilla homepage</a></p>
-      </section>
+    <section>
+      <img
+        src="dinosaur.png"
+        alt="A red Tyrannosaurus Rex: A two legged dinosaur standing upright like a human, with small arms, and a large head with lots of sharp teeth." />
+      <p>
+        Here we will add a link to the
+        <a href="https://www.mozilla.org/">Mozilla homepage</a>
+      </p>
+    </section>
   </body>
 </html>
 ```
@@ -195,9 +200,11 @@ customElements.define('popup-info', PopUpInfo);
 ```
 
 ```html
-<popup-info img="img/alt.png" data-text="Your card validation code (CVC) is an extra
+<popup-info
+  img="img/alt.png"
+  data-text="Your card validation code (CVC) is an extra
                                     security feature — it is the last 3 or 4
-                                    numbers on the back of your card.">
+                                    numbers on the back of your card."></popup-info>
 ```
 
 ### Internal versus external styles

--- a/files/en-us/web/web_components/using_templates_and_slots/index.md
+++ b/files/en-us/web/web_components/using_templates_and_slots/index.md
@@ -151,14 +151,36 @@ First of all, we use the {{HTMLElement("slot")}} element within a {{HTMLElement(
 ```html
 <template id="element-details-template">
   <style>
-  details {font-family: "Open Sans Light",Helvetica,Arial}
-  .name {font-weight: bold; color: #217ac0; font-size: 120%}
-  h4 { margin: 10px 0 -8px 0; }
-  h4 span { background: #217ac0; padding: 2px 6px 2px 6px }
-  h4 span { border: 1px solid #cee9f9; border-radius: 4px }
-  h4 span { color: white }
-  .attributes { margin-left: 22px; font-size: 90% }
-  .attributes p { margin-left: 16px; font-style: italic }
+    details {
+      font-family: "Open Sans Light", Helvetica, Arial;
+    }
+    .name {
+      font-weight: bold;
+      color: #217ac0;
+      font-size: 120%;
+    }
+    h4 {
+      margin: 10px 0 -8px 0;
+    }
+    h4 span {
+      background: #217ac0;
+      padding: 2px 6px 2px 6px;
+    }
+    h4 span {
+      border: 1px solid #cee9f9;
+      border-radius: 4px;
+    }
+    h4 span {
+      color: white;
+    }
+    .attributes {
+      margin-left: 22px;
+      font-size: 90%;
+    }
+    .attributes p {
+      margin-left: 16px;
+      font-style: italic;
+    }
   </style>
   <details>
     <summary>
@@ -172,7 +194,7 @@ First of all, we use the {{HTMLElement("slot")}} element within a {{HTMLElement(
       <slot name="attributes"><p>None</p></slot>
     </div>
   </details>
-  <hr>
+  <hr />
 </template>
 ```
 

--- a/files/en-us/web/xpath/functions/current/index.md
+++ b/files/en-us/web/xpath/functions/current/index.md
@@ -38,7 +38,7 @@ In an inner expression (e.g. in square brackets), the current node is still the 
 
 ```xml
 <xsl:value-of select="current()"/>
-  ```
+```
 
 ```xml
 <xsl:value-of select="foo/bar[current() = X]"/>


### PR DESCRIPTION
Adding to #20638

The PR focuses only on HTML code fences.

**Note:** This is the last one for HTML :partying_face: 
Following cases have not been touched:
- frameworks related HTML template code
- code where manual formatting is better
- where `<span` or `<code` tags gets split over multiple lines
