### PR TITLE
Replace <dimension> with <number>

### DIFF
--- a/files/en-us/web/css/css_types/index.md
+++ b/files/en-us/web/css/css_types/index.md
@@ -70,7 +70,7 @@ These data types are used to indicate quantities, indexes, and positions. The ma
 - {{cssxref("&lt;ratio&gt;")}}
   - : A ratio, written with the syntax `<number> / <number>`.
 - {{cssxref("&lt;flex&gt;")}}
-  - : A flexible length introduced for [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), written as a `<dimension>` with the `fr` unit attached and used for grid track sizing.
+  - : A flexible length introduced for [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), written as a `<number>` with the `fr` unit attached and used for grid track sizing.
 
 ## Quantities
 


### PR DESCRIPTION
The article states:
"written as a `<dimension>` with the `fr` unit attached."

I feel that it should be:
"written as a `<number>` with the `fr` unit attached."

But this whole problem can come from an alternative way to read the sentence.

My feeling is that the article can be interpreted like "we need to write this as a dimension plus the `fr` unit 
=> Like 12px fr

Tricky. I am not a native english speaker so I cannot really tell.