### PR TITLE
CSS Data Types: Simplify page structure

### DIFF
--- a/files/en-us/web/css/css_types/index.md
+++ b/files/en-us/web/css/css_types/index.md
@@ -39,84 +39,84 @@ These types include keywords and identifiers as well as strings, and URLs.
   - : The computed value of the property on the element's parent.
 - CSS-wide keyword: `unset`
   - : Acts as `inherit` or `initial` depending on whether the property is inherited or not.
-- `<custom-ident>`
-  - : A user-defined identifier, for example the name assigned using the {{cssxref("grid-area")}} property. See more information on the {{cssxref("&lt;custom-ident&gt;")}} page.
-- `<dashed-ident>`
-  - : A `<custom-ident>` with the additional restriction that it must start with two dashes, for example with [CSS Custom Properties](/en-US/docs/Web/CSS/Using_CSS_custom_properties). See more information on the {{cssxref("&lt;dashed-ident&gt;")}} page.
-- `<string>`
-  - : A quoted string, such as used for a value of the {{cssxref("content")}} property. See more information on the {{cssxref("&lt;string&gt;")}} type.
-- `<url>`
-  - : A pointer to a resource, for example as the value of {{cssxref("background-image")}}. See more information on the {{cssxref("url", "url()")}} page.
+- {{cssxref("&lt;custom-ident&gt;")}}
+  - : A user-defined identifier, for example the name assigned using the {{cssxref("grid-area")}} property.
+- {{cssxref("&lt;dashed-ident&gt;")}}
+  - : A `<custom-ident>` with the additional restriction that it must start with two dashes, for example with [CSS Custom Properties](/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+- {{cssxref("&lt;string&gt;")}}
+  - : A quoted string, such as used for a value of the {{cssxref("content")}} property.
+- {{cssxref("&lt;url&gt;", "url()")}}
+  - : A pointer to a resource, for example as the value of {{cssxref("background-image")}}.
 
 ## Numeric data types
 
 These data types are used to indicate quantities, indexes, and positions. The majority of these are defined in the Values and Units specification, however additional types are described in other specifications where they are specific to that specification alone — for example the `fr` unit in [CSS Grid Layout](https://www.w3.org/TR/css-grid-1/#fr-unit).
 
-- `<integer>`
-  - : One or more decimal units 0 through 9. See more information on the {{cssxref("&lt;integer&gt;")}} page.
-- `<number>`
-  - : Real numbers which may also have a fractional component, for example 1 or 1.34. See more information on the {{cssxref("&lt;number&gt;")}} page.
-- `<dimension>`
-  - : A number with a unit attached to it, for example 23px or 15em. See more information on the {{cssxref("&lt;dimension&gt;")}} page.
-- `<percentage>`
-  - : A number with a percentage sign attached to it, for example 10%. See more information on the {{cssxref("&lt;percentage&gt;")}} page.
-- `<ratio>`
-  - : A ratio, written with the syntax `<number> / <number>`. See more information on the {{cssxref("&lt;ratio&gt;")}} page.
-- `<flex>`
-  - : A flexible length introduced for [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), written as a `<dimension>` with the `fr` unit attached and used for grid track sizing. See more information on the {{cssxref("&lt;flex&gt;")}} page.
+- {{cssxref("&lt;integer&gt;")}}
+  - : One or more decimal units 0 through 9.
+- {{cssxref("&lt;number&gt;")}}
+  - : Real numbers which may also have a fractional component, for example 1 or 1.34.
+- {{cssxref("&lt;dimension&gt;")}}
+  - : A number with a unit attached to it, for example 23px or 15em.
+- {{cssxref("&lt;percentage&gt;")}}
+  - : A number with a percentage sign attached to it, for example 10%.
+- {{cssxref("&lt;ratio&gt;")}}
+  - : A ratio, written with the syntax `<number> / <number>`.
+- {{cssxref("&lt;flex&gt;")}}
+  - : A flexible length introduced for [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), written as a `<dimension>` with the `fr` unit attached and used for grid track sizing.
 
 ## Quantities
 
 These types are used to specify distance and other quantities.
 
-- `<length>`
-  - : Lengths are a `<dimension>` and refer to distances. See more information on the {{cssxref("&lt;length&gt;")}} page.
-- `<angle>`
-  - : Angles are used in properties such as {{cssxref("gradient/linear-gradient", "linear-gradient()")}} and are a `<dimension>` with one of `deg`, `grad`, `rad`, or `turn` units attached. See more information on the {{cssxref("&lt;angle&gt;")}} page.
-- `<time>`
-  - : Duration units are a `<dimension>` with an `s` or `ms` unit. See more information on the {{cssxref("&lt;time&gt;")}} page.
-- `<frequency>`
-  - : Frequencies are a `<dimension>` with a `Hz` or `kHz` unit attached. See more information on the {{cssxref("&lt;frequency&gt;")}} page.
-- `<resolution>`
-  - : Is a `<dimension>` with a unit identifier of `dpi`, `dpcm`, `dppx`, or `x`. See more information on the {{cssxref("&lt;resolution&gt;")}} page.
+- {{cssxref("&lt;length&gt;")}}
+  - : Lengths are a `<dimension>` and refer to distances.
+- {{cssxref("&lt;angle&gt;")}}
+  - : Angles are used in properties such as {{cssxref("gradient/linear-gradient", "linear-gradient()")}} and are a `<dimension>` with one of `deg`, `grad`, `rad`, or `turn` units attached.
+- {{cssxref("&lt;time&gt;")}}
+  - : Duration units are a `<dimension>` with an `s` or `ms` unit.
+- {{cssxref("&lt;frequency&gt;")}}
+  - : Frequencies are a `<dimension>` with a `Hz` or `kHz` unit attached.
+- {{cssxref("&lt;resolution&gt;")}}
+  - : Is a `<dimension>` with a unit identifier of `dpi`, `dpcm`, `dppx`, or `x`.
 
 ## Combinations of types
 
 Some CSS properties can take a dimension or a percentage value. In this case the percentage value will be resolved to a quantity that matches the allowable dimension. Properties which can accept a percentage in addition to a dimension will use one of the types listed below.
 
-- `<length-percentage>`
-  - : A type that can accept a length or a percentage as a value. See more information on the {{cssxref("&lt;length-percentage&gt;")}} page.
-- `<frequency-percentage>`
-  - : A type that can accept a frequency or a percentage as a value. See more information on the {{cssxref("&lt;frequency-percentage&gt;")}} page.
-- `<angle-percentage>`
-  - : A type that can accept an angle or a percentage as a value. See more information on the {{cssxref("&lt;angle-percentage&gt;")}} page.
-- `<time-percentage>`
-  - : A type that can accept a time or a percentage as a value. See more information on the {{cssxref("&lt;time-percentage&gt;")}} page.
+- {{cssxref("&lt;length-percentage&gt;")}}
+  - : A type that can accept a length or a percentage as a value.
+- {{cssxref("&lt;frequency-percentage&gt;")}}
+  - : A type that can accept a frequency or a percentage as a value.
+- {{cssxref("&lt;angle-percentage&gt;")}}
+  - : A type that can accept an angle or a percentage as a value.
+- {{cssxref("&lt;time-percentage&gt;")}}
+  - : A type that can accept a time or a percentage as a value.
 
 ## Color
 
 [The CSS Color Specification](https://www.w3.org/TR/css-color-3/) defines the {{cssxref("&lt;color&gt;")}} data type, and other types which relate to color in CSS.
 
-- `<color>`
-  - : Specified as a keyword or a numerical color value. See more information on the {{cssxref("&lt;color&gt;")}} page.
-- `<alpha-value>`
+- {{cssxref("&lt;color&gt;")}}
+  - : Specified as a keyword or a numerical color value.
+- {{cssxref("&lt;alpha-value&gt;")}}
   - : Specifies the transparency of a color. May be a `<number>`, in which case 0 is fully transparent and 1 is fully opaque, or a `<percentage>`, in which case 0% is fully transparent and 100% fully opaque.
 
 ## Images
 
 [The CSS Images Specification](https://www.w3.org/TR/css-images-3/) defines the data types which deal with images, including gradients.
 
-- `<image>`
-  - : A URL reference to an image or a color gradient. See more information on the {{cssxref("&lt;image&gt;")}} page.
-- `<color-stop-list>`
+- {{cssxref("&lt;image&gt;")}}
+  - : A URL reference to an image or a color gradient.
+- {{cssxref("&lt;color-stop-list&gt;")}}
   - : A list of two or more color stops with optional transition information using a color hint.
-- `<linear-color-stop>`
+- {{cssxref("&lt;linear-color-stop&gt;")}}
   - : A `<color>` and a `<length-percentage>` to indicate the color stop for this part of the gradient.
-- `<linear-color-hint>`
+- {{cssxref("&lt;linear-color-hint&gt;")}}
   - : A `<length-percentage>` to indicate how the color interpolates.
-- `<ending-shape>`
+- {{cssxref("&lt;ending-shape&gt;")}}
   - : Used for radial gradients; can have a keyword value of `circle` or `ellipse`.
-- `<size>`
+- {{cssxref("&lt;size&gt;")}}
   - : Determines the size of the radial gradient's ending shape. This accepts a value of a keyword or a `<length>` but not a percentage.
 
 ## 2D positioning


### PR DESCRIPTION
### Description

Simplify the list of data types:

1. Make the titles linkable.
2. remove all the unhelpful sentences "_See more information on the XXX page._"

### Motivation

Simplify page structure to make it easy to read. It should have a list of data types with short descriptions, like we have in [CSS Functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions).
