### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arguments/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.md
@@ -54,7 +54,7 @@ Each argument index can also be set or reassigned:
 arguments[1] = 'new value';
 ```
 
-Non-strict functions that only has simple parameters (that is, no rest, default, or restructured parameters) will sync the new value of parameters with the `arguments` object, and vice versa:
+Non-strict functions that only has simple parameters (that is, no rest, default, or destructured parameters) will sync the new value of parameters with the `arguments` object, and vice versa:
 
 ```js
 function func(a) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
It's a destructured parameters. But, It's mentioned as restructured parameters.  This minor typo issue may raise a slight confusion...
```diff
- Non-strict functions that only has simple parameters (that is, no rest, default, or restructured parameters) will sync the new value of parameters with the `arguments` object, and vice versa:
+ Non-strict functions that only has simple parameters (that is, no rest, default, or destructured parameters) will sync the new value of parameters with the `arguments` object, and vice versa:
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Try to diminish the slight confusion

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments#:~:text=rest%2C%20default%2C%20or-,restructured,-parameters)%20will%20sync
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
