### PR TITLE
Remove `spec-urls` from CSS functions

### DIFF
--- a/files/en-us/web/css/acos/index.md
+++ b/files/en-us/web/css/acos/index.md
@@ -11,7 +11,6 @@ tags:
   - acos
   - Experimental
 browser-compat: css.types.acos
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/asin/index.md
+++ b/files/en-us/web/css/asin/index.md
@@ -11,7 +11,6 @@ tags:
   - asin
   - Experimental
 browser-compat: css.types.asin
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/atan/index.md
+++ b/files/en-us/web/css/atan/index.md
@@ -11,7 +11,6 @@ tags:
   - atan
   - Experimental
 browser-compat: css.types.atan
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/atan2/index.md
+++ b/files/en-us/web/css/atan2/index.md
@@ -11,7 +11,6 @@ tags:
   - atan2
   - Experimental
 browser-compat: css.types.atan2
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -11,7 +11,6 @@ tags:
   - cos
   - Experimental
 browser-compat: css.types.cos
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -11,7 +11,6 @@ tags:
   - log
   - Experimental
 browser-compat: css.types.log
-spec-urls: https://www.w3.org/TR/css-values-4/#exponent-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -11,7 +11,6 @@ tags:
   - sin
   - Experimental
 browser-compat: css.types.sin
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -11,7 +11,6 @@ tags:
   - tan
   - Experimental
 browser-compat: css.types.tan
-spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 
 {{CSSRef}}{{SeeCompatTable}}


### PR DESCRIPTION
### Description
CSS function pages I created have both  `spec-urls:` and a similar spec link in BCD. This PR removed the duplicate links to specs.

### Motivation
A request by @wbamberg.
