### PR TITLE
Fix spelling of an expression

### DIFF
--- a/files/en-us/glossary/modem/index.md
+++ b/files/en-us/glossary/modem/index.md
@@ -6,7 +6,7 @@ tags:
   - Navigation
 ---
 
-A modem ("**modulator-demodulator**") is a device that converts digital information to analog signals and vice-versa, for sending data through networks.
+A modem ("**modulator-demodulator**") is a device that converts digital information to analog signals and vice versa, for sending data through networks.
 
 Different kinds are used for different networks: DSL modems for telephone wires, Wi-Fi modems for short-range wireless radio signals, 3G modems for cellular data towers, and so on.
 

--- a/files/en-us/web/api/filesystementry/isdirectory/index.md
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.md
@@ -24,7 +24,7 @@ and `false` if it's not.
 You can also use {{domxref("FileSystemEntry.isFile", "isFile")}} to determine if the
 entry is a file.
 
-> **Warning:** You should not assume that any entry which isn't a directory is a file or vice-versa.
+> **Warning:** You should not assume that any entry which isn't a directory is a file or vice versa.
 > There are other types of file descriptors on many operating systems. Be sure to use
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.

--- a/files/en-us/web/api/filesystementry/isfile/index.md
+++ b/files/en-us/web/api/filesystementry/isfile/index.md
@@ -24,7 +24,7 @@ represents a file (meaning it's a {{domxref("FileSystemFileEntry")}}) and
 You can also use {{domxref("FileSystemEntry.isDirectory", "isDirectory")}} to determine
 if the entry is a directory.
 
-> **Warning:** You should not assume that any entry which isn't a file is a directory or vice-versa.
+> **Warning:** You should not assume that any entry which isn't a file is a directory or vice versa.
 > There are other types of file descriptors on many operating systems. Be sure to use
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -13,7 +13,7 @@ browser-compat: api.HTMLLinkElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLLinkElement`** interface represents reference information for external resources and the relationship of those resources to a document and vice-versa (corresponds to [`<link>`](/en-US/docs/Web/HTML/Element/link) element; not to be confused with [`<a>`](/en-US/docs/Web/HTML/Element/a), which is represented by [`HTMLAnchorElement`](/en-US/docs/Web/API/HTMLAnchorElement)). This object inherits all of the properties and methods of the {{domxref("HTMLElement")}} interface.
+The **`HTMLLinkElement`** interface represents reference information for external resources and the relationship of those resources to a document and vice versa (corresponds to [`<link>`](/en-US/docs/Web/HTML/Element/link) element; not to be confused with [`<a>`](/en-US/docs/Web/HTML/Element/a), which is represented by [`HTMLAnchorElement`](/en-US/docs/Web/API/HTMLAnchorElement)). This object inherits all of the properties and methods of the {{domxref("HTMLElement")}} interface.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -289,7 +289,7 @@ function handleVisibilityChange() {
 }
 ```
 
-Since the event itself doesn't state whether the document has switched from visible to invisible or vice-versa, the {{domxref("document.hidden")}} property is checked to see if the document is not currently visible. Since it's theoretically possible to get called multiple times, we only proceed if we haven't already paused the timers and saved the visibility states of the existing ads.
+Since the event itself doesn't state whether the document has switched from visible to invisible or vice versa, the {{domxref("document.hidden")}} property is checked to see if the document is not currently visible. Since it's theoretically possible to get called multiple times, we only proceed if we haven't already paused the timers and saved the visibility states of the existing ads.
 
 To pause the timers, all we need to do is remove the ads from the set of visible ads (`visibleAds`) and mark them as inactive. To do so, we begin by saving the set of visible ads into a variable known as `previouslyVisibleAds` to be sure we can restore them when the user tabs back into the document, and we then empty the `visibleAds` set so they won't be treated as visible. Then, for each of the ads that are being suspended, we call our `updateAdTimer()` function, which handles updating the ad's total visible time counter, then we set their `dataset.lastViewStarted` property to 0, which indicates that the tab's timer isn't running.
 

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -16,7 +16,7 @@ A **`Selection`** object represents the range of text selected by the user or th
 
 A user may make a selection from left to right (in document order) or right to left (reverse of document order). The **_anchor_** is where the user began the selection and the **_focus_** is where the user ends the selection. If you make a selection with a desktop mouse, the anchor is placed where you pressed the mouse button, and the focus is placed where you released the mouse button.
 
-> **Note:** _Anchor_ and _focus_ should not be confused with the _start_ and _end_ positions of a selection. The anchor can be placed before the focus or vice-versa, depending on the direction you made your selection.
+> **Note:** _Anchor_ and _focus_ should not be confused with the _start_ and _end_ positions of a selection. The anchor can be placed before the focus or vice versa, depending on the direction you made your selection.
 
 ## Properties
 

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -88,7 +88,7 @@ When starting the signaling process, an **offer** is created by the user initiat
 - `name`
   - : The sender's username.
 - `target`
-  - : The username of the person to receive the description (if the caller is sending the message, this specifies the callee, and vice-versa).
+  - : The username of the person to receive the description (if the caller is sending the message, this specifies the callee, and vice versa).
 - `sdp`
   - : The SDP (Session Description Protocol) string describing the local end of the connection from the perspective of the sender (or the remote end of the connection from the receiver's point of view).
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -193,5 +193,5 @@ If this value isn't 0, there's pending data still, so you may wish to wait befor
 
 ## Security considerations
 
-WebSockets should not be used in a mixed content environment; that is, you shouldn't open a non-secure WebSocket connection from a page loaded using HTTPS or vice-versa.
+WebSockets should not be used in a mixed content environment; that is, you shouldn't open a non-secure WebSocket connection from a page loaded using HTTPS or vice versa.
 Most browsers now only allow secure WebSocket connections, and no longer support using them in insecure contexts.

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -90,7 +90,7 @@ Either the client or the server can choose to send a message at any time — tha
 
 ### Format
 
-Each data frame (from the client to the server or vice-versa) follows this same format:
+Each data frame (from the client to the server or vice versa) follows this same format:
 
 ```bash
 Frame format:

--- a/files/en-us/web/api/webxr_device_api/cameras/index.md
+++ b/files/en-us/web/api/webxr_device_api/cameras/index.md
@@ -296,7 +296,7 @@ Here, `[0, 0, dollyDistance]` is a vector wherein `dollyDistance` is the distanc
 
 ### Trucking (Moving left or right)
 
-**Trucking** using a physical camera uses the same kind of rigging as dollying, but instead of moving the camera forward and backward, it moves from left to right or vice-versa. The camera doesn't rotate at all, so the focus of the shot slowly glides off the screen. This can suggest concentration, time passing, or contemplation when attempting to establish emotion in a scene. It's also used frequently in "walk-and-talk" scenes, wherein the camera glides alongside the characters and they walk through the scene.
+**Trucking** using a physical camera uses the same kind of rigging as dollying, but instead of moving the camera forward and backward, it moves from left to right or vice versa. The camera doesn't rotate at all, so the focus of the shot slowly glides off the screen. This can suggest concentration, time passing, or contemplation when attempting to establish emotion in a scene. It's also used frequently in "walk-and-talk" scenes, wherein the camera glides alongside the characters and they walk through the scene.
 
 ![A diagram showing how a camera trucks left and right](camera-truck.png)
 

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -105,7 +105,7 @@ The input source's {{domxref("XRInputSource.gripSpace", "gripSpace")}} property 
 **Figure: The coordinate system for the right hand's grip space.**
 ![A diagram showing how the grip space indicates the local coordinate system for the player's hand relative to the world.](dark_right.svg)
 
-The grip space's native origin, located around the center of the player's fist, is (0, 0, 0) within the input source's local coordinate system, while the {{domxref("XRSpace")}} specified by `gripSpace` can be used at any time to convert coordinates or vectors from the input source's space into world coordinates (or vice-versa).
+The grip space's native origin, located around the center of the player's fist, is (0, 0, 0) within the input source's local coordinate system, while the {{domxref("XRSpace")}} specified by `gripSpace` can be used at any time to convert coordinates or vectors from the input source's space into world coordinates (or vice versa).
 
 This means that if you use a 3D model to represent your controller, your player's avatar's hands, or anything else representative of the controller's position in space, the `gripSpace` can be used as the transform matrix that correctly positions and orients the object's model for rendering. To do this, it's necessary to use the transform to convert the grip space to the world coordinate system used by WebGL for rendering purposes.
 

--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -47,7 +47,7 @@ Because each of these is defined using a reference space as its foundation, the 
 
 ## Describing a position relative to a space
 
-There are two scenarios in which you may need to describe a position and/or orientation relative to a space. The first is [described above](#offsetting_or_moving_reference_spaces): applying a reference space to an offset (or vice-versa, since the result is the same) to determine the transform matrix that represents the resulting location in the space's coordinate system.
+There are two scenarios in which you may need to describe a position and/or orientation relative to a space. The first is [described above](#offsetting_or_moving_reference_spaces): applying a reference space to an offset (or vice versa, since the result is the same) to determine the transform matrix that represents the resulting location in the space's coordinate system.
 
 ### Poses
 

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -18,7 +18,7 @@ including Cross-Site Scripting ({{Glossary("Cross-site_scripting", "XSS")}}) and
 These attacks are used for everything from data theft, to site defacement, to malware distribution.
 
 CSP is designed to be fully backward compatible (except CSP version 2 where there are some explicitly-mentioned inconsistencies in backward compatibility; more details [here](https://www.w3.org/TR/CSP2/) section 1.1).
-Browsers that don't support it still work with servers that implement it, and vice-versa: browsers that don't support CSP ignore it, functioning as usual, defaulting to the standard same-origin policy for web content.
+Browsers that don't support it still work with servers that implement it, and vice versa: browsers that don't support CSP ignore it, functioning as usual, defaulting to the standard same-origin policy for web content.
 If the site doesn't offer the CSP header, browsers likewise use the standard [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
 To enable CSP, you need to configure your web server to return the {{HTTPHeader("Content-Security-Policy")}} HTTP header.

--- a/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
@@ -60,7 +60,7 @@ Math.clz32(3.5);         // 30
 
 ### Implementing Count Leading Ones and beyond
 
-At present, there is no `Math.clon` for "Count Leading Ones" (named "clon", not "clo", because "clo" and "clz" are too similar especially for non-English-speaking people). However, a `clon` function can easily be created by inverting the bits of a number and passing the result to `Math.clz32`. Doing this will work because the inverse of 1 is 0 and vice-versa. Thus, inverting the bits will inverse the measured quantity of 0's (from `Math.clz32`), thereby making `Math.clz32` count the number of ones instead of counting the number of zeros.
+At present, there is no `Math.clon` for "Count Leading Ones" (named "clon", not "clo", because "clo" and "clz" are too similar especially for non-English-speaking people). However, a `clon` function can easily be created by inverting the bits of a number and passing the result to `Math.clz32`. Doing this will work because the inverse of 1 is 0 and vice versa. Thus, inverting the bits will inverse the measured quantity of 0's (from `Math.clz32`), thereby making `Math.clz32` count the number of ones instead of counting the number of zeros.
 
 Consider the following 32-bit word:
 

--- a/meta/content/en/legacy/archiving.md
+++ b/meta/content/en/legacy/archiving.md
@@ -29,7 +29,7 @@ you can follow the below steps to unarchive it:
 > When removing the page from MDN, remember to use the [delete command](#deleting-a-document).
 
 **Note:** You can have an archived page with non-archived pages below it in the
-hierarchy, and vice-versa. To achieve this you need to have the same directory
+hierarchy, and vice versa. To achieve this you need to have the same directory
 structure in both the `content` and `archive-content` repos. Whether a page
 is non-archived or archived depends on which repo its `index.html` file is
 in. As an example, compare the [archived-content mozilla directory](https://github.com/mdn/archived-content/tree/main/files/en-us/mozilla)


### PR DESCRIPTION
There should be no hyphen in "vice versa".