### PR TITLE
Add two links

### DIFF
--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain), and classes. It also supports functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain), and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented programming with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports functional programming since functions are [first-class](/en-US/docs/Glossary/First-class_Function) — they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented programming with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports functional programming since functions are [first-class](/en-US/docs/Glossary/First-class_Function) that can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function) — they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented programming with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports functional programming since functions are [first-class](/en-US/docs/Glossary/First-class_Function) — they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented programming with object prototypes and classes. It also supports functional programming since functions can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented paradigm with [prototypal inheritance](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain). It also supports functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented paradigm with [prototypal inheritance](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain). It also supports functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain), and classes. It also supports functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function) — they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{jsSidebar}}
 
-JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain), and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
+JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports the object-oriented paradigm with [object prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and classes. It also supports the functional paradigm since functions are [first-class](/en-US/docs/Glossary/First-class_Function), so they can be easily created via expressions and passed around like any other object.
 
 This page serves as a quick overview of various JavaScript language features, written for readers with background in other languages, such as C or Java.
 


### PR DESCRIPTION
### Description

Since classes are actually special function in js, and js is not a class-based language, so I think removing it from this context (I mean talking about OOP) will be better specially for beginners.


