### PR TITLE
[page-type] Add page-type for CSS pseudo-elements

### DIFF
--- a/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-color-swatch'
 slug: Web/CSS/::-moz-color-swatch
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-focus-inner'
 slug: Web/CSS/::-moz-focus-inner
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-page-sequence'
 slug: Web/CSS/::-moz-page-sequence
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-page/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-page/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-page'
 slug: Web/CSS/::-moz-page
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-progress-bar'
 slug: Web/CSS/::-moz-progress-bar
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-range-progress'
 slug: Web/CSS/::-moz-range-progress
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-range-thumb'
 slug: Web/CSS/::-moz-range-thumb
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-range-track'
 slug: Web/CSS/::-moz-range-track
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-moz-scrolled-page-sequence'
 slug: Web/CSS/::-moz-scrolled-page-sequence
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-inner-spin-button'
 slug: Web/CSS/::-webkit-inner-spin-button
+page-type: css-pseudo-element
 tags:
   - CSS
   - NeedsBrowserCompatibility

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-meter-bar'
 slug: Web/CSS/::-webkit-meter-bar
+page-type: css-pseudo-element
 tags:
   - '-webkit-meter-bar'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-meter-even-less-good-value'
 slug: Web/CSS/::-webkit-meter-even-less-good-value
+page-type: css-pseudo-element
 tags:
   - '-webkit-meter-even-less-good-value'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-meter-inner-element'
 slug: Web/CSS/::-webkit-meter-inner-element
+page-type: css-pseudo-element
 tags:
   - '-webkit-meter-inner-element'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-meter-optimum-value'
 slug: Web/CSS/::-webkit-meter-optimum-value
+page-type: css-pseudo-element
 tags:
   - '::-webkit-meter-optimum-value'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-meter-suboptimum-value'
 slug: Web/CSS/::-webkit-meter-suboptimum-value
+page-type: css-pseudo-element
 tags:
   - '-webkit-meter-suboptimum-value'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-outer-spin-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-outer-spin-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-outer-spin-button'
 slug: Web/CSS/::-webkit-outer-spin-button
+page-type: css-pseudo-element
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-progress-bar'
 slug: Web/CSS/::-webkit-progress-bar
+page-type: css-pseudo-element
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-progress-inner-element'
 slug: Web/CSS/::-webkit-progress-inner-element
+page-type: css-pseudo-element
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-progress-value'
 slug: Web/CSS/::-webkit-progress-value
+page-type: css-pseudo-element
 tags:
   - CSS
   - Non-standard

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-scrollbar'
 slug: Web/CSS/::-webkit-scrollbar
+page-type: css-pseudo-element
 tags:
   - '::-webkit-scrollbar'
   - CSS

--- a/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-search-cancel-button'
 slug: Web/CSS/::-webkit-search-cancel-button
+page-type: css-pseudo-element
 tags:
   - CSS
   - NeedsExample

--- a/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-search-results-button'
 slug: Web/CSS/::-webkit-search-results-button
+page-type: css-pseudo-element
 tags:
   - CSS
   - NeedsExample

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-slider-runnable-track'
 slug: Web/CSS/::-webkit-slider-runnable-track
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS:WebKit Extensions

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::-webkit-slider-thumb'
 slug: Web/CSS/::-webkit-slider-thumb
+page-type: css-pseudo-element
 tags:
   - CSS
   - NeedsBrowserCompatibility

--- a/files/en-us/web/css/_doublecolon_after/index.md
+++ b/files/en-us/web/css/_doublecolon_after/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::after (:after)'
 slug: Web/CSS/::after
+page-type: css-pseudo-element
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::backdrop'
 slug: Web/CSS/::backdrop
+page-type: css-pseudo-element
 tags:
   - API
   - CSS

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -1,6 +1,7 @@
 ---
 title: "::before (:before)"
 slug: Web/CSS/::before
+page-type: css-pseudo-element
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_doublecolon_cue-region/index.md
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::cue-region'
 slug: Web/CSS/::cue-region
+page-type: css-pseudo-element
 tags:
   - '::cue-region'
   - CSS

--- a/files/en-us/web/css/_doublecolon_cue/index.md
+++ b/files/en-us/web/css/_doublecolon_cue/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::cue'
 slug: Web/CSS/::cue
+page-type: css-pseudo-element
 tags:
   - '::cue'
   - CSS

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::file-selector-button'
 slug: Web/CSS/::file-selector-button
+page-type: css-pseudo-element
 tags:
   - CSS
   - Pseudo-element

--- a/files/en-us/web/css/_doublecolon_first-letter/index.md
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::first-letter (:first-letter)'
 slug: Web/CSS/::first-letter
+page-type: css-pseudo-element
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::first-line (:first-line)'
 slug: Web/CSS/::first-line
+page-type: css-pseudo-element
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.md
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::grammar-error'
 slug: Web/CSS/::grammar-error
+page-type: css-pseudo-element
 tags:
   - CSS
   - Experimental

--- a/files/en-us/web/css/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/_doublecolon_marker/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::marker'
 slug: Web/CSS/::marker
+page-type: css-pseudo-element
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::part()'
 slug: Web/CSS/::part
+page-type: css-pseudo-element
 tags:
   - '::part'
   - CSS

--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::placeholder'
 slug: Web/CSS/::placeholder
+page-type: css-pseudo-element
 tags:
   - '::placeholder'
   - CSS

--- a/files/en-us/web/css/_doublecolon_selection/index.md
+++ b/files/en-us/web/css/_doublecolon_selection/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::selection'
 slug: Web/CSS/::selection
+page-type: css-pseudo-element
 tags:
   - CSS
   - Layout

--- a/files/en-us/web/css/_doublecolon_slotted/index.md
+++ b/files/en-us/web/css/_doublecolon_slotted/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::slotted()'
 slug: Web/CSS/::slotted
+page-type: css-pseudo-element
 tags:
   - '::slotted'
   - CSS

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.md
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::spelling-error'
 slug: Web/CSS/::spelling-error
+page-type: css-pseudo-element
 tags:
   - CSS
   - Experimental

--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -1,6 +1,7 @@
 ---
 title: '::target-text'
 slug: Web/CSS/::target-text
+page-type: css-pseudo-element
 tags:
   - '::target-text'
   - CSS


### PR DESCRIPTION
This PR adds `page-type` values for CSS pseudo-elements, following the analysis in https://github.com/mdn/content/issues/15540.