### PR TITLE
Add alt text to performance page css waterfall flowchart

### DIFF
--- a/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
+++ b/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
@@ -22,7 +22,7 @@ However, the performance cost of modifying a CSS property can vary from one prop
 
 The process a browser uses to paint changes to a page when an element is animating CSS properties can be described as a waterfall consisting of the following steps:
 
-![](css-rendering-waterfall.png)
+![Flowchart of the CSS rendering waterfall. In order, the steps are recalculate style, layout, and paint.](css-rendering-waterfall.png)
 
 1. **Recalculate Style**: when a property for an element changes, the browser must recalculate computed styles.
 2. **Layout**: next, the browser uses the computed styles to figure out the position and geometry for the elements. This operation is labeled "layout" but is also sometimes called "reflow".


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added `alt` text to CSS rendering waterfall image describing the contents of the flowchart for accessibility purposes.

### Motivation

This alt text describes both the text contained in the flowchart and also conveys the order of the waterfall process depicted in the chart.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/20735


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
