### PR TITLE
Grammatical error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -39,7 +39,7 @@ splice(start, deleteCount, item1, item2, itemN)
     In this case, no element will be deleted but the method will behave as an adding function, adding as many elements as items provided.
 
     If negative, it will begin that many elements from the end of the array.
-    (In this case, the origin `-1`, meaning `-n` is the index of the `n`th last element, and is therefore equivalent to the index of `array.length - n`.)
+    (In this case, the origin is `-1`, meaning `-n` is the index of the `n`th last element, and is therefore equivalent to the index of `array.length - n`.)
     If `start` is `-Infinity`, it will begin from index `0`.
 
 - `deleteCount` {{optional_inline}}


### PR DESCRIPTION
### Description
Just a minor grammatical error, said "origin `-1`" when it clearly meant "origin **is** `-1`"

### Motivation

It gives a more concrete definition for readers.

### Additional details

N/A

### Related issues and pull requests

N/A