### PR TITLE
fix: remove em and strong in headings

### DIFF
--- a/files/en-us/games/anatomy/index.md
+++ b/files/en-us/games/anatomy/index.md
@@ -52,7 +52,7 @@ Timing the main loop to when the browser paints to the display allows you to run
 
 But do not immediately assume animations require frame-by-frame control. Simple animations can be easily performed, even GPU-accelerated, with CSS animations and other tools included in the browser. There are a lot of them and they will make your life easier.
 
-## Building a _better_ main loop in JavaScript
+## Building a better main loop in JavaScript
 
 There are two obvious issues with our previous main loop: `main()` pollutes the `{{ domxref("window") }}` object (where all global variables are stored) and the example code did not leave us with a way to _stop_ the loop unless the whole tab is closed or refreshed. For the first issue, if you want the main loop to just run and you do not need easy (direct) access to it, you could create it as an Immediately-Invoked Function Expression (IIFE).
 
@@ -114,7 +114,7 @@ window.cancelAnimationFrame(MyGame.stopMain);
 
 The key to programming a main loop, in JavaScript, is to attach it to whatever event should be driving your action and pay attention to how the different systems involved interplay. You may have multiple components driven by multiple different types of events. This feels like unnecessary complexity but it might just be good optimization (not necessarily, of course). The problem is that you are not programming a typical main loop. In JavaScript, you are using the browser's main loop and you are trying to do so effectively.
 
