### PR TITLE
chore: filecheck image files on commit

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,5 @@
 {
   "*": "prettier --ignore-unknown --write",
-  "*.md": "markdownlint-cli2-fix"
+  "*.md": "markdownlint-cli2-fix",
+  "*.{svg,png,jpeg,jpg,gif}": "yarn filecheck"
 }


### PR DESCRIPTION
I tried with an SVG and it did block the commit if I added a `<script>` tag, but didn't see it compressing the image when I added some spacing into it.