### PR TITLE
Generic description for private class features, return overrides example

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -11,55 +11,48 @@ browser-compat: javascript.classes.private_class_fields
 
 {{JsSidebar("Classes")}}
 
-Class fields are {{ jsxref('Classes/Public_class_fields','public') }} by default, but private class members can be created
-by using a hash `#` prefix. The privacy encapsulation of these class features is
-enforced by JavaScript itself.
+Class fields are [public](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) by default, but private class members can be created by using a hash `#` prefix. The privacy encapsulation of these class features is enforced by JavaScript itself.
 
 Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) objects or [closures](/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
 
 ## Syntax
 
 ```js-nolint
-class ClassWithPrivateField {
+class ClassWithPrivate {
   #privateField;
-}
+  #privateFieldWithInitializer = 42;
 
-class ClassWithPrivateMethod {
   #privateMethod() {
-    return 'hello world';
+    // …
   }
-}
 
-class ClassWithPrivateStaticField {
-  static #PRIVATE_STATIC_FIELD;
-}
+  static #privateStaticField;
+  static #privateStaticFieldWithInitializer = 42;
 
-class ClassWithPrivateStaticMethod {
   static #privateStaticMethod() {
-    return 'hello world';
+    // …
   }
 }
 ```
 
-## Examples
+## Description
 
-### Private fields
+Most class features have their private counterparts:
 
-Private fields include private instance fields and private static fields.
+- Private fields
+- Private methods
+- Private static fields
+- Private static methods
+- Private getters
+- Private setters
+- Private static getters
+- Private static setters
 
-#### Private instance fields
+These features are collectively called _private properties_. However, [constructors](/en-US/docs/Web/JavaScript/Reference/Classes/constructor) cannot be private in JavaScript. To prevent classes from being constructed outside of the class, you have to [use a private flag](#simulating_private_constructors).
 
-Private instance fields are declared with **# names** (pronounced
-"_hash names_"), which are identifiers prefixed with `#`. The
-`#` is a part of the name itself. Private fields are accessible on
-the class constructor from inside the class
-declaration itself. They are used for declaration of field names as well
-as for accessing a field's value.
+Private properties are declared with **# names** (pronounced "hash names"), which are identifiers prefixed with `#`. The hash prefix is an inherent part of the property name — you can draw relationship with the old underscore prefix convention `_privateField` — but it's not an ordinary string property, so you can't dynamically access it with the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors#bracket_notation).
 
-It is a syntax error to refer to `#` names from out of scope.
-It is also a syntax error to refer to private fields
-that were not declared before they were called, or to attempt to remove
-declared fields with `delete`.
+It is a syntax error to refer to `#` names from outside of the class. It is also a syntax error to refer to private properties that were not declared in the class body, or to attempt to remove declared properties with [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete).
 
 ```js example-bad
 class ClassWithPrivateField {
@@ -67,18 +60,47 @@ class ClassWithPrivateField {
 
   constructor() {
     this.#privateField = 42;
-    delete this.#privateField;   // Syntax error
+    delete this.#privateField; // Syntax error
     this.#undeclaredField = 444; // Syntax error
   }
 }
 
-const instance = new ClassWithPrivateField()
-instance.#privateField === 42;   // Syntax error
+const instance = new ClassWithPrivateField();
+instance.#privateField === 42; // Syntax error
 ```
 
-> **Note:** Use the [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) operator to check for potentially missing private fields (or private methods). This will return `true` if the private field or method exists, and `false` otherwise.
+JavaScript, being a dynamic language, is able to perform this compile-time check because of the special hash identifier syntax, making it different from normal properties on the syntax level.
 
-Like public fields, private fields are added at construction time in a base class, or at the point where `super()` is invoked in a subclass.
+If you access a private property from an object that doesn't have the property, a {{jsxref("TypeError")}} is thrown, instead of returning `undefined` as normal properties do.
+
+```js example-bad
+class C {
+  #x;
+
+  static getX(obj) {
+    return obj.#x;
+  }
+}
+
+console.log(C.getX(new C())); // undefined
+console.log(C.getX({})); // TypeError: Cannot read private member #x from an object whose class did not declare it
+```
+
+You can use the [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) operator to check for potentially missing private fields (or private methods). This will return `true` if the private field or method exists, and `false` otherwise.
+
+Note a corollary of private names being always pre-declared and non-deletable: if you found that an object possesses one private property of the current class (either from a `try...catch` or an `in` check), it must possess all other private properties. An object possessing the private properties of a class generally means it was constructed by that class (although [not always](#returning_overriding_object)).
+
+Private properties are not part of the [prototypical inheritance](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) model since they can only be accessed within the current class's body and aren't inherited by subclasses. Private properties with the same name within different classes are entirely different and do not interoperate with each other. See them as external metadata attached to each instance, managed by the class.
+
+## Examples
+
+### Private fields
+
+Private fields include private instance fields and private static fields. Private fields are accessible on the class constructor from inside the class declaration itself. They are used for declaration of field names as well as for accessing a field's value.
+
+#### Private instance fields
+
+Like public fields, private fields are added before the constructor runs in a base class, or immediately after [`super()`](/en-US/docs/Web/JavaScript/Reference/Operators/super) is invoked in a subclass.
 
 ```js
 class ClassWithPrivateField {
@@ -104,6 +126,37 @@ new SubClass();
 
 > **Note:** `#privateField` from the `ClassWithPrivateField` base class is private to `ClassWithPrivateField` and is not accessible from the derived `Subclass`.
 
+#### Returning overriding object
+
+A class's constructor can return a different object, which will be used as the new `this` for the derived class constructor. The derived class may then define private fields on that returned object — meaning it is possible to "stamp" private fields onto unrelated objects.
+
+```js
+class Stamper extends class {
+  // A base class whose constructor returns the object it's given
+  constructor(obj) {
+    return obj;
+  }
+} {
+  // This declaration will "stamp" the private field onto the object
+  // returned by the base class constructor
+  #stamp = 42;
+  static getStamp(obj) {
+    return obj.#stamp;
+  }
+}
+
+const obj = {};
+new Stamper(obj);
+// `Stamper` calls `Base`, which returns `obj`, so `obj` is
+// now the `this` value. `Stamper` then defines `#stamp` on `obj`
+
+console.log(obj); // In some dev tools, it shows {#stamp: 42}
+console.log(getStamp(obj)); // 42
+console.log(obj instanceof Stamper); // false
+```
+
+> **Warning:** This is a potentially very confusing thing to do. You are generally advised to avoid returning anything from the constructor — especially something unrelated to `this`.
+
 #### Private static fields
 
 Private static fields are added to the class constructor at class evaluation time. Like their public counterparts, private static fields are only accessible on the class itself or on the `this` context of static methods, but not on the `this` context of instance methods.
@@ -127,11 +180,7 @@ console.log(ClassWithPrivateStaticField.publicStaticMethod()); // 42
 console.log(new ClassWithPrivateStaticField().publicInstanceMethod()); // 42
 ```
 
-There is a restriction on private static fields: Only the class which
-defines the private static field can access the field. This can lead to unexpected behavior when using **`this`**.
-In the following example, `this` refers to the `SubClass` class (not
-the `BaseClassWithPrivateStaticField` class) when we try to call
-`SubClass.basePublicStaticMethod()`, and so causes a `TypeError`.
+There is a restriction on private static fields: Only the class which defines the private static field can access the field. This can lead to unexpected behavior when using [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this). In the following example, `this` refers to the `SubClass` class (not the `BaseClassWithPrivateStaticField` class) when we try to call `SubClass.basePublicStaticMethod()`, and so causes a `TypeError`.
 
 ```js
 class BaseClassWithPrivateStaticField {
@@ -143,34 +192,27 @@ class BaseClassWithPrivateStaticField {
   }
 }
 
-class SubClass extends BaseClassWithPrivateStaticField { };
-
-let error = null;
+class SubClass extends BaseClassWithPrivateStaticField {}
 
 try {
   SubClass.basePublicStaticMethod();
 } catch (e) {
-  error = e;
+  console.log(e);
+  // TypeError: Cannot write private member #PRIVATE_STATIC_FIELD
+  // to an object whose class did not declare it
 }
-
-console.log(error instanceof TypeError);
-// true
-console.log(error);
-// TypeError: Cannot write private member #PRIVATE_STATIC_FIELD
-// to an object whose class did not declare it
 ```
 
 ### Private methods
 
 #### Private instance methods
 
-Private instance methods are methods available on class instances whose access is
-restricted in the same manner as private instance fields.
+Private instance methods are methods available on class instances whose access is restricted in the same manner as private instance fields.
 
 ```js
 class ClassWithPrivateMethod {
   #privateMethod() {
-    return 'hello world';
+    return "hello world";
   }
 
   getPrivateMessage() {
@@ -183,9 +225,7 @@ console.log(instance.getPrivateMessage());
 // hello world
 ```
 
-Private instance methods may be generator, async, or async generator functions. Private
-getters and setters are also possible, although _not_ in generator, async, or
-async generator forms.
+Private instance methods may be generator, async, or async generator functions. Private getters and setters are also possible, and follow the same syntax requirements as their public [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get) and [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set) counterparts.
 
 ```js
 class ClassWithPrivateAccessor {
@@ -199,7 +239,7 @@ class ClassWithPrivateAccessor {
   }
 
   constructor() {
-    this.#decoratedMessage = 'hello world';
+    this.#decoratedMessage = "hello world";
     console.log(this.#decoratedMessage);
   }
 }
@@ -210,9 +250,7 @@ new ClassWithPrivateAccessor();
 
 #### Private static methods
 
-Like their public equivalent, private static methods are called on the class itself,
-not instances of the class. Like private static fields, they are only accessible from
-inside the class declaration.
+Like their public equivalent, private static methods are called on the class itself, not instances of the class. Like private static fields, they are only accessible from inside the class declaration.
 
 ```js
 class ClassWithPrivateStaticMethod {
@@ -237,12 +275,7 @@ console.log(ClassWithPrivateStaticMethod.publicStaticMethod2() === 42);
 
 Private static methods may be generator, async, and async generator functions.
 
-The same restriction previously mentioned for private static fields holds
-for private static methods, and similarly can lead to unexpected behavior when using
-**`this`**.
-In the following example, when we try to call `Derived.publicStaticMethod2()`,
-`this` refers to the `Derived` class (not
-the `Base` class) and so causes a `TypeError`.
+The same restriction previously mentioned for private static fields holds for private static methods, and similarly can lead to unexpected behavior when using `this`. In the following example, when we try to call `Derived.publicStaticMethod2()`, `this` refers to the `Derived` class (not the `Base` class) and so causes a `TypeError`.
 
 ```js
 class Base {
@@ -266,6 +299,32 @@ console.log(Derived.publicStaticMethod2());
 // from an object whose class did not declare it
 ```
 
+### Simulating private constructors
+
+Many other languages include the capability to mark a constructor as private, which prevents the class from being instantiated outside of the class itself — you can only use static factory methods that create instances, or not be able to create instances at all. JavaScript does not have a native way to do this, but it can be accomplished by using a private static flag.
+
+```js
+class PrivateConstructor {
+  static #isInternalConstructing = false;
+
+  constructor() {
+    if (!PrivateConstructor.#isInternalConstructing) {
+      throw new TypeError("PrivateConstructor is not constructable");
+    }
+  }
+
+  static create() {
+    PrivateConstructor.#isInternalConstructing = true;
+    const instance = new PrivateConstructor();
+    PrivateConstructor.#isInternalConstructing = false;
+    return instance;
+  }
+}
+
+new PrivateConstructor(); // TypeError: PrivateConstructor is not constructable
+PrivateConstructor.create(); // PrivateConstructor {}
+```
+
 ## Specifications
 
 {{Specifications}}
@@ -276,8 +335,8 @@ console.log(Derived.publicStaticMethod2());
 
 ## See also
 
+- [Using classes](/en-US/docs/Web/JavaScript/Guide/Using_Classes)
 - [Working with private class features](/en-US/docs/Web/JavaScript/Guide/Working_With_Private_Class_Features)
 - [Public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
 - [The Semantics of All JS Class Elements](https://rfrn.org/~shu/2018/05/02/the-semantics-of-all-js-class-elements.html)
-- [Public and private class fields](https://v8.dev/features/class-fields)
-  article at the v8.dev site
+- [Public and private class fields](https://v8.dev/features/class-fields) article at the v8.dev site


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"Return overrides" is a very illuminating trick with private fields that help people understand how they work. This feature also motivates some important spec features, such as [allowing hosts to reject adding private fields](https://github.com/tc39/ecma262/pull/2807).

In addition, this page is not clearly differentiating between "private fields" and "private properties", and does not offer a higher-level overview of all features available, which this PR attempts to fix.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
