### PR TITLE
Fix macro and epoch name in Date.now()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -26,7 +26,7 @@ Date.now()
 
 ### Return value
 
-A {{jsxref("Number")}} representing the milliseconds elapsed since the UNIX epoch.
+A number representing the milliseconds elapsed since the ECMAScript epoch.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -26,7 +26,7 @@ Date.now()
 
 ### Return value
 
-A number representing the milliseconds elapsed since the ECMAScript epoch.
+A number representing the milliseconds elapsed since the [ECMAScript epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Number` shouldn't be a `jsxref` macro because it is linked to the wrapper objects.
And it should be "ECMAScript epoch" rather than "UNIX epoch".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
