### PR TITLE
Create separate list of page-type values

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -50,7 +50,7 @@ If you want to get a team together to work on an update, or you just want to rep
 
 ## The page-type front matter key
 
-We have defined a front matter key `page-type` to describe the type of MDN pages. This project is a work in progress: so far we have only defined `page-type` values for the [CSS pages](/en-US/docs/Web/CSS) and the [Web API pages](/en-US/docs/Web/API). The templates linked below indicate which `page-type` values you should set for each page type.
+We have defined a front matter key `page-type` to clearly identify the type of MDN pages. The templates linked below indicate which `page-type` values you should set for each page type.
 
 For the complete list of page types see [The page-type front matter key](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key).
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -50,76 +50,9 @@ If you want to get a team together to work on an update, or you just want to rep
 
 ## The page-type front matter key
 
-We have defined a front matter key `page-type` to describe the type of MDN pages. This project is a work in progress: so far we have only defined `page-type` values for the [CSS pages](/en-US/docs/Web/CSS) and the [Web API pages](/en-US/docs/Web/API).
+We have defined a front matter key `page-type` to describe the type of MDN pages. This project is a work in progress: so far we have only defined `page-type` values for the [CSS pages](/en-US/docs/Web/CSS) and the [Web API pages](/en-US/docs/Web/API). The templates linked below indicate which `page-type` values you should set for each page type.
 
