### PR TITLE
Update/(media query) - Chanted value from 12450px to 1250px

### DIFF
--- a/files/en-us/web/css/media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.md
@@ -114,10 +114,10 @@ This example applies styles when the user's _primary_ input mechanism (such as a
 ```
 
 Many media features are _range features_, which means they can be prefixed with "min-" or "max-" to express "minimum condition" or "maximum condition" constraints.
-For example, this CSS will apply styles only if your browser's {{glossary("viewport")}} width is equal to or narrower than 12450px:
+For example, this CSS will apply styles only if your browser's {{glossary("viewport")}} width is equal to or narrower than 1250px:
 
 ```css
-@media (max-width: 12450px) {
+@media (max-width: 1250px) {
   /* … */
 }
 ```


### PR DESCRIPTION
### Description

Changed value from 12450px to 1250px

### Motivation

When you are on the docs, you often copy and paste things into the code to verify it works, and then tweak it. 

I've copied the media query with a value of 12450px and went on to test - didn't work. Scratched my head on why this isn't working, after a while I've realised its 12450px, not 1250px. Making this little change could help people stop scratching their head, because it's so easy to overlook the extra number.
