### PR TITLE
Document WebGL color spaces

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/drawingbuffercolorspace/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbuffercolorspace/index.md
@@ -1,0 +1,51 @@
+---
+title: WebGLRenderingContext.drawingBufferColorSpace
+slug: Web/API/WebGLRenderingContext/drawingBufferColorSpace
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - WebGL
+  - WebGLRenderingContext
+browser-compat: api.WebGLRenderingContext.drawingBufferColorSpace
+---
+
+{{APIRef("WebGL")}}
+
+The **`WebGLRenderingContext.drawingBufferColorSpace`** property specifies the color space of the WebGL drawing buffer. Along with the default (`srgb`), the `display-p3` color space can be used.
+
+See [`WebGLRenderingContext.unpackColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/unpackColorSpace) for specifying the color space for textures.
+
+## Value
+
+This property can have the following values:
+
+- `"srgb"` selects the [sRGB color space](https://en.wikipedia.org/wiki/SRGB). This is the default value.
+- `"display-p3"` selects the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+
+If an invalid value is specified, then the value of `drawingBufferColorSpace` will remain unchanged.
+
+## Examples
+
+### Setting the drawing buffer color space to draw a Display P3 red
+
+```js
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+gl.drawingBufferColorSpace = "display-p3";
+gl.clearColor(1, 0, 0, 1);
+gl.clear(glP3.COLOR_BUFFER_BIT);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`WebGLRenderingContext.unpackColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/unpackColorSpace)

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -300,6 +300,13 @@ The following properties and methods provide general information and functionali
 - {{domxref("WebGLRenderingContext.flush()")}}
   - : Empties different buffer commands, causing all commands to be executed as quickly as possible.
 
+## Color spaces
+
+- {{domxref("WebGLRenderingContext.drawingBufferColorSpace")}}
+  - : Specifies the color space of the WebGL drawing buffer.
+- {{domxref("WebGLRenderingContext.unpackColorSpace")}}
+  - : Specifies the color space to convert to when importing textures.
+
 ## Working with extensions
 
 These methods manage WebGL extensions:

--- a/files/en-us/web/api/webglrenderingcontext/unpackcolorspace/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/unpackcolorspace/index.md
@@ -1,0 +1,71 @@
+---
+title: WebGLRenderingContext.unpackColorSpace
+slug: Web/API/WebGLRenderingContext/unpackColorSpace
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - WebGL
+  - WebGLRenderingContext
+browser-compat: api.WebGLRenderingContext.unpackColorSpace
+---
+
+{{APIRef("WebGL")}}
+
+The **`WebGLRenderingContext.unpackColorSpace`** property specifies the color space to convert to when importing textures. Along with the default (`srgb`), the `display-p3` color space can be used.
+
+Texture image sources can be the following:
+
+- [`ImageBitmap`](/en-US/docs/Web/API/ImageBitmap)
+- [`ImageData`](/en-US/docs/Web/API/ImageData)
+- [`HTMLImageElement`](/en-US/docs/Web/API/HTMLImageElement)
+- [`HTMLCanvasElement`](/en-US/docs/Web/API/HTMLCanvasElement)
+- [`HTMLVideoElement`](/en-US/docs/Web/API/HTMLVideoElement)
+- [`OffscreenCanvas`](/en-US/docs/Web/API/OffscreenCanvas)
+- [`VideoFrame`](/en-US/docs/Web/API/VideoFrame)
+
+Textures are imported using the [`WebGLRenderingContext.texImage2D()`](/en-US/docs/Web/API/WebGLRenderingContext/texImage2D) and [`WebGLRenderingContext.texSubImage2D()`](/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D) methods and conversion to the specified `unpackColorSpace` color space happens during import.
+
+Note that this doesn't apply to [`HTMLImageElement`](/en-US/docs/Web/API/HTMLImageElement) when the `UNPACK_COLORSPACE_CONVERSION_WEBGL` pixel storage parameter is set to `NONE`.
+
+## Value
+
+This property can have the following values:
+
+- `"srgb"` selects the [sRGB color space](https://en.wikipedia.org/wiki/SRGB). This is the default value.
+- `"display-p3"` selects the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+
+If an invalid value is specified, then the value of `unpackColorSpace` will remain unchanged.
+
+## Examples
+
+### Converting sRGB ImageData to display-p3 in a texture
+
+```js
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+
+gl.drawingBufferColorSpace = "display-p3";
+gl.unpackColorSpace = "display-p3";
+
+// Some sRGB ImageData
+// Will be converted from sRGB to Display P3
+const imageData = new ImageData(data, 32, 32);
+
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`WebGLRenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace)


### PR DESCRIPTION
### Description

WebGL allows color management (display-p3 colors) now as well.
One new property for the drawing buffer color space and another property for color space conversion when importing textures have been added.

### Motivation

I saw the two properties added to BCD but couldn't find MDN pages.
https://github.com/mdn/browser-compat-data/pull/17675

### Additional details

The spec change happened here: https://github.com/KhronosGroup/WebGL/pull/3292
https://ccameron-chromium.github.io/webgl-examples/p3.html has some demo code
