### PR TITLE
Remove IE note about contenteditable

### DIFF
--- a/files/en-us/web/api/htmlelement/contenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.md
@@ -39,13 +39,6 @@ A string.
 
 {{Compat}}
 
-In Internet Explorer, `contenteditable` cannot be applied to the
-{{htmlelement("table")}}, {{htmlelement("col")}}, {{htmlelement("colgroup")}},
-{{htmlelement("tbody")}}, {{htmlelement("td")}}, {{htmlelement("tfoot")}},
-{{htmlelement("th")}}, {{htmlelement("thead")}}, and {{htmlelement("tr")}} elements
-directly. A content editable {{htmlelement("span")}} or {{htmlelement("div")}} element
-can be placed inside the individual table cells.
-
 ## See also
 
 - [Making content editable](/en-US/docs/Web/Guide/HTML/Editable_content)


### PR DESCRIPTION
Not 100% sure if we're removing IE notes. But if yes, that here is a PR.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
