### PR TITLE
[page-type] Add page-type for CSS pseudo-classes

### DIFF
--- a/files/en-us/web/css/_colon_-moz-broken/index.md
+++ b/files/en-us/web/css/_colon_-moz-broken/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":-moz-broken"
 slug: Web/CSS/:-moz-broken
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-drag-over/index.md
+++ b/files/en-us/web/css/_colon_-moz-drag-over/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-drag-over'
 slug: Web/CSS/:-moz-drag-over
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-first-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-first-node/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-first-node'
 slug: Web/CSS/:-moz-first-node
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-focusring/index.md
+++ b/files/en-us/web/css/_colon_-moz-focusring/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-focusring'
 slug: Web/CSS/:-moz-focusring
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-handler-blocked'
 slug: Web/CSS/:-moz-handler-blocked
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-handler-crashed'
 slug: Web/CSS/:-moz-handler-crashed
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-handler-disabled'
 slug: Web/CSS/:-moz-handler-disabled
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-last-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-last-node/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-last-node'
 slug: Web/CSS/:-moz-last-node
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-list-bullet/index.md
+++ b/files/en-us/web/css/_colon_-moz-list-bullet/index.md
@@ -1,6 +1,7 @@
 ---
 title: "::-moz-list-bullet"
 slug: Web/CSS/:-moz-list-bullet
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-list-number/index.md
+++ b/files/en-us/web/css/_colon_-moz-list-number/index.md
@@ -1,6 +1,7 @@
 ---
 title: "::-moz-list-number"
 slug: Web/CSS/:-moz-list-number
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-loading/index.md
+++ b/files/en-us/web/css/_colon_-moz-loading/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-loading'
 slug: Web/CSS/:-moz-loading
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-locale-dir(ltr)/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir(ltr)/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-locale-dir(ltr)'
 slug: Web/CSS/:-moz-locale-dir(ltr)
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-locale-dir(rtl)/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir(rtl)/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-locale-dir(rtl)'
 slug: Web/CSS/:-moz-locale-dir(rtl)
+page-type: css-pseudo-class
 tags:
   - ':-moz-locale-dir'
   - CSS

--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":-moz-only-whitespace"
 slug: Web/CSS/:-moz-only-whitespace
+page-type: css-pseudo-class
 tags:
   - ":-moz-only-whitespace"
   - CSS

--- a/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":-moz-submit-invalid"
 slug: Web/CSS/:-moz-submit-invalid
+page-type: css-pseudo-class
 tags:
   - ":-moz-submit-invalid"
   - CSS

--- a/files/en-us/web/css/_colon_-moz-suppressed/index.md
+++ b/files/en-us/web/css/_colon_-moz-suppressed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":-moz-suppressed"
 slug: Web/CSS/:-moz-suppressed
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/en-us/web/css/_colon_-moz-user-disabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":-moz-user-disabled"
 slug: Web/CSS/:-moz-user-disabled
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/en-us/web/css/_colon_-moz-window-inactive/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':-moz-window-inactive'
 slug: Web/CSS/:-moz-window-inactive
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_colon_active/index.md
+++ b/files/en-us/web/css/_colon_active/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":active"
 slug: Web/CSS/:active
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_any-link/index.md
+++ b/files/en-us/web/css/_colon_any-link/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":any-link"
 slug: Web/CSS/:any-link
+page-type: css-pseudo-class
 tags:
   - ":any-link"
   - CSS

--- a/files/en-us/web/css/_colon_autofill/index.md
+++ b/files/en-us/web/css/_colon_autofill/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":autofill"
 slug: Web/CSS/:autofill
+page-type: css-pseudo-class
 tags:
   - CSS
   - Pseudo-class

--- a/files/en-us/web/css/_colon_blank/index.md
+++ b/files/en-us/web/css/_colon_blank/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":blank"
 slug: Web/CSS/:blank
+page-type: css-pseudo-class
 tags:
   - ":blank"
   - CSS

--- a/files/en-us/web/css/_colon_checked/index.md
+++ b/files/en-us/web/css/_colon_checked/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":checked"
 slug: Web/CSS/:checked
+page-type: css-pseudo-class
 tags:
   - ":checked"
   - CSS

--- a/files/en-us/web/css/_colon_default/index.md
+++ b/files/en-us/web/css/_colon_default/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":default"
 slug: Web/CSS/:default
+page-type: css-pseudo-class
 tags:
   - ":default"
   - CSS

--- a/files/en-us/web/css/_colon_defined/index.md
+++ b/files/en-us/web/css/_colon_defined/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":defined"
 slug: Web/CSS/:defined
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_dir/index.md
+++ b/files/en-us/web/css/_colon_dir/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":dir()"
 slug: Web/CSS/:dir
