### PR TITLE
Fix 'unexpected token' error in example JS code

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
@@ -622,7 +622,7 @@ Now let's make this function truly reusable across components. `selectOnFocus()`
        const onFocus = (event) => node.select(); // event handler
        node.addEventListener('focus', onFocus); // when node gets focus call onFocus()
        return {
-         destroy: () => node.removeEventListener('focus', onFocus); // this will be executed when the node is removed from the DOM
+         destroy: () => node.removeEventListener('focus', onFocus) // this will be executed when the node is removed from the DOM
        }
      }
    }

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_reactivity_lifecycle_accessibility/index.md
@@ -622,7 +622,7 @@ Now let's make this function truly reusable across components. `selectOnFocus()`
        const onFocus = (event) => node.select(); // event handler
        node.addEventListener('focus', onFocus); // when node gets focus call onFocus()
        return {
-         destroy: () => node.removeEventListener('focus', onFocus) // this will be executed when the node is removed from the DOM
+         destroy: () => node.removeEventListener('focus', onFocus), // this will be executed when the node is removed from the DOM
        }
      }
    }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This change relates to JS code in point 2 of the 'Making the action reusable' section. The JS object returned by the function 'selectOnFocus' has a semicolon in it that causes an 'unexpected token' error. Removing the semicolon fixes the problem and matches the code found on the REPL (https://svelte.dev/repl/d1fa84a5a4494366b179c87395940039?version=3.23.2).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fixes a syntax error in tutorial. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
