### PR TITLE
`exp()` - New CSS functional notation

### DIFF
--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -11,7 +11,6 @@ tags:
   - exp
   - Experimental
 browser-compat: css.types.exp
-spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -41,7 +41,7 @@ The `exp(number)` function accepts only one value as its parameter.
 
 Returns a {{cssxref("&lt;number&gt;")}} which is the result of calculating `e` raised to the power of `number`.
 
-## Formal syntax
+### Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -39,7 +39,7 @@ The `exp(number)` function accepts only one value as its parameter.
 
 Returns a {{cssxref("&lt;number&gt;")}} which is the result of calculating `e` raised to the power of `number`.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -37,7 +37,7 @@ The `exp(number)` function accepts only one value as its parameter.
 
 ### Return value
 
-Returns a {{cssxref("&lt;number&gt;")}} of `e` raised to the power of a `number`.
+Returns a {{cssxref("&lt;number&gt;")}} which is the result of calculating `e` raised to the power of `number`.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -15,7 +15,9 @@ browser-compat: css.types.exp
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`exp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns `e` raised to the power of a number.
+The **`exp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that takes an number as an argument and returns the mathematical constant `e` raised to the power of the given number.
+
+The mathematical constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)) represents Euler's number and is the base of natural logarithms, and is approximately `2.71828`.
 
 The function contains a calculation which returns the same value as {{CSSxRef("pow", "pow(e, number)")}}.
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -33,7 +33,7 @@ width: calc(100px * exp(1));  /* 100px * 2.718281828459045 = 217px */
 The `exp(number)` function accepts only one value as its parameter.
 
 - `number`
-  - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be raised by a power of `e`.
+  - : A calculation which resolves to a {{cssxref("&lt;number&gt;")}}. Representing the value to be raised by a power of `e`.
 
 ### Return value
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -29,7 +29,7 @@ width: calc(100px * exp(0));  /* 100px * 1 = 100px */
 width: calc(100px * exp(1));  /* 100px * 2.718281828459045 = 217px */
 ```
 
-### Parameters
+### Parameter
 
 The `exp(number)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -38,7 +38,7 @@ The `exp(number)` function accepts only one value as its parameter.
 
 ### Return value
 
-Returns A {{cssxref("&lt;number&gt;")}} of `e` raised to the power of a `number`.
+Returns a {{cssxref("&lt;number&gt;")}} of `e` raised to the power of a `number`.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -1,0 +1,60 @@
+---
+title: exp()
+slug: Web/CSS/exp
+tags:
+  - CSS
+  - CSS Function
+  - Function
+  - Math
+  - Reference
+  - Web
+  - exp
+  - Experimental
+browser-compat: css.types.exp
+spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+The **`exp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns `e` raised to the power of a number.
+
+The function contains a calculation which returns the same value as {{CSSxRef("pow", "pow(e, number)")}}.
+
+## Syntax
+
+```css
+/* A <number> value */
+width: calc(100px * exp(-1)); /* 100px * 0.367879441171442 = 36px */
+width: calc(100px * exp(0));  /* 100px * 1 = 100px */
+width: calc(100px * exp(1));  /* 100px * 2.718281828459045 = 217px */
+```
+
+### Parameters
+
+The `exp(number)` function accepts only one value as its parameter.
+
+- `number`
+  - : A {{cssxref("&lt;number&gt;")}} greater than or equal to 0. Representing the value to be raised by a power of `e`.
+
+### Return value
+
+Returns A {{cssxref("&lt;number&gt;")}} of `e` raised to the power of a `number`.
+
+### Formal syntax
+
+{{CSSSyntax}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{CSSxRef("pow")}}
+- {{CSSxRef("sqrt")}}
+- {{CSSxRef("hypot")}}
+- {{CSSxRef("log")}}


### PR DESCRIPTION
### Description
Document the CSS `exp()` functional notation.

### Motivation
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function.

### Additional details
https://www.w3.org/TR/css-values-4/#exponent-funcs

### Related issues and pull requests

* BCD - https://github.com/mdn/browser-compat-data/pull/17256
* Syntaxes - https://github.com/mdn/data/pull/593
