### PR TITLE
chore(docs) Title capitalization - use sentence case for article titles

### DIFF
--- a/files/en-us/mdn/at_ten/history_of_mdn/index.md
+++ b/files/en-us/mdn/at_ten/history_of_mdn/index.md
@@ -1,5 +1,5 @@
 ---
-title: The History of MDN
+title: The history of MDN
 slug: MDN/At_ten/History_of_MDN
 tags:
   - History

--- a/files/en-us/mdn/community/contributing/security_vulnerability_response/index.md
+++ b/files/en-us/mdn/community/contributing/security_vulnerability_response/index.md
@@ -1,5 +1,5 @@
 ---
-title: Security Vulnerability Response Steps
+title: Security vulnerability response steps
 slug: MDN/Community/Contributing/Security_vulnerability_response
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/discussions/index.md
+++ b/files/en-us/mdn/community/discussions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Community Discussions
+title: Community discussions
 slug: MDN/Community/Discussions
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/index.md
+++ b/files/en-us/mdn/community/index.md
@@ -1,5 +1,5 @@
 ---
-title: Community Guidelines
+title: Community guidelines
 slug: MDN/Community
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/mdn_content/issues/index.md
+++ b/files/en-us/mdn/community/mdn_content/issues/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using Issues on MDN Content
+title: Using issues on MDN Web Docs
 slug: MDN/Community/MDN_content/Issues
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/mdn_content/pull_requests/index.md
+++ b/files/en-us/mdn/community/mdn_content/pull_requests/index.md
@@ -1,5 +1,5 @@
 ---
-title: Pull Request Etiquette and Process for MDN Content
+title: Pull request etiquette and process for MDN Web Docs
 slug: MDN/Community/MDN_content/Pull_requests
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/web/accessibility/information_for_web_authors/index.md
+++ b/files/en-us/web/accessibility/information_for_web_authors/index.md
@@ -1,5 +1,5 @@
 ---
-title: Accessibility Information for Web Authors
+title: Accessibility information for web authors
 slug: Web/Accessibility/Information_for_Web_authors
 tags:
   - Accessibility

--- a/files/en-us/web/api/performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/index.md
@@ -1,5 +1,5 @@
 ---
-title: Performance Timeline
+title: Performance Timeline API
 slug: Web/API/Performance_Timeline
 page-type: web-api-overview
 tags:

--- a/files/en-us/web/api/xsltprocessor/browser_differences/index.md
+++ b/files/en-us/web/api/xsltprocessor/browser_differences/index.md
@@ -1,5 +1,5 @@
 ---
-title: Browser Differences
+title: Browser differences
 slug: Web/API/XSLTProcessor/Browser_Differences
 page-type: guide
 ---

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -1,5 +1,5 @@
 ---
-title: Breadcrumb Navigation
+title: Breadcrumb navigation
 slug: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
 page-type: guide
 tags:

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.md
@@ -1,5 +1,5 @@
 ---
-title: Split Navigation
+title: Split navigation
 slug: Web/CSS/Layout_cookbook/Split_Navigation
 page-type: guide
 tags:

--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Getting started
 slug: Web/Guide/AJAX/Getting_Started
 tags:
   - AJAX

--- a/files/en-us/web/javascript/memory_management/index.md
+++ b/files/en-us/web/javascript/memory_management/index.md
@@ -1,5 +1,5 @@
 ---
-title: Memory Management
+title: Memory management
 slug: Web/JavaScript/Memory_Management
 tags:
   - Garbage collection

--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -1,5 +1,5 @@
 ---
-title: Web Performance
+title: Web performance
 slug: Web/Performance
 tags:
   - API

--- a/files/en-us/web/progressive_web_apps/responsive/responsive_navigation_patterns/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/responsive_navigation_patterns/index.md
@@ -1,5 +1,5 @@
 ---
-title: Responsive Navigation Patterns
+title: Responsive navigation patterns
 slug: Web/Progressive_web_apps/Responsive/Responsive_navigation_patterns
 tags:
   - Guide

--- a/files/en-us/web/security/firefox_security_guidelines/index.md
+++ b/files/en-us/web/security/firefox_security_guidelines/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox Security Guidelines
+title: Firefox security guidelines
 slug: Web/Security/Firefox_Security_Guidelines
 tags:
   - Security

--- a/files/en-us/web/svg/server-configuration/index.md
+++ b/files/en-us/web/svg/server-configuration/index.md
@@ -1,5 +1,5 @@
 ---
-title: Server Configuration
+title: Server configuration
 slug: Web/SVG/Server-configuration
 tags:
   - SVG

--- a/files/en-us/web/svg/specification_deviations/index.md
+++ b/files/en-us/web/svg/specification_deviations/index.md
@@ -1,5 +1,5 @@
 ---
-title: Specification Deviations
+title: Specification deviations
 slug: Web/SVG/Specification_Deviations
 tags:
   - SVG

--- a/files/en-us/web/svg/tutorial/basic_transformations/index.md
+++ b/files/en-us/web/svg/tutorial/basic_transformations/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Transformations
+title: Basic transformations
 slug: Web/SVG/Tutorial/Basic_Transformations
 tags:
   - Intermediate

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/an_overview/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/an_overview/index.md
@@ -1,5 +1,5 @@
 ---
-title: An Overview
+title: An overview
 slug: Web/XSLT/Transforming_XML_with_XSLT/An_Overview
 tags:
   - NeedsHelp

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.md
@@ -1,5 +1,5 @@
 ---
-title: For Further Reading
+title: For further reading
 slug: Web/XSLT/Transforming_XML_with_XSLT/For_Further_Reading
 tags:
   - NeedsContent

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.md
@@ -1,5 +1,5 @@
 ---
-title: Advanced Example
+title: Advanced example
 slug: Web/XSLT/XSLT_JS_interface_in_Gecko/Advanced_Example
 tags:
   - XSLT

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/basic_example/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Example
+title: Basic example
 slug: Web/XSLT/XSLT_JS_interface_in_Gecko/Basic_Example
 tags:
   - XSLT

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/interface_list/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/interface_list/index.md
@@ -1,5 +1,5 @@
 ---
-title: Interface List
+title: Interface list
 slug: Web/XSLT/XSLT_JS_interface_in_Gecko/Interface_List
 tags:
   - NeedsContent

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/setting_parameters/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/setting_parameters/index.md
@@ -1,5 +1,5 @@
 ---
-title: Setting Parameters
+title: Setting parameters
 slug: Web/XSLT/XSLT_JS_interface_in_Gecko/Setting_Parameters
 tags:
   - XSLT


### PR DESCRIPTION
This PR fixes a few articles which use capitalization style that deviates from [our style guides](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#titles).

Found using:

```bash
grep -rE "title: [A-Z][a-z]+ [A-Z][a-z]+" files
```