### PR TITLE
[page type] Add page-type for CSS modules

### DIFF
--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compositing and Blending
 slug: Web/CSS/Compositing_and_Blending
+page-type: css-module
 tags:
   - CSS
   - Compositing and Blending

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Animations
 slug: Web/CSS/CSS_Animations
+page-type: css-module
 tags:
   - CSS
   - CSS Animations

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Backgrounds and Borders
 slug: Web/CSS/CSS_Backgrounds_and_Borders
+page-type: css-module
 tags:
   - CSS
   - CSS Backgrounds and Borders

--- a/files/en-us/web/css/css_basic_user_interface/index.md
+++ b/files/en-us/web/css/css_basic_user_interface/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Basic User Interface
 slug: Web/CSS/CSS_Basic_User_Interface
+page-type: css-module
 tags:
   - CSS
   - CSS Basic User Interface

--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Box Alignment
 slug: Web/CSS/CSS_Box_Alignment
+page-type: css-module
 tags:
   - CSS
   - CSS Box Alignment

--- a/files/en-us/web/css/css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Box Model
 slug: Web/CSS/CSS_Box_Model
+page-type: css-module
 tags:
   - CSS
   - CSS Box Model

--- a/files/en-us/web/css/css_charsets/index.md
+++ b/files/en-us/web/css/css_charsets/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Charsets
 slug: Web/CSS/CSS_Charsets
+page-type: css-module
 tags:
   - CSS
   - CSS Charsets

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Colors
 slug: Web/CSS/CSS_Colors
+page-type: css-module
 tags:
   - CSS
   - CSS Colors

--- a/files/en-us/web/css/css_columns/index.md
+++ b/files/en-us/web/css/css_columns/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Multi-column Layout
 slug: Web/CSS/CSS_Columns
+page-type: css-module
 tags:
   - CSS
   - CSS Multi-column Layout

--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Conditional Rules
 slug: Web/CSS/CSS_Conditional_Rules
+page-type: css-module
 tags:
   - CSS
   - CSS Conditional Rules

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Containment
 slug: Web/CSS/CSS_Containment
+page-type: css-module
 tags:
   - CSS
   - CSS Containment

--- a/files/en-us/web/css/css_counter_styles/index.md
+++ b/files/en-us/web/css/css_counter_styles/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Counter Styles
 slug: Web/CSS/CSS_Counter_Styles
+page-type: css-module
 tags:
   - CSS
   - CSS Counter Styles

--- a/files/en-us/web/css/css_device_adaptation/index.md
+++ b/files/en-us/web/css/css_device_adaptation/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Device Adaptation
 slug: Web/CSS/CSS_Device_Adaptation
+page-type: css-module
 tags:
   - CSS
   - CSS Device Adaptation

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Display
 slug: Web/CSS/CSS_Display
+page-type: css-module
 tags:
   - CSS
   - CSS Display

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Flexible Box Layout
 slug: Web/CSS/CSS_Flexible_Box_Layout
+page-type: css-module
 tags:
   - CSS
   - CSS Flexible Boxes

--- a/files/en-us/web/css/css_fonts/index.md
+++ b/files/en-us/web/css/css_fonts/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Fonts
 slug: Web/CSS/CSS_Fonts
+page-type: css-module
 tags:
   - CSS
   - CSS Fonts

--- a/files/en-us/web/css/css_fragmentation/index.md
+++ b/files/en-us/web/css/css_fragmentation/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Fragmentation
 slug: Web/CSS/CSS_Fragmentation
+page-type: css-module
 tags:
   - CSS
   - CSS Fragmentation

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Generated Content
 slug: Web/CSS/CSS_Generated_Content
+page-type: css-module
 tags:
   - CSS
   - CSS Generated Content

--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Grid Layout
 slug: Web/CSS/CSS_Grid_Layout
+page-type: css-module
 tags:
   - CSS
   - Grid Layout

--- a/files/en-us/web/css/css_images/index.md
+++ b/files/en-us/web/css/css_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Images
 slug: Web/CSS/CSS_Images
+page-type: css-module
 tags:
   - CSS
   - CSS Images

--- a/files/en-us/web/css/css_lists_and_counters/index.md
+++ b/files/en-us/web/css/css_lists_and_counters/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Lists
 slug: Web/CSS/CSS_Lists_and_Counters
+page-type: css-module
 tags:
   - CSS
   - CSS Lists

--- a/files/en-us/web/css/css_logical_properties/index.md
+++ b/files/en-us/web/css/css_logical_properties/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Logical Properties and Values
 slug: Web/CSS/CSS_Logical_Properties
+page-type: css-module
 tags:
   - CSS
   - CSS Logical Properties

--- a/files/en-us/web/css/css_masking/index.md
+++ b/files/en-us/web/css/css_masking/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Masking
 slug: Web/CSS/CSS_Masking
+page-type: css-module
 tags:
   - CSS
   - CSS Masking

--- a/files/en-us/web/css/css_miscellaneous/index.md
+++ b/files/en-us/web/css/css_miscellaneous/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Miscellaneous
 slug: Web/CSS/CSS_Miscellaneous
