### PR TITLE
Fix DL formatting in <img> element page

### DIFF
--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<img>: The Image Embed element'
+title: "<img>: The Image Embed element"
 slug: Web/HTML/Element/img
 tags:
   - Content
@@ -86,9 +86,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     >
     > In these cases, the browser may replace the image with the text in the element's `alt` attribute. For these reasons and others, provide a useful value for `alt` whenever possible.
 
-  Setting this attribute to an empty string (`alt=""`) indicates that this image is _not_ a key part of the content (it's decoration or a tracking pixel), and that non-visual browsers may omit it from {{glossary("Rendering engine", "rendering")}}. Visual browsers will also hide the broken image icon if the `alt` is empty and the image failed to display.
+    Setting this attribute to an empty string (`alt=""`) indicates that this image is _not_ a key part of the content (it's decoration or a tracking pixel), and that non-visual browsers may omit it from {{glossary("Rendering engine", "rendering")}}. Visual browsers will also hide the broken image icon if the `alt` is empty and the image failed to display.
 
-  This attribute is also used when copying and pasting the image to text, or saving a linked image to a bookmark.
+    This attribute is also used when copying and pasting the image to text, or saving a linked image to a bookmark.
 
 - {{htmlattrdef("crossorigin")}}
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attributes had a broken `<dl>`:

<img width="800" alt="Screen Shot 2022-09-27 at 8 53 19 PM" src="https://user-images.githubusercontent.com/432915/192683818-7f6d8e12-6060-4bdd-b895-1d412aad6a72.png">

This PR fixes it:

<img width="813" alt="Screen Shot 2022-09-27 at 8 54 04 PM" src="https://user-images.githubusercontent.com/432915/192683878-06aa2e6a-c3e3-45fd-b47d-4290ea600af2.png">
