### PR TITLE
Remove reference to fallbacks failing with comma seperated lists

### DIFF
--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -198,7 +198,7 @@ Using the [`var()`](/en-US/docs/Web/CSS/var) function, you can define multiple *
 
 > **Note:** Fallback values aren't used to fix the browser compatibility. If the browser doesn't support CSS custom properties, the fallback value won't help. It's just a backup for the browser which supports CSS custom properties to choose a different value if the given variable isn't defined or has an invalid value.
 
-The first argument to the function is the name of the [custom property](https://www.w3.org/TR/css-variables/#custom-property) to be substituted. The second argument to the function, if provided, is a fallback value, which is used as the substitution value when the referenced [custom property](https://www.w3.org/TR/css-variables/#custom-property) is invalid. The function only accepts two parameters, assigning everything following the first comma as the second parameter. If that second parameter is invalid, such as if a comma-separated list is provided, the fallback will fail. For example:
+The first argument to the function is the name of the [custom property](https://www.w3.org/TR/css-variables/#custom-property) to be substituted. The second argument to the function, if provided, is a fallback value, which is used as the substitution value when the referenced [custom property](https://www.w3.org/TR/css-variables/#custom-property) is invalid. The function only accepts two parameters, assigning everything following the first comma as the second parameter. If that second parameter is invalid, the fallback will fail. For example:
 
 ```css
 .two {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove reference to fallbacks failing with comma seperated lists, which isn’t true in certain cases.

### Motivation

If you’re setting a colour fallback to be used in an `rgb()` colour then you need to pass in a comma seperated list. For example:

```
--color: 0,0,0;
color: rgb(var(--color,255,0,0);
```

That’ll display as black with the color property defined, and red if not.

### Additional details

From https://www.w3.org/TR/css-variables-1/:

> Note: The syntax of the fallback, like that of [custom properties](https://www.w3.org/TR/css-variables-1/#custom-property), allows commas. For example, var(--foo, red, blue) defines a fallback of red, blue; that is, anything between the first comma and the end of the function is considered a fallback value.