### PR TITLE
CSS `abs()` function - Add BCD browser compatibility

### DIFF
--- a/files/en-us/web/css/abs/index.md
+++ b/files/en-us/web/css/abs/index.md
@@ -11,10 +11,10 @@ tags:
   - Web
   - abs
   - Experimental
-spec-urls: https://drafts.csswg.org/css-values/#sign-funcs
+browser-compat: css.types.abs
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`abs()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns the absolute value of the argument, as the same type as the input.
 
@@ -69,6 +69,10 @@ div {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
### Description

Add BCD browser compatibility to CSS `abs()` function.

### Motivation

Now that BCD was merged, we can update the `abs()` functions on MDN.

### Related issues and pull requests

BCD: https://github.com/mdn/browser-compat-data/pull/10552
