### PR TITLE
Mention null in IDBVersionChangeEvent.newVersion

### DIFF
--- a/files/en-us/web/api/idbversionchangeevent/newversion/index.md
+++ b/files/en-us/web/api/idbversionchangeevent/newversion/index.md
@@ -24,7 +24,7 @@ database.
 
 ## Value
 
-A number that is a 64-bit integer.
+A number that is a 64-bit integer or null if the database is being deleted.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

IDBVersionChangeEvent.newVersion can return null when the database is being deleted.

### Motivation

I noticed one of my version change events had `newVersion` set to `null` and I was wondering under which conditions this could be the case.

### Additional details

[The spec](https://w3c.github.io/IndexedDB/#dom-idbversionchangeevent-newversion) mentions this value being null as well.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
