### PR TITLE
fix: check for mutations length

### DIFF
--- a/files/en-us/web/api/mutationobserver/takerecords/index.md
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.md
@@ -74,7 +74,7 @@ let mutations = observer.takeRecords();
 
 observer.disconnect();
 
-if (mutations) {
+if (mutations.length > 0) {
   callback(mutations);
 }
 ```


### PR DESCRIPTION
### Description

It's not good enough to just check for `mutations` since an empty array will also evaluate to `true`.