### PR TITLE
rel="stylesheet" instead of rel="alternate"

### DIFF
--- a/files/en-us/web/css/alternative_style_sheets/index.md
+++ b/files/en-us/web/css/alternative_style_sheets/index.md
@@ -41,8 +41,8 @@ No matter what style is selected, the rules from the reset.css stylesheet will a
 
 Any stylesheet in a document falls into one of the following categories:
 
-- **Persistent** (no `rel="alternate"`, no `title=""`): always applies to the document.
-- **Preferred** (no `rel="alternate"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
+- **Persistent** (no `rel="stylesheet"`, no `title=""`): always applies to the document.
+- **Preferred** (no `rel="stylesheet"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
 - **Alternate** (`rel="alternate stylesheet"`, `title="…"` must be specified): disabled by default, can be selected.
 
 When style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same `title` are part of the same choice. Style sheets linked without a `title` attribute are always applied.


### PR DESCRIPTION
I'm not an expert on this. But this is the way it's described elsewhere and it works this way. The way it is described here right now (with rel="alternate" for preferred styles) it's not working (and it sounds illogical, too, to me).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
