### PR TITLE
fix: Sidebar macros stuck to text

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.commands.onCommand
 ---
 
-{{AddonSidebar()}}Fired when a command is executed using its associated keyboard shortcut.
+{{AddonSidebar()}}
+
+Fired when a command is executed using its associated keyboard shortcut.
 
 The listener is passed the command's name. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.extension.isAllowedFileSchemeAccess
 ---
 
-{{AddonSidebar()}}Returns `true` if the extension can access the "file://" scheme, `false` otherwise.
+{{AddonSidebar()}}
+
+Returns `true` if the extension can access the "file://" scheme, `false` otherwise.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -12,7 +12,9 @@ tags:
 browser-compat: webextensions.api.history.onTitleChanged
 ---
 
-{{AddonSidebar()}}Fired when the title of a page visited by the user is recorded. To listen for visits to a page you use {{WebExtAPIRef("history.onVisited")}}. However, the {{WebExtAPIRef("history.HistoryItem")}} that this event passes to its listener does not include the page title, because the page title is typically not known at the time `history.onVisited` is sent. Instead, the stored {{WebExtAPIRef("history.HistoryItem")}} is updated with the page title after the page has loaded, once the title is known. The `history.onTitleChanged` event is fired at that time. So if you need to know the titles of pages as they are visited, listen for `history.onTitleChanged`.
+{{AddonSidebar()}}
+
+Fired when the title of a page visited by the user is recorded. To listen for visits to a page you use {{WebExtAPIRef("history.onVisited")}}. However, the {{WebExtAPIRef("history.HistoryItem")}} that this event passes to its listener does not include the page title, because the page title is typically not known at the time `history.onVisited` is sent. Instead, the stored {{WebExtAPIRef("history.HistoryItem")}} is updated with the page title after the page has loaded, once the title is known. The `history.onTitleChanged` event is fired at that time. So if you need to know the titles of pages as they are visited, listen for `history.onTitleChanged`.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -12,7 +12,9 @@ tags:
 browser-compat: webextensions.api.management.getPermissionWarningsById
 ---
 
-{{AddonSidebar()}}When the user installs or upgrades an add-on, the browser may warn the user about any particularly powerful [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) that the add-on has requested. Not all permissions result in warnings, and this behavior is not standardized across browsers.
+{{AddonSidebar()}}
+
+When the user installs or upgrades an add-on, the browser may warn the user about any particularly powerful [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) that the add-on has requested. Not all permissions result in warnings, and this behavior is not standardized across browsers.
 
 Given the ID of an add-on, this function returns the permission warnings for it as an array of strings.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -12,7 +12,9 @@ tags:
 browser-compat: webextensions.api.management.getPermissionWarningsByManifest
 ---
 
