### PR TITLE
fix: Markdownlint BASE tag

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -34,7 +34,6 @@
         "a",
         "abbr",
         "annotation",
-        "base",
         "br",
         "caption",
         "code",

--- a/files/en-us/web/api/node/baseuri/index.md
+++ b/files/en-us/web/api/node/baseuri/index.md
@@ -45,7 +45,7 @@ const output = document.querySelector("output");
 output.value = output.baseURI;
 ```
 
-{{EmbedLiveSample("Without <base>", "100%", 40)}}
+{{EmbedLiveSample("Without_base", "100%", 40)}}
 
 ### With \<base>
 
@@ -59,7 +59,7 @@ const output = document.querySelector("output");
 output.value = output.baseURI;
 ```
 
-{{EmbedLiveSample("With <base>", "100%", 40)}}
+{{EmbedLiveSample("With_base", "100%", 40)}}
 
 ## Specifications
 


### PR DESCRIPTION
Checking to see if the escaped ID will play well with the EmbedLiveSample