### PR TITLE
Fixed the error in the 2nd example of Raw strings

### DIFF
--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -279,13 +279,13 @@ In addition, the {{jsxref("String.raw()")}} method exists to create raw strings 
 
 ```js
 const str = String.raw`Hi\n${2 + 3}!`;
-// "Hi\\n5!"
+// "Hi\n5!"
 
 str.length;
 // 6
 
 Array.from(str).join(",");
-// "H,i,\\,n,5,!"
+// "H,i,\,n,5,!"
 ```
 
 `String.raw` functions like an "identity" tag if the literal doesn't contain any escape sequences. In case you want an actual identity tag that always works as if the literal is untagged, you can make a custom function that passes the "cooked" (i.e. escape sequences are processed) literal array to `String.raw`, pretending they are raw strings.


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Two backslashes were given in the original example output. However, the correct output would contain only one backslash.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The incorrect example output is very confusing for someone who is just learning this material.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
