### PR TITLE
Fix typo in Strikethrough element example

### DIFF
--- a/files/en-us/web/html/element/s/index.md
+++ b/files/en-us/web/html/element/s/index.md
@@ -88,7 +88,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ```html
 <s>Today's Special: Salmon</s> SOLD OUT<br />
-<span class="sould-out">Today's Special: Salmon</span> SOLD OUT
+<span class="sold-out">Today's Special: Salmon</span> SOLD OUT
 ```
 
 {{EmbedLiveSample("Examples")}}


### PR DESCRIPTION
Referencing a CSS class that does not exist. It is now referencing the existing CSS class from the example

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

A typo in the strike through documentation

### Motivation

I was reading the documentation to learn about the strike through and noticed the error 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
