### PR TITLE
API(background sync): add missing sidebar data

### DIFF
--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -16,9 +16,7 @@ tags:
 browser-compat: api.SyncManager
 ---
 
-{{securecontext_header}}{{SeeCompatTable}}
-
-{{DefaultAPISidebar("Background Sync")}}
+{{DefaultAPISidebar("Background Sync")}}{{Securecontext_Header}}{{SeeCompatTable}}
 
 The Background Synchronization API provides a way to defer tasks to be run in a {{domxref('Service Worker API','service worker')}} until the user has a stable network connection.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
@@ -72,7 +72,5 @@ self.onsync = (event) => {
 
 ## See also
 
-<ul>
- <li><a href="https://web.dev/periodic-background-sync/">Richer offline experiences with the Periodic Background Sync API</a></li>
- <li><a href="https://webplatformapis.com/periodic_sync/periodicSync_improved.html">A Periodic Background Sync demo app</a></li>
-</ul>
+- [Richer offline experiences with the Periodic Background Sync API](https://web.dev/periodic-background-sync/)
+- [A Periodic Background Sync demo app](https://webplatformapis.com/periodic_sync/periodicSync_improved.html)

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -13,6 +13,13 @@
       "properties": [],
       "events": []
     },
+    "Background Sync": {
+      "overview": ["Background Synchronization API"],
+      "interfaces": ["SyncManager", "SyncEvent"],
+      "methods": ["ServiceWorkerRegistration.sync()"],
+      "properties": [],
+      "events": ["ServiceWorkerGlobalScope: sync"]
+    },
     "Background Tasks": {
       "overview": ["Background Tasks API"],
       "interfaces": ["IdleDeadline"],


### PR DESCRIPTION
### Description

The pages
https://developer.mozilla.org/en-US/docs/Web/API/Background_Synchronization_API
https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event
uses sidebar `{{DefaultAPISidebar("Background Sync")}}`.
But the sidebars are empty.

The PR adds the required data in GroupData.json