### PR TITLE
Fix CSS property links in `::selection`.

### DIFF
--- a/files/en-us/web/css/_doublecolon_selection/index.md
+++ b/files/en-us/web/css/_doublecolon_selection/index.md
@@ -25,7 +25,7 @@ Only certain CSS properties can be used with `::selection`:
 - {{CSSxRef("background-color")}}
 - {{CSSxRef("text-decoration")}} and its associated properties
 - {{CSSxRef("text-shadow")}}
-- {{SVGAttr("stroke-color")}}, {{SVGAttr("fill-color")}} and {{SVGAttr("stroke-width")}}
+- {{CSSxRef("-webkit-text-stroke-color")}}, {{CSSxRef("-webkit-text-fill-color")}} and {{CSSxRef("-webkit-text-stroke-width")}}
 
 In particular, {{CSSxRef("background-image")}} is ignored.
 


### PR DESCRIPTION
### Description

These were pointing to SVG properties, not CSS properties.


