### PR TITLE
[page type] Add page-type for CSS types

### DIFF
--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -1,6 +1,7 @@
 ---
 title: "-moz-image-rect"
 slug: Web/CSS/-moz-image-rect
+page-type: css-type
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -1,7 +1,7 @@
 ---
 title: "-moz-image-rect"
 slug: Web/CSS/-moz-image-rect
-page-type: css-type
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: <alpha-value>
 slug: Web/CSS/alpha-value
+page-type: css-type
 tags:
   - Alpha
   - Alpha-value

--- a/files/en-us/web/css/angle-percentage/index.md
+++ b/files/en-us/web/css/angle-percentage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <angle-percentage>
 slug: Web/CSS/angle-percentage
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/angle/index.md
+++ b/files/en-us/web/css/angle/index.md
@@ -1,6 +1,7 @@
 ---
 title: <angle>
 slug: Web/CSS/angle
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -1,6 +1,7 @@
 ---
 title: <basic-shape>
 slug: Web/CSS/basic-shape
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/blend-mode/index.md
+++ b/files/en-us/web/css/blend-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: <blend-mode>
 slug: Web/CSS/blend-mode
+page-type: css-type
 tags:
   - Blend modes
   - CSS

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: <color>
 slug: Web/CSS/color_value
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/custom-ident/index.md
+++ b/files/en-us/web/css/custom-ident/index.md
@@ -1,6 +1,7 @@
 ---
 title: <custom-ident>
 slug: Web/CSS/custom-ident
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/dimension/index.md
+++ b/files/en-us/web/css/dimension/index.md
@@ -1,6 +1,7 @@
 ---
 title: <dimension>
 slug: Web/CSS/dimension
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-box/index.md
+++ b/files/en-us/web/css/display-box/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-box>
 slug: Web/CSS/display-box
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-inside/index.md
+++ b/files/en-us/web/css/display-inside/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-inside>
 slug: Web/CSS/display-inside
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-internal/index.md
+++ b/files/en-us/web/css/display-internal/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-internal>
 slug: Web/CSS/display-internal
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-legacy/index.md
+++ b/files/en-us/web/css/display-legacy/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-legacy>
 slug: Web/CSS/display-legacy
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-listitem/index.md
+++ b/files/en-us/web/css/display-listitem/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-listitem>
 slug: Web/CSS/display-listitem
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/display-outside/index.md
+++ b/files/en-us/web/css/display-outside/index.md
@@ -1,6 +1,7 @@
 ---
 title: <display-outside>
 slug: Web/CSS/display-outside
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -1,6 +1,7 @@
 ---
 title: <easing-function>
 slug: Web/CSS/easing-function
+page-type: css-type
 tags:
   - API
   - CSS

--- a/files/en-us/web/css/filter-function/index.md
+++ b/files/en-us/web/css/filter-function/index.md
@@ -1,6 +1,7 @@
 ---
 title: <filter-function>
 slug: Web/CSS/filter-function
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/flex_value/index.md
+++ b/files/en-us/web/css/flex_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: <flex>
 slug: Web/CSS/flex_value
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/frequency-percentage/index.md
+++ b/files/en-us/web/css/frequency-percentage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <frequency-percentage>
 slug: Web/CSS/frequency-percentage
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/frequency/index.md
+++ b/files/en-us/web/css/frequency/index.md
@@ -1,6 +1,7 @@
 ---
 title: <frequency>
 slug: Web/CSS/frequency
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/gradient/index.md
+++ b/files/en-us/web/css/gradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: <gradient>
 slug: Web/CSS/gradient
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/hex-color/index.md
+++ b/files/en-us/web/css/hex-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: <hex-color>
 slug: Web/CSS/hex-color
+page-type: css-type
 tags:
   - Reference
   - CSS

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -1,6 +1,7 @@
 ---
 title: <ident>
 slug: Web/CSS/ident
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/image/index.md
+++ b/files/en-us/web/css/image/index.md
@@ -1,6 +1,7 @@
 ---
 title: <image>
 slug: Web/CSS/image
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/integer/index.md
+++ b/files/en-us/web/css/integer/index.md
@@ -1,6 +1,7 @@
 ---
 title: <integer>
 slug: Web/CSS/integer
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/length-percentage/index.md
+++ b/files/en-us/web/css/length-percentage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <length-percentage>
 slug: Web/CSS/length-percentage
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: <length>
 slug: Web/CSS/length
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/named-color/index.md
+++ b/files/en-us/web/css/named-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: <named-color>
 slug: Web/CSS/named-color
+page-type: css-type
 tags:
   - Reference
   - CSS Data Type

--- a/files/en-us/web/css/number/index.md
+++ b/files/en-us/web/css/number/index.md
@@ -1,6 +1,7 @@
 ---
 title: <number>
 slug: Web/CSS/number
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/percentage/index.md
+++ b/files/en-us/web/css/percentage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <percentage>
 slug: Web/CSS/percentage
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: <position>
 slug: Web/CSS/position_value
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/ratio/index.md
+++ b/files/en-us/web/css/ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: <ratio>
 slug: Web/CSS/ratio
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/resolution/index.md
+++ b/files/en-us/web/css/resolution/index.md
@@ -1,6 +1,7 @@
 ---
 title: <resolution>
 slug: Web/CSS/resolution
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/shape/index.md
+++ b/files/en-us/web/css/shape/index.md
@@ -1,6 +1,7 @@
 ---
 title: <shape>
 slug: Web/CSS/shape
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/string/index.md
+++ b/files/en-us/web/css/string/index.md
@@ -1,6 +1,7 @@
 ---
 title: <string>
 slug: Web/CSS/string
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <time-percentage>
 slug: Web/CSS/time-percentage
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/time/index.md
+++ b/files/en-us/web/css/time/index.md
@@ -1,6 +1,7 @@
 ---
 title: <time>
 slug: Web/CSS/time
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/transform-function/index.md
+++ b/files/en-us/web/css/transform-function/index.md
@@ -1,6 +1,7 @@
 ---
 title: <transform-function>
 slug: Web/CSS/transform-function
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/translation-value/index.md
+++ b/files/en-us/web/css/translation-value/index.md
@@ -1,6 +1,7 @@
 ---
 title: <translation-value>
 slug: Web/CSS/translation-value
+page-type: css-type
 tags:
   - CSS
   - CSS Data Type


### PR DESCRIPTION
This PR adds `page-type` values for CSS types, following the analysis in https://github.com/mdn/content/issues/15540.