### PR TITLE
fix: remove placeholder text

### DIFF
--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -185,7 +185,7 @@ When the result type in the `resultType` parameter is specified as `ANY_TYPE`, t
 
 It could be any of the simple types (`NUMBER_TYPE, STRING_TYPE, BOOLEAN_TYPE`), **but**, if the returned result type is a node-set then it will **only** be an `UNORDERED_NODE_ITERATOR_TYPE`.
 
-To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet =====Any_Type Example===== \<pre> \</pre>
+To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix.
 
 ## Examples
 


### PR DESCRIPTION
Noticed looking at escaped tags. Seemed like an old placeholder note from before the conversion