### PR TITLE
Firefox 63 notes: update link to the bug for CSS MQ4 range syntax

### DIFF
--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -40,7 +40,7 @@ This article provides information about the changes in Firefox 63 that will affe
 - Re-enabled support for [webkit-prefixed pixel-density @media queries](/en-US/docs/Web/CSS/@media/-webkit-device-pixel-ratio) ({{bug(1444139)}}).
 - Support added for the [CSS Flexible Box Layout](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout) (Flexbox) properties {{CSSxRef("align-self")}}, {{CSSxRef("align-content")}}, and {{CSSxRef("align-items")}} as well as the {{CSSxRef("justify-content")}} property ({{bug(1472843)}}).
 - Implemented the `path()` function for {{CSSxRef("offset-path")}} ({{bug(1429298)}}).
-- Implemented [syntax improvements from the Media Queries Level 4 specification](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4) ({{bug(1472843)}}).
+- Implemented [syntax improvements from the Media Queries Level 4 specification](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4) ({{bug(1422225)}}).
 - Renamed `offset-*` properties to {{CSSxRef("inset-block-start")}}, {{CSSxRef("inset-block-end")}}, {{CSSxRef("inset-inline-start")}}, and {{CSSxRef("inset-inline-end")}} ({{bug(1464782)}}).
 - Added support for the [prefers-reduced-motion](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media feature ({{bug(1365045)}}, {{bug(1475462)}}).
 - Added flow relative values (`block`, `inline`) for the {{CSSxRef("resize")}} property ({{bug(1464786)}}).


### PR DESCRIPTION
### Description

The CSS section notes the following improvement:

> Implemented [syntax improvements from the Media Queries Level 4 specification](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4) ([bug 1472843](https://bugzilla.mozilla.org/show_bug.cgi?id=1472843)).

However, that bug id is the wrong one (it was the same as the Flexbox bug that is two bullets above.)

This patch updates the bug id to the correct one.

### Motivation

For the better web archeology.

### Additional details

[<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63#css)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
