### PR TITLE
docs(contain): add missing value in info box

### DIFF
--- a/files/en-us/web/css/contain/index.md
+++ b/files/en-us/web/css/contain/index.md
@@ -26,7 +26,7 @@ Changes within an element with containment applied are not propagated outside of
 
 This property is useful on pages that contain a lot of widgets that are all independent, as it can be used to prevent each widget's internals from having side effects outside of the widget's bounding-box.
 
-> **Note:** If applied (with value: `paint`, `strict` or `content`), this property creates:
+> **Note:** If applied (with value: `layout`, `paint`, `strict` or `content`), this property creates:
 >
 > 1. A new [containing block](/en-US/docs/Web/CSS/Containing_block) (for the descendants whose {{cssxref("position")}} property is `absolute` or `fixed`).
 > 2. A new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add `layout` value as one that creates a new formatting context, stacking context and containing block in `contain` doc page.
[layout containtment spec](https://w3c.github.io/csswg-drafts/css-contain-2/#containment-layout)