### PR TITLE
[tiny] Fix minor typo

### DIFF
--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -327,7 +327,7 @@ The function that we will be using to compose our matrices is `multiplyArrayOfMa
 ```js
 let transformMatrix = MDN.multiplyArrayOfMatrices([
   rotateAroundZAxis(Math.PI * 0.5),    // Step 3: rotate around 90 degrees
-  translate(0, 200, 0),                // Step 2: move down 100 pixels
+  translate(0, 200, 0),                // Step 2: move down 200 pixels
   scale(0.8, 0.8, 0.8),                // Step 1: scale down
 ]);
 ```
@@ -344,7 +344,7 @@ let transformMatrix = MDN.multiplyArrayOfMatrices([
   translate(0, -200, 0),               // Step 5: move back up
   rotateAroundZAxis(-Math.PI * 0.5),   // Step 4: rotate back
   rotateAroundZAxis(Math.PI * 0.5),    // Step 3: rotate around 90 degrees
-  translate(0, 200, 0),                // Step 2: move down 100 pixels
+  translate(0, 200, 0),                // Step 2: move down 200 pixels
   scale(0.8, 0.8, 0.8),                // Step 1: scale down
 ]);
 ```


### PR DESCRIPTION
Fix comment describing matrix translation.

### Description

Fix a minor typo in comments for matrix translation code.

### Motivation

Typos in documentation degrade trust in source for readers.

### Additional details


### Related issues and pull requests
