### PR TITLE
Web AP methods/probs sorted into static/instance headings - A

### DIFF
--- a/files/en-us/web/api/aescbcparams/index.md
+++ b/files/en-us/web/api/aescbcparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-AesCbcParams
 
 The **`AesCbcParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.encrypt()")}}, {{domxref("SubtleCrypto.decrypt()")}}, {{domxref("SubtleCrypto.wrapKey()")}}, or {{domxref("SubtleCrypto.unwrapKey()")}}, when using the [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc) algorithm.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `AES-CBC`.

--- a/files/en-us/web/api/aesctrparams/index.md
+++ b/files/en-us/web/api/aesctrparams/index.md
@@ -31,7 +31,7 @@ Essentially: the nonce should ensure that counter blocks are not reused from one
 
 > **Note:** See [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D) for more information.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `AES-CTR`.

--- a/files/en-us/web/api/aesgcmparams/index.md
+++ b/files/en-us/web/api/aesgcmparams/index.md
@@ -17,7 +17,7 @@ The **`AesGcmParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/We
 
 For details of how to supply appropriate values for this parameter, see the specification for AES-GCM: [NIST SP800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), in particular section 5.2.1.1 on Input Data.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `AES-GCM`.

--- a/files/en-us/web/api/aeskeygenparams/index.md
+++ b/files/en-us/web/api/aeskeygenparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams
 
 The **`AesKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `AES-CBC`, `AES-CTR`, `AES-GCM`, or `AES-KW`, depending on the algorithm you want to use.

--- a/files/en-us/web/api/ambientlightsensor/index.md
+++ b/files/en-us/web/api/ambientlightsensor/index.md
@@ -31,12 +31,12 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 - {{domxref("AmbientLightSensor.AmbientLightSensor()", "AmbientLightSensor()")}} {{Experimental_Inline}}
   - : Creates a new `AmbientLightSensor` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('AmbientLightSensor.illuminance')}} {{Experimental_Inline}}
   - : Returns the current light level in [lux](https://en.wikipedia.org/wiki/Lux) of the ambient light level around the hosting device.
 
-## Methods
+## Instance methods
 
 _`AmbientLightSensor` doesn't have own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -51,7 +51,7 @@ An `AnalyserNode` has exactly one input and one output. The node works even if t
 - {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}}
   - : Creates a new instance of an `AnalyserNode` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -66,7 +66,7 @@ _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 - {{domxref("AnalyserNode.smoothingTimeConstant")}}
   - : A double value representing the averaging constant with the last analysis frame — basically, it makes the transition between values over time smoother.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/angle_instanced_arrays/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/index.md
@@ -27,7 +27,7 @@ This extension exposes one new constant, which can be used in the {{domxref("Web
 - `ext.VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE`
   - : Returns a {{domxref("WebGL_API/Types", "GLint")}} describing the frequency divisor used for instanced rendering when used in the {{domxref("WebGLRenderingContext.getVertexAttrib()", "gl.getVertexAttrib()")}} as the `pname` parameter.
 
-## Methods
+## Instance methods
 
 This extension exposes three new methods.
 

--- a/files/en-us/web/api/animation/index.md
+++ b/files/en-us/web/api/animation/index.md
@@ -24,7 +24,7 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
 - {{domxref("Animation.Animation()", "Animation()")}}
   - : Creates a new `Animation` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("Animation.currentTime")}}
   - : The current time value of the animation in milliseconds, whether running or paused. If the animation lacks a {{domxref("AnimationTimeline", "timeline")}}, is inactive or hasn't been played yet, its value is `null`.
@@ -49,7 +49,7 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
 - {{domxref("Animation.timeline")}}
   - : Gets or sets the {{domxref("AnimationTimeline", "timeline")}} associated with this animation.
 
-## Methods
+## Instance methods
 
 - {{domxref("Animation.cancel()")}}
   - : Clears all {{domxref("KeyframeEffect", "keyframeEffects")}} caused by this animation and aborts its playback.

--- a/files/en-us/web/api/animationeffect/index.md
+++ b/files/en-us/web/api/animationeffect/index.md
@@ -16,7 +16,7 @@ browser-compat: api.AnimationEffect
 
 The `AnimationEffect` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) defines current and future _animation effects_ like {{domxref("KeyframeEffect")}}, which can be passed to {{domxref("Animation")}} objects for playing, and {{domxref("KeyframeEffect")}} (which is used by [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions)).
 
-## Methods
+## Instance methods
 
 - {{domxref("AnimationEffect.getTiming()")}}
   - : Returns the object associated with the animation containing all the animation's timing values.

--- a/files/en-us/web/api/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/index.md
@@ -21,7 +21,7 @@ The **`AnimationEvent`** interface represents events providing information relat
 - {{domxref("AnimationEvent.AnimationEvent", "AnimationEvent()")}}
   - : Creates an `AnimationEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
