### PR TITLE
[page type] Add page-type for CSS properties, part 2

### DIFF
--- a/files/en-us/web/css/border-top-right-radius/index.md
+++ b/files/en-us/web/css/border-top-right-radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-top-right-radius
 slug: Web/CSS/border-top-right-radius
+page-type: css-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-top-style/index.md
+++ b/files/en-us/web/css/border-top-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-top-style
 slug: Web/CSS/border-top-style
+page-type: css-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-top-width/index.md
+++ b/files/en-us/web/css/border-top-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-top-width
 slug: Web/CSS/border-top-width
+page-type: css-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/bottom/index.md
+++ b/files/en-us/web/css/bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: bottom
 slug: Web/CSS/bottom
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-align
 slug: Web/CSS/box-align
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-decoration-break/index.md
+++ b/files/en-us/web/css/box-decoration-break/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-decoration-break
 slug: Web/CSS/box-decoration-break
+page-type: css-property
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/box-direction/index.md
+++ b/files/en-us/web/css/box-direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-direction
 slug: Web/CSS/box-direction
+page-type: css-property
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/box-flex-group/index.md
+++ b/files/en-us/web/css/box-flex-group/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-flex-group
 slug: Web/CSS/box-flex-group
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-flex
 slug: Web/CSS/box-flex
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-lines/index.md
+++ b/files/en-us/web/css/box-lines/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-lines
 slug: Web/CSS/box-lines
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-ordinal-group/index.md
+++ b/files/en-us/web/css/box-ordinal-group/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-ordinal-group
 slug: Web/CSS/box-ordinal-group
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-orient/index.md
+++ b/files/en-us/web/css/box-orient/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-orient
 slug: Web/CSS/box-orient
+page-type: css-property
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/box-pack/index.md
+++ b/files/en-us/web/css/box-pack/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-pack
 slug: Web/CSS/box-pack
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-shadow
 slug: Web/CSS/box-shadow
+page-type: css-property
 tags:
   - CSS
   - CSS Backgrounds and Borders

--- a/files/en-us/web/css/box-sizing/index.md
+++ b/files/en-us/web/css/box-sizing/index.md
@@ -1,6 +1,7 @@
 ---
 title: box-sizing
 slug: Web/CSS/box-sizing
+page-type: css-property
 tags:
   - Boxes
   - CSS

--- a/files/en-us/web/css/break-after/index.md
+++ b/files/en-us/web/css/break-after/index.md
@@ -1,6 +1,7 @@
 ---
 title: break-after
 slug: Web/CSS/break-after
+page-type: css-property
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/break-before/index.md
+++ b/files/en-us/web/css/break-before/index.md
@@ -1,6 +1,7 @@
 ---
 title: break-before
 slug: Web/CSS/break-before
+page-type: css-property
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/break-inside/index.md
+++ b/files/en-us/web/css/break-inside/index.md
@@ -1,6 +1,7 @@
 ---
 title: break-inside
 slug: Web/CSS/break-inside
+page-type: css-property
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -1,6 +1,7 @@
 ---
 title: caption-side
 slug: Web/CSS/caption-side
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/caret-color/index.md
+++ b/files/en-us/web/css/caret-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: caret-color
 slug: Web/CSS/caret-color
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/clear/index.md
+++ b/files/en-us/web/css/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: clear
 slug: Web/CSS/clear
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -1,6 +1,7 @@
 ---
 title: clip-path
 slug: Web/CSS/clip-path
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/clip/index.md
+++ b/files/en-us/web/css/clip/index.md
@@ -1,6 +1,7 @@
 ---
 title: clip
 slug: Web/CSS/clip
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/color-scheme/index.md
+++ b/files/en-us/web/css/color-scheme/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-scheme
 slug: Web/CSS/color-scheme
+page-type: css-property
 tags:
   - CSS
   - CSS Colors

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -1,6 +1,7 @@
 ---
 title: color
 slug: Web/CSS/color
+page-type: css-property
 tags:
   - CSS
   - CSS Colors

