### PR TITLE
Remove inaccuracy in "first element to exclude"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -44,7 +44,7 @@ slice(start, end)
 
 - `end` {{optional_inline}}
 
-  - : The index of the first element to exclude from the returned array. `slice`
+  - : The index of the element **before** which extraction should stop. `slice`
     extracts up to but not including `end`. For example,
     `slice(1,4)` extracts the second element through the fourth element
     (elements indexed 1, 2, and 3).


### PR DESCRIPTION
### The index of the first element to exclude from the returned array.

This is not accurate. In the following case, our **first** excluded element is 1, which is at the beginning of the array, not at the tail of the slice:

```JavaScript
const nums = [1, 2, 3, 4, 5];

const extracted = nums.slice(1, 4);
```
Talking about the first element to be excluded is not very relevant. Pointing where to stop extracting is a better approach.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
