### PR TITLE
Fix inheritance recommendation in index.md

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -162,13 +162,11 @@ function Rectangle() {
   Shape.call(this); // call super constructor.
 }
 
-// subclass extends superclass
-Rectangle.prototype = Object.create(Shape.prototype);
-
-//If you don't set Rectangle.prototype.constructor to Rectangle,
-//it will take the prototype.constructor of Shape (parent).
-//To avoid that, we set the prototype.constructor to Rectangle (child).
-Rectangle.prototype.constructor = Rectangle;
+// This reassigns the prototype and takes care of updating the constructor property of the child prototype. 
+// This method is ill performing because the prototype is not set when the object is created. Many engines 
+// optimize the prototype and try to guess the location of the method in memory when calling an instance in advance; 
+// but setting the prototype dynamically disrupts all those optimizations.
+Object.setPrototypeOf(Rectangle.prototype, Shape.prototype)
 
 const rect = new Rectangle();
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the docs on Inheritance, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain, it is recommended not to reassign the prototype of a constructor function because it points the prototype to a new object and old instances will not be able to access the newly assigned prototype. It is recommended to use setPrototypeOf.

### Motivation

I noticed a discrepancy in the docs between inheritance and Object.create. In the inheritance doc, it's recommended to use Object.setPrototypeOf to achieve inheritance with constructor functions. In the Object.create doc, it still references the old approach with Object.create.
The discrepancy was confusing for me so I thought I would propose an update. Also in the docs it recommends not using Object.setPrototypeOf because of performance reasons. So I'm still unsure of how to correctly do inheritance with constructor functions. 

### Additional details

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#classical_inheritance_with_object.create

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#with_object.setprototypeof

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