--- a/files/en-us/web/css/column-count/index.md
+++ b/files/en-us/web/css/column-count/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-count
 slug: Web/CSS/column-count
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-fill
 slug: Web/CSS/column-fill
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-gap
 slug: Web/CSS/column-gap
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/column-rule-color/index.md
+++ b/files/en-us/web/css/column-rule-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-rule-color
 slug: Web/CSS/column-rule-color
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-rule-style/index.md
+++ b/files/en-us/web/css/column-rule-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-rule-style
 slug: Web/CSS/column-rule-style
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-rule-width/index.md
+++ b/files/en-us/web/css/column-rule-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-rule-width
 slug: Web/CSS/column-rule-width
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-span/index.md
+++ b/files/en-us/web/css/column-span/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-span
 slug: Web/CSS/column-span
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/column-width/index.md
+++ b/files/en-us/web/css/column-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-width
 slug: Web/CSS/column-width
+page-type: css-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/contain-intrinsic-size/index.md
+++ b/files/en-us/web/css/contain-intrinsic-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: contain-intrinsic-size
 slug: Web/CSS/contain-intrinsic-size
+page-type: css-property
 browser-compat: css.properties.contain-intrinsic-size
 ---
 

--- a/files/en-us/web/css/contain/index.md
+++ b/files/en-us/web/css/contain/index.md
@@ -1,6 +1,7 @@
 ---
 title: contain
 slug: Web/CSS/contain
+page-type: css-property
 tags:
   - CSS
   - CSS Containment

--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: content-visibility
 slug: Web/CSS/content-visibility
+page-type: css-property
 tags:
   - CSS
   - CSS Containment

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -1,6 +1,7 @@
 ---
 title: content
 slug: Web/CSS/content
+page-type: css-property
 tags:
   - CSS
   - CSS Counter

--- a/files/en-us/web/css/counter-increment/index.md
+++ b/files/en-us/web/css/counter-increment/index.md
@@ -1,6 +1,7 @@
 ---
 title: counter-increment
 slug: Web/CSS/counter-increment
+page-type: css-property
 tags:
   - CSS
   - CSS Counter

--- a/files/en-us/web/css/counter-reset/index.md
+++ b/files/en-us/web/css/counter-reset/index.md
@@ -1,6 +1,7 @@
 ---
 title: counter-reset
 slug: Web/CSS/counter-reset
+page-type: css-property
 tags:
   - CSS
   - CSS Counter

--- a/files/en-us/web/css/counter-set/index.md
+++ b/files/en-us/web/css/counter-set/index.md
@@ -1,6 +1,7 @@
 ---
 title: counter-set
 slug: Web/CSS/counter-set
+page-type: css-property
 tags:
   - CSS
   - CSS Counter

--- a/files/en-us/web/css/cursor/index.md
+++ b/files/en-us/web/css/cursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: cursor
 slug: Web/CSS/cursor
+page-type: css-property
 tags:
   - Arrow
   - CSS

--- a/files/en-us/web/css/direction/index.md
+++ b/files/en-us/web/css/direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: direction
 slug: Web/CSS/direction
+page-type: css-property
 tags:
   - BiDi
   - CSS

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -1,6 +1,7 @@
 ---
 title: display
 slug: Web/CSS/display
+page-type: css-property
 tags:
   - CSS
   - CSS Display

