### PR TITLE
Primitive toString can be called on primitives

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.BigInt.toString
 
 {{JSRef}}
 
-The **`toString()`** method returns a string representing the
-specified {{jsxref("BigInt")}} object. The trailing "n" is not part of the string.
+The **`toString()`** method returns a string representing the specified {{jsxref("BigInt")}} value. The trailing "n" is not part of the string.
 
 {{EmbedInteractiveExample("pages/js/bigint-tostring.html")}}
 
@@ -27,60 +26,55 @@ toString(radix)
 ### Parameters
 
 - `radix` {{optional_inline}}
-  - : Optional. An integer in the range 2 through 36 specifying the base to use for
-    representing numeric values.
+  - : An integer in the range 2 through 36 specifying the base to use for representing the BigInt value. Defaults to 10.
 
 ### Return value
 
-A string representing the specified {{jsxref("BigInt")}} object.
+A string representing the specified {{jsxref("BigInt")}} value.
 
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : If `toString()` is given a radix less than 2 or greater than 36, a
-    {{jsxref("RangeError")}} is thrown.
+  - : Thrown if `radix` is less than 2 or greater than 36.
 
 ## Description
 
-The {{jsxref("BigInt")}} object overrides the `toString()` method of the
-{{jsxref("Object")}} object; it does not inherit
-{{jsxref("Object.prototype.toString()")}}. For {{jsxref( "BigInt")}} objects, the
-`toString()` method returns a string representation of the object in the
-specified radix.
+The {{jsxref("BigInt")}} object overrides the `toString` method of {{jsxref("Object")}}; it does not inherit
+{{jsxref("Object.prototype.toString()")}}. For {{jsxref("BigInt")}} values, the `toString()` method returns a string representation of the value in the specified radix.
 
-The `toString()` method parses its first argument, and attempts to return a
-string representation in the specified radix (base). For radixes above 10, the letters
-of the alphabet indicate numerals greater than 9. For example, for hexadecimal numbers
-(base 16) `a` through `f` are used.
+For radixes above 10, the letters of the alphabet indicate digits greater than 9. For example, for hexadecimal numbers (base 16) `a` through `f` are used.
 
-If the `radix` is not specified, the preferred radix is assumed to be 10.
+If the specified BigInt value is negative, the sign is preserved. This is the case even if the radix is 2; the string returned is the positive binary representation of the BigInt value preceded by a `-` sign, **not** the two's complement of the BigInt value.
 
-If the `bigIntObj` is negative, the sign is preserved. This is the case even
-if the radix is 2; the string returned is the positive binary representation of the
-`bigIntObj` preceded by a `-` sign, **not** the two's
-complement of the `bigIntObj`.
+The `toString()` method requires its `this` value to be a `BigInt` primitive or wrapper object. It throws a {{jsxref("TypeError")}} for other `this` values without attempting to coerce them to BigInt values.
+
+Because `BigInt` doesn't have a [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, JavaScript calls the `toString()` method automatically when a `BigInt` _object_ is used in a context expecting a string, such as in a [template literal](/en-US/docs/Web/JavaScript/Reference/Template_literals). However, BigInt _primitive_ values do not consult the `toString()` method to be [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) — rather, they are directly converted using the same algorithm as the initial `toString()` implementation.
+
+```js
+BigInt.prototype.toString = () => "Overridden";
+console.log(`${1n}`); // "1"
+console.log(`${Object(1n)}`); // "Overridden"
+```
 
 ## Examples
 
-### Using `toString`
+### Using toString()
 
 ```js
-17n.toString();      // '17'
-66n.toString(2);     // '1000010'
-254n.toString(16);   // 'fe'
--10n.toString(2);    // -1010'
--0xffn.toString(2);  // '-11111111'
+17n.toString(); // "17"
+66n.toString(2); // "1000010"
+254n.toString(16); // "fe"
+(-10n).toString(2); // "-1010"
+(-0xffn).toString(2); // "-11111111"
 ```
 
-### Negative-zero `BigInt`
+### Negative-zero BigInt
 
