### PR TITLE
Fix splice example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -159,8 +159,8 @@ The `splice()` method preserves the array's sparseness.
 
 ```js
 const arr = [1, 3, 4, , 6];
-console.log(arr.splice(1, 2)); // [empty, 3]
-console.log(arr); // [1, 4, empty, 6]
+console.log(arr.splice(1, 2)); // [3, 4]
+console.log(arr); // [1, empty, 6]
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -158,9 +158,9 @@ const removed = myFish.splice(2);
 The `splice()` method preserves the array's sparseness.
 
 ```js
-const arr = [1, 3, 4, , 6];
-console.log(arr.splice(1, 2)); // [3, 4]
-console.log(arr); // [1, empty, 6]
+const arr = [1, , 3, 4, , 6];
+console.log(arr.splice(1, 2)); // [empty, 3]
+console.log(arr); // [1, 4, empty, 6]
 ```
 
 ## Specifications


### PR DESCRIPTION
for sparse input, doc represented incorrect output

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

for sparse input, doc represented incorrect output.
- Hence, updated documentation to show what would be actual output

### Motivation

- Make documentation truthful and less confusing

### Additional details
NA

### Related issues and pull requests

NA


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
