### PR TITLE
Update the doc about mpadded attributes

### DIFF
--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -35,8 +35,8 @@ For the `depth`, `height`, `lspace`, `voffset` and `width` attributes, some brow
 1. An optional `+` or `-` sign as a prefix, specifying an increment or decrement to the corresponding dimension (if absent, the corresponding dimension is set directly to specified value).
 2. Followed by an [`<unsigned-number>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) (let's call it α below).
 3. Optionally followed by a value (if absent, the specified value is interpreted as "100 times α percent").
-   - A [unit](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#units). The specified value is interpreted the same as [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
-   - A [namedspace constant](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#constants). The specified value is interpreted as α times the constant.
+   - A [unit](/en-US/docs/Web/MathML/Attribute/Values#units). The specified value is interpreted the same as [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
+   - A [namedspace constant](/en-US/docs/Web/MathML/Attribute/Values#constants). The specified value is interpreted as α times the constant.
    - A pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α times the corresponding dimension of the content.
    - A percent sign followed by a pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α% the corresponding dimension of the content.
 

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -15,28 +15,39 @@ The MathML `<mpadded>` element is used to add extra padding and to set the gener
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `depth`
-  - : Sets or increments the depth. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired depth (below the baseline) of the `<mpadded>` element.
 - `height`
-  - : Sets or increments the height. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired height (above the baseline) of the `<mpadded>` element.
 - `lspace`
-  - : Sets or increments the horizontal position. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
 - `voffset`
-  - : Sets or increments the vertical position. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the vertical location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
 - `width`
-  - : Sets or increments the width. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired depth (below the baseline) of the `<mpadded>` element.
 
-### Pseudo-units
+### Legacy syntax
 
-It is possible to use the keywords `"depth`", `"height"`, and `"width"` as a pseudo-unit for the attributes `depth`, `height`, `lspace`, `voffset`, and `width`. They represent each length of the same-named dimension.
+For the `depth`, `height`, `lspace`, `voffset` and `width` attributes, some browsers may instead accept a more complex syntax:
+
+1. An optional `+` or `-` sign as a prefix, specifying an increment or decrement to the corresponding dimension (if absent, the corresponding dimension is set directly to specified value).
+2. Followed by an [`<unsigned-number>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) (let's call it α below).
+3. Optionally followed by a value (if absent, the specified value is interpreted as "100 times α percent").
+   - A [unit](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#units). The specified value is interpreted the same as [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
+   - A [namedspace constant](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#constants). The specified value is interpreted as α times the constant.
+   - A pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α times the corresponding dimension of the content.
+   - A percent sign followed by a pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α% the corresponding dimension of the content.
 
 ## Examples
 
+### Dimensions and offsets
+
 ```html
 <math display="block">
-  <mpadded height="+150px" width="100px" lspace="2height"
+  <mpadded width="400px" height="5em" depth="4em"
+           lspace="300px" voffset="-2em"
            style="background: lightblue">
     <mi>x</mi>
     <mo>+</mo>
@@ -45,7 +56,35 @@ It is possible to use the keywords `"depth`", `"height"`, and `"width"` as a pse
 </math>
 ```
 
-{{ EmbedLiveSample('mover_example', 700, 200, "", "") }}
+{{ EmbedLiveSample('dimensions_and_offsets_example', 700, 200, "", "") }}
+
+### Legacy syntax
+
+```html
+<math display="block">
+  <!-- increment by a length -->
+  <mpadded width="+20px" style="background: lightblue">
+    <mtext>+20px</mtext>
+  </mpadded>
+
+  <!-- set to a pseudo-unit -->
+  <mpadded width="2width" style="background: lightgreen">
+    <mtext>2width</mtext>
+  </mpadded>
+
+  <!-- increment by a percent of a pseudo-unit -->
+  <mpadded width="+400%height" style="background: lightyellow">
+    <mtext>+400%height</mtext>
+  </mpadded>
+
+  <!-- decrement to a multiple of a namedspace -->
+  <mpadded width="-1thickmathspace" style="background: pink">
+    <mtext>-.5thickmathspace</mtext>
+  </mpadded>
+</math>
+```
+
+{{ EmbedLiveSample('legacy_syntax_example', 700, 200, "", "") }}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Update the doc about mpadded attributes: Indicate that <length-percentage> are accepted as values (per MathML Core) but elaborate about the legacy MathML3 syntax. Also add more examples. The Browser compatibility table need more subfeatuires to indicate what browsers support precisely.

### Motivation

Help to clarify what browsers support and legacy syntax.

### Additional details

https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded
https://w3c.github.io/mathml/#presm_mpaddedatt

### Related issues and pull requests

N/A