+page-type: css-module
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_motion_path/index.md
+++ b/files/en-us/web/css/css_motion_path/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Motion Path
 slug: Web/CSS/CSS_Motion_Path
+page-type: css-module
 tags:
   - CSS
   - CSS Motion Path

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Namespaces
 slug: Web/CSS/CSS_Namespaces
+page-type: css-module
 tags:
   - CSS
   - CSS Namespaces

--- a/files/en-us/web/css/css_overflow/index.md
+++ b/files/en-us/web/css/css_overflow/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Overflow
 slug: Web/CSS/CSS_Overflow
+page-type: css-module
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_pages/index.md
+++ b/files/en-us/web/css/css_pages/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Paged Media
 slug: Web/CSS/CSS_Pages
+page-type: css-module
 tags:
   - CSS
   - CSS Paged Media

--- a/files/en-us/web/css/css_positioning/index.md
+++ b/files/en-us/web/css/css_positioning/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Positioned Layout
 slug: Web/CSS/CSS_Positioning
+page-type: css-module
 tags:
   - CSS
   - CSS Positioning

--- a/files/en-us/web/css/css_ruby/index.md
+++ b/files/en-us/web/css/css_ruby/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Ruby Layout
 slug: Web/CSS/CSS_Ruby
+page-type: css-module
 tags:
   - CSS
   - CSS Ruby

--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Scroll Snap
 slug: Web/CSS/CSS_Scroll_Snap
+page-type: css-module
 tags:
   - CSS
   - CSS Scroll Snap

--- a/files/en-us/web/css/css_scroll_snap_points/index.md
+++ b/files/en-us/web/css/css_scroll_snap_points/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Scroll Snap Points
 slug: Web/CSS/CSS_Scroll_Snap_Points
+page-type: css-module
 tags:
   - CSS
   - CSS Scroll Snap

--- a/files/en-us/web/css/css_scrollbars/index.md
+++ b/files/en-us/web/css/css_scrollbars/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Scrollbars
 slug: Web/CSS/CSS_Scrollbars
+page-type: css-module
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Shapes
 slug: Web/CSS/CSS_Shapes
+page-type: css-module
 tags:
   - Boundaries
   - CSS

--- a/files/en-us/web/css/css_table/index.md
+++ b/files/en-us/web/css/css_table/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Table
 slug: Web/CSS/CSS_Table
+page-type: css-module
 tags:
   - CSS
   - CSS Table

--- a/files/en-us/web/css/css_text/index.md
+++ b/files/en-us/web/css/css_text/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Text
 slug: Web/CSS/CSS_Text
+page-type: css-module
 tags:
   - CSS
   - CSS Text

--- a/files/en-us/web/css/css_text_decoration/index.md
+++ b/files/en-us/web/css/css_text_decoration/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Text Decoration
 slug: Web/CSS/CSS_Text_Decoration
+page-type: css-module
 tags:
   - CSS
   - CSS Text Decoration

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Transforms
 slug: Web/CSS/CSS_Transforms
+page-type: css-module
 tags:
   - CSS
   - CSS Transforms

--- a/files/en-us/web/css/css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Transitions
 slug: Web/CSS/CSS_Transitions
+page-type: css-module
 tags:
   - CSS
   - CSS Transitions

--- a/files/en-us/web/css/css_variables/index.md
+++ b/files/en-us/web/css/css_variables/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Custom Properties for Cascading Variables
 slug: Web/CSS/CSS_Variables
+page-type: css-module
 tags:
   - CSS
   - CSS Variables

--- a/files/en-us/web/css/css_writing_modes/index.md
+++ b/files/en-us/web/css/css_writing_modes/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Writing Modes
 slug: Web/CSS/CSS_Writing_Modes
+page-type: css-module
 tags:
   - CSS
   - CSS Writing Modes

--- a/files/en-us/web/css/cssom_view/index.md
+++ b/files/en-us/web/css/cssom_view/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSOM View
 slug: Web/CSS/CSSOM_View
+page-type: css-module
 tags:
   - CSS
   - CSSOM

--- a/files/en-us/web/css/filter_effects/index.md
+++ b/files/en-us/web/css/filter_effects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Filter Effects
 slug: Web/CSS/Filter_Effects
+page-type: css-module
 tags:
   - CSS
   - Filter Effects

--- a/files/en-us/web/css/media_queries/index.md
+++ b/files/en-us/web/css/media_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: Media queries
 slug: Web/CSS/Media_Queries
+page-type: css-module
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/paged_media/index.md
+++ b/files/en-us/web/css/paged_media/index.md
@@ -1,6 +1,7 @@
 ---
 title: Paged media
 slug: Web/CSS/Paged_Media
+page-type: css-module
 tags:
   - CSS
   - Guide


### PR DESCRIPTION
This PR adds `page-type` values for CSS module pages, following the analysis in https://github.com/mdn/content/issues/15540.

Module pages give an overview of a CSS module (more or less aka specification, AFAICT). So they are a bit like API overview pages in Web/API. Not all these module pages follow a consistent pattern, but most of them seem to.