### PR TITLE
Add some missing guides to GroupData.json

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -106,7 +106,7 @@
     "Clipboard API": {
       "overview": ["Clipboard API"],
       "guides": [
-        "docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard"
+        "/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard"
       ],
       "interfaces": ["Clipboard", "ClipboardEvent", "ClipboardItem"],
       "dictionaries": ["ClipboardPermissionDescriptor"],
@@ -513,7 +513,7 @@
     },
     "History API": {
       "overview": ["History API"],
-      "guides": ["docs/Web/API/History_API/Working_with_the_History_API"],
+      "guides": ["/docs/Web/API/History_API/Working_with_the_History_API"],
       "interfaces": ["History"],
       "methods": [],
       "properties": [],
@@ -739,7 +739,7 @@
     "Intersection Observer API": {
       "overview": ["Intersection Observer API"],
       "guides": [
-        "docs/Web/API/Intersection_Observer_API/Timing_element_visibility"
+        "/docs/Web/API/Intersection_Observer_API/Timing_element_visibility"
       ],
       "interfaces": ["IntersectionObserver", "IntersectionObserverEntry"],
       "methods": [],
@@ -2102,7 +2102,7 @@
     },
     "WebXR Device API": {
       "overview": ["WebXR Device API"],
-      "guides": ["docs/Web/API/WebXR_Device_API/Fundamentals"],
+      "guides": ["/docs/Web/API/WebXR_Device_API/Fundamentals"],
       "interfaces": [
         "XRAnchor",
         "XRBoundedReferenceSpace",

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -105,6 +105,9 @@
     },
     "Clipboard API": {
       "overview": ["Clipboard API"],
+      "guides": [
+        "docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard"
+      ],
       "interfaces": ["Clipboard", "ClipboardEvent", "ClipboardItem"],
       "dictionaries": ["ClipboardPermissionDescriptor"],
       "methods": [],
@@ -510,6 +513,7 @@
     },
     "History API": {
       "overview": ["History API"],
+      "guides": ["docs/Web/API/History_API/Working_with_the_History_API"],
       "interfaces": ["History"],
       "methods": [],
       "properties": [],
@@ -734,6 +738,9 @@
     },
     "Intersection Observer API": {
       "overview": ["Intersection Observer API"],
+      "guides": [
+        "docs/Web/API/Intersection_Observer_API/Timing_element_visibility"
+      ],
       "interfaces": ["IntersectionObserver", "IntersectionObserverEntry"],
       "methods": [],
       "properties": ["indexedDB"],
@@ -2095,6 +2102,7 @@
     },
     "WebXR Device API": {
       "overview": ["WebXR Device API"],
+      "guides": ["docs/Web/API/WebXR_Device_API/Fundamentals"],
       "interfaces": [
         "XRAnchor",
         "XRBoundedReferenceSpace",


### PR DESCRIPTION
This is based on having done an audit of APIs in the GroupData.json that were missing a "guides" value but for which we actually do have some guides docs.