### PR TITLE
Revert "chore(deps): bump tj-actions/changed-files from 29.0.9 to 31.0.1 (#21076)"

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v31.0.1
+        uses: tj-actions/changed-files@v29.0.9
         with:
           files: |
             **/*.md


### PR DESCRIPTION
This reverts commit 1dca32bf2be96ed9cd18df848e2466f2537817bb, which seems to have broken our CI; see https://github.com/mdn/content/actions/runs/3132569283/jobs/5085046761