### PR TITLE
Finalize mathml core transition

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -10,7 +10,7 @@ tags:
 
 This is an alphabetical list of MathML attributes. More details for each attribute are available on relevant [MathML element pages](/en-US/docs/Web/MathML/Element) and on the [global attributes page](/en-US/docs/Web/MathML/Global_attributes). The [values](/en-US/docs/Web/MathML/Attribute/Values) page also describes some  notes on common values used by MathML attributes.
 
-> **Note:** As explained on the main [MathML](/en-US/docs/Web/MathML) page, documentation is focused on a subset of the language that is relevant for browsers. See the [MathML Full](https://w3c.github.io/mathml/) specification if you want details about other MathML attributes.
+> **Note:** As explained on the main [MathML](/en-US/docs/Web/MathML) page, MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification. However, legacy features that are still implemented by some browsers are also documented. You can find further details for these and other features in [MathML 4](https://w3c.github.io/mathml/).
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -10,7 +10,7 @@ tags:
 
 This is an alphabetical list of MathML elements. All of them implement the {{domxref("MathMLElement")}} class.
 
-> **Note:** As explained on the main [MathML](/en-US/docs/Web/MathML) page, documentation is focused on a subset of the language that is relevant for browsers. See the [MathML Full](https://w3c.github.io/mathml/) specification if you want details about other MathML elements.
+> **Note:** As explained on the main [MathML](/en-US/docs/Web/MathML) page, MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification. However, legacy features that are still implemented by some browsers are also documented. You can find further details for these and other features in [MathML 4](https://w3c.github.io/mathml/).
 
 ## MathML elements A to Z
 

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -17,7 +17,7 @@ The **`<semantics>`** [MathML](/en-US/docs/Web/MathML) element associates annota
 
 By default, only the first child of the `<semantics>` element is rendered while the others have their [display](/en-US/docs/Web/CSS/display) set to `none`.
 
-> **Note:** Legacy MathML specifications allowed renderers to decide the default rendering according to available annotations. The following rules for determining the visible child have been implemented in some browsers. See [MathML Full](https://w3c.github.io/mathml/) for the distinction between Presentation and Content MathML.
+> **Note:** Legacy MathML specifications allowed renderers to decide the default rendering according to available annotations. The following rules for determining the visible child have been implemented in some browsers. See [MathML 4](https://w3c.github.io/mathml/) for the distinction between Presentation and Content MathML.
 >
 >
 > - If no other rules apply: By default only the first child is rendered, which is supposed to be Presentation MathML.

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -20,7 +20,7 @@ browser-compat: mathml.elements.math
 
 Below you will find links to documentation, examples, and tools to work with MathML. MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification but, due to an erratic standardization history, legacy MathML features may still show up in existing implementations and web content.
 
-> **Note:** It is highly recommended that developers and authors switch to that MathML Core, perhaps relying on other web technologies to cover missing use cases. The Math WG is maintaining a set of [MathML polyfills](https://github.com/mathml-refresh/mathml-polyfills) to facilitate that transition.
+> **Note:** It is highly recommended that developers and authors switch to MathML Core, perhaps relying on other web technologies to cover missing use cases. The Math WG is maintaining a set of [MathML polyfills](https://github.com/mathml-refresh/mathml-polyfills) to facilitate that transition.
 
 ## MathML reference
 

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -18,7 +18,9 @@ browser-compat: mathml.elements.math
 
 [MathML Core](https://w3c.github.io/mathml-core/) is a subset with increased implementation details based on rules from [LaTeX](https://en.wikipedia.org/wiki/LaTeX) and the [Open Font Format](https://docs.microsoft.com/typography/opentype/spec/math). It is tailored for browsers and designed specifically to work well with other web standards including [HTML](/en-US/docs/Web/HTML), [CSS](/en-US/docs/Web/CSS), [DOM](/en-US/docs/Web/API/Document_Object_Model), [JavaScript](/en-US/docs/Web/JavaScript).
 
-Below you will find links to documentation, examples, and tools to work with MathML. Although many of these still use the [MathML Full](https://w3c.github.io/mathml/) specification as a reference, transition towards [MathML Core](https://w3c.github.io/mathml-core/) is in progress. It is highly recommended that developers and authors switch to that specification, perhaps relying on other web technologies to cover missing use cases from the legacy specification.
+Below you will find links to documentation, examples, and tools to work with MathML. MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification but, due to an erratic standardization history, legacy MathML features may still show up in existing implementations and web content.
+
+> **Note:** It is highly recommended that developers and authors switch to that MathML Core, perhaps relying on other web technologies to cover missing use cases. The Math WG is maintaining a set of [MathML polyfills](https://github.com/mathml-refresh/mathml-polyfills) to facilitate that transition.
 
 ## MathML reference
 


### PR DESCRIPTION
### Description

Finalize how MathML Core, MathML 4 and legacy MathML features are presented.

### Motivation

As of today, the MDN MathML documentation has been updated with the following rule of thumb:

1. Use [MathML Core](https://w3c.github.io/mathml-core/) as a reference browser-oriented standard. By default, all the documentation and examples are compatible with that specification.
2. MathML features that are not [considered irrelevant](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features) are still documented with a comment that they are "deprecated" or "non-standard", "may be implemented by some browsers" or similar. [MathML 4](https://w3c.github.io/mathml/) is mentioned for further details.

This commit finalizes the transition to MathML Core by making explicit it is the reference specification and mentioning legacy features / MathML 4 when needed.

### Additional details

N/A

### Related issues and pull requests

N/A