-There is no negative-zero `BigInt` as there are no negative zeros in
-integers. `-0.0` is an IEEE floating-point concept that only appears in the
-JavaScript [`Number`](/en-US/docs/Web/JavaScript/Data_structures#number_type) type.
+There is no negative-zero `BigInt` as there are no negative zeros in integers. `-0.0` is an IEEE floating-point concept that only appears in the JavaScript [`Number`](/en-US/docs/Web/JavaScript/Data_structures#number_type) type.
 
 ```js
-(-0n).toString();      // '0'
-BigInt(-0).toString(); // '0'
+(-0n).toString(); // "0"
+BigInt(-0).toString(); // "0"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Boolean.toString
 
 {{JSRef}}
 
-The **`toString()`** method returns a string representing the
-specified Boolean object.
+The **`toString()`** method returns a string representing the specified boolean value.
 
 {{EmbedInteractiveExample("pages/js/boolean-tostring.html")}}
 
@@ -25,32 +24,31 @@ toString()
 
 ### Return value
 
-A string representing the specified {{jsxref("Boolean")}} object.
+A string representing the specified boolean value.
 
 ## Description
 
-The {{jsxref("Boolean")}} object overrides the `toString` method of the
-{{jsxref("Object")}} object; it does not inherit
-{{jsxref("Object.prototype.toString()")}}. For `Boolean` objects, the
-`toString` method returns a string representation of the object.
+The {{jsxref("Boolean")}} object overrides the `toString` method of {{jsxref("Object")}}; it does not inherit
+{{jsxref("Object.prototype.toString()")}}. For `Boolean` values, the `toString` method returns a string representation of the boolean value, which is either `"true"` or `"false"`.
 
-JavaScript calls the `toString()` method automatically when a
-{{jsxref("Boolean")}} is to be represented as a text value or when a
-{{jsxref("Boolean")}} is referred to in a string concatenation.
+The `toString()` method requires its `this` value to be a `Boolean` primitive or wrapper object. It throws a {{jsxref("TypeError")}} for other `this` values without attempting to coerce them to boolean values.
 
-For {{jsxref("Boolean")}} objects and values, the built-in `toString()`
-method returns the string `"true"` or `"false"` depending on the
-value of the boolean object.
+Because `Boolean` doesn't have a [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, JavaScript calls the `toString()` method automatically when a `Boolean` _object_ is used in a context expecting a string, such as in a [template literal](/en-US/docs/Web/JavaScript/Reference/Template_literals). However, boolean _primitive_ values do not consult the `toString()` method to be [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) — rather, they are directly converted using the same algorithm as the initial `toString()` implementation.
+
+```js
+Boolean.prototype.toString = () => "Overridden";
+console.log(`${true}`); // "true"
+console.log(`${new Boolean(true)}`); // "Overridden"
+```
 
 ## Examples
 
 ### Using toString()
 
-In the following code, `flag.toString()` returns `"true"`:
-
 ```js
 const flag = new Boolean(true);
-const myVar = flag.toString();
+console.log(flag.toString()); // "true"
+console.log(false.toString()); // "false"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tostring/index.md
@@ -11,8 +11,7 @@ browser-compat: javascript.builtins.Number.toString
 
 {{JSRef}}
 
-The **`toString()`** method returns a string representing the
-specified {{jsxref("Number")}} object.
+The **`toString()`** method returns a string representing the specified number value.
 
 {{EmbedInteractiveExample("pages/js/number-tostring.html")}}
 
@@ -26,61 +25,61 @@ toString(radix)
 ### Parameters
 
 - `radix` {{optional_inline}}
-  - : An integer in the range `2` through `36` specifying the base
-    to use for representing numeric values.
+  - : An integer in the range `2` through `36` specifying the base to use for representing the number value. Defaults to 10.
 
 ### Return value
 
-A string representing the specified {{jsxref("Number")}} object.
+A string representing the specified number value.
 
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : If `toString()` is given a `radix` less than
-    `2` or greater than `36`, a {{jsxref("RangeError")}} is thrown.
+  - : Thrown if `radix` is less than 2 or greater than 36.
 
 ## Description
 
-The {{jsxref("Number")}} object overrides the `toString()` method of the
-{{jsxref("Object")}}. For {{jsxref("Number")}} objects, the
-`toString()` method returns a string representation of the object in the
-specified radix.
+The {{jsxref("Number")}} object overrides the `toString` method of {{jsxref("Object")}}; it does not inherit
+{{jsxref("Object.prototype.toString()")}}. For `Number` values, the `toString` method returns a string representation of the value in the specified radix.
 
-The `toString()` method parses its first argument, and attempts to return a
-string representation in the specified `radix` (base). For radices
-above `10`, the letters of the alphabet indicate numerals greater than 9. For
-example, for hexadecimal numbers (base 16), `a` through `f` are
-used.
+For radixes above 10, the letters of the alphabet indicate digits greater than 9. For example, for hexadecimal numbers (base 16) `a` through `f` are used.
 
-If the `radix` is not specified, the preferred radix is assumed
-to be `10`.
+If the specified number value is negative, the sign is preserved. This is the case even if the radix is 2; the string returned is the positive binary representation of the number value preceded by a `-` sign, **not** the two's complement of the number value.
 
-If the `numObj` is negative, the sign is preserved. This is the
-case even if the radix is `2`; the string returned is the positive binary
-representation of the `numObj` preceded by a `-` sign,
-**not** the two's complement of the `numObj`.
+Both `0` and `-0` have `"0"` as their string representation. {{jsxref("Infinity")}} returns `"Infinity"` and {{jsxref("NaN")}} returns `"NaN"`.
 
-If the `numObj` is not a whole number, the 'dot' sign is used to
-separate the decimal places.
+If the number is not a whole number, the decimal point `.` is used to separate the decimal places. [Scientific notation](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#exponential) is used if the radix is 10 and the number's magnitude (ignoring sign) is greater than or equal to 10<sup>21</sup> or less than 10<sup>-6</sup>. In this case, the returned string always explicitly specifies the sign of the exponent.
+
+```js
+console.log((10 ** 21.5).toString()); // "3.1622776601683794e+21"
+console.log((10 ** 21.5).toString(8)); // "526665530627250154000000"
+```
+
+The `toString()` method requires its `this` value to be a `Number` primitive or wrapper object. It throws a {{jsxref("TypeError")}} for other `this` values without attempting to coerce them to number values.
+
+Because `Number` doesn't have a [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, JavaScript calls the `toString()` method automatically when a `Number` _object_ is used in a context expecting a string, such as in a [template literal](/en-US/docs/Web/JavaScript/Reference/Template_literals). However, Number _primitive_ values do not consult the `toString()` method to be [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) — rather, they are directly converted using the same algorithm as the initial `toString()` implementation.
+
+```js
+Number.prototype.toString = () => "Overridden";
+console.log(`${1}`); // "1"
+console.log(`${new Number(1)}`); // "Overridden"
+```
 
 ## Examples
 
-### Using toString
+### Using toString()
 
 ```js
 const count = 10;
+console.log(count.toString()); // "10"
 
-console.log(count.toString());    // displays '10'
-console.log((17).toString());     // displays '17'
-console.log((17.2).toString());   // displays '17.2'
+console.log((17).toString()); // "17"
+console.log((17.2).toString()); // "17.2"
 
 const x = 6;
-
-console.log(x.toString(2));       // displays '110'
-console.log((254).toString(16));  // displays 'fe'
-
-console.log((-10).toString(2));   // displays '-1010'
-console.log((-0xff).toString(2)); // displays '-11111111'
+console.log(x.toString(2)); // "110"
+console.log((254).toString(16)); // "fe"
+console.log((-10).toString(2)); // "-1010"
+console.log((-0xff).toString(2)); // "-11111111"
 ```
 
 ### Converting radix of number strings

--- a/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.String.toString
 
 {{JSRef}}
 
-The **`toString()`** method of a string object returns a string representing the specified string.
+The **`toString()`** method returns a string representing the specified string value.
 
 {{EmbedInteractiveExample("pages/js/string-tostring.html")}}
 
@@ -24,15 +24,22 @@ toString()
 
 ### Return value
 
-The string value of the `String` wrapper object.
+A string representing the specified string value.
 
 ## Description
 
-The {{jsxref("String")}} object overrides the `toString()` method of the
-{{jsxref("Object")}} object; it does not inherit
-{{jsxref("Object.prototype.toString()")}}. For {{jsxref("String")}} objects, the
-`toString()` method returns a string representation of the object and is the
-same as the {{jsxref("String.prototype.valueOf()")}} method.
+The {{jsxref("String")}} object overrides the `toString` method of {{jsxref("Object")}}; it does not inherit
+{{jsxref("Object.prototype.toString()")}}. For `String` values, the `toString` method returns the string itself (if it's a primitive) or the string that the `String` object wraps. It has the exact same implementation as {{jsxref("String.prototype.valueOf()")}}.
+
+The `toString()` method requires its `this` value to be a `String` primitive or wrapper object. It throws a {{jsxref("TypeError")}} for other `this` values without attempting to coerce them to string values.
+
+Because `String` doesn't have a [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) method, JavaScript calls the `toString()` method automatically when a `String` _object_ is used in a context expecting a string, such as in a [template literal](/en-US/docs/Web/JavaScript/Reference/Template_literals). However, String _primitive_ values do not consult the `toString()` method to be [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) — since they are already strings, no conversion is performed.
+
+```js
+String.prototype.toString = () => "Overridden";
+console.log(`${"foo"}`); // "foo"
+console.log(`${new String("foo")}`); // "Overridden"
+```
 
 ## Examples
 
@@ -43,7 +50,7 @@ The following example displays the string value of a {{jsxref("String")}} object
 ```js
 const x = new String("Hello world");
 
-console.log(x.toString()); // logs 'Hello world'
+console.log(x.toString()); // "Hello world"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.toString
 
 {{JSRef}}
 
-The **`toString()`** method returns a string representing the specified {{jsxref("Symbol")}} object.
+The **`toString()`** method returns a string representing the specified symbol value.
 
 {{EmbedInteractiveExample("pages/js/symbol-prototype-tostring.html")}}
 
@@ -24,32 +24,40 @@ toString()
 
 ### Return value
 
-A string representing the specified {{jsxref("Symbol")}} object.
+A string representing the specified symbol value.
 
 ## Description
 
-The {{jsxref("Symbol")}} object overrides the `toString` method of the {{jsxref("Object")}} object; it does not inherit {{jsxref("Object.prototype.toString()")}}. For `Symbol` objects, the `toString` method returns a string representation of the object.
+The {{jsxref("Symbol")}} object overrides the `toString` method of {{jsxref("Object")}}; it does not inherit
+{{jsxref("Object.prototype.toString()")}}. For `Symbol` values, the `toString` method returns a descriptive string in the form `"Symbol(description)"`, where `description` is the symbol's [description](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description).
 
-### No string concatenation
+The `toString()` method requires its `this` value to be a `Symbol` primitive or wrapper object. It throws a {{jsxref("TypeError")}} for other `this` values without attempting to coerce them to symbol values.
 
-While you can call `toString()` on Symbols, you cannot use string concatenation with them:
-
-```js
-Symbol('foo') + 'bar'        // TypeError: Can't convert symbol to string
-```
+Because `Symbol` has a [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive) method, that method always takes priority over `toString()` when a `Symbol` object is [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). However, because `Symbol.prototype[@@toPrimitive]()` returns a symbol primitive, and symbol primitives throw a {{jsxref("TypeError")}} when implicitly converted to a string, the `toString()` method is never implicitly called by the language. To stringify a symbol, you must explicitly call its `toString()` method or use the [`String()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String#using_string_to_stringify_a_symbol) function.
 
 ## Examples
 
 ### Using toString()
 
 ```js
-Symbol('desc').toString()    // "Symbol(desc)"
+Symbol("desc").toString(); // "Symbol(desc)"
 
 // well-known symbols
-Symbol.iterator.toString()   // "Symbol(Symbol.iterator)
+Symbol.iterator.toString(); // "Symbol(Symbol.iterator)"
 
 // global symbols
-Symbol.for('foo').toString() // "Symbol(foo)"
+Symbol.for("foo").toString(); // "Symbol(foo)"
+```
+
+### Implicitly calling toString()
+
+The only way to make JavaScript implicitly call `toString()` instead of [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive) on a symbol wrapper object is by [deleting](/en-US/docs/Web/JavaScript/Reference/Operators/delete) the `@@toPrimitive` method first.
+
+> **Warning:** You should not do this in practice. Never mutate built-in objects unless you know exactly what you're doing.
+
+```js
+delete Symbol.prototype[Symbol.toPrimitive];
+console.log(`${Object(Symbol("foo"))}`); // "Symbol(foo)"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `toString()` method pages, as they are currently described, makes it sound like that they can only be called on the primitive wrapper objects—instead, they can be called on primitive values as well. This adds a lot more information about how the five primitive `toString()` methods behave.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
