### PR TITLE
Update MathML documentation about the <ms> element

### DIFF
--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -11,19 +11,33 @@ browser-compat: mathml.elements.ms
 
 {{MathMLRef}}
 
-The MathML `<ms>` element represents a _string literal_ meant to be interpreted by programming languages and computer algebra systems. By default, string literals are displayed as enclosed by double quotes (`&quot;`); by using the `lquote` and `rquote` attributes, you can set custom characters to display. Note that quotation marks should not be specified unless they are part of the string literal. The content of an `<ms>` element is not an ASCII string per se, but rather a sequence of characters and {{ MathMLElement("malignmark") }} elements.
+The MathML `<ms>` element represents a _string literal_ meant to be interpreted by programming languages and computer algebra systems.
 
 ## Attributes
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+Some browsers may also support the following deprecated attributes and will render the content of the `<ms>` element surrounded by the specified opening and closing quotes:
+
 - `lquote`
-  - : The opening quote character (depends on [`dir`](#attr-dir)) to enclose the content. The default value is "`&quot;".`
+  - : The opening quote to enclose the content. The default value is `&quot;`.
 
 - `rquote`
-  - : The closing quote mark (depends on [`dir`](#attr-dir)) to enclose the content. The default value is "`&quot;".`
+  - : The closing quote to enclose the content. The default value is `&quot;`.
 
 ## Examples
+
+### Default rendering
+
+```html
+<math display="block">
+  <ms>Hello World!</ms>
+</math>
+```
+
+{{ EmbedLiveSample('default_rendering', 700, 200, "", "") }}
+
+### Legacy quote attributes
 
 ```html
 <math display="block">
@@ -31,7 +45,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 </math>
 ```
 
-{{ EmbedLiveSample('ms_example', 700, 200, "", "") }}
+{{ EmbedLiveSample('legacy_quote_attributes', 700, 200, "", "") }}
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the documentation to indicate to make clear lquote/rquote are deprecated.

### Motivation

The lquote/rquote attributes are not part of MathML Core and only supported by Firefox (not WebKit or Chromium). The plan is to unship them. 

### Additional details

https://bugzilla.mozilla.org/show_bug.cgi?id=1793387
https://bugs.webkit.org/show_bug.cgi?id=125859#c2

### Related issues and pull requests

https://github.com/mdn/browser-compat-data/pull/17928