### PR TITLE
fix: remove VAR

### DIFF
--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -54,8 +54,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the object store has been deleted.
 - `DataError` {{domxref("DOMException")}}
-  - : Thrown if the `key` is not a [valid key](https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-valid-key)
-    or a [key range](https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-key-range).
+  - : Thrown if `key` is not a [valid key](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#key) or a [key range](/en-US/docs/Web/API/IDBKeyRange).
 
 ## Examples
 

--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -54,13 +54,8 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the object store has been deleted.
 - `DataError` {{domxref("DOMException")}}
-  - : Thrown if the <var>key</var> is not a <a
-          href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-valid-key"
-          >valid key</a
-        > or a <a
-          href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-key-range"
-          >key range</a
-        >.
+  - : Thrown if the `key` is not a [valid key](https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-valid-key)
+    or a [key range](https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#dfn-key-range).
 
 ## Examples
 

--- a/files/en-us/web/api/svglength/index.md
+++ b/files/en-us/web/api/svglength/index.md
@@ -25,7 +25,7 @@ An `SVGLength` object can be designated as read only, which means that attempts 
   <tbody>
     <tr>
       <th scope="row">Also implement</th>
-      <td><var>None</var></td>
+      <td>None</td>
     </tr>
     <tr>
       <th scope="row">Methods</th>


### PR DESCRIPTION
Was trying to see if VAR could be added back for Markdownlint, but there were the 2 place I thought were probalby better without