### PR TITLE
[page type] Add page-type for miscellaneous CSS pages

### DIFF
--- a/files/en-us/web/css/adjacent_sibling_combinator/index.md
+++ b/files/en-us/web/css/adjacent_sibling_combinator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adjacent sibling combinator
 slug: Web/CSS/Adjacent_sibling_combinator
+page-type: css-combinator
 tags:
   - CSS
   - NeedsMobileBrowserCompatibility

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attribute selectors
 slug: Web/CSS/Attribute_selectors
+page-type: css-selector
 tags:
   - Attribute selectors
   - CSS

--- a/files/en-us/web/css/child_combinator/index.md
+++ b/files/en-us/web/css/child_combinator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Child combinator
 slug: Web/CSS/Child_combinator
+page-type: css-combinator
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Class selectors
 slug: Web/CSS/Class_selectors
+page-type: css-selector
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/column_combinator/index.md
+++ b/files/en-us/web/css/column_combinator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Column combinator
 slug: Web/CSS/Column_combinator
+page-type: css-combinator
 tags:
   - CSS
   - Experimental

--- a/files/en-us/web/css/descendant_combinator/index.md
+++ b/files/en-us/web/css/descendant_combinator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Descendant combinator
 slug: Web/CSS/Descendant_combinator
+page-type: css-combinator
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/fit-content/index.md
+++ b/files/en-us/web/css/fit-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: fit-content
 slug: Web/CSS/fit-content
+page-type: css-keyword
 tags:
   - CSS
   - Keyword

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -1,6 +1,7 @@
 ---
 title: General sibling combinator
 slug: Web/CSS/General_sibling_combinator
+page-type: css-combinator
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/id_selectors/index.md
+++ b/files/en-us/web/css/id_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: ID selectors
 slug: Web/CSS/ID_selectors
+page-type: css-selector
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/inherit/index.md
+++ b/files/en-us/web/css/inherit/index.md
@@ -1,6 +1,7 @@
 ---
 title: inherit
 slug: Web/CSS/inherit
+page-type: css-keyword
 tags:
   - CSS
   - CSS Cascade

--- a/files/en-us/web/css/initial/index.md
+++ b/files/en-us/web/css/initial/index.md
@@ -1,6 +1,7 @@
 ---
 title: initial
 slug: Web/CSS/initial
+page-type: css-keyword
 tags:
   - CSS
   - CSS Cascade

--- a/files/en-us/web/css/max-content/index.md
+++ b/files/en-us/web/css/max-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: max-content
 slug: Web/CSS/max-content
+page-type: css-keyword
 tags:
   - CSS
   - CSS Grid

--- a/files/en-us/web/css/min-content/index.md
+++ b/files/en-us/web/css/min-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: min-content
 slug: Web/CSS/min-content
+page-type: css-keyword
 tags:
   - CSS
   - Keyword

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -1,6 +1,7 @@
 ---
 title: revert-layer
 slug: Web/CSS/revert-layer
+page-type: css-keyword
 tags:
   - CSS
   - CSS Value

--- a/files/en-us/web/css/revert/index.md
+++ b/files/en-us/web/css/revert/index.md
@@ -1,6 +1,7 @@
 ---
 title: revert
 slug: Web/CSS/revert
+page-type: css-keyword
 tags:
   - CSS
   - CSS Cascade

--- a/files/en-us/web/css/selector_list/index.md
+++ b/files/en-us/web/css/selector_list/index.md
@@ -1,6 +1,7 @@
 ---
 title: Selector list
 slug: Web/CSS/Selector_list
+page-type: css-combinator
 tags:
   - CSS
   - Selector

--- a/files/en-us/web/css/type_selectors/index.md
+++ b/files/en-us/web/css/type_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Type selectors
 slug: Web/CSS/Type_selectors
+page-type: css-selector
 tags:
   - CSS
   - HTML

--- a/files/en-us/web/css/universal_selectors/index.md
+++ b/files/en-us/web/css/universal_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Universal selectors
 slug: Web/CSS/Universal_selectors
+page-type: css-selector
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/unset/index.md
+++ b/files/en-us/web/css/unset/index.md
@@ -1,6 +1,7 @@
 ---
 title: unset
 slug: Web/CSS/unset
+page-type: css-keyword
 tags:
   - CSS
   - CSS Cascade


### PR DESCRIPTION
This PR adds `page-type` values for three different sorts of CSS pages, following the analysis in https://github.com/mdn/content/issues/15540:

- CSS combinators: `css-combinator`
- CSS keyword: `css-keyword`
- CSS selector: `css-selector`

These are all pretty tiny categories but it seems hard to argue that they are not parts of the language that our taxonomy ought to recognize.
