### PR TITLE
fix(doc): Fix fibonacci-worker example url

### DIFF
--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -767,7 +767,7 @@ The web page creates a `<div>` element with the ID `result`, which gets used to 
 
 Finally, a message is sent to the worker to start it.
 
-[Try this example live](https://mdn.github.io/fibonacci-worker/).
+[Try this example live](https://mdn.github.io/dom-examples/web-workers/fibonacci-worker/).
 
 ### Dividing tasks among multiple workers
 


### PR DESCRIPTION
### Description

This PR fixes `fibonacci-worker` url live example.

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/523306/194213976-71663bea-9d03-4175-890a-fd98bf13ca9d.png">


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change will help reader to try the fibonacci-worker live example. Without it, the link redirects to a 404 page.
