### PR TITLE
browser-compat should be a string if possible

### DIFF
--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -9,8 +9,7 @@ tags:
   - Web
   - color
   - rgba
-browser-compat:
-  - css.types.color.rgba
+browser-compat: css.types.color.rgba
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
The browser-compat front matter key should be a string unless it really needs to be an array.