### PR TITLE
Fix issue 21122: clamp() description

### DIFF
--- a/files/en-us/web/css/clamp/index.md
+++ b/files/en-us/web/css/clamp/index.md
@@ -19,7 +19,7 @@ browser-compat: css.types.clamp
 
 The **`clamp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) clamps a value between an upper and lower bound. `clamp()` enables selecting a middle value within a range of values between a defined minimum and maximum. It takes three parameters: a minimum value, a preferred value, and a maximum allowed value. The `clamp()` function can be used anywhere a {{CSSxRef("&lt;length&gt;")}}, {{CSSxRef("&lt;frequency&gt;")}}, {{CSSxRef("&lt;angle&gt;")}}, {{CSSxRef("&lt;time&gt;")}}, {{CSSxRef("&lt;percentage&gt;")}}, {{CSSxRef("&lt;number&gt;")}}, or {{CSSxRef("&lt;integer&gt;")}} is allowed.
 
-`clamp(MIN, VAL, MAX)` is resolved as `{{CSSxRef("max", "max()")}}(MIN, {{CSSxRef("min", "min()")}}(VAL, MAX))`.
+`clamp(MIN, VAL, MAX)` is resolved as `{{CSSxRef("max", "max")}}(MIN, {{CSSxRef("min", "min")}}(VAL, MAX))`.
 
 {{EmbedInteractiveExample("pages/css/function-clamp.html")}}
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/21122.

Per the issue, I think it wants to say that `clamp()` is the equivalent of `max(MIN, min(VAL, MAX))`, but the brackets after `max` and `min` were making it incoherent.