### PR TITLE
[page type] Add page-type for CSS properties, part 3

### DIFF
--- a/files/en-us/web/css/justify-self/index.md
+++ b/files/en-us/web/css/justify-self/index.md
@@ -1,6 +1,7 @@
 ---
 title: justify-self
 slug: Web/CSS/justify-self
+page-type: css-property
 tags:
   - CSS
   - CSS Box Alignment

--- a/files/en-us/web/css/justify-tracks/index.md
+++ b/files/en-us/web/css/justify-tracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: justify-tracks
 slug: Web/CSS/justify-tracks
+page-type: css-property
 tags:
   - CSS
   - Experimental

--- a/files/en-us/web/css/left/index.md
+++ b/files/en-us/web/css/left/index.md
@@ -1,6 +1,7 @@
 ---
 title: left
 slug: Web/CSS/left
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/letter-spacing/index.md
+++ b/files/en-us/web/css/letter-spacing/index.md
@@ -1,6 +1,7 @@
 ---
 title: letter-spacing
 slug: Web/CSS/letter-spacing
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/line-break/index.md
+++ b/files/en-us/web/css/line-break/index.md
@@ -1,6 +1,7 @@
 ---
 title: line-break
 slug: Web/CSS/line-break
+page-type: css-property
 tags:
   - Asian
   - CSS

--- a/files/en-us/web/css/line-height-step/index.md
+++ b/files/en-us/web/css/line-height-step/index.md
@@ -1,6 +1,7 @@
 ---
 title: line-height-step
 slug: Web/CSS/line-height-step
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/line-height/index.md
+++ b/files/en-us/web/css/line-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: line-height
 slug: Web/CSS/line-height
+page-type: css-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/list-style-image/index.md
+++ b/files/en-us/web/css/list-style-image/index.md
@@ -1,6 +1,7 @@
 ---
 title: list-style-image
 slug: Web/CSS/list-style-image
+page-type: css-property
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/list-style-position/index.md
+++ b/files/en-us/web/css/list-style-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: list-style-position
 slug: Web/CSS/list-style-position
+page-type: css-property
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: list-style-type
 slug: Web/CSS/list-style-type
+page-type: css-property
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/margin-block-end/index.md
+++ b/files/en-us/web/css/margin-block-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-block-end
 slug: Web/CSS/margin-block-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin-block-start/index.md
+++ b/files/en-us/web/css/margin-block-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-block-start
 slug: Web/CSS/margin-block-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin-bottom/index.md
+++ b/files/en-us/web/css/margin-bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-bottom
 slug: Web/CSS/margin-bottom
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/margin-inline-end/index.md
+++ b/files/en-us/web/css/margin-inline-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-inline-end
 slug: Web/CSS/margin-inline-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin-inline-start/index.md
+++ b/files/en-us/web/css/margin-inline-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-inline-start
 slug: Web/CSS/margin-inline-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-left
 slug: Web/CSS/margin-left
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/margin-right/index.md
+++ b/files/en-us/web/css/margin-right/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-right
 slug: Web/CSS/margin-right
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/margin-top/index.md
+++ b/files/en-us/web/css/margin-top/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-top
 slug: Web/CSS/margin-top
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/margin-trim/index.md
+++ b/files/en-us/web/css/margin-trim/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-trim
 slug: Web/CSS/margin-trim
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/mask-border-mode/index.md
+++ b/files/en-us/web/css/mask-border-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-mode
 slug: Web/CSS/mask-border-mode
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-border-outset/index.md
+++ b/files/en-us/web/css/mask-border-outset/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-outset
 slug: Web/CSS/mask-border-outset
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-border-repeat/index.md
+++ b/files/en-us/web/css/mask-border-repeat/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-repeat
 slug: Web/CSS/mask-border-repeat
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-border-slice/index.md
+++ b/files/en-us/web/css/mask-border-slice/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-slice
 slug: Web/CSS/mask-border-slice
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-border-source/index.md
+++ b/files/en-us/web/css/mask-border-source/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-source
 slug: Web/CSS/mask-border-source
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-border-width/index.md
+++ b/files/en-us/web/css/mask-border-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border-width
 slug: Web/CSS/mask-border-width
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-clip
 slug: Web/CSS/mask-clip
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-composite/index.md
+++ b/files/en-us/web/css/mask-composite/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-composite
 slug: Web/CSS/mask-composite
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-image
 slug: Web/CSS/mask-image
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-mode/index.md
+++ b/files/en-us/web/css/mask-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-mode
 slug: Web/CSS/mask-mode
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-origin
 slug: Web/CSS/mask-origin
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-position/index.md
+++ b/files/en-us/web/css/mask-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-position
 slug: Web/CSS/mask-position
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-repeat
 slug: Web/CSS/mask-repeat
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-size/index.md
+++ b/files/en-us/web/css/mask-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-size
 slug: Web/CSS/mask-size
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-type
 slug: Web/CSS/mask-type
