### PR TITLE
findLastIndex correct description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.TypedArray.findLastIndex
 
 {{JSRef}}
 
-The **`findLastIndex()`** method returns the index of the first element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
+The **`findLastIndex()`** method returns the index of the last element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
 If no values satisfy the testing function, -1 is returned.
 
 See also the {{jsxref("TypedArray.findLast()", "findLast()")}} method, which returns the value of the found element rather than its index.


### PR DESCRIPTION
findLastIndex should return the last element not the first.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Just a small type in the findLastIndex docs that states it returns the first element.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Just wanted to fix typo and avoid confusion
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
