### PR TITLE
Add note about circular ref

### DIFF
--- a/files/en-us/glossary/global_object/index.md
+++ b/files/en-us/glossary/global_object/index.md
@@ -20,9 +20,10 @@ The [`globalThis`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThi
 
 The properties of the global object are automatically added to the {{glossary("global scope")}}.
 
-In JavaScript, the global object will always hold a reference to itself:
+In JavaScript, the global object always holds a reference to itself:
 
 ```js
+console.log(globalThis === globalThis.globalThis); // true (everywhere)
 console.log(window === window.window); // true (in a browser)
 console.log(self === self.self); // true (in a browser or a Web Worker)
 console.log(frames === frames.frames); // true (in a browser)

--- a/files/en-us/glossary/global_object/index.md
+++ b/files/en-us/glossary/global_object/index.md
@@ -20,6 +20,15 @@ The [`globalThis`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThi
 
 The properties of the global object are automatically added to the {{glossary("global scope")}}.
 
+In JavaScript, the global object will always hold a reference to itself:
+
+```js
+console.log(window === window.window); // true (in a browser)
+console.log(self === self.self); // true (in a browser or a Web Worker)
+console.log(frames === frames.frames); // true (in a browser)
+console.log(global === global.global); // true (in Node.js)
+```
+
 ## See also
 
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added note about the circular reference that always exists on the global object.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Referencing variables created with no keyword or with `var` works by detecting if that reference exists in `globalThis`. To make `globalThis` referenceable, it must be a property of itself.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
