### PR TITLE
Safari StorageArea.{get,remove} do not support empty keys

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -52,6 +52,15 @@ If managed storage is not set, `undefined` will be returned.
 >
 > When this API is used as `chrome.storage.local.get()`, it correctly passes an Object to the callback function.
 
+## Safari empty key bug
+
+Safari has a bug which prevents this method from retreiving the data associated with the empty key `""` if it is explicitly specified. Specifically, Safari will throw an error `Error: Invalid empty key found in array passed to StorageArea.get()`. Instead, developers can pass `null` as the first argument to retreive all data in the storage area and then choose the desired data:
+
+```js
+const data = await StorageArea.get(null);
+cosnole.log(data['']);
+```
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -40,6 +40,13 @@ let removingItem = browser.storage.<storageType>.remove(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments if the operation succeeded. If the operation failed, the promise will be rejected with an error message.
 
+## Safari empty key bug
+
+Safari has a bug which prevents this method from deleting the data associated with the empty key `""`. Specifically, `StorageArea.remove("")` and `StorageArea.remove([""])` will both throw `Error: Invalid empty key found in array passed to storage.StorageArea.remove()`. Instead, storage can be cleared via two other alternatives:
+
+- call to {{WebExtAPIRef("storage.StorageArea.clear")}} which will remove all data from the storge area, including this recod, or
+- call to {{WebExtAPIRef("storage.StorageArea.set")}} to overwrite this this data with some blank value like empty string `""` (record consumes 2 bytes from quota), or number `0` (record consmes 1 byte from quota).
+
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add note that `StorageArea.{get,remove}` on Safari do not support empty storage keys. Also, add an explanation of how to work around this limitation.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Inform readers of cross-platform compatibility limitations.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Matching BCD PR: https://github.com/mdn/browser-compat-data/pull/17826
This originally came up here: https://github.com/w3c/webextensions/issues/278
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