@@ -32,7 +32,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
 - {{domxref("AnimationEvent.pseudoElement")}} {{ReadOnlyInline}}
   - : A string, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on. If the animation doesn't run on a pseudo-element but on the element, an empty string: `''`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/index.md
@@ -27,7 +27,7 @@ As animations play, they report changes to their {{domxref("Animation.playState"
 - {{domxref("AnimationPlaybackEvent.AnimationPlaybackEvent", "AnimationPlaybackEvent()")}}
   - : Constructs a new `AnimationPlaybackEvent` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("AnimationPlaybackEvent.currentTime")}} {{ReadOnlyInline}}
   - : The current time of the animation that generated the event.

--- a/files/en-us/web/api/animationtimeline/index.md
+++ b/files/en-us/web/api/animationtimeline/index.md
@@ -18,7 +18,7 @@ browser-compat: api.AnimationTimeline
 
 The `AnimationTimeline` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) represents the timeline of an animation. This interface exists to define timeline features (inherited by {{domxref("DocumentTimeline")}} and future timeline types) and is not itself directly used by developers. Anywhere you see `AnimationTimeline`, you should use `DocumentTimeline` or any other timeline type instead.
 
-## Properties
+## Instance properties
 
 - {{domxref("AnimationTimeline.currentTime")}} {{ReadOnlyInline}}
   - : Returns the time value in milliseconds for this timeline or `null` if this timeline is inactive.

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -26,7 +26,7 @@ The name is deemed _local_ when it ignores the eventual namespace prefix and dee
 
 > **Note:** This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being a SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
 
-## Properties
+## Instance properties
 
 _This interface also inherits the properties of its parent interfaces, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 
