### PR TITLE
Web AP methods/props sorted to static/instance headings - BC

### DIFF
--- a/files/en-us/web/api/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/index.md
@@ -24,7 +24,7 @@ It is the event type passed to `onbackgroundfetchabort` and `onbackgroundfetchcl
 - {{domxref("BackgroundFetchEvent.BackgroundFetchEvent()", "BackgroundFetchEvent()")}} {{Experimental_Inline}}
   - : Creates a new `BackgroundFetchEvent` object. This constructor is not typically used, as the browser creates these objects itself and provides them to background fetch event callbacks.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
@@ -35,7 +35,7 @@ _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
 None.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/index.md
@@ -17,11 +17,11 @@ browser-compat: api.BackgroundFetchManager
 
 The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref('BackgroundFetchManager.fetch','fetch()' )}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.

--- a/files/en-us/web/api/backgroundfetchrecord/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/index.md
@@ -19,7 +19,7 @@ A `BackgroundFetchRecord` is created by the {{domxref("BackgroundFetchManager.fe
 
 There will be one `BackgroundFetchRecord` for each resource requested by `fetch()`.
 
-## Properties
+## Instance properties
 
 - {{domxref("BackgroundFetchRecord.request","request")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref("Request")}}.

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -19,7 +19,7 @@ A `BackgroundFetchRegistration` instance is returned by the {{domxref("Backgroun
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 The following properties are available synchronously, as convenience properties copied from those in the `BackgroundFetchRegistration` instance.
 
@@ -55,7 +55,7 @@ The following properties are available synchronously, as convenience properties 
 - {{domxref("BackgroundFetchRegistration.recordsAvailable")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("boolean")}} indicating whether the `recordsAvailable` flag is set.
 
-## Methods
+## Instance methods
 
 - {{domxref("BackgroundFetchRegistration.abort","BackgroundFetchRegistration.abort()")}} {{Experimental_Inline}}
   - : Aborts the background fetch. Returns a {{jsxref("Promise")}} that resolves with `true` if the fetch was successfully aborted.

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.md
@@ -22,11 +22,11 @@ The **`BackgroundFetchUpdateUIEvent`** interface of the {{domxref('Background Fe
 - {{domxref("BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent()", "BackgroundFetchUpdateUIEvent()")}} {{Experimental_Inline}}
   - : Creates a new `BackgroundFetchUIEvent` object. This constructor is not typically used, as the browser creates these objects itself for the {{domxref("ServiceWorkerGlobalScope.backgroundfetchsuccess_event", "backgroundfetchsuccess")}} and {{domxref("ServiceWorkerGlobalScope.backgroundfetchfail_event", "backgroundfetchfail")}} events.
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from {{domxref("Event")}}, and {{domxref("BackgroundFetchEvent")}}._
 
-## Methods
+## Instance methods
 
 - {{domxref("BackgroundFetchUpdateUIEvent.updateUI()")}} {{Experimental_Inline}}
   - : Updates the title and icon in the user interface to show the status of a background fetch. Resolves with a {{jsxref("Promise")}}.

--- a/files/en-us/web/api/barprop/index.md
+++ b/files/en-us/web/api/barprop/index.md
@@ -29,7 +29,7 @@ The **`BarProp`** interface of the {{domxref('Document Object Model')}} represen
 
 The `BarProp` interface is not accessed directly, but via one of these elements.
 
-## Properties
+## Instance properties
 
 - {{domxref("BarProp.visible")}} {{ReadOnlyInline}}
   - : A {{jsxref("Boolean")}}, which is true if the bar represented by the used interface element is visible.

--- a/files/en-us/web/api/baseaudiocontext/index.md
+++ b/files/en-us/web/api/baseaudiocontext/index.md
@@ -22,7 +22,7 @@ A `BaseAudioContext` can be a target of events, therefore it implements the {{do
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("BaseAudioContext.audioWorklet")}} {{ReadOnlyInline}} {{securecontext_inline}}
   - : Returns the {{domxref("AudioWorklet")}} object, which can be used to create and manage {{domxref("AudioNode")}}s in which JavaScript code implementing the {{domxref("AudioWorkletProcessor")}} interface are run in the background to process audio data.
@@ -37,12 +37,7 @@ A `BaseAudioContext` can be a target of events, therefore it implements the {{do
 - {{domxref("BaseAudioContext.state")}} {{ReadOnlyInline}}
   - : Returns the current state of the `AudioContext`.
 
-### Events
-
-- {{domxref("BaseAudioContext.statechange_event", "statechange")}}
-  - : Fired when the `AudioContext`'s state changes due to the calling of one of the state change methods ({{domxref("AudioContext.suspend")}}, {{domxref("AudioContext.resume")}}, or {{domxref("AudioContext.close")}}).
-
-## Methods
+## Instance methods
 
 _Also implements methods from the interface_ {{domxref("EventTarget")}}.
 
@@ -84,6 +79,11 @@ _Also implements methods from the interface_ {{domxref("EventTarget")}}.
   - : Creates a {{domxref("WaveShaperNode")}}, which is used to implement non-linear distortion effects.
 - {{domxref("BaseAudioContext.decodeAudioData()")}}
   - : Asynchronously decodes audio file data contained in an {{jsxref("ArrayBuffer")}}. In this case, the `ArrayBuffer` is usually loaded from an {{domxref("XMLHttpRequest")}}'s `response` attribute after setting the `responseType` to `arraybuffer`. This method only works on complete files, not fragments of audio files.
+
+## Events
+
+- {{domxref("BaseAudioContext.statechange_event", "statechange")}}
+  - : Fired when the `AudioContext`'s state changes due to the calling of one of the state change methods ({{domxref("AudioContext.suspend")}}, {{domxref("AudioContext.resume")}}, or {{domxref("AudioContext.close")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/batterymanager/index.md
+++ b/files/en-us/web/api/batterymanager/index.md
@@ -17,7 +17,7 @@ The `BatteryManager` interface of the [Battery Status API](/en-US/docs/Web/API/B
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("BatteryManager.charging")}} {{ReadOnlyInline}}
   - : A Boolean value indicating whether the battery is currently being charged.
@@ -28,7 +28,7 @@ The `BatteryManager` interface of the [Battery Status API](/en-US/docs/Web/API/B
 - {{domxref("BatteryManager.level")}} {{ReadOnlyInline}}
   - : A number representing the system's battery charge level scaled to a value between 0.0 and 1.0.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface:_ {{domxref("EventTarget")}}.
 

--- a/files/en-us/web/api/beforeinstallpromptevent/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/index.md
@@ -26,7 +26,7 @@ This interface inherits from the {{domxref("Event")}} interface.
 - {{domxref("BeforeInstallPromptEvent.BeforeInstallPromptEvent","BeforeInstallPromptEvent()")}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Creates a new `BeforeInstallPromptEvent` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("Event")}}._
 
@@ -35,7 +35,7 @@ _Inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("BeforeInstallPromptEvent.userChoice")}} {{ReadOnlyInline}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves to a string containing either "accepted" or "dismissed".
 
-## Methods
+## Instance methods
 
 - {{domxref("BeforeInstallPromptEvent.prompt()")}} {{Experimental_Inline}}
   - : Allows a developer to show the install prompt at a time of their own choosing. This method returns a {{jsxref("Promise")}}.

--- a/files/en-us/web/api/biquadfilternode/index.md
+++ b/files/en-us/web/api/biquadfilternode/index.md
@@ -47,7 +47,7 @@ The `BiquadFilterNode` interface represents a simple low-order filter, and is cr
 - {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}}
   - : Creates a new instance of a `BiquadFilterNode` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -213,7 +213,7 @@ _Inherits properties from its parent, {{domxref("AudioNode")}}_.
       </tbody>
     </table>
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/index.md
@@ -28,7 +28,7 @@ The **`BlobEvent`** interface represents events associated with a {{domxref("Blo
 - {{domxref("BlobEvent.BlobEvent", "BlobEvent()")}}
   - : Creates a `BlobEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent {{domxref("Event")}}_.
 
