### PR TITLE
[page type] Add page-type for CSS media features

### DIFF
--- a/files/en-us/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/en-us/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-moz-device-pixel-ratio"
 slug: Web/CSS/@media/-moz-device-pixel-ratio
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/-ms-high-contrast/index.md
+++ b/files/en-us/web/css/@media/-ms-high-contrast/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-ms-high-contrast"
 slug: Web/CSS/@media/-ms-high-contrast
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-animation"
 slug: Web/CSS/@media/-webkit-animation
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-device-pixel-ratio"
 slug: Web/CSS/@media/-webkit-device-pixel-ratio
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-transform-2d"
 slug: Web/CSS/@media/-webkit-transform-2d
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-transform-3d"
 slug: Web/CSS/@media/-webkit-transform-3d
+page-type: css-media-feature
 tags:
   - "-webkit-transform-3d"
   - 3D

--- a/files/en-us/web/css/@media/-webkit-transition/index.md
+++ b/files/en-us/web/css/@media/-webkit-transition/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-transition"
 slug: Web/CSS/@media/-webkit-transition
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/any-hover/index.md
+++ b/files/en-us/web/css/@media/any-hover/index.md
@@ -1,6 +1,7 @@
 ---
 title: any-hover
 slug: Web/CSS/@media/any-hover
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/any-pointer/index.md
+++ b/files/en-us/web/css/@media/any-pointer/index.md
@@ -1,6 +1,7 @@
 ---
 title: any-pointer
 slug: Web/CSS/@media/any-pointer
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/aspect-ratio/index.md
+++ b/files/en-us/web/css/@media/aspect-ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: aspect-ratio
 slug: Web/CSS/@media/aspect-ratio
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/aural/index.md
+++ b/files/en-us/web/css/@media/aural/index.md
@@ -1,6 +1,7 @@
 ---
 title: aural
 slug: Web/CSS/@media/aural
+page-type: css-media-feature
 tags:
   - CSS
   - Deprecated

--- a/files/en-us/web/css/@media/color-gamut/index.md
+++ b/files/en-us/web/css/@media/color-gamut/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-gamut
 slug: Web/CSS/@media/color-gamut
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/color-index/index.md
+++ b/files/en-us/web/css/@media/color-index/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-index
 slug: Web/CSS/@media/color-index
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/color/index.md
+++ b/files/en-us/web/css/@media/color/index.md
@@ -1,6 +1,7 @@
 ---
 title: color
 slug: Web/CSS/@media/color
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/device-aspect-ratio/index.md
+++ b/files/en-us/web/css/@media/device-aspect-ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: device-aspect-ratio
 slug: Web/CSS/@media/device-aspect-ratio
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/device-height/index.md
+++ b/files/en-us/web/css/@media/device-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: device-height
 slug: Web/CSS/@media/device-height
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/device-width/index.md
+++ b/files/en-us/web/css/@media/device-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: device-width
 slug: Web/CSS/@media/device-width
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/display-mode/index.md
+++ b/files/en-us/web/css/@media/display-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: display-mode
 slug: Web/CSS/@media/display-mode
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/dynamic-range/index.md
+++ b/files/en-us/web/css/@media/dynamic-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: dynamic-range
 slug: Web/CSS/@media/dynamic-range
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/forced-colors/index.md
+++ b/files/en-us/web/css/@media/forced-colors/index.md
@@ -1,6 +1,7 @@
 ---
 title: forced-colors
 slug: Web/CSS/@media/forced-colors
+page-type: css-media-feature
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/@media/grid/index.md
+++ b/files/en-us/web/css/@media/grid/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid
 slug: Web/CSS/@media/grid
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/height/index.md
+++ b/files/en-us/web/css/@media/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: height
 slug: Web/CSS/@media/height
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/hover/index.md
+++ b/files/en-us/web/css/@media/hover/index.md
@@ -1,6 +1,7 @@
 ---
 title: hover
 slug: Web/CSS/@media/hover
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/inverted-colors/index.md
+++ b/files/en-us/web/css/@media/inverted-colors/index.md
@@ -1,6 +1,7 @@
 ---
 title: inverted-colors
 slug: Web/CSS/@media/inverted-colors
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/monochrome/index.md
+++ b/files/en-us/web/css/@media/monochrome/index.md
@@ -1,6 +1,7 @@
 ---
 title: monochrome
 slug: Web/CSS/@media/monochrome
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/orientation/index.md
+++ b/files/en-us/web/css/@media/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: orientation
 slug: Web/CSS/@media/orientation
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/overflow-block/index.md
+++ b/files/en-us/web/css/@media/overflow-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-block
 slug: Web/CSS/@media/overflow-block
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/overflow-inline/index.md
+++ b/files/en-us/web/css/@media/overflow-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-inline
 slug: Web/CSS/@media/overflow-inline
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/pointer/index.md
+++ b/files/en-us/web/css/@media/pointer/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointer
 slug: Web/CSS/@media/pointer
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefers-color-scheme
 slug: Web/CSS/@media/prefers-color-scheme
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/prefers-contrast/index.md
+++ b/files/en-us/web/css/@media/prefers-contrast/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefers-contrast
 slug: Web/CSS/@media/prefers-contrast
+page-type: css-media-feature
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/@media/prefers-reduced-data/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-data/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefers-reduced-data
 slug: Web/CSS/@media/prefers-reduced-data
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefers-reduced-motion
 slug: Web/CSS/@media/prefers-reduced-motion
+page-type: css-media-feature
 tags:
   - "@media"
   - Accessibility

--- a/files/en-us/web/css/@media/resolution/index.md
+++ b/files/en-us/web/css/@media/resolution/index.md
@@ -1,6 +1,7 @@
 ---
 title: resolution
 slug: Web/CSS/@media/resolution
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/scripting/index.md
+++ b/files/en-us/web/css/@media/scripting/index.md
@@ -1,6 +1,7 @@
 ---
 title: scripting
 slug: Web/CSS/@media/scripting
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/shape/index.md
+++ b/files/en-us/web/css/@media/shape/index.md
@@ -1,6 +1,7 @@
 ---
 title: shape
 slug: Web/CSS/@media/shape
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/update-frequency/index.md
+++ b/files/en-us/web/css/@media/update-frequency/index.md
@@ -1,6 +1,7 @@
 ---
 title: update
 slug: Web/CSS/@media/update-frequency
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/video-dynamic-range/index.md
+++ b/files/en-us/web/css/@media/video-dynamic-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: video-dynamic-range
 slug: Web/CSS/@media/video-dynamic-range
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS

--- a/files/en-us/web/css/@media/width/index.md
+++ b/files/en-us/web/css/@media/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: width
 slug: Web/CSS/@media/width
+page-type: css-media-feature
 tags:
   - "@media"
   - CSS


### PR DESCRIPTION
This PR adds `page-type` values for CSS media features, following the analysis in https://github.com/mdn/content/issues/15540.