### PR TITLE
non-idiomatic function name

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -267,7 +267,7 @@ function fetchCurrentData() {
     // maybe do something with j
 
     // fulfillment value given to user of
-    // fetch_current_data().then()
+    // fetchCurrentData().then()
     return j;
   });
 }


### PR DESCRIPTION
The last comment within the `fetchCurrentData`  function declaration refers to the fulfillment value of the returned promise, but instead of referencing the containing function `fetchCurrentData().then` it uses a non-idiomatic name `fetch_current_data().then`
