### PR TITLE
JS: RegExp add missing static properties

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -2,12 +2,12 @@
 title: RegExp
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
 tags:
-  - Class
-  - JavaScript
-  - Reference
-  - RegExp
-  - Regular Expressions
-  - Polyfill
+- Class
+- JavaScript
+- Reference
+- RegExp
+- Regular Expressions
+- Polyfill
 browser-compat: javascript.builtins.RegExp
 ---
 
@@ -110,7 +110,15 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
 - {{JSxRef("RegExp.n", "RegExp.$1-$9")}}
   - : The legacy read-only static properties that contain parenthesized substring matches.
 - {{JSxRef("RegExp.input", "RegExp.input ($_)")}} {{Non-standard_Inline}}
-  - : A static property that contains the last string against which a regular expression was successfully matched.
+  - : A static read-only property that contains the last string against which a regular expression was successfully matched.
+- {{JSxRef("RegExp.lastMatch", "RegExp.lastMatch ($&)")}} {{Non-standard_Inline}}
+  - : A static read-only property that contains the last matched characters.
+- {{JSxRef("RegExp.lastParen", "RegExp.lastParen ($+)")}} {{Non-standard_Inline}}
+  - : A static property that contains the last parenthesized substring match.
+- {{JSxRef("RegExp.leftContext", "RegExp.leftContext ($`)")}} {{Non-standard_Inline}}
+  - : A static read-only property that contains the substring preceding the most recent match.
+- {{JSxRef("RegExp.rightContext", "RegExp.rightContext ($')")}} {{Non-standard_Inline}}
+  - : A static read-only property that contains the substring following the most recent match.
 
 ## Instance properties
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -2,12 +2,12 @@
 title: RegExp
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
 tags:
-- Class
-- JavaScript
-- Reference
-- RegExp
-- Regular Expressions
-- Polyfill
+  - Class
+  - JavaScript
+  - Reference
+  - RegExp
+  - Regular Expressions
+  - Polyfill
 browser-compat: javascript.builtins.RegExp
 ---
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -107,6 +107,10 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
 
 - {{jsxref("RegExp.@@species", "get RegExp[@@species]")}}
   - : The constructor function that is used to create derived objects.
+- {{JSxRef("RegExp.n", "RegExp.$1-$9")}}
+  - : The legacy read-only static properties that contain parenthesized substring matches.
+- {{JSxRef("RegExp.input", "RegExp.input ($_)")}} {{Non-standard_Inline}}
+  - : A static property that contains the last string against which a regular expression was successfully matched.
 
 ## Instance properties
 
@@ -252,7 +256,7 @@ console.log(regex.lastIndex); // logs '15'
 
 The [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) feature introduces a solution, by allowing for a statement as simple as `\p{scx=Cyrl}`.
 
-### Extracting sub-domain name from URL
+### Extracting subdomain name from URL
 
 ```js
 const url = "http://xxx.domain.com";


### PR DESCRIPTION
### Description

The PR adds two missing static properties to the page.
Though non standard they need to be listed on the page.