### PR TITLE
Web API interface headings - Initial test

### DIFF
--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -21,12 +21,12 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 - {{domxref("AbortController()")}}
   - : Creates a new `AbortController` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("AbortController.signal")}} {{ReadOnlyInline}}
   - : Returns an {{domxref("AbortSignal")}} object instance, which can be used to communicate with, or to abort, a DOM request.
 
-## Methods
+## Instance methods
 
 - {{domxref("AbortController.abort()")}}
   - : Aborts a DOM request before it has completed. This is able to abort [fetch requests](/en-US/docs/Web/API/fetch), consumption of any response bodies, and streams.

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -17,7 +17,7 @@ The **`AbortSignal`** interface represents a signal object that allows you to co
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The AbortSignal interface also inherits properties from its parent interface, {{domxref("EventTarget")}}._
 
@@ -26,19 +26,19 @@ _The AbortSignal interface also inherits properties from its parent interface, {
 - {{domxref("AbortSignal.reason")}} {{ReadOnlyInline}}
   - : A JavaScript value providing the abort reason, once the signal has aborted.
 
-## Methods
-
-_The **`AbortSignal`** interface inherits methods from its parent interface, {{domxref("EventTarget")}}._
-
-- {{domxref("AbortSignal.throwIfAborted()")}}
-  - : Throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
-
 ## Static methods
 
 - {{domxref("AbortSignal.abort()")}}
   - : Returns an **`AbortSignal`** instance that is already set as aborted.
 - {{domxref("AbortSignal.timeout()")}}
   - : Returns an **`AbortSignal`** instance that will automatically abort after a specified time.
+
+## Instance methods
+
+_The **`AbortSignal`** interface inherits methods from its parent interface, {{domxref("EventTarget")}}._
+
+- {{domxref("AbortSignal.throwIfAborted()")}}
+  - : Throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
 
 ## Events
 

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -19,7 +19,7 @@ The **`AbortSignal`** interface represents a signal object that allows you to co
 
 ## Instance properties
 
-_The AbortSignal interface also inherits properties from its parent interface, {{domxref("EventTarget")}}._
+_The AbortSignal interface may also inherit properties from its parent interface, {{domxref("EventTarget")}}._
 
 - {{domxref("AbortSignal.aborted")}} {{ReadOnlyInline}}
   - : A {{Glossary("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (`true`) or not (`false`).
@@ -35,7 +35,7 @@ _The AbortSignal interface also inherits properties from its parent interface, {
 
 ## Instance methods
 
-_The **`AbortSignal`** interface inherits methods from its parent interface, {{domxref("EventTarget")}}._
+_The **`AbortSignal`** interface may also inherit methods from its parent interface, {{domxref("EventTarget")}}._
 
 - {{domxref("AbortSignal.throwIfAborted()")}}
   - : Throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.

--- a/files/en-us/web/api/absoluteorientationsensor/index.md
+++ b/files/en-us/web/api/absoluteorientationsensor/index.md
@@ -31,11 +31,11 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 - {{domxref("AbsoluteOrientationSensor.AbsoluteOrientationSensor", "AbsoluteOrientationSensor()")}}
   - : Creates a new `AbsoluteOrientationSensor` object.
 
-## Properties
+## Instance properties
 
 _No specific properties; inherits properties from its ancestors {{domxref('OrientationSensor')}} and {{domxref('Sensor')}}._
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestors {{domxref('OrientationSensor')}} and {{domxref('Sensor')}}._
 

--- a/files/en-us/web/api/abstractrange/index.md
+++ b/files/en-us/web/api/abstractrange/index.md
@@ -16,7 +16,7 @@ The **`AbstractRange`** abstract interface is the base class upon which all {{Gl
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("AbstractRange.collapsed", "collapsed")}} {{ReadOnlyInline}}
   - : A Boolean value which is `true` if the range is _collapsed_. A collapsed range is a range whose start position and end position are the same, resulting in a zero-character-long range.
@@ -29,7 +29,7 @@ The **`AbstractRange`** abstract interface is the base class upon which all {{Gl
 - {{domxref("AbstractRange.startOffset", "startOffset")}} {{ReadOnlyInline}}
   - : An integer value indicating the offset, in characters, from the beginning of the node's contents to the last character of the contents referred to by the range object. This value must be less than the length of the node indicated in `startContainer`.
 
-## Methods
+## Instance methods
 
 _The `AbstractRange` interface does provide any methods._
 

--- a/files/en-us/web/api/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/index.md
@@ -31,7 +31,7 @@ If a feature policy blocks the use of a feature, it is because your code is inco
 - {{domxref("Accelerometer.Accelerometer()", "Accelerometer()")}} {{Experimental_Inline}}
   - : Creates a new `Accelerometer` object.
 
-## Properties
+## Instance properties
 
 _In addition to the properties listed below, `Accelerometer` inherits properties from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 
@@ -42,7 +42,7 @@ _In addition to the properties listed below, `Accelerometer` inherits properties
 - {{domxref('Accelerometer.z')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a double containing the acceleration of the device along the device's z axis.
 
-## Methods
+## Instance methods
 
 _`Accelerometer` doesn't have own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/index.md
@@ -26,7 +26,7 @@ Many event targets (including elements, documents, and windows) also support set
 - {{domxref("EventTarget.EventTarget()", "EventTarget()")}}
   - : Creates a new `EventTarget` object instance.
 
-## Methods
+## Instance methods
 
 - {{domxref("EventTarget.addEventListener()")}}
   - : Registers an event handler of a specific event type on the `EventTarget`.

--- a/files/en-us/web/api/orientationsensor/index.md
+++ b/files/en-us/web/api/orientationsensor/index.md
@@ -30,12 +30,12 @@ Below is a list of interfaces based on the OrientationSensor interface.
 - {{domxref('AbsoluteOrientationSensor')}}
 - {{domxref('RelativeOrientationSensor')}}
 
-## Properties
+## Instance properties
 
 - {{domxref("OrientationSensor.quaternion")}}
   - : Returns a four element {{jsxref('Array')}} whose elements contain the components of the unit quaternion representing the device's orientation.
 
-## Methods
+## Instance methods
 
 - {{domxref("OrientationSensor.populateMatrix()")}}
   - : Populates the given object with the rotation matrix based on the latest sensor reading. The rotation matrix is shown below.

--- a/files/en-us/web/api/sensor/index.md
+++ b/files/en-us/web/api/sensor/index.md
@@ -37,7 +37,7 @@ Below is a list of interfaces based on the `Sensor` interface.
 - {{domxref('Magnetometer')}}
 - {{domxref('OrientationSensor')}}
 
-## Properties
+## Instance properties
 
 - {{domxref('Sensor.activated')}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether the sensor is active.
@@ -46,7 +46,7 @@ Below is a list of interfaces based on the `Sensor` interface.
 - {{domxref('Sensor.timestamp')}} {{ReadOnlyInline}}
   - : Returns the time stamp of the latest sensor reading.
 
-## Methods
+## Instance methods
 
 - {{domxref('Sensor.start()')}}
   - : Activates one of the sensors based on `Sensor`.


### PR DESCRIPTION
We recently agreed that Web interface should split up the static/instance methods and properties under separate headings to match [this template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_reference_page_template).
```
## Static properties
## Instance properties
## Static methods
## Instance methods
```
This updates a small fraction. 
