### PR TITLE
Further fix ByteLengthQueuingStrategy()/CountQueuingStrategy() params

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -25,6 +25,8 @@ new ByteLengthQueuingStrategy(highWaterMark)
 
 ### Parameters
 
+An object with the following property:
+
 - `highWaterMark`
   - : The total number of bytes worth of chunks that can be contained in the internal queue before backpressure is applied.
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -28,7 +28,7 @@ new ByteLengthQueuingStrategy(highWaterMark)
 An object with the following property:
 
 - `highWaterMark`
-  - : The total number of bytes worth of chunks that can be contained in the internal queue before backpressure is applied.
+  - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
 
     Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` parameter specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
 

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -24,6 +24,8 @@ new CountQueuingStrategy(highWaterMark)
 
 ### Parameters
 
+An object with the following property:
+
 - `highWaterMark`
   - : The total number of chunks that can be contained in the internal
     queue before backpressure is applied.


### PR DESCRIPTION
https://streams.spec.whatwg.org/#blqs-class-definition and https://streams.spec.whatwg.org/#cqs-class-definition show that the `ByteLengthQueuingStrategy()` and `CountQueuingStrategy()` constructors take a `QueuingStrategyInit` object — and, as specified at https://streams.spec.whatwg.org/#dictdef-queuingstrategyinit, that object has a single property, `highWaterMark`.