### PR TITLE
fix: Make compact CSS example compact once more

### DIFF
--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -526,35 +526,15 @@ div p + p {
 
 The next example shows the equivalent CSS in a more compressed format. Although the two examples work the same, the one below is more difficult to read.
 
-```css
-body {
-  font: 1em/150% Helvetica, Arial, sans-serif;
-  padding: 1em;
-  margin: 0 auto;
-  max-width: 33em;
-}
-@media (min-width: 70em) {
-  body {
-    font-size: 130%;
-  }
-}
+```css-nolint
+body {font: 1em/150% Helvetica, Arial, sans-serif; padding: 1em; margin: 0 auto; max-width: 33em;}
+@media (min-width: 70em) { body { font-size: 130%;}}
 
-h1 {
-  font-size: 1.5em;
-}
+h1 {font-size: 1.5em;}
 
-div p,
-#id:first-line {
-  background-color: red;
-  border-radius: 3px;
-}
-div p {
-  margin: 0;
-  padding: 1em;
-}
-div p + p {
-  padding-top: 0;
-}
+div p, #id:first-line {background-color: red; border-radius: 3px;}
+div p {margin: 0; padding: 1em;}
+div p + p {padding-top: 0;}
 ```
 
 For your own projects, you will format your code according to personal preference. For team projects, you may find that a team or project has its own style guide.


### PR DESCRIPTION
### Description

Make the example of CSS code that's compact and hard to read compact and hard to read.

### Motivation

Prettier was run on this file in #20639, but it's meant to be an example of hard to read compact CSS.

### Additional details

This file will probably need to be added to https://github.com/mdn/content/blob/main/.prettierignore once a "full pass is made on each folder"

### Related issues and pull requests

Fixes #21324