### PR TITLE
A minute content reordering

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -79,8 +79,8 @@ position changes (because their values are relative to the viewport and not abso
 
 If you need the bounding rectangle relative to the top-left corner of the document,
 just add the current scrolling position to the `top` and `left`
-properties (these can be obtained using {{domxref("window.scrollX")}} and
-{{domxref("window.scrollY")}}) to get a bounding rectangle which is independent from the
+properties (these can be obtained using {{domxref("window.scrollY")}} and
+{{domxref("window.scrollX")}}) to get a bounding rectangle which is independent from the
 current scrolling position.
 
 ## Examples


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
 The scrolling position `window.scrollY` is relative to the `top` and `window.scrollX` is relative to the `left`. In docs, 
ordered as `top` and `left` corresponded as `window.scrollX` and `window.scrollY`.
It would make sense, To switch as `window.scrollY` and then `window.scrollX` will downsize the puzzlement

```diff
- scrolling position to the `top` and `left` properties (these can be obtained using {{domxref("window.scrollX")}} and {{domxref("window.scrollY")}}) 
+ scrolling position to the `top` and `left` properties (these can be obtained using {{domxref("window.scrollY")}} and {{domxref("window.scrollX")}}) 
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
A little misordering will introduce tiny confusion. Try to downsize that confusion.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect#:~:text=If%20you%20need,current%20scrolling%20position.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
