### PR TITLE
fix: remove FQDN from MDN links

### DIFF
--- a/files/en-us/learn/common_questions/what_is_a_domain_name/index.md
+++ b/files/en-us/learn/common_questions/what_is_a_domain_name/index.md
@@ -72,7 +72,7 @@ Each of those parts provides specific information about the whole domain name.
 
     The label located right before the TLD is also called a _Secondary Level Domain_ (SLD).
 
-    A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www\.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. [mozilla.org](https://www.mozilla.org/en-US/)), you can create "subdomains" with different content located at each, like [developer.mozilla.org](https://developer.mozilla.org), [iot.mozilla.org](https://iot.mozilla.org/), or [bugzilla.mozilla.org](https://bugzilla.mozilla.org).
+    A domain name can have many labels (or components). It is not mandatory nor necessary to have 3 labels to form a domain name. For instance, www\.inf.ed.ac.uk is a valid domain name. For any domain you control (e.g. [mozilla.org](https://www.mozilla.org/en-US/)), you can create "subdomains" with different content located at each, like [developer.mozilla.org](/), [iot.mozilla.org](https://iot.mozilla.org/), or [bugzilla.mozilla.org](https://bugzilla.mozilla.org).
 
 ### Buying a domain name
 

--- a/files/en-us/mdn/at_ten/history_of_mdn/index.md
+++ b/files/en-us/mdn/at_ten/history_of_mdn/index.md
@@ -6,7 +6,7 @@ tags:
   - MDN Meta
 ---
 
-In this talk from 2015, several contributors of the MDN project look at the past ten years of [developer.mozilla.org](https://developer.mozilla.org), and at the decade to come. You will hear the story of different wiki software migrations, how a documentation community was built, and many more highlights of the history of the site. The group then also talks about current challenges and projects the MDN community is working on this year.
+In this talk from 2015, several contributors of the MDN project look at the past ten years of [developer.mozilla.org](/), and at the decade to come. You will hear the story of different wiki software migrations, how a documentation community was built, and many more highlights of the history of the site. The group then also talks about current challenges and projects the MDN community is working on this year.
 
 <div id="audio"><pre class="brush: html hidden">&#x3C;audio controls="controls">
   Looks like your browser doesn't have a built-in audio player. Grab the file and play it yourself from here: https://videos.cdn.mozilla.net/uploads/mdn/MDN10/MDN_RoundTable.mp3

--- a/files/en-us/mdn/community/contributing/our_repositories/index.md
+++ b/files/en-us/mdn/community/contributing/our_repositories/index.md
@@ -10,7 +10,7 @@ tags:
 
 {{MDNSidebar}}
 
-[MDN Web Docs](https://developer.mozilla.org) is a complex project with lots of moving parts. It's a good idea to get familiar with the projects different repositories. This document intends to help you find the different repositories (repos) you may need when contributing to different parts of the MDN Web Docs project.
+[MDN Web Docs](/) is a complex project with lots of moving parts. It's a good idea to get familiar with the projects different repositories. This document intends to help you find the different repositories (repos) you may need when contributing to different parts of the MDN Web Docs project.
 
 ## Repository tiers
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
@@ -16,7 +16,7 @@ browser-compat: api.CanvasRenderingContext2D.wordSpacing
 
 The **`CanvasRenderingContext2D.wordSpacing`** property of the [Canvas API](/en-US/docs/Web/API/Canvas_API) specifies the spacing between words when drawing text.
 
-This corresponds to the CSS [`word-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-spacing) property.
+This corresponds to the CSS [`word-spacing`](/en-US/docs/Web/CSS/word-spacing) property.
 
 ## Value
 

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -88,7 +88,7 @@ For more information about `NaN` and its comparison, see [Equality comparison an
 
 ### Observably distinct NaN values
 
-There's a motivation for `NaN` being unequal to itself. It's possible to produce two floating point numbers with different binary representations but are both `NaN`, because in [IEEE 754 encoding](https://en.wikipedia.org/wiki/NaN#Floating_point), any floating point number with exponent `0x7ff` and a non-zero mantissa is `NaN`. In JavaScript, you can do bit-level manipulation using [typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays).
+There's a motivation for `NaN` being unequal to itself. It's possible to produce two floating point numbers with different binary representations but are both `NaN`, because in [IEEE 754 encoding](https://en.wikipedia.org/wiki/NaN#Floating_point), any floating point number with exponent `0x7ff` and a non-zero mantissa is `NaN`. In JavaScript, you can do bit-level manipulation using [typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays).
 
 ```js
 const f2b = (x) => new Uint8Array(new Float64Array([x]).buffer);

--- a/files/en-us/web/progressive_web_apps/loading/index.md
+++ b/files/en-us/web/progressive_web_apps/loading/index.md
@@ -124,7 +124,7 @@ This will remove the blur effect within half a second, which looks good enough f
 
 The image loading mechanism discussed in the above section works OK — it loads the images after rendering the HTML structure, and applies a nice transition effect in the process. The problem is that it still loads _all_ the images at once, even though the user will only see the first two or three upon page load.
 
-This problem can be solved by loading the images only when needed: this is called _lazy loading_. [Lazy loading](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading) is a technique to load images only when they appear in the viewport. There are several ways to tell the browser to lazy load images.
+This problem can be solved by loading the images only when needed: this is called _lazy loading_. [Lazy loading](/en-US/docs/Web/Performance/Lazy_loading) is a technique to load images only when they appear in the viewport. There are several ways to tell the browser to lazy load images.
 
 ### The loading attribute on \<img>
 


### PR DESCRIPTION
This could probably be caught with a Markdownlint rule, but there are a few project files that would likely get caught because they need the full URL