### PR TITLE
Update resource URL for i18n language tag

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -22,7 +22,7 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 ## Types
 
 - {{WebExtAPIRef("i18n.LanguageCode")}}
-  - : A [language tag](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10) such as `"en-US"` or "`fr`".
+  - : A [language tag](https://www.rfc-editor.org/rfc/rfc9110.html#name-language-tags) such as `"en-US"` or "`fr`".
 
 ## Functions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The current resource page prompts users to refer IETF Documents.
Original prompt message as follows:
> This document has been superseded. See IETF Documents for more information.

### Motivation

Updated resources are helpful for the readers.

### Additional details

- Current URL: https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10
- Updated URL: https://www.rfc-editor.org/rfc/rfc9110.html#name-language-tags

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
