### PR TITLE
update: Nav menu background colors

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -477,7 +477,8 @@ a {
 a:link,
 a:visited,
 a:focus {
-  background: dodgerblue;
+  background: palegoldenrod;
+  color: black;
 }
 
 a:hover {
@@ -485,7 +486,7 @@ a:hover {
 }
 
 a:active {
-  background: hotpink;
+  background: darkred;
   color: white;
 }
 ```

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -477,7 +477,7 @@ a {
 a:link,
 a:visited,
 a:focus {
-  background: yellow;
+  background: dodgerblue;
 }
 
 a:hover {
@@ -485,7 +485,7 @@ a:hover {
 }
 
 a:active {
-  background: red;
+  background: hotpink;
   color: white;
 }
 ```


### PR DESCRIPTION
### Description
 I've replaced the colors because the yellow and red are harsh on the eyes.

I kept the language of the color simple, and I believe there wouldn't be any issue to identify the property of the color. 'hotpink' is pink, 'dodgerblue' is blue and orange is orange.

### Motivation

The currently used colors that display in the nav example are harsh on the eyes when you first scroll to that part of the site. You get greeted with a harsh yellow. When you activate the button, you get a harsh red... I think more subtle colors are more appropriate. 