### PR TITLE
Universal selector is a selector of type `type`

### DIFF
--- a/files/en-us/web/css/universal_selectors/index.md
+++ b/files/en-us/web/css/universal_selectors/index.md
@@ -21,7 +21,7 @@ The CSS **universal selector** (`*`) matches elements of any type.
 }
 ```
 
-The universal selector is a special [Type selector](/en-US/docs/Web/CSS/Type_selectors) and can therefore be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
+The universal selector is a special [type selector](/en-US/docs/Web/CSS/Type_selectors) and can therefore be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
 
 - `ns|*` - matches all elements in namespace _ns_
 - `*|*` - matches all elements

--- a/files/en-us/web/css/universal_selectors/index.md
+++ b/files/en-us/web/css/universal_selectors/index.md
@@ -21,7 +21,7 @@ The CSS **universal selector** (`*`) matches elements of any type.
 }
 ```
 
-Universal selectors can be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
+The universal selector is a special [Type selector](/en-US/docs/Web/CSS/Type_selectors) and can therefore be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
 
 - `ns|*` - matches all elements in namespace _ns_
 - `*|*` - matches all elements


### PR DESCRIPTION
This case is a follow-up of this discussion: https://github.com/mdn/content/pull/21307 

@wbamberg, @estelle and I convened of adding the mention of the universal selector being of type `type` on this page.

Here is a proposition of fix.