### PR TITLE
Attribute is enumerated, not boolean

### DIFF
--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -10,9 +10,15 @@ browser-compat: html.global_attributes.hidden
 
 {{HTMLSidebar("Global_attributes")}}
 
-The **`hidden`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a Boolean attribute indicating that the element is not yet, or is no longer, _relevant_. For example, it can be used to hide elements of the page that can't be used until the login process has been completed. Browsers won't render elements with the `hidden` attribute set.
+The **`hidden`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute indicating that the element is not yet, or is no longer, _relevant_. For example, it can be used to hide elements of the page that can't be used until the login process has been completed. Browsers won't render elements with the `hidden` attribute set.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-hidden.html","tabbed-shorter")}}
+
+The attribute must take one of the following values:
+
+ - `hidden` or an empty string, which indicates that the element is hidden.
+
+If the attribute is given without a value, like `<label hidden>Hidden Label</label>` or has an invalid value, like `<label hidden="oops">Hidden Label</label>`, its value is treated as an empty string, and will be hidden. If the attribute is not included, the element is not hidden.
 
 The `hidden` attribute must not be used to hide content just from one presentation. If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
 

--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -14,7 +14,7 @@ The **`hidden`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-hidden.html","tabbed-shorter")}}
 
-The attribute must take one of the following values:
+The attribute takes the following value:
 
  - `hidden` or an empty string, which indicates that the element is hidden.
 

--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -18,7 +18,7 @@ The attribute takes the following value:
 
 - `hidden` or an empty string, which indicates that the element is hidden.
 
-If the attribute is given without a value, like `<label hidden>Hidden Label</label>` or has an invalid value, like `<label hidden="oops">Hidden Label</label>`, its value is treated as an empty string, and will be hidden. If the attribute is not included, the element is not hidden.
+If the attribute is given without a value, like `<label hidden>Hidden Label</label>`, or has an invalid value, like `<label hidden="oops">Hidden Label</label>`, its value is treated as an empty string, and will be hidden. If the attribute is not included, the element is not hidden.
 
 The `hidden` attribute must not be used to hide content just from one presentation. If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
 

--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -16,7 +16,7 @@ The **`hidden`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a
 
 The attribute takes the following value:
 
- - `hidden` or an empty string, which indicates that the element is hidden.
+- `hidden` or an empty string, which indicates that the element is hidden.
 
 If the attribute is given without a value, like `<label hidden>Hidden Label</label>` or has an invalid value, like `<label hidden="oops">Hidden Label</label>`, its value is treated as an empty string, and will be hidden. If the attribute is not included, the element is not hidden.
 


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute

There is a second attribute value, `until-found`, which is not part of this PR.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
