### PR TITLE
Error event is cancelable; onerror signature is special

### DIFF
--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -14,23 +14,44 @@ browser-compat: api.Window.error_event
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 
-This event is not cancelable and does not bubble.
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('error', (event) => {});
+addEventListener("error", (event) => {});
 
-onerror = (event) => { };
+onerror = (event, source, lineno, colno, error) => {};
 ```
+
+> **Note:** Due to historical reasons, `onerror` on `window` is the only event handler property that receives more than one argument.
 
 ## Event type
 
 The event object is a {{domxref("UIEvent")}} instance if it was generated from a user interface element, or an {{domxref("Event")}} instance otherwise.
 
 {{InheritanceDiagram("UIEvent")}}
+
+## Usage notes
+
+Unlike other events, the `error` event is canceled by returning `true` from the handler instead of returning `false`. When canceled, the error won't appear in the console, but the current script will still stop executing.
+
+The event handler's signature is asymmetric between `addEventListener()` and `onerror`. The event handler passed to `addEventLister` receives a single {{domxref("ErrorEvent")}} object, while the `onerror` handler receives five arguments, matching the {{domxref("ErrorEvent")}} object's properties:
+
+- `event`
+  - : A string containing a human-readable error message describing the problem. Same as {{domxref("ErrorEvent.message")}}.
+- `source`
+  - : A string containing the URL of the script that generated the error.
+- `lineno`
+  - : An integer containing the line number of the script file on which the error occurred.
+- `colno`
+  - : An integer containing the column number of the script file on which the error occurred.
+- `error`
+  - : The error being thrown. Usually an {{jsxref("Error")}} object.
+
+> **Note:** These parameter names are observable with an [HTML event handler attribute](/en-US/docs/Web/HTML/Attributes#event_handler_attributes), where the first parameter is called `event` instead of `message`.
+
+This special behavior only happens for the `onerror` event handler on `window`. The [`Element.onerror`](/en-US/docs/Web/API/Element/error_event) handler still receives a single {{domxref("ErrorEvent")}} object.
 
 ## Examples
 
@@ -95,17 +116,17 @@ img {
 #### JavaScript
 
 ```js
-const log = document.querySelector('.event-log-contents');
+const log = document.querySelector(".event-log-contents");
 
-window.addEventListener('error', (event) => {
-    log.textContent = `${log.textContent}${event.type}: ${event.message}\n`;
-    console.log(event)
+window.addEventListener("error", (event) => {
+  log.textContent = `${log.textContent}${event.type}: ${event.message}\n`;
+  console.log(event);
 });
 
-const scriptError = document.querySelector('#script-error');
-scriptError.addEventListener('click', () => {
-    const badCode = 'const s;';
-    eval(badCode);
+const scriptError = document.querySelector("#script-error");
+scriptError.addEventListener("click", () => {
+  const badCode = "const s;";
+  eval(badCode);
 });
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix #19295. I was playing with `onerror` and I noticed some interesting behaviors.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

- https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
