### PR TITLE
Fix typo in ReadableStreamBYOBReader.read() code example

### DIFF
--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -109,7 +109,7 @@ function readStream(reader) {
       .then(function processBytes({ done, value }) {
         // Result objects contain two properties:
         // done  - true if the stream has already given all its data.
-        // value - some data. Always defined, even when done is true.
+        // value - some data. 'undefined' if the reader is canceled.
 
         if (done) {
           // There is no more data in the stream

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -109,7 +109,7 @@ function readStream(reader) {
       .then(function processBytes({ done, value }) {
         // Result objects contain two properties:
         // done  - true if the stream has already given all its data.
-        // value - some data. Always undefined when done is true.
+        // value - some data. Always defined, even when done is true.
 
         if (done) {
           // There is no more data in the stream


### PR DESCRIPTION
### Description

This fixes the a typo in ReadableStreamBYOBReader.read() code example to match the text reference above and the published specs.

### Motivation

This comment typo is a important difference between the two ReadableStream readers.

### Additional details

Second item in the paragraph above the code example
https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader/read#return_value
and the linked spec https://streams.spec.whatwg.org/#ref-for-byob-reader-read%E2%91%A2

### Related issues and pull requests

none.