### PR TITLE
web-accessible-resource changes

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -39,7 +39,7 @@ browser-compat: webextensions.manifest.web_accessible_resources
 
 ## Description
 
-Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages.
+Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.
 
 > **Note:** Until Firefox 105, extensions could access resources packaged in other extensions by default. From Firefox 105 onwards, to enable other extensions to access an extension's resources they must be included in this key.
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -41,6 +41,8 @@ browser-compat: webextensions.manifest.web_accessible_resources
 
 Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages.
 
+> **Note:** Until Firefox 105, extensions could access resources packaged in other extensions by default. From Firefox 105 onwards, to enable other extensions to access an extension's resources they must be included in this key.
+
 For example, the [Beastify example extension](https://github.com/mdn/webextensions-examples/tree/master/beastify) replaces a web page with an image of a beast selected by the user. The beast images are packaged with the extension. To make the selected image visible, the extension adds [`<img>`](/en-US/docs/Web/HTML/Element/img) elements whose `src` attribute points to the beast's image. For the web page to be able to load the images, they must be made web accessible.
 
 With the `web_accessible_resources` key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -53,6 +53,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Support for defining persistent scripts using {{WebExtAPIRef("scripting")}} has been added. A script is identified as persistent using the `persistAcrossSessions` property in {{WebExtAPIRef("scripting.RegisteredContentScript")}} ({{bug("1751436")}}).
+- An extension's resources can no longer be loaded by other extensions by default. To enable other extensions to load resources they must be listed in the extension's [`web_accessible_resources`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) manifest key ({{bug("1711168")}}).
 
 ## Older versions
 


### PR DESCRIPTION
### Description

Provides information that from Firefox 105 extension resources are not available by default to other extensions. To make the resources available they need to be included in the web-accessible-resource manifest key.

### Motivation

Provide documentation for [Bug 1711168](https://bugzilla.mozilla.org/show_bug.cgi?id=1711168) support extensions in web_accessible_resources.