### PR TITLE
Add warning similar to textContent's warning

### DIFF
--- a/files/en-us/web/api/htmlelement/innertext/index.md
+++ b/files/en-us/web/api/htmlelement/innertext/index.md
@@ -27,6 +27,9 @@ A string representing the rendered text content of an element.
 
 If the element itself is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("Node.textContent")}} property.
 
+> **Warning:** Setting `innerText` on a node removes _all_ of the node's children
+> and replaces them with a single text node with the given string value.
+
 ## Examples
 
 This example compares `innerText` with {{domxref("Node.textContent")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a warning regarding setting the value of innerText

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I faced this issue and discovered that this behavior was not clear on the MDN page.
On `textContent` page there was a warning and not on `innerText`, I thought it could help the readers.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #20714
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
