### PR TITLE
`log()` - New CSS functional notation

### DIFF
--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -26,9 +26,9 @@ In CSS, when a single parameter is passed, the natural logarithm `e`, or approxi
 
 ```css
 /* A <number> value */
-width: calc(100px * log(7.389));  /* 100px * logE(7.389) = 100px * 2 = 200px */
-width: calc(100px * log(8, 2));   /* 100px * log2(8) =     100px * 3 = 300px */
-width: calc(100px * log(625, 5)); /* 100px * log5(625) =   100px * 4 = 400px */
+width: calc(100px * log(7.389));  /* 200px */
+width: calc(100px * log(8, 2));   /* 300px */
+width: calc(100px * log(625, 5)); /* 400px */
 ```
 
 ### Parameters

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -18,7 +18,9 @@ spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
 
 The **`log()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns the logarithm of a number.
 
-The [logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of [exponentiation](en-US/docs/Web/CSS/exp); it is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter. In CSS, when a single parameter is passed, the natural logarithm `e`, or approximately 2.7182818, is used, though the base can be set to any value with an optional second parameter. 
+The [logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of {{CSSxRef("exp", "exponentiation")}}; it is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter.
+
+In CSS, when a single parameter is passed, the natural logarithm `e`, or approximately `2.7182818`, is used, though the base can be set to any value with an optional second parameter.
 
 ## Syntax
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -24,9 +24,9 @@ The [logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse
 
 ```css
 /* A <number> value */
-width: calc(100px * log(7.389));
-width: calc(100px * log(8, 2));
-width: calc(100px * log(625, 5));
+width: calc(100px * log(7.389));  /* 100px * logE(7.389) = 100px * 2 = 200px */
+width: calc(100px * log(8, 2));   /* 100px * log2(8) =     100px * 3 = 300px */
+width: calc(100px * log(625, 5)); /* 100px * log5(625) =   100px * 4 = 400px */
 ```
 
 ### Parameter

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -18,6 +18,8 @@ spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
 
 The **`log()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns the logarithm of a number.
 
+The [logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of [exponentiation](en-US/docs/Web/CSS/exp); it is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter. In CSS, when a single parameter is passed, the natural logarithm `e`, or approximately 2.7182818, is used, though the base can be set to any value with an optional second parameter. 
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -31,7 +31,7 @@ width: calc(100px * log(625, 5)); /* 100px * log5(625) =   100px * 4 = 400px */
 
 ### Parameter
 
-The `log(x, y)` function accepts two comma-separated values as its parameters.
+The `log(x, y?)` function accepts two comma-separated values as its parameters.
 
 - `x`
   - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -1,0 +1,63 @@
+---
+title: log()
+slug: Web/CSS/log
+tags:
+  - CSS
+  - CSS Function
+  - Function
+  - Math
+  - Reference
+  - Web
+  - log
+  - Experimental
+browser-compat: css.types.log
+spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+The **`log()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns the logarithm of a number.
+
+## Syntax
+
+```css
+/* A <number> value */
+width: calc(100px * log(7.389));
+width: calc(100px * log(8, 2));
+width: calc(100px * log(625, 5));
+```
+
+### Parameter
+
+The `log(x, y)` function accepts two comma-separated values as its parameters.
+
+- `x`
+  - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.
+
+- `y`
+  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not deffined, the default logarithm base is `e`.
+
+### Return value
+
+The logarithm of `x`, when `y` is deffined.
+
+The natural logarithm (base `e`) of `x`, when `y` is not deffined.
+
+### Formal syntax
+
+{{CSSSyntax}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{CSSxRef("pow")}}
+- {{CSSxRef("sqrt")}}
+- {{CSSxRef("hypot")}}
+- {{CSSxRef("exp")}}

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -31,21 +31,21 @@ width: calc(100px * log(8, 2));   /* 100px * log2(8) =     100px * 3 = 300px */
 width: calc(100px * log(625, 5)); /* 100px * log5(625) =   100px * 4 = 400px */
 ```
 
-### Parameter
+### Parameters
 
-The `log(x, y?)` function accepts two comma-separated values as its parameters.
+The `log(value, base?)` function accepts two comma-separated values as its parameters.
 
-- `x`
+- `value`
   - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.
 
-- `y`
+- `base`
   - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithmic base `e` is used. 
 
 ### Return value
 
-The logarithm of `x`, when `y` is defined.
+The logarithm of `value`, when `base` is defined.
 
-The natural logarithm (base `e`) of `x`, when `y` is not defined.
+The natural logarithm (base `e`) of `value`, when `base` is not defined.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -35,13 +35,13 @@ The `log(x, y)` function accepts two comma-separated values as its parameters.
   - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.
 
 - `y`
-  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not deffined, the default logarithm base is `e`.
+  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithm base is `e`.
 
 ### Return value
 
-The logarithm of `x`, when `y` is deffined.
+The logarithm of `x`, when `y` is defined.
 
-The natural logarithm (base `e`) of `x`, when `y` is not deffined.
+The natural logarithm (base `e`) of `x`, when `y` is not defined.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -39,7 +39,7 @@ The `log(value, base?)` function accepts two comma-separated values as its param
   - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.
 
 - `base`
-  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithmic base `e` is used. 
+  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithmic base `e` is used.
 
 ### Return value
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -35,7 +35,7 @@ The `log(x, y)` function accepts two comma-separated values as its parameters.
   - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be logarithmed.
 
 - `y`
-  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithm base is `e`.
+  - : Optional. A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the base of the logarithm. If not defined, the default logarithmic base `e` is used. 
 
 ### Return value
 


### PR DESCRIPTION
### Description
Document the CSS `log()` functional notation.

### Motivation
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function.

### Additional details
https://www.w3.org/TR/css-values-4/#exponent-funcs

### Related issues and pull requests

* BCD - https://github.com/mdn/browser-compat-data/pull/17255
* Syntaxes - https://github.com/mdn/data/pull/593
