### PR TITLE
[page type] Add page-type for CSS guides

### DIFF
--- a/files/en-us/web/css/actual_value/index.md
+++ b/files/en-us/web/css/actual_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Actual value
 slug: Web/CSS/actual_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/alternative_style_sheets/index.md
+++ b/files/en-us/web/css/alternative_style_sheets/index.md
@@ -1,6 +1,7 @@
 ---
 title: Alternative style sheets
 slug: Web/CSS/Alternative_style_sheets
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -1,6 +1,7 @@
 ---
 title: At-rules
 slug: Web/CSS/At-rule
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introducing the CSS Cascade
 slug: Web/CSS/Cascade
+page-type: guide
 tags:
   - CSS
   - Cascade

--- a/files/en-us/web/css/comments/index.md
+++ b/files/en-us/web/css/comments/index.md
@@ -1,6 +1,7 @@
 ---
 title: Comments
 slug: Web/CSS/Comments
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/computed_value/index.md
+++ b/files/en-us/web/css/computed_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Computed value
 slug: Web/CSS/computed_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -1,6 +1,7 @@
 ---
 title: Layout and the containing block
 slug: Web/CSS/Containing_block
+page-type: guide
 tags:
   - CSS
   - CSS Position

--- a/files/en-us/web/css/css_animations/tips/index.md
+++ b/files/en-us/web/css/css_animations/tips/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Animations tips and tricks
 slug: Web/CSS/CSS_Animations/Tips
+page-type: guide
 tags:
   - CSS
   - CSS Animations

--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS animations
 slug: Web/CSS/CSS_Animations/Using_CSS_animations
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Border-image generator
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator
+page-type: guide
 tags:
   - CSS
   - Tools

--- a/files/en-us/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Border-radius generator
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-radius_generator
+page-type: guide
 tags:
   - CSS
   - CSS Borders

--- a/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box-shadow generator
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Box-shadow_generator
+page-type: guide
 tags:
   - CSS
   - Tools

--- a/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resizing background images with background-size
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images
+page-type: guide
 tags:
   - CSS
   - CSS Background

--- a/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using multiple backgrounds
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
+page-type: guide
 tags:
   - CSS
   - CSS Background

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box alignment for block, absolutely positioned and table layout
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables
+page-type: guide
 tags:
   - Block
   - CSS

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box alignment in Flexbox
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box alignment in grid layout
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Grid_Layout
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_multi-column_layout/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_multi-column_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box alignment in Multi-column Layout
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Multi-column_Layout
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to the CSS basic box model
 slug: Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
+page-type: guide
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mastering margin collapsing
 slug: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
+page-type: guide
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/css_colors/applying_color/index.md
+++ b/files/en-us/web/css/css_colors/applying_color/index.md
@@ -1,6 +1,7 @@
 ---
 title: Applying color to HTML elements using CSS
 slug: Web/CSS/CSS_Colors/Applying_color
+page-type: guide
 tags:
   - Beginner
   - CSS

--- a/files/en-us/web/css/css_colors/color_picker_tool/index.md
+++ b/files/en-us/web/css/css_colors/color_picker_tool/index.md
@@ -1,6 +1,7 @@
 ---
 title: Color picker tool
 slug: Web/CSS/CSS_Colors/Color_picker_tool
+page-type: guide
 tags:
   - CSS
   - CSS Color Picker

--- a/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts of multi-column layout
 slug: Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol
+page-type: guide
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_columns/handling_content_breaks_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_content_breaks_in_multicol/index.md
@@ -1,6 +1,7 @@
 ---
 title: Handling content breaks in multi-column layout
 slug: Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol
+page-type: guide
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -1,6 +1,7 @@
 ---
 title: Handling overflow in multi-column layout
 slug: Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol
+page-type: guide
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_columns/spanning_columns/index.md
+++ b/files/en-us/web/css/css_columns/spanning_columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: Spanning and balancing columns
 slug: Web/CSS/CSS_Columns/Spanning_Columns
+page-type: guide
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_columns/styling_columns/index.md
+++ b/files/en-us/web/css/css_columns/styling_columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: Styling columns
 slug: Web/CSS/CSS_Columns/Styling_Columns
+page-type: guide
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using multi-column layouts
 slug: Web/CSS/CSS_Columns/Using_multi-column_layouts
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_conditional_rules/using_feature_queries/index.md
+++ b/files/en-us/web/css/css_conditional_rules/using_feature_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using feature queries
 slug: Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries
+page-type: guide
 tags:
   - CSS
   - Conditional CSS

