### PR TITLE
Updated index.md - mongoose primer

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -129,9 +129,8 @@ Installing _Mongoose_ adds all its dependencies, including the MongoDB database 
 
 ### Connecting to MongoDB
 
-_Mongoose_ requires a connection to a MongoDB database. You can `require()` and connect to a locally hosted database with `mongoose.connect()`, as shown below.
-
-> **Note:** This is a trivial example and not a valid mongoDB connection. An explanation of how to set up a working MongoDB database will be covered in the next section.
+_Mongoose_ requires a connection to a MongoDB database.
+You can `require()` and connect to a locally hosted database with `mongoose.connect()` as shown below (for the tutorial we'll instead connect to an internet-hosted database).
 
 ```js
 // Import the mongoose module

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -131,6 +131,8 @@ Installing _Mongoose_ adds all its dependencies, including the MongoDB database 
 
 _Mongoose_ requires a connection to a MongoDB database. You can `require()` and connect to a locally hosted database with `mongoose.connect()`, as shown below.
 
+> **Note:** This is a trivial example and not a valid mongoDB connection. An explanation of how to set up a working MongoDB database will be covered in the next section.
+
 ```js
 // Import the mongoose module
 const mongoose = require("mongoose");


### PR DESCRIPTION
Provide a note reminder that mongoose.connect() example is not a valid connection. Creating a mongoDB is covered in the next section.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a reminder that mongoose connect example is not a valid connection and further instructions are in the next section. 

### Motivation

If readers are new to express they are likely trying to follow along and adding this example code into their express-local-library project. It will be useful to remind them not to try and connect to this invalid database and that they will learn how to create and connect to a database in the next section. 


