### PR TITLE
Small tweak for mathsize and mtable@width

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -272,7 +272,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>mathsize</code></td>
       <td><a href="/en-US/docs/Web/MathML/Global_attributes">All MathML elements</a></td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/font-size">font-size</a> for the element.
+        A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) used as a [font-size](/en-US/docs/Web/CSS/font-size) for the element.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -272,7 +272,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>mathsize</code></td>
       <td><a href="/en-US/docs/Web/MathML/Global_attributes">All MathML elements</a></td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> used as a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> for the element.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> used as a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> for the element.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -272,7 +272,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>mathsize</code></td>
       <td><a href="/en-US/docs/Web/MathML/Global_attributes">All MathML elements</a></td>
       <td>
-        A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) used as a [font-size](/en-US/docs/Web/CSS/font-size) for the element.
+        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> used as a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> for the element.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -49,7 +49,9 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - {{ unimplemented_inline() }} rowspacing
   - : Specifies the space between table rows.
 - `width`
-  - : Specifies the width of the entire table. Accepts [length values](/en-US/docs/Web/MathML/Attribute/Values#lengths).
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the width of the entire table.
+
+> **Note:** For the `width` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/global_attributes/index.md
+++ b/files/en-us/web/mathml/global_attributes/index.md
@@ -48,7 +48,7 @@ In addition to the basic MathML global attributes, the following global attribut
   - : A [color](/en-US/docs/Web/CSS/color) for the element.
 
 - [`mathsize`](/en-US/docs/Web/MathML/Global_attributes/mathsize)
-  - : A [font-size](/en-US/docs/Web/CSS/font-size) for the element.
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) used as a [font-size](/en-US/docs/Web/CSS/font-size) for the element.
 
 - [`mathvariant`](/en-US/docs/Web/MathML/Global_attributes/mathvariant)
   - A logical classes of token elements.

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -34,6 +34,8 @@ The **`mathsize`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) 
 - {{cssxref("&lt;percentage&gt;")}}
   - : A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.
 
+> **Note:** Some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
### Description

State that accepted values are `<length-percentage>` and add notes to say that some browsers support legacy values.

### Motivation

Rely on existing CSS type to make accepted values clearer, tell web dev about legacy support whose data is added in [1] and in general makes things more consistent with other length attributes (see the list in [1]).

### Additional details

N/A

### Related issues and pull requests

[1] https://github.com/mdn/browser-compat-data/pull/17934