### PR TITLE
add multiple ways to make function statement treated as an expression

### DIFF
--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -47,7 +47,7 @@ void (2 === '2'); // void (2 === '2'), returns undefined
 
 ### Immediately Invoked Function Expressions
 
-When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE), the `function` keyword cannot be at the immediate start of the statement, because that would be parsed as a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and would generate a syntax error when the parenthese representing invocation is reached — if the function is unnamed, it would immediately be a syntax error if the function is parsed as a declaration.
+When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE), the `function` keyword cannot be at the immediate start of the statement, because that would be parsed as a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and would generate a syntax error when the parentheses representing invocation is reached — if the function is unnamed, it would immediately be a syntax error if the function is parsed as a declaration.
 
 ```js example-bad
 function iife() {

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -48,7 +48,7 @@ void (2 === '2'); // void (2 === '2'), returns undefined
 ### Immediately Invoked Function Expressions
 
 When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE),
-`void` can be used to force the `function` keyword
+`void`, or any other [unary operator](en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#unary_operators) can be used to force the `function` keyword
 to be treated as an expression instead of a declaration.
 
 ```js

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -48,7 +48,7 @@ void (2 === '2'); // void (2 === '2'), returns undefined
 ### Immediately Invoked Function Expressions
 
 When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE),
-`void` can be used to force the `function` keyword
+`void`, or any other [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#unary_operators) can be used to force the `function` keyword
 to be treated as an expression instead of a declaration.
 
 ```js

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -47,20 +47,37 @@ void (2 === '2'); // void (2 === '2'), returns undefined
 
 ### Immediately Invoked Function Expressions
 
-When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE),
-`void`, or any other [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#unary_operators) can be used to force the `function` keyword
-to be treated as an expression instead of a declaration.
+When using an [immediately-invoked function expression](/en-US/docs/Glossary/IIFE), the `function` keyword cannot be at the immediate start of the statement, because that would be parsed as a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function), and would generate a syntax error when the parenthese representing invocation is reached — if the function is unnamed, it would immediately be a syntax error if the function is parsed as a declaration.
+
+```js example-bad
+function iife() {
+  console.log("Executed!");
+}(); // SyntaxError: Unexpected token ')'
+
+function () {
+  console.log("Executed!");
+}(); // SyntaxError: Function statements require a function name
+```
+
+In order for the function to be parsed as an [expression](/en-US/docs/Web/JavaScript/Reference/Operators/function), the `function` keyword has to appear at a position that only accepts expressions, not statements. This can be achieved be prefixing the keyword with a [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#unary_operators), which only accepts expressions as operands. Function invocation has higher [precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) than unary operators, so it will be executed first. Its return value (which is almost always `undefined`) will be passed to the unary operator and then immediately discarded.
+
+Of all the unary operators, `void` offers the best semantic, because it clearly signals that the return value of the function invocation should be discarded.
 
 ```js
-void function iife() {
+void function () {
   console.log("Executed!");
 }();
 
 // Output: "Executed!"
 ```
 
-Executing the above function without the `void` keyword will result in an
-**Uncaught SyntaxError**.
+This is a bit longer than wrapping the function expression in parentheses, which has the same effect of forcing the `function` keyword to be parsed as the start of an expression instead of a statement.
+
+```js
+(function () {
+  console.log("Executed!");
+})();
+```
 
 ### JavaScript URIs
 


### PR DESCRIPTION
### Description

We can use any unary operator to make the function statement treated as a unary expression. 