### PR TITLE
Bring more consistency to MathML element documentation

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -12,7 +12,9 @@ browser-compat: mathml.elements.maction
 
 {{MathMLRef}}{{Deprecated_Header}}
 
-The deprecated MathML **`<maction>`** element used to provide a possibility to bind an actions to mathematical expressions. Nowadays, it is recommended to rely on [JavaScript](/en-US/docs/Web/JavaScript) and other Web technologies to implement this use case. Some browsers will just render the first child of an `<maction>` element and ignore its `actiontype` and `selection` attributes.
+The **`<maction>`** [MathML](/en-US/docs/Web/MathML) element allows to bind actions to mathematical expressions. By default, only the first child is rendered but some browsers may take into account `actiontype` and `selection` attributes to implement custom behaviors.
+
+> **Note:** Historically, this element provided a mechanism to make MathML formulas interactive. Nowadays, it is recommended to rely on [JavaScript](/en-US/docs/Web/JavaScript) and other Web technologies to implement this use case.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -10,7 +10,7 @@ browser-compat: mathml.elements.math
 
 {{MathMLRef}}
 
-The `<math>` element is the top-level MathML element, used to write a single mathematical formula. It can be placed in HTML content where [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) is permitted.
+The **`<math>`** [MathML](/en-US/docs/Web/MathML) element is the top-level MathML element, used to write a single mathematical formula. It can be placed in HTML content where [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) is permitted.
 
 > **Note:** See the [Authoring MathML page](/en-US/docs/Web/MathML/Authoring#using_mathml) for tips to properly integrate MathML formulas in your web pages and the [Examples](/en-US/docs/Web/MathML/Examples) page for more demos.
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -6,10 +6,11 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+  - Non-standard
 browser-compat: mathml.elements.menclose
 ---
 
-{{MathMLRef}}
+{{MathMLRef}}{{Non-standard_Header}}
 
 The **`<menclose>`** [MathML](/en-US/docs/Web/MathML) element renders its content inside an enclosing notation specified by the `notation` attribute.
 
@@ -56,7 +57,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Specifications
 
-{{Specifications}}
+The `<mfenced>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_mfenced).
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.menclose
 
 {{MathMLRef}}
 
-The MathML `<menclose>` element renders its content inside an enclosing notation specified by the `notation` attribute.
+The **`<menclose>`** [MathML](/en-US/docs/Web/MathML) element renders its content inside an enclosing notation specified by the `notation` attribute.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -57,7 +57,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Specifications
 
-The `<mfenced>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_mfenced).
+The `<menclose>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_menclose).
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/element/merror/index.md
+++ b/files/en-us/web/mathml/element/merror/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.merror
 
 {{MathMLRef}}
 
-The MathML `<merror>` element is used to display contents as error messages. The intent of this element is to provide a standard way for programs that generate MathML from other input to report syntax errors.
+The **`<merror>`** [MathML](/en-US/docs/Web/MathML) element is used to display contents as error messages. The intent of this element is to provide a standard way for programs that generate MathML from other input to report syntax errors.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -7,10 +7,11 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+  - Non-standard
 browser-compat: mathml.elements.mfenced
 ---
 
-{{MathMLRef}}{{Deprecated_Header}}
+{{MathMLRef}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`<mfenced>`** [MathML](/en-US/docs/Web/MathML) element provides the possibility to add custom opening and closing parentheses (such as brackets) and separators (such as commas or semicolons) to an expression.
 
@@ -71,7 +72,7 @@ Rendering in your browser:
 
 ## Specifications
 
-{{Specifications}}
+The `<mfenced>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_mfenced).
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -7,13 +7,14 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
-  - Non-standard
 browser-compat: mathml.elements.mfenced
 ---
 
-{{MathMLRef}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{MathMLRef}}{{Deprecated_Header}}
 
