### PR TITLE
Fix link Asynchronous flow control using async

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
@@ -23,7 +23,7 @@ Async has a lot of useful methods (check out [the documentation](https://caolan.
 
 Most of the methods we use in _Express_ are asynchronous—you specify an operation to perform, passing a callback. The method returns immediately, and the callback is invoked when the requested operation completes. By convention in _Express_, callback functions pass an _error_ value as the first parameter (or `null` on success) and the results from the function (if there are any) as the second parameter.
 
-If a controller only needs to _perform **one** asynchronous operation_ to get the information required to render a page then the implementation is easy—we render the template in the callback. The code fragment below shows this for a function that renders the count of a model `SomeModel` (using the Mongoose [`countDocuments`](https://mongoosejs.com/docs/api.html#model_Model.countDocuments) method):
+If a controller only needs to _perform **one** asynchronous operation_ to get the information required to render a page then the implementation is easy—we render the template in the callback. The code fragment below shows this for a function that renders the count of a model `SomeModel` (using the Mongoose [`countDocuments`](https://mongoosejs.com/docs/api.html#model_Model-countDocuments) method):
 
 ```js
 exports.some_model_count = function (req, res, next) {


### PR DESCRIPTION
The link redirecting to https://mongoosejs.com/docs/api.html#model_Model.countDocuments , actually stays at the top of the page, it does not go to the countDocuments method part, instead https://mongoosejs.com/docs/api.html#model_Model-countDocuments goes to the method part on the page.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
