### PR TITLE
Mention indirect eval in optional chaining

### DIFF
--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -111,6 +111,7 @@ const result = someInterface.customMethod?.();
 
 #### With `eval`
 The global {{JSxRef("eval")}} function has multiple ways of indirect execution, and using it with the optional chaining operator is one of the ways to indirectly call `eval()`. Indirect eval has several quirks:
+
 - It works in the global scope instead of the surrounding lexical scope.
 - Strictness of the surrounding context is not inherited, so strict mode is only enforced if the source string itself has `"use strict";`.
 - If there is a variable declared with `var` or a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and the source string is not in strict mode, it will become a global variable.

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -109,12 +109,7 @@ const result = someInterface.customMethod?.();
 > you have to use `?.` at this position as
 > well: `someInterface?.customMethod?.()`
 
-#### With `eval`
-The global {{JSxRef("eval")}} function has multiple ways of indirect execution, and using it with the optional chaining operator is one of the ways to indirectly call `eval()`. Indirect eval has several quirks:
-
-- It works in the global scope instead of the surrounding lexical scope.
-- Strictness of the surrounding context is not inherited, so strict mode is only enforced if the source string itself has `"use strict";`.
-- If there is a variable declared with `var` or a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and the source string is not in strict mode, it will become a global variable.
+`eval?.()` is the shortest way to enter _indirect eval_ mode. For more information, see the [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#description) reference page.
 
 ### Optional chaining with expressions
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -109,6 +109,12 @@ const result = someInterface.customMethod?.();
 > you have to use `?.` at this position as
 > well: `someInterface?.customMethod?.()`
 
+#### With `eval`
+The global {{JSxRef("eval")}} function has multiple ways of indirect execution, and using it with the optional chaining operator is one of the ways to indirectly call `eval()`. Indirect eval has several quirks:
+- It works in the global scope instead of the surrounding lexical scope.
+- Strictness of the surrounding context is not inherited, so strict mode is only enforced if the source string itself has `"use strict";`.
+- If there is a variable declared with `var` or a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and the source string is not in strict mode, it will become a global variable.
+
 ### Optional chaining with expressions
 
 You can also use the optional chaining operator when accessing properties with an expression using


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a section about indirect `eval`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This is mentioned on the page about the `eval` global function, and I felt that this also had to be mentioned on the page about the optional chaining operator.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#description)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
None!

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
