### PR TITLE
screen.orientation returns a ScreenOrientation and not a string

### DIFF
--- a/files/en-us/web/api/screen/orientation/index.md
+++ b/files/en-us/web/api/screen/orientation/index.md
@@ -28,7 +28,7 @@ Note that older, prefixed versions returned a string equivalent to
 ## Examples
 
 ```js
-switch (screen.orientation) {
+switch (screen.orientation.type) {
   case "landscape-primary":
     console.log("That looks good.");
     break;


### PR DESCRIPTION
When I ran this JS example in Firefox 107:
```
switch (screen.orientation) {
  case "landscape-primary":
    console.log("That looks good.");
    break;
  case "landscape-secondary":
    console.log("Mmmh… the screen is upside down!");
    break;
  case "portrait-secondary":
  case "portrait-primary":
    console.log("Mmmh… you should rotate your device to landscape");
    break;
  default:
    console.log("The orientation API isn't supported in this browser :(");
}
```
 I got `The orientation API isn't supported in this browser :(` which is not true

To confirm, I put `screen.orientation` in Console, and got: `ScreenOrientation { type: "landscape-primary", angle: 0, onchange: null }`

After I changed `screen.orientation` to `screen.orientation.type` in the switch statement, the example started working, and printed "That looks good."

### Description

changed `screen.orientation` to `screen.orientation.type`

### Motivation
To make example work

### Additional details

Tested on Firefox 105, Nightly 107 and on Microsoft Edge