--- a/files/en-us/web/css/empty-cells/index.md
+++ b/files/en-us/web/css/empty-cells/index.md
@@ -1,6 +1,7 @@
 ---
 title: empty-cells
 slug: Web/CSS/empty-cells
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -1,6 +1,7 @@
 ---
 title: filter
 slug: Web/CSS/filter
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/flex-basis/index.md
+++ b/files/en-us/web/css/flex-basis/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-basis
 slug: Web/CSS/flex-basis
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/flex-direction/index.md
+++ b/files/en-us/web/css/flex-direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-direction
 slug: Web/CSS/flex-direction
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/flex-grow/index.md
+++ b/files/en-us/web/css/flex-grow/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-grow
 slug: Web/CSS/flex-grow
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/flex-shrink/index.md
+++ b/files/en-us/web/css/flex-shrink/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-shrink
 slug: Web/CSS/flex-shrink
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/flex-wrap/index.md
+++ b/files/en-us/web/css/flex-wrap/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-wrap
 slug: Web/CSS/flex-wrap
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/float/index.md
+++ b/files/en-us/web/css/float/index.md
@@ -1,6 +1,7 @@
 ---
 title: float
 slug: Web/CSS/float
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-family
 slug: Web/CSS/font-family
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-feature-settings/index.md
+++ b/files/en-us/web/css/font-feature-settings/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-feature-settings
 slug: Web/CSS/font-feature-settings
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-kerning/index.md
+++ b/files/en-us/web/css/font-kerning/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-kerning
 slug: Web/CSS/font-kerning
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-language-override/index.md
+++ b/files/en-us/web/css/font-language-override/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-language-override
 slug: Web/CSS/font-language-override
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-optical-sizing/index.md
+++ b/files/en-us/web/css/font-optical-sizing/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-optical-sizing
 slug: Web/CSS/font-optical-sizing
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-size-adjust/index.md
+++ b/files/en-us/web/css/font-size-adjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-size-adjust
 slug: Web/CSS/font-size-adjust
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-size/index.md
+++ b/files/en-us/web/css/font-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-size
 slug: Web/CSS/font-size
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-smooth/index.md
+++ b/files/en-us/web/css/font-smooth/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-smooth
 slug: Web/CSS/font-smooth
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/font-stretch/index.md
+++ b/files/en-us/web/css/font-stretch/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-stretch
 slug: Web/CSS/font-stretch
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-style/index.md
+++ b/files/en-us/web/css/font-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-style
 slug: Web/CSS/font-style
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-synthesis
 slug: Web/CSS/font-synthesis
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-alternates/index.md
+++ b/files/en-us/web/css/font-variant-alternates/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-alternates
 slug: Web/CSS/font-variant-alternates
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-caps/index.md
+++ b/files/en-us/web/css/font-variant-caps/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-caps
 slug: Web/CSS/font-variant-caps
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-east-asian/index.md
+++ b/files/en-us/web/css/font-variant-east-asian/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-east-asian
 slug: Web/CSS/font-variant-east-asian
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/font-variant-ligatures/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-ligatures
 slug: Web/CSS/font-variant-ligatures
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-numeric
 slug: Web/CSS/font-variant-numeric
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variant-position/index.md
+++ b/files/en-us/web/css/font-variant-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant-position
 slug: Web/CSS/font-variant-position
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-variation-settings/index.md
+++ b/files/en-us/web/css/font-variation-settings/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variation-settings
 slug: Web/CSS/font-variation-settings
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font-weight/index.md
+++ b/files/en-us/web/css/font-weight/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-weight
 slug: Web/CSS/font-weight
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/forced-color-adjust/index.md
+++ b/files/en-us/web/css/forced-color-adjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: forced-color-adjust
 slug: Web/CSS/forced-color-adjust
+page-type: css-property
 tags:
   - Adjusting Colors
   - CSS

--- a/files/en-us/web/css/gap/index.md
+++ b/files/en-us/web/css/gap/index.md
@@ -1,6 +1,7 @@
 ---
 title: gap (grid-gap)
 slug: Web/CSS/gap
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/grid-auto-columns/index.md
+++ b/files/en-us/web/css/grid-auto-columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-auto-columns
 slug: Web/CSS/grid-auto-columns
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-auto-flow/index.md
+++ b/files/en-us/web/css/grid-auto-flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-auto-flow
 slug: Web/CSS/grid-auto-flow
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-auto-rows/index.md
+++ b/files/en-us/web/css/grid-auto-rows/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-auto-rows
 slug: Web/CSS/grid-auto-rows
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-column-end/index.md
+++ b/files/en-us/web/css/grid-column-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-column-end
 slug: Web/CSS/grid-column-end
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-column-start/index.md
+++ b/files/en-us/web/css/grid-column-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-column-start
 slug: Web/CSS/grid-column-start
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-row-end/index.md
+++ b/files/en-us/web/css/grid-row-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-row-end
 slug: Web/CSS/grid-row-end
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-row-start/index.md
+++ b/files/en-us/web/css/grid-row-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-row-start
 slug: Web/CSS/grid-row-start
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-template-areas/index.md
+++ b/files/en-us/web/css/grid-template-areas/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-template-areas
 slug: Web/CSS/grid-template-areas
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-template-columns/index.md
+++ b/files/en-us/web/css/grid-template-columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-template-columns
 slug: Web/CSS/grid-template-columns
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-template-rows/index.md
+++ b/files/en-us/web/css/grid-template-rows/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-template-rows
 slug: Web/CSS/grid-template-rows
