### PR TITLE
Document CSS page types

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -23,6 +23,7 @@ browser-compat: css.properties.NameOfTheProperty
 > ---
 > title: NameOfTheProperty
 > slug: Web/CSS/NameOfTheProperty
+> page-type: css-property OR css-shorthand-property
 > tags:
 >   - CSS
 >   - Reference
@@ -40,6 +41,8 @@ browser-compat: css.properties.NameOfTheProperty
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/CSS/NameOfTheProperty`.
 >     For example, the [`background-color`](/en-US/docs/Web/CSS/background-color) property slug is `Web/CSS/background-color`.
+> - **page-type**
+>   - : The `page-type` key for CSS properties is `css-shorthand-property` for shorthand properties, otherwise `css-property`.
 > - **tags**
 >
 >   - : Always include the following tags: **CSS**, **Reference**, **CSS Property**, _NameOfTheProperty_ (e.g. **background-color**).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -23,6 +23,7 @@ browser-compat: css.selectors.NameOfTheSelector
 > ---
 > title: :NameOfTheSelector
 > slug: Web/CSS/:NameOfTheSelector
+> page-type: css-selector OR css-pseudo-class OR css-pseudo-element OR css-combinator
 > tags:
 >   - CSS
 >   - Reference
@@ -40,6 +41,8 @@ browser-compat: css.selectors.NameOfTheSelector
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/CSS/:NameOfTheSelector`.
 >     For example, the [`:hover`](/en-US/docs/Web/CSS/:hover) selector slug is `Web/CSS/:hover`.
+> - **page-type**
+>   - : The `page-type` key for CSS properties is one of `css-selector`, `css-pseudo-class`, or `css-pseudo-element`, depending on whether the selector is a [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), a [combinator](/en-US/docs/Web/CSS/CSS_Selectors#combinators), or a [basic selector](/en-US/docs/Web/CSS/CSS_Selectors#basic_selectors).
 > - **tags**
 >
 >   - : Always include the following tags: **CSS**, **Reference**, _NameOfTheSelector_ (e.g. **:hover**).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -50,7 +50,7 @@ If you want to get a team together to work on an update, or you just want to rep
 
 ## The page-type front matter key
 
-We have defined a front matter key `page-type` to describe the type of MDN pages. This project is a work in progress: so far we have only defined `page-type` values for the [Web API pages](/en-US/docs/Web/API).
+We have defined a front matter key `page-type` to describe the type of MDN pages. This project is a work in progress: so far we have only defined `page-type` values for the [CSS pages](/en-US/docs/Web/CSS) and the [Web API pages](/en-US/docs/Web/API).
 
 ### Generic page types
 
@@ -89,6 +89,37 @@ This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/
   - : A page documenting a WebGL extension, like [`WEBGL_draw_buffers`](/en-US/docs/Web/API/WEBGL_draw_buffers).
 - `webgl-extension-method`
   - : A page documenting a method on WebGL extension, like [`OES_vertex_array_object.bindVertexArrayOES()`](/en-US/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES).
+
+### CSS page types
+
+This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `css-at-rule`
+  - : A page documenting a CSS [at-rule](/en-US/docs/Web/CSS/At-rule), like {{cssxref("@charset")}}.
+- `css-at-rule-descriptor`
+  - : A page documenting a CSS at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/web/css/@counter-style/prefix).
+- `css-combinator`
+  - : A page documenting a CSS combinator, like the [descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator).
+- `css-function`
+  - : A page documenting a CSS [function](/en-US/docs/Web/CSS/CSS_Functions), like {{cssxref("max")}}.
+- `css-keyword`
+  - : A page documenting a CSS keyword, like {{cssxref("inherit")}}.
+- `css-media-feature`
+  - : A page documenting a CSS [media feature](/en-US/docs/Web/CSS/@media#media_features), like [`hover`](/en-US/docs/Web/CSS/@media/hover).
+- `css-module`
+  - : An overview page for a CSS module, like [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations).
+- `css-property`
+  - : A page documenting a CSS property, like {{cssxref("background-color")}}.
+- `css-pseudo-class`
+  - : A page documenting a CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), like {{cssxref(":enabled")}}.
+- `css-pseudo-element`
+  - : A page documenting a CSS [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), like {{cssxref("::before")}}.
+- `css-selector`
+  - : A page documenting a CSS [basic selector](/en-US/docs/Web/CSS/CSS_Selectors#basic_selectors), like the [class selector](/en-US/docs/Web/CSS/Class_selectors).
+- `css-shorthand-property`
+  - : A page documenting a CSS [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties), like {{cssxref("background")}}.
+- `css-type`
+  - : A page documenting a CSS [data type](/en-US/docs/Web/CSS/CSS_Types), like [`<color>`](/en-US/docs/Web/CSS/color_value).
 
 ## API landing page
 


### PR DESCRIPTION
Add some meta-docs for CSS page types.

We ought to have templates for all the page types, really, and we should restructure this page so it's not so unwieldy. Maybe a separate page just listing page types?

And much as writing tables is a chore I feel tables would work better here.