### PR TITLE
Update documentation for mspace attributes

### DIFF
--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -15,16 +15,16 @@ The MathML `<mspace>` element is used to display a blank space, whose size is se
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `depth`
-  - : The desired depth (below the baseline) of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
+  - :  A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired depth (below the baseline) of the space.
 - `height`
-  - : The desired height (above the baseline) of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired height (above the baseline) of the space.
 - `width`
-  - : The desired width of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired width of the space.
 
-Note that some common attributes like `mathcolor`, `mathvariant` or `dir` have no effect on `<mspace>`.
+> **Note:** For the `depth`, `height`, `width` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Update documentation for mspace attributes:
- Rely on CSS data type and add a note about deprecated MathML lengths, as done in #21218
- Also remove comment that some attributes have no effect on <mspace> this is not very helpful and not 100% accurate either (it has some non-visual side effect).

### Motivation

Align with MathML Core and modern browser implementations to help web developers.

### Additional details

https://w3c.github.io/mathml-core/#space-mspace

### Related issues and pull requests

See also PR #21218