-### Generic page types
-
-These page types are not specific to a particular MDN technology area:
-
-- `guide`
-  - : A generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
-- `landing-page`
-  - : A page that acts primarily as a navigation aid, listing links to other pages. See [Landing page](#landing_page).
-
-### Web API page types
-
-This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
-
-- `web-api-overview`
-  - : A page giving an overview of a Web API, like the [Fetch API](/en-US/docs/Web/API/Fetch_API). See [API landing page](#api_landing_page).
-- `web-api-global-function`
-  - : A page documenting a Web API global function, like [`fetch()`](/en-US/docs/Web/API/fetch). See [API reference subpage](#api_reference_subpage).
-- `web-api-global-property`
-  - : A page documenting a Web API global property, like [`origin`](/en-US/docs/Web/API/origin). See [API reference subpage](#api_reference_subpage).
-- `web-api-interface`
-  - : A page documenting a Web API interface, like [`Request`](/en-US/docs/Web/API/Request). See [API reference page](#api_reference_page).
-- `web-api-constructor`
-  - : A page documenting a constructor for a Web API interface, like [`Request()`](/en-US/docs/Web/API/Request/Request). See [API reference subpage](#api_reference_subpage).
-- `web-api-instance-method`
-  - : A page documenting a method on a Web API interface instance, like [`geolocation.getCurrentPosition()`](/en-US/docs/Web/API/Geolocation/getCurrentPosition). See [API reference subpage](#api_reference_subpage).
-- `web-api-instance-property`
-  - : A page documenting a property of a Web API interface instance, like [`request.headers`](/en-US/docs/Web/API/Request/headers). See [API reference subpage](#api_reference_subpage).
-- `web-api-static-method`
-  - : A page documenting a static method on a Web API interface, like [`Response.error()`](/en-US/docs/Web/API/Response/error). See [API reference subpage](#api_reference_subpage).
-- `web-api-static-property`
-  - : A page documenting a static property of a Web API interface, like [`Notification.permission`](/en-US/docs/Web/API/Notification/permission). See [API reference subpage](#api_reference_subpage).
-- `web-api-event`
-  - : A page documenting a event fired on a Web API interface instance, like [`Notification.click`](/en-US/docs/Web/API/Notification/click_event). See [API reference subpage](#api_reference_subpage).
-- `webgl-extension`
-  - : A page documenting a WebGL extension, like [`WEBGL_draw_buffers`](/en-US/docs/Web/API/WEBGL_draw_buffers).
-- `webgl-extension-method`
-  - : A page documenting a method on WebGL extension, like [`OES_vertex_array_object.bindVertexArrayOES()`](/en-US/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES).
-
-### CSS page types
-
-This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
-
-- `css-at-rule`
-  - : A page documenting a CSS [at-rule](/en-US/docs/Web/CSS/At-rule), like {{cssxref("@charset")}}.
-- `css-at-rule-descriptor`
-  - : A page documenting a CSS at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/web/css/@counter-style/prefix).
-- `css-combinator`
-  - : A page documenting a CSS combinator, like the [descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator).
-- `css-function`
-  - : A page documenting a CSS [function](/en-US/docs/Web/CSS/CSS_Functions), like {{cssxref("max")}}.
-- `css-keyword`
-  - : A page documenting a CSS keyword, like {{cssxref("inherit")}}.
-- `css-media-feature`
-  - : A page documenting a CSS [media feature](/en-US/docs/Web/CSS/@media#media_features), like [`hover`](/en-US/docs/Web/CSS/@media/hover).
-- `css-module`
-  - : An overview page for a CSS module, like [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations).
-- `css-property`
-  - : A page documenting a CSS property, like {{cssxref("background-color")}}.
-- `css-pseudo-class`
-  - : A page documenting a CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), like {{cssxref(":enabled")}}.
-- `css-pseudo-element`
-  - : A page documenting a CSS [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), like {{cssxref("::before")}}.
-- `css-selector`
-  - : A page documenting a CSS [basic selector](/en-US/docs/Web/CSS/CSS_Selectors#basic_selectors), like the [class selector](/en-US/docs/Web/CSS/Class_selectors).
-- `css-shorthand-property`
-  - : A page documenting a CSS [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties), like {{cssxref("background")}}.
-- `css-type`
-  - : A page documenting a CSS [data type](/en-US/docs/Web/CSS/CSS_Types), like [`<color>`](/en-US/docs/Web/CSS/color_value).
+For the complete list of page types see [The page-type front matter key](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key).
 
 ## API landing page
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -1,0 +1,69 @@
+---
+title: The page-type front matter key
+slug: MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key
+page-type: mdn-writing-guide
+tags:
+  - meta
+  - writing-guide
+---
+
+{{MDNSidebar}}
+
+The `page-type` front matter key describes the type of an MDN page.
+
+Like any other front matter key, the `page-type` key is specified in the YAML at the start of "index.md":
+
+```md
+---
+title: Geolocation.getCurrentPosition()
+slug: Web/API/Geolocation/getCurrentPosition
+page-type: web-api-instance-method
+browser-compat: api.Geolocation.getCurrentPosition
+---
+```
+
+Each main area of the site — JavaScript, CSS, and so on — has a set of domain-specific `page-type` values, and there is also a set of generic values that can appear in any area of the site.
+
+This project is a work in progress: so far we have only defined `page-type` values for the [CSS pages](/en-US/docs/Web/CSS) and the [Web API pages](/en-US/docs/Web/API).
+
+## Generic page types
+
+These page types are not specific to a particular MDN technology area:
+
+- `guide`: A generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
+- `landing-page`:
+
+## Web API page types
+
+This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `web-api-overview`: gives an overview of a Web API, like the [Fetch API](/en-US/docs/Web/API/Fetch_API).
+- `web-api-global-function`: a global function, like [`fetch()`](/en-US/docs/Web/API/fetch).
+- `web-api-global-property`: a global property, like [`origin`](/en-US/docs/Web/API/origin).
+- `web-api-interface`: a Web API interface, like [`Request`](/en-US/docs/Web/API/Request).
+- `web-api-constructor`: a constructor, like [`Request()`](/en-US/docs/Web/API/Request/Request).
+- `web-api-instance-method`: an instance method, like [`cache.add()`](/en-US/docs/Web/API/Cache/add).
+- `web-api-instance-property`: an instance property, like [`request.headers`](/en-US/docs/Web/API/Request/headers).
+- `web-api-static-method`: a static method, like [`Response.error()`](/en-US/docs/Web/API/Response/error).
+- `web-api-static-property`: a static property, like [`Notification.permission`](/en-US/docs/Web/API/Notification/permission).
+- `web-api-event`: an event, like [`Notification.click`](/en-US/docs/Web/API/Notification/click_event). See [API reference subpage](#api_reference_subpage).
+- `webgl-extension`: a WebGL extension, like [`WEBGL_draw_buffers`](/en-US/docs/Web/API/WEBGL_draw_buffers).
+- `webgl-extension-method`: a WebGL extension method, like [`OES_vertex_array_object.bindVertexArrayOES()`](/en-US/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES).
+
+## CSS page types
+
+This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `css-at-rule`: an [at-rule](/en-US/docs/Web/CSS/At-rule), like {{cssxref("@charset")}}.
+- `css-at-rule-descriptor`: an at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/web/css/@counter-style/prefix).
+- `css-combinator`: a combinator, like the [descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator).
+- `css-function`: a [function](/en-US/docs/Web/CSS/CSS_Functions), like {{cssxref("max")}}.
+- `css-keyword`: a keyword, like {{cssxref("inherit")}}.
+- `css-media-feature`: a [media feature](/en-US/docs/Web/CSS/@media#media_features), like [`hover`](/en-US/docs/Web/CSS/@media/hover).
+- `css-module`: a module, like [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations).
+- `css-property`: a property, like {{cssxref("background-color")}}.
+- `css-pseudo-class`: a [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), like {{cssxref(":enabled")}}.
+- `css-pseudo-element`: a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), like {{cssxref("::before")}}.
+- `css-selector`: a [basic selector](/en-US/docs/Web/CSS/CSS_Selectors#basic_selectors), like the [class selector](/en-US/docs/Web/CSS/Class_selectors).
+- `css-shorthand-property`: a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties), like {{cssxref("background")}}.
+- `css-type`: a [data type](/en-US/docs/Web/CSS/CSS_Types), like [`<color>`](/en-US/docs/Web/CSS/color_value).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -31,7 +31,7 @@ This project is a work in progress: so far we have only defined `page-type` valu
 These page types are not specific to a particular MDN technology area:
 
 - `guide`: A generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
-- `landing-page`:
+- `landing-page`: A page that acts primarily as a navigation aid, listing links to other pages. See [Landing page](#landing_page).
 
 ## Web API page types
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -55,7 +55,7 @@ This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/
 This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
 - `css-at-rule`: an [at-rule](/en-US/docs/Web/CSS/At-rule), like {{cssxref("@charset")}}.
-- `css-at-rule-descriptor`: an at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/web/css/@counter-style/prefix).
+- `css-at-rule-descriptor`: an at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/Web/CSS/@counter-style/prefix).
 - `css-combinator`: a combinator, like the [descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator).
 - `css-function`: a [function](/en-US/docs/Web/CSS/CSS_Functions), like {{cssxref("max")}}.
 - `css-keyword`: a keyword, like {{cssxref("inherit")}}.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -10,6 +10,7 @@ tags:
 {{MDNSidebar}}
 
 The `page-type` front matter key describes the type of an MDN page.
+This allows MDN content tools to better automate content checking and sidebar organization.
 
 Like any other front matter key, the `page-type` key is specified in the YAML at the start of "index.md":
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -31,8 +31,8 @@ This project is a work in progress: so far we have only defined `page-type` valu
 
 These page types are not specific to a particular MDN technology area:
 
-- `guide`: A generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
-- `landing-page`: A page that acts primarily as a navigation aid, listing links to other pages. See [Landing page](#landing_page).
+- `guide`: a generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
+- `landing-page`: a page that acts primarily as a navigation aid, listing links to other pages. See [Landing page](#landing_page).
 
 ## Web API page types
 


### PR DESCRIPTION
Per https://github.com/mdn/content/pull/21170#issuecomment-1264775534, this makes a separate page listing `page-type` values.

I did experiment with a table but didn't like it[1], so went with a list and very concise text, so each item fits on a line (on my screen :) and so is easily scannable.

@hamishwillee .

[1] specific reasons for not liking tables:
- they would probably end up being >150 characters wide, so we would by our own standards need them to be in HTML
- the page-type value would get wrapped at hyphens, like:

```
landing-
page
```

I suppose we could get around that with some extra hacks, but it didn't seem like a good idea.