### PR TITLE
Remove broken link

### DIFF
--- a/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
+++ b/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
@@ -104,8 +104,6 @@ In the context of the rendering waterfall, some properties are more expensive th
   </tbody>
 </table>
 
-> **Note:** The [CSS Triggers](https://csstriggers.com/) website shows how much of the waterfall is triggered for each CSS property, with information for most CSS properties by browser engine.
-
 ## Developer tools
 
 Most web browsers include tools to provide insight into the work the browser is doing when it animates elements of a page. Using these tools you can measure an application's animation frame rate, and diagnose performance bottlenecks if any are found.


### PR DESCRIPTION
Remove reference and URL to CSS Triggers website because it has been down for quite some time.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

CSS Triggers website seems to be unavailable for quite some time now, which led to a 404 page when the link was clicked.

### Motivation

To avoid users clicking on the link only to find out that the referred website is unavailable.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
