### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -156,7 +156,7 @@ function clock() {
   // Minute marks
   ctx.save();
   ctx.lineWidth = 5;
-  for (i = 0; i < 60; i++) {
+  for (let i = 0; i < 60; i++) {
     if (i % 5 !== 0) {
       ctx.beginPath();
       ctx.moveTo(117, 0);


### PR DESCRIPTION
### Description

In the animated clock example's code, the for loop on line 30 of the is missing the keyword let in its first expression's variable declaration. 
https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations

### Motivation

Help minimize syntax errors in examples on mdn web docs

