### PR TITLE
Move selectstart event to Node

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7954,6 +7954,7 @@
 /en-US/docs/Web/API/Document/pointerover_event	/en-US/docs/Web/API/Element/pointerover_event
 /en-US/docs/Web/API/Document/pointerup_event	/en-US/docs/Web/API/Element/pointerup_event
 /en-US/docs/Web/API/Document/resourcetimingbufferfull_event	/en-US/docs/Web/API/Performance/resourcetimingbufferfull_event
+/en-US/docs/Web/API/Document/selectstart_event	/en-US/docs/Web/API/Node/selectstart_event
 /en-US/docs/Web/API/Document/timeline/currentTime	/en-US/docs/Web/API/AnimationTimeline/currentTime
 /en-US/docs/Web/API/Document/touchcancel_event	/en-US/docs/Web/API/Element/touchcancel_event
 /en-US/docs/Web/API/Document/touchend_event	/en-US/docs/Web/API/Element/touchend_event
@@ -8300,7 +8301,7 @@
 /en-US/docs/Web/API/GlobalEventHandlers/onsecuritypolicyviolation	/en-US/docs/Web/API/Element/securitypolicyviolation_event
 /en-US/docs/Web/API/GlobalEventHandlers/onselect	/en-US/docs/Web/API/HTMLInputElement/select_event
 /en-US/docs/Web/API/GlobalEventHandlers/onselectionchange	/en-US/docs/Web/API/HTMLInputElement/selectionchange_event
-/en-US/docs/Web/API/GlobalEventHandlers/onselectstart	/en-US/docs/Web/API/Document/selectstart_event
+/en-US/docs/Web/API/GlobalEventHandlers/onselectstart	/en-US/docs/Web/API/Node/selectstart_event
 /en-US/docs/Web/API/GlobalEventHandlers/onslotchange	/en-US/docs/Web/API/HTMLSlotElement/slotchange_event
 /en-US/docs/Web/API/GlobalEventHandlers/onsubmit	/en-US/docs/Web/API/HTMLFormElement/submit_event
 /en-US/docs/Web/API/GlobalEventHandlers/ontouchcancel	/en-US/docs/Web/API/Element/touchcancel_event
@@ -11633,7 +11634,7 @@
 /en-US/docs/Web/Events/select	/en-US/docs/Web/API/HTMLInputElement/select_event
 /en-US/docs/Web/Events/selectedcandidatepairchange	/en-US/docs/Web/API/RTCIceTransport/selectedcandidatepairchange_event
 /en-US/docs/Web/Events/selectionchange	/en-US/docs/Web/API/HTMLInputElement/selectionchange_event
-/en-US/docs/Web/Events/selectstart	/en-US/docs/Web/API/Document/selectstart_event
+/en-US/docs/Web/Events/selectstart	/en-US/docs/Web/API/Node/selectstart_event
 /en-US/docs/Web/Events/shippingaddresschange	/en-US/docs/Web/API/PaymentRequest/shippingaddresschange_event
 /en-US/docs/Web/Events/shippingoptionchange	/en-US/docs/Web/API/PaymentRequest/shippingoptionchange_event
 /en-US/docs/Web/Events/show	/en-US/docs/Web/API/Element/show_event

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -30636,22 +30636,6 @@
       "teoli"
     ]
   },