-## Building a _more_ _optimized_ main loop in JavaScript
+## Building a more optimized main loop in JavaScript
 
 Ultimately, in JavaScript, the browser is running its own main loop and your code exists in some of its stages. The above sections describe main loops which try not to wrestle away control from the browser. These main methods attach themselves to `window.requestAnimationFrame()`, which asks the browser for control over the upcoming frame. It is up to the browser how to relate these requests to their main loop. The [W3C spec for requestAnimationFrame](https://www.w3.org/TR/animation-timing/) does not really define exactly when the browsers must perform the requestAnimationFrame callbacks. This can be a benefit because it leaves browser vendors free to experiment with the solutions that they feel are best and tweak it over time.
 

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -115,7 +115,7 @@ body {
 
 {{ EmbedLiveSample('Defining_a_grid', '100%', 400) }}
 
-### Flexible grids with the **fr** unit
+### Flexible grids with the fr unit
 
 In addition to creating grids using lengths and percentages, we can use the `fr` unit to flexibly size grid rows and columns. This unit represents one fraction of the available space in the grid container.
 

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -33,7 +33,7 @@ It's outside the scope of this articleâ€”as a light introduction to JavaScriptâ€
 
 The section below introduces some aspects of the core language and offers an opportunity to play with a few browser API features too. Have fun!
 
-## A _Hello world!_ example
+## A "Hello world!" example
 
 JavaScript is one of the most popular modern web technologies! As your JavaScript skills grow, your websites will enter a new dimension of power and creativity.
 

--- a/files/en-us/learn/performance/business_case_for_performance/index.md
+++ b/files/en-us/learn/performance/business_case_for_performance/index.md
@@ -42,7 +42,7 @@ Setting a web performance budget can help you make sure the team stays on track 
 
 Defining and promoting a budget helps performance proponent advocates for good user experience against competing interests, such as marketing, sales, or even other developers that may want to add videos, 3rd party scripts, or even frameworks. [Performance budgets](/en-US/docs/Web/Performance/Performance_budgets) help developer teams protect optimal performance for users while enabling the business to tap into new markets and deliver custom experiences.
 
-### **K**ey **P**erformance **I**ndicators
+### Key Performance Indicators
 
 Setting key performance indicators (KPI) as objectives can highlight performance objectives that are also business objectives. KPIs can be both a set of important business metrics in measuring the impact of user experience and performance on the business's top line, and a way of demonstrating the benefits of prioritizing performance. Here are some KPIs to consider:
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
@@ -130,7 +130,7 @@ When you look back at your browser, you'll notice something unfortunate: your li
 
 We don't only want to eat; we have other things to — well — to do. Next we'll look at how we can make different component calls render unique content.
 
-## Make a _unique_ `<Todo />`
+## Make a unique `<Todo />`
 
 Components are powerful because they let us re-use pieces of our UI, and refer to one place for the source of that UI. The problem is, we don't typically want to reuse all of each component; we want to reuse most parts, and change small pieces. This is where props come in.
 

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -104,7 +104,7 @@ In terms of what option to choose on Windows, we'd strongly recommend trying to 
 
 Generally you'll find these two terms used interchangeably. Technically, a terminal is software that starts and connects to a shell. A shell is your session and session environment (where things like the prompt and shortcuts might be customized). The command line is the literal line where you enter commands and the cursor blinks.
 
-### Do you _have_ to use the terminal?
+### Do you have to use the terminal?
 
 Although there's a great wealth of tools available from the command line, if you're using tools like [Visual Studio Code](https://code.visualstudio.com/) there's also a mass of extensions that can be used as a proxy to using terminal commands without needing to use the terminal directly. However, you won't find a code editor extension for everything you want to do — you'll have to get some experience with the terminal eventually.
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -29,7 +29,7 @@ The rest of this page summarizes these and other incompatibilities.
 
 ## JavaScript APIs
 
-### _chrome.\*_ and _browser.\*_ namespace
+### chrome.\* and browser.\* namespace
 
 - **In Firefox:** The equivalent APIs are accessed using the `browser` namespace.
 

--- a/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
+++ b/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
@@ -64,7 +64,7 @@ The nature of space can change depending upon what MIME type is being used, and 
 
 ## See Also
 
-### **MDN**
+### MDN
 
 - [Accessibility: What users can do to browse more safely](/en-US/docs/Web/Accessibility/Accessibility:_What_users_can_to_to_browse_safely)
 - [Web accessibility for seizures and physical reactions](/en-US/docs/Web/Accessibility/Seizure_disorders)

--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -81,7 +81,7 @@ Unless you're creating an HTML version of a productivity application, you should
 
 Take into account the diversity of available keyboards and the various keyboard language preferences. Modifier keys are often used to create language specific common punctuation symbols and number characters. For example, numbers, when the keyboard language preference is set to French (France), use the Shift key.
 
-#### **Don't** use HTML instead
+#### Don't use HTML instead
 
 The `aria-keyshortcuts` attribute is very similar to the [problematic](https://webaim.org/techniques/keyboard/accesskey#spec) HTML {{htmlattrxref('accesskey')}}, which generates a keyboard shortcut for the current element. When an `accesskey` is defined for an element, the browser defines the modifiers and does all the work of handling the shortcut with no scripting required. Every browser and operating system combination has their own modifier keys for the non-modifier set in the `accesskey` attribute. What may work for one combination of operating system, assistive technology, and browser may not work with other combinations. With `aria-keyshortcuts`, the modifier keys are included in the attribute value list of key combinations and the functionality has to be scripted in.
 

--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -351,7 +351,7 @@ document.getAnimations().forEach((animation) => {
 
 One of the easiest ways is to start with an image that is already in existence, using it as an image source, and then animating it. Remember, you can use GIFs, JPGs, PNGs, SVGs and other file types here as an image source, as long as they are allowed file types—and sizes—in your environment. SVGs are often not allowed, due to security concerns. The MDN document, [Basic animations](/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations), provides outstanding examples of this, using multiple image sources for the sun, earth, and moon, and using several canvas methods to control the speed and animation of the earth as it orbits around the sun, and the moon as it orbits around the earth. Use the codepen available with this tutorial to adjust `ctx.rotate` in the code to see how the animation is affected when changes are made.
 
-#### If you absolutely, positively _must_ use a flashing animation…
+#### If you absolutely, positively must use a flashing animation…
 
 Make sure it has a control on it. Make sure it is turned off when the viewer first encounters it, and that a user must opt-in to see the animation.
 

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -155,7 +155,7 @@ function clearOutputCookies() {
 
 {{EmbedLiveSample('Example_1_Simple_usage', 200, 72)}}
 
-### Example #2: Get a sample cookie named _test2_
+### Example #2: Get a sample cookie named test2
 
 ```js
 // Note that we are setting `SameSite=None;` in this example because the example

--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -34,7 +34,7 @@ This source code contains a couple of line feeds after the `DOCTYPE` and a bunch
 
 This is so that whitespace characters don't impact the layout of your page. Creating space around and inside elements is the job of CSS.
 
-### What _does_ happen to whitespace?
+### What does happen to whitespace?
 
 They don't just disappear, however.
 

--- a/files/en-us/web/api/formdata/using_formdata_objects/index.md
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.md
@@ -199,7 +199,7 @@ formElem.addEventListener('formdata', (e) => {
 
 > **Note:** The `formdata` event and {{domxref("FormDataEvent")}} object are available in Chrome from version 77 (and other equivalent Chromiums), and Firefox 72 (first available behind the `dom.formdata.event.enabled` pref in Firefox 71).
 
-## Submitting forms and uploading files via AJAX _without_ `FormData` objects
+## Submitting forms and uploading files via AJAX without `FormData` objects
 
 If you want to know how to serialize and submit a form via [AJAX](/en-US/docs/Web/Guide/AJAX) _without_ using FormData objects, please read [this paragraph](/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files).
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -16,7 +16,7 @@ The main steps to drag and drop are to define a _drop zone_ (i.e. a target eleme
 
 Note that {{domxref("HTML_Drag_and_Drop_API","HTML drag and drop")}} defines two different APIs to support dragging and dropping files. One API is the {{domxref("DataTransfer")}} interface and the second API is the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces. This example illustrates the use of both APIs (and does not use any Gecko specific interfaces).
 
-## Define the drop _zone_
+## Define the drop zone
 
 The _target element_ of the {{domxref("HTMLElement/drop_event", "drop")}} event needs an `ondrop` event handler. The following code snippet shows how this is done with a {{HTMLelement("div")}} element:
 

--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -69,7 +69,7 @@ Mozilla and Firefox support some features not in the standard drag-and-drop mode
 
 This section is a summary of the basic steps to add drag-and-drop functionality to an application.
 
-### Identify what is _draggable_
+### Identify what is draggable
 
 Making an element _draggable_ requires adding the {{htmlattrxref("draggable")}} attribute and the {{domxref("HTMLElement.dragstart_event","ondragstart")}} event handler, as shown in the following code sample:
 
@@ -133,7 +133,7 @@ Learn more about drag feedback images in:
 
 - [Setting the Drag Feedback Image](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#setting_the_drag_feedback_image)
 
-### Define the drag _effect_
+### Define the drag effect
 
 The {{domxref("DataTransfer.dropEffect","dropEffect")}} property is used to control the feedback the user is given during a drag-and-drop operation. It typically affects which cursor the browser displays while dragging. For example, when the user hovers over a drop target, the browser's cursor may indicate the type of operation that will occur.
 
@@ -157,7 +157,7 @@ For more details, see:
 
 - [Drag Effects](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#drag_effects)
 
-### Define a _drop zone_
+### Define a drop zone
 
 By default, the browser prevents anything from happening when dropping something onto most HTML elements. To change that behavior so that an element becomes a _drop zone_ or is _droppable_, the element must have both {{domxref("HTMLElement.dragover_event","ondragover")}} and {{domxref("HTMLElement.drop_event","ondrop")}} event handler attributes.
 
@@ -191,7 +191,7 @@ For more information, see:
 
 - [Specifying Drop Targets](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#specifying_drop_targets)
 
-### Handle the drop _effect_
+### Handle the drop effect
 
 The handler for the {{domxref("Document/drop_event", "drop")}} event is free to process the drag data in an application-specific way.
 

--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -75,7 +75,7 @@ li::after {
 
 {{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 150)}}
 
-### _decimal-leading-zero_ compared to lower-alpha
+### decimal-leading-zero compared to lower-alpha
 
 #### HTML
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -257,7 +257,7 @@ console.log(removedItems);
 // ["Strawberry", "Mango", "Cherry"]
 ```
 
-### Truncate an array down to just its first _N_ items
+### Truncate an array down to just its first N items
 
 This example uses the [`splice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) method to truncate the `fruits` array down to just its first 2 items.
 

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -11,7 +11,7 @@ tags:
 
 This article provides some XPath code snippets — simple examples of how to a few simple **utility functions** based on standard interfaces from the [DOM Level 3 XPath specification](https://www.w3.org/TR/DOM-Level-3-XPath/) that expose XPath functionality to JavaScript code. The snippets are functions you can use in the real world in your own code.
 
-### Node-specific _evaluator_ function
+### Node-specific evaluator function
 
 The following custom utility function can be used to evaluate XPath expressions on given XML nodes. The first argument is a DOM node or Document object, while the second is a string defining an XPath expression.
 


### PR DESCRIPTION
Strips out non-literal `_` and `*` from headings