-{{AddonSidebar()}}When the user installs or upgrades an add-on, the browser may warn the user about any particularly powerful [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) that the add-on has requested. Not all permissions result in warnings, and this behavior is not standardized across browsers.
+{{AddonSidebar()}}
+
+When the user installs or upgrades an add-on, the browser may warn the user about any particularly powerful [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) that the add-on has requested. Not all permissions result in warnings, and this behavior is not standardized across browsers.
 
 Given the text of a [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file, this function returns the permission warnings that would be given for the resulting add-on, as an array of strings.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
@@ -13,7 +13,9 @@ tags:
 browser-compat: webextensions.api.management.install
 ---
 
-{{AddonSidebar()}}Installs and enables a theme extension from the given URL.
+{{AddonSidebar()}}
+
+Installs and enables a theme extension from the given URL.
 
 This API requires the "management" [API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and will only work with signed themes.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -13,7 +13,9 @@ tags:
 browser-compat: webextensions.api.pageAction.openPopup
 ---
 
-{{AddonSidebar()}}Open the page action's popup.
+{{AddonSidebar()}}
+
+Open the page action's popup.
 
 You can only call this function from inside the handler for a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -11,7 +11,9 @@ tags:
 browser-compat: webextensions.api.permissions
 ---
 
-{{AddonSidebar}}Enables extensions to request extra permissions at runtime, after they have been installed.
+{{AddonSidebar}}
+
+Enables extensions to request extra permissions at runtime, after they have been installed.
 
 Extensions need permissions to access more powerful WebExtension APIs. They can ask for permissions at install time, by including the permissions they need in the [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) manifest.json key. The main advantages of asking for permissions at install time are:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.runtime.connectNative
 ---
 
-{{AddonSidebar()}}Connects the extension to a native application on the user's computer. This takes the name of a native application as a parameter. It starts the native application and returns a {{WebExtAPIRef("runtime.Port")}} object to the caller. The caller can then use the `Port` to exchange messages with the native application using `Port.postMessage()` and `port.onMessage`. The native application will run until it exits itself, or the caller calls `Port.disconnect()`, or the page that created the `Port` is destroyed. Once the `Port` is disconnected the browser will give the process a few seconds to exit gracefully, and then kill it if it has not exited.
+{{AddonSidebar()}}
+
+Connects the extension to a native application on the user's computer. This takes the name of a native application as a parameter. It starts the native application and returns a {{WebExtAPIRef("runtime.Port")}} object to the caller. The caller can then use the `Port` to exchange messages with the native application using `Port.postMessage()` and `port.onMessage`. The native application will run until it exits itself, or the caller calls `Port.disconnect()`, or the page that created the `Port` is destroyed. Once the `Port` is disconnected the browser will give the process a few seconds to exit gracefully, and then kill it if it has not exited.
 
 For more information, see [Native messaging](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.runtime.openOptionsPage
 ---
 
-{{AddonSidebar()}}If your extension has an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) defined, this method opens it.
+{{AddonSidebar()}}
+
+If your extension has an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) defined, this method opens it.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -13,7 +13,9 @@ tags:
 browser-compat: webextensions.api.sessions.forgetClosedTab
 ---
 
-{{AddonSidebar()}}Removes a closed tab from the browser's list of recently closed tabs. Note that the sites visited by that tab are not removed from the browser's history. Use the {{WebExtAPIRef("browsingData")}} or {{WebExtAPIRef("history")}} APIs to remove history.
+{{AddonSidebar()}}
+
+Removes a closed tab from the browser's list of recently closed tabs. Note that the sites visited by that tab are not removed from the browser's history. Use the {{WebExtAPIRef("browsingData")}} or {{WebExtAPIRef("history")}} APIs to remove history.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -13,7 +13,9 @@ tags:
 browser-compat: webextensions.api.sessions.forgetClosedWindow
 ---
 
-{{AddonSidebar()}}Removes a closed window from the browser's list of recently closed windows. Note that the sites visited by that window are not removed from the browser's history. Use the {{WebExtAPIRef("browsingData")}} or {{WebExtAPIRef("history")}} APIs to remove history.
+{{AddonSidebar()}}
+
+Removes a closed window from the browser's list of recently closed windows. Note that the sites visited by that window are not removed from the browser's history. Use the {{WebExtAPIRef("browsingData")}} or {{WebExtAPIRef("history")}} APIs to remove history.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -12,7 +12,9 @@ tags:
 browser-compat: webextensions.api.sidebarAction.open
 ---
 
-{{AddonSidebar()}}Open the sidebar in the active window.
+{{AddonSidebar()}}
+
+Open the sidebar in the active window.
 
 You can only call this function from inside the handler for a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.storage.StorageChange
 ---
 
-{{AddonSidebar()}}`StorageChange` is an object representing a change to a storage area.
+{{AddonSidebar()}}
+
+`StorageChange` is an object representing a change to a storage area.
 
 ## Type
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.tabs.highlight
 ---
 
-{{AddonSidebar()}}Highlights (selects) one or more tabs. Tabs are specified using a window ID and a range of tab indices.
+{{AddonSidebar()}}
+
+Highlights (selects) one or more tabs. Tabs are specified using a window ID and a range of tab indices.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
@@ -16,7 +16,9 @@ tags:
 browser-compat: webextensions.api.userScripts.onBeforeScript
 ---
 
-{{AddonSidebar}}The `onBeforeScript` event of the {{WebExtAPIRef("userScripts","browser.userScripts")}} is fired before a user script is executed. It can only be included in the API script, the script registered in [`"user_scripts"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts), where it is used to detect that the custom API methods should be exported to the user script.
+{{AddonSidebar}}
+
+The `onBeforeScript` event of the {{WebExtAPIRef("userScripts","browser.userScripts")}} is fired before a user script is executed. It can only be included in the API script, the script registered in [`"user_scripts"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts), where it is used to detect that the custom API methods should be exported to the user script.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.webNavigation.onReferenceFragmentUpdated
 ---
 
-{{AddonSidebar()}}Fired if the [fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier) for a page is changed. For example, if a page implements a table of contents using fragments, and the user clicks an entry in the table of contents, this event will fire. All future events for this frame will use the updated URL.
+{{AddonSidebar()}}
+
+Fired if the [fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier) for a page is changed. For example, if a page implements a table of contents using fragments, and the user clicks an entry in the table of contents, this event will fire. All future events for this frame will use the updated URL.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.webNavigation.TransitionQualifier
 ---
 
-{{AddonSidebar()}}Extra information about a transition. Note that many values here are not currently supported in Firefox: see the [browser compatibility table](#browser_compatibility) for details.
+{{AddonSidebar()}}
+
+Extra information about a transition. Note that many values here are not currently supported in Firefox: see the [browser compatibility table](#browser_compatibility) for details.
 
 ## Type
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -14,7 +14,9 @@ tags:
 browser-compat: webextensions.api.webRequest.handlerBehaviorChanged
 ---
 
-{{AddonSidebar()}}This function can be used to ensure that event listeners are applied correctly when pages are in the browser's in-memory cache. If the browser has loaded a page, and the page is reloaded, the browser may reload the page from its in-memory cache, and in this case, events will not be triggered for the request.
+{{AddonSidebar()}}
+
+This function can be used to ensure that event listeners are applied correctly when pages are in the browser's in-memory cache. If the browser has loaded a page, and the page is reloaded, the browser may reload the page from its in-memory cache, and in this case, events will not be triggered for the request.
 
 Suppose an extension's job is to block web requests against a pattern, and the following scenario happens:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -11,7 +11,9 @@ tags:
 browser-compat: webextensions.api.webRequest.StreamFilter.disconnect
 ---
 
-{{AddonSidebar()}}Disconnects the filter from the request. After this, the browser will continue to process the response, but no more filter events will fire, and no more filter function calls will have any effect. Note the difference between this function and {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}. With `disconnect()`, the browser will continue to process any further response data, but it won't be accessible through the filter. With `close()`, the browser will ignore any response data that hasn't already been passed through to the rendering engine.
+{{AddonSidebar()}}
+
+Disconnects the filter from the request. After this, the browser will continue to process the response, but no more filter events will fire, and no more filter function calls will have any effect. Note the difference between this function and {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}. With `disconnect()`, the browser will continue to process any further response data, but it won't be accessible through the filter. With `close()`, the browser will ignore any response data that hasn't already been passed through to the rendering engine.
 
 You should always call `disconnect()` or `close()` once you don't need to interact with the response any further.
 

--- a/files/en-us/web/api/aeskeygenparams/index.md
+++ b/files/en-us/web/api/aeskeygenparams/index.md
@@ -11,7 +11,9 @@ tags:
 spec-urls: https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams
 ---
 
-{{ APIRef("Web Crypto API") }}The **`AesKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
+{{ APIRef("Web Crypto API") }}
+
+The **`AesKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
 
 ## Properties
 

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -11,7 +11,9 @@ tags:
 spec-urls: https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams
 ---
 
-{{ APIRef("Web Crypto API") }}The **`EcKeyImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
+{{ APIRef("Web Crypto API") }}
+
+The **`EcKeyImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 
 ## Properties
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.md
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.md
@@ -5,7 +5,9 @@ page-type: web-api-instance-method
 browser-compat: api.FileReaderSync.readAsArrayBuffer
 ---
 
-{{APIRef("File API")}}The `readAsArrayBuffer()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{jsxref("ArrayBuffer")}}. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
+{{APIRef("File API")}}
+
+The `readAsArrayBuffer()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{jsxref("ArrayBuffer")}}. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
 ## Syntax
 

--- a/files/en-us/web/api/hkdfparams/index.md
+++ b/files/en-us/web/api/hkdfparams/index.md
@@ -11,7 +11,9 @@ tags:
 spec-urls: https://w3c.github.io/webcrypto/#dfn-HkdfParams
 ---
 
-{{ APIRef("Web Crypto API") }}The **`HkdfParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when using the [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf) algorithm.
+{{ APIRef("Web Crypto API") }}
+
+The **`HkdfParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when using the [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf) algorithm.
 
 ## Properties
 

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: api.SecurityPolicyViolationEvent.disposition
 ---
 
-{{HTTPSidebar}}")}}
+{{HTTPSidebar}}
 
 The **`disposition`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated policy

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: api.SecurityPolicyViolationEvent.lineNumber
 ---
 
-{{HTTPSidebar}}")}}
+{{HTTPSidebar}}
 
 The **`lineNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document


### PR DESCRIPTION
Only seems to affect a few of the Addon sidebars, and a few malformed HTTP ones