-The deprecated MathML `<mfenced>` element used to provide the possibility to add custom opening and closing parentheses (such as brackets) and separators (such as commas or semicolons) to an expression. It has been removed from the latest MathML standard and modern browsers no longer support it. Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead.
+The **`<mfenced>`** [MathML](/en-US/docs/Web/MathML) element provides the possibility to add custom opening and closing parentheses (such as brackets) and separators (such as commas or semicolons) to an expression.
+
+> **Note:** Historically, the `<mfenced>` element was defined as a shorthand for writing fenced expressions and equivalent to an expanded form involving {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements. Nowadays, it is recommended to use that equivalent form instead.
 
 ## Attributes
 
@@ -70,7 +71,7 @@ Rendering in your browser:
 
 ## Specifications
 
-The \<mfenced> element is no longer part of the [latest MathML standard](https://github.com/w3c/mathml/issues/2). Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead, or, for backwards compatibility, see [mathml-polyfills/mfenced.](https://github.com/mathml-refresh/mathml-polyfills/tree/main/mfenced)
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mfrac
 
 {{MathMLRef}}
 
-The MathML `<mfrac>` element is used to display fractions. It can also be used
+The **`<mfrac>`** [MathML](/en-US/docs/Web/MathML) element is used to display fractions. It can also be used
 to mark up fraction-like objects such as
 [binomial coefficients](https://en.wikipedia.org/wiki/Binomial_coefficient)
 and [Legendre symbols](https://en.wikipedia.org/wiki/Legendre_symbol).

--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mi
 
 {{MathMLRef}}
 
-The MathML `<mi>` element indicates that the content should be rendered as an **identifier** such as function names, variables or symbolic constants. You can also have arbitrary text in it to mark up terms.
+The **`<mi>`** [MathML](/en-US/docs/Web/MathML) element indicates that the content should be rendered as an **identifier** such as function names, variables or symbolic constants. You can also have arbitrary text in it to mark up terms.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mmultiscripts
 
 {{MathMLRef}}
 
-The MathML `<mmultiscripts>` element is used to attach an arbitrary number of subscripts and superscripts to an expression at once, generalizing the {{ MathMLElement("msubsup") }} element. Scripts can be either prescripts (placed before the expression) or postscripts (placed after it).
+The **`<mmultiscripts>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an arbitrary number of subscripts and superscripts to an expression at once, generalizing the {{ MathMLElement("msubsup") }} element. Scripts can be either prescripts (placed before the expression) or postscripts (placed after it).
 
 MathML uses the syntax below, that is a base expression, followed by an arbitrary number of postsubscript-postsuperscript pairs (attached in the given order) optionally followed by an `<mprescripts>` and an arbitrary number of presubscript-presuperscript pairs (attached in the given order). In addition you are able to use `<none/>` as a placeholder for empty scripts.
 

--- a/files/en-us/web/mathml/element/mn/index.md
+++ b/files/en-us/web/mathml/element/mn/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mn
 
 {{MathMLRef}}
 
-The MathML `<mn>` element represents a numeric literal which is normally a sequence of digits with a possible separator (a dot or a comma). However, it is also allowed to have arbitrary text in it which is actually a numeric quantity, for example "eleven".
+The **`<mn>`** [MathML](/en-US/docs/Web/MathML) element represents a **numeric** literal which is normally a sequence of digits with a possible separator (a dot or a comma). However, it is also allowed to have arbitrary text in it which is actually a numeric quantity, for example "eleven".
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mo
 
 {{MathMLRef}}
 
-The MathML `<mo>` element represents an operator in a broad sense. Besides operators in strict mathematical meaning, this element also includes "operators" like parentheses, separators like comma and semicolon, or "absolute value" bars.
+The **`<mo>`** [MathML](/en-US/docs/Web/MathML) element represents an **operator** in a broad sense. Besides operators in strict mathematical meaning, this element also includes "operators" like parentheses, separators like comma and semicolon, or "absolute value" bars.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mover
 
 {{MathMLRef}}
 
-The MathML `<mover>` element is used to attach an accent or a limit over an expression. Use the following syntax: `<mover> base overscript </mover>`
+The **`<mover>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an accent or a limit over an expression. Use the following syntax: `<mover> base overscript </mover>`
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mpadded
 
 {{MathMLRef}}
 
-The MathML `<mpadded>` element is used to add extra padding and to set the general adjustment of position and size of enclosed contents.
+The **`<mpadded>`** [MathML](/en-US/docs/Web/MathML) element is used to add extra padding and to set the general adjustment of position and size of enclosed contents.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mphantom/index.md
+++ b/files/en-us/web/mathml/element/mphantom/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mphantom
 
 {{MathMLRef}}
 
-The MathML `<mphantom>` element is rendered invisibly, but dimensions (such as height, width, and baseline position) are still kept.
+The **`<mphantom>`** [MathML](/en-US/docs/Web/MathML) element is rendered invisibly, but dimensions (such as height, width, and baseline position) are still kept.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mroot/index.md
+++ b/files/en-us/web/mathml/element/mroot/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mroot
 
 {{MathMLRef}}
 
-The MathML `<mroot>` element is used to display roots with an explicit index. Two arguments are accepted, which leads to the syntax: `<mroot> base index </mroot>`.
+The **`<mroot>`** [MathML](/en-US/docs/Web/MathML) element is used to display roots with an explicit index. Two arguments are accepted, which leads to the syntax: `<mroot> base index </mroot>`.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mrow/index.md
+++ b/files/en-us/web/mathml/element/mrow/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mrow
 
 {{MathMLRef}}
 
-The MathML `<mrow>` element is used to group sub-expressions, which usually contain one or more [operators](/en-US/docs/Web/MathML/Element/mo) with their respective operands (such as {{ MathMLElement("mi") }} and {{ MathMLElement("mn") }}). This element renders as a horizontal row containing its arguments.
+The **`<mrow>`** [MathML](/en-US/docs/Web/MathML) element is used to group sub-expressions, which usually contain one or more [operators](/en-US/docs/Web/MathML/Element/mo) with their respective operands (such as {{ MathMLElement("mi") }} and {{ MathMLElement("mn") }}). This element renders as a horizontal row containing its arguments.
 
 When writing a MathML expression, you should group elements within an `<mrow>` in the same way as they are grouped in the mathematical interpretation of the expression. Proper grouping helps the rendering of the expression in several ways:
 

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.ms
 
 {{MathMLRef}}
 
-The MathML `<ms>` element represents a _string literal_ meant to be interpreted by programming languages and computer algebra systems.
+The **`<ms>`** [MathML](/en-US/docs/Web/MathML) element represents a **string** literal meant to be interpreted by programming languages and computer algebra systems.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mspace
 
 {{MathMLRef}}
 
-The MathML `<mspace>` element is used to display a blank space, whose size is set by its attributes.
+The **`<mspace>`** [MathML](/en-US/docs/Web/MathML) element is used to display a blank space, whose size is set by its attributes.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/msqrt/index.md
+++ b/files/en-us/web/mathml/element/msqrt/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.msqrt
 
 {{MathMLRef}}
 
-The MathML `<msqrt>` element is used to display square roots (no index is displayed). The square root accepts only one argument, which leads to the following syntax: `<msqrt> base </msqrt>`.
+The **`<msqrt>`** [MathML](/en-US/docs/Web/MathML) element is used to display square roots (no index is displayed). The square root accepts only one argument, which leads to the following syntax: `<msqrt> base </msqrt>`.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mstyle
 
 {{MathMLRef}}
 
-The MathML `<mstyle>` element is used to change the style of its children.
+The **`<mstyle>`** [MathML](/en-US/docs/Web/MathML) element is used to change the style of its children.
 
 > **Note:** Historically, this element accepted almost all the MathML attributes and it was used to override the default attribute values of its descendants. It was later restricted to only a few relevant styling attributes that were used in existing web pages. Nowadays, these styling attributes are [common to all MathML elements](/en-US/docs/Web/MathML/Global_attributes) and so `<mstyle>` is really just equivalent to an [`<mrow>`](/en-US/docs/Web/MathML/Element/mrow) element. However, `<mstyle>` may still be relevant for compatibility with MathML implementations outside browsers.
 

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.msub
 
 {{MathMLRef}}
 
-The MathML `<msub>` element is used to attach a subscript to an expression.
+The **`<msub>`** [MathML](/en-US/docs/Web/MathML) element is used to attach a subscript to an expression.
 
 It uses the following syntax: `<msub> base subscript </msub>`.
 

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.msubsup
 
 {{MathMLRef}}
 
-The MathML `<msubsup>` element is used to attach both a subscript and a superscript, together, to an expression.
+The **`<msubsup>`** [MathML](/en-US/docs/Web/MathML) element is used to attach both a subscript and a superscript, together, to an expression.
 
 It uses the following syntax: `<msubsup> base subscript superscript </msubsup>`.
 

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.msup
 
 {{MathMLRef}}
 
-The MathML `<msup>` element is used to attach a superscript to an expression.
+The **`<msup>`** [MathML](/en-US/docs/Web/MathML) element is used to attach a superscript to an expression.
 
 It uses the following syntax: `<msup> base superscript </msup>`.
 

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mtable
 
 {{MathMLRef}}
 
-The MathML `<mtable>` element allows you to create tables or matrices. Inside a `<mtable>` only {{ MathMLElement("mtr") }} and {{ MathMLElement("mtd") }} elements may appear. These elements are similar to {{ HTMLElement("table") }}, {{ HTMLElement("tr") }} and {{ HTMLElement("td") }} elements of [HTML](/en-US/docs/Web/HTML).
+The **`<mtable>`** [MathML](/en-US/docs/Web/MathML) element allows you to create tables or matrices. Inside a `<mtable>` only {{ MathMLElement("mtr") }} and {{ MathMLElement("mtd") }} elements may appear. These elements are similar to {{ HTMLElement("table") }}, {{ HTMLElement("tr") }} and {{ HTMLElement("td") }} elements of [HTML](/en-US/docs/Web/HTML).
 
 > **Note:** The `<mtable>` element resets the `displaystyle` attribute to `false`. If you want to use this element as an inline-block, you might want to set `<mtable displaystyle="true">...</mtable>`.
 

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mtd
 
 {{MathMLRef}}
 
-The MathML `<mtd>` element represents a cell in a table or a matrix. It may only appear in a {{ MathMLElement("mtr") }} element. This element is similar to the {{ HTMLElement("td") }} element of [HTML](/en-US/docs/Web/HTML).
+The **`<mtd>`** [MathML](/en-US/docs/Web/MathML) element represents a cell in a table or a matrix. It may only appear in a {{ MathMLElement("mtr") }} element. This element is similar to the {{ HTMLElement("td") }} element of [HTML](/en-US/docs/Web/HTML).
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mtext/index.md
+++ b/files/en-us/web/mathml/element/mtext/index.md
@@ -11,9 +11,9 @@ browser-compat: mathml.elements.mtext
 
 {{MathMLRef}}
 
-The MathML \<mtext> element is used to render arbitrary text with _no_ notational meaning, such as comments or annotations.
+The **`<mtext>`** [MathML](/en-US/docs/Web/MathML) element is used to render arbitrary text with _no_ notational meaning, such as comments or annotations.
 
-To display text _with_ notational meaning, use {{ MathMLElement("mi") }} and {{ MathMLElement("mo") }} instead.
+To display text _with_ notational meaning, use {{ MathMLElement("mi") }}, {{ MathMLElement("mn") }}, {{ MathMLElement("mo") }} or {{ MathMLElement("ms") }} instead.
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.mtr
 
 {{MathMLRef}}
 
-The MathML `<mtr>` element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
+The **`<mtr>`** [MathML](/en-US/docs/Web/MathML) element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.munder
 
 {{MathMLRef}}
 
-The MathML `<munder>` element is used to attach an accent or a limit under an expression. It uses the following syntax: `<munder> base underscript </munder>`
+The **`<munder>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an accent or a limit under an expression. It uses the following syntax: `<munder> base underscript </munder>`
 
 ## Attributes
 

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -11,7 +11,7 @@ browser-compat: mathml.elements.munderover
 
 {{MathMLRef}}
 
-The MathML `<munderover>` element is used to attach accents or limits both under and over an expression.
+The **`<munderover>`** [MathML](/en-US/docs/Web/MathML) element is used to attach accents or limits both under and over an expression.
 
 It uses the following syntax: `<munderover> base underscript overscript </munderover>`
 

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -10,7 +10,7 @@ browser-compat: mathml.elements.semantics
 
 {{MathMLRef}}
 
-The `<semantics>` element associates annotations with a MathML expression, for example its text source as a [lightweight markup language](https://en.wikipedia.org/wiki/Lightweight_markup_language) or mathematical meaning expressed in a special {{glossary("XML")}} dialect. Typically, its structure is:
+The **`<semantics>`** [MathML](/en-US/docs/Web/MathML) element associates annotations with a MathML expression, for example its text source as a [lightweight markup language](https://en.wikipedia.org/wiki/Lightweight_markup_language) or mathematical meaning expressed in a special {{glossary("XML")}} dialect. Typically, its structure is:
 
 - a first child which is a MathML expression to be annotated.
 - subsequent `<annotation>` or `<annotation-xml>` elements, the latter being reserved for XML formats such as [OpenMath](https://en.wikipedia.org/wiki/OpenMath).

--- a/files/en-us/web/mathml/global_attributes/href/index.md
+++ b/files/en-us/web/mathml/global_attributes/href/index.md
@@ -5,10 +5,11 @@ tags:
   - Global attributes
   - MathML
   - Reference
+  - Non-standard
 browser-compat: mathml.global_attributes.href
 ---
 
-{{MathMLRef("Global_attributes")}}
+{{MathMLRef("Global_attributes")}}{{Non-standard_Header}}
 
 The **`href`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) creates a hyperlink on the MathML element pointing to the specified URL.
 
@@ -40,11 +41,7 @@ The **`href`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) crea
 
 ## Specifications
 
-{{Specifications}}
-
-- `href` is defined in MathML 3 on all elements but is currently not integrated into MathML Core.
-
-- MathML 2 had no direct support for linking, and instead followed the W3C Recommendation ["XML Linking Language"](https://www.w3.org/TR/2010/REC-xlink11-20100506/) in defining links using the `xlink:href` attribute.
+The `href` attribute is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#interf_link).
 
 ## Browser compatibility
 


### PR DESCRIPTION
### Description

Bring more consistency to MathML element documentation:
- Start with "The elementname (in strong/code style) MathML (linking to MathML page) element...", similar to how it is done in HTML.
- For deprecated elements (mfenced and maction), move recommendation for replacement in a separate note (and don't use past or "deprecated" in the main description).
- Make menclose "non-standard" like mfenced, and for the two of them refer to MathML 4 (see discussion on https://github.com/mdn/browser-compat-data/pull/17941)
- For token elements, put in strong the word whose initial is in the tag name (as done for mi == identifier). Also, mention more token elements in the description of mtext.

### Motivation

More consistency.

### Additional details

N/A

### Related issues and pull requests

https://github.com/mdn/browser-compat-data/pull/17941