### PR TITLE
fix: Markdownlint DFN tag

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -42,7 +42,6 @@
         "colgroup",
         "dd",
         "details",
-        "dfn",
         "div",
         "dl",
         "dt",

--- a/files/en-us/web/html/element/source/index.md
+++ b/files/en-us/web/html/element/source/index.md
@@ -37,7 +37,7 @@ The **`<source>`** [HTML](/en-US/docs/Web/HTML) element specifies multiple media
       <td>It must have a start tag, but must not have an end tag.</td>
     </tr>
     <tr>
-      <th scope="row"><dfn>Permitted parents</dfn></th>
+      <th scope="row">Permitted parents</th>
       <td>
         <div>
           A media element—{{HTMLElement("audio")}} or


### PR DESCRIPTION
112 other hits for this row don't use the tag, so I think it's OK to remove and deny the future instances