### PR TITLE
Update content about Certificate Transparency

### DIFF
--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -10,11 +10,11 @@ browser-compat: http.headers.Expect-CT
 
 {{HTTPSidebar}}
 
-The `Expect-CT` header lets sites opt in to reporting and/or enforcement of [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) requirements, to prevent the use of misissued certificates for that site from going unnoticed.
+The `Expect-CT` header allowed sites opt in to reporting and/or enforcement of [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) requirements before they were enforced by default. Certificate Transparency aims to prevent the use of misissued certificates for that site from going unnoticed. Only Google Chrome and other Chromium-based browsers implemented `Expect-CT` and now Chromium plans to deprecate and eventually remove `Expect-CT` because ["Expect-CT has now outlived its usefulness"](https://chromestatus.com/feature/6244547273687040).
 
 CT requirements can be satisfied via any one of the following mechanisms:
 
-- X.509v3 certificate extension to allow embedding of signed certificate timestamps issued by individual logs
+- X.509v3 certificate extension to allow embedding of signed certificate timestamps issued by individual logs. Most TLS certificates issued by publicly-trusted CAs and used online contain embedded CT.
 - A TLS extension of type `signed_certificate_timestamp` sent during the handshake
 - Supporting OCSP stapling (that is, the `status_request` TLS extension) and providing a `SignedCertificateTimestampList`
 
@@ -22,7 +22,7 @@ CT requirements can be satisfied via any one of the following mechanisms:
 
 > **Note:** Browsers **ignore** the `Expect-CT` header over HTTP; the header only has effect on HTTPS connections.
 
-> **Note:** The `Expect-CT` will likely become obsolete in June 2021. Since May 2018 new certificates are expected to support SCTs by default. Certificates before March 2018 were allowed to have a lifetime of 39 months, those will all be expired in June 2021.
+> **Note:** The `Expect-CT` is mostly obsolete since June 2021. Since May 2018, all new TLS certificates are expected to support SCTs by default. Certificates issued before March 2018 were allowed to have a lifetime of 39 months, so they had expired in June 2021. Chromium plans to deprecate `Expect-CT` header and to eventually remove it.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -9,8 +9,11 @@ browser-compat: http.headers.Expect-CT
 ---
 
 {{HTTPSidebar}}
+{{Deprecated_Header}}
 
-The `Expect-CT` header allowed sites opt in to reporting and/or enforcement of [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) requirements before they were enforced by default. Certificate Transparency aims to prevent the use of misissued certificates for that site from going unnoticed. Only Google Chrome and other Chromium-based browsers implemented `Expect-CT` and now Chromium plans to deprecate and eventually remove `Expect-CT` because ["Expect-CT has now outlived its usefulness"](https://chromestatus.com/feature/6244547273687040).
+The `Expect-CT` header lets sites opt in to reporting and/or enforcement of [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) requirements. Certificate Transparency (CT) aims to prevent the use of misissued certificates for that site from going unnoticed.
+
+Only Google Chrome and other Chromium-based browsers implemented `Expect-CT`, and Chromium has deprecated the header from version 107, because Chromium now enforces CT by default. See the [Chrome Platform Status](https://chromestatus.com/feature/6244547273687040) update.
 
 CT requirements can be satisfied via any one of the following mechanisms:
 

--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -28,7 +28,7 @@ The specification states that compliant servers _must_ provide a number of these
 - A TLS extension of type `signed_certificate_timestamp` sent during the handshake
 - OCSP stapling (that is, the `status_request` TLS extension) and providing a `SignedCertificateTimestampList` with one or more SCTs
 
-With the X.509 certificate extension, the included SCTs are decided by the issuing CA. Since June 2021, most acively used and valid publicly-trusted certificates contain transparency data embedded in this extension. This method should not require web servers to be modified.
+With the X.509 certificate extension, the included SCTs are decided by the issuing CA. Since June 2021, most actively used and valid publicly-trusted certificates contain transparency data embedded in this extension. This method should not require web servers to be modified.
 
 With the latter methods, servers will need to be updated to send the required data. The advantage is that the server operator can customize the CT log sources providing the SCTs sent via the TLS extension/stapled OCSP response.
 
@@ -39,5 +39,3 @@ Google Chrome requires CT log inclusion for all certificates issues with a notBe
 Apple [requires](https://support.apple.com/en-gb/HT205280) a varying number of SCTs in order for Safari and other servers to trust server certificates.
 
 Firefox [does not](https://bugzilla.mozilla.org/show_bug.cgi?id=1281469) currently check or require the use of CT logs for sites that users visit.
-
-The [Expect-CT header](/en-US/docs/Web/HTTP/Headers/Expect-CT) allowed sites opt in to reporting and/or enforcement of Certificate Transparency requirements before they were enforced by default (e.g. in Chrome, even if the certificate was issued with a notBefore date prior to 30 April 2018).

--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -28,7 +28,7 @@ The specification states that compliant servers _must_ provide a number of these
 - A TLS extension of type `signed_certificate_timestamp` sent during the handshake
 - OCSP stapling (that is, the `status_request` TLS extension) and providing a `SignedCertificateTimestampList` with one or more SCTs
 
-With the X.509 certificate extension, the included SCTs are decided by the issuing CA. There should be no need for web servers to be modified if this mechanism is used.
+With the X.509 certificate extension, the included SCTs are decided by the issuing CA. Since June 2021, most acively used and valid publicly-trusted certificates contain transparency data embedded in this extension. This method should not require web servers to be modified.
 
 With the latter methods, servers will need to be updated to send the required data. The advantage is that the server operator can customize the CT log sources providing the SCTs sent via the TLS extension/stapled OCSP response.
 
@@ -40,4 +40,4 @@ Apple [requires](https://support.apple.com/en-gb/HT205280) a varying number of S
 
 Firefox [does not](https://bugzilla.mozilla.org/show_bug.cgi?id=1281469) currently check or require the use of CT logs for sites that users visit.
 
-The [Expect-CT header](/en-US/docs/Web/HTTP/Headers/Expect-CT) can be used to request that a browser _always_ enforces the requirement for certificate transparency (e.g. in Chrome, even if the certificate was issued with a notBefore date prior to April).
+The [Expect-CT header](/en-US/docs/Web/HTTP/Headers/Expect-CT) allowed sites opt in to reporting and/or enforcement of Certificate Transparency requirements before they were enforced by default (e.g. in Chrome, even if the certificate was issued with a notBefore date prior to 30 April 2018).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Update content about Certificate Transparency to note that Chromium plans to deprecate and remove the `Expect-CT` HTTP header.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Keep MDN updated and discourage developers from using obsolete headers.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
[Chrome Platform Status](https://chromestatus.com/feature/5098783126323200)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Matching BCD PR: https://github.com/mdn/browser-compat-data/pull/17800
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
