### PR TITLE
Universal selector is a type selector

### DIFF
--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -21,14 +21,6 @@ CSS selectors can be grouped into the following categories based on the type of 
 
 ## Basic selectors
 
-- [Universal selector](/en-US/docs/Web/CSS/Universal_selectors)
-
-  - : Selects all elements. Optionally, it may be restricted to a specific namespace or to all namespaces.
-
-    **Syntax:** `*` `ns|*` `*|*`
-
-    **Example:** `*` will match all the elements of the document.
-
 - [Type selector](/en-US/docs/Web/CSS/Type_selectors)
 
   - : Selects all elements that have the given node name.
@@ -36,6 +28,7 @@ CSS selectors can be grouped into the following categories based on the type of 
     **Syntax:** `elementname`
 
     **Example:** `input` will match any {{HTMLElement("input")}} element.
+    > **Note:** The universal selector is a special type selector, that represents an element of any element type. **Syntax:** `*`.
 
 - [Class selector](/en-US/docs/Web/CSS/Class_selectors)
 


### PR DESCRIPTION
According to the spec:
"The universal selector is a special type selector, that represents an element of any element type."

https://w3c.github.io/csswg-drafts/selectors-4/#the-universal-selector

My suggestion is to add a mention of the universal selector as a note in the Type selector section.

EDIT:
We could alternatively keep the original universal selector section and have a note mentioning that the universal selector is a special type selector.