@@ -45,7 +45,7 @@ _This interface also inherits the properties of its parent interfaces, {{domxref
 - {{domxref("Attr.value", "value")}}
   - : The attribute's value, a string that can be set and get using this property.
 
-## Methods
+## Instance methods
 
 _This interface has no specific methods, but inherits the methods of its parent interfaces, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/index.md
@@ -22,7 +22,7 @@ Objects of these types are designed to hold small audio snippets, typically less
 - {{domxref("AudioBuffer.AudioBuffer", "AudioBuffer()")}}
   - : Creates and returns a new `AudioBuffer` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioBuffer.sampleRate")}} {{ReadOnlyInline}}
   - : Returns a float representing the sample rate, in samples per second, of the PCM data stored in the buffer.
@@ -33,7 +33,7 @@ Objects of these types are designed to hold small audio snippets, typically less
 - {{domxref("AudioBuffer.numberOfChannels")}} {{ReadOnlyInline}}
   - : Returns an integer representing the number of discrete audio channels described by the PCM data stored in the buffer.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioBuffer.getChannelData()")}}
   - : Returns a {{jsxref("Float32Array")}} containing the PCM data associated with the channel, defined by the `channel` parameter (with `0` representing the first channel).

--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -51,7 +51,7 @@ Multiple calls to {{domxref("AudioScheduledSourceNode/stop", "stop()")}} are all
 - {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
   - : Creates and returns a new `AudioBufferSourceNode` object. As an alternative, you can use the {{domxref("BaseAudioContext.createBufferSource()")}} factory method; see [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioScheduledSourceNode")}}_.
 
@@ -68,16 +68,16 @@ _Inherits properties from its parent, {{domxref("AudioScheduledSourceNode")}}_.
 - {{domxref("AudioBufferSourceNode.playbackRate")}}
   - : An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} that defines the speed factor at which the audio asset will be played, where a value of 1.0 is the sound's natural sampling rate. Since no pitch correction is applied on the output, this can be used to change the pitch of the sample. This value is compounded with `detune` to determine the final playback rate.
 
-### Event handlers
-
-_Inherits event handlers from its parent, {{domxref("AudioScheduledSourceNode")}}_.
-
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}, and overrides the following method:_.
 
 - {{domxref("AudioBufferSourceNode.start", "start()")}}
   - : Schedules playback of the audio data contained in the buffer, or begins playback immediately. Additionally allows the start offset and play duration to be set.
+
+## Event handlers
+
+_Inherits event handlers from its parent, {{domxref("AudioScheduledSourceNode")}}_.
 
 ## Examples
 

--- a/files/en-us/web/api/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/index.md
@@ -26,7 +26,7 @@ An audio context controls both the creation of the nodes it contains and the exe
 - {{domxref("AudioContext.AudioContext", "AudioContext()")}}
   - : Creates and returns a new `AudioContext` object.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent interface, {{domxref("BaseAudioContext")}}._
 
@@ -35,7 +35,7 @@ _Also inherits properties from its parent interface, {{domxref("BaseAudioContext
 - {{domxref("AudioContext.outputLatency")}} {{ReadOnlyInline}}
   - : Returns an estimation of the output latency of the current audio context.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from its parent interface, {{domxref("BaseAudioContext")}}._
 

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -38,7 +38,7 @@ In planar format, the number of planes is equal to {{domxref("AudioData.numberOf
 - {{domxref("AudioData.AudioData", "AudioData()")}} {{Experimental_Inline}}
   - : Creates a new `AudioData` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioData.format")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the sample format of the audio.
@@ -53,7 +53,7 @@ In planar format, the number of planes is equal to {{domxref("AudioData.numberOf
 - {{domxref("AudioData.timestamp")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the timestamp of the audio in microseconds.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioData.allocationSize()")}} {{Experimental_Inline}}
   - : Returns the number of bytes required to hold the sample as filtered by options passed into the method.

--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -20,14 +20,14 @@ The **`AudioDecoder`** interface of the {{domxref('WebCodecs API','','',' ')}} d
 - {{domxref("AudioDecoder.AudioDecoder", "AudioDecoder()")}} {{Experimental_Inline}}
   - : Creates a new `AudioDecoder` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioDecoder.decodeQueueSize")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An integer representing the number of decode queue requests.
 - {{domxref("AudioDecoder.state")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Represents the state of the underlying codec and whether it is configured for decoding.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioDecoder.configure()")}} {{Experimental_Inline}}
   - : Enqueues a control message to configure the audio decoder for decoding chunks.

--- a/files/en-us/web/api/audiodestinationnode/index.md
+++ b/files/en-us/web/api/audiodestinationnode/index.md
@@ -46,14 +46,14 @@ The `AudioDestinationNode` of a given `AudioContext` can be retrieved using the 
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
 - {{domxref("AudioDestinationNode.maxChannelCount")}}
   - : An `unsigned long` defining the maximum number of channels that the physical device can handle.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -19,14 +19,14 @@ The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebC
 - {{domxref("AudioEncoder.AudioEncoder", "AudioEncoder()")}} {{Experimental_Inline}}
   - : Creates a new `AudioEncoder` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioEncoder.encodeQueueSize")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An integer representing the number of encode queue requests.
 - {{domxref("AudioEncoder.state")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Represents the state of the underlying codec and whether it is configured for encoding.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioEncoder.configure()")}} {{Experimental_Inline}}
   - : Enqueues a control message to configure the audio encoder for encoding chunks.

--- a/files/en-us/web/api/audiolistener/index.md
+++ b/files/en-us/web/api/audiolistener/index.md
@@ -19,7 +19,7 @@ It is important to note that there is only one listener per context and that it 
 
 ![We see the position, up and front vectors of an AudioListener, with the up and front vectors at 90° from the other.](webaudiolistenerreduced.png)
 
-## Properties
+## Instance properties
 
 > **Note:** The position, forward, and up value are set and retrieved using different syntaxes. Retrieval is done by accessing, for example, `AudioListener.positionX`, while setting the same property is done with `AudioListener.positionX.value`. This is why these values are not marked read only, which is how they appear in the specification's IDL.
 
@@ -42,7 +42,7 @@ It is important to note that there is only one listener per context and that it 
 - {{domxref("AudioListener.upZ")}}
   - : Represents the longitudinal (back and forth) position of the top of the listener's head in the same cartesian coordinate system as the position (`positionX`, `positionY`, and `positionZ`) values. The forward and up values are linearly independent of each other. The default is 0.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioListener.setOrientation()")}} {{deprecated_inline}}
   - : Sets the orientation of the listener.

--- a/files/en-us/web/api/audionode/index.md
+++ b/files/en-us/web/api/audionode/index.md
@@ -26,6 +26,31 @@ Examples include:
 
 > **Note:** An `AudioNode` can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.
 
+## Instance properties
+
+- {{domxref("AudioNode.context")}} {{ReadOnlyInline}}
+  - : Returns the associated {{domxref("BaseAudioContext")}}, that is the object representing the processing graph the node is participating in.
+- {{domxref("AudioNode.numberOfInputs")}} {{ReadOnlyInline}}
+  - : Returns the number of inputs feeding the node. Source nodes are defined as nodes having a `numberOfInputs` property with a value of `0`.
+- {{domxref("AudioNode.numberOfOutputs")}} {{ReadOnlyInline}}
+  - : Returns the number of outputs coming out of the node. Destination nodes — like {{ domxref("AudioDestinationNode") }} — have a value of `0` for this attribute.
+- {{domxref("AudioNode.channelCount")}}
+  - : Represents an integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. Its usage and precise definition depend on the value of {{domxref("AudioNode.channelCountMode")}}.
+- {{domxref("AudioNode.channelCountMode")}}
+  - : Represents an enumerated value describing the way channels must be matched between the node's inputs and outputs.
+- {{domxref("AudioNode.channelInterpretation")}}
+  - : Represents an enumerated value describing the meaning of the channels. This interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
+    The possible values are `"speakers"` or `"discrete"`.
+
+## Instance methods
+
+_Also implements methods from the interface_ {{domxref("EventTarget")}}.
+
+- {{domxref("AudioNode.connect()")}}
+  - : Allows us to connect the output of this node to be input into another node, either as audio data or as the value of an {{domxref("AudioParam")}}.
+- {{domxref("AudioNode.disconnect()")}}
+  - : Allows us to disconnect the current node from another one it is already connected to.
+
 ## Description
 
 ### The audio routing graph
@@ -72,31 +97,6 @@ You are free to use either constructors or factory methods, or mix both, however
 - Slightly better performance: In both Chrome and Firefox, the factory methods call the constructors internally.
 
 _Brief history:_ The first version of the Web Audio spec only defined the factory methods. After a [design review in October 2013](https://github.com/WebAudio/web-audio-api/issues/250), it was decided to add constructors because they have numerous benefits over factory methods. The constructors were added to the spec from August to October 2016. Factory methods continue to be included in the spec and are not deprecated.
-
-## Instance properties
-
-- {{domxref("AudioNode.context")}} {{ReadOnlyInline}}
-  - : Returns the associated {{domxref("BaseAudioContext")}}, that is the object representing the processing graph the node is participating in.
-- {{domxref("AudioNode.numberOfInputs")}} {{ReadOnlyInline}}
-  - : Returns the number of inputs feeding the node. Source nodes are defined as nodes having a `numberOfInputs` property with a value of `0`.
-- {{domxref("AudioNode.numberOfOutputs")}} {{ReadOnlyInline}}
-  - : Returns the number of outputs coming out of the node. Destination nodes — like {{ domxref("AudioDestinationNode") }} — have a value of `0` for this attribute.
-- {{domxref("AudioNode.channelCount")}}
-  - : Represents an integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. Its usage and precise definition depend on the value of {{domxref("AudioNode.channelCountMode")}}.
-- {{domxref("AudioNode.channelCountMode")}}
-  - : Represents an enumerated value describing the way channels must be matched between the node's inputs and outputs.
-- {{domxref("AudioNode.channelInterpretation")}}
-  - : Represents an enumerated value describing the meaning of the channels. This interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
-    The possible values are `"speakers"` or `"discrete"`.
-
-## Instance methods
-
-_Also implements methods from the interface_ {{domxref("EventTarget")}}.
-
-- {{domxref("AudioNode.connect()")}}
-  - : Allows us to connect the output of this node to be input into another node, either as audio data or as the value of an {{domxref("AudioParam")}}.
-- {{domxref("AudioNode.disconnect()")}}
-  - : Allows us to disconnect the current node from another one it is already connected to.
 
 ## Example
 

--- a/files/en-us/web/api/audionode/index.md
+++ b/files/en-us/web/api/audionode/index.md
@@ -73,7 +73,7 @@ You are free to use either constructors or factory methods, or mix both, however
 
 _Brief history:_ The first version of the Web Audio spec only defined the factory methods. After a [design review in October 2013](https://github.com/WebAudio/web-audio-api/issues/250), it was decided to add constructors because they have numerous benefits over factory methods. The constructors were added to the spec from August to October 2016. Factory methods continue to be included in the spec and are not deprecated.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioNode.context")}} {{ReadOnlyInline}}
   - : Returns the associated {{domxref("BaseAudioContext")}}, that is the object representing the processing graph the node is participating in.
@@ -89,7 +89,7 @@ _Brief history:_ The first version of the Web Audio spec only defined the factor
   - : Represents an enumerated value describing the meaning of the channels. This interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
     The possible values are `"speakers"` or `"discrete"`.
 
-## Methods
+## Instance methods
 
 _Also implements methods from the interface_ {{domxref("EventTarget")}}.
 

--- a/files/en-us/web/api/audioparam/index.md
+++ b/files/en-us/web/api/audioparam/index.md
@@ -34,7 +34,7 @@ An _a-rate_ `AudioParam` takes the current audio parameter value for each [sampl
 
 A _k-rate_ `AudioParam` uses the same initial audio parameter value for the whole block processed; that is, 128 sample frames. In other words, the same value applies to every frame in the audio as it's processed by the node.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioParam.defaultValue")}} {{ReadOnlyInline}}
   - : Represents the initial value of the attribute as defined by the specific {{domxref("AudioNode")}} creating the `AudioParam`.
@@ -45,7 +45,7 @@ A _k-rate_ `AudioParam` uses the same initial audio parameter value for the whol
 - {{domxref("AudioParam.value")}}
   - : Represents the parameter's current value as of the current time; initially set to the value of {{domxref("AudioParam.defaultValue", "defaultValue")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioParam.setValueAtTime()")}}
   - : Schedules an instant change to the value of the `AudioParam` at a precise time, as measured against {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}. The new value is given by the `value` parameter.

--- a/files/en-us/web/api/audioparamdescriptor/index.md
+++ b/files/en-us/web/api/audioparamdescriptor/index.md
@@ -20,7 +20,7 @@ The **`AudioParamDescriptor`** dictionary of the [Web Audio API](/en-US/docs/Web
 
 It is used to create custom `AudioParam`s on an {{domxref("AudioWorkletNode")}}. If the underlying {{domxref("AudioWorkletProcessor")}} has a {{domxref("AudioWorkletProcessor.parameterDescriptors", "parameterDescriptors")}} static getter, then the returned array of objects based on this dictionary is used internally by `AudioWorkletNode` constructor to populate its {{domxref("AudioWorkletNode.parameters", "parameters")}} property accordingly.
 
-## Properties
+## Instance properties
 
 - `name`
   - : The string which represents the name of the `AudioParam`. Under this name the `AudioParam` will be available in the {{domxref("AudioWorkletNode.parameters", "parameters")}} property of the node, and under this name the {{domxref("AudioWorkletProcessor.process")}} method will acquire the calculated values of this `AudioParam`.

--- a/files/en-us/web/api/audioparammap/index.md
+++ b/files/en-us/web/api/audioparammap/index.md
@@ -11,14 +11,14 @@ browser-compat: api.AudioParamMap
 
 The Web Audio API interface **`AudioParamMap`** represents a set of multiple audio parameters, each described as a mapping of a string identifying the parameter to the {{domxref("AudioParam")}} object representing its value.
 
-## Properties
+## Instance properties
 
 The `AudioParamMap` object is accessed as a {{jsxref("Map")}} in which each parameter is identified by a name string which is mapped to an `AudioParam` containing the value of that parameter. In addition, there are the following properties available:
 
 - {{domxref("AudioParamMap.size", "size")}}
   - : ?
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioParamMap.entries", "entries()")}}
   - : ?

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -25,7 +25,7 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 - `AudioProcessingEvent()` {{Deprecated_Inline}}
   - : Creates a new `AudioProcessingEvent` object.
 
-## Properties
+## Instance properties
 
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/audioscheduledsourcenode/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/index.md
@@ -24,11 +24,11 @@ Unless stated otherwise, nodes based upon `AudioScheduledSourceNode` output sile
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent interface, {{domxref("AudioNode")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("AudioNode")}}, and adds the following methods:_
 

--- a/files/en-us/web/api/audiotrack/index.md
+++ b/files/en-us/web/api/audiotrack/index.md
@@ -20,7 +20,7 @@ The **`AudioTrack`** interface represents a single audio track from one of the H
 
 The most common use for accessing an `AudioTrack` object is to toggle its {{domxref("AudioTrack.enabled", "enabled")}} property in order to mute and unmute the track.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioTrack.enabled", "enabled")}}
   - : A Boolean value which controls whether or not the audio track's sound is enabled. Setting this value to `false` mutes the track's audio.

--- a/files/en-us/web/api/audiotracklist/index.md
+++ b/files/en-us/web/api/audiotracklist/index.md
@@ -24,14 +24,14 @@ Retrieve an instance of this object with {{domxref('HTMLMediaElement.audioTracks
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("EventTarget")}}._
 
 - {{domxref("AudioTrackList.length", "length")}} {{ReadOnlyInline}}
   - : The number of tracks in the list.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/audioworklet/index.md
+++ b/files/en-us/web/api/audioworklet/index.md
@@ -29,11 +29,11 @@ Access the audio context's instance of `AudioWorklet` through the {{domxref("Bas
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `AudioWorklet` interface does not define any properties of its own, but does inherit properties of {{domxref("Worklet")}}._
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from {{domxref('Worklet')}}. The `AudioWorklet` interface does not define any methods of its own._
 

--- a/files/en-us/web/api/audioworkletglobalscope/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/index.md
@@ -28,7 +28,7 @@ As the global execution context is shared across the current `BaseAudioContext`,
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioWorkletGlobalScope.currentFrame", "currentFrame")}} {{ReadOnlyInline}}
   - : Returns an integer that represents the ever-increasing current sample-frame of the audio block being processed. It is incremented by 128 (the size of a render quantum) after the processing of each audio block.
@@ -37,7 +37,7 @@ As the global execution context is shared across the current `BaseAudioContext`,
 - {{domxref("AudioWorkletGlobalScope.sampleRate", "sampleRate")}} {{ReadOnlyInline}}
   - : Returns a float that represents the sample rate of the associated {{domxref("BaseAudioContext")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("AudioWorkletGlobalScope.registerProcessor", "registerProcessor()")}}
   - : Registers a class derived from the {{domxref('AudioWorkletProcessor')}} interface. The class can then be used by creating an {{domxref("AudioWorkletNode")}}, providing its registered name.

--- a/files/en-us/web/api/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/index.md
@@ -25,7 +25,7 @@ The **`AudioWorkletNode`** interface of the [Web Audio API](/en-US/docs/Web/API/
 - {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode()")}}
   - : Creates a new instance of an `AudioWorkletNode` object.
 
-## Properties
+## Instance properties
 
 _Also Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -39,7 +39,7 @@ _Also Inherits properties from its parent, {{domxref("AudioNode")}}_.
 - {{domxref("AudioWorkletNode.processorerror_event", "processorerror")}}
   - : Fired when an error is thrown in associated {{domxref("AudioWorkletProcessor")}}. Once fired, the processor and consequently the node will output silence throughout its lifetime.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/index.md
@@ -25,12 +25,12 @@ The **`AudioWorkletProcessor`** interface of the [Web Audio API](/en-US/docs/Web
 - {{domxref("AudioWorkletProcessor.AudioWorkletProcessor", "AudioWorkletProcessor()")}}
   - : Creates a new instance of an `AudioWorkletProcessor` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("AudioWorkletProcessor.port", "port")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("MessagePort")}} used for bidirectional communication between the processor and the {{domxref("AudioWorkletNode")}} which it belongs to. The other end is available under the {{domxref("AudioWorkletNode.port", "port")}} property of the node.
 
-## Methods
+## Instance methods
 
 _The `AudioWorkletProcessor` interface does not define any methods of its own. However, you must provide a {{domxref("AudioWorkletProcessor.process", "process()")}} method, which is called in order to process the audio stream._
 

--- a/files/en-us/web/api/authenticatorassertionresponse/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/index.md
@@ -23,7 +23,7 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 > **Note:** This interface is restricted to top-level contexts. Use from within an {{HTMLElement("iframe")}} element will not have any effect.
 
-## Properties
+## Instance properties
 
 - `AuthenticatorAssertionResponse.clientDataJSON` {{securecontext_inline}} {{ReadOnlyInline}}
   - : The client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorAttestationResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
@@ -34,7 +34,7 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 - {{domxref("AuthenticatorAssertionResponse.userHandle")}} {{securecontext_inline}} {{ReadOnlyInline}}
   - : An {{jsxref("ArrayBuffer")}} containing an opaque user identifier.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/authenticatorattestationresponse/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/index.md
@@ -23,14 +23,14 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 > **Note:** This interface is restricted to top-level contexts. Use from within an {{HTMLElement("iframe")}} element will not have any effect.
 
-## Properties
+## Instance properties
 
 - `AuthenticatorAttestationResponse.clientDataJSON` {{securecontext_inline}} {{ReadOnlyInline}}
   - : Client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
 - {{domxref("AuthenticatorAttestationResponse.attestationObject")}} {{securecontext_inline}} {{ReadOnlyInline}}
   - : An {{jsxref("ArrayBuffer")}} containing authenticator data and an attestation statement for a newly-created key pair.
 
-## Methods
+## Instance methods
 
 - {{domxref("AuthenticatorAttestationResponse.getTransports()")}} {{securecontext_inline}}
   - : Returns an {{jsxref("Array")}} of strings describing which transport methods (e.g. `usb`, `nfc`) are believed to be supported with the authenticator. The array may be empty if the information is not available.

--- a/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
+++ b/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
@@ -27,7 +27,7 @@ child objects of `AuthenticatorResponse`, specifically
 
 An {{jsxref("ArrayBuffer")}}.
 
-## Properties
+## Instance properties
 
 After the `clientDataJSON` object is converted from an
 `ArrayBuffer` to a JavaScript object, it will have the following properties:

--- a/files/en-us/web/api/authenticatorresponse/index.md
+++ b/files/en-us/web/api/authenticatorresponse/index.md
@@ -24,12 +24,12 @@ Below is a list of interfaces based on the AuthenticatorResponse interface.
 - {{domxref("AuthenticatorAssertionResponse")}}
 - {{domxref("AuthenticatorAttestationResponse")}}
 
-## Properties
+## Instance properties
 
 - {{domxref("AuthenticatorResponse.clientDataJSON")}}
   - : A [JSON](/en-US/docs/Learn/JavaScript/Objects/JSON) string in an {{jsxref("ArrayBuffer")}}, representing the client data that was passed to {{domxref("CredentialsContainer.create()")}} or {{domxref("CredentialsContainer.get()")}}.
 
-## Methods
+## Instance methods
 
 None.
 


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with A

Moved to have consistent headings and ordering.