--- a/files/en-us/web/css/css_container_queries/index.md
+++ b/files/en-us/web/css/css_container_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Container Queries
 slug: Web/CSS/CSS_Container_Queries
+page-type: guide
 tags:
   - CSS
   - CSS Containment

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS counters
 slug: Web/CSS/CSS_Counter_Styles/Using_CSS_counters
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -1,6 +1,7 @@
 ---
 title: Aligning items in a flex container
 slug: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
+page-type: guide
 tags:
   - Align
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Backwards compatibility of flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
+page-type: guide
 tags:
   - '@supports'
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts of flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
+page-type: guide
 tags:
   - CSS
   - Flex

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Controlling ratios of flex items along the main axis
 slug: >-
+page-type: guide
   Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
 tags:
   - Basis

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
@@ -1,8 +1,8 @@
 ---
 title: Controlling ratios of flex items along the main axis
 slug: >-
-page-type: guide
   Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
+page-type: guide
 tags:
   - Basis
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mastering wrapping of flex items
 slug: Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items
+page-type: guide
 tags:
   - CSS
   - Flex

--- a/files/en-us/web/css/css_flexible_box_layout/ordering_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/ordering_flex_items/index.md
@@ -1,6 +1,7 @@
 ---
 title: Ordering flex items
 slug: Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items
+page-type: guide
 tags:
   - Accessibility
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,8 +1,8 @@
 ---
 title: Relationship of flexbox to other layout methods
 slug: >-
-page-type: guide
   Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,6 +1,7 @@
 ---
 title: Relationship of flexbox to other layout methods
 slug: >-
+page-type: guide
   Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
 tags:
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Typical use cases of flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
+page-type: guide
 tags:
   - CSS
   - Flexible Box

--- a/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Block and inline layout in normal flow
 slug: Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow
+page-type: guide
 tags:
   - CSS
   - CSS Flow Layout

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Flow layout and overflow
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
+page-type: guide
 tags:
   - CSS
   - Flow Layout

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Flow layout and writing modes
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes
+page-type: guide
 tags:
   - CSS
   - Flow Layout

--- a/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: In flow and out of flow
 slug: Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
+page-type: guide
 tags:
   - CSS
   - CSS Flow Layout

--- a/files/en-us/web/css/css_flow_layout/index.md
+++ b/files/en-us/web/css/css_flow_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Flow Layout
 slug: Web/CSS/CSS_Flow_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Flow Layout

--- a/files/en-us/web/css/css_flow_layout/intro_to_formatting_contexts/index.md
+++ b/files/en-us/web/css/css_flow_layout/intro_to_formatting_contexts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to formatting contexts
 slug: Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts
+page-type: guide
 tags:
   - BFC
   - Block Formatting Context

--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: OpenType font features guide
 slug: Web/CSS/CSS_Fonts/OpenType_fonts_guide
+page-type: guide
 tags:
   - CSS
   - Fonts

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Variable fonts guide
 slug: Web/CSS/CSS_Fonts/Variable_Fonts_Guide
+page-type: guide
 tags:
   - CSS
   - Fonts

--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Functional Notation
 slug: Web/CSS/CSS_Functions
+page-type: guide
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Auto-placement in grid layout
 slug: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts of grid layout
 slug: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Box alignment in grid layout
 slug: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
+page-type: guide
 tags:
   - Alignment in Grids
   - Boxes

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Grid Layout and progressive enhancement
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grid layout and accessibility
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility
+page-type: guide
 tags:
   - Accessibility
   - CSS

--- a/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grids, logical values, and writing modes
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grid template areas
 slug: Web/CSS/CSS_Grid_Layout/Grid_Template_Areas
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grid layout using named grid lines
 slug: Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grid layout using line-based placement
 slug: Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Masonry layout
 slug: Web/CSS/CSS_Grid_Layout/Masonry_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Realizing common layouts using grids
 slug: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Relationship of grid layout to other layout methods
 slug: Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
+page-type: guide
 tags:
   - CSS
   - CSS Grids

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -1,6 +1,7 @@
 ---
 title: Subgrid
 slug: Web/CSS/CSS_Grid_Layout/Subgrid
+page-type: guide
 tags:
   - CSS
   - CSS Display

--- a/files/en-us/web/css/css_houdini/index.md
+++ b/files/en-us/web/css/css_houdini/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Houdini
 slug: Web/CSS/CSS_Houdini
+page-type: guide
 tags:
   - CSS
   - Houdini

