### PR TITLE
Revise note regarding boundary crossing events

### DIFF
--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -21,13 +21,8 @@ be targeted at the capture element until capture is released (via
 {{domxref("Element.releasePointerCapture()")}} or the
 {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired).
 
-> **Note:** When pointer capture is set,
-> {{domxref("HTMLElement/pointerover_event", "pointerover")}},
-> {{domxref("HTMLElement/pointerout_event", "pointerout")}},
-> {{domxref("HTMLElement/pointerenter_event", "pointerenter")}}, and
-> {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} events are only generated
-> when crossing the boundary of the capture target. This has the effect of suppressing
-> these events on all other elements.
+> **Note:** Pointer capture will cause the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set.
+> For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), an [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture) will be called on the element when a `pointerdown` event triggers. The capture can be released manually by calling {{domxref('element.releasePointerCapture')}} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
 
 ### Overview of pointer capture
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Revise incorrect note regarding boundary crossing events.

### Motivation

The following is untrue. These events are suppressed when pointer is captured.

> `pointerover`, `pointerout`, `pointerenter`, and `pointerleave` events are only generated when crossing the boundary of the capture target.

### Additional details

When a pointer is captured by a target:
 - [The pointer is considered to be always inside the boundaries of the capturing element](https://www.w3.org/TR/pointerevents/#the-pointerover-event)
 - [invocation of hit-testing is suppressed](https://www.w3.org/TR/pointerevents/#implicit-pointer-capture)

Therefore, no boundary crossing events are triggered, even on the capture target element.

### Related issues and pull requests

Fixes #21268
Related to #15069

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
