### PR TITLE
[page type] Add page-type for CSS shorthand properties

### DIFF
--- a/files/en-us/web/css/-moz-outline-radius/index.md
+++ b/files/en-us/web/css/-moz-outline-radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-moz-outline-radius"
 slug: Web/CSS/-moz-outline-radius
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/-webkit-border-before/index.md
+++ b/files/en-us/web/css/-webkit-border-before/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-border-before"
 slug: Web/CSS/-webkit-border-before
+page-type: css-shorthand-property
 tags:
   - "-webkit-border-before"
   - CSS

--- a/files/en-us/web/css/-webkit-text-stroke/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-webkit-text-stroke"
 slug: Web/CSS/-webkit-text-stroke
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -1,6 +1,7 @@
 ---
 title: all
 slug: Web/CSS/all
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Cascade

--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: animation
 slug: Web/CSS/animation
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Animations

--- a/files/en-us/web/css/background/index.md
+++ b/files/en-us/web/css/background/index.md
@@ -1,6 +1,7 @@
 ---
 title: background
 slug: Web/CSS/background
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Background

--- a/files/en-us/web/css/border-block-end/index.md
+++ b/files/en-us/web/css/border-block-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-block-end
 slug: Web/CSS/border-block-end
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-block-start/index.md
+++ b/files/en-us/web/css/border-block-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-block-start
 slug: Web/CSS/border-block-start
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-block
 slug: Web/CSS/border-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-bottom/index.md
+++ b/files/en-us/web/css/border-bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-bottom
 slug: Web/CSS/border-bottom
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-color/index.md
+++ b/files/en-us/web/css/border-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-color
 slug: Web/CSS/border-color
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-inline-end
 slug: Web/CSS/border-inline-end
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-inline-start/index.md
+++ b/files/en-us/web/css/border-inline-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-inline-start
 slug: Web/CSS/border-inline-start
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-inline/index.md
+++ b/files/en-us/web/css/border-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-inline
 slug: Web/CSS/border-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/border-left/index.md
+++ b/files/en-us/web/css/border-left/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-left
 slug: Web/CSS/border-left
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-right/index.md
+++ b/files/en-us/web/css/border-right/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-right
 slug: Web/CSS/border-right
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-style/index.md
+++ b/files/en-us/web/css/border-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-style
 slug: Web/CSS/border-style
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-top/index.md
+++ b/files/en-us/web/css/border-top/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-top
 slug: Web/CSS/border-top
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border-width/index.md
+++ b/files/en-us/web/css/border-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: border-width
 slug: Web/CSS/border-width
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -1,6 +1,7 @@
 ---
 title: border
 slug: Web/CSS/border
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/column-rule/index.md
+++ b/files/en-us/web/css/column-rule/index.md
@@ -1,6 +1,7 @@
 ---
 title: column-rule
 slug: Web/CSS/column-rule
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/columns/index.md
+++ b/files/en-us/web/css/columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: columns
 slug: Web/CSS/columns
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/flex-flow/index.md
+++ b/files/en-us/web/css/flex-flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex-flow
 slug: Web/CSS/flex-flow
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -1,6 +1,7 @@
 ---
 title: flex
 slug: Web/CSS/flex
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/font-variant/index.md
+++ b/files/en-us/web/css/font-variant/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant
 slug: Web/CSS/font-variant
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/font/index.md
+++ b/files/en-us/web/css/font/index.md
@@ -1,6 +1,7 @@
 ---
 title: font
 slug: Web/CSS/font
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/grid-area/index.md
+++ b/files/en-us/web/css/grid-area/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-area
 slug: Web/CSS/grid-area
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-column/index.md
+++ b/files/en-us/web/css/grid-column/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-column
 slug: Web/CSS/grid-column
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-row/index.md
+++ b/files/en-us/web/css/grid-row/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-row
 slug: Web/CSS/grid-row
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid-template/index.md
+++ b/files/en-us/web/css/grid-template/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid-template
 slug: Web/CSS/grid-template
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/grid/index.md
+++ b/files/en-us/web/css/grid/index.md
@@ -1,6 +1,7 @@
 ---
 title: grid
 slug: Web/CSS/grid
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/inset-block/index.md
+++ b/files/en-us/web/css/inset-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-block
 slug: Web/CSS/inset-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset-inline/index.md
