### PR TITLE
Tweak doc for mfrac attributes

### DIFF
--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -24,17 +24,14 @@ and [Legendre symbols](https://en.wikipedia.org/wiki/Legendre_symbol).
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `denomalign` {{deprecated_inline}}
   - : The alignment of the denominator under the fraction. Possible values are: `left`, `center` (default), and `right`.
-    This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 - `linethickness`
-  - : The thickness of the horizontal fraction line. This attributes accepts any [length values](/en-US/docs/Web/CSS/length).
-    The values `medium`, `thin`, and `thick` are deprecated and will be removed in the future.
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the thickness of the horizontal fraction line. Some browsers may also accept deprecated values `medium`, `thin` and `thick` but their exact interpretation is left to implementers.
 - `numalign` {{deprecated_inline}}
   - : The alignment of the numerator over the fraction. Possible values are: `left`, `center` (default), and `right`.
-    This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 
 ## Examples
 


### PR DESCRIPTION

### Description

- numalign/denomalign: These are already removed from MathML Core and Firefox ; there is already a deprecated_inline, so no need to repeat they are deprecated. Also the recommendation to use `text-align` is incorrect, currently there is no CSS alternative.

- linethickness: Use <length-percentage> and tweak the doc about name values.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