+page-type: css-pseudo-class
 tags:
   - BiDi
   - CSS

--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":disabled"
 slug: Web/CSS/:disabled
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_empty/index.md
+++ b/files/en-us/web/css/_colon_empty/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":empty"
 slug: Web/CSS/:empty
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_enabled/index.md
+++ b/files/en-us/web/css/_colon_enabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":enabled"
 slug: Web/CSS/:enabled
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_first-child/index.md
+++ b/files/en-us/web/css/_colon_first-child/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":first-child"
 slug: Web/CSS/:first-child
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":first-of-type"
 slug: Web/CSS/:first-of-type
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_first/index.md
+++ b/files/en-us/web/css/_colon_first/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":first"
 slug: Web/CSS/:first
+page-type: css-pseudo-class
 tags:
   - "@page"
   - CSS

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":focus-visible"
 slug: Web/CSS/:focus-visible
+page-type: css-pseudo-class
 tags:
   - ":focus"
   - ":focus-visible"

--- a/files/en-us/web/css/_colon_focus-within/index.md
+++ b/files/en-us/web/css/_colon_focus-within/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":focus-within"
 slug: Web/CSS/:focus-within
+page-type: css-pseudo-class
 tags:
   - ":focus"
   - ":focus-within"

--- a/files/en-us/web/css/_colon_focus/index.md
+++ b/files/en-us/web/css/_colon_focus/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":focus"
 slug: Web/CSS/:focus
+page-type: css-pseudo-class
 tags:
   - ":focus"
   - CSS

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":fullscreen"
 slug: Web/CSS/:fullscreen
+page-type: css-pseudo-class
 tags:
   - CSS
   - Fullscreen

--- a/files/en-us/web/css/_colon_future/index.md
+++ b/files/en-us/web/css/_colon_future/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":future"
 slug: Web/CSS/:future
+page-type: css-pseudo-class
 browser-compat: css.selectors.future
 ---
 

--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -1,6 +1,7 @@
 ---
 title: ':has()'
 slug: Web/CSS/:has
+page-type: css-pseudo-class
 tags:
   - ':has'
   - CSS

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":host-context()"
 slug: Web/CSS/:host-context
+page-type: css-pseudo-class
 tags:
   - ":host-context()"
   - CSS

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":host"
 slug: Web/CSS/:host
+page-type: css-pseudo-class
 tags:
   - ":host"
   - CSS

--- a/files/en-us/web/css/_colon_host_function/index.md
+++ b/files/en-us/web/css/_colon_host_function/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":host()"
 slug: Web/CSS/:host_function
+page-type: css-pseudo-class
 tags:
   - ":host()"
   - CSS

--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":hover"
 slug: Web/CSS/:hover
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_in-range/index.md
+++ b/files/en-us/web/css/_colon_in-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":in-range"
 slug: Web/CSS/:in-range
+page-type: css-pseudo-class
 tags:
   - CSS
   - Pseudo-class

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":indeterminate"
 slug: Web/CSS/:indeterminate
+page-type: css-pseudo-class
 tags:
   - ":indeterminate"
   - CSS

--- a/files/en-us/web/css/_colon_invalid/index.md
+++ b/files/en-us/web/css/_colon_invalid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":invalid"
 slug: Web/CSS/:invalid
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":is()"
 slug: Web/CSS/:is
+page-type: css-pseudo-class
 tags:
   - ":is"
   - CSS

--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":lang()"
 slug: Web/CSS/:lang
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_last-child/index.md
+++ b/files/en-us/web/css/_colon_last-child/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":last-child"
 slug: Web/CSS/:last-child
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_last-of-type/index.md
+++ b/files/en-us/web/css/_colon_last-of-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":last-of-type"
 slug: Web/CSS/:last-of-type
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_left/index.md
+++ b/files/en-us/web/css/_colon_left/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":left"
 slug: Web/CSS/:left
+page-type: css-pseudo-class
 tags:
   - "@page"
   - CSS

--- a/files/en-us/web/css/_colon_link/index.md
+++ b/files/en-us/web/css/_colon_link/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":link"
 slug: Web/CSS/:link
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":local-link"
 slug: Web/CSS/:local-link
+page-type: css-pseudo-class
 spec-urls: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":not()"
 slug: Web/CSS/:not
+page-type: css-pseudo-class
 tags:
   - ":not()"
   - CSS

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-child()"
 slug: Web/CSS/:nth-child
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_nth-col/index.md
+++ b/files/en-us/web/css/_colon_nth-col/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-col"
 slug: Web/CSS/:nth-col
+page-type: css-pseudo-class
 browser-compat: css.selectors.nth-col
 ---
 

