### PR TITLE
Improve clarity

### DIFF
--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -38,7 +38,7 @@ try {
 
 ## Description
 
-The `try` statement always starts with a `try` block. Then, a `catch` block, a `finally` block, or both must be present. This gives us three forms for the `try` statement:
+The `try` statement always starts with a `try` block. Then, at least a `catch` block or a `finally` block must be present. It's also possible to have both `catch` and `finally` blocks as well. This gives us three forms for the `try` statement:
 
 - `try...catch`
 - `try...finally`

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -38,7 +38,7 @@ try {
 
 ## Description
 
-The `try` statement always starts with a `try` block. Then, at least a `catch` block or a `finally` block must be present. It's also possible to have both `catch` and `finally` blocks as well. This gives us three forms for the `try` statement:
+The `try` statement always starts with a `try` block. Then, a `catch` block or a `finally` block must be present. It's also possible to have both `catch` and `finally` blocks. This gives us three forms for the `try` statement:
 
 - `try...catch`
 - `try...finally`


### PR DESCRIPTION
### Then, a `catch` block, a `finally` block, or both must be present.

This is not accurate. One of `catch` or `finally` must be present. Having "both" together is **optional**. Using "must" for the presence of both is not accurate.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
