### PR TITLE
Update <mo> attribute references

### DIFF
--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -29,9 +29,11 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `denomalign` {{deprecated_inline}}
   - : The alignment of the denominator under the fraction. Possible values are: `left`, `center` (default), and `right`.
 - `linethickness`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the thickness of the horizontal fraction line. Some browsers may also accept deprecated values `medium`, `thin` and `thick` but their exact interpretation is left to implementers.
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the thickness of the horizontal fraction line.
 - `numalign` {{deprecated_inline}}
   - : The alignment of the numerator over the fraction. Possible values are: `left`, `center` (default), and `right`.
+
+> **Note:** For the `linethickness` attribute, some browsers may also accept deprecated values `medium`, `thin` and `thick` (whose exact interpretation is left to implementers) or [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -33,7 +33,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `numalign` {{deprecated_inline}}
   - : The alignment of the numerator over the fraction. Possible values are: `left`, `center` (default), and `right`.
 
-> **Note:** For the `linethickness` attribute, some browsers may also accept deprecated values `medium`, `thin` and `thick` (whose exact interpretation is left to implementers) or [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
+> **Note:** For the `linethickness` attribute, some browsers may also accept the deprecated values `medium`, `thin` and `thick` (whose exact interpretation is left to implementers) or [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -15,45 +15,40 @@ The MathML `<mo>` element represents an operator in a broad sense. Besides opera
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes), this element accepts the following attributes [whose default values depend on the operator's form and content](https://w3c.github.io/mathml-core/#algorithm-for-determining-the-properties-of-an-embellished-operator):
 
 - `accent`
-  - : If the operator is used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) this attribute specifies whether the operator should be treated as an accent.
-    Allowed values are `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover), which implies slightly different size and placement.
+
 - `fence`
-  - : There is no visual effect for this attribute, but it specifies whether the operator is a fence (such as parentheses).
-    Allowed values are `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
+
 - `lspace`
-  - : The amount of space before the operator (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units). The constant `thickmathspace` (5/18em) is the default value.
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the amount of space before the operator.
 
 - `maxsize`
 
-  - : If `stretchy` is `true`, this attribute specifies the maximum size of the operator. Allowed values are:
-
-    - `infinity`
-    - an arbitrary [length](/en-US/docs/Web/MathML/Attribute/Values#lengths)
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the maximum size of the operator when it is stretchy.
 
 - `minsize`
 
-  - : If `stretchy` is `true`, this attribute specifies the minimum size of the operator. Allowed values are:
-
-    - `infinity`
-    - an arbitrary [length](/en-US/docs/Web/MathML/Attribute/Values#lengths)
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum size of the operator when it is stretchy.
 
 - `movablelimits`
-  - : Specifies whether attached under- and overscripts move to sub- and superscript positions when `displaystyle` is `false`.
-    Allowed values are either `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether attached under- and overscripts move to sub- and superscript positions when [`math-style`](/en-US/docs/Web/CSS/math-style) set to `compact`.
+
 - `rspace`
-  - : The amount of space after the operator (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units). The constant `thickmathspace` (5/18em) is the default value.
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the amount of space after the operator.
 - `separator`
-  - : There is no visual effect for this attribute, but it specifies whether the operator is a separator (such as commas).
-    Allowed values are `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator is a separator (such as commas). There is no visual effect for this attribute.
+
 - `stretchy`
-  - : Specifies whether the operator stretches to the size of the adjacent element.
-    Allowed values are `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator stretches to the size of the adjacent element.
+
 - `symmetric`
-  - : If `stretchy` is `true`, this attribute specifies whether the operator should be vertically symmetric around the imaginary math axis (centered fraction line).
-    The default value is `true` if **stretchy** is set to `true` and otherwise `false`. Allowed values are `true` or `false`.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether a stretchy operator should be vertically symmetric around the imaginary math axis (centered fraction line).
+
+> **Note:** For the `lspace`, `maxsize`, `minsize` and `rspace` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Update mo attribute references:

- Don't mention default values. These are obtained via a more complex dictionary-based algorithm, so just refer to the spec for now.
- Elaborate (a bit) on the effect of the accent attribute.
- For movablelimits, refer to `math-style: compact` rather than `displaystyle` is `false` (slightly more accurate).
- Update the accepted values based on MathML Core, which relies on existing `<boolean>` and `<length-percentage>` types mentioned elsewhere on MDN.
- Previous point removes the "infinity" value which is not implemented in any browser.
- Also add a note to mention that some browsers may still support legacy MathML lengths and do the same for mfrac.

### Motivation

Align with MathML Core and modern browser implementations to help web developers.

### Additional details

https://w3c.github.io/mathml-core/#dictionary-based-attributes

### Related issues and pull requests

N/A