### PR TITLE
[page type] Add page type to 'contribute a recipe' page

### DIFF
--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -1,6 +1,7 @@
 ---
 title: Contribute a recipe
 slug: Web/CSS/Layout_cookbook/Contribute_a_recipe
+page-type: guide
 tags:
   - CSS
   - Contribute


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15540. The "contribute a recipe" page: https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe is a guide page. I missed it before because I removed it from the other layout cookbook pages when I considered making them `css-recipe` pages.