### PR TITLE
Fix broken link to novalidate attribute

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -517,7 +517,7 @@ First, the HTML. Again, feel free to build this along with us:
 </form>
 ```
 
-This simple form uses the [`novalidate`](/en-US/docs/Web/HTML/Attributes/novalidate) attribute to turn off the browser's automatic validation; this lets our script take control over validation.
+This simple form uses the [`novalidate`](/en-US/docs/Web/HTML/Element/form#attr-novalidate) attribute to turn off the browser's automatic validation; this lets our script take control over validation.
 However, this doesn't disable support for the constraint validation API nor the application of CSS pseudo-classes like {{cssxref(":valid")}}, etc.
 That means that even though the browser doesn't automatically check the validity of the form before sending its data, you can still do it yourself and style the form accordingly.
 


### PR DESCRIPTION
In the "Validating forms using JavaScript" section under "A more detailed example," the novalidate attribute link (currently pointing to /en-US/docs/Web/HTML/Attributes/novalidate) is broken and takes the user to a page not found placeholder.

Proposing to fix the broken link by linking to the attribute description on the form element page (/en-US/docs/Web/HTML/Element/form#attr-novalidate) instead.

novalidate is also mentioned in the HTML attribute reference (en-US/docs/Web/HTML/Attributes), but does not appear to have an anchor link and only refers the reader to the above form element page.