### PR TITLE
PannerNode constructor argument rollOffFactor typo

### DIFF
--- a/files/en-us/web/api/pannernode/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/pannernode/index.md
@@ -51,8 +51,8 @@ new PannerNode(context, options)
       - : The {{domxref("PannerNode.refDistance")}} you want the {{domxref("PannerNode")}} to have. The default is `1`, and negative values are not allowed.
     - `maxDistance`
       - : The {{domxref("PannerNode.maxDistance")}} you want the {{domxref("PannerNode")}} to have. The default is `10000`, and non-positive values are not allowed.
-    - `rollOffFactor`
-      - : The {{domxref("PannerNode.rollOffFactor")}} you want the {{domxref("PannerNode")}} to have. The default is `1`, and negative values are not allowed.
+    - `rolloffFactor`
+      - : The {{domxref("PannerNode.rolloffFactor")}} you want the {{domxref("PannerNode")}} to have. The default is `1`, and negative values are not allowed.
     - `coneInnerAngle`
       - : The {{domxref("PannerNode.coneInnerAngle")}} you want the {{domxref("PannerNode")}} to have (the default is `360`.)
     - `coneOuterAngle`


### PR DESCRIPTION
### Description

According to the spec, this PannerNode constructor option should have a lowercase "o" in "off".

### Motivation

I am trying to implement the glTF KHR_audio extension in a WebGPU/WebGL2 renderer. There was a spelling discrepancy between the Positional Emitter (KHR glTF documentation) and the PannerNode (Web Audio MDN documentation), so I looked further into it and it looks like the MDN docs are incorrect and the spellings are actually supposed to be identical. 

### Additional details

https://webaudio.github.io/web-audio-api/#dom-panneroptions-rollofffactor
https://github.com/KhronosGroup/glTF/tree/5d3a2a35d139c72a7001aa4872041572b2e42fae/extensions/2.0/Khronos/KHR_audio
