### PR TITLE
Incorrect JavaScript snippet

### DIFF
--- a/files/en-us/web/api/window/window/index.md
+++ b/files/en-us/web/api/window/window/index.md
@@ -31,7 +31,7 @@ In web pages, the window object is also a _global object_. This means:
 1. Global variables of your script are, in fact, properties of `window`:
 
    ```js
-   const global = { data: 0 };
+   var global = { data: 0 };
    alert(global === window.global); // displays "true"
    ```
 


### PR DESCRIPTION
There's an issue with one of the suggested snippets on this page. 

The first suggested snippet, under the bullet point below, is incorrect:
1. Global variables of your script are, in fact, properties of `window`:

```js 
const global = { data: 0 }; 
alert(global === window.global); // displays "true" 
```
The above snippet displays an alert message with `false` and not `true` as suggested by the snippet, which is incorrect.  

Variables declared with `const`  and `let` don't become properties of the `window` object.   

The only way to create a global variable that becomes a property of the `window` object, is to either declare a variable with `var` or initialize the variable without declaring it, like so:   

Example 1: declaring variable with `var`
```js
   var global = { data: 0 };
   alert(global === window.global); // displays "true"
  ```
  
Example 2: initializing a variable without declaration
```js
   global = { data: 0 };
   alert(global === window.global); // displays "true"
   ```