### PR TITLE
fix: add nolint to avoid wrong formatting

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -93,7 +93,7 @@ When you group selectors in this way, if any selector is syntactically invalid, 
 
 In the following example, the invalid class selector rule will be ignored, whereas the `h1` would still be styled.
 
-```css
+```css-nolint
 h1 {
   color: blue;
 }
@@ -105,9 +105,8 @@ h1 {
 
 When combined however, neither the `h1` nor the class will be styled as the entire rule is deemed invalid.
 
-```css
-h1,
-.special {
+```css-nolint
+h1, ..special {
   color: blue;
 }
 ```


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53544726/190584808-75fefe8f-a2cd-4635-bff8-cea7e87dd5e0.png)
![image](https://user-images.githubusercontent.com/53544726/190585027-f9410b94-a06e-4592-b936-25b280c9ac72.png)
This is a worng example, accidentally formatted incorrectly in this [commit](https://github.com/mdn/content/commit/ffe4e4b49b540a18cc4c0e98d7cbd11795d8a360#diff-cfefcc2d9da9d9045b17f04c9028dfd0be6da38bafdd5573d37c3af3bfd2776aL108)