### PR TITLE
Confusing Terminology

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -64,7 +64,7 @@ The `finally()` method is very similar to calling
     `Promise.resolve(2).finally(() => 77)` will return a
     new resolved promise with the result `2`.
   - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)`
-    (which will return a resolved promise with the value `88`),
+    (which will return a rejected promise with the value `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.
   - But, both `Promise.reject(3).finally(() => {throw 99})` and


### PR DESCRIPTION
Rejected promises are `rejected` and not `resolved`.   

Using the term `"resolved"`(which is typically used for resolved promises) interchangeably for rejected promises is confusing, misleading, and inconsistent with the terminology used to describe the settled state of promise objects.

The below excerpt mentions that a `rejected` promise is `resolved` to the value `88`. 

 - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)` (which will return a resolved promise with the value `88`), `Promise.reject(3).finally(() => 88)` will return a rejected promise with the reason `3`.

