### PR TITLE
Typo fix in `rust_to_was` index.md: "out" -> "our"

### DIFF
--- a/files/en-us/webassembly/rust_to_wasm/index.md
+++ b/files/en-us/webassembly/rust_to_wasm/index.md
@@ -239,7 +239,7 @@ Load `index.html` from the web server (if you used the Python3 example: `http://
 
 If you want to use the WebAssembly module with npm, we'll need to make a few changes.
 
-Let's start by recompiling out Rust with the target bundler option:
+Let's start by recompiling our Rust with the target bundler option:
 
 ```bash
 wasm-pack build --target bundler


### PR DESCRIPTION
### Description

Very tiny typo fix to the `rust_to_was` `index.md` file: Change "recompiling **out** rust" to "recompiling **our** rust".

### Motivation

Was reading it today and "recompiling out rust" struck me as sounding a little odd.