### PR TITLE
rewrite confusing statement

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -23,7 +23,7 @@ A service worker is an event-driven [worker](/en-US/docs/Web/API/Worker) registe
 
 A service worker is run in a worker context: it therefore has no DOM access, and runs on a different thread to the main JavaScript that powers your app, so it is non-blocking. It is designed to be fully async; as a consequence, APIs such as synchronous [XHR](/en-US/docs/Web/API/XMLHttpRequest) and [Web Storage](/en-US/docs/Web/API/Web_Storage_API) can't be used inside a service worker.
 
-Service workers only run over HTTPS, for security reasons. Having modified network requests, wide open to _man in the middle_ attacks would be really bad. In Firefox, Service Worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
+Service workers only run over HTTPS, for security reasons. Most significantly, HTTP connections are susceptable to malicious code injection by _man in the middle_ attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
 
 > **Note:** On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox Devtools options/gear menu.
 

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -23,7 +23,7 @@ A service worker is an event-driven [worker](/en-US/docs/Web/API/Worker) registe
 
 A service worker is run in a worker context: it therefore has no DOM access, and runs on a different thread to the main JavaScript that powers your app, so it is non-blocking. It is designed to be fully async; as a consequence, APIs such as synchronous [XHR](/en-US/docs/Web/API/XMLHttpRequest) and [Web Storage](/en-US/docs/Web/API/Web_Storage_API) can't be used inside a service worker.
 
-Service workers only run over HTTPS, for security reasons. Most significantly, HTTP connections are susceptable to malicious code injection by _man in the middle_ attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
+Service workers only run over HTTPS, for security reasons. Most significantly, HTTP connections are susceptable to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
 
 > **Note:** On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox Devtools options/gear menu.
 


### PR DESCRIPTION
### Description
The original statement is difficult to understand: "Having modified network requests, wide open to man in the middle attacks would be really bad." Modified network requests _**are**_ a man in the middle attack. The point missing here is that HTTP allows for a man in the middle attack which modifies the network request to inject a service worker, and that would be really bad given how powerful these APIs are.

### Motivation
Clarify the statement

### Additional details
N/A

### Related issues and pull requests
N/A
