### PR TITLE
clarify surprising return value

### DIFF
--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -47,10 +47,11 @@ console.log(document.fonts.check("12px courier"));
 console.log(document.fonts.check("12px MyFont", "ß"));
 ```
 
-The use of a non-existing font in the font specification results in a return value of `true`. The following example line will print `true`.
+If the font given in the font specification does not exist, this function returns `true`:
 
 ```js
 console.log(document.fonts.check("12px NonExistingFont"));
+// true
 ```
 
 ## Specifications

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -35,7 +35,7 @@ check(font, text)
 
 A {{jsxref("Boolean")}} value that is `true` if the font list is available.
 
-The method returns `true` if the font list contains system or non-existing fonts. This prevents user tracking by locally installed fonts.
+The method returns `true` if the font list contains system or nonexistent fonts. This prevents websites from identifying users by the fonts they have installed.
 
 ## Examples
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -35,6 +35,8 @@ check(font, text)
 
 A {{jsxref("Boolean")}} value that is `true` if the font list is available.
 
+The method returns `true` if the font list contains system or non-existing fonts. This prevents user tracking by locally installed fonts.
+
 ## Examples
 
 In the following example, the first line will print `true` if the Courier font is available at `12px`. The second line will print `true` if the font `MyFont` contains the "ß" character.
@@ -43,6 +45,12 @@ In the following example, the first line will print `true` if the Courier font i
 console.log(document.fonts.check("12px courier"));
 
 console.log(document.fonts.check("12px MyFont", "ß"));
+```
+
+The use of a non-existing font in the font specification results in a return value of `true`. The following example line will print `true`.
+
+```js
+console.log(document.fonts.check("12px NonExistingFont"));
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`document.fonts.check()` returns `true` for non-existing or nonsensical font names. Cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1252821#c3 and https://drafts.csswg.org/css-font-loading/Overview.bs for the details.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The continued return value of `true` is surprising for people being confronted with `document.fonts.check()`, if they want to use it to test for anything else than their own fonts.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
