### PR TITLE
Fix improper use of <cite> element

### DIFF
--- a/files/en-us/web/html/element/figure/index.md
+++ b/files/en-us/web/html/element/figure/index.md
@@ -137,7 +137,7 @@ function NavigatorExample() {
 
 ```html
 <figure>
-  <figcaption><cite>Edsger Dijkstra:</cite></figcaption>
+  <figcaption><b>Edsger Dijkstra:</b></figcaption>
   <blockquote>
     If debugging is the process of removing software bugs, then programming must
     be the process of putting them in.


### PR DESCRIPTION
Reference from HTML Living Standard:

<figure>
<blockquote cite="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element"> <p>The cite element represents the title of a work [...]</p> <p>A person's name is not the title of a work — even if people call that person a piece of work — and the element must therefore not be used to mark up people's names.</p> </blockquote>
<figcaption><cite>HTML Living Standard – 4.5.6 The cite element</cite> (Last Updated 15 September 2022)</figcaption> </figure>

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
