### PR TITLE
Update links from RFC 7540 to RFC 9113

### DIFF
--- a/files/en-us/web/http/headers/connection/index.md
+++ b/files/en-us/web/http/headers/connection/index.md
@@ -18,10 +18,11 @@ network connection stays open after the current transaction finishes. If the val
 is `keep-alive`, the connection is persistent and not closed, allowing for
 subsequent requests to the same server to be done.
 
-> **Warning:** Connection-specific header fields such as {{HTTPHeader("Connection")}} and
-> {{HTTPHeader("Keep-Alive")}} are
-> [prohibited in HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2).
-> Chrome and Firefox ignore them in HTTP/2 responses, but Safari conforms to the HTTP/2
+> **Warning:** Connection-specific header fields such as
+> {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}} are prohibited
+> in [HTTP/2](https://httpwg.org/specs/rfc9113.html#ConnectionSpecific) and
+> [HTTP/3](https://httpwg.org/specs/rfc9114.html#header-formatting). Chrome and
+> Firefox ignore them in HTTP/2 responses, but Safari conforms to the HTTP/2
 > spec requirements and does not load any response that contains them.
 
 Except for the standard hop-by-hop headers ({{HTTPHeader("Keep-Alive")}},

--- a/files/en-us/web/http/headers/keep-alive/index.md
+++ b/files/en-us/web/http/headers/keep-alive/index.md
@@ -16,7 +16,12 @@ The **`Keep-Alive`** general header allows the sender to hint about how the conn
 
 > **Note:** Set the {{HTTPHeader("Connection")}} header to "keep-alive" for this header to have any effect.
 
-> **Warning:** Connection-specific header fields such as {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}} are [prohibited in HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2). Chrome and Firefox ignore them in HTTP/2 responses, but Safari conforms to the HTTP/2 specification requirements and does not load any response that contains them.
+> **Warning:** Connection-specific header fields such as
+> {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}} are prohibited
+> in [HTTP/2](https://httpwg.org/specs/rfc9113.html#ConnectionSpecific) and
+> [HTTP/3](https://httpwg.org/specs/rfc9114.html#header-formatting). Chrome and
+> Firefox ignore them in HTTP/2 responses, but Safari conforms to the HTTP/2
+> specification requirements and does not load any response that contains them.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/te/index.md
+++ b/files/en-us/web/http/headers/te/index.md
@@ -14,9 +14,10 @@ The **`TE`** request header specifies the transfer encodings
 the user agent is willing to accept. (you could informally call it
 `Accept-Transfer-Encoding`, which would be more intuitive).
 
-> **Note:** [In HTTP/2,
-> the `TE` header field is only accepted
-> if the `trailers` value is set.](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2)
+> **Note:** In
+> [HTTP/2](https://httpwg.org/specs/rfc9113.html#ConnectionSpecific) and
+> [HTTP/3](https://httpwg.org/specs/rfc9114.html#header-formatting), the `TE`
+> header field is only accepted if the `trailers` value is set.
 
 See also the {{HTTPHeader("Transfer-Encoding")}} response header for more details on
 transfer encodings. Note that `chunked` is always acceptable for HTTP/1.1


### PR DESCRIPTION
### Description
There were some specific links to RFC 7540, these can be updated.

### Motivation
There are new revisions of HTTP specs.

### Additional details
At the same time, the notes mention a topic that applies equally to HTTP/3. So add that too. However, the specific comment about HTTP/2 compat is not expanded to cover HTTP/3, since there is not evidence that I am aware of.

See https://httpwg.org for more details.

### Related issues and pull requests
N/A