### PR TITLE
use absolute path for cite's href

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -299,7 +299,7 @@ There is a {{htmlelement("cite")}} element, but this is meant to contain the tit
 ```html
 <p>
   According to the
-  <a href="/en-US/docs/Web/HTML/Element/blockquote">
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote">
     <cite>MDN blockquote page</cite></a>:
 </p>
 
@@ -309,7 +309,7 @@ There is a {{htmlelement("cite")}} element, but this is meant to contain the tit
 </blockquote>
 
 <p>The quote element — <code>&lt;q&gt;</code> — is <q cite="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q">intended
-for short quotations that don't require paragraph breaks.</q> — <a href="/en-US/docs/Web/HTML/Element/q">
+for short quotations that don't require paragraph breaks.</q> — <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q">
 <cite>MDN q page</cite></a>.</p>
 ```
 


### PR DESCRIPTION
In the preview it redirects to `https://yari-demos.prod.mdn.mozit.cloud/en-US/docs/Web/HTML/Element/blockquote` which is not correct.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

use absolute path for cite element's href tag because in preview it redirects to the wrong path.

### Motivation

my change eliminates confusion in understanding the code.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
