### PR TITLE
Improve consistency for the documentation about accent/accentunder

### DIFF
--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -18,7 +18,7 @@ The MathML `<mo>` element represents an operator in a broad sense. Besides opera
 In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes), this element accepts the following attributes [whose default values depend on the operator's form and content](https://w3c.github.io/mathml-core/#algorithm-for-determining-the-properties-of-an-embellished-operator):
 
 - `accent`
-  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover), which implies slightly different size and placement.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover)  (i.e. drawn bigger and closer to the base expression).
 
 - `fence`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -15,11 +15,10 @@ The MathML `<mover>` element is used to attach an accent or a limit over an expr
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attribute:
 
 - `accent`
-  - : If `true` the over-script is an _accent_, which is drawn closer to the base expression.
-    If `false` (default value) the over-script is a _limit_ over the base expression.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the over script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -15,11 +15,10 @@ The MathML `<munder>` element is used to attach an accent or a limit under an ex
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attribute:
 
 - `accentunder`
-  - : If `true`, the element is an _accent_, which is drawn closer to the base expression.
-    If `false` (default value), the element is a _limit_ under the base expression.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -17,14 +17,12 @@ It uses the following syntax: `<munderover> base underscript overscript </munder
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `accent`
-  - : If `true`, the overscript is an _accent_, which is drawn closer to the base expression.
-    If `false` (default value), the overscript is a _limit_ over the base expression.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the over script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 - `accentunder`
-  - : If `true`, the underscript is an _accent_, which is drawn closer to the base expression.
-    If `false` (default value), the underscript is a _limit_ under the base expression.
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Improve consistency for the documentation about accent/accentunder:
- Rely on the <boolean> data type to describe the accepted values.
- Use consistent description of what an accent is, and that they apply to under/over scripts.
- Remove the mention of "limit" which is not defined in the spec.

### Motivation

Clarify a bit the doc.

### Additional details

N/A

### Related issues and pull requests

https://github.com/mdn/content/pull/21247
https://github.com/mdn/content/pull/21218