### PR TITLE
Fix overformatted code

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -136,7 +136,7 @@ expression return is not needed:
 
 Multiline statements require body braces and return:
 
-```js
+```js-nolint
 // The parentheses are optional with one single parameter
 param => {
   const a = 1;

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -138,7 +138,7 @@ Multiline statements require body braces and return:
 
 ```js
 // The parentheses are optional with one single parameter
-(param) => {
+param => {
   const a = 1;
   return a + param;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I think the comment `// The parentheses are optional with one single parameter` can be vague, but then the following snippet for `(param1, paramN)` clears it out!

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The code should align with the comment, it can be ambiguous for the reader.