### PR TITLE
[Web API] Geometry APIs are structured cloneable

### DIFF
--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -93,6 +93,34 @@ It clones by recursing through the input object while maintaining a map of previ
       <td></td>
     </tr>
     <tr>
+      <td>{{domxref("DOMPoint")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMPointReadOnly")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMRect")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMRectReadOnly")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMQuad")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMMatrix")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMMatrixReadOnly")}}</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>{{jsxref("Array")}}</td>
       <td></td>
     </tr>


### PR DESCRIPTION
See https://drafts.fxtf.org/geometry/#structured-serialization

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

List the `DOMPoint`, `DOMPointReadOnly`, `DOMRect`, `DOMRectReadOnly`, `DOMQuad`, `DOMMatrix`, `DOMMatrixReadOnly` interfaces as supporting structured clone.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

They were incorrectly absent...

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Possibly further interfaces are still missing. Check for [`[Serializable]` extended attribute](https://html.spec.whatwg.org/multipage/structured-data.html#serializable) in webidl: https://searchfox.org/mozilla-central/search?q=Serializable&path=.webidl&case=true&regexp=false

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