--- a/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -1,6 +1,7 @@
 ---
 title: Implementing image sprites in CSS
 slug: Web/CSS/CSS_Images/Implementing_image_sprites_in_CSS
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_images/using_css_gradients/index.md
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS gradients
 slug: Web/CSS/CSS_Images/Using_CSS_gradients
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_lists_and_counters/consistent_list_indentation/index.md
+++ b/files/en-us/web/css/css_lists_and_counters/consistent_list_indentation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Consistent list indentation
 slug: Web/CSS/CSS_Lists_and_Counters/Consistent_list_indentation
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_logical_properties/basic_concepts/index.md
+++ b/files/en-us/web/css/css_logical_properties/basic_concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts of Logical Properties and Values
 slug: Web/CSS/CSS_Logical_Properties/Basic_concepts
+page-type: guide
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/css_logical_properties/floating_and_positioning/index.md
+++ b/files/en-us/web/css/css_logical_properties/floating_and_positioning/index.md
@@ -1,6 +1,7 @@
 ---
 title: Logical properties for floating and positioning
 slug: Web/CSS/CSS_Logical_Properties/Floating_and_positioning
+page-type: guide
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Logical properties for margins, borders, and padding
 slug: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
+page-type: guide
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/css_logical_properties/sizing/index.md
+++ b/files/en-us/web/css/css_logical_properties/sizing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Logical properties for sizing
 slug: Web/CSS/CSS_Logical_Properties/Sizing
+page-type: guide
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using z-index
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Adding_z-index
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/index.md
@@ -1,6 +1,7 @@
 ---
 title: Understanding CSS z-index
 slug: Web/CSS/CSS_Positioning/Understanding_z_index
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: Stacking with floated blocks
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_and_float
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -1,6 +1,7 @@
 ---
 title: Stacking context example 1
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -1,6 +1,7 @@
 ---
 title: Stacking context example 2
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -1,6 +1,7 @@
 ---
 title: Stacking context example 3
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -1,6 +1,7 @@
 ---
 title: Stacking without the z-index property
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -1,6 +1,7 @@
 ---
 title: The stacking context
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts of CSS Scroll Snap
 slug: Web/CSS/CSS_Scroll_Snap/Basic_concepts
+page-type: guide
 tags:
   - CSS
   - CSS Scroll Snap

--- a/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the :target pseudo-class in selectors
 slug: Web/CSS/CSS_Selectors/Using_the_:target_pseudo-class_in_selectors
+page-type: guide
 tags:
   - ':target'
   - CSS

--- a/files/en-us/web/css/css_shapes/basic_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/basic_shapes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic shapes
 slug: Web/CSS/CSS_Shapes/Basic_Shapes
+page-type: guide
 tags:
   - CSS
   - CSS Shapes

--- a/files/en-us/web/css/css_shapes/from_box_values/index.md
+++ b/files/en-us/web/css/css_shapes/from_box_values/index.md
@@ -1,6 +1,7 @@
 ---
 title: Shapes from box values
 slug: Web/CSS/CSS_Shapes/From_box_values
+page-type: guide
 tags:
   - Boundaries
   - Boxes

--- a/files/en-us/web/css/css_shapes/overview_of_css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/overview_of_css_shapes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Overview of shapes
 slug: Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes
+page-type: guide
 tags:
   - CSS
   - CSS Shapes

--- a/files/en-us/web/css/css_shapes/shapes_from_images/index.md
+++ b/files/en-us/web/css/css_shapes/shapes_from_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: Shapes from images
 slug: Web/CSS/CSS_Shapes/Shapes_From_Images
+page-type: guide
 tags:
   - CSS
   - CSS Shapes

--- a/files/en-us/web/css/css_text/wrapping_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_text/index.md
@@ -1,6 +1,7 @@
 ---
 title: Wrapping and breaking text
 slug: Web/CSS/CSS_Text/Wrapping_Text
+page-type: guide
 tags:
   - CSS
   - CSS Text

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS transforms
 slug: Web/CSS/CSS_Transforms/Using_CSS_transforms
+page-type: guide
 tags:
   - 3D
   - Advanced

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS transitions
 slug: Web/CSS/CSS_Transitions/Using_CSS_transitions
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/css_types/index.md
+++ b/files/en-us/web/css/css_types/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS data types
 slug: Web/CSS/CSS_Types
+page-type: guide
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS values and units
 slug: Web/CSS/CSS_Values_and_Units
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/cssom_view/coordinate_systems/index.md
+++ b/files/en-us/web/css/cssom_view/coordinate_systems/index.md
@@ -1,6 +1,7 @@
 ---
 title: Coordinate systems
 slug: Web/CSS/CSSOM_View/Coordinate_systems
