### PR TITLE
modify dialog example markup

### DIFF
--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -51,27 +51,25 @@ button.
 <!-- Simple pop-up dialog box, containing a form -->
 <dialog id="favDialog">
   <form method="dialog">
-    <section>
-      <p>
-        <label for="favAnimal">Favorite animal:</label>
-        <select id="favAnimal" name="favAnimal">
-          <option></option>
-          <option>Brine shrimp</option>
-          <option>Red panda</option>
-          <option>Spider monkey</option>
-        </select>
-      </p>
-    </section>
-    <menu>
+    <p>
+      <label for="favAnimal">Favorite animal:</label>
+      <select id="favAnimal" name="favAnimal">
+        <option></option>
+        <option>Brine shrimp</option>
+        <option>Red panda</option>
+        <option>Spider monkey</option>
+      </select>
+    </p>
+    <div>
       <button id="cancel" type="reset">Cancel</button>
       <button type="submit">Confirm</button>
-    </menu>
+    </div>
   </form>
 </dialog>
 
-<menu>
+<div>
   <button id="updateDetails">Update details</button>
-</menu>
+</div>
 
 <script>
   (() => {


### PR DESCRIPTION
companion PR which contains the same changes but on the example file - https://github.com/mdn/dom-examples/pull/172

### Description

Revises and corrects markup for the modal dialog example

### Motivation

 I was working with a developer who had invalid nesting of buttons in a menu element.  They pointed to this page as being the reason why they thought it was ok.
