### PR TITLE
Fix case in policyOptions function names

### DIFF
--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -37,11 +37,11 @@ createPolicy(policyName, policyOptions)
 
   - : User-defined functions for converting strings into trusted values.
 
-    - `CreateHTML(input[,args])`
+    - `createHTML(input[,args])`
       - : A callback function in the form of a string that contains code to run when creating a {{domxref("TrustedHTML")}} object.
-    - `CreateScript(input[,args])`
+    - `createScript(input[,args])`
       - : A callback function in the form of a string that contains code to run when creating a {{domxref("TrustedScript")}} object.
-    - `CreateScriptURL(input[,args])`
+    - `createScriptURL(input[,args])`
       - : A callback function in the form of a string that contains code to run when creating a {{domxref("TrustedScriptURL")}} object.
 
 ### Return value


### PR DESCRIPTION
### Description

This is a mini drive-by fix to the case of the `policyOption` function names, they should not start by a capital letter.

### Motivation

I was playing with TrustedTypes, and noticed that the documentation suggested passing `CreateScriptURL`, but the browser wants `createScriptURL`.

### Additional details

n/a

### Related issues and pull requests

n/a

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