+page-type: guide
 tags:
   - CSS
   - CSSOM

--- a/files/en-us/web/css/display/two-value_syntax_of_display/index.md
+++ b/files/en-us/web/css/display/two-value_syntax_of_display/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adapting to the new two-value syntax of display
 slug: Web/CSS/display/two-value_syntax_of_display
+page-type: guide
 tags:
   - CSS
   - Example

--- a/files/en-us/web/css/faq/index.md
+++ b/files/en-us/web/css/faq/index.md
@@ -1,6 +1,7 @@
 ---
 title: Questions about CSS
 slug: Web/CSS/FAQ
+page-type: guide
 tags:
   - Beginner
   - CSS

--- a/files/en-us/web/css/inheritance/index.md
+++ b/files/en-us/web/css/inheritance/index.md
@@ -1,6 +1,7 @@
 ---
 title: Inheritance
 slug: Web/CSS/inheritance
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/initial_value/index.md
+++ b/files/en-us/web/css/initial_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Initial value
 slug: Web/CSS/initial_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/inline_formatting_context/index.md
+++ b/files/en-us/web/css/inline_formatting_context/index.md
@@ -1,6 +1,7 @@
 ---
 title: Inline formatting context
 slug: Web/CSS/Inline_formatting_context
+page-type: guide
 tags:
   - CSS
   - Formatting context

--- a/files/en-us/web/css/layout_mode/index.md
+++ b/files/en-us/web/css/layout_mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Layout mode
 slug: Web/CSS/Layout_mode
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/media_queries/testing_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/testing_media_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: Testing media queries programmatically
 slug: Web/CSS/Media_Queries/Testing_media_queries
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using media queries
 slug: Web/CSS/Media_Queries/Using_media_queries
+page-type: guide
 tags:
   - Advanced
   - CSS

--- a/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using media queries for accessibility
 slug: Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility
+page-type: guide
 tags:
   - "@media"
   - Accessibility

--- a/files/en-us/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
+++ b/files/en-us/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
@@ -1,6 +1,7 @@
 ---
 title: Guide to scroll anchoring
 slug: Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.md
+++ b/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.md
@@ -1,6 +1,7 @@
 ---
 title: Privacy and the :visited selector
 slug: Web/CSS/Privacy_and_the_:visited_selector
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/replaced_element/index.md
+++ b/files/en-us/web/css/replaced_element/index.md
@@ -1,6 +1,7 @@
 ---
 title: Replaced elements
 slug: Web/CSS/Replaced_element
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/resolved_value/index.md
+++ b/files/en-us/web/css/resolved_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resolved value
 slug: Web/CSS/resolved_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/scaling_of_svg_backgrounds/index.md
+++ b/files/en-us/web/css/scaling_of_svg_backgrounds/index.md
@@ -1,6 +1,7 @@
 ---
 title: Scaling of SVG backgrounds
 slug: Web/CSS/Scaling_of_SVG_backgrounds
+page-type: guide
 tags:
   - CSS
   - CSS Background

--- a/files/en-us/web/css/shorthand_properties/index.md
+++ b/files/en-us/web/css/shorthand_properties/index.md
@@ -1,6 +1,7 @@
 ---
 title: Shorthand properties
 slug: Web/CSS/Shorthand_properties
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -1,6 +1,7 @@
 ---
 title: Specificity
 slug: Web/CSS/Specificity
+page-type: guide
 tags:
   - CSS
   - Example

--- a/files/en-us/web/css/specified_value/index.md
+++ b/files/en-us/web/css/specified_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Specified value
 slug: Web/CSS/specified_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Syntax
 slug: Web/CSS/Syntax
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Used value
 slug: Web/CSS/used_value
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS custom properties (variables)
 slug: Web/CSS/Using_CSS_custom_properties
+page-type: guide
 tags:
   - CSS
   - CSS Variables

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Value definition syntax
 slug: Web/CSS/Value_definition_syntax
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/viewport_concepts/index.md
+++ b/files/en-us/web/css/viewport_concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Viewport concepts
 slug: Web/CSS/Viewport_concepts
+page-type: guide
 tags:
   - Best practices
   - CSS

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: Visual formatting model
 slug: Web/CSS/Visual_formatting_model
+page-type: guide
 tags:
   - CSS
   - CSS Box Model


### PR DESCRIPTION
This PR adds `page-type` values for CSS guide pages, following the analysis in https://github.com/mdn/content/issues/15540.

Guide pages are a kind of "fallback" for when a page isn't any other identifiable type.