### PR TITLE
pathname/index.md details

### DIFF
--- a/files/en-us/web/api/location/pathname/index.md
+++ b/files/en-us/web/api/location/pathname/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Location.pathname
 {{ApiRef("Location")}}
 
 The **`pathname`** property of the {{domxref("Location")}}
-interface is a string containing the path of the URL for the location, which will be the empty string if there is no path. If not empty, it contains an initial '/' followed by the path of the URL, not including the query string or fragment.
+interface is a string containing the path of the URL for the location. If there is no path, `pathname` will be empty: otherwise, `pathname` contains an initial '/' followed by the path of the URL, not including the query string or fragment.
 
 ## Value
 

--- a/files/en-us/web/api/location/pathname/index.md
+++ b/files/en-us/web/api/location/pathname/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Location.pathname
 {{ApiRef("Location")}}
 
 The **`pathname`** property of the {{domxref("Location")}}
-interface is a string containing the path of the URL for the location, which will be the empty string if there is no path.
+interface is a string containing the path of the URL for the location, which will be the empty string if there is no path. If not empty, it contains an initial '/' followed by the path of the URL, not including the query string or fragment.
 
 ## Value
 


### PR DESCRIPTION
### Description

Copied the details of pathname from ../index.md. (The same was already in place for protocol/index: it copied details from ../index.md.)

### Motivation
Because as it was, pathname/index.md was incomplete/confusing/misleading. Yes, this does add duplication - but so it was for protocol/index.md already.