### PR TITLE
Don't use <div /> as  a button

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -149,10 +149,10 @@ The HTML file looks like this:
 
   <body>
     <div id="popup-content">
-      <div class="button beast">Frog</div>
-      <div class="button beast">Turtle</div>
-      <div class="button beast">Snake</div>
-      <div class="button reset">Reset</div>
+      <button class="button beast">Frog</button>
+      <button class="button beast">Turtle</button>
+      <button class="button beast">Snake</button>
+      <button class="button reset">Reset</button>
     </div>
     <div id="error-content" class="hidden">
       <p>Can't beastify this web page.</p>
@@ -182,6 +182,9 @@ body {
 }
 
 .button {
+  border: none;
+  display: block;
+  width: 100%;
   margin: 3% auto;
   padding: 4px;
   text-align: center;

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -149,10 +149,10 @@ The HTML file looks like this:
 
   <body>
     <div id="popup-content">
-      <button class="button beast">Frog</button>
-      <button class="button beast">Turtle</button>
-      <button class="button beast">Snake</button>
-      <button class="button reset">Reset</button>
+      <button>Frog</button>
+      <button>Turtle</button>
+      <button>Snake</button>
+      <button type="reset">Reset</button>
     </div>
     <div id="error-content" class="hidden">
       <p>Can't beastify this web page.</p>
@@ -163,7 +163,7 @@ The HTML file looks like this:
 </html>
 ```
 
-We have a [`<div>`](/en-US/docs/Web/HTML/Element/div) element with an ID of `"popup-content"` that contains an element for each animal choice. We have another `<div>` with an ID of `"error-content"` and a class `"hidden"`. We'll use that in case there's a problem initializing the popup.
+We have a [`<div>`](/en-US/docs/Web/HTML/Element/div) element with an ID of `"popup-content"` that contains a button for each animal choice and a reset button. We have another `<div>` with an ID of `"error-content"` and a class `"hidden"`. We'll use that in case there's a problem initializing the popup.
 
 Note that we include the CSS and JS files from this file, just like a web page.
 
@@ -181,29 +181,26 @@ body {
   display: none;
 }
 
-.button {
+button {
   border: none;
-  display: block;
+  width: 100%;
   margin: 3% auto;
   padding: 4px;
   text-align: center;
   font-size: 1.5em;
   cursor: pointer;
-}
-
-.beast:hover {
-  background-color: #CFF2F2;
-}
-
-.beast {
   background-color: #E5F2F2;
 }
 
-.reset {
+button:hover {
+  background-color: #CFF2F2;
+}
+
+button[type="reset"] {
   background-color: #FBFBC9;
 }
 
-.reset:hover {
+button[type="reset"]:hover {
   background-color: #EAEA9D;
 }
 ```
@@ -279,15 +276,15 @@ function listenForClicks() {
      * Get the active tab,
      * then call "beastify()" or "reset()" as appropriate.
      */
-    if (e.target.classList.contains("beast")) {
-      browser.tabs
-        .query({ active: true, currentWindow: true })
-        .then(beastify)
-        .catch(reportError);
-    } else if (e.target.classList.contains("reset")) {
+    if (e.target.type = "reset") {
       browser.tabs
         .query({ active: true, currentWindow: true })
         .then(reset)
+        .catch(reportError);
+    } else {
+      browser.tabs
+        .query({ active: true, currentWindow: true })
+        .then(beastify)
         .catch(reportError);
     }
   });

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -184,7 +184,6 @@ body {
 .button {
   border: none;
   display: block;
-  width: 100%;
   margin: 3% auto;
   padding: 4px;
   text-align: center;


### PR DESCRIPTION
This changes the `<div />` elements used as buttons in the tutorial to `<button />` elements. I know that this is not the scope of this tutorial but as using `<div />`s as buttons is considered a bad practice it should not be done here. I also added three lines of css to stick to the old styles.

Read more about the accessibility issues when using `<div />`s as buttons here: https://benmyers.dev/blog/clickable-divs/

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