@@ -37,7 +37,7 @@ _Inherits properties from its parent {{domxref("Event")}}_.
 - {{domxref("BlobEvent.timecode")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} indicating the difference between the timestamp of the first chunk in data and the timestamp of the first chunk in the first BlobEvent produced by this recorder. Note that the timecode in the first produced BlobEvent does not need to be zero.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent {{domxref("Event")}}._
 

--- a/files/en-us/web/api/bluetooth/index.md
+++ b/files/en-us/web/api/bluetooth/index.md
@@ -20,7 +20,7 @@ options.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent {{domxref("EventTarget")}}._
 
@@ -30,7 +30,7 @@ _Inherits properties from its parent {{domxref("EventTarget")}}._
     allows the user to open. A BluetoothDevice representing the beacon would be available
     through `navigator.bluetooth.referringDevice`.
 
-## Methods
+## Instance methods
 
 - {{domxref("Bluetooth.getAvailability","Bluetooth.getAvailability()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolved to a boolean value indicating

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.md
@@ -19,7 +19,7 @@ The **`BluetoothCharacteristicProperties`** interface of the [Web Bluetooth API]
 
 This interface is returned by calling {{DOMxRef("BluetoothRemoteGATTCharacteristic.properties")}}.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("BluetoothCharacteristicProperties.authenticatedSignedWrites","authenticatedSignedWrites")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a `boolean` that is `true` if signed writing to the characteristic value is permitted.

--- a/files/en-us/web/api/bluetoothdevice/index.md
+++ b/files/en-us/web/api/bluetoothdevice/index.md
@@ -20,7 +20,7 @@ environment.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("BluetoothDevice.id")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A string that uniquely identifies a device.
@@ -29,7 +29,7 @@ environment.
 - {{DOMxRef("BluetoothDevice.gatt")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A reference to the device's {{DOMxRef("BluetoothRemoteGATTServer")}}.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("BluetoothDevice.watchAdvertisements()")}} {{Experimental_Inline}}
   - : A {{jsxref("Promise")}} that resolves to `undefined` or is rejected with

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
@@ -19,7 +19,7 @@ The `BluetoothRemoteGattCharacteristic` interface of the [Web Bluetooth API](/en
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("BluetoothRemoteGATTCharacteristic.service")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{DOMxRef("BluetoothRemoteGATTService")}} this characteristic belongs to.
@@ -35,7 +35,7 @@ The `BluetoothRemoteGattCharacteristic` interface of the [Web Bluetooth API](/en
 - `oncharacteristicvaluechanged` {{Experimental_Inline}}
   - : Event handler for the `characteristicvaluechanged` event.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("BluetoothRemoteGATTCharacteristic.getDescriptor()")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Promise")}} that resolves to the first {{DOMxRef("BluetoothRemoteGATTDescriptor")}} for a given descriptor UUID.

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
@@ -18,7 +18,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor
 The `BluetoothRemoteGATTDescriptor` interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) provides a GATT Descriptor,
 which provides further information about a characteristic's value.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("BluetoothRemoteGATTDescriptor.characteristic")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{DOMxRef("BluetoothRemoteGATTCharacteristic")}} this descriptor belongs
@@ -31,7 +31,7 @@ which provides further information about a characteristic's value.
   - : Returns the currently cached descriptor value. This value gets updated when the
     value of the descriptor is read.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("BluetoothRemoteGATTDescriptor.readValue()")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Promise")}} that resolves to

--- a/files/en-us/web/api/bluetoothremotegattserver/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.md
@@ -18,7 +18,7 @@ browser-compat: api.BluetoothRemoteGATTServer
 The **`BluetoothRemoteGATTServer`** interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) represents a GATT
 Server on a remote device.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("BluetoothRemoteGATTServer.connected")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A boolean value that returns true while this script execution environment is
@@ -27,7 +27,7 @@ Server on a remote device.
 - {{DOMxRef("BluetoothRemoteGATTServer.device")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A reference to the {{DOMxRef("BluetoothDevice")}} running the server.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("BluetoothRemoteGATTServer.connect()")}} {{Experimental_Inline}}
   - : Causes the script execution environment to connect to `this.device`.

--- a/files/en-us/web/api/bluetoothremotegattservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.md
@@ -22,7 +22,7 @@ and a list of the characteristics of this service.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("BluetoothRemoteGATTService.device")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns information about a Bluetooth device through an instance of
@@ -33,7 +33,7 @@ and a list of the characteristics of this service.
 - {{domxref("BluetoothRemoteGATTService.uuid")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a string representing the UUID of this service.
 
-## Methods
+## Instance methods
 
 - {{domxref("BluetoothRemoteGATTService.getCharacteristic()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} to an instance of

--- a/files/en-us/web/api/bluetoothuuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/index.md
@@ -22,7 +22,7 @@ The Bluetooth registry contains lists of descriptors, services, and characterist
 
 The `BluetoothUUID` interface provides methods to retrieve these 128-bit UUIDs.
 
-## Properties
+## Instance properties
 
 None.
 
@@ -30,7 +30,7 @@ None.
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("BluetoothUUID.canonicalUUID()")}} {{Experimental_Inline}}
   - : Returns the 128-bit UUID when passed the 16- or 32-bit UUID alias.

--- a/files/en-us/web/api/broadcastchannel/index.md
+++ b/files/en-us/web/api/broadcastchannel/index.md
@@ -24,14 +24,14 @@ The **`BroadcastChannel`** interface represents a named channel that any {{gloss
 - {{domxref("BroadcastChannel.BroadcastChannel", "BroadcastChannel()")}}
   - : Creates an object linking to the named channel.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("EventTarget")}}._
 
 - {{domxref("BroadcastChannel.name")}} {{ReadOnlyInline}}
   - : Returns a string, the name of the channel.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.md
@@ -20,11 +20,11 @@ The **`ByteLengthQueuingStrategy`** interface of the [Streams API](/en-US/docs/W
 - {{domxref("ByteLengthQueuingStrategy.ByteLengthQueuingStrategy", "ByteLengthQueuingStrategy()")}}
   - : Creates a new `ByteLengthQueuingStrategy` object instance.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("ByteLengthQueuingStrategy.size()")}}
   - : Returns the given chunk's `byteLength` property.

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -31,7 +31,7 @@ You are also responsible for periodically purging cache entries. Each browser ha
 
 {{securecontext_header}}
 
-## Methods
+## Instance methods
 
 - {{domxref("Cache.match", "Cache.match(request, options)")}}
   - : Returns a {{jsxref("Promise")}} that resolves to the response associated with the first matching request in the `Cache` object.

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -35,7 +35,7 @@ You can access `CacheStorage` through the global {{domxref("caches")}} property.
 
 {{securecontext_header}}
 
-## Methods
+## Instance methods
 
 - {{domxref("CacheStorage.match()")}}
   - : Checks if a given {{domxref("Request")}} is a key in any of the {{domxref("Cache")}} objects that the {{domxref("CacheStorage")}} object tracks, and returns a {{jsxref("Promise")}} that resolves to that match.

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.md
@@ -21,14 +21,14 @@ Part of the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Streams_AP
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface inherits the properties of its parent, {{domxref("MediaStreamTrack")}}._
 
 - {{domxref("CanvasCaptureMediaStreamTrack.canvas")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("HTMLCanvasElement")}} object whose surface is captured in real-time.
 
-## Methods
+## Instance methods
 
 _This interface inherits the methods of its parent, {{domxref("MediaStreamTrack")}}._
 

--- a/files/en-us/web/api/canvasgradient/index.md
+++ b/files/en-us/web/api/canvasgradient/index.md
@@ -18,11 +18,11 @@ The **`CanvasGradient`** interface represents an [opaque object](https://en.wiki
 
 It can be used as a {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}}.
 
-## Properties
+## Instance properties
 
 _As an opaque object, there is no exposed property._
 
-## Methods
+## Instance methods
 
 - {{domxref("CanvasGradient.addColorStop()")}}
   - : Adds a new stop, defined by an `offset` and a `color`, to the gradient.

--- a/files/en-us/web/api/canvaspattern/index.md
+++ b/files/en-us/web/api/canvaspattern/index.md
@@ -16,11 +16,11 @@ The **`CanvasPattern`** interface represents an [opaque object](https://en.wikip
 
 It can be used as a {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}}.
 
-## Properties
+## Instance properties
 
 _As an opaque object, this has no exposed property._
 
-## Methods
+## Instance methods
 
 _There are no inherited method._
 

--- a/files/en-us/web/api/caretposition/index.md
+++ b/files/en-us/web/api/caretposition/index.md
@@ -15,7 +15,7 @@ browser-compat: api.CaretPosition
 
 The `CaretPosition` interface represents the caret position, an indicator for the text insertion point. You can get a `CaretPosition` using the {{domxref("Document.caretPositionFromPoint()")}} method.
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any properties._
 
@@ -24,7 +24,7 @@ _This interface doesn't inherit any properties._
 - {{domxref("CaretPosition.offset")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a `long` representing the character offset in the caret position node.
 
-## Methods
+## Instance methods
 
 - {{domxref("CaretPosition.getClientRect")}} {{Experimental_Inline}}
   - : Returns the client rectangle for the caret range.

--- a/files/en-us/web/api/cdatasection/index.md
+++ b/files/en-us/web/api/cdatasection/index.md
@@ -36,12 +36,12 @@ of a CDATA section itself, `]]>`.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no specific properties and implements those of its parent
 {{DOMxRef("Text")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no specific methods and implements those of its parent
 {{DOMxRef("Text")}}._

--- a/files/en-us/web/api/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/index.md
@@ -53,11 +53,11 @@ Using a `ChannelMergerNode`, it is possible to create outputs with more channels
 - {{domxref("ChannelMergerNode.ChannelMergerNode()", "ChannelMergerNode()")}}
   - : Creates a new `ChannelMergerNode` object instance.
 
-## Properties
+## Instance properties
 
 _No specific property; inherits properties from its parent, {{domxref("AudioNode")}}_.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/index.md
@@ -61,11 +61,11 @@ If your `ChannelSplitterNode` always has one single input, the amount of outputs
 - {{domxref("ChannelSplitterNode.ChannelSplitterNode()","ChannelSplitterNode()")}}
   - : Creates a new `ChannelSplitterNode` object instance.
 
-## Properties
+## Instance properties
 
 _No specific property; inherits properties from its parent, {{domxref("AudioNode")}}_.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/characterdata/index.md
+++ b/files/en-us/web/api/characterdata/index.md
@@ -14,7 +14,7 @@ The **`CharacterData`** abstract interface represents a {{domxref("Node")}} obje
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parents, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 
@@ -27,7 +27,7 @@ _This interface also inherits properties from its parents, {{domxref("Node")}} a
 - {{domxref("CharacterData.previousElementSibling")}} {{ReadOnlyInline}}
   - : Returns the first {{domxref("Element")}} that _precedes_ this node, and is a sibling.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parents, {{domxref("Node")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/client/index.md
+++ b/files/en-us/web/api/client/index.md
@@ -18,12 +18,12 @@ browser-compat: api.Client
 
 The `Client` interface represents an executable context such as a {{domxref("Worker")}}, or a {{domxref("SharedWorker")}}. {{domxref("Window")}} clients are represented by the more-specific {{domxref("WindowClient")}}. You can get `Client`/`WindowClient` objects from methods such as {{domxref("Clients.matchAll","Clients.matchAll()")}} and {{domxref("Clients.get","Clients.get()")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("Client.postMessage()")}}
   - : Sends a message to the client.
 
-## Properties
+## Instance properties
 
 - {{domxref("Client.id")}} {{ReadOnlyInline}}
   - : The universally unique identifier of the client as a string.

--- a/files/en-us/web/api/clients/index.md
+++ b/files/en-us/web/api/clients/index.md
@@ -18,7 +18,7 @@ browser-compat: api.Clients
 
 The `Clients` interface provides access to {{domxref("Client")}} objects. Access it via `{{domxref("ServiceWorkerGlobalScope", "self")}}.clients` within a [service worker](/en-US/docs/Web/API/Service_Worker_API).
 
-## Methods
+## Instance methods
 
 - {{domxref("Clients.get()")}}
   - : Returns a {{jsxref("Promise")}} for a {{domxref("Client")}} matching a given {{domxref("Client.id", "id")}}.

--- a/files/en-us/web/api/clipboard/index.md
+++ b/files/en-us/web/api/clipboard/index.md
@@ -31,7 +31,7 @@ Calls to the methods of the `Clipboard` object will not succeed if the user hasn
 
 All of the Clipboard API methods operate asynchronously; they return a {{jsxref("Promise")}} which is resolved once the clipboard access has been completed. The promise is rejected if clipboard access is denied.
 
-## Methods
+## Instance methods
 
 _`Clipboard` is based on the {{domxref("EventTarget")}} interface, and includes its methods._
 

--- a/files/en-us/web/api/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/index.md
@@ -25,14 +25,14 @@ The **`ClipboardEvent`** interface represents events providing information relat
 - {{domxref("ClipboardEvent.ClipboardEvent", "ClipboardEvent()")}}
   - : Creates a `ClipboardEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("ClipboardEvent.clipboardData")}} {{ReadOnlyInline}}
   - : A {{domxref("DataTransfer")}} object containing the data affected by the user-initiated {{domxref("Element/cut_event", "cut")}}, {{domxref("Element/copy_event", "copy")}}, or {{domxref("Element/paste_event", "paste")}} operation, along with its MIME type.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its parent {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/index.md
@@ -32,7 +32,7 @@ Access to the contents of the clipboard is gated behind the [Permissions API](/e
 - {{domxref("ClipboardItem.ClipboardItem", "ClipboardItem()")}}
   - : Creates a new **`ClipboardItem`** object, with the {{Glossary("MIME type")}} as the key and {{domxref("Blob")}} as the value.
 
-## Properties
+## Instance properties
 
 _This interface provides the following properties._
 
@@ -41,7 +41,7 @@ _This interface provides the following properties._
 - {{domxref("ClipboardItem.presentationStyle", "presentationStyle")}} {{ReadOnlyInline}}
   - : Returns one of the following: `"unspecified"`, `"inline"` or `"attachment"`.
 
-## Methods
+## Instance methods
 
 _This interface defines the following methods._
 

--- a/files/en-us/web/api/closeevent/index.md
+++ b/files/en-us/web/api/closeevent/index.md
@@ -23,7 +23,7 @@ A `CloseEvent` is sent to clients using {{Glossary("WebSockets")}} when the conn
 - {{domxref("CloseEvent.CloseEvent", "CloseEvent()")}}
   - : Creates a new `CloseEvent`.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("Event")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("CloseEvent.wasClean")}} {{ReadOnlyInline}}
   - : Returns a boolean value that Indicates whether or not the connection was cleanly closed.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/comment/index.md
+++ b/files/en-us/web/api/comment/index.md
@@ -16,7 +16,7 @@ Comments are represented in HTML and XML as content between '`<!--`' and '`-->`'
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no specific property, but inherits those of its parent, {{domxref("CharacterData")}}, and indirectly those of {{domxref("Node")}}._
 
@@ -25,7 +25,7 @@ _This interface has no specific property, but inherits those of its parent, {{do
 - {{ domxref("Comment.Comment()", "Comment()") }}
   - : Returns a new `Comment` object with the parameter as its textual content. If not present, its default value is the empty string, `''`.
 
-## Methods
+## Instance methods
 
 _This interface has no specific method, but inherits those of its parent, {{domxref("CharacterData")}}, and indirectly those of {{domxref("Node")}}._
 

--- a/files/en-us/web/api/compositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/index.md
@@ -22,7 +22,7 @@ The DOM **`CompositionEvent`** represents events that occur due to the user indi
 - {{domxref("CompositionEvent.CompositionEvent()", "CompositionEvent()")}}
   - : Creates a new `CompositionEvent` object instance.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties of its parent, {{domxref("UIEvent")}}, and its ancestor — {{domxref("Event")}}._
 
@@ -31,7 +31,7 @@ _This interface also inherits properties of its parent, {{domxref("UIEvent")}}, 
 - {{domxref("CompositionEvent.locale")}} {{ReadOnlyInline}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Returns the locale of current input method (for example, the keyboard layout locale if the composition is associated with IME).
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parent, {{domxref("UIEvent")}}, and its ancestor — {{domxref("Event")}}._
 

--- a/files/en-us/web/api/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/index.md
@@ -19,7 +19,7 @@ The **`CompressionStream`** interface of the {{domxref('Compression Streams API'
 - {{domxref("CompressionStream.CompressionStream", "CompressionStream()")}}
   - : Creates a new `CompressionStream`
 
-## Properties
+## Instance properties
 
 - {{domxref("CompressionStream.readable")}}
   - : Returns the {{domxref("ReadableStream")}} instance controlled by this object.

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -32,7 +32,7 @@ gives a few [Usage](#usage) examples.
 
 {{AvailableInWorkers}}
 
-## Methods
+## Instance methods
 
 - {{domxref("console.assert()")}}
   - : Log a message and stack trace to console if the first argument is `false`.

--- a/files/en-us/web/api/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/index.md
@@ -39,7 +39,7 @@ A `ConstantSourceNode` has no inputs and exactly one monaural (one-channel) outp
 - {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
   - : Creates and returns a new `ConstantSourceNode` instance, optionally specifying an object which establishes initial values for the object's properties. As an alternative, you can use the {{domxref("BaseAudioContext.createConstantSource()")}} factory method; see [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent interface, {{domxref("AudioScheduledSourceNode")}}, and adds the following properties:_
 
@@ -55,7 +55,7 @@ _Inherits events from its parent interface, {{domxref("AudioScheduledSourceNode"
 - {{domxref("AudioScheduledSourceNode.ended_event","ended")}}
   - : Fired whenever the {{domxref('ConstantSourceNode')}} data has stopped playing.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("AudioScheduledSourceNode")}}._
 

--- a/files/en-us/web/api/constraint_validation/index.md
+++ b/files/en-us/web/api/constraint_validation/index.md
@@ -43,7 +43,7 @@ The constraint validation API extends the interfaces for the form-associated ele
 - {{domxref("HTMLSelectElement")}}
 - {{domxref("HTMLTextAreaElement")}}
 
-#### Properties
+#### Instance properties
 
 - {{domxref('HTMLObjectElement.validity', 'validity')}}
   - : A read-only property that returns a [`ValidityState`](/en-US/docs/Web/API/ValidityState) object, whose properties represent validation errors for the value of that element.
@@ -52,7 +52,7 @@ The constraint validation API extends the interfaces for the form-associated ele
 - {{domxref('HTMLObjectElement.willValidate', 'willValidate')}}
   - : A read-only boolean property that returns `true` if the element is a candidate for constraint validation; and `false` otherwise. Elements with the `HTMLObjectElement` interface are _never_ candidates for constraint validation. Others may be barred from constraint validation depending on specific conditions.
 
-#### Methods
+#### Instance methods
 
 - {{domxref('HTMLInputElement.checkValidity', 'checkValidity()')}}
   - : Checks the element's value against its constraints. If the value is invalid, it fires an [invalid](/en-US/docs/Web/API/HTMLInputElement/invalid_event) event at the element and returns `false`; otherwise it returns `true`.

--- a/files/en-us/web/api/contactaddress/index.md
+++ b/files/en-us/web/api/contactaddress/index.md
@@ -17,11 +17,11 @@ The **`ContactAddress`** interface of the {{domxref('contact_picker_api','Contac
 
 It may be useful to refer to the Universal Postal Union website's [Addressing S42 standard](https://www.upu.int/en/Postal-Solutions/Programmes-Services/Addressing-Solutions#addressing-s42-standard) materials, which provide information about international standards for postal addresses.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("PaymentAddress")}}_.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("PaymentAddress")}}_.
 

--- a/files/en-us/web/api/contactsmanager/index.md
+++ b/files/en-us/web/api/contactsmanager/index.md
@@ -18,7 +18,7 @@ The **`ContactsManager`** interface of the {{domxref('Contact Picker API')}} all
 
 The `ContactsManager` is available through the global {{domxref('navigator.contacts')}} property.
 
-## Methods
+## Instance methods
 
 - {{domxref('ContactsManager.select','select()')}} {{Experimental_Inline}}
   - : Returns a {{jsxref('Promise')}} which, when resolved, presents the user with a contact picker which allows them to select contact(s) they wish to share.

--- a/files/en-us/web/api/contentindex/index.md
+++ b/files/en-us/web/api/contentindex/index.md
@@ -17,11 +17,11 @@ browser-compat: api.ContentIndex
 
 The **`ContentIndex`** interface of the [Content Index API](/en-US/docs/Web/API/Content_Index_API) allows developers to register their offline enabled content with the browser.
 
-## Properties
+## Instance properties
 
 There are no properties of this interface.
 
-## Methods
+## Instance methods
 
 - {{domxref('ContentIndex.add()')}} {{Experimental_Inline}}
   - : Registers an item with the [content index](/en-US/docs/Web/API/Content_Index_API).

--- a/files/en-us/web/api/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/index.md
@@ -28,14 +28,14 @@ The {{domxref("ServiceWorkerGlobalScope.contentdelete_event", 'contentdelete')}}
 - {{domxref("ContentIndexEvent.ContentIndexEvent", "ContentIndexEvent()")}} {{Experimental_Inline}}
   - : Creates and returns a new `ContentIndexEvent` object whose type and other options are configured as specified.
 
-## Properties
+## Instance properties
 
 _In addition to the properties listed below, this interface inherits the properties of its parent interface, {{domxref("ExtendableEvent")}}._
 
 - {{domxref("ContentIndexEvent.id", "id")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref('String')}} which identifies the deleted content index via it's `id`.
 
-## Methods
+## Instance methods
 
 _While `ContentIndexEvent` offers no methods of its own, it inherits any specified by its parent interface, {{domxref("ExtendableEvent")}}._
 

--- a/files/en-us/web/api/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/index.md
@@ -49,7 +49,7 @@ The `ConvolverNode` interface is an {{domxref("AudioNode")}} that performs a Lin
 - {{domxref("ConvolverNode.ConvolverNode()", "ConvolverNode()")}}
   - : Creates a new `ConvolverNode` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -58,7 +58,7 @@ _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 - {{domxref("ConvolverNode.normalize")}}
   - : A boolean that controls whether the impulse response from the buffer will be scaled by an equal-power normalization when the `buffer` attribute is set, or not.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -30,7 +30,7 @@ Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
 - {{domxref("CookieChangeEvent.CookieChangeEvent", "CookieChangeEvent()")}} {{Experimental_Inline}}
   - : Creates a new `CookieChangeEvent`.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("Event")}}._
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -19,7 +19,7 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 {{InheritanceDiagram}}
 
-## Methods
+## Instance methods
 
 - {{domxref("CookieStore.delete()")}} {{Experimental_Inline}}
   - : The `delete()` method deletes a cookie with the given name or options object, it returns a {{jsxref("Promise")}} that resolves when the deletion completes.

--- a/files/en-us/web/api/cookiestoremanager/index.md
+++ b/files/en-us/web/api/cookiestoremanager/index.md
@@ -19,7 +19,7 @@ A `CookieStoreManager` has an associated {{domxref("ServiceWorkerRegistration")}
 
 To get a `CookieStoreManager`, call {{domxref("ServiceWorkerRegistration.cookies")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("CookieStoreManager.getSubscriptions()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("promise")}} which resolves to a list of the cookie change subscriptions for this service worker registration.

--- a/files/en-us/web/api/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/index.md
@@ -20,11 +20,11 @@ The **`CountQueuingStrategy`** interface of the [Streams API](/en-US/docs/Web/AP
 - {{domxref("CountQueuingStrategy.CountQueuingStrategy", "CountQueuingStrategy()")}}
   - : Creates a new `CountQueuingStrategy` object instance.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("CountQueuingStrategy.size()")}}
   - : Returns `1`.

--- a/files/en-us/web/api/crashreportbody/index.md
+++ b/files/en-us/web/api/crashreportbody/index.md
@@ -20,7 +20,7 @@ A crash report is generated when a document becomes unusable due to the browser 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - `reason` {{experimental_inline}}
 

--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -22,7 +22,7 @@ The **`Credential`** interface of the [Credential Management API](/en-US/docs/We
 - {{domxref("PublicKeyCredential")}}
 - {{domxref("FederatedCredential")}}
 
-## Properties
+## Instance properties
 
 - {{domxref("Credential.id")}} {{ReadOnlyInline}}
   - : Returns a string containing the credential's identifier. This might be any one of a GUID, username, or email address.
@@ -33,7 +33,7 @@ The **`Credential`** interface of the [Credential Management API](/en-US/docs/We
 
 None.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/credentialscontainer/index.md
+++ b/files/en-us/web/api/credentialscontainer/index.md
@@ -17,7 +17,7 @@ browser-compat: api.CredentialsContainer
 
 The **`CredentialsContainer`** interface of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API) exposes methods to request credentials and notify the user agent when events such as successful sign in or sign out happen. This interface is accessible from {{domxref('Navigator.credentials')}}.
 
-## Properties
+## Instance properties
 
 None.
 
@@ -25,7 +25,7 @@ None.
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("CredentialsContainer.create()")}} {{securecontext_inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a new {{domxref("Credential")}} instance based on the provided options, or `null` if no `Credential` object can be created. In exceptional circumstances, the {{jsxref("Promise")}} may reject.

--- a/files/en-us/web/api/crypto/index.md
+++ b/files/en-us/web/api/crypto/index.md
@@ -25,14 +25,14 @@ It allows access to a cryptographically strong random number generator and to cr
 
 The [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) is accessed through the global {{domxref("crypto_property", "crypto")}} property, which is a `Crypto` object.
 
-## Properties
+## Instance properties
 
 _This interface implements properties defined on {{domxref("Crypto/getRandomValues", "RandomSource")}}._
 
 - {{domxref("Crypto.subtle")}} {{ReadOnlyInline}} {{SecureContext_inline}}
   - : Returns a {{domxref("SubtleCrypto")}} object providing access to common cryptographic primitives, like hashing, signing, encryption, or decryption.
 
-## Methods
+## Instance methods
 
 _This interface implements methods defined on {{domxref("Crypto/getRandomValues", "RandomSource")}}._
 

--- a/files/en-us/web/api/cryptokey/index.md
+++ b/files/en-us/web/api/cryptokey/index.md
@@ -23,7 +23,7 @@ The **`CryptoKey`** interface of the [Web Crypto API](/en-US/docs/Web/API/Web_Cr
 
 For security reasons, the `CryptoKey` interface can only be used in a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 
-## Properties
+## Instance properties
 
 - `CryptoKey.type`
 

--- a/files/en-us/web/api/cryptokeypair/index.md
+++ b/files/en-us/web/api/cryptokeypair/index.md
@@ -19,7 +19,7 @@ A `CryptoKeyPair` object can be obtained using {{domxref("SubtleCrypto.generateK
 
 It contains two properties, which are both [`CryptoKey`](/en-US/docs/Web/API/CryptoKey) objects: a `privateKey` property containing the private key and a `publicKey` property containing the public key.
 
-## Properties
+## Instance properties
 
 - `CryptoKeyPair.privateKey`
   - : A [`CryptoKey`](/en-US/docs/Web/API/CryptoKey) object representing the private key. For encryption and decryption algorithms, this key is used to decrypt. For signing and verification algorithms it is used to sign.

--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -15,20 +15,16 @@ browser-compat: api.CSS
 
 The **`CSS`** interface holds useful CSS-related methods. No objects with this interface are implemented: it contains only static methods and is therefore a utilitarian interface.
 
-## Properties
-
-_The CSS interface is a utility interface and no object of this type can be created: only static properties are defined on it._
-
-### Static properties
+## Static properties
 
 - {{DOMxRef("CSS.paintWorklet")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Provides access to the Worklet responsible for all the classes related to painting.
 
-## Methods
+## Instance properties
 
-_The CSS interface is a utility interface and no object of this type can be created: only static methods are defined on it._
+_The CSS interface is a utility interface and no object of this type can be created: only static properties are defined on it._
 
-### Static methods
+## Static methods
 
 _No inherited static methods_.
 
@@ -45,6 +41,10 @@ _No inherited static methods_.
     ```js
     CSS.em(3) // CSSUnitValue {value: 3, unit: "em"}
     ```
+
+## Instance methods
+
+_The CSS interface is a utility interface and no object of this type can be created: only static methods are defined on it._
 
 ## Specifications
 

--- a/files/en-us/web/api/cssanimation/index.md
+++ b/files/en-us/web/api/cssanimation/index.md
@@ -17,7 +17,7 @@ The **`CSSAnimation`** interface of the {{domxref('Web Animations API','','',' '
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 Inherits properties from its ancestor {{domxref("Animation")}} and adds {{domxref("animationName")}}.
 
@@ -28,7 +28,7 @@ Inherits properties from its ancestor {{domxref("Animation")}} and adds {{domxre
 
 No specific event handlers; inherits methods from its ancestor {{domxref("Animation")}}.
 
-## Methods
+## Instance methods
 
 No specific methods; inherits methods from its ancestor {{domxref("Animation")}}.
 

--- a/files/en-us/web/api/cssconditionrule/index.md
+++ b/files/en-us/web/api/cssconditionrule/index.md
@@ -18,14 +18,14 @@ Two objects derive from `CSSConditionRule`: {{domxref("CSSMediaRule")}} and {{do
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestors {{domxref("CSSRule")}} and {{domxref("CSSGroupingRule")}}._
 
 - {{domxref("CSSConditionRule.conditionText")}}
   - : Represents the text of the condition of the rule.
 
-## Methods
+## Instance methods
 
 No specific methods; inherits methods from its ancestors {{domxref("CSSRule")}} and {{domxref("CSSGroupingRule")}}.
 

--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -16,7 +16,7 @@ The **`CSSCounterStyleRule`** interface represents an {{CSSxRef("@counter-style"
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent {{DOMxRef("CSSRule")}}._
 
@@ -43,7 +43,7 @@ _This interface also inherits properties from its parent {{DOMxRef("CSSRule")}}.
 - {{DOMxRef("CSSCounterStyleRule.fallback")}}
   - : A string object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific method but inherits methods from its parent {{DOMxRef("CSSRule")}}._
 

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -17,14 +17,14 @@ The **`CSSFontFaceRule`** interface represents an {{cssxref("@font-face")}} [at-
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSFontFaceRule.style")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("CSSStyleDeclaration")}}.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssgroupingrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/index.md
@@ -16,14 +16,14 @@ The **`CSSGroupingRule`** interface of the [CSS Object Model](/en-US/docs/Web/AP
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("CSSRule")}}._
 
 - {{domxref("CSSGroupingRule.cssRules")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -21,11 +21,11 @@ The CSSImageValue object represents an [`<image>`](/en-US/docs/Web/CSS/image) th
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 _Inherits methods from {{domxref('CSSStyleValue')}}._
 

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -16,7 +16,7 @@ The **`CSSImportRule`** interface represents an {{cssxref("@import")}} [at-rule]
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -27,7 +27,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSImportRule.styleSheet")}} {{ReadOnlyInline}}
   - : Returns the associated stylesheet.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -17,7 +17,7 @@ The **`CSSKeyframeRule`** interface describes an object representing a set of st
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -26,7 +26,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSKeyframeRule.style")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("CSSStyleDeclaration")}} of the CSS style associated with the keyframe.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -17,7 +17,7 @@ The **`CSSKeyframesRule`** interface describes an object representing a complete
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -26,7 +26,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSKeyframesRule.cssRules")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("CSSRuleList")}} of the keyframes in the list.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -26,12 +26,12 @@ The interface instance name is a {{Glossary("stringifier")}} meaning that when u
 - {{domxref("CSSKeywordValue.CSSKeywordValue", "CSSKeywordValue()")}} {{Experimental_Inline}}
   - : Creates a new `CSSKeywordValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSKeywordValue.value')}} {{Experimental_Inline}}
   - : Returns or sets the value of the `CSSKeywordValue`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from {{domxref('CSSStyleValue')}}._
 

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -24,14 +24,18 @@ The **`CSSMathInvert`** interface of the {{domxref('CSS_Object_Model#css_typed_o
 - {{domxref("CSSMathInvert.CSSMathInvert", "CSSMathInvert()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathInvert` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathInvert.value')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericValue')}} object.
 
-## Methods
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -24,14 +24,18 @@ The **`CSSMathMax`** interface of the {{domxref('CSS_Object_Model#css_typed_obje
 - {{domxref("CSSMathMax.CSSMathMax", "CSSMathMax()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathMax` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathMax.values')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Methods
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -24,14 +24,18 @@ The **`CSSMathMin`** interface of the {{domxref('CSS_Object_Model#css_typed_obje
 - {{domxref("CSSMathMin.CSSMathMin", "CSSMathMin()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathMin` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathMin.values')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Methods
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/index.md
@@ -24,14 +24,18 @@ The **`CSSMathNegate`** interface of the {{domxref('CSS_Object_Model#css_typed_o
 - {{domxref("CSSMathNegate.CSSMathNegate", "CSSMathNegate()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathNegate` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathNegate.value')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericValue')}} object.
 
-## Methods
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -25,14 +25,18 @@ The **`CSSMathProduct`** interface of the {{domxref('CSS_Object_Model#css_typed_
 - {{domxref("CSSMathProduct.CSSMathProduct", "CSSMathProduct()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathProduct` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathProduct.values')}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-## Methods
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -26,18 +26,22 @@ A CSSMathSum is the object type returned when the [`StylePropertyMapReadOnly.get
 - {{domxref("CSSMathSum.CSSMathSum", "CSSMathSum()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMathSum` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathSum.values')}} {{Experimental_Inline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
-### Event handlers
+## Static methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+
+## Event handlers
 
 No
-
-## Methods
-
-None.
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -30,18 +30,22 @@ Below is a list of interfaces based on the CSSMathValue interface.
 - {{domxref('CSSMathProduct')}}
 - {{domxref('CSSMathSum')}}
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMathValue.operator')}} {{Experimental_Inline}}
   - : Indicates the operator that the current subtype represents.
 
-### Event handlers
+## Static methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
+
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
+
+## Event handlers
 
 No
-
-## Methods
-
-None.
 
 ## Examples
 

--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -25,7 +25,7 @@ The **`CSSMatrixComponent`** interface of the {{domxref('CSS_Object_Model#css_ty
 - {{domxref("CSSMatrixComponent.CSSMatrixComponent", "CSSMatrixComponent()")}} {{Experimental_Inline}}
   - : Creates a new `CSSMatrixComponent` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSMatrixComponent.matrix','matrix')}} {{Experimental_Inline}}
   - : A matrix.

--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -16,14 +16,14 @@ The **`CSSMediaRule`** interface represents a single CSS {{cssxref("@media")}} r
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestors {{domxref("CSSConditionRule")}}, {{domxref("CSSGroupingRule")}}, and {{domxref("CSSRule")}}._
 
 - {{domxref("CSSMediaRule.media")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("MediaList")}} representing the intended destination medium for style information.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestors {{domxref("CSSConditionRule")}}, {{domxref("CSSGroupingRule")}}, and {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -16,7 +16,7 @@ The **`CSSNamespaceRule`** interface describes an object representing a single C
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -25,7 +25,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSNamespaceRule.prefix")}}
   - : Returns a string with the name of the prefix associated to this namespace. If there is no such prefix, returns an empty string.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssnumericarray/index.md
+++ b/files/en-us/web/api/cssnumericarray/index.md
@@ -17,7 +17,7 @@ browser-compat: api.CSSNumericArray
 
 The **`CSSNumericArray`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} contains a list of {{domxref("CSSNumericValue")}} objects.
 
-## Properties
+## Instance properties
 
 - {{domxref("CSSNumericArray.length")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns how many {{domxref("CSSNumericValue")}} objects are contained within the `CSSNumericArray`.

--- a/files/en-us/web/api/cssnumericvalue/index.md
+++ b/files/en-us/web/api/cssnumericvalue/index.md
@@ -34,13 +34,16 @@ Below is a list of interfaces based on the CSSNumericValue interface.
 - {{domxref('CSSNumericArray')}}
 - {{domxref('CSSUnitValue')}}
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Static methods
 
-### Instance methods
+- {{domxref('CSSNumericValue.parse')}} {{Experimental_Inline}}
+  - : Allows a `CSSNumericValue` to be constructed directly from a string containing CSS.
+
+## Instance methods
 
 - {{domxref('CSSNumericValue.add')}} {{Experimental_Inline}}
   - : Adds a supplied number to the `CSSNumericValue`.
@@ -62,11 +65,6 @@ None.
   - : Converts an existing `CSSNumericValue` into a {{domxref("CSSMathSum")}} object with values of a specified unit.
 - {{domxref('CSSNumericValue.type')}} {{Experimental_Inline}}
   - : Returns the type of `CSSNumericValue`, one of `angle`, `flex`, `frequency`, `length`, `resolution`, `percent`, `percentHint`, or `time`.
-
-### Static methods
-
-- {{domxref('CSSNumericValue.parse')}} {{Experimental_Inline}}
-  - : Allows a `CSSNumericValue` to be constructed directly from a string containing CSS.
 
 ## Specifications
 

--- a/files/en-us/web/api/csspagerule/index.md
+++ b/files/en-us/web/api/csspagerule/index.md
@@ -16,7 +16,7 @@ browser-compat: api.CSSPageRule
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -25,7 +25,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSPageRule.style")}} {{ReadOnlyInline}}
   - : Returns the [declaration block](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block) associated with the at-rule.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/index.md
@@ -25,7 +25,7 @@ The **`CSSPerspective`** interface of the {{domxref('CSS_Object_Model#css_typed_
 - {{domxref("CSSPerspective.CSSPerspective", "CSSPerspective()")}} {{Experimental_Inline}}
   - : Creates a new `CSSPerspective` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSPerspective.length','length')}} {{Experimental_Inline}}
   - : Returns or sets the distance from z=0.

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -23,14 +23,14 @@ The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/
 - {{domxref("CSSPositionValue.CSSPositionValue", "CSSPositionValue()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Creates a new `CSSPositionValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSPositionValue.x')}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Returns the item's position along the web page's horizontal axis.
 - {{domxref('CSSPositionValue.y')}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Returns the item's position along the vertical axis.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/cssprimitivevalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/index.md
@@ -30,7 +30,7 @@ Conversions are allowed between absolute values (from millimeters to centimeters
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("CSSValue")}}_.
 
@@ -67,7 +67,7 @@ _Inherits properties from its parent, {{DOMxRef("CSSValue")}}_.
     | `CSS_UNKNOWN`    | The value is not a recognized CSS2 value. The value can only be obtained by using the {{DOMxRef("CSSValue.cssText", "cssText")}} attribute.                                  |
     | `CSS_URI`        | The value is a {{CSSxRef("url", "url()")}}. The value can be obtained by using the `getStringValue()` method.                                                                |
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("CSSPrimitiveValue.getCounterValue()")}} {{Deprecated_Inline}}
   - : This method is used to get the [counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) value. If this CSS value doesn't contain a counter value, a {{DOMxRef("DOMException")}} is raised. Modification to the corresponding style property can be achieved using the {{DOMxRef("Counter")}} interface.

--- a/files/en-us/web/api/csspropertyrule/index.md
+++ b/files/en-us/web/api/csspropertyrule/index.md
@@ -19,7 +19,7 @@ The **`CSSPropertyRule`** interface of the {{domxref('CSS_Properties_and_Values_
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -32,7 +32,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSPropertyRule.syntax")}} {{ReadOnlyInline}}
   - : Returns the literal syntax of the custom property.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/csspseudoelement/index.md
+++ b/files/en-us/web/api/csspseudoelement/index.md
@@ -18,14 +18,14 @@ The **`CSSPseudoElement`** interface represents a pseudo-element that may be the
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{DOMxRef('CSSPseudoElement.element')}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns the originating/parent {{DOMxRef('Element')}} of the pseudo-element.
 - {{DOMxRef('CSSPseudoElement.type')}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns the pseudo-element selector as a string.
 
-## Methods
+## Instance methods
 
 _`CSSPseudoElement` extends {{DOMxRef('EventTarget')}}, so it inherits the following methods:_
 

--- a/files/en-us/web/api/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/index.md
@@ -25,7 +25,7 @@ The **`CSSRotate`** interface of the {{domxref('CSS_Object_Model#css_typed_objec
 - {{domxref("CSSRotate.CSSRotate", "CSSRotate()")}} {{Experimental_Inline}}
   - : Creates a new `CSSRotate` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSRotate.x','x')}} {{Experimental_Inline}}
   - : Returns or sets the x-axis value.

--- a/files/en-us/web/api/cssrule/index.md
+++ b/files/en-us/web/api/cssrule/index.md
@@ -28,7 +28,7 @@ The **`CSSRule`** interface represents a single CSS rule. There are several type
 - {{DOMXRef("CSSFontFeatureValuesRule")}}
 - {{DOMXRef("CSSViewportRule")}}
 
-## Properties common to all CSSRule instances
+## Instance properties common to all CSSRule instances
 
 The `CSSRule` interface specifies the properties common to all rules, while properties unique to specific rule types are specified in the more specialized interfaces for those rules' respective types.
 

--- a/files/en-us/web/api/cssrule/index.md
+++ b/files/en-us/web/api/cssrule/index.md
@@ -28,7 +28,7 @@ The **`CSSRule`** interface represents a single CSS rule. There are several type
 - {{DOMXRef("CSSFontFeatureValuesRule")}}
 - {{DOMXRef("CSSViewportRule")}}
 
-## Instance properties common to all CSSRule instances
+## Instance properties
 
 The `CSSRule` interface specifies the properties common to all rules, while properties unique to specific rule types are specified in the more specialized interfaces for those rules' respective types.
 

--- a/files/en-us/web/api/cssrulelist/index.md
+++ b/files/en-us/web/api/cssrulelist/index.md
@@ -20,12 +20,12 @@ To edit the underlying rules returned by `CSSRule` objects, use {{domxref("CSSSt
 
 The interface has no constructor. An instance of `CSSRuleList` is returned by {{domxref("CSSStyleSheet.cssRules")}} and {{domxref("CSSKeyframesRule.cssRules")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("CSSRuleList.length")}} {{ReadOnlyInline}}
   - : Returns an integer representing the number of {{domxref("CSSRule")}} objects in the collection.
 
-## Methods
+## Instance methods
 
 - {{domxref("CSSRuleList.item()")}}
   - : Gets a single {{domxref("CSSRule")}}.

--- a/files/en-us/web/api/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/index.md
@@ -25,7 +25,7 @@ The **`CSSScale`** interface of the {{domxref('CSS_Object_Model#css_typed_object
 - {{domxref("CSSScale.CSSScale", "CSSScale()")}} {{Experimental_Inline}}
   - : Creates a new `CSSScale` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSScale.x','x')}} {{Experimental_Inline}}
   - : Returns or sets the x-axis value.

--- a/files/en-us/web/api/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/index.md
@@ -26,7 +26,7 @@ The **`CSSSkew`** interface of the {{domxref('CSS_Object_Model#css_typed_object_
 - {{domxref("CSSSkew.CSSSkew", "CSSSkew()")}} {{Experimental_Inline}}
   - : Creates a new `CSSSkew` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSSkew.ax','ax')}} {{Experimental_Inline}}
   - : Returns or sets the x-axis value.

--- a/files/en-us/web/api/cssskewx/index.md
+++ b/files/en-us/web/api/cssskewx/index.md
@@ -25,7 +25,7 @@ The **`CSSSkewX`** interface of the {{domxref('CSS_Object_Model#css_typed_object
 - {{domxref("CSSSkewX.CSSSkewX", "CSSSkewX()")}} {{Experimental_Inline}}
   - : Creates a new `CSSSkewX` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSSkewX.ax','ax')}} {{Experimental_Inline}}
   - : Returns or sets the x-axis value.

--- a/files/en-us/web/api/cssskewy/index.md
+++ b/files/en-us/web/api/cssskewy/index.md
@@ -25,14 +25,14 @@ The **`CSSSkewY`** interface of the {{domxref('CSS_Object_Model#css_typed_object
 - {{domxref("CSSSkewY.CSSSkewY", "CSSSkewY()")}} {{Experimental_Inline}}
   - : Creates a new `CSSSkewY` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor_ {{domxref("CSSTransformValue")}}.
 
 - {{domxref('CSSSkewY.ay','ay')}} {{Experimental_Inline}}
   - : Returns or sets the y-axis value.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor_ {{domxref("CSSTransformValue")}}.
 

--- a/files/en-us/web/api/cssstyledeclaration/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/index.md
@@ -37,7 +37,7 @@ A `CSSStyleDeclaration` object can be exposed using three different APIs:
 - {{DOMxRef("CSSStyleDeclaration.named_properties", '<code>CSSStyleDeclaration</code> named properties', "", 1)}}
   - : Dashed and camel-cased attributes for all supported CSS properties.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("CSSStyleDeclaration.getPropertyPriority()")}}
   - : Returns the optional priority, "important".

--- a/files/en-us/web/api/cssstylerule/index.md
+++ b/files/en-us/web/api/cssstylerule/index.md
@@ -17,7 +17,7 @@ The **`CSSStyleRule`** interface represents a single CSS style rule.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
@@ -28,7 +28,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 - {{domxref("CSSStyleRule.styleMap")}} {{ReadOnlyInline}}
   - : Returns a {{domxref('StylePropertyMap')}} object which provides access to the rule's property-value pairs.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestor {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/index.md
@@ -41,7 +41,7 @@ See the [Obtaining a StyleSheet](#obtaining_a_stylesheet) section for the variou
 - {{domxref("CSSStyleSheet.CSSStyleSheet()", "CSSStyleSheet()")}}
   - : Creates a new `CSSStyleSheet` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("StyleSheet")}}._
 
@@ -54,7 +54,7 @@ _Inherits properties from its parent, {{domxref("StyleSheet")}}._
 - {{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}
   - : If this stylesheet is imported into the document using an {{cssxref("@import")}} rule, the `ownerRule` property returns the corresponding {{domxref("CSSImportRule")}}; otherwise, this property's value is `null`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("StyleSheet")}}._
 

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -28,7 +28,7 @@ Below is a list of interfaces based on the `CSSStyleValue` interface.
 - {{domxref('CSSTransformValue')}}
 - {{domxref('CSSUnparsedValue')}}
 
-## Methods
+## Instance methods
 
 - {{domxref("CSSStyleValue.parse()")}} {{Experimental_Inline}}
   - : Sets a specific CSS property to the specified values and returns the first value as a {{domxref('CSSStyleValue')}} object.

--- a/files/en-us/web/api/csssupportsrule/index.md
+++ b/files/en-us/web/api/csssupportsrule/index.md
@@ -16,11 +16,11 @@ The **`CSSSupportsRule`** interface represents a single CSS {{cssxref("@supports
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestors {{domxref("CSSConditionRule")}}, {{domxref("CSSGroupingRule")}}, and {{domxref("CSSRule")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestors {{domxref("CSSConditionRule")}}, {{domxref("CSSGroupingRule")}}, and {{domxref("CSSRule")}}._
 

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -18,12 +18,12 @@ browser-compat: api.CSSTransformComponent
 
 The **`CSSTransformComponent`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface.
 
-## Properties
+## Instance properties
 
 - {{domxref("CSSTransformComponent.is2D")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a boolean indicting whether the transform is 2D or 3D.
 
-## Methods
+## Instance methods
 
 - {{domxref("CSSTransformComponent.toMatrix()")}} {{Experimental_Inline}}
   - : Returns a new {{domxref('DOMMatrix')}} object.

--- a/files/en-us/web/api/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/index.md
@@ -38,14 +38,14 @@ Below is a list of interfaces based on the `CSSTransformValue` interface.
 - {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}} {{Experimental_Inline}}
   - : Creates a new `CSSTransformValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("CSSTransformValue.length")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns how many transform components are contained within the `CSSTransformValue`.
 - {{domxref("CSSTransformValue.is2D")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a boolean indicating whether the transform is 2D or 3D.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its ancestor {{domxref('CSSStyleValue')}}._
 

--- a/files/en-us/web/api/csstransition/index.md
+++ b/files/en-us/web/api/csstransition/index.md
@@ -17,7 +17,7 @@ The **`CSSTransition`** interface of the {{domxref('Web Animations API','','',' 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 Inherits properties from its ancestor {{domxref("Animation")}} and adds {{domxref("transitionProperty")}}.
 
@@ -28,7 +28,7 @@ Inherits properties from its ancestor {{domxref("Animation")}} and adds {{domxre
 
 No specific event handlers; inherits methods from its ancestor {{domxref("Animation")}}.
 
-## Methods
+## Instance methods
 
 No specific methods; inherits methods from its ancestor {{domxref("Animation")}}.
 

--- a/files/en-us/web/api/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/index.md
@@ -25,7 +25,7 @@ The **`CSSTranslate`** interface of the {{domxref('CSS_Object_Model#css_typed_ob
 - {{domxref("CSSTranslate.CSSTranslate", "CSSTranslate()")}} {{Experimental_Inline}}
   - : Creates a new `CSSTranslate` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSTranslate.x','x')}} {{Experimental_Inline}}
   - : Returns or sets the x-axis value.

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -24,18 +24,22 @@ The **`CSSUnitValue`** interface of the {{domxref('CSS_Object_Model#css_typed_ob
 - {{domxref("CSSUnitValue.CSSUnitValue", "CSSUnitValue()")}} {{Experimental_Inline}}
   - : Creates a new `CSSUnitValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSUnitValue.value')}} {{Experimental_Inline}}
   - : Returns a double indicating the number of units.
 - {{domxref('CSSUnitValue.unit')}} {{Experimental_Inline}}
   - : Returns a string indicating the type of unit.
 
-### Event handlers
+## Static methods
 
-None.
+_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
 
-## Methods
+## Instance methods
+
+_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
+
+## Event handlers
 
 None.
 

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -27,12 +27,12 @@ Custom properties are represented by `CSSUnparsedValue` and {{cssxref('var()')}}
 - {{domxref("CSSUnparsedValue.CSSUnparsedValue", "CSSUnparsedValue()")}} {{Experimental_Inline}}
   - : Creates a new `CSSUnparsedValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSUnparsedValue.length')}} {{Experimental_Inline}}
   - : Returns the number of items in the `CSSUnparsedValue` object.
 
-## Methods
+## Instance methods
 
 - {{domxref('CSSUnparsedValue.entries()')}} {{Experimental_Inline}}
   - : Returns an array of a given object's own enumerable property `[key, value]` pairs in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).

--- a/files/en-us/web/api/cssvalue/index.md
+++ b/files/en-us/web/api/cssvalue/index.md
@@ -25,7 +25,7 @@ The **`CSSValue`** interface represents the current computed value of a CSS prop
 > - the untyped [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model), widely supported, or
 > - the modern [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API), less supported and considered experimental.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("CSSValue.cssText")}} {{Deprecated_Inline}}
   - : A string representing the current value.

--- a/files/en-us/web/api/cssvaluelist/index.md
+++ b/files/en-us/web/api/cssvaluelist/index.md
@@ -30,14 +30,14 @@ The items in the `CSSValueList` are accessible via an integral index, starting f
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("CSSValue")}}_.
 
 - {{DOMxRef("CSSValueList.length")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : An `unsigned long` representing the number of `CSSValues` in the list.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("CSSValueList.item()")}} {{Deprecated_Inline}}
   - : This method is used to retrieve a {{DOMxRef("CSSValue")}} by ordinal index. The order in this collection represents the order of the values in the CSS style property. If index is greater than or equal to the number of values in the list, this returns `null`.

--- a/files/en-us/web/api/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.md
@@ -22,14 +22,14 @@ The **`CSSVariableReferenceValue`** interface of the {{domxref('CSS_Object_Model
 - {{domxref("CSSVariableReferenceValue.CSSVariableReferenceValue", "CSSVariableReferenceValue()")}} {{Experimental_Inline}}
   - : Creates a new `CSSVariableReferenceValue` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('CSSVariableReferenceValue.variable')}} {{Experimental_Inline}}
   - : Returns the custom name passed to the constructor.
 - {{domxref('CSSVariableReferenceValue.fallback')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the built-in CSS value for the custom name.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/customelementregistry/index.md
+++ b/files/en-us/web/api/customelementregistry/index.md
@@ -15,7 +15,7 @@ browser-compat: api.CustomElementRegistry
 
 The **`CustomElementRegistry`** interface provides methods for registering custom elements and querying registered elements. To get an instance of it, use the {{domxref("window.customElements")}} property.
 
-## Methods
+## Instance methods
 
 - {{domxref("CustomElementRegistry.define()")}}
   - : Defines a new [custom element](/en-US/docs/Web/Web_Components/Using_custom_elements).

--- a/files/en-us/web/api/customevent/index.md
+++ b/files/en-us/web/api/customevent/index.md
@@ -21,14 +21,14 @@ The **`CustomEvent`** interface represents events initialized by an application 
 - {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}
   - : Creates a new `CustomEvent`.
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from its parent, {{domxref("Event")}}._
 
 - {{domxref("CustomEvent.detail")}} {{ReadOnlyInline}}
   - : Returns any data passed when initializing the event.
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -29,12 +29,12 @@ States are stored as a `<dashed-ident>` as this format can then be accessed from
 In the same way that you can use CSS to determine if a checkbox is checked using the {{cssxref(":checked")}} pseudo-class,
 you can use a custom state pseudo-class to select a custom element that is in a certain state.
 
-## Properties
+## Instance properties
 
 - {{domxref("CustomStateSet.size")}} {{Experimental_Inline}}
   - : Returns the number of values in the `CustomStateSet`.
 
-## Methods
+## Instance methods
 
 - {{domxref("CustomStateSet.add()")}} {{Experimental_Inline}}
   - : Adds a value to the set, first checking that the _value_ is a `<dashed-ident>`.


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with B and C

Moved to have consistent headings and ordering.