### PR TITLE
Fix page title: prototytpe->prototype

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
@@ -1,5 +1,5 @@
 ---
-title: Intl.PluralRules.prototytpe.select()
+title: Intl.PluralRules.prototype.select()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select
 tags:
   - Internationalization
@@ -45,19 +45,19 @@ options of a {{jsxref("Intl.PluralRules")}} object.
 ### Using select()
 
 ```js
-new Intl.PluralRules('ar-EG').select(0);
+new Intl.PluralRules("ar-EG").select(0);
 // → 'zero'
 
-new Intl.PluralRules('ar-EG').select(1);
+new Intl.PluralRules("ar-EG").select(1);
 // → 'one'
 
-new Intl.PluralRules('ar-EG').select(2);
+new Intl.PluralRules("ar-EG").select(2);
 // → 'two'
 
-new Intl.PluralRules('ar-EG').select(6);
+new Intl.PluralRules("ar-EG").select(6);
 // → 'few'
 
-new Intl.PluralRules('ar-EG').select(18);
+new Intl.PluralRules("ar-EG").select(18);
 // → 'many'
 ```
 


### PR DESCRIPTION
Fix typo in page title: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select .