### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -49,11 +49,11 @@ Next, create the "icons" directory inside the "buttons" directory, and save the 
 
 **"page-16.png":**
 
-![](page-16.png)
+!["16 pixel icon of a lined sheet of paper"](page-16.png)
 
 **"page-32.png":**
 
-![](page-32.png)
+!["32 pixel icon of a lined sheet of paper"](page-32.png)
 
 > **Note:** These icons are from the [bitsies!](https://www.iconfinder.com/iconsets/bitsies) iconset created by Recep Kütük.
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add alt text for page-16.png and page-32.png icons on "Add a button to the toolbar" page (https://developer.mozilla.org/en-US/docs/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar)

### Motivation

As requested in Issue #20735 to reduce the number of missing `alt` attributes on pages

### Additional details

Last set of images requiring alt text for the page

### Related issues and pull requests

Relates to #20735
