### PR TITLE
Add hasOwnProperty

### DIFF
--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -190,6 +190,18 @@ function hasPerson(name) {
 hasPerson("hasOwnProperty"); // false
 ```
 
+Also, you can use {{jsxref("Object.prototype.hasOwnProperty()")}}.
+
+```js
+const ages = { alice: 18, bob: 27 };
+
+function hasPerson(name) {
+  return ages.hasOwnProperty(name);
+}
+
+hasPerson("alice"); // true
+```
+
 Alternatively, you should consider using a [null prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype) or a {{jsxref("Map")}} for storing `ages`, to avoid other bugs.
 
 ```js example-good


### PR DESCRIPTION
### Description

Object.prototype.hasOwnProperty() method has been added as an alternative to Object.hasOwn"

### Motivation

Having only one instance may reduce the effectiveness of the MDN resource.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