+page-type: css-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/masonry-auto-flow/index.md
+++ b/files/en-us/web/css/masonry-auto-flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: masonry-auto-flow
 slug: Web/CSS/masonry-auto-flow
+page-type: css-property
 tags:
   - CSS
   - Experimental

--- a/files/en-us/web/css/math-style/index.md
+++ b/files/en-us/web/css/math-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: math-style
 slug: Web/CSS/math-style
+page-type: css-property
 tags:
   - CSS
   - MathML

--- a/files/en-us/web/css/max-block-size/index.md
+++ b/files/en-us/web/css/max-block-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: max-block-size
 slug: Web/CSS/max-block-size
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: max-height
 slug: Web/CSS/max-height
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/max-inline-size/index.md
+++ b/files/en-us/web/css/max-inline-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: max-inline-size
 slug: Web/CSS/max-inline-size
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: max-width
 slug: Web/CSS/max-width
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/min-block-size/index.md
+++ b/files/en-us/web/css/min-block-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: min-block-size
 slug: Web/CSS/min-block-size
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: min-height
 slug: Web/CSS/min-height
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/min-inline-size/index.md
+++ b/files/en-us/web/css/min-inline-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: min-inline-size
 slug: Web/CSS/min-inline-size
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/min-width/index.md
+++ b/files/en-us/web/css/min-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: min-width
 slug: Web/CSS/min-width
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: mix-blend-mode
 slug: Web/CSS/mix-blend-mode
+page-type: css-property
 tags:
   - Blending
   - CSS

--- a/files/en-us/web/css/object-fit/index.md
+++ b/files/en-us/web/css/object-fit/index.md
@@ -1,6 +1,7 @@
 ---
 title: object-fit
 slug: Web/CSS/object-fit
+page-type: css-property
 tags:
   - CSS
   - CSS Images

--- a/files/en-us/web/css/object-position/index.md
+++ b/files/en-us/web/css/object-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: object-position
 slug: Web/CSS/object-position
+page-type: css-property
 tags:
   - CSS
   - CSS Images

--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset-anchor
 slug: Web/CSS/offset-anchor
+page-type: css-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/offset-distance/index.md
+++ b/files/en-us/web/css/offset-distance/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset-distance
 slug: Web/CSS/offset-distance
+page-type: css-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset-path
 slug: Web/CSS/offset-path
+page-type: css-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset-position
 slug: Web/CSS/offset-position
+page-type: css-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/offset-rotate/index.md
+++ b/files/en-us/web/css/offset-rotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset-rotate
 slug: Web/CSS/offset-rotate
+page-type: css-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/opacity/index.md
+++ b/files/en-us/web/css/opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: opacity
 slug: Web/CSS/opacity
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/order/index.md
+++ b/files/en-us/web/css/order/index.md
@@ -1,6 +1,7 @@
 ---
 title: order
 slug: Web/CSS/order
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/orphans/index.md
+++ b/files/en-us/web/css/orphans/index.md
@@ -1,6 +1,7 @@
 ---
 title: orphans
 slug: Web/CSS/orphans
