### PR TITLE
fix: remove duplicate words

### DIFF
--- a/files/en-us/learn/mathml/first_steps/getting_started/index.md
+++ b/files/en-us/learn/mathml/first_steps/getting_started/index.md
@@ -106,7 +106,7 @@ You may also notice some subtle change in the appearance: the text and vertical 
 
 ## Grouping with the \<mrow> element
 
-The `<math>` element can actually contain an arbitrary number of children and will essentially render them in a row. For instance, the simple formula "1 + 2 + 3" would be be encoded like this in MathML:
+The `<math>` element can actually contain an arbitrary number of children and will essentially render them in a row. For instance, the simple formula "1 + 2 + 3" would be encoded like this in MathML:
 
 ```html
 <math>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -113,7 +113,7 @@ npm install -g jshint
 
 You can then point these tools at JavaScript files you want to lint, for example:
 
-![jshint filename.js was entered at the command line. The response is a list of of line numbers and a description of the error found.](js-hint-commandline.png)
+![jshint filename.js was entered at the command line. The response is a list of line numbers and a description of the error found.](js-hint-commandline.png)
 
 You can also use these tools with a task runner/build tool such as [Gulp](https://gulpjs.com/) or [Webpack](https://webpack.github.io/) to automatically lint your JavaScript during development. (see [Using a task runner to automate testing tools](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Automated_testing#using_a_task_runner_to_automate_testing_tools) in a later article.) See [ESLint integrations](https://eslint.org/docs/user-guide/integrations) for ESLint options; JSHint is supported out of the box by Grunt, and also has other integrations available, e.g. [JSHint loader for Webpack](https://github.com/webpack-contrib/jshint-loader).
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontkerning/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontkerning/index.md
@@ -65,7 +65,7 @@ ctx.fillText(`AVA Ta We (${ctx.fontKerning})`, 5, 110);
 
 ### Result
 
-Note that the the last string has font kerning disabled, so adjacent characters are evenly spread.
+Note that the last string has font kerning disabled, so adjacent characters are evenly spread.
 
 {{ EmbedLiveSample('Examples', 700, 150) }}
 


### PR DESCRIPTION
Ran a pass with Vale. Others were "Nom Nom" and "Makey Makey", but they're company product names