### PR TITLE
20971 add notes about relaxed range restrictions on `formatRange` and `selectRange`

### DIFF
--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -35,6 +35,9 @@ No notable changes.
 
 - The [TextDecoderStream](/en-US/docs/Web/API/TextDecoderStream) and [TextEncoderStream](/en-US/docs/Web/API/TextEncoderStream) interfaces, part of the [Encoding API](/en-US/docs/Web/API/Encoding_API), are now supported ({{bug(1486949)}}).
 
+- The [OffscreenCanvas API](/en-US/docs/Web/API/OffscreenCanvas) provides a canvas that can be rendered off-screen in both Window and [Web Worker contexts](/en-US/docs/Web/API/OffscreenCanvas#asynchronous_display_of_frames_produced_by_an_offscreencanvas), decoupling the DOM and the Canvas API so that `<canvas>` elements are no longer dependent on the DOM.
+  The [OffscreenCanvasRenderingContext2D](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) interface is supported and enabled by default ({{bug(1746110)}}).
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -25,7 +25,9 @@ No notable changes.
 
 ### JavaScript
 
-No notable changes.
+- Range restrictions are relaxed on `formatRange` and `selectRange` functions for `Intl.DateTimeFormat`, `Intl.NumberFormat`, and `Intl.PluralRules`.
+  For example, `formatRange(x, y)` can be called where and `x` > `y` such as `formatRange(-500, -1000)`.
+  The intention of this change is to relax ordering rules so that negative ranges (e.g., "losses ranging from -$500 to -$1000") can be formatted correctly ({{bug(1780545)}}).
 
 ### APIs
 

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -25,9 +25,7 @@ No notable changes.
 
 ### JavaScript
 
-- Range restrictions are relaxed on `formatRange` and `selectRange` functions for [`Intl.DateTimeFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), [`Intl.NumberFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), and [`Intl.PluralRules`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
-  For example, `formatRange(x, y)` can be called where and `x` > `y` such as `formatRange(-500, -1000)`.
-  The intention of this change is to relax ordering rules so that negative ranges (e.g., "losses ranging from -$500 to -$1000") can be formatted correctly ({{bug(1780545)}}).
+- Range restrictions have been relaxed on `formatRange` and `selectRange` functions for [`Intl.DateTimeFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), [`Intl.NumberFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), and [`Intl.PluralRules`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) objects. This change now allows negative ranges ({{bug(1780545)}}).
 
 ### APIs
 

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -25,7 +25,7 @@ No notable changes.
 
 ### JavaScript
 
-- Range restrictions are relaxed on `formatRange` and `selectRange` functions for `Intl.DateTimeFormat`, `Intl.NumberFormat`, and `Intl.PluralRules`.
+- Range restrictions are relaxed on `formatRange` and `selectRange` functions for [`Intl.DateTimeFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), [`Intl.NumberFormat`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), and [`Intl.PluralRules`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).
   For example, `formatRange(x, y)` can be called where and `x` > `y` such as `formatRange(-500, -1000)`.
   The intention of this change is to relax ordering rules so that negative ranges (e.g., "losses ranging from -$500 to -$1000") can be formatted correctly ({{bug(1780545)}}).
 

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -33,8 +33,8 @@ No notable changes.
 
 - The [TextDecoderStream](/en-US/docs/Web/API/TextDecoderStream) and [TextEncoderStream](/en-US/docs/Web/API/TextEncoderStream) interfaces, part of the [Encoding API](/en-US/docs/Web/API/Encoding_API), are now supported ({{bug(1486949)}}).
 
-- The [OffscreenCanvas API](/en-US/docs/Web/API/OffscreenCanvas) provides a canvas that can be rendered off-screen in both Window and [Web Worker contexts](/en-US/docs/Web/API/OffscreenCanvas#asynchronous_display_of_frames_produced_by_an_offscreencanvas), decoupling the DOM and the Canvas API so that `<canvas>` elements are no longer dependent on the DOM.
-  The [OffscreenCanvasRenderingContext2D](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) interface is supported and enabled by default ({{bug(1746110)}}).
+- The [OffscreenCanvas](/en-US/docs/Web/API/OffscreenCanvas) API provides a canvas that can be rendered off-screen in both window and [web worker](/en-US/docs/Web/API/OffscreenCanvas#asynchronous_display_of_frames_produced_by_an_offscreencanvas) contexts.
+  This allows `<canvas>` elements to be decoupled from the DOM. The [OffscreenCanvasRenderingContext2D](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) interface provides support for this and is now enabled by default ({{bug(1746110)}}).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 


### PR DESCRIPTION
This change adds a note about relaxed ordering rules for

* `Intl.DateTimeFormat`
* `Intl.NumberFormat`
* `Intl.PluralRules`

It's now possible to compare values such as negative date ranges

```javascript
// Given startDate of 'Jan 20th' and an endDate of 'Jan 10th'
const date1 = new Date(Date.UTC(2022, 0, 20, 10, 0, 0));
const date2 = new Date(Date.UTC(2022, 0, 10, 10, 0, 0));

const fmt2 = new Intl.DateTimeFormat("en", {
  year: 'numeric',
  month: 'short',
  day: 'numeric',
});

console.log(fmt2.formatRange(date2, date1));
// > "Jan 10 – 20, 2022"
```


## Bugs

https://bugzilla.mozilla.org/show_bug.cgi?id=1780545

Fixes #20971
