### PR TITLE
Add destructured example

### DIFF
--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -466,6 +466,5 @@ for (const [key, val] of Objects.entries()) {
 // "bar" 2
 ```
 
-
 {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling",
   "Web/JavaScript/Guide/Functions")}}

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -454,7 +454,7 @@ for (const i of arr) {
 }
 ```
 
-The {{jsxref("Statements/for...of","for...of")}} statement can also be used with [array destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to loop over objects using iterators like {{jsxref("Object.entries()")}}:
+The `for...of` and `for...in` statements can also be used with [destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment). For example, you can simultaneously loop over the keys and values of an object using {{jsxref("Object.entries()")}}.
 
 ```js
 const obj = { foo: 1, bar: 2 };

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -454,5 +454,16 @@ for (const i of arr) {
 }
 ```
 
+The {{jsxref("statements/for...of","for...of")}} statement can also be used with [array destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to loop over objects using iterators like [`Object.entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries):
+```
+const obj = {foo: 1, bar: 2}
+
+for (const [key, val] of Objects.entries()) {
+  console.log(key); // logs "foo", "bar"
+  console.log(val); // logs "1", "2"
+}
+```
+
+
 {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling",
   "Web/JavaScript/Guide/Functions")}}

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -454,14 +454,16 @@ for (const i of arr) {
 }
 ```
 
-The {{jsxref("statements/for...of","for...of")}} statement can also be used with [array destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to loop over objects using iterators like [`Object.entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries):
-```
-const obj = {foo: 1, bar: 2}
+The {{jsxref("Statements/for...of","for...of")}} statement can also be used with [array destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to loop over objects using iterators like {{jsxref("Object.entries()")}}:
+
+```js
+const obj = { foo: 1, bar: 2 };
 
 for (const [key, val] of Objects.entries()) {
-  console.log(key); // logs "foo", "bar"
-  console.log(val); // logs "1", "2"
+  console.log(key, val);
 }
+// "foo" 1
+// "bar" 2
 ```
 
 


### PR DESCRIPTION
One of the most common use cases of the for... of loop is iterating over object key/value pairs. I added this example with internal cross-refereneces. This has the added benefit of showing that for... of can be used to iterate over destructured values (not obvious to a novice).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added an example in the for... of documentation to show how it can be used to loop over object key/value pairs. 

### Motivation

I needed to use this example and I could not find it on the docs. I also wasn't sure if for... of could even be used with destructuring, or to loop over objects.

### Additional details



### Related issues and pull requests


