### PR TITLE
Fix incorrect grammar (`display` -> `displayed`)

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -36,7 +36,7 @@ The canvas API is able to use any of the following data types as an image source
 - {{domxref("ImageBitmap")}}
   - : A bitmap image, eventually cropped. Such type are used to extract part of an image, a _sprite_, from a larger image
 - {{domxref("OffscreenCanvas")}}
-  - : A special kind of `<canvas>` that is not displayed and is prepared without being display. Using such an image source allows to switch to it without the composition of the content to be visible to the user.
+  - : A special kind of `<canvas>` that is not displayed and is prepared without being displayed. Using such an image source allows to switch to it without the composition of the content to be visible to the user.
 - {{domxref("VideoFrame")}}
   - : An image representing one single frame of a video.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Fixed a minor grammar issue at the end of a sentence.

```diff
- A special kind of `<canvas>` that is not displayed and is prepared without being display.
+ A special kind of `<canvas>` that is not displayed and is prepared without being displayed.
```

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Noticed there was a clear grammar issue with this word. A grammar improvement here helps readers more easily follow the sentence. I re-read the sentence thinking I had missed something due to the grammar error and hope others won't have to.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

[Link to Highlight](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Using_images#:~:text=A%20special%20kind%20of%20%3Ccanvas%3E%20that%20is%20not%20displayed%20and%20is%20prepared%20without%20being%20display.)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
