### PR TITLE
Remove an unnecessary link in HTML contenteditable

### DIFF
--- a/files/en-us/web/html/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/global_attributes/contenteditable/index.md
@@ -42,7 +42,6 @@ You can set the color used to draw the text insertion {{Glossary("caret")}} with
 
 ## See also
 
-- [Making content editable](/en-US/docs/Web/Guide/HTML/Editable_content)
 - All [global attributes](/en-US/docs/Web/HTML/Global_attributes)
 - {{domxref("HTMLElement.contentEditable")}} and {{domxref("HTMLElement.isContentEditable")}}
 - The CSS {{cssxref("caret-color")}} property


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove an unnecessary link in HTML contenteditable

### Motivation

The article "Making content editable" has been removed. It is replaced with a redirect to this page. So the link became recursive.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
