### PR TITLE
Add strict mode of class example

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -73,6 +73,36 @@ export default myStrictFunction;
 
 All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) are strict mode code, including both [class declarations](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) and [class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) — and so also including all parts of class bodies.
 
+```js
+const testObjWithStrictMode = {
+    printThis: function () {
+        'use strict'; // strict mode
+        console.log(this);
+    }
+}
+let printThis = testObjWithStrictMode.printThis;
+printThis(); // undefined, because strict mode is enabled
+
+
+const testObjWithoutStrictMode = {
+    printThis: function () {
+        console.log(this);
+    }
+}
+printThis = testObjWithoutStrictMode.printThis;
+printThis(); // Window object, becuase not enable strict mode.
+
+
+class TestClassStrictMode {
+    printThis() {
+        console.log(this);
+    }
+}
+const testClassStrictMode = new TestClassStrictMode();
+printThis = testClassStrictMode.printThis;
+printThis(); // undefined, because printThis() is in a class, strict mode enabled by default.
+```
+
 ## Changes in strict mode
 
 Strict mode changes both syntax and runtime behavior. Changes generally fall into these categories: changes converting mistakes into errors (as syntax errors or at runtime), changes simplifying how the particular variable for a given use of a name is computed, changes simplifying `eval` and `arguments`, changes making it easier to write "secure" JavaScript, and changes anticipating future ECMAScript evolution.

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -74,22 +74,14 @@ export default myStrictFunction;
 All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) are strict mode code, including both [class declarations](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) and [class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) — and so also including all parts of class bodies.
 
 ```js
-const testObjWithStrictMode = {
-    printThis: function () {
-        'use strict'; // strict mode
-        console.log(this);
-    }
-}
-let printThis = testObjWithStrictMode.printThis;
-printThis(); // undefined, because strict mode is enabled
-
-
 const testObjWithoutStrictMode = {
     printThis: function () {
+        // enable strict mode will output undefined
+        // "use strict";
         console.log(this);
     }
 }
-printThis = testObjWithoutStrictMode.printThis;
+let printThis = testObjWithoutStrictMode.printThis;
 printThis(); // Window object, becuase not enable strict mode.
 
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -75,13 +75,15 @@ All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) 
 
 ```js
 class C {
-    // All code here is evaluated in strict mode
-    test() {delete Object.prototype;}
+  // All code here is evaluated in strict mode
+  test() {
+    delete Object.prototype;
+  }
 }
-new C().test();// TypeError, because strict mode
+new C().test(); // TypeError, because test() is in strict mode
 
 const C = class {
-    // All code here is evaluated in strict mode
+  // All code here is evaluated in strict mode
 };
 
 // Code here may not be in strict mode

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -74,25 +74,19 @@ export default myStrictFunction;
 All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) are strict mode code, including both [class declarations](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) and [class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) — and so also including all parts of class bodies.
 
 ```js
-const testObjWithoutStrictMode = {
-    printThis: function () {
-        // enable strict mode will output undefined
-        // "use strict";
-        console.log(this);
+class C {
+    // All code here is evaluated in strict mode
+    test(){
+        delete Object.prototype
     }
 }
-let printThis = testObjWithoutStrictMode.printThis;
-printThis(); // Window object, becuase not enable strict mode.
+new C().test();// Throw error, because strict mode
 
-
-class TestClassStrictMode {
-    printThis() {
-        console.log(this);
-    }
-}
-const testClassStrictMode = new TestClassStrictMode();
-printThis = testClassStrictMode.printThis;
-printThis(); // undefined, because printThis() is in a class, strict mode enabled by default.
+const C = class {
+    // All code here is evaluated in strict mode
+};
+// Code here may not be in strict mode
+delete Object.prototype // Will not throw error
 ```
 
 ## Changes in strict mode

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -76,9 +76,7 @@ All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) 
 ```js
 class C {
     // All code here is evaluated in strict mode
-    test(){
-        delete Object.prototype
-    }
+    test() {delete Object.prototype;}
 }
 new C().test();// Throw error, because strict mode
 
@@ -86,7 +84,7 @@ const C = class {
     // All code here is evaluated in strict mode
 };
 // Code here may not be in strict mode
-delete Object.prototype // Will not throw error
+delete Object.prototype; // Will not throw error
 ```
 
 ## Changes in strict mode

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -78,7 +78,7 @@ class C {
     // All code here is evaluated in strict mode
     test() {delete Object.prototype;}
 }
-new C().test();// Throw error, because strict mode
+new C().test();// TypeError, because strict mode
 
 const C = class {
     // All code here is evaluated in strict mode

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -74,15 +74,15 @@ export default myStrictFunction;
 All parts of ECMAScript [classes](/en-US/docs/Web/JavaScript/Reference/Classes) are strict mode code, including both [class declarations](/en-US/docs/Web/JavaScript/Reference/Classes#class_declarations) and [class expressions](/en-US/docs/Web/JavaScript/Reference/Classes#class_expressions) — and so also including all parts of class bodies.
 
 ```js
-class C {
+class C1 {
   // All code here is evaluated in strict mode
   test() {
     delete Object.prototype;
   }
 }
-new C().test(); // TypeError, because test() is in strict mode
+new C1().test(); // TypeError, because test() is in strict mode
 
-const C = class {
+const C2 = class {
   // All code here is evaluated in strict mode
 };
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -83,6 +83,7 @@ new C().test();// TypeError, because strict mode
 const C = class {
     // All code here is evaluated in strict mode
 };
+
 // Code here may not be in strict mode
 delete Object.prototype; // Will not throw error
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add an example for strict mode strict mode.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
 Class's strict mode example is missing. Hope this example can help people understand more about class's strict mode.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

This example compare the object and class in strict mode, because in non strict mode, `this` will point to `window` object,
and in strict mode, `this` will point to `undefined`

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
