### PR TITLE
Wording should unambiguously match implementation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Array.findLast
 
 {{JSRef}}
 
-The **`findLast()`** method returns the value of the first element from the end of an array that satisfies the provided testing function.
+The **`findLast()`** method iterates the array in reverse order and returns the value of the first element that satisfies the provided testing function.
 If no elements satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 {{EmbedInteractiveExample("pages/js/array-findlast.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Array.findLast
 
 {{JSRef}}
 
-The **`findLast()`** method returns the value of the last element in an array that satisfies the provided testing function.
+The **`findLast()`** method returns the value of the first element from the end of an array that satisfies the provided testing function.
 If no elements satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 {{EmbedInteractiveExample("pages/js/array-findlast.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Array.findLastIndex
 
 {{JSRef}}
 
-The **`findLastIndex()`** method returns the index of the last element in an array that satisfies the provided testing function.
+The **`findLastIndex()`** method iterates the array in reverse order and returns the index of the first element that satisfies the provided testing function.
 If no elements satisfy the testing function, -1 is returned.
 
 {{EmbedInteractiveExample("pages/js/array-findlastindex.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.TypedArray.findLast
 
 {{JSRef}}
 
-The **`findLast()`** method returns the value of the last element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
+The **`findLast()`** method iterates the array in reverse order and returns the value of the first element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
 If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 See also the {{jsxref("TypedArray.findLastIndex()", "findLastIndex()")}} method, which returns the index of the found element instead of its value.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.TypedArray.findLast
 
 {{JSRef}}
 
-The **`findLast()`** method iterates the array in reverse order and returns the value of the first element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
+The **`findLast()`** method iterates a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) in reverse order and returns the value of the first element that satisfies the provided testing function.
 If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 See also the {{jsxref("TypedArray.findLastIndex()", "findLastIndex()")}} method, which returns the index of the found element instead of its value.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.TypedArray.findLastIndex
 
 {{JSRef}}
 
-The **`findLastIndex()`** method returns the index of the last element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
+The **`findLastIndex()`** method iterates the array in reverse order and returns the index of the first element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
 If no values satisfy the testing function, -1 is returned.
 
 See also the {{jsxref("TypedArray.findLast()", "findLast()")}} method, which returns the value of the found element rather than its index.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.TypedArray.findLastIndex
 
 {{JSRef}}
 
-The **`findLastIndex()`** method iterates the array in reverse order and returns the index of the first element in a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) that satisfies the provided testing function.
+The **`findLastIndex()`** method iterates a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) in reverse order and returns the index of the first element that satisfies the provided testing function.
 If no values satisfy the testing function, -1 is returned.
 
 See also the {{jsxref("TypedArray.findLast()", "findLast()")}} method, which returns the value of the found element rather than its index.


### PR DESCRIPTION
Based on the ECMAScript Language Specification description of Array.findLastIndex, Array.findRight and Array.findIndexRight would be more accurate names.

I tried to use Array.findLast to find the value of the last element in an array that passed a test whose condition could change during iteration. Instead, it found the value of the first element that passed the test, going from the end of the array to the beginning of the array. The name "findLast" is ambiguous, since "last" could mean the last item that passed a test, where all items were tested, or it could mean the item closest to the end that passed a test.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
