### PR TITLE
Added a note regarding Lax-Allowing-Unsafe

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/samesite/index.md
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.md
@@ -32,6 +32,8 @@ Cookies are not sent on normal cross-site subrequests (for example to load image
 This is the default cookie value if `SameSite` has not been explicitly specified in recent browser versions (see the "SameSite: Defaults to Lax" feature in the Browser Compatibility).
 
 > **Note:** `Lax` replaced `None` as the default value in order to ensure that users have reasonably robust defense against some classes of cross-site request forgery ({{Glossary("CSRF")}}) attacks.
+>
+> In order to mitigate breakages due to the new default value, browsers may implement an intervention such that the cookies can be sent with top-level cross-site unsafe requests if they are less than 2 minutes old. Implemented by [Chrome](https://www.chromium.org/updates/same-site#20191101) and [Firefox](https://phabricator.services.mozilla.com/D63081), this behavior ["Lax-Allowing-Unsafe"](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-10#section-5.4.7.2) should be considered as a temporary, transitional measure.
 
 ### `Strict`
 

--- a/files/en-us/web/http/headers/set-cookie/samesite/index.md
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.md
@@ -33,7 +33,7 @@ This is the default cookie value if `SameSite` has not been explicitly specified
 
 > **Note:** `Lax` replaced `None` as the default value in order to ensure that users have reasonably robust defense against some classes of cross-site request forgery ({{Glossary("CSRF")}}) attacks.
 >
-> In order to mitigate breakages due to the new default value, browsers may implement an intervention such that the cookies can be sent with top-level cross-site unsafe requests if they are less than 2 minutes old. Implemented by [Chrome](https://www.chromium.org/updates/same-site#20191101) and [Firefox](https://phabricator.services.mozilla.com/D63081), this behavior ["Lax-Allowing-Unsafe"](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-10#section-5.4.7.2) should be considered as a temporary, transitional measure.
+> In order to mitigate breakage due to the new default value, browsers may implement a ["Lax-Allowing-Unsafe"](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-10#section-5.4.7.2) enforcement mode such that cookies can be sent with top-level cross-site unsafe requests if they are less than 2 minutes old. The [Chrome implementation](https://www.chromium.org/updates/same-site#20191101) and [Firefox implementation](https://phabricator.services.mozilla.com/D63081) of that "Lax-Allowing-Unsafe" enforcement mode should be considered a temporary, transitional measure only.
 
 ### `Strict`
 


### PR DESCRIPTION
### Description

Added a note regarding `Lax-Allowing-Unsafe` / `Lax+Post` intervention.

### Motivation

To inform the readers about the current browser behavior.

### Additional details

* [Chrome](https://www.chromium.org/updates/same-site#20191101): `Lax+POST`
* [Firefox](https://phabricator.services.mozilla.com/D63081): `network.cookie.sameSite.laxPlusPOST.timeout`
* [RFC6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-10#section-5.4.7.2): `Lax-Allowing-Unsafe`

### Related issues and pull requests

* Related to https://github.com/httpwg/http-extensions/pull/1435.
* Might need an update depending on how https://github.com/httpwg/http-extensions/issues/2104 goes.
