### PR TITLE
Fixes @page size example

### DIFF
--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -113,7 +113,7 @@ where
 }
 ```
 
-### Specifying custom size
+### Specifying a custom size
 
 ```css
 @page {

--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -109,7 +109,15 @@ where
 
 ```css
 @page {
-  size: 4in 6in landscape;
+  size: A4 landscape;
+}
+```
+
+### Specifying custom size
+
+```css
+@page {
+  size: 4in 6in;
 }
 ```
 


### PR DESCRIPTION
Hello,

According to the specification and formal notation, the orientation parameter (`portrait` or `landscape`) should only be used with a predefined `<page-size>` (ie `A4`), but not with custom sizes.

Thanks !