### PR TITLE
Change image to media element

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlmediaelement/crossorigin/index.md
@@ -13,7 +13,7 @@ browser-compat: api.HTMLMediaElement.crossOrigin
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLMediaElement.crossOrigin`** property is the CORS setting for this image element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
+The **`HTMLMediaElement.crossOrigin`** property is the CORS setting for this media element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This documentation page relates to the `crossOrigin` attribute on HTMLMediaElement, so this PR changes the description from "image element" to "media element".

### Motivation

More accurate documentation.

### Additional details

N/A

### Related issues and pull requests

N/A