### PR TITLE
@font-face src tech() function - add to experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -639,7 +639,7 @@ See {{bug(1774589)}} for more details.
 
 ### @font-face src feature checking checking
 
-The `@font-face` [`src` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src) now supports the `tech()` function, allowing fallback of whether a font resource is downloaded based on whether the user-agent supports a particular font feature or technology.
+The `@font-face` [`src` descriptor](/en-US/docs/Web/CSS/@font-face/src) now supports the `tech()` function, allowing fallback of whether a font resource is downloaded based on whether the user-agent supports a particular font feature or technology.
 See {{bug(1715546)}} for more details.
 
 <table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -637,6 +637,47 @@ See {{bug(1774589)}} for more details.
   </tbody>
 </table>
 
+### @font-face src feature checking checking
+
+The `@font-face` [`src` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src) now supports the `tech()` function, allowing fallback of whether a font resource is downloaded based on whether the user-agent supports a particular font feature or technology.
+See {{bug(1715546)}} for more details.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>105</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>105</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>105</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>105</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.font-tech.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -106,6 +106,7 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 
 ## Formal syntax
 
+```
 @font-face {
   <declaration-list>
 }

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -106,7 +106,7 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 
 ## Formal syntax
 
-```
+```css-nolint
 @font-face {
   <declaration-list>
 }

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -106,7 +106,6 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 
 ## Formal syntax
 
-```css-nolint
 @font-face {
   <declaration-list>
 }


### PR DESCRIPTION
FF105 adds support for using `@font-face` `src` `tech()` function to specify the font technologies in a file, allowing a user agent to reject the src (see https://bugzilla.mozilla.org/show_bug.cgi?id=1786804)

Note, there are no associated docs. This is behind a pref because the syntax is still under discussion. We will add docs when things stabilise.

Other docs work can be tracked in #19833