### PR TITLE
[page type] Add page-type for CSS landing pages

### DIFF
--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animatable CSS properties
 slug: Web/CSS/CSS_animated_properties
+page-type: landing-page
 tags:
   - CSS
   - CSS Animations

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS selectors
 slug: Web/CSS/CSS_Selectors
+page-type: landing-page
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/index.md
+++ b/files/en-us/web/css/layout_cookbook/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Layout cookbook
 slug: Web/CSS/Layout_cookbook
+page-type: landing-page
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/microsoft_extensions/index.md
+++ b/files/en-us/web/css/microsoft_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft CSS extensions
 slug: Web/CSS/Microsoft_Extensions
+page-type: landing-page
 tags:
   - CSS
   - CSS:Microsoft Extensions

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mozilla CSS extensions
 slug: Web/CSS/Mozilla_Extensions
+page-type: landing-page
 tags:
   - CSS
   - CSS:Mozilla Extensions

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pseudo-classes
 slug: Web/CSS/Pseudo-classes
+page-type: landing-page
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pseudo-elements
 slug: Web/CSS/Pseudo-elements
+page-type: landing-page
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS reference
 slug: Web/CSS/Reference
+page-type: landing-page
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Tutorials
 slug: Web/CSS/Tutorials
+page-type: landing-page
 tags:
   - CSS
   - Guide


### PR DESCRIPTION
This PR adds `page-type` values for CSS landing pages, following the analysis in https://github.com/mdn/content/issues/15540.

https://developer.mozilla.org/en-US/docs/web/css/tutorials especially is a sad page, but I will at least fix some of the links in a follow up. Longer term we should really redo the IA for CSS.