+page-type: css-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -1,6 +1,7 @@
 ---
 title: hanging-punctuation
 slug: Web/CSS/hanging-punctuation
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: height
 slug: Web/CSS/height
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -1,6 +1,7 @@
 ---
 title: hyphenate-character
 slug: Web/CSS/hyphenate-character
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/hyphens/index.md
+++ b/files/en-us/web/css/hyphens/index.md
@@ -1,6 +1,7 @@
 ---
 title: hyphens
 slug: Web/CSS/hyphens
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/image-orientation/index.md
+++ b/files/en-us/web/css/image-orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: image-orientation
 slug: Web/CSS/image-orientation
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: image-rendering
 slug: Web/CSS/image-rendering
+page-type: css-property
 tags:
   - CSS
   - CSS Images

--- a/files/en-us/web/css/image-resolution/index.md
+++ b/files/en-us/web/css/image-resolution/index.md
@@ -1,6 +1,7 @@
 ---
 title: image-resolution
 slug: Web/CSS/image-resolution
+page-type: css-property
 tags:
   - CSS
   - CSS Images

--- a/files/en-us/web/css/ime-mode/index.md
+++ b/files/en-us/web/css/ime-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ime-mode
 slug: Web/CSS/ime-mode
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/initial-letter-align/index.md
+++ b/files/en-us/web/css/initial-letter-align/index.md
@@ -1,6 +1,7 @@
 ---
 title: initial-letter-align
 slug: Web/CSS/initial-letter-align
+page-type: css-property
 tags:
   - Align
   - CSS

--- a/files/en-us/web/css/initial-letter/index.md
+++ b/files/en-us/web/css/initial-letter/index.md
@@ -1,6 +1,7 @@
 ---
 title: initial-letter
 slug: Web/CSS/initial-letter
+page-type: css-property
 tags:
   - CSS
   - CSS Inline

--- a/files/en-us/web/css/inline-size/index.md
+++ b/files/en-us/web/css/inline-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: inline-size
 slug: Web/CSS/inline-size
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset-block-end/index.md
+++ b/files/en-us/web/css/inset-block-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-block-end
 slug: Web/CSS/inset-block-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset-block-start/index.md
+++ b/files/en-us/web/css/inset-block-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-block-start
 slug: Web/CSS/inset-block-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset-inline-end/index.md
+++ b/files/en-us/web/css/inset-inline-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-inline-end
 slug: Web/CSS/inset-inline-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset-inline-start/index.md
+++ b/files/en-us/web/css/inset-inline-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-inline-start
 slug: Web/CSS/inset-inline-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/isolation/index.md
+++ b/files/en-us/web/css/isolation/index.md
@@ -1,6 +1,7 @@
 ---
 title: isolation
 slug: Web/CSS/isolation
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/justify-content/index.md
+++ b/files/en-us/web/css/justify-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: justify-content
 slug: Web/CSS/justify-content
+page-type: css-property
 tags:
   - CSS
   - CSS Box Alignment

--- a/files/en-us/web/css/justify-items/index.md
+++ b/files/en-us/web/css/justify-items/index.md
@@ -1,6 +1,7 @@
 ---
 title: justify-items
 slug: Web/CSS/justify-items
+page-type: css-property
 tags:
   - CSS
   - CSS Box Alignment


### PR DESCRIPTION
This PR is part 2 of adding `page-type` values for CSS properties, following the analysis in https://github.com/mdn/content/issues/15540.