### PR TITLE
Clarify that we use plural for Examples heading even if there's only one

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -21,7 +21,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 >
 > ```md
 > ---
-> title: 'NameOfTheParentInterface: NameOfTheEvent event'
+> title: "NameOfTheParentInterface: NameOfTheEvent event"
 > slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event
 > page-type: web-api-event
 > tags:
@@ -107,9 +107,9 @@ You could copy most of this from the property's summary on the corresponding API
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('NameOfTheEvent', (event) => {});
+addEventListener("NameOfTheEvent", (event) => {});
 
-onNameOfTheEvent = (event) => { };
+onNameOfTheEvent = (event) => {};
 ```
 
 ## Event type
@@ -147,6 +147,8 @@ and
 which can provide more information.
 
 ## Examples
+
+Note that we use the plural "Examples" even if the page only contains one example.
 
 ### A descriptive heading
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -139,6 +139,8 @@ The _name of interface_ extends the following APIs, adding the listed features.
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -135,6 +135,8 @@ Here is an example where a method can raise a `DOMException` with a name of `Ind
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -99,6 +99,8 @@ Include a description of the property's value, including data type and what it r
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -103,6 +103,8 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
@@ -72,6 +72,8 @@ Include a complete description of the attribute or role.
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -114,6 +114,8 @@ Include a description of the property and what component subvalues make up a com
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -97,6 +97,8 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -21,7 +21,7 @@ browser-compat: path.to.feature.NameOfTheElement
 >
 > ```md
 > ---
-> title: '<NameOfTheElement>: The NameOfTheElement element'
+> title: "<NameOfTheElement>: The NameOfTheElement element"
 > slug: Web/HTML/Element/NameOfTheElement
 > tags:
 >   - NameOfTheElement
@@ -110,6 +110,8 @@ Include a table of the events fired on this type of element, if any.
 | etc.       |                                  |
 
 ## Examples
+
+Note that we use the plural "Examples" even if the page only contains one example.
 
 ### A descriptive heading
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -129,6 +129,8 @@ If the header has a lot of available directives, feel free to include multiple d
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -115,6 +115,8 @@ This element implements the {{domxref("NameOfSVGDOMElement")}} interface.
 
 ## Examples
 
+Note that we use the plural "Examples" even if the page only contains one example.
+
 ### A descriptive heading
 
 Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.


### PR DESCRIPTION
Clarify that we always use "Examples" plural for the heading text, even if there is only one example.

I think this has been discussed and agreed before although I can't find where.
