### PR TITLE
[page type] Add page-type for CSS at-rules and at-rule descriptors

### DIFF
--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -1,6 +1,7 @@
 ---
 title: '@charset'
 slug: Web/CSS/@charset
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@color-profile"
 slug: Web/CSS/@color-profile
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@counter-style/additive-symbols/index.md
+++ b/files/en-us/web/css/@counter-style/additive-symbols/index.md
@@ -1,6 +1,7 @@
 ---
 title: additive-symbols
 slug: Web/CSS/@counter-style/additive-symbols
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/fallback/index.md
+++ b/files/en-us/web/css/@counter-style/fallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: fallback
 slug: Web/CSS/@counter-style/fallback
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/index.md
+++ b/files/en-us/web/css/@counter-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@counter-style"
 slug: Web/CSS/@counter-style
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@counter-style/negative/index.md
+++ b/files/en-us/web/css/@counter-style/negative/index.md
@@ -1,6 +1,7 @@
 ---
 title: negative
 slug: Web/CSS/@counter-style/negative
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/pad/index.md
+++ b/files/en-us/web/css/@counter-style/pad/index.md
@@ -1,6 +1,7 @@
 ---
 title: pad
 slug: Web/CSS/@counter-style/pad
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/prefix/index.md
+++ b/files/en-us/web/css/@counter-style/prefix/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefix
 slug: Web/CSS/@counter-style/prefix
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/range/index.md
+++ b/files/en-us/web/css/@counter-style/range/index.md
@@ -1,6 +1,7 @@
 ---
 title: range
 slug: Web/CSS/@counter-style/range
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -1,6 +1,7 @@
 ---
 title: speak-as
 slug: Web/CSS/@counter-style/speak-as
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/suffix/index.md
+++ b/files/en-us/web/css/@counter-style/suffix/index.md
@@ -1,6 +1,7 @@
 ---
 title: suffix
 slug: Web/CSS/@counter-style/suffix
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/symbols/index.md
+++ b/files/en-us/web/css/@counter-style/symbols/index.md
@@ -1,6 +1,7 @@
 ---
 title: symbols
 slug: Web/CSS/@counter-style/symbols
+page-type: css-at-rule-descriptor
 tags:
   - '@counter-style'
   - At-rule descriptor

--- a/files/en-us/web/css/@counter-style/system/index.md
+++ b/files/en-us/web/css/@counter-style/system/index.md
@@ -1,6 +1,7 @@
 ---
 title: system
 slug: Web/CSS/@counter-style/system
+page-type: css-at-rule-descriptor
 tags:
   - "@counter-style"
   - At-rule descriptor

--- a/files/en-us/web/css/@document/index.md
+++ b/files/en-us/web/css/@document/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@document"
 slug: Web/CSS/@document
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@font-face/ascent-override/index.md
+++ b/files/en-us/web/css/@font-face/ascent-override/index.md
@@ -1,6 +1,7 @@
 ---
 title: ascent-override
 slug: Web/CSS/@font-face/ascent-override
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/descent-override/index.md
+++ b/files/en-us/web/css/@font-face/descent-override/index.md
@@ -1,6 +1,7 @@
 ---
 title: descent-override
 slug: Web/CSS/@font-face/descent-override
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-display/index.md
+++ b/files/en-us/web/css/@font-face/font-display/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-display
 slug: Web/CSS/@font-face/font-display
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-family/index.md
+++ b/files/en-us/web/css/@font-face/font-family/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-family
 slug: Web/CSS/@font-face/font-family
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-stretch/index.md
+++ b/files/en-us/web/css/@font-face/font-stretch/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-stretch
 slug: Web/CSS/@font-face/font-stretch
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-style/index.md
+++ b/files/en-us/web/css/@font-face/font-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-style
 slug: Web/CSS/@font-face/font-style
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-variant/index.md
+++ b/files/en-us/web/css/@font-face/font-variant/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant
 slug: Web/CSS/@font-face/font-variant
+page-type: css-at-rule-descriptor
 browser-compat: css.at-rules.font-face.font-variant
 ---
 

--- a/files/en-us/web/css/@font-face/font-variation-settings/index.md
+++ b/files/en-us/web/css/@font-face/font-variation-settings/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variation-settings
 slug: Web/CSS/@font-face/font-variation-settings
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-weight
 slug: Web/CSS/@font-face/font-weight
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@font-face"
 slug: Web/CSS/@font-face
+page-type: css-at-rule
 tags:
   - "@font-face"
   - At-rule

--- a/files/en-us/web/css/@font-face/line-gap-override/index.md
+++ b/files/en-us/web/css/@font-face/line-gap-override/index.md
@@ -1,6 +1,7 @@
 ---
 title: line-gap-override
 slug: Web/CSS/@font-face/line-gap-override
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/size-adjust/index.md
+++ b/files/en-us/web/css/@font-face/size-adjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: size-adjust
 slug: Web/CSS/@font-face/size-adjust
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -1,6 +1,7 @@
 ---
 title: src
 slug: Web/CSS/@font-face/src
+page-type: css-at-rule-descriptor
 tags:
   - "@font-face"
   - At-rule descriptor

--- a/files/en-us/web/css/@font-face/unicode-range/index.md
+++ b/files/en-us/web/css/@font-face/unicode-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: unicode-range
 slug: Web/CSS/@font-face/unicode-range
+page-type: css-at-rule-descriptor
 tags:
   - At-rule descriptor
   - CSS

--- a/files/en-us/web/css/@font-feature-values/index.md
+++ b/files/en-us/web/css/@font-feature-values/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@font-feature-values"
 slug: Web/CSS/@font-feature-values
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@import"
 slug: Web/CSS/@import
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@keyframes"
 slug: Web/CSS/@keyframes
+page-type: css-at-rule
 tags:
   - Animations
   - At-rule

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@layer"
 slug: Web/CSS/@layer
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@media"
 slug: Web/CSS/@media
+page-type: css-at-rule
 tags:
   - "@media"
   - At-rule

--- a/files/en-us/web/css/@namespace/index.md
+++ b/files/en-us/web/css/@namespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@namespace"
 slug: Web/CSS/@namespace
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@page"
 slug: Web/CSS/@page
+page-type: css-at-rule
 tags:
   - "@page"
   - At-rule

--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: size
 slug: Web/CSS/@page/size
+page-type: css-at-rule-descriptor
 tags:
   - "@page"
   - At-rule descriptor

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@property"
 slug: Web/CSS/@property
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -1,6 +1,7 @@
 ---
 title: inherits
 slug: Web/CSS/@property/inherits
+page-type: css-at-rule-descriptor
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: initial-value
 slug: Web/CSS/@property/initial-value
+page-type: css-at-rule-descriptor
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -1,6 +1,7 @@
 ---
 title: syntax
 slug: Web/CSS/@property/syntax
+page-type: css-at-rule-descriptor
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/@scroll-timeline/index.md
+++ b/files/en-us/web/css/@scroll-timeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@scroll-timeline"
 slug: Web/CSS/@scroll-timeline
+page-type: css-at-rule
 tags:
   - Animations
   - Scroll

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@supports"
 slug: Web/CSS/@supports
+page-type: css-at-rule
 tags:
   - At-rule
   - CSS

--- a/files/en-us/web/css/@viewport/index.md
+++ b/files/en-us/web/css/@viewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: "@viewport"
 slug: Web/CSS/@viewport
+page-type: css-at-rule
 tags:
   - "@viewport"
   - At-rule


### PR DESCRIPTION
This PR adds `page-type` values for CSS at-rules and at-rule descriptors, following the analysis in https://github.com/mdn/content/issues/15540.