### PR TITLE
Highlight that as(U)IntN is static

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -25,13 +25,18 @@ BigInt.asIntN(bits, bigint)
 ### Parameters
 
 - `bits`
-  - : The amount of bits available for the integer size.
+  - : The amount of bits available for the returned BigInt. Should be an integer between 0 and 2<sup>53</sup> - 1, inclusive.
 - `bigint`
   - : The BigInt value to clamp to fit into the supplied bits.
 
-### Returns
+### Return value
 
 The value of `bigint` modulo 2^`bits`, as a signed integer.
+
+### Exceptions
+
+- {{jsxref("RangeError")}}
+  - : Thrown if `bits` is negative or greater than 2<sup>53</sup> - 1.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -53,6 +53,8 @@ If the leading bit of the remaining number is `1`, the result is negative. For e
 
 > **Note:** `BigInt` values are always encoded as two's complement in binary.
 
+Unlike similar language APIs such as {{jsxref("Number.prototype.toExponential()")}}, `asIntN` is a static property of {{jsxref("BigInt")}}, so you always use it as `BigInt.asIntN()`, rather than as a method of a BigInt value. Exposing `asIntN()` as a "standard library function" allows [interop with asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
+
 ## Examples
 
 ### Staying in 64-bit ranges

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -45,6 +45,8 @@ The `BigInt.asUintN` method clamps a `BigInt` value to the given number of bits,
 
 > **Note:** `BigInt` values are always encoded as two's complement in binary.
 
+Unlike similar language APIs such as {{jsxref("Number.prototype.toExponential()")}}, `asUintN` is a static property of {{jsxref("BigInt")}}, so you always use it as `BigInt.asUintN()`, rather than as a method of a BigInt value. Exposing `asUintN()` as a "standard library function" allows [interop with asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
+
 ## Examples
 
 ### Staying in 64-bit ranges

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -25,13 +25,18 @@ BigInt.asUintN(bits, bigint)
 ### Parameters
 
 - `bits`
-  - : The amount of bits available for the integer size.
+  - : The amount of bits available for the returned BigInt. Should be an integer between 0 and 2<sup>53</sup> - 1, inclusive.
 - `bigint`
   - : The BigInt value to clamp to fit into the supplied bits.
 
-### Returns
+### Return value
 
 The value of `bigint` modulo 2^`bits`, as an unsigned integer.
+
+### Exceptions
+
+ - {{jsxref("RangeError")}}
+   - : Thrown if `bits` is negative or greater than 2<sup>53</sup> - 1.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -35,8 +35,8 @@ The value of `bigint` modulo 2^`bits`, as an unsigned integer.
 
 ### Exceptions
 
- - {{jsxref("RangeError")}}
-   - : Thrown if `bits` is negative or greater than 2<sup>53</sup> - 1.
+- {{jsxref("RangeError")}}
+  - : Thrown if `bits` is negative or greater than 2<sup>53</sup> - 1.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It had been a bit of a gotcha that `asIntN` is not used like `1n.asIntN(64)`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
