### PR TITLE
Incorrect example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -107,8 +107,8 @@ function isPrime(element) {
   return true;
 }
 
-console.log([4, 6, 8, 12].findLast(isPrime)); // undefined, not found
-console.log([4, 5, 7, 8, 9, 11, 12].findLast(isPrime)); // 11
+console.log([4, 6, 8, 12].findLastIndex(isPrime)); // -1, not found
+console.log([4, 5, 7, 8, 9, 11, 12].findLastIndex(isPrime)); // 5
 ```
 
 ### Using findLastIndex() on sparse arrays


### PR DESCRIPTION
In the examples section of findLastIndex, the first example states, "Find the index of the last prime number in an array" the example is to get the last prime number, not the index of the last prime number.


### Description

On [Array.prototype.findLastIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex) documentation page, in example section the first example the title says _Find the index of the last prime number in an array_, but the example written is to get last prime number instead of getting the last index of a prime number. We are showing example for `Array.prototype.findLast` instead of `Array.prototype.findLastIndex`. 

### Motivation

The intent of the example and the description is not the same. It might confuse new readers. 
