### PR TITLE
Correct `role="alert"` information

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -37,7 +37,7 @@ The [`alert`](https://www.w3.org/TR/wai-aria-1.1/#alert) role is of the five [li
 
 The most important thing to know about the `alert` role is that it's for content that is dynamically displayed, not for content that appears on page load. It is perfect for situations such as when a user fills out a form and JavaScript is used to add an error message - the alert would immediately read out the message. It should not be used on HTML that the user hasn't interacted with. For example, if a page loads with multiple visible alerts scattered throughout, the alert role should not be used, as the messages were not dynamically triggered.
 
-As with all other [live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), alerts will only be announced when the content of the element with `role="alert"` is *updated*. Make sure that the element with the role is present in the page's markup first - this will "prime" the browser and screen reader to keep watching the element for changes. After this, any changes to the content will be announced. Do not try to dynamically add/generate an element with `role="alert"` that is already populated with the alert message you want announced - this generally does *not* lead to an announcement, as it is not a content change.
+As with all other [live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), alerts will only be announced when the content of the element with `role="alert"` is _updated_. Make sure that the element with the role is present in the page's markup first - this will "prime" the browser and screen reader to keep watching the element for changes. After this, any changes to the content will be announced. Do not try to dynamically add/generate an element with `role="alert"` that is already populated with the alert message you want announced - this generally does _not_ lead to an announcement, as it is not a content change.
 
 As the `alert` role reads out any content that has changed, it should be used with caution. Alerts, by definition, are disruptive. Several alerts at once, and unnecessary alerts, create bad user experiences.
 
@@ -47,7 +47,7 @@ Following are four ways of creating alerts:
 
 ### Example 1: Making ready-made content inside an element with an alert role visible
 
-If the content *inside* the element with `role="alert"` is initially hidden using CSS, making it visible will cause the alert to fire. This means that an existing alert container element can be "reused" multiple times.
+If the content _inside_ the element with `role="alert"` is initially hidden using CSS, making it visible will cause the alert to fire. This means that an existing alert container element can be "reused" multiple times.
 
 ```css
 .hidden {
@@ -68,7 +68,7 @@ document.getElementById("expirationWarning").firstChild.classList.remove("hidden
 
 ### Example 2: Dynamically changing the content inside an element with an alert role
 
-Using JavaScript, you can dynamically change the content *inside* the element with `role="alert"`. Note that if you need to fire the same alert multiple times (i.e. the content you're dynamically inserting is the same as before), this generally won't be seen as a change and will *not* lead to an announcement. For this reason, it's usually best to briefly "clear" the contents of the alert container before then injecting the alert message.
+Using JavaScript, you can dynamically change the content _inside_ the element with `role="alert"`. Note that if you need to fire the same alert multiple times (i.e. the content you're dynamically inserting is the same as before), this generally won't be seen as a change and will _not_ lead to an announcement. For this reason, it's usually best to briefly "clear" the contents of the alert container before then injecting the alert message.
 
 ```html
 <div id="alertContainer" role="alert"></div>

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -43,7 +43,7 @@ As the `alert` role reads out any content that has changed, it should be used wi
 
 ## Examples
 
-Following are common examples of alerts and how to implement them:
+The following are common examples of alerts and how to implement them:
 
 ### Example 1: Making ready-made content inside an element with an alert role visible
 

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -83,7 +83,7 @@ document.getElementById('alertContainer').innerHTML ="Your session will expire i
 
 ### Example 3: Visually hidden alert container for screen reader notifications
 
-It's possible to visually hide the alert container itself, and use it to provide updates/notifications explicitly for screen readers. This can be useful in situations where content on the page has been updated - for instance, after performing a search that dynamically updates a list of results on the current page, but where the change would not be immediately obvious to a screen reader user.
+It's possible to visually hide the alert container itself, and use it to provide updates/notifications explicitly for screen readers. This can be useful in situations where important content on the page has been updated, but where the change would not be immediately obvious to a screen reader user.
 
 However, make sure that the container is not hidden using `display:none`, as this will hide it even from assistive technologies, meaning that they won't be notified of any changes. Instead, use something like the [`.visually-hidden` styles](https://www.a11yproject.com/posts/how-to-hide-content/).
 
@@ -107,7 +107,7 @@ However, make sure that the container is not hidden using `display:none`, as thi
 // clear the contents of the container
 document.getElementById('hiddenAlertContainer').innerHTML = "";
 // inject the new alert message
-document.getElementById('hiddenAlertContainer').innerHTML ="Search results have been updated.";
+document.getElementById('hiddenAlertContainer').innerHTML ="All items were removed from your inventory.";
 ```
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -83,7 +83,7 @@ document.getElementById('alertContainer').innerHTML ="Your session will expire i
 
 ### Example 3: Visually hidden alert container for screen reader notifications
 
-It's possible to visually hide the alert container itself, and use it to provide updates/notifications explicitly for screen readers. This can be useful in situations where important content on the page has been updated, but where the change would not be immediately obvious to a screen reader user.
+It's possible to visually hide the alert container itself, and use it to provide updates/notifications explicitly for screen readers. This can be useful in situations where important content on the page has been updated, but where the change would not be immediately obvious to a screen-reader user.
 
 However, make sure that the container is not hidden using `display:none`, as this will hide it even from assistive technologies, meaning that they won't be notified of any changes. Instead, use something like the [`.visually-hidden` styles](https://www.a11yproject.com/posts/how-to-hide-content/).
 

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -37,81 +37,17 @@ The [`alert`](https://www.w3.org/TR/wai-aria-1.1/#alert) role is of the five [li
 
 The most important thing to know about the `alert` role is that it's for content that is dynamically displayed, not for content that appears on page load. It is perfect for situations such as when a user fills out a form and JavaScript is used to add an error message - the alert would immediately read out the message. It should not be used on HTML that the user hasn't interacted with. For example, if a page loads with multiple visible alerts scattered throughout, the alert role should not be used, as the messages were not dynamically triggered.
 
-If an element has `role="alert"` and `display: none;` set, when the [`display`](/en-US/docs/Web/CSS/CSS_Display) value is changed with CSS or JavaScript, it automatically triggers the screen reader to read out the content.
+As with all other [live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), alerts will only be announced when the content of the element with `role="alert"` is *updated*. Make sure that the element with the role is present in the page's markup first - this will "prime" the browser and screen reader to keep watching the element for changes. After this, any changes to the content will be announced. Do not try to dynamically add/generate an element with `role="alert"` that is already populated with the alert message you want announced - this generally does *not* lead to an announcement, as it is not a content change.
 
-```html
-<p role="alert" style="display: none;">
-  This alert will trigger when the element becomes visible.
-</p>
-```
-
-While triggering an alert via CSS alone is possible, it is better to rely on JavaScript because it has more browser/screen reader support and is often more appropriate as part of a larger user interaction, such as inside an event handler or form validation.
-
-With JavaScript, developers control the adding and removing of alerts as appropriate.
-
-```html
-<button type="button">Trigger alert</button>
-<p class="alert">The alert will trigger when the button is pressed.</p>
-```
-
-```js
-const btn = document.querySelector("button");
-btn.addEventListener("click", triggerAlert);
-
-function triggerAlert() {
-  const alertEl = document.querySelector(".alert");
-  alertEl.setAttribute("role", "alert");
-}
-```
-
-As the `alert` role reads out content that has changed, bring the user's attention to it immediately, it should not be used for static content nor used regularly. Alerts, by definition, are disruptive. Several alerts at once, and unnecessary alerts, create bad user experiences.
+As the `alert` role reads out any content that has changed, it should be used with caution. Alerts, by definition, are disruptive. Several alerts at once, and unnecessary alerts, create bad user experiences.
 
 ## Examples
 
 Following are four ways of creating alerts:
 
-### Example 1: Adding the role in the HTML code
+### Example 1: Making ready-made content inside an element with an alert role visible
 
-Here, the alert role is added directly into the HTML source code. When the element finishes loading the screen reader will be notified of the alert.
-
-```html
-<h2 role="alert">
-  Your form could not be submitted because of 3 validation errors.
-</h2>
-```
-
-If the element is in the original source code when the page loads, the screen reader will announce the error immediately after announcing the page title.
-
-### Example 2: Dynamically adding an element with the alert role
-
-This snippet dynamically creates an element with an alert role and adds it to the document structure.
-
-```js
-const myAlert = document.createElement("p");
-myAlert.setAttribute("role", "alert");
-const myAlertText = document.createTextNode(
-  "You must agree with our terms of service to create an account."
-);
-myAlert.appendChild(myAlertText);
-document.body.appendChild(myAlert);
-```
-
-### Example 3: Adding alert role to an existing element
-
-Sometimes it is useful to add an `alert` role to an element that is already visible on the page rather than creating a new element. This allows the developer to reiterate information that has become more relevant or urgent to the user. For example, a form control may have instructions about the expected value. If a different value is entered, `role="alert"` can be added to the instruction text so that the screen reader announces it as an alert.
-
-```html
-<p id="formInstruction">You must select at least 3 options</p>
-```
-
-```js
-// When the user tries to submit the form with less than 3 checkboxes selected:
-document.getElementById("formInstruction").setAttribute("role", "alert");
-```
-
-### Example 4: Making an element with an alert role visible
-
-If an element already has `role="alert"` and is initially hidden using CSS, making it visible will cause the alert to fire as if it was just added to the page. This means that an existing alert can be "reused" multiple times.
+If the content *inside* the element with `role="alert"` is initially hidden using CSS, making it visible will cause the alert to fire. This means that an existing alert container element can be "reused" multiple times.
 
 ```css
 .hidden {
@@ -120,14 +56,58 @@ If an element already has `role="alert"` and is initially hidden using CSS, maki
 ```
 
 ```html
-<p id="expirationWarning" role="alert" class="hidden">
-  Your log in session will expire in 2 minutes
-</p>
+<div id="expirationWarning" role="alert">
+  <span class="hidden">Your log in session will expire in 2 minutes</span>
+</div>
 ```
 
 ```js
-// removing the 'hidden' class makes the element visible, which will make the screen reader announce the alert:
-document.getElementById("expirationWarning").classList.remove("hidden");
+// removing the 'hidden' class makes the content inside the element visible, which will make the screen reader announce the alert:
+document.getElementById("expirationWarning").firstChild.classList.remove("hidden");
+```
+
+### Example 2: Dynamically changing the content inside an element with an alert role
+
+Using JavaScript, you can dynamically change the content *inside* the element with `role="alert"`. Note that if you need to fire the same alert multiple times (i.e. the content you're dynamically inserting is the same as before), this generally won't be seen as a change and will *not* lead to an announcement. For this reason, it's usually best to briefly "clear" the contents of the alert container before then injecting the alert message.
+
+```html
+<div id="alertContainer" role="alert"></div>
+```
+
+```js
+// clear the contents of the container
+document.getElementById('alertContainer').innerHTML = "";
+// inject the new alert message
+document.getElementById('alertContainer').innerHTML ="Your session will expire in " + expiration + " minutes";
+```
+
+### Example 3: Visually hidden alert container for screen reader notifications
+
+It's possible to visually hide the alert container itself, and use it to provide updates/notifications explicitly for screen readers. This can be useful in situations where content on the page has been updated - for instance, after performing a search that dynamically updates a list of results on the current page, but where the change would not be immediately obvious to a screen reader user.
+
+However, make sure that the container is not hidden using `display:none`, as this will hide it even from assistive technologies, meaning that they won't be notified of any changes. Instead, use something like the [`.visually-hidden` styles](https://www.a11yproject.com/posts/how-to-hide-content/).
+
+```html
+<div id="hiddenAlertContainer" role="alert" class="visually-hidden"></div>
+```
+
+```css
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+```
+
+```js
+// clear the contents of the container
+document.getElementById('hiddenAlertContainer').innerHTML = "";
+// inject the new alert message
+document.getElementById('hiddenAlertContainer').innerHTML ="Search results have been updated.";
 ```
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -43,7 +43,7 @@ As the `alert` role reads out any content that has changed, it should be used wi
 
 ## Examples
 
-Following are four ways of creating alerts:
+Following are common examples of alerts and how to implement them:
 
 ### Example 1: Making ready-made content inside an element with an alert role visible
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The information currently on https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role is, unfortunately, outright wrong. Like all live regions, the container with `role="alert"` needs to first be "primed". After that, any *subsequent* content updates are announced. It doesn't work (or, when it does, it's mostly a fluke/down to internal browser timings) to just dynamically show a container by flipping its `display` property, or adding `role="alert"` to an existing element, or having that `role="alert"` and the message already present in the static markup on page load.

### Motivation

This PR corrects both the prose, and replaces the broken/incorrect examples with working/correct ones.

The current incorrect information seems to be constantly causing confusion ... most recently here https://webaim.org/discussion/mail_message?id=48125

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
