### PR TITLE
Document color spaces with ImageData

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -20,6 +20,7 @@ specified dimensions. All of the pixels in the new object are transparent black.
 ## Syntax
 
 ```js-nolint
+createImageData(width, height)
 createImageData(width, height, settings)
 createImageData(imagedata)
 ```

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -34,7 +34,7 @@ createImageData(imagedata)
     rectangle around the horizontal axis.
 - `settings` {{optional_inline}}
   - : An object with the following properties:
-    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+    - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 - `imagedata`
   - : An existing `ImageData` object from which to copy the width and height.
     The image itself is **not** copied.

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -20,7 +20,7 @@ specified dimensions. All of the pixels in the new object are transparent black.
 ## Syntax
 
 ```js-nolint
-createImageData(width, height)
+createImageData(width, height, settings)
 createImageData(imagedata)
 ```
 
@@ -32,6 +32,9 @@ createImageData(imagedata)
 - `height`
   - : The height to give the new `ImageData` object. A negative value flips the
     rectangle around the horizontal axis.
+- `settings` {{optional_inline}}
+  - : An object with the following properties:
+    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 - `imagedata`
   - : An existing `ImageData` object from which to copy the width and height.
     The image itself is **not** copied.

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -39,6 +39,7 @@ manipulation of canvas contents in [Pixel manipulation with canvas](/en-US/docs/
 ## Syntax
 
 ```js-nolint
+getImageData(sx, sy, sw, sh)
 getImageData(sx, sy, sw, sh, settings)
 ```
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -39,7 +39,7 @@ manipulation of canvas contents in [Pixel manipulation with canvas](/en-US/docs/
 ## Syntax
 
 ```js-nolint
-getImageData(sx, sy, sw, sh)
+getImageData(sx, sy, sw, sh, settings)
 ```
 
 ### Parameters
@@ -56,6 +56,9 @@ getImageData(sx, sy, sw, sh)
 - `sh`
   - : The height of the rectangle from which the `ImageData` will be extracted.
     Positive values are down, and negative are up.
+- `settings` {{optional_inline}}
+  - : An object with the following properties:
+    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 
 ### Return value
 
@@ -111,6 +114,20 @@ image.addEventListener("load", () => {
 #### Result
 
 {{EmbedLiveSample("Getting_image_data_from_a_canvas", "", 420)}}
+
+### Color space conversion
+
+The optional `colorSpace` setting allows you to get image data in the desired format.
+
+```js
+const context = canvas.getContext("2d", { colorSpace: "display-p3" });
+context.fillStyle = "color(display-p3 0.5 0 0)";
+context.fillRect(0, 0, 10, 10);
+
+// Get ImageData converted to sRGB
+const imageData = context.getImageData(0, 0, 1, 1, { colorSpace: "srgb" });
+console.log(imageData.colorSpace);  // "srgb"
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -58,7 +58,7 @@ getImageData(sx, sy, sw, sh, settings)
     Positive values are down, and negative are up.
 - `settings` {{optional_inline}}
   - : An object with the following properties:
-    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+    - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 
 ### Return value
 

--- a/files/en-us/web/api/imagedata/colorspace/index.md
+++ b/files/en-us/web/api/imagedata/colorspace/index.md
@@ -28,7 +28,7 @@ This property can have the following values:
 
 ### Getting the color space of canvas image data
 
-The [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method allows you explicitly request a color space. If it doesn't match the color space the canvas was initialized with, a conversion will be performed.
+The [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method allows you to explicitly request a color space. If it doesn't match the color space the canvas was initialized with, a conversion will be performed.
 Use the `colorSpace` property to know which color space your `ImageData` object is in.
 
 ```js

--- a/files/en-us/web/api/imagedata/colorspace/index.md
+++ b/files/en-us/web/api/imagedata/colorspace/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ImageData.colorSpace
 
 {{APIRef("Canvas API")}}
 
-The read-only **`ImageData.colorSpace`** property is a string indicating the color space of the pixels.
+The read-only **`ImageData.colorSpace`** property is a string indicating the color space of the image data.
 
 The color space can be set during `ImageData` initialization using either the [`ImageData()`](/en-US/docs/Web/API/ImageData/ImageData) constructor or the [`createImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData) method.
 

--- a/files/en-us/web/api/imagedata/colorspace/index.md
+++ b/files/en-us/web/api/imagedata/colorspace/index.md
@@ -1,0 +1,61 @@
+---
+title: ImageData.colorSpace
+slug: Web/API/ImageData/colorSpace
+page-type: web-api-instance-property
+tags:
+  - API
+  - Canvas
+  - ImageData
+  - Property
+  - Reference
+browser-compat: api.ImageData.colorSpace
+---
+
+{{APIRef("Canvas API")}}
+
+The read-only **`ImageData.colorSpace`** property is a string indicating the color space of the pixels.
+
+The color space can be set during `ImageData` initialization using either the [`ImageData()`](/en-US/docs/Web/API/ImageData/ImageData) constructor or the [`createImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData) method.
+
+## Value
+
+This property can have the following values:
+
+- `"srgb"` representing the [sRGB color space](https://en.wikipedia.org/wiki/SRGB).
+- `"display-p3"` representing the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+
+## Examples
+
+### Getting the color space of canvas image data
+
+The [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method allows you explicitly request a color space. If it doesn't match the color space the canvas was initialized with, a conversion will be performed.
+Use the `colorSpace` property to know which color space your `ImageData` object is in.
+
+```js
+const context = canvas.getContext("2d", { colorSpace: "display-p3" });
+context.fillStyle = "color(display-p3 0.5 0 0)";
+context.fillRect(0, 0, 10, 10);
+
+const p3ImageData = context.getImageData(0, 0, 1, 1);
+console.log(p3ImageData.colorSpace);  // "display-p3"
+
+const srgbImageData = context.getImageData(0, 0, 1, 1, { colorSpace: "srgb" });
+console.log(srgbImageData.colorSpace);  // "srgb"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`CanvasRenderingContext2D.createImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData)
+- [`CanvasRenderingContext2D.getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData)
+- [`colorSpace` setting in `canvas.getContext()`](/en-US/docs/Web/API/HTMLCanvasElement/getContext#colorspace)
+- Setting WebGL color spaces:
+  - [`WebGLRenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace)
+  - [`WebGLRenderingContext.unpackColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/unpackColorSpace)

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -39,9 +39,8 @@ new ImageData(dataArray, width, height, settings)
   - : An unsigned long representing the height of the image. This value is optional if an
     array is given: the height will be inferred from the array's size and the given width.
 - `settings` {{optional_inline}}
-  - : An object with the following values:
-- `colorSpace`
-  - : One of `"srgb"`, `"rec2020"`, or `"display-p3"`.
+  - : An object with the following properties:
+    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 - `dataArray`
   - : A {{jsxref("Uint8ClampedArray")}} containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
 
@@ -64,6 +63,14 @@ pixels tall, containing a total of 20,000 pixels.
 ```js
 let imageData = new ImageData(200, 100);
 // ImageData { width: 200, height: 100, data: Uint8ClampedArray[80000] }
+```
+
+### ImageData using the display-p3 color space
+
+This example creates an `ImageData` object with the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+
+```js
+let imageData = new ImageData(200, 100, { colorSpace: "display-p3" });
 ```
 
 ### Initializing ImageData with an array

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -40,7 +40,7 @@ new ImageData(dataArray, width, height, settings)
     array is given: the height will be inferred from the array's size and the given width.
 - `settings` {{optional_inline}}
   - : An object with the following properties:
-    - `colorSpace`: Specifies the color space of the pixels. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+    - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
 - `dataArray`
   - : A {{jsxref("Uint8ClampedArray")}} containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
 

--- a/files/en-us/web/api/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/index.md
@@ -27,6 +27,8 @@ It is created using the {{domxref("ImageData.ImageData", "ImageData()")}} constr
 
 - {{domxref("ImageData.data")}} {{ReadOnlyInline}}
   - : A {{jsxref("Uint8ClampedArray")}} representing a one-dimensional array containing the data in the RGBA order, with integer values between `0` and `255` (inclusive).
+- {{domxref("ImageData.colorSpace")}} {{ReadOnlyInline}}
+  - : A string indicating the color space of the pixels.
 - {{domxref("ImageData.height")}} {{ReadOnlyInline}}
   - : An `unsigned long` representing the actual height, in pixels, of the `ImageData`.
 - {{domxref("ImageData.width")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/index.md
@@ -28,7 +28,7 @@ It is created using the {{domxref("ImageData.ImageData", "ImageData()")}} constr
 - {{domxref("ImageData.data")}} {{ReadOnlyInline}}
   - : A {{jsxref("Uint8ClampedArray")}} representing a one-dimensional array containing the data in the RGBA order, with integer values between `0` and `255` (inclusive).
 - {{domxref("ImageData.colorSpace")}} {{ReadOnlyInline}}
-  - : A string indicating the color space of the pixels.
+  - : A string indicating the color space of the image data.
 - {{domxref("ImageData.height")}} {{ReadOnlyInline}}
   - : An `unsigned long` representing the actual height, in pixels, of the `ImageData`.
 - {{domxref("ImageData.width")}} {{ReadOnlyInline}}


### PR DESCRIPTION
### Description

ImageData has been extended so that it allows you to work with different color spaces.
If I see it correctly, the API additions are:
- A new `settings` object in the `ImageData()` constructor
- A new `settings` object in the `CanvasRenderingContext2D.createImageData()` method
- A new `settings` object in the `CanvasRenderingContext2D.getImageData()` method
- A new read-only `ImageData.colorSpace` property.

### Motivation

Documenting how to use color spaces. Supported in WebKittens and Chromiums.

### Additional details

None.

### Related issues and pull requests

I will update BCD to add the mdn_url for api.ImageData.colorSpace.