+page-type: css-property
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: outline-color
 slug: Web/CSS/outline-color
+page-type: css-property
 tags:
   - CSS
   - CSS Outline

--- a/files/en-us/web/css/outline-offset/index.md
+++ b/files/en-us/web/css/outline-offset/index.md
@@ -1,6 +1,7 @@
 ---
 title: outline-offset
 slug: Web/CSS/outline-offset
+page-type: css-property
 tags:
   - CSS
   - CSS Outline

--- a/files/en-us/web/css/outline-style/index.md
+++ b/files/en-us/web/css/outline-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: outline-style
 slug: Web/CSS/outline-style
+page-type: css-property
 tags:
   - CSS
   - CSS Outline

--- a/files/en-us/web/css/outline-width/index.md
+++ b/files/en-us/web/css/outline-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: outline-width
 slug: Web/CSS/outline-width
+page-type: css-property
 tags:
   - CSS
   - CSS Outline

--- a/files/en-us/web/css/overflow-anchor/index.md
+++ b/files/en-us/web/css/overflow-anchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-anchor
 slug: Web/CSS/overflow-anchor
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/overflow-block/index.md
+++ b/files/en-us/web/css/overflow-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-block
 slug: Web/CSS/overflow-block
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overflow-clip-margin/index.md
+++ b/files/en-us/web/css/overflow-clip-margin/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-clip-margin
 slug: Web/CSS/overflow-clip-margin
+page-type: css-property
 tags:
   - CSS
   - CSS Overflow

--- a/files/en-us/web/css/overflow-inline/index.md
+++ b/files/en-us/web/css/overflow-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-inline
 slug: Web/CSS/overflow-inline
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overflow-wrap/index.md
+++ b/files/en-us/web/css/overflow-wrap/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-wrap
 slug: Web/CSS/overflow-wrap
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/overflow-x/index.md
+++ b/files/en-us/web/css/overflow-x/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-x
 slug: Web/CSS/overflow-x
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overflow-y/index.md
+++ b/files/en-us/web/css/overflow-y/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow-y
 slug: Web/CSS/overflow-y
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: overscroll-behavior-block
 slug: Web/CSS/overscroll-behavior-block
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: overscroll-behavior-inline
 slug: Web/CSS/overscroll-behavior-inline
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -1,6 +1,7 @@
 ---
 title: overscroll-behavior-x
 slug: Web/CSS/overscroll-behavior-x
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -1,6 +1,7 @@
 ---
 title: overscroll-behavior-y
 slug: Web/CSS/overscroll-behavior-y
+page-type: css-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-block-end
 slug: Web/CSS/padding-block-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-block-start
 slug: Web/CSS/padding-block-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/padding-bottom/index.md
+++ b/files/en-us/web/css/padding-bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-bottom
 slug: Web/CSS/padding-bottom
+page-type: css-property
 tags:
   - CSS
   - CSS Padding

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-inline-end
 slug: Web/CSS/padding-inline-end
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-inline-start
 slug: Web/CSS/padding-inline-start
+page-type: css-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/padding-left/index.md
+++ b/files/en-us/web/css/padding-left/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-left
 slug: Web/CSS/padding-left
+page-type: css-property
 tags:
   - CSS
   - CSS Padding

--- a/files/en-us/web/css/padding-right/index.md
+++ b/files/en-us/web/css/padding-right/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-right
 slug: Web/CSS/padding-right
+page-type: css-property
 tags:
   - CSS
   - CSS Padding

--- a/files/en-us/web/css/padding-top/index.md
+++ b/files/en-us/web/css/padding-top/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-top
 slug: Web/CSS/padding-top
+page-type: css-property
 tags:
   - CSS
   - CSS Padding

