### PR TITLE
Function#bind() doesn't inherit static properties

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -83,7 +83,14 @@ const BoundBase = Base.bind(null, 1, 2);
 console.log(new Base() instanceof BoundBase); // true
 ```
 
-The bound function's [`length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) property is the `length` of the target function minus the number of arguments being bound (not counting the `thisArg` parameter), with 0 being the minimum value. The bound function's [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) property is the `name` of the target function plus a `"bound "` prefix.
+The bound function has the following properties:
+
+- [`length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
+  - : The `length` of the target function minus the number of arguments being bound (not counting the `thisArg` parameter), with 0 being the minimum value.
+- [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name)
+  - : The `name` of the target function plus a `"bound "` prefix.
+
+The bound function also inherits the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of the target function. However, it doesn't have other properties of the target function (such as [static properties](/en-US/docs/Web/JavaScript/Reference/Classes/static) if the target function is a class).
 
 ## Examples
 
@@ -273,6 +280,25 @@ const slice = Function.prototype.call.bind(unboundSlice);
 // ...
 
 slice(arguments);
+```
+
+### Binding classes
+
+Using `bind()` on classes preserves most of the class's semantics, except that all static properties of the current class are lost. However, because the prototype chain is preserved, you can still access the static properties of the parent class.
+
+```js
+class Base {
+  static baseProp = "base";
+}
+
+class Derived extends Base {
+  static derivedProp = "derived";
+}
+
+const BoundDerived = Derived.bind(null);
+console.log(BoundDerived.baseProp); // "base"
+console.log(BoundDerived.derivedProp); // undefined
+console.log(new BoundDerived() instanceof Derived); // true
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -90,7 +90,7 @@ The bound function has the following properties:
 - [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name)
   - : The `name` of the target function plus a `"bound "` prefix.
 
-The bound function also inherits the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of the target function. However, it doesn't have other properties of the target function (such as [static properties](/en-US/docs/Web/JavaScript/Reference/Classes/static) if the target function is a class).
+The bound function also inherits the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of the target function. However, it doesn't have other own properties of the target function (such as [static properties](/en-US/docs/Web/JavaScript/Reference/Classes/static) if the target function is a class).
 
 ## Examples
 
@@ -284,7 +284,7 @@ slice(arguments);
 
 ### Binding classes
 
-Using `bind()` on classes preserves most of the class's semantics, except that all static properties of the current class are lost. However, because the prototype chain is preserved, you can still access the static properties of the parent class.
+Using `bind()` on classes preserves most of the class's semantics, except that all static own properties of the current class are lost. However, because the prototype chain is preserved, you can still access static properties inherited from the parent class.
 
 ```js
 class Base {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix #20880

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