+++ b/files/en-us/web/css/inset-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset-inline
 slug: Web/CSS/inset-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/inset/index.md
+++ b/files/en-us/web/css/inset/index.md
@@ -1,6 +1,7 @@
 ---
 title: inset
 slug: Web/CSS/inset
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/list-style/index.md
+++ b/files/en-us/web/css/list-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: list-style
 slug: Web/CSS/list-style
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-block
 slug: Web/CSS/margin-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin-inline
 slug: Web/CSS/margin-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Logical Property

--- a/files/en-us/web/css/margin/index.md
+++ b/files/en-us/web/css/margin/index.md
@@ -1,6 +1,7 @@
 ---
 title: margin
 slug: Web/CSS/margin
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/mask-border/index.md
+++ b/files/en-us/web/css/mask-border/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask-border
 slug: Web/CSS/mask-border
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask
 slug: Web/CSS/mask
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/offset/index.md
+++ b/files/en-us/web/css/offset/index.md
@@ -1,6 +1,7 @@
 ---
 title: offset
 slug: Web/CSS/offset
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/outline/index.md
+++ b/files/en-us/web/css/outline/index.md
@@ -1,6 +1,7 @@
 ---
 title: outline
 slug: Web/CSS/outline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Outline

--- a/files/en-us/web/css/overflow/index.md
+++ b/files/en-us/web/css/overflow/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow
 slug: Web/CSS/overflow
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -1,6 +1,7 @@
 ---
 title: overscroll-behavior
 slug: Web/CSS/overscroll-behavior
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-block
 slug: Web/CSS/padding-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding-inline
 slug: Web/CSS/padding-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -1,6 +1,7 @@
 ---
 title: padding
 slug: Web/CSS/padding
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Padding

--- a/files/en-us/web/css/place-content/index.md
+++ b/files/en-us/web/css/place-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: place-content
 slug: Web/CSS/place-content
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Box Alignment

--- a/files/en-us/web/css/place-items/index.md
+++ b/files/en-us/web/css/place-items/index.md
@@ -1,6 +1,7 @@
 ---
 title: place-items
 slug: Web/CSS/place-items
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/place-self/index.md
+++ b/files/en-us/web/css/place-self/index.md
@@ -1,6 +1,7 @@
 ---
 title: place-self
 slug: Web/CSS/place-self
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Box Alignment

--- a/files/en-us/web/css/scroll-margin-block/index.md
+++ b/files/en-us/web/css/scroll-margin-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-block
 slug: Web/CSS/scroll-margin-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin-inline/index.md
+++ b/files/en-us/web/css/scroll-margin-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin-inline
 slug: Web/CSS/scroll-margin-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-margin/index.md
+++ b/files/en-us/web/css/scroll-margin/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-margin
 slug: Web/CSS/scroll-margin
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-padding-block/index.md
+++ b/files/en-us/web/css/scroll-padding-block/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-padding-block
 slug: Web/CSS/scroll-padding-block
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Scroll Snap

--- a/files/en-us/web/css/scroll-padding-inline/index.md
+++ b/files/en-us/web/css/scroll-padding-inline/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-padding-inline
 slug: Web/CSS/scroll-padding-inline
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/scroll-padding/index.md
+++ b/files/en-us/web/css/scroll-padding/index.md
@@ -1,6 +1,7 @@
 ---
 title: scroll-padding
 slug: Web/CSS/scroll-padding
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/text-decoration/index.md
+++ b/files/en-us/web/css/text-decoration/index.md
@@ -1,6 +1,7 @@
 ---
 title: text-decoration
 slug: Web/CSS/text-decoration
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/text-emphasis/index.md
+++ b/files/en-us/web/css/text-emphasis/index.md
@@ -1,6 +1,7 @@
 ---
 title: text-emphasis
 slug: Web/CSS/text-emphasis
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -1,6 +1,7 @@
 ---
 title: transition
 slug: Web/CSS/transition
+page-type: css-shorthand-property
 tags:
   - CSS
   - CSS Property


### PR DESCRIPTION
This PR adds `page-type` values for CSS shorthand properties, following the analysis in https://github.com/mdn/content/issues/15540.