### PR TITLE
Make relational operators' relationship more explicit

### DIFF
--- a/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
@@ -25,7 +25,7 @@ x >= y
 
 ## Description
 
-The operands are compared using the same algorithm as the [Less than](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than) operator, except the two operands are swapped, and equal values return `true`.
+The operands are compared using the same algorithm as the [Less than](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than) operator, except the two operands are swapped, and equal values (after attempting coercion) return `true`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -35,7 +35,7 @@ The operands are compared with multiple rounds of coercion, which can be summari
 - If either value is [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN), the operator returns `false`.
 - Otherwise the values are compared as numeric values. BigInt and number values can be compared together.
 
-Other operators, including [`>`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than), [`>=`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal), and [`<=`](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal) use the same algorithm as `<`. There are two cases where all four operators return `false`:
+Other operators, including [`>`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than), [`>=`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal), and [`<=`](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal), use the same algorithm as `<`. There are two cases where all four operators return `false`:
 
 - If one of the operands gets converted to a BigInt, while the other gets converted to a string that cannot be converted to a BigInt value (it throws a [syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax) when passed to [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)).
 - If one of the operands gets converted to `NaN`. (For example, strings that cannot be converted to numbers, or `undefined`.)

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -35,7 +35,7 @@ The operands are compared with multiple rounds of coercion, which can be summari
 - If either value is [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN), the operator returns `false`.
 - Otherwise the values are compared as numeric values. BigInt and number values can be compared together.
 
-Other operators including [`>`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than), [`>=`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal), and [`<=`](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal) use the same algorithm as `<`. There are two cases where all four operators return `false`:
+Other operators, including [`>`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than), [`>=`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal), and [`<=`](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal) use the same algorithm as `<`. There are two cases where all four operators return `false`:
 
 - If one of the operands gets converted to a BigInt, while the other gets converted to a string that cannot be converted to a BigInt value (it throws a [syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax) when passed to [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)).
 - If one of the operands gets converted to `NaN`. (For example, strings that cannot be converted to numbers, or `undefined`.)

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -35,6 +35,22 @@ The operands are compared with multiple rounds of coercion, which can be summari
 - If either value is [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN), the operator returns `false`.
 - Otherwise the values are compared as numeric values. BigInt and number values can be compared together.
 
+Other operators including [`>`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than), [`>=`](/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal), and [`<=`](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal) use the same algorithm as `<`. There are two cases where all four operators return `false`:
+
+- If one of the operands gets converted to a BigInt, while the other gets converted to a string that cannot be converted to a BigInt value (it throws a [syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax) when passed to [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt)).
+- If one of the operands gets converted to `NaN`. (For example, strings that cannot be converted to numbers, or `undefined`.)
+
+For all other cases, the four operators have the following relationships:
+
+```js
+x < y === !(x >= y);
+x <= y === !(x > y);
+x > y === y < x;
+x >= y === y <= x;
+```
+
+> **Note:** One observable difference between `<` and `>` is the order of coercion, especially if the coercion to primitive has side effects. All comparison operators coerce the left operand before the right operand.
+
 ## Examples
 
 ### String to string comparison
@@ -92,6 +108,29 @@ console.log(3 < undefined);    // false
 console.log(3 < NaN);          // false
 console.log(NaN < 3);          // false
 ```
+
+### Comparison with side effects
+
+Comparisons always coerce their operands to primitives. This means the same object may end up having different values within one comparison expression. For example, you may have two values that are both greater than and less than the other.
+
+```js
+class Mystery {
+  static #coercionCount = -1;
+  valueOf() {
+    Mystery.#coercionCount++;
+    // The left operand is coerced first, so this will return 0
+    // Then it returns 1 for the right operand
+    return Mystery.#coercionCount % 2;
+  }
+}
+
+const l = new Mystery();
+const r = new Mystery();
+console.log(l < r && r < l);
+// true
+```
+
+> **Warning:** This can be a source of confusion. If your objects provide custom primitive conversion logic, make sure it is _idempotent_: multiple coercions should return the same value.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
@@ -23,7 +23,7 @@ x <= y
 
 ## Description
 
-The operands are compared using the same algorithm as the [Less than](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than) operator, except that equal values return `true`.
+The operands are compared using the same algorithm as the [Less than](/en-US/docs/Web/JavaScript/Reference/Operators/Less_than) operator, except that equal values (after attempting coercion) return `true`.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is no relational operator in JS that does not coerce (it will behave kind of weirdly anyway). I find it interesting to document how it behaves. Technically we could do the same for `==`, but this appears to be more illuminating. The relationship between different relational operators and how they reuse the same algorithm can also be more explicitly demonstrated.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
