### PR TITLE
Add another way to obtain URLSearchParams() object

### DIFF
--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -45,7 +45,10 @@ various inputs.
 ```js
 // Retrieve params via url.search, passed into ctor
 const url = new URL('https://example.com?foo=1&bar=2');
-const params = new URLSearchParams(url.search);
+const params1 = new URLSearchParams(url.search);
+
+// Get the URLSearchParams object directly from an URL object
+const params1a = url.searchParams
 
 // Pass in a string literal
 const params2 = new URLSearchParams("foo=1&bar=2");


### PR DESCRIPTION
Another way to obtain URLSearchParams object is to directly retrieve it from a URL object.  The URL().searchParams will return a URLSearchParams object.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add another way to obtain URLSearchParams() object

### Motivation

In the examples, we are constructing a URLSearchParams object using the URL object's search property. It is also a good place to mention that URL object have a property called searchParams which is already a URLSearchParams() object. So readers are aware of a simpler way to get a URLSearchParams object from a URL object.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