--- a/files/en-us/web/css/page-break-after/index.md
+++ b/files/en-us/web/css/page-break-after/index.md
@@ -1,6 +1,7 @@
 ---
 title: page-break-after
 slug: Web/CSS/page-break-after
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/page-break-before/index.md
+++ b/files/en-us/web/css/page-break-before/index.md
@@ -1,6 +1,7 @@
 ---
 title: page-break-before
 slug: Web/CSS/page-break-before
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/page-break-inside/index.md
+++ b/files/en-us/web/css/page-break-inside/index.md
@@ -1,6 +1,7 @@
 ---
 title: page-break-inside
 slug: Web/CSS/page-break-inside
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/paint-order/index.md
+++ b/files/en-us/web/css/paint-order/index.md
@@ -1,6 +1,7 @@
 ---
 title: paint-order
 slug: Web/CSS/paint-order
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/perspective-origin/index.md
+++ b/files/en-us/web/css/perspective-origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: perspective-origin
 slug: Web/CSS/perspective-origin
+page-type: css-property
 tags:
   - 3D
   - CSS

--- a/files/en-us/web/css/perspective/index.md
+++ b/files/en-us/web/css/perspective/index.md
@@ -1,6 +1,7 @@
 ---
 title: perspective
 slug: Web/CSS/perspective
+page-type: css-property
 tags:
   - 3D
   - CSS

--- a/files/en-us/web/css/pointer-events/index.md
+++ b/files/en-us/web/css/pointer-events/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointer-events
 slug: Web/CSS/pointer-events
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -1,6 +1,7 @@
 ---
 title: position
 slug: Web/CSS/position
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/print-color-adjust/index.md
+++ b/files/en-us/web/css/print-color-adjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: print-color-adjust
 slug: Web/CSS/print-color-adjust
+page-type: css-property
 tags:
   - Adjusting Colors
   - CSS

--- a/files/en-us/web/css/quotes/index.md
+++ b/files/en-us/web/css/quotes/index.md
@@ -1,6 +1,7 @@
 ---
 title: quotes
 slug: Web/CSS/quotes
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/resize/index.md
+++ b/files/en-us/web/css/resize/index.md
@@ -1,6 +1,7 @@
 ---
 title: resize
 slug: Web/CSS/resize
+page-type: css-property
 tags:
   - Basic User Interface
   - CSS

--- a/files/en-us/web/css/right/index.md
+++ b/files/en-us/web/css/right/index.md
@@ -1,6 +1,7 @@
 ---
 title: right
 slug: Web/CSS/right
+page-type: css-property
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/rotate/index.md
+++ b/files/en-us/web/css/rotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: rotate
 slug: Web/CSS/rotate
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -1,6 +1,7 @@
 ---
 title: row-gap
 slug: Web/CSS/row-gap
+page-type: css-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/ruby-align/index.md
+++ b/files/en-us/web/css/ruby-align/index.md
@@ -1,6 +1,7 @@
 ---
 title: ruby-align
 slug: Web/CSS/ruby-align
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: ruby-position
 slug: Web/CSS/ruby-position
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scale/index.md
+++ b/files/en-us/web/css/scale/index.md
@@ -1,6 +1,7 @@
 ---
 title: scale
 slug: Web/CSS/scale
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-behavior/index.md
+++ b/files/en-us/web/css/scroll-behavior/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-behavior
 slug: Web/CSS/scroll-behavior
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin-block-end/index.md
+++ b/files/en-us/web/css/scroll-margin-block-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-block-end
 slug: Web/CSS/scroll-margin-block-end
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin-block-start/index.md
+++ b/files/en-us/web/css/scroll-margin-block-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-block-start
 slug: Web/CSS/scroll-margin-block-start
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin-bottom/index.md
+++ b/files/en-us/web/css/scroll-margin-bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-bottom
 slug: Web/CSS/scroll-margin-bottom
+page-type: css-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin-inline-end/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-inline-end
 slug: Web/CSS/scroll-margin-inline-end
+page-type: css-property
 tags:
   - CSS
   - CSS Property


### PR DESCRIPTION
This PR is part 3 of adding `page-type` values for CSS properties, following the analysis in https://github.com/mdn/content/issues/15540.