### PR TITLE
Better unicode property escape summary

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -262,7 +262,7 @@ console.log(regex.lastIndex); // logs '15'
 // and so on
 ```
 
-The [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) feature provides a simpler way to target particular Unicode ranges, by allowing for statements like `\p{L}/u` (to match a letter from any language), or `\p{scx=Cyrl}` (to match any Cyrillic letter).
+The [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) feature provides a simpler way to target particular Unicode ranges, by allowing for statements like `\p{scx=Cyrl}` (to match any Cyrillic letter), or `\p{L}/u` (to match a letter from any language).
 
 ### Extracting subdomain name from URL
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -262,7 +262,7 @@ console.log(regex.lastIndex); // logs '15'
 // and so on
 ```
 
-The [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) feature introduces a solution, by allowing for a statement as simple as `\p{scx=Cyrl}`.
+The [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) feature provides a simpler way to target particular Unicode ranges, by allowing for statements like `\p{L}/u` (to match a letter from any language), or `\p{scx=Cyrl}` (to match any Cyrillic letter).
 
 ### Extracting subdomain name from URL
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Making it a little more clear why Unicode property escapes are a helpful alternative to specifying unicode ranges manually. Adds a second example, and explains the existing example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The `Cyrl` string in the existing example doesn't occur on the [linked page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), so although most people could guess what it does, getting a definitive answer is a bit of a pain.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
