### PR TITLE
fix: code fence for empty string

### DIFF
--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -19,8 +19,7 @@ browser-compat: api.AnimationEvent.pseudoElement
 
 The **`AnimationEvent.pseudoElement`** read-only property is a
 string, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on.
-If the animation doesn't run on a pseudo-element but on the element, an empty string:
-` ''``. `
+If the animation doesn't run on a pseudo-element but on the element, an empty string: `''`.
 
 ## Value
 


### PR DESCRIPTION
Noticed this in the translated content repo. It looks like it might have been a bad conversion from HTML, unless I'm missing something