### PR TITLE
No longer mark PerformanceObserve experimental; remove impl status prose

### DIFF
--- a/files/en-us/web/api/performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/index.md
@@ -45,29 +45,15 @@ This interface includes a {{domxref("PerformanceEntry.toJSON","toJSON()")}} meth
 
 ## Performance observers
 
-{{SeeCompatTable}}
-
 The _performance observer_ interfaces allow an application to register an _observer_ for specific performance event types, and when one of those event types is recorded, the application is _notified_ of the event via the observer's callback function that was specified when the observer was created.
 
 When the observer (callback) is invoked, the callback's parameters include a _{{domxref("PerformanceObserverEntryList","performance observer entry list")}}_ that contains only _observed_ {{domxref("PerformanceEntry","performance entries")}}. That is, the list contains entries only for the event types that were specified when the observer's {{domxref("PerformanceObserver.observe","observe()")}} method was invoked. The {{domxref("PerformanceObserverEntryList","performance observer entry list")}} interface has the same three `getEntries*()` methods as the {{domxref("Performance")}} interface. However, note there is one key difference with these methods; the {{domxref("PerformanceObserverEntryList","performance observer entry list")}} versions are used to retrieve _observed_ performance entries within the observer callback.
 
 Besides the {{domxref("PerformanceObserver","PerformanceObserver's")}} interface's {{domxref("PerformanceObserver.observe","observe()")}} method (which is used to register the {{domxref("PerformanceEntry.entryType","entry types")}} to _observe_), the {{domxref("PerformanceObserver")}} interface also has a {{domxref("PerformanceObserver.disconnect","disconnect()")}} method that stops an observer from receiving further events.
 
-Performance observers were added to the `Level 2` version of the standard and were not widely implemented.
-
 ## Specifications
 
 {{Specifications}}
-
-## Implementation status
-
-A summary of the interfaces' implementation status is provided below, including a link to more detailed information.
-
-- Performance interface extensions: As shown in the {{domxref("Performance")}} interface's [Browser Compatibility](/en-US/docs/Web/API/Performance#browser_compatibility) table, most of these interfaces are broadly implemented by desktop browsers and have less support on mobile devices.
-- PerformanceEntry: As shown in the {{domxref("PerformanceEntry")}} interface's [Browser Compatibility](/en-US/docs/Web/API/PerformanceEntry#browser_compatibility) table, most of these interfaces are broadly implemented by desktop browsers and have less support on mobile devices.
-- Performance Observers {{experimental_inline}}: As shown in the {{domxref("PerformanceObserver")}} interface's [Browser Compatibility](/en-US/docs/Web/API/PerformanceObserver#browser_compatibility) table, this interface has no shipping implementations.
-
-To test your browser's support for these interfaces, run the [`perf-api-support`](https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html) application.
 
 ## See also
 

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -129,8 +129,6 @@ function perfEntryToJSON() {
 
 ## Performance Observers
 
-{{SeeCompatTable}}
-
 The _performance observer_ interfaces allow an application to register an _observer_ for specific performance event types, and when one of those event types is recorded, the application is _notified_ of the event via the observer's callback function that was specified at the time, the observer was created. When the observer (callback) is invoked the callback's parameters include a _{{domxref("PerformanceObserverEntryList","performance observer entry list")}}_ that only contains _observed_ {{domxref("PerformanceEntry","performance entries")}}. That is, the list only contains entries for the event types that were specified when the observer's {{domxref("PerformanceObserver.observe","observe()")}} method was invoked.
 
 The following example shows how to register two observers: the first one registers for several event types and the second observer only registers for one event type.
@@ -181,13 +179,6 @@ function printPerfEntry(pe) {
 ```
 
 The {{domxref("PerformanceObserverEntryList","performance observer entry list")}} interface has the same three `getEntries*()` methods as the {{domxref("Performance")}} interface and these methods are used to retrieve _observed_ performance entries within the observer callback. These methods have been used in the above stated example.
-
-## Specifications
-
-The interfaces described in this document are defined in the **Performance Timeline** standard which has two levels:
-
-- [Performance Timeline Level 2](https://w3c.github.io/performance-timeline/); Editors Draft; Work In Progress. This version introduces _performance observers_ (and the {{domxref("PerformanceObserver")}} and {{domxref("PerformanceObserverEntryList")}} interfaces).
-- [Performance Timeline](https://www.w3.org/TR/performance-timeline/); W3C Recommendation 12 December 2013
 
 ## See also
 


### PR DESCRIPTION
### Description

PerformanceObserver is stable. See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver#browser_compatibility

Remove prose text about implementation status and specifications. These outdate too quickly. It's the reason we have BCD and spec tables :)

### Motivation

Motivated by this OWD issue filed by the Performance WG https://github.com/openwebdocs/project/issues/62

### Additional details

None

### Related issues and pull requests

None