### PR TITLE
[page type] Add page type for custom properties page

### DIFF
--- a/files/en-us/web/css/--_star_/index.md
+++ b/files/en-us/web/css/--_star_/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Custom properties (--*): CSS variables"
 slug: Web/CSS/--*
+page-type: guide
 tags:
   - CSS
   - CSS Custom Properties
@@ -29,10 +30,6 @@ Custom properties are scoped to the element(s) they are declared on, and partici
   - : This value matches any sequence of one or more tokens, so long as the sequence does not contain an disallowed token. It represents the entirety of what a valid declaration can have as its value.
 
 > **Note:** Custom property names are case sensitive — `--my-color` will be treated as a separate custom property to `--My-color`.
-
-### Formal syntax
-
-{{CSSSyntax}}
 
 ## Example
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15540. This is the last of the CSS pages to get a page type!

And it is a bit problematic.

The "custom properties" page: https://developer.mozilla.org/en-US/docs/Web/CSS/--_star_ is pretending to be a CSS property page but it isn't, really:

- all the other property pages have a name that's the name of the property: this one isn't.
- all the other property pages have syntax in webref: this one doesn't.
- all the other property pages describe a single property: this one describes some syntax for CSS variables.

So I have made it a guide, and also removed the formal syntax, which did not work. In future I think we should look at making this look less like a property page (including removing and reworking the "formal definition" bit, which will also not work in webref).
