### PR TITLE
[page type] Add page-type for CSS recipes

### DIFF
--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Breadcrumb Navigation
 slug: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -1,6 +1,7 @@
 ---
 title: Card
 slug: Web/CSS/Layout_cookbook/Card
+page-type: guide
 tags:
   - CSS
   - CSS Cookbook

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -1,6 +1,7 @@
 ---
 title: Center an element
 slug: Web/CSS/Layout_cookbook/Center_an_element
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/en-us/web/css/layout_cookbook/column_layouts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Column layouts
 slug: Web/CSS/Layout_cookbook/Column_layouts
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cookbook template
 slug: Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template
+page-type: guide
 tags:
   - CSS
   - Contribute

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grid wrapper
 slug: Web/CSS/Layout_cookbook/Grid_wrapper
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -1,6 +1,7 @@
 ---
 title: List group with badges
 slug: Web/CSS/Layout_cookbook/List_group_with_badges
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Recipe: Media objects'
 slug: Web/CSS/Layout_cookbook/Media_objects
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pagination
 slug: Web/CSS/Layout_cookbook/Pagination
+page-type: guide
 tags:
   - CSS
   - CSS Cookbook

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Split Navigation
 slug: Web/CSS/Layout_cookbook/Split_Navigation
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sticky footers
 slug: Web/CSS/Layout_cookbook/Sticky_footers
+page-type: guide
 tags:
   - CSS
   - Guide


### PR DESCRIPTION
This PR assigns `page-type: "guide"` values for CSS recipe pages.

Part of https://github.com/mdn/content/issues/15540.

I'm on the fence about these pages.

In https://github.com/mdn/content/issues/15540 I suggested making them a "css-recipe" type and there are reasons for that: they're clearly a specific kind of page, and they have a distinctive structure.

On the other hand, I think having as few types as possible is a good thing, and there are only a few of these pages, and tbh they don't seem to be an integral part of the reference docs. I think that it's OK to treat these as guide pages for now, and we can always invent a dedicated type in future if it seems worth doing (like, if we put a lot more work into them in future we might want to define/enforce a structure for them).

So in this PR I'm making them guide pages.