### PR TITLE
Fix tags for CSS MathML properties

### DIFF
--- a/files/en-us/web/css/math-depth/index.md
+++ b/files/en-us/web/css/math-depth/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/math-depth
 tags:
   - CSS
   - MathML
-  - Property
+  - CSS Property
   - Reference
   - math-depth
   - Experimental

--- a/files/en-us/web/css/math-shift/index.md
+++ b/files/en-us/web/css/math-shift/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/math-shift
 tags:
   - CSS
   - MathML
-  - Property
+  - CSS Property
   - Reference
   - math-shift
   - Experimental

--- a/files/en-us/web/css/math-style/index.md
+++ b/files/en-us/web/css/math-style/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/math-style
 tags:
   - CSS
   - MathML
-  - Property
+  - CSS Property
   - Reference
   - math-style
   - Experimental


### PR DESCRIPTION
The MathML properties had incorrect tags, which meant [formal syntax didn't show up properly](https://github.com/mdn/yari/blob/ce38e3b287f9f02916c4eeab3d51a10bb14a39af/kumascript/macros/CSSSyntax.ejs#L88):

https://developer.mozilla.org/en-US/docs/Web/CSS/math-depth#formal_syntax
https://developer.mozilla.org/en-US/docs/Web/CSS/math-shift#formal_syntax
https://developer.mozilla.org/en-US/docs/Web/CSS/math-style#formal_syntax

This PR fixes that, and gets us closer to resolving https://github.com/mdn/content/issues/18780.

Hopefully page types will make problems like this less likely.
