### PR TITLE
docs: updated the navigation url of content on video

### DIFF
--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -45,7 +45,13 @@ For the average website, [25% of bandwidth comes from video](https://discuss.htt
 
 ## Optimizing video delivery
 
-It's best to [compress all video](#compress), [optimize `<source>` order](#omptimize), set [autoplay](#video_autoplay), [remove audio from muted video](#muted), [optimize video preload](#video_preload), and [consider streaming](#consider_streaming) the video. The sections below describe each of these optimization techniques.
+The sections below describe the following optimization techniques:
+- [compress all video](#compress_all_videos)
+- [optimize `<source>` order](#optimize_source_order)
+- [set autoplay](#video_autoplay)
+- [remove audio from muted video](#remove_audio_from_muted_hero_videos)
+- [optimize video preload](#video_preload)
+- [consider streaming](#consider_streaming)
 
 ### Compress all videos
 

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -45,7 +45,7 @@ For the average website, [25% of bandwidth comes from video](https://discuss.htt
 
 ## Optimizing video delivery
 
-It's best to [compress all video](#compress), [optimize `<source>` order](#omptimize), set [autoplay](/en-US/docs/Learn/Performance/Multimedia#video_autoplay), [remove audio from muted video](#muted), [optimize video preload](/en-US/docs/Learn/Performance/Multimedia#video_preload), and [consider streaming](/en-US/docs/Learn/Performance/Multimedia#consider_streaming) the video. The sections below describe each of these optimization techniques.
+It's best to [compress all video](#compress), [optimize `<source>` order](#omptimize), set [autoplay](#video_autoplay), [remove audio from muted video](#muted), [optimize video preload](#video_preload), and [consider streaming](#consider_streaming) the video. The sections below describe each of these optimization techniques.
 
 ### Compress all videos
 

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -46,6 +46,7 @@ For the average website, [25% of bandwidth comes from video](https://discuss.htt
 ## Optimizing video delivery
 
 The sections below describe the following optimization techniques:
+
 - [compress all video](#compress_all_videos)
 - [optimize `<source>` order](#optimize_source_order)
 - [set autoplay](#video_autoplay)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated the hash-based URLs for in-page navigation on the multimedia [video](https://developer.mozilla.org/en-US/docs/Learn/Performance/video) page. The in-page navigation was pointing to a different page earlier, I have updated them with the correct URLs.

### Motivation

I was going through the video page on MDN & encountered this issue. So, I have opened this PR to fix it to ensure a good user experience for the readers of MDN.

### Additional details

[MDN Video Page](https://developer.mozilla.org/en-US/docs/Learn/Performance/video)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
