### PR TITLE
Fixing explanation of inherited properties

### DIFF
--- a/files/en-us/web/css/initial_value/index.md
+++ b/files/en-us/web/css/initial_value/index.md
@@ -13,8 +13,8 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
 
 The **initial value** of a [CSS](/en-US/docs/Web/CSS) property is its default value, as listed in its definition table in the specification. The usage of the initial value depends on whether a property is inherited or not:
 
-- For [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value is used on the _root element only_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
-- For [non-inherited properties](/en-US/docs/Web/CSS/inheritance#non-inherited_properties), the initial value is used on _all elements_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
+- For [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value is used on _all elements_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
+- For [non-inherited properties](/en-US/docs/Web/CSS/inheritance#non-inherited_properties), the initial value is used on the _root element only_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
 
 You can explicitly specify the initial value by using the {{cssxref("initial")}} keyword.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The existing explanation of inherited vs non-inherited properties on https://developer.mozilla.org/en-US/docs/Web/CSS/initial_value was backward in terms of where they were applied. This pull request fixes that by swapping the explanations of where they are applied so that they are correct.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fixing wrong content so future readers/learners are not confused

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

N/A

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
