### PR TITLE
Fix (further) the highWaterMark description in ByteLengthQueuingStrategy

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -28,6 +28,8 @@ new ByteLengthQueuingStrategy(highWaterMark)
 - `highWaterMark`
   - : The total number of bytes worth of chunks that can be contained in the internal queue before backpressure is applied.
 
+    Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` parameter specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
+
 ### Return value
 
 An instance of the {{domxref("ByteLengthQueuingStrategy")}} object.

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -26,9 +26,7 @@ new ByteLengthQueuingStrategy(highWaterMark)
 ### Parameters
 
 - `highWaterMark`
-  - : An object containing a `highWaterMark` property. This is a non-negative
-    integer defining the total number of bytes worth of chunks that can be contained in the internal
-    queue before backpressure is applied.
+  - : The total number of bytes worth of chunks that can be contained in the internal queue before backpressure is applied.
 
 ### Return value
 

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -25,8 +25,7 @@ new CountQueuingStrategy(highWaterMark)
 ### Parameters
 
 - `highWaterMark`
-  - : An object containing a `highWaterMark` property. This is a non-negative
-    integer defining the total number of chunks that can be contained in the internal
+  - : The total number of chunks that can be contained in the internal
     queue before backpressure is applied.
 
 ### Return value


### PR DESCRIPTION
`highWaterMark` is not an object, and also not an integer — instead per https://streams.spec.whatwg.org/#dom-queuingstrategy-highwatermark it’s just a number.