### PR TITLE
[page type] Add page-type for new CSS pages

### DIFF
--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -1,6 +1,7 @@
 ---
 title: ":modal"
 slug: Web/CSS/:modal
+page-type: css-pseudo-class
 tags:
   - CSS
   - Modal

--- a/files/en-us/web/css/acos/index.md
+++ b/files/en-us/web/css/acos/index.md
@@ -1,6 +1,7 @@
 ---
 title: acos()
 slug: Web/CSS/acos
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -1,6 +1,7 @@
 ---
 title: animation-composition
 slug: Web/CSS/animation-composition
+page-type: css-property
 tags:
   - CSS
   - CSS Animations

--- a/files/en-us/web/css/asin/index.md
+++ b/files/en-us/web/css/asin/index.md
@@ -1,6 +1,7 @@
 ---
 title: asin()
 slug: Web/CSS/asin
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/atan/index.md
+++ b/files/en-us/web/css/atan/index.md
@@ -1,6 +1,7 @@
 ---
 title: atan()
 slug: Web/CSS/atan
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/atan2/index.md
+++ b/files/en-us/web/css/atan2/index.md
@@ -1,6 +1,7 @@
 ---
 title: atan2()
 slug: Web/CSS/atan2
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -1,6 +1,7 @@
 ---
 title: oklab()
 slug: Web/CSS/color_value/oklab
+page-type: css-function
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -1,6 +1,7 @@
 ---
 title: oklch()
 slug: Web/CSS/color_value/oklch
+page-type: css-function
 tags:
   - CSS
   - CSS Data Type

--- a/files/en-us/web/css/color_value/system_color_keywords/index.md
+++ b/files/en-us/web/css/color_value/system_color_keywords/index.md
@@ -1,6 +1,7 @@
 ---
 title: System color keywords
 slug: Web/CSS/color_value/system_color_keywords
+page-type: css-type
 tags:
   - Reference
   - color

--- a/files/en-us/web/css/contain-intrinsic-height/index.md
+++ b/files/en-us/web/css/contain-intrinsic-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: contain-intrinsic-height
 slug: Web/CSS/contain-intrinsic-height
+page-type: css-property
 browser-compat: css.properties.contain-intrinsic-height
 ---
 

--- a/files/en-us/web/css/contain-intrinsic-width/index.md
+++ b/files/en-us/web/css/contain-intrinsic-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: contain-intrinsic-width
 slug: Web/CSS/contain-intrinsic-width
+page-type: css-property
 browser-compat: css.properties.contain-intrinsic-width
 ---
 

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -1,6 +1,7 @@
 ---
 title: cos()
 slug: Web/CSS/cos
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -1,6 +1,7 @@
 ---
 title: exp()
 slug: Web/CSS/exp
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/important/index.md
+++ b/files/en-us/web/css/important/index.md
@@ -1,6 +1,7 @@
 ---
 title: '!important'
 slug: Web/CSS/important
+page-type: css-keyword
 tags:
   - CSS
   - Reference

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -1,6 +1,7 @@
 ---
 title: log()
 slug: Web/CSS/log
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/math-depth/index.md
+++ b/files/en-us/web/css/math-depth/index.md
@@ -1,6 +1,7 @@
 ---
 title: math-depth
 slug: Web/CSS/math-depth
+page-type: css-property
 tags:
   - CSS
   - MathML

--- a/files/en-us/web/css/math-shift/index.md
+++ b/files/en-us/web/css/math-shift/index.md
@@ -1,6 +1,7 @@
 ---
 title: math-shift
 slug: Web/CSS/math-shift
+page-type: css-property
 tags:
   - CSS
   - MathML

--- a/files/en-us/web/css/pow/index.md
+++ b/files/en-us/web/css/pow/index.md
@@ -1,6 +1,7 @@
 ---
 title: pow()
 slug: Web/CSS/pow
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/sign/index.md
+++ b/files/en-us/web/css/sign/index.md
@@ -1,6 +1,7 @@
 ---
 title: sign()
 slug: Web/CSS/sign
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -1,6 +1,7 @@
 ---
 title: sin()
 slug: Web/CSS/sin
+page-type: css-function
 tags:
   - CSS
   - CSS Function

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -1,6 +1,7 @@
 ---
 title: tan()
 slug: Web/CSS/tan
+page-type: css-function
 tags:
   - CSS
   - CSS Function


### PR DESCRIPTION
This PR adds `page-type` values for CSS pages that are new since the time I did the analysis in https://github.com/mdn/content/issues/15540.

They are unproblematic. https://developer.mozilla.org/en-US/docs/web/css/color_value/system_color_keywords should be made into a `<system-color>` CSS type page.
