### PR TITLE
update: changed background example color to meet accessibility guidelines 

### DIFF
--- a/files/en-us/web/css/accent-color/index.md
+++ b/files/en-us/web/css/accent-color/index.md
@@ -34,7 +34,7 @@ Browsers that support `accent-color` currently apply it to the following HTML el
 accent-color: auto;
 
 /* <color> values */
-accent-color: red;
+accent-color: darkred;
 accent-color: #5729e9;
 accent-color: rgb(0, 200, 0);
 accent-color: hsl(228, 4%, 24%);


### PR DESCRIPTION
Red background with white text/icon does not meet the accessibility guidelines due to contrast.

"Very low contrast between text and background colors." - used WAVE google chrome plugin to check it.
 