--- a/files/en-us/web/css/_colon_nth-last-child/index.md
+++ b/files/en-us/web/css/_colon_nth-last-child/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-last-child()"
 slug: Web/CSS/:nth-last-child
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_nth-last-col/index.md
+++ b/files/en-us/web/css/_colon_nth-last-col/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-last-col"
 slug: Web/CSS/:nth-last-col
+page-type: css-pseudo-class
 browser-compat: css.selectors.nth-last-col
 ---
 

--- a/files/en-us/web/css/_colon_nth-last-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-last-of-type()"
 slug: Web/CSS/:nth-last-of-type
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":nth-of-type()"
 slug: Web/CSS/:nth-of-type
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_only-child/index.md
+++ b/files/en-us/web/css/_colon_only-child/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":only-child"
 slug: Web/CSS/:only-child
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_only-of-type/index.md
+++ b/files/en-us/web/css/_colon_only-of-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":only-of-type"
 slug: Web/CSS/:only-of-type
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_optional/index.md
+++ b/files/en-us/web/css/_colon_optional/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":optional"
 slug: Web/CSS/:optional
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_out-of-range/index.md
+++ b/files/en-us/web/css/_colon_out-of-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":out-of-range"
 slug: Web/CSS/:out-of-range
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_past/index.md
+++ b/files/en-us/web/css/_colon_past/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":past"
 slug: Web/CSS/:past
+page-type: css-pseudo-class
 browser-compat: css.selectors.past
 ---
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":paused"
 slug: Web/CSS/:paused
+page-type: css-pseudo-class
 tags:
   - CSS
   - Pseudo-class

--- a/files/en-us/web/css/_colon_picture-in-picture/index.md
+++ b/files/en-us/web/css/_colon_picture-in-picture/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":picture-in-picture"
 slug: Web/CSS/:picture-in-picture
+page-type: css-pseudo-class
 tags:
   - CSS
   - Picture-in-Picture

--- a/files/en-us/web/css/_colon_placeholder-shown/index.md
+++ b/files/en-us/web/css/_colon_placeholder-shown/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":placeholder-shown"
 slug: Web/CSS/:placeholder-shown
+page-type: css-pseudo-class
 tags:
   - ":placeholder-shown"
   - CSS

--- a/files/en-us/web/css/_colon_playing/index.md
+++ b/files/en-us/web/css/_colon_playing/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":playing"
 slug: Web/CSS/:playing
+page-type: css-pseudo-class
 tags:
   - CSS
   - Pseudo-class

--- a/files/en-us/web/css/_colon_read-only/index.md
+++ b/files/en-us/web/css/_colon_read-only/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":read-only"
 slug: Web/CSS/:read-only
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_read-write/index.md
+++ b/files/en-us/web/css/_colon_read-write/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":read-write"
 slug: Web/CSS/:read-write
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_required/index.md
+++ b/files/en-us/web/css/_colon_required/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":required"
 slug: Web/CSS/:required
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_right/index.md
+++ b/files/en-us/web/css/_colon_right/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":right"
 slug: Web/CSS/:right
+page-type: css-pseudo-class
 tags:
   - "@page"
   - CSS

--- a/files/en-us/web/css/_colon_root/index.md
+++ b/files/en-us/web/css/_colon_root/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":root"
 slug: Web/CSS/:root
+page-type: css-pseudo-class
 tags:
   - CSS
   - Element

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":scope"
 slug: Web/CSS/:scope
+page-type: css-pseudo-class
 tags:
   - ":scope"
   - CSS

--- a/files/en-us/web/css/_colon_target-within/index.md
+++ b/files/en-us/web/css/_colon_target-within/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":target-within"
 slug: Web/CSS/:target-within
+page-type: css-pseudo-class
 browser-compat: css.selectors.target-within
 ---
 

--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":target"
 slug: Web/CSS/:target
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_user-invalid/index.md
+++ b/files/en-us/web/css/_colon_user-invalid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":user-invalid (:-moz-ui-invalid)"
 slug: Web/CSS/:user-invalid
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS Selectors

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":user-valid (:-moz-ui-valid)"
 slug: web/css/:user-valid
+page-type: css-pseudo-class
 tags:
   - CSS
   - CSS Selectors

--- a/files/en-us/web/css/_colon_valid/index.md
+++ b/files/en-us/web/css/_colon_valid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":valid"
 slug: Web/CSS/:valid
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_visited/index.md
+++ b/files/en-us/web/css/_colon_visited/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":visited"
 slug: Web/CSS/:visited
+page-type: css-pseudo-class
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":where()"
 slug: Web/CSS/:where
+page-type: css-pseudo-class
 tags:
   - ":where"
   - CSS


### PR DESCRIPTION
This PR adds `page-type` values for CSS pseudo-classes, following the analysis in https://github.com/mdn/content/issues/15540.