### PR TITLE
Add property tag to devtool pages

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -5,6 +5,7 @@ tags:
   - API
   - Add-ons
   - Extensions
+  - Property
   - Reference
   - WebExtensions
   - devtools.inspectedWindow

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -5,6 +5,7 @@ tags:
   - API
   - Add-ons
   - Extensions
+  - Property
   - Reference
   - WebExtensions
   - devtools.network

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -5,6 +5,7 @@ tags:
   - API
   - Add-ons
   - Extensions
+  - Property
   - Reference
   - WebExtensions
   - devtools.panels


### PR DESCRIPTION
### Description

Following the discussion on "Add devtools interfaces to web extension side bar"[#5158](https://github.com/mdn/yari/issues/5158), adds the property tag to the devtools pages, so they appear in the side bar menu, like this:

![image](https://user-images.githubusercontent.com/7352080/191572612-d6bd428a-5962-46ad-a24e-5eab675ae130.png)