### PR TITLE
Update the simple RFC 7231 refs to use RFC 9110

### DIFF
--- a/files/en-us/glossary/cacheable/index.md
+++ b/files/en-us/glossary/cacheable/index.md
@@ -47,6 +47,6 @@ Cache-Control: no-cache
 
 ## See also
 
-- Definition of [cacheable](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.3) in the HTTP specification.
+- Details about [methods and caching](https://httpwg.org/specs/rfc9110.html#rfc.section.9.2.3) are provided in the HTTP specification.
 - Description of common cacheable methods: {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}
 - Description of common non-cacheable methods: {{HTTPMethod("PUT")}}, {{HTTPMethod("DELETE")}}, often {{HTTPMethod("POST")}}

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -39,6 +39,6 @@ DELETE /idX/delete HTTP/1.1   -> Returns 404
 
 ## See also
 
-- Definition of [idempotent](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.2) in the HTTP specification.
+- Definition of [idempotent](https://httpwg.org/specs/rfc9110.html#idempotent.methods) in the HTTP specification.
 - Description of common idempotent methods: {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("DELETE")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("TRACE")}}
 - Description of common non-idempotent methods: {{HTTPMethod("POST")}}, {{HTTPMethod("PATCH")}}, {{HTTPMethod("CONNECT")}}

--- a/files/en-us/glossary/representation_header/index.md
+++ b/files/en-us/glossary/representation_header/index.md
@@ -21,7 +21,7 @@ Representation headers include: {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Co
 
 ## See also
 
-- [RFC 7231, section 3: Representations](https://datatracker.ietf.org/doc/html/rfc7231#section-3)
+- [RFC 9110, section 3.2: Representations](https://httpwg.org/specs/rfc9110.html#representations)
 - [List of all HTTP headers](/en-US/docs/Web/HTTP/Headers)
 - {{Glossary("Payload header")}}
 - {{glossary("Entity header")}}

--- a/files/en-us/glossary/request_header/index.md
+++ b/files/en-us/glossary/request_header/index.md
@@ -32,4 +32,4 @@ Cache-Control: max-age=0
 ## See also
 
 - [List of all HTTP headers](/en-US/docs/Web/HTTP/Headers)
-- [RFC 7231, section 5: Request header fields](https://datatracker.ietf.org/doc/html/rfc7231#section-5)
+- [RFC 9110, section 6.3: Header Fields](https://httpwg.org/specs/rfc9110.html#header.fields)

--- a/files/en-us/glossary/safe/http/index.md
+++ b/files/en-us/glossary/safe/http/index.md
@@ -34,6 +34,6 @@ DELETE /idX/delete HTTP/1.1
 
 ## See also
 
-- Definition of [safe](https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1) in the HTTP specification.
+- Definition of [safe](https://httpwg.org/specs/rfc9110.html#safe.methods) in the HTTP specification.
 - Description of common safe methods: {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}, {{HTTPMethod("OPTIONS")}}
 - Description of common unsafe methods: {{HTTPMethod("PUT")}}, {{HTTPMethod("DELETE")}}, {{HTTPMethod("POST")}}

--- a/files/en-us/web/http/methods/patch/index.md
+++ b/files/en-us/web/http/methods/patch/index.md
@@ -77,7 +77,7 @@ Content-Length: 100
 
 ### Response
 
-A successful response is indicated by any [2xx](https://datatracker.ietf.org/doc/html/rfc7231#section-6.3) status code.
+A successful response is indicated by any [2xx](https://httpwg.org/specs/rfc9110.html#status.2xx) status code.
 
 In the example below a {{HTTPStatus("204")}} response code is used, because the response does not carry a payload body. A {{HTTPStatus("200")}} response could have contained a payload body.
 

--- a/files/en-us/web/http/network_error_logging/index.md
+++ b/files/en-us/web/http/network_error_logging/index.md
@@ -128,7 +128,7 @@ The type of the network error may be one of the following pre-defined values fro
 - `tcp.failed`
   - : The TCP connection failed due to reasons not covered by previous errors
 - `http.error`
-  - : The user agent successfully received a response, but it had a [4xx](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5) or [5xx](https://datatracker.ietf.org/doc/html/rfc7231#section-6.6) status code
+  - : The user agent successfully received a response, but it had a [4xx](https://httpwg.org/specs/rfc9110.html#status.4xx) or [5xx](https://httpwg.org/specs/rfc9110.html#status.5xx) status code
 - `http.protocol.error`
   - : The connection was aborted due to an HTTP protocol error
 - `http.response.invalid`

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -22,7 +22,7 @@ Responses are grouped in five classes:
 4. [Client error responses](#client_error_responses) (`400`–`499`)
 5. [Server error responses](#server_error_responses) (`500`–`599`)
 
-The below status codes are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
+The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 
 > **Note:** If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
 

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -22,7 +22,7 @@ Responses are grouped in five classes:
 4. [Client error responses](#client_error_responses) (`400`–`499`)
 5. [Server error responses](#server_error_responses) (`500`–`599`)
 
-The below status codes are defined by [section 10 of RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-10). You can find an updated specification in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-6).
+The below status codes are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 
 > **Note:** If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
 


### PR DESCRIPTION
### Description

There were some specific links to RFC 7231, these can be updated. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

There are new revisions of HTTP specs.

### Additional details

A lot of these are straightforward substitutions. However, some are more gnarly so I've punted on those (see links below)

### Related issues and pull requests

* httpwg.org
* Glossry page that needs more substantial rewrite to replace "payload" with the RFC 9110 term "content" - https://github.com/mdn/content/issues/20741
* `toUTCString()` - this is JavaScript and the ECMAscript definition still refers to RFC 7231 explicitly https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
