### PR TITLE
Fixing a Mislabelled Code Example

### DIFF
--- a/files/en-us/web/css/selector_list/index.md
+++ b/files/en-us/web/css/selector_list/index.md
@@ -36,12 +36,7 @@ element, element, element { style properties }
 Grouping selectors in a single line using a comma-separated lists.
 
 ```css
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   font-family: helvetica;
 }
 ```


### PR DESCRIPTION
### Description
There appears to be a typo with an example's result code snippet. The title of the code example states that it should represent a "single line", but the code showed a multiple line example.

### Motivation

Improve documentation

### Additional details

Error located here: https://developer.mozilla.org/en-US/docs/Web/CSS/Selector_list#single_line_grouping