-  "Web/API/Document/selectstart_event": {
-    "modified": "2020-10-15T21:39:05.806Z",
-    "contributors": [
-      "mfuji09",
-      "wbamberg",
-      "chrisdavidmills",
-      "irenesmith",
-      "mfluehr",
-      "erikadoyle",
-      "Ehsan",
-      "wirmar",
-      "Nickolay",
-      "Sebastianz",
-      "teoli"
-    ]
-  },
   "Web/API/Document/styleSheetSets": {
     "modified": "2020-12-11T06:37:41.616Z",
     "contributors": [
@@ -51188,6 +51172,22 @@
       "Waldo",
       "Callek",
       "JesseW"
+    ]
+  },
+  "Web/API/Node/selectstart_event": {
+    "modified": "2020-10-15T21:39:05.806Z",
+    "contributors": [
+      "mfuji09",
+      "wbamberg",
+      "chrisdavidmills",
+      "irenesmith",
+      "mfluehr",
+      "erikadoyle",
+      "Ehsan",
+      "wirmar",
+      "Nickolay",
+      "Sebastianz",
+      "teoli"
     ]
   },
   "Web/API/Node/textContent": {

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -60,6 +60,6 @@ document.onselectionchange = () => {
 
 ## See also
 
-- {{domxref("Document/selectstart_event", "selectstart")}}
+- {{domxref("Node/selectstart_event", "selectstart")}}
 - {{domxref("Document.getSelection()")}}
 - {{domxref("Selection", "Selection")}}

--- a/files/en-us/web/api/node/selectstart_event/index.md
+++ b/files/en-us/web/api/node/selectstart_event/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Document: selectstart event'
-slug: Web/API/Document/selectstart_event
+title: 'Node: selectstart event'
+slug: Web/API/Node/selectstart_event
 page-type: web-api-event
 tags:
   - Document
@@ -9,9 +9,8 @@ tags:
   - Selection
   - Selection API
   - selectstart
-browser-compat: api.Document.selectstart_event
+browser-compat: api.Node.selectstart_event
 ---
-
 {{APIRef}}
 
 The **`selectstart`** event of the [Selection API](/en-US/docs/Web/API/Selection) is fired when a user starts a new selection.

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -162,6 +162,6 @@ Other key terms used in this section.
 ## See also
 
 - {{DOMxRef("Window.getSelection")}}, {{DOMxRef("Document.getSelection")}}, {{DOMxRef("Range")}}
-- Selection-related events: {{domxref("Document/selectionchange_event", "selectionchange")}} and {{domxref("Document/selectstart_event", "selectstart")}}
+- Selection-related events: {{domxref("Document/selectionchange_event", "selectionchange")}} and {{domxref("Node/selectstart_event", "selectstart")}}
 - HTML inputs provide simpler helper APIs for working with selection (see {{DOMxRef("HTMLInputElement.setSelectionRange()")}})
 - {{DOMxRef("Document.activeElement")}}, {{DOMxRef("HTMLElement.focus")}}, and {{DOMxRef("HTMLElement.blur")}}

--- a/files/en-us/web/api/selection_api/index.md
+++ b/files/en-us/web/api/selection_api/index.md
@@ -22,7 +22,7 @@ The {{domxref("Window/getSelection()", "Window.getSelection()")}} and {{domxref(
 
 The Selection API also provides two events, both firing on {{domxref("Document")}}:
 
-- the {{domxref("Document/selectstart_event", "selectstart")}} event is fired when the user starts to make a new selection
+- the {{domxref("Node/selectstart_event", "selectstart")}} event is fired when the user starts to make a new selection
 - the {{domxref("Document/selectionchange_event", "selectionchange")}} event is fired when the current selection changes.
 
 ## Interfaces
@@ -35,7 +35,7 @@ The Selection API also provides two events, both firing on {{domxref("Document")
   - : A method returning a `Selection` object representing the current selection or current position of the caret.
 - {{domxref("Document/selectionchange_event", "Document.selectionchange")}}
   - : An event which is fired when the current selection is changed.
-- {{domxref("Document/selectstart_event", "Document.selectstart")}}
+- {{domxref("Node/selectstart_event", "Node.selectstart")}}
   - : An event which is fired when a user starts a new selection.
 
 ## Specifications

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -931,7 +931,6 @@ This section lists events that have _their own_ reference pages on MDN. If you a
   - [readystatechange event](/en-US/docs/Web/API/Document/readystatechange_event)
   - [scroll event](/en-US/docs/Web/API/Document/scroll_event)
   - [selectionchange event](/en-US/docs/Web/API/Document/selectionchange_event)
-  - [selectstart event](/en-US/docs/Web/API/Document/selectstart_event)
   - [touchcancel event](/en-US/docs/Web/API/Document/touchcancel_event)
   - [touchend event](/en-US/docs/Web/API/Document/touchend_event)
   - [touchmove event](/en-US/docs/Web/API/Document/touchmove_event)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Document/selectstart_event has a broken compat table.

In https://github.com/mdn/browser-compat-data/pull/16359 it was decided it is better to have the `selectstart` event under `Node`.  Unfortunately, the accompanying mdn/content PR (https://github.com/mdn/content/pull/18106) did not move the `selectstart` event from `Document` to `Node`. This PR fixed that. 