### PR TITLE
fix: BookmarkTreeNodeType is a type

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -7,8 +7,8 @@ tags:
   - BookmarkTreeNodeType
   - Bookmarks
   - Extensions
-  - Property
   - Reference
+  - Type
   - WebExtensions
 browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeType
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`bookmarks.BookmarkTreeNode` was tagged as a Property (and appeared in the sidebar accordingly), when in fact it's a Type.

### Motivation

Avoids confusion.

### Additional details

The page itself mentions that it's a type.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
