### PR TITLE
Update MathML documentation for mtable, mtr and mtd elements

### DIFF
--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -11,13 +11,11 @@ browser-compat: mathml.elements.mtable
 
 {{MathMLRef}}
 
-The **`<mtable>`** [MathML](/en-US/docs/Web/MathML) element allows you to create tables or matrices. Inside a `<mtable>` only {{ MathMLElement("mtr") }} and {{ MathMLElement("mtd") }} elements may appear. These elements are similar to {{ HTMLElement("table") }}, {{ HTMLElement("tr") }} and {{ HTMLElement("td") }} elements of [HTML](/en-US/docs/Web/HTML).
-
-> **Note:** The `<mtable>` element resets the `displaystyle` attribute to `false`. If you want to use this element as an inline-block, you might want to set `<mtable displaystyle="true">...</mtable>`.
+The **`<mtable>`** [MathML](/en-US/docs/Web/MathML) element allows you to create tables or matrices. Its children are {{ MathMLElement("mtr") }} elements (representing rows), each of them having {{ MathMLElement("mtd") }} elements as its children (representing cells). These elements are similar to {{ HTMLElement("table") }}, {{ HTMLElement("tr") }} and {{ HTMLElement("td") }} elements of [HTML](/en-US/docs/Web/HTML).
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). Some browsers may also support the following attributes:
 
 - `align`
 
@@ -37,17 +35,17 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `columnlines`
   - : Specifies column borders. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
 - `columnspacing`
-  - : Specifies the space between table columns.
+  - : Specifies the space between table columns. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnspacing="1em 2em"`). Possible values are [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
 - `frame`
   - : Specifies borders of the entire table. Possible values are: `none` (default), `solid` and `dashed`.
 - `framespacing`
-  - : Specifies additional space added between the table and frame.
+  - : Specifies additional space added between the table and frame. The first value specifies the spacing on the right and left; the second value specifies the spacing above and below. Possible values are  [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
 - `rowalign`
   - : Specifies the vertical alignment of the cells. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowalign="top bottom axis"`). Possible values are: `axis`, `baseline` (default), `bottom`, `center` and `top`.
 - `rowlines`
   - : Specifies row borders. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
-- {{ unimplemented_inline() }} rowspacing
-  - : Specifies the space between table rows.
+- `rowspacing`
+  - : Specifies the space between table rows. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowspacing="1em 2em"`). Possible values are [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
 - `width`
   - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the width of the entire table.
 

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -15,18 +15,21 @@ The **`<mtd>`** [MathML](/en-US/docs/Web/MathML) element represents a cell in a 
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
+
+- `columnspan`
+  - : A non-negative integer value that indicates on how many columns does the cell extend.
+- `rowspan`
+  - : A non-negative integer value that indicates on how many rows does the cell extend.
+
+Some browsers may also support the following attributes:
 
 - `columnalign`
   - : Specifies the horizontal alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `left`, `center` and `right`.
-- `columnspan`
-  - : A non-negative integer value that indicates on how many columns does the cell extend.
 - `rowalign`
   - : Specifies the vertical alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
-- `rowspan`
-  - : A non-negative integer value that indicates on how many rows does the cell extend.
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -11,18 +11,16 @@ browser-compat: mathml.elements.mtr
 
 {{MathMLRef}}
 
-The **`<mtr>`** [MathML](/en-US/docs/Web/MathML) element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
+The **`<mtr>`** [MathML](/en-US/docs/Web/MathML) element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element and its children are {{ MathMLElement("mtd") }} elements representing cells. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). Some browsers may also support the following attributes:
 
 - `columnalign`
-  - : Overrides the horizontal alignment of cells specified by {{ MathMLElement("mtable") }} for this row.
-    Possible values are: `left`, `center` and `right`.
+  - : Overrides the horizontal alignment of cells specified by {{ MathMLElement("mtable") }} for this row. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnalign="left center right"`). Possible values are: `left`, `center` and `right`.
 - `rowalign`
-  - : Overrides the vertical alignment of cells specified by {{ MathMLElement("mtable") }} for this row.
-    Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
+  - : Overrides the vertical alignment of cells specified by {{ MathMLElement("mtable") }} for this row. Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

- Improve explanation of how mtable/mtr/mtd are nested.
- Try to clarify attributes that are only supported by some browsers (not in MathML Core)
- Elaborate description of some attributes that can take multiple parameters (also remove one unimplemented tag)
- Remove the note about displaystyle. Although it's not false, it's probably not so important. Or otherwise we should document the displaystyle/scriptlevel changes for all MathML elements.

### Motivation

Fix/improve doc and update with respect to MathML Core.

### Additional details

N/A

### Related issues and pull requests

N/A