### PR TITLE
FF105 RelNote - Font Loading API in workers

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -936,47 +936,6 @@ This new API provides low-level support for performing computation and graphics 
   </tbody>
 </table>
 
-### CSS Font Loading API
-
-The [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) can now be used in worker threads.
-See {{bug(1072107)}}.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.font-loading-api.workers.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Audio Output API
 
 #### MediaDevices.selectAudioOutput()

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -36,6 +36,8 @@ No notable changes.
 - The [OffscreenCanvas](/en-US/docs/Web/API/OffscreenCanvas) API provides a canvas that can be rendered off-screen in both window and [web worker](/en-US/docs/Web/API/OffscreenCanvas#asynchronous_display_of_frames_produced_by_an_offscreencanvas) contexts.
   This allows `<canvas>` elements to be decoupled from the DOM. The [OffscreenCanvasRenderingContext2D](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) interface provides support for this and is now enabled by default ({{bug(1746110)}}).
 
+- The [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) can now be used in worker threads ({{bug(1072107)}}).
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi


### PR DESCRIPTION
FF105 ships font loading API support for workers in https://bugzilla.mozilla.org/show_bug.cgi?id=1779009. This removes the information in the experimental features page and adds it to the release note.

Other docs work for this can be tracked in #21070