### PR TITLE
Add alt text to various pages' images

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -399,11 +399,11 @@ Finally, we need to include the images of the beasts.
 
 Create a new directory called "beasts", and add the three images in that directory, with the appropriate names. You can get the images from [the GitHub repository](https://github.com/mdn/webextensions-examples/tree/master/beastify/beasts), or from here:
 
-![](frog.jpg)
+![A brown frog.](frog.jpg)
 
-![](snake.jpg)
+![An emerald tree boa with white stripes.](snake.jpg)
 
-![](turtle.jpg)
+![A red-eared slider turtle.](turtle.jpg)
 
 ## Testing it out
 

--- a/files/en-us/web/guide/user_input_methods/index.md
+++ b/files/en-us/web/guide/user_input_methods/index.md
@@ -19,7 +19,7 @@ Modern web user input goes beyond simple mouse and keyboard: think of touchscree
 
 The following diagram illustrates the typical workflow for implementing user input mechanisms:
 
-![](user-input-and-controls.png)
+![Flowchart of user input and controls workflow. The first step is to decide what input mechanism you're using, and the second step is to implement controls.](user-input-and-controls.png)
 
 First of all, you need to decide which input mechanisms you want to cover in your application out of mouse, keyboard, finger touch and so on. Once you decided the input mechanisms, you can control them using tools offered by the web platform or JavaScript libraries.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added descriptive alt text for animal photographs, as well as an equivalent text description of the written contents of a flowchart.

### Motivation

The alt text attributes have been added for accessibility purposes.

### Additional details

Specific species' names have been added to the snake and turtle images with a high level of confidence. Frog species was not identifiable with any great confidence.

https://www.sfzoo.org/emerald-tree-boa/
https://www.beardsleyzoo.org/red-eared-slider.html


### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/20735


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
