### PR TITLE
extractContents() returns a DocumentFragment

### DIFF
--- a/files/en-us/web/api/range/extractcontents/index.md
+++ b/files/en-us/web/api/range/extractcontents/index.md
@@ -36,7 +36,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+A {{ domxref("DocumentFragment") }} object.
 
 ## Examples
 


### PR DESCRIPTION
### Description

extractContent should return a DocumentFragment object.

### Motivation
### Additional details

https://dom.spec.whatwg.org/#dom-range-extractcontents

### Related issues and pull requests

Fixes #21342