### PR TITLE
Web AP methods/props sorted to static/instance headings - DEF

### DIFF
--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -25,7 +25,7 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
 - {{domxref("DataTransfer.DataTransfer","DataTransfer()")}}
   - : Creates and returns a new `DataTransfer` object.
 
-## Properties
+## Instance properties
 
 ### Standard properties
 
@@ -58,7 +58,7 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
 - {{domxref("DataTransfer.mozItemCount")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Gives the number of items in the drag operation. Removed in Firefox 71.
 
-## Methods
+## Instance methods
 
 ### Standard methods
 

--- a/files/en-us/web/api/datatransferitem/index.md
+++ b/files/en-us/web/api/datatransferitem/index.md
@@ -19,14 +19,14 @@ The **`DataTransferItem`** object represents one drag data item. During a _drag 
 
 This interface has no constructor.
 
-## Properties
+## Instance properties
 
 - {{domxref("DataTransferItem.kind")}} {{ReadOnlyInline}}
   - : The _kind_ of drag data item, `string` or `file`.
 - {{domxref("DataTransferItem.type")}} {{ReadOnlyInline}}
   - : The drag data item's type, typically a MIME type.
 
-## Methods
+## Instance methods
 
 - {{domxref("DataTransferItem.getAsFile()")}}
   - : Returns the {{domxref("File")}} object associated with the drag data item (or null if the drag item is not a file).

--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -21,12 +21,12 @@ The individual items can be accessed using the [array operator](/en-US/docs/Web/
 
 This interface has no constructor.
 
-## Properties
+## Instance properties
 
 - {{domxref("DataTransferItemList.length")}} {{ReadOnlyInline}}
   - : An `unsigned long` that is the number of drag items in the list.
 
-## Methods
+## Instance methods
 
 - {{domxref("DataTransferItemList.add()")}}
   - : Adds an item (either a {{domxref("File")}} object or a string) to the drag item list and returns a {{domxref("DataTransferItem")}} object for the new item.

--- a/files/en-us/web/api/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/index.md
@@ -19,7 +19,7 @@ The **`DecompressionStream`** interface of the {{domxref('Compression Streams AP
 - {{domxref("DecompressionStream.DecompressionStream", "DecompressionStream()")}}
   - : Creates a new `DecompressionStream`
 
-## Properties
+## Instance properties
 
 - {{domxref("DecompressionStream.readable")}}
   - : Returns the {{domxref("ReadableStream")}} instance controlled by this object.

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -18,14 +18,14 @@ The **`DedicatedWorkerGlobalScope`** object (the {{domxref("Worker")}} global sc
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 
 - {{domxref("DedicatedWorkerGlobalScope.name")}} {{ReadOnlyInline}}
   - : The name that the {{domxref("Worker")}} was (optionally) given when it was created using the {{domxref("Worker.Worker", "Worker()")}} constructor. This is mainly useful for debugging purposes.
 
-### Properties inherited from WorkerGlobalScope
+### Instance properties inherited from WorkerGlobalScope
 
 - {{domxref("WorkerGlobalScope.self")}}
   - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
@@ -38,7 +38,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/delaynode/index.md
+++ b/files/en-us/web/api/delaynode/index.md
@@ -54,14 +54,14 @@ When creating a graph that has a cycle, it is mandatory to have at least one `De
 - {{domxref("DelayNode.DelayNode", "DelayNode()")}}
   - : Creates a new instance of an DelayNode object instance. As an alternative, you can use the {{domxref("BaseAudioContext.createDelay()")}} factory method; see [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}._
 
 - {{domxref("DelayNode.delayTime")}} {{ReadOnlyInline}}
   - : An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the amount of delay to apply, specified in seconds.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its parent, {{domxref("AudioNode")}}._
 

--- a/files/en-us/web/api/deprecationreportbody/index.md
+++ b/files/en-us/web/api/deprecationreportbody/index.md
@@ -24,7 +24,7 @@ A deprecation report is generated when a deprecated feature (for example a depre
 
 An instance of `DeprecationReportBody` is returned as the value of {{domxref("Report.body")}} when {{domxref("Report.Type")}} is `deprecation`. The interface has no constructor.
 
-## Properties
+## Instance properties
 
 This interface also inherits properties from {{domxref("ReportBody")}}.
 
@@ -41,7 +41,7 @@ This interface also inherits properties from {{domxref("ReportBody")}}.
 - {{domxref("DeprecationReportBody.columnNumber")}} {{experimental_inline}}
   - : A number representing the column in the source file in which the deprecated feature was used, if known, or `null` otherwise.
 
-## Methods
+## Instance methods
 
 This interface also inherits methods from {{domxref("ReportBody")}}.
 

--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -27,7 +27,7 @@ The **`DeviceMotionEvent`** interface provides web developers with information a
 - {{domxref("DeviceMotionEvent.DeviceMotionEvent", "DeviceMotionEvent()")}}
   - : Creates a new `DeviceMotionEvent`.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("DeviceMotionEvent.acceleration")}} {{ReadOnlyInline}}
   - : An object giving the acceleration of the device on the three axis X, Y and Z. Acceleration is expressed in [m/s²](https://en.wikipedia.org/wiki/Meter_per_second_squared).

--- a/files/en-us/web/api/devicemotioneventacceleration/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/index.md
@@ -14,7 +14,7 @@ browser-compat: api.DeviceMotionEventAcceleration
 
 The **`DeviceMotionEventAcceleration`** object provides information about the amount of acceleration the device is experiencing along all three axes.
 
-## Properties
+## Instance properties
 
 - {{domxref("DeviceMotionEventAcceleration.x")}} {{ReadOnlyInline}}
   - : The amount of acceleration along the X axis.

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.md
@@ -14,7 +14,7 @@ browser-compat: api.DeviceMotionEventRotationRate
 
 A `DeviceMotionEventRotationRate` object provides information about the rate at which the device is rotating around all three axes.
 
-## Properties
+## Instance properties
 
 - {{ domxref("DeviceMotionEventRotationRate.alpha") }} {{ReadOnlyInline}}
   - : The amount of rotation around the Z axis, in degrees per second.

--- a/files/en-us/web/api/deviceorientationevent/index.md
+++ b/files/en-us/web/api/deviceorientationevent/index.md
@@ -20,7 +20,7 @@ The **`DeviceOrientationEvent`** object provides web developers with information
 - {{domxref("DeviceOrientationEvent.DeviceOrientationEvent","DeviceOrientationEvent.DeviceOrientationEvent()")}}
   - : Creates a new `DeviceOrientationEvent`.
 
-## Properties
+## Instance properties
 
 - {{domxref("DeviceOrientationEvent.absolute")}} {{ReadOnlyInline}}
   - : A boolean that indicates whether or not the device is providing orientation data absolutely.

--- a/files/en-us/web/api/deviceproximityevent/index.md
+++ b/files/en-us/web/api/deviceproximityevent/index.md
@@ -18,7 +18,7 @@ browser-compat: api.DeviceProximityEvent
 
 The **`DeviceProximityEvent`** interface provides information about the distance of a nearby physical object using the proximity sensor of a device.
 
-## Properties
+## Instance properties
 
 - `DeviceProximityEvent.max` {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The maximum sensing distance the sensor is able to report, in centimeters.

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -46,7 +46,7 @@ const dirEntry = fs.root.getDirectory('project_dir', {create: true});
 - <a href="#getdirectory">getDirectory()</a>
 - <a href="#removerecursively">removeRecursively()</a>
 
-## Methods
+## Instance methods
 
 ### createReader()
 

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -26,7 +26,7 @@ The `Document` interface describes the common properties and methods for any kin
 - {{DOMxRef("Document.Document", "Document()")}}
   - : Creates a new `Document` object.
 
-## Properties
+## Instance properties
 
 _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventTarget")}} interfaces._
 
@@ -174,7 +174,7 @@ _The `Document` interface for HTML documents inherits from the {{DOMxRef("HTMLDo
 - {{DOMxRef("Document.xmlVersion")}} {{Deprecated_Inline}}
   - : Returns the version number as specified in the XML declaration or `"1.0"` if the declaration is absent.
 
-## Methods
+## Instance methods
 
 _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventTarget")}} interfaces._
 

--- a/files/en-us/web/api/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/index.md
@@ -25,7 +25,7 @@ It is used as a lightweight version of {{domxref("Document")}} that stores a seg
 - {{ domxref("DocumentFragment.DocumentFragment()", "DocumentFragment()") }}
   - : Creates and returns a new `DocumentFragment` object.
 
-## Properties
+## Instance properties
 
 _This interface has no specific properties, but inherits those of its parent, {{domxref("Node")}}._
 
@@ -38,7 +38,7 @@ _This interface has no specific properties, but inherits those of its parent, {{
 - {{ domxref("DocumentFragment.lastElementChild") }} {{ReadOnlyInline}}
   - : Returns the {{domxref("Element")}} that is the last child of the `DocumentFragment` object, or `null` if there is none.
 
-## Methods
+## Instance methods
 
 _This interface inherits the methods of its parent, {{domxref("Node")}}._
 

--- a/files/en-us/web/api/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/index.md
@@ -26,7 +26,7 @@ The **`DocumentTimeline`** interface of the [Web Animations API](/en-US/docs/Web
 - {{domxref("DocumentTimeline.DocumentTimeline", "DocumentTimeline()")}}
   - : Creates a new `DocumentTimeline` object associated with the active document of the current browsing context.
 
-## Properties
+## Instance properties
 
 _This interface inherits its property from its parent, {{domxref("AnimationTimeline")}}._
 

--- a/files/en-us/web/api/documenttype/index.md
+++ b/files/en-us/web/api/documenttype/index.md
@@ -16,7 +16,7 @@ The **`DocumentType`** interface represents a {{domxref("Node")}} containing a d
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("Node")}}._
 
@@ -31,7 +31,7 @@ _Inherits properties from its parent, {{domxref("Node")}}._
 - {{domxref("DocumentType.systemId")}} {{ReadOnlyInline}}
   - : A string, eg `"http://www.w3.org/TR/html4/strict.dtd"`, now an empty string for HTML.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Node")}}._
 

--- a/files/en-us/web/api/domerror/index.md
+++ b/files/en-us/web/api/domerror/index.md
@@ -16,7 +16,7 @@ browser-compat: api.DOMError
 
 The **`DOMError`** interface describes an error object that contains an error name.
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMError.name")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : Returns a string representing one of the error type names (see below).

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -27,7 +27,7 @@ Each exception has a **name**, which is a short "PascalCase"-style string identi
 - {{domxref("DOMException.DOMException()", "DOMException()")}}
   - : Returns a `DOMException` object with a specified message and name.
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMException.code")}} {{deprecated_inline}} {{ReadOnlyInline}}
   - : Returns one of the legacy error code constants, or `0` if none match.

--- a/files/en-us/web/api/domhighrestimestamp/index.md
+++ b/files/en-us/web/api/domhighrestimestamp/index.md
@@ -47,7 +47,7 @@ event.timeStamp;
 
 In Firefox, you can also enable `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
-## Properties
+## Instance properties
 
 _This type has no properties. It is a double-precision floating-point value._
 
@@ -68,7 +68,7 @@ The **time origin** is a standard time which is considered to be the beginning o
 - If the script's global object is a {{domxref("WorkerGlobalScope")}} (that is, the script is running as a web worker), the time origin is the moment at which the worker was created.
 - In all other cases, the time origin is undefined.
 
-## Methods
+## Instance methods
 
 _This type has no methods._
 

--- a/files/en-us/web/api/domimplementation/index.md
+++ b/files/en-us/web/api/domimplementation/index.md
@@ -18,7 +18,7 @@ The **`DOMImplementation`** interface represents an object providing methods whi
 
 _This interface has no specific property and doesn't inherit any._
 
-## Methods
+## Instance methods
 
 _No inherited method._
 

--- a/files/en-us/web/api/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/index.md
@@ -31,7 +31,7 @@ This interface should be available inside [web workers](/en-US/docs/Web/API/Web_
 - {{domxref("DOMMatrix.DOMMatrix","DOMMatrix()")}}
   - : Creates and returns a new `DOMMatrix` object.
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from {{domxref("DOMMatrixReadOnly")}}, though some of these properties are altered to be mutable._
 
@@ -54,7 +54,7 @@ _This interface inherits properties from {{domxref("DOMMatrixReadOnly")}}, thoug
     | `e`  | `m41`           |
     | `f`  | `m42`           |
 
-## Methods
+## Instance methods
 
 _This interface includes the following methods, as well as the methods it inherits from {{domxref("DOMMatrixReadOnly")}}._
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -19,7 +19,7 @@ This interface should be available inside [web workers](/en-US/docs/Web/API/Web_
 - {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}}
   - : Creates a new `DOMMatrixReadOnly` object.
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any properties._
 
@@ -42,7 +42,7 @@ _This interface doesn't inherit any properties._
     | `e` | `m41`         |
     | `f` | `m42`         |
 
-## Methods
+## Instance methods
 
 _This interface doesn't inherit any methods. None of the following methods alter the original matrix._
 

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -41,7 +41,7 @@ from a URL-addressable resource, returning a `Document` in its
 - {{domxref("DOMParser.DOMParser","DOMParser()")}}
   - : Creates a new `DOMParser` object.
 
-## Methods
+## Instance methods
 
 - {{domxref("DOMParser.parseFromString()")}}
   - : Parses a string using either the HTML parser or the XML parser, returning an {{domxref("HTMLDocument")}} or {{domxref("XMLDocument")}}.

--- a/files/en-us/web/api/dompoint/index.md
+++ b/files/en-us/web/api/dompoint/index.md
@@ -30,18 +30,9 @@ In general, a positive `x` component represents a position to the right of the o
 - {{domxref("DOMPoint.DOMPoint","DOMPoint()")}}
   - : Creates and returns a new `DOMPoint` object given the values of zero or more of its coordinate components and optionally the `w` perspective value. You can also use an existing `DOMPoint` or `DOMPointReadOnly` or an object to create a new point by calling the {{domxref("DOMPoint.fromPoint()")}} static method.
 
-## Methods
+## Instance properties
 
-_`DOMPoint` inherits methods from its parent, {{domxref("DOMPointReadOnly")}}._
-
-## Static methods
-
-- {{domxref("DOMPoint.fromPoint()", "DOMPoint.fromPoint()")}}
-  - : Creates a new mutable `DOMPoint` object given an existing point (or an object containing matching properties) which provides the values for its properties.
-
-## Properties
-
-_`DOMPoint` inherits properties from its parent, {{domxref("DOMPointReadOnly")}}._
+_`DOMPoint` may also inherit properties from its parent, {{domxref("DOMPointReadOnly")}}._
 
 - {{domxref("DOMPoint.x")}}
   - : The `x` coordinate of the `DOMPoint`.
@@ -51,6 +42,17 @@ _`DOMPoint` inherits properties from its parent, {{domxref("DOMPointReadOnly")}}
   - : The `z` coordinate of the `DOMPoint`.
 - {{domxref("DOMPoint.w")}}
   - : The perspective value of the `DOMPoint`.
+
+## Instance methods
+
+_`DOMPoint` inherits instance methods from its parent, {{domxref("DOMPointReadOnly")}}._
+
+## Static methods
+
+_`DOMPoint` may also inherit static methods from its parent, {{domxref("DOMPointReadOnly")}}._
+
+- {{domxref("DOMPoint.fromPoint()", "DOMPoint.fromPoint()")}}
+  - : Creates a new mutable `DOMPoint` object given an existing point (or an object containing matching properties) which provides the values for its properties.
 
 ## Examples
 

--- a/files/en-us/web/api/dompointreadonly/index.md
+++ b/files/en-us/web/api/dompointreadonly/index.md
@@ -46,7 +46,7 @@ const point = DOMPointReadOnly.fromPoint({x: 100, y: 100, z: 50, w: 1.0});
 - {{domxref("DOMPointReadOnly.DOMPointReadOnly","DOMPointReadOnly()")}}
   - : Creates a new `DOMPointReadOnly` object given the values of its coordinates and perspective. To create a point using an object, you can instead use {{domxref("DOMPointReadOnly.fromPoint()")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMPointReadOnly.x")}} {{ReadOnlyInline}}
   - : The point's horizontal coordinate, `x`.
@@ -62,7 +62,7 @@ const point = DOMPointReadOnly.fromPoint({x: 100, y: 100, z: 50, w: 1.0});
 - {{domxref("DOMPointReadOnly.fromPoint()")}}
   - : A static method that creates a new `DOMPointReadOnly` object given the coordinates provided in the specified object.
 
-## Methods
+## Instance methods
 
 - {{domxref("DOMPointReadOnly.matrixTransform", "matrixTransform()")}}
   - : Applies a matrix transform specified as an object to the `DOMPointReadOnly` object.

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -20,12 +20,12 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 - {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}}
   - : Creates a new `DOMQuad` object.
 
-## Properties
+## Instance properties
 
 - p1,p2,p3,p4 {{ReadOnlyInline}}
   - : are {{domxref("DOMPoint")}} objects for each of the `DOMQuad` object's four corners.
 
-## Methods
+## Instance methods
 
 - {{domxref("DOMQuad.fromRect()")}}
   - : Returns a new `DOMQuad` object based on the passed set of coordinates.

--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -29,7 +29,7 @@ It inherits from its parent, {{domxref("DOMRectReadOnly")}}.
 - {{domxref("DOMRect.DOMRect","DOMRect()")}}
   - : Creates a new `DOMRect` object.
 
-## Properties
+## Instance properties
 
 _`DOMRect` inherits properties from its parent, {{domxref("DOMRectReadOnly")}}. The difference is that they are not read-only anymore._
 
@@ -50,14 +50,16 @@ _`DOMRect` inherits properties from its parent, {{domxref("DOMRectReadOnly")}}. 
 - {{domxref("DOMRectReadOnly.left")}}
   - : Returns the left coordinate value of the `DOMRect` (has the same value as `x`, or `x + width` if `width` is negative).
 
-## Methods
-
-_`DOMRect` inherits methods from its parent, {{domxref("DOMRectReadOnly")}}._
-
 ## Static methods
+
+_`DOMRect` may also inherit static methods from its parent, {{domxref("DOMRectReadOnly")}}._
 
 - {{domxref("DOMRect.fromRect()")}}
   - : Creates a new `DOMRect` object with a given location and dimensions.
+
+## Instance methods
+
+_`DOMRect` may inherit methods from its parent, {{domxref("DOMRectReadOnly")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/index.md
@@ -23,7 +23,7 @@ The **`DOMRectReadOnly`** interface specifies the standard properties used by {{
 - {{domxref("DOMRectReadOnly.DOMRectReadOnly","DOMRectReadOnly()")}}
   - : Defined to create a new `DOMRectReadOnly` object. Note that this constructor cannot be called by 3rd party JavaScript; doing so returns an `"Illegal constructor"` {{jsxref('TypeError')}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMRectReadOnly.x")}} {{ReadOnlyInline}}
   - : The x coordinate of the `DOMRect`'s origin.

--- a/files/en-us/web/api/domstringlist/index.md
+++ b/files/en-us/web/api/domstringlist/index.md
@@ -14,12 +14,12 @@ browser-compat: api.DOMStringList
 
 A type returned by some APIs which contains a list of [DOMString](/en-US/docs/Web/API/DOMString) (strings).
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMStringList.length")}} {{ReadOnlyInline}}
   - : Returns the length of the list.
 
-## Methods
+## Instance methods
 
 - {{domxref("DOMStringList.item()")}}
   - : Returns a string.

--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -14,14 +14,14 @@ The **`DOMTokenList`** interface represents a set of space-separated tokens. Suc
 
 A `DOMTokenList` is indexed beginning with `0` as with JavaScript {{jsxref("Array")}} objects. `DOMTokenList` is always case-sensitive.
 
-## Properties
+## Instance properties
 
 - {{domxref("DOMTokenList.length")}} {{ReadOnlyInline}}
   - : An `integer` representing the number of objects stored in the object.
 - {{domxref("DOMTokenList.value")}}
   - : A {{Glossary("stringifier")}} property that returns the value of the list as a string.
 
-## Methods
+## Instance methods
 
 - {{domxref("DOMTokenList.item()")}}
   - : Returns the item in the list by its index, or `null` if the index is greater than or equal to the list's `length`.

--- a/files/en-us/web/api/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/index.md
@@ -18,7 +18,7 @@ This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref(
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref('DragEvent.dataTransfer')}} {{ReadOnlyInline}}
   - : The data that is transferred during a drag and drop interaction.

--- a/files/en-us/web/api/dynamicscompressornode/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/index.md
@@ -49,7 +49,7 @@ The `DynamicsCompressorNode` interface provides a compression effect, which lowe
 - {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
   - : Creates a new instance of an `DynamicsCompressorNode` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -66,7 +66,7 @@ _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 - {{domxref("DynamicsCompressorNode.release")}} {{ReadOnlyInline}}
   - : A [k-rate](/en-US/docs/Web/API/AudioParam#k-rate) {{domxref("AudioParam")}} representing the amount of time, in seconds, required to increase the gain by 10 dB.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.md
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.md
@@ -19,7 +19,7 @@ ECDH enables two people who each have a key pair consisting of a public and a pr
 
 The parameters for ECDH `deriveKey()` therefore include the other entity's public key, which is combined with this entity's private key to derive the shared secret.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `ECDH`.

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -17,7 +17,7 @@ browser-compat:
 
 The **`EcdsaParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.sign()")}} or {{domxref("SubtleCrypto.verify()")}} when using the [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) algorithm.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `ECDSA`.

--- a/files/en-us/web/api/eckeygenparams/index.md
+++ b/files/en-us/web/api/eckeygenparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams
 
 The **`EcKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams
 
 The **`EcKeyImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -23,7 +23,7 @@ Languages outside the realm of the Web platform, like XUL through the `XULElemen
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, and by extension that interface's parent, {{DOMxRef("EventTarget")}}._
 
@@ -94,7 +94,7 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 - {{DOMxRef("Element.tagName")}} {{ReadOnlyInline}}
   - : Returns a string with the name of the tag for the given element.
 
-### Properties included from ARIA
+### Instance properties included from ARIA
 
 _The `Element` interface includes the following properties, defined on the `ARIAMixin` mixin._
 
@@ -179,7 +179,7 @@ _The `Element` interface includes the following properties, defined on the `ARIA
 - {{domxref("Element.ariaValueText")}}
   - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
-## Methods
+## Instance methods
 
 _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own parent, {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -18,7 +18,7 @@ The **`ElementInternals`** interface of the [Document Object Model](/en-US/docs/
 
 This interface has no constructor. An `ElementInternals` object is returned when calling {{domxref("HTMLElement.attachInternals()")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("ElementInternals.shadowRoot")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("ShadowRoot")}} object associated with this element.
@@ -36,7 +36,7 @@ This interface has no constructor. An `ElementInternals` object is returned when
 - {{domxref("ElementInternals.labels")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("NodeList")}} of all of the label elements associated with this element.
 
-### Properties included from ARIA
+### Instance properties included from ARIA
 
 The `ElementInternals` interface includes the following properties, defined on the `ARIAMixin` mixin.
 
@@ -125,7 +125,7 @@ The `ElementInternals` interface includes the following properties, defined on t
 - {{domxref("ElementInternals.ariaValueText")}}
   - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
-## Methods
+## Instance methods
 
 - {{domxref("ElementInternals.setFormValue()")}}
   - : Sets the element's submission value and state, communicating these to the user agent.

--- a/files/en-us/web/api/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/index.md
@@ -20,7 +20,7 @@ The **`EncodedAudioChunk`** interface of the {{domxref('WebCodecs API','','',' '
 - {{domxref("EncodedAudioChunk.EncodedAudioChunk", "EncodedAudioChunk()")}} {{Experimental_Inline}}
   - : Creates a new `EncodedAudioChunk` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("EncodedAudioChunk.type")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a string indicating whether this chunk of data is a key chunk.
@@ -31,7 +31,7 @@ The **`EncodedAudioChunk`** interface of the {{domxref('WebCodecs API','','',' '
 - {{domxref("EncodedAudioChunk.byteLength")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an integer representing the length of the audio in bytes.
 
-## Methods
+## Instance methods
 
 - {{domxref("EncodedAudioChunk.copyTo()")}} {{Experimental_Inline}}
   - : Copies the encoded audio data.

--- a/files/en-us/web/api/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/index.md
@@ -20,7 +20,7 @@ The **`EncodedVideoChunk`** interface of the {{domxref('WebCodecs API','','',' '
 - {{domxref("EncodedVideoChunk.EncodedVideoChunk", "EncodedVideoChunk()")}} {{Experimental_Inline}}
   - : Creates a new `EncodedVideoChunk` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("EncodedVideoChunk.type")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a string indicating whether this chunk of data is a key chunk.
@@ -31,7 +31,7 @@ The **`EncodedVideoChunk`** interface of the {{domxref('WebCodecs API','','',' '
 - {{domxref("EncodedVideoChunk.byteLength")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an integer representing the length of the video in bytes.
 
-## Methods
+## Instance methods
 
 - {{domxref("EncodedVideoChunk.copyTo()")}} {{Experimental_Inline}}
   - : Copies the encoded video data.

--- a/files/en-us/web/api/errorevent/index.md
+++ b/files/en-us/web/api/errorevent/index.md
@@ -15,7 +15,7 @@ The **`ErrorEvent`** interface represents events providing information related t
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
@@ -35,7 +35,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
 - {{domxref("ErrorEvent.ErrorEvent", "ErrorEvent()")}}
   - : Creates an `ErrorEvent` event with the given parameters.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -80,7 +80,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("Event.Event", "Event()")}}
   - : Creates an `Event` object, returning it to the caller.
 
-## Properties
+## Instance properties
 
 - {{domxref("Event.bubbles")}} {{ReadOnlyInline}}
   - : A boolean value indicating whether or not the event bubbles up through the DOM.
@@ -118,7 +118,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("Event.srcElement")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : An alias (from old versions of Microsoft Internet Explorer) for {{domxref("Event.target")}}. Use {{domxref("Event.target")}} instead.
 
-## Methods
+## Instance methods
 
 - {{domxref("Event.composedPath()")}}
   - : Returns the event's path (an array of objects on which listeners will be invoked). This does not include nodes in shadow trees if the shadow root was created with its {{domxref("ShadowRoot.mode")}} closed.

--- a/files/en-us/web/api/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/index.md
@@ -33,7 +33,7 @@ Unlike [WebSockets](/en-US/docs/Web/API/WebSockets_API), server-sent events are 
 - {{domxref("EventSource.EventSource", "EventSource()")}}
   - : Creates a new `EventSource` to handle receiving server-sent events from a specified URL, optionally in credentials mode.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("EventTarget")}}._
 
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("EventTarget
 - {{domxref("EventSource.withCredentials")}} {{ReadOnlyInline}}
   - : A boolean value indicating whether the `EventSource` object was instantiated with cross-origin ([CORS](/en-US/docs/Web/HTTP/CORS)) credentials set (`true`), or not (`false`, the default).
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.md
@@ -47,7 +47,7 @@ This extension exposes seven new constants.
 - `ext.GPU_DISJOINT_EXT`
   - : A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the GPU performed any disjoint operation.
 
-## Methods
+## Instance methods
 
 This extension exposes eight new methods.
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -29,7 +29,7 @@ Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are
 - {{domxref("ExtendableCookieChangeEvent.ExtendableCookieChangeEvent", "ExtendableCookieChangeEvent()")}}
   - : Creates a new `ExtendableCookieChangeEvent`.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("ExtendableEvent")}}._
 

--- a/files/en-us/web/api/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/index.md
@@ -33,11 +33,11 @@ This interface inherits from the {{domxref("Event")}} interface.
 - {{domxref("ExtendableEvent.ExtendableEvent()", "ExtendableEvent()")}}
   - : Creates a new `ExtendableEvent` object.
 
-## Properties
+## Instance properties
 
 _Doesn't implement any specific properties, but inherits properties from its parent, {{domxref("Event")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/index.md
@@ -24,7 +24,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 - {{domxref("ExtendableMessageEvent.ExtendableMessageEvent","ExtendableMessageEvent()")}}
   - : Creates a new `ExtendableMessageEvent` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("ExtendableEvent")}}_.
 
@@ -39,7 +39,7 @@ _Inherits properties from its parent, {{domxref("ExtendableEvent")}}_.
 - {{domxref("ExtendableMessageEvent.ports")}} {{ReadOnlyInline}}
   - : Returns the array containing the {{domxref("MessagePort")}} objects representing the ports of the associated message channel.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("ExtendableEvent")}}_.
 

--- a/files/en-us/web/api/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/index.md
@@ -21,7 +21,7 @@ The **`EyeDropper`** interface represents an instance of an eyedropper tool that
 - {{DOMxRef("EyeDropper.EyeDropper", "EyeDropper()")}} {{Experimental_Inline}}
   - : Returns a new `EyeDropper` instance.
 
-## Methods
+## Instance methods
 
 _The `EyeDropper` interface doesn't inherit any methods_.
 

--- a/files/en-us/web/api/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/index.md
@@ -26,7 +26,7 @@ In browsers that support it, an instance of this interface may be passed in the 
 - {{domxref("FederatedCredential.FederatedCredential()","FederatedCredential()")}} {{Experimental_Inline}}
   - : Creates a new `FederatedCredential` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
@@ -39,7 +39,7 @@ _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 None.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/index.md
@@ -24,7 +24,7 @@ This is the event type for `fetch` events dispatched on the {{domxref("ServiceWo
 - {{domxref("FetchEvent.FetchEvent()", "FetchEvent()")}}
   - : Creates a new `FetchEvent` object. This constructor is not typically used. The browser creates these objects itself and provides them to `fetch` event callbacks.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
@@ -39,7 +39,7 @@ _Inherits properties from its ancestor, {{domxref("Event")}}_.
 - {{domxref("FetchEvent.request")}} {{ReadOnlyInline}}
   - : The {{domxref("Request")}} the browser intends to make.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("ExtendableEvent")}}_.
 

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -43,7 +43,7 @@ To write content to file, create a FileWriter object by calling [`createWriter()
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 ### createWriter()
 

--- a/files/en-us/web/api/filelist/index.md
+++ b/files/en-us/web/api/filelist/index.md
@@ -25,12 +25,12 @@ The following line of code fetches the first file in the node's file list as a [
 const file = document.getElementById('fileItem').files[0];
 ```
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("FileList/length", "length")}} {{ReadOnlyInline}}
   - : A read-only value indicating the number of files in the list.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("FileList/item", "item()")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("File")}} object representing the file at the specified index in the file list.

--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -30,7 +30,7 @@ File objects may be obtained from a {{domxref("FileList")}} object returned as a
 
 See [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files_from_web_applications) for details and examples.
 
-## Properties
+## Instance properties
 
 - {{domxref("FileReader.error")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMException")}} representing the error that occurred while reading the file.
@@ -47,7 +47,7 @@ See [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files
 - {{domxref("FileReader.result")}} {{ReadOnlyInline}}
   - : The file's contents. This property is only valid after the read operation is complete, and the format of the data depends on which of the methods was used to initiate the read operation.
 
-## Methods
+## Instance methods
 
 - {{domxref("FileReader.abort()")}}
   - : Aborts the read operation. Upon return, the `readyState` will be `DONE`.

--- a/files/en-us/web/api/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/index.md
@@ -16,11 +16,11 @@ The `FileReaderSync` interface allows to read {{DOMxRef("File")}} or {{DOMxRef("
 
 > **Warning:** This interface is **only available** in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
-## Properties
+## Instance properties
 
 This interface does not have any properties.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("FileReaderSync.readAsArrayBuffer","FileReaderSync.readAsArrayBuffer()")}}
   - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into an {{jsxref("ArrayBuffer")}} representing the input data as a binary string.

--- a/files/en-us/web/api/filesystem/index.md
+++ b/files/en-us/web/api/filesystem/index.md
@@ -25,7 +25,7 @@ There are two ways to get access to a `FileSystem` object:
 1. You can directly ask for one representing a sandboxed file system created just for your web app directly by calling `window.requestFileSystem()`. If that call is successful, it executes a callback handler, which receives as a parameter a `FileSystem` object describing the file system.
 2. You can get it from a file system entry object, through its {{domxref("FileSystemEntry.filesystem", "filesystem")}} property.
 
-## Properties
+## Instance properties
 
 - {{domxref("FileSystem.name")}} {{ReadOnlyInline}}
   - : A string representing the file system's name. This name is unique among the entire list of exposed file systems.

--- a/files/en-us/web/api/filesystemdirectoryentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/index.md
@@ -51,11 +51,11 @@ function onFs(fs){
 window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, onFs, onError);
 ```
 
-## Properties
+## Instance properties
 
 _This interface has no properties of its own, but inherits properties from its parent interface, {{domxref("FileSystemEntry")}}._
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from its parent interface, {{domxref("FileSystemEntry")}}._
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -19,11 +19,11 @@ The **`FileSystemDirectoryHandle`** interface of the {{domxref('File System Acce
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("FileSystemHandle")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("FileSystemHandle")}}._
 

--- a/files/en-us/web/api/filesystemdirectoryreader/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/index.md
@@ -17,7 +17,7 @@ browser-compat: api.FileSystemDirectoryReader
 
 The `FileSystemDirectoryReader` interface of the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) lets you access the {{domxref("FileSystemFileEntry")}}-based objects (generally {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}) representing each entry in a directory.
 
-## Methods
+## Instance methods
 
 - {{domxref("FileSystemDirectoryReader.readEntries", "readEntries()")}}
   - : Returns an array containing some number of the directory's entries. Each item in the array is an object based on {{domxref("FileSystemEntry")}}—typically either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.

--- a/files/en-us/web/api/filesystementry/index.md
+++ b/files/en-us/web/api/filesystementry/index.md
@@ -47,7 +47,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, (fs) => {
 }, onError);
 ```
 
-## Properties
+## Instance properties
 
 _This interface provides the following properties._
 
@@ -62,7 +62,7 @@ _This interface provides the following properties._
 - {{domxref("FileSystemEntry.name", "name")}} {{ReadOnlyInline}}
   - : A string containing the name of the entry (the final part of the path, after the last "/" character).
 
-## Methods
+## Instance methods
 
 _This interface defines the following methods._
 

--- a/files/en-us/web/api/filesystemfileentry/index.md
+++ b/files/en-us/web/api/filesystemfileentry/index.md
@@ -19,11 +19,11 @@ The **`FileSystemFileEntry`** interface of the [File and Directory Entries API](
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits the properties of its parent interface, {{domxref("FileSystemEntry")}}, but has no properties unique to this interface._
 
-## Methods
+## Instance methods
 
 - {{domxref("FileSystemFileEntry.file", "file()")}}
   - : Creates a new {{domxref("File")}} object which can be used to read the file.

--- a/files/en-us/web/api/filesystemfilehandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/index.md
@@ -20,11 +20,11 @@ Note that read and write operations depend on file-access permissions that do no
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("FileSystemHandle")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("FileSystemHandle")}}._
 

--- a/files/en-us/web/api/filesystemhandle/index.md
+++ b/files/en-us/web/api/filesystemhandle/index.md
@@ -26,14 +26,14 @@ Below is a list of interfaces based on the FileSystemHandle interface.
 - {{domxref("FileSystemDirectoryHandle")}}
   - : Provides a handle to a directory entry.
 
-## Properties
+## Instance properties
 
 - {{domxref('FileSystemHandle.kind','kind')}} {{ReadOnlyInline}}
   - : Returns the type of entry. This is `'file'` if the associated entry is a file or `'directory'`.
 - {{domxref('FileSystemHandle.name', 'name')}} {{ReadOnlyInline}}
   - : Returns the name of the associated entry.
 
-## Methods
+## Instance methods
 
 - {{domxref('FileSystemHandle.isSameEntry()', 'isSameEntry()')}}
   - : Compares two {{domxref("FileSystemHandle", "handles")}} to see if the associated entries (either a file or directory) match.

--- a/files/en-us/web/api/filesystemsync/index.md
+++ b/files/en-us/web/api/filesystemsync/index.md
@@ -25,7 +25,7 @@ In the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_E
 
 The `FileSystemSync` object is your gateway to the entire API and you will use it a lot. So once you have a reference, cache the object in a global variable or class property.
 
-## Properties
+## Instance properties
 
 - `name` {{ReadOnlyInline}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : A string that represents the name of the file system. The name must be unique across the list of exposed file systems.

--- a/files/en-us/web/api/filesystemwritablefilestream/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.md
@@ -19,11 +19,11 @@ The **`FileSystemWritableFileStream`** interface of the {{domxref('File System A
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("WritableStream")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("WritableStream")}}._
 

--- a/files/en-us/web/api/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/index.md
@@ -22,14 +22,14 @@ The **`FocusEvent`** interface represents focus-related events, including {{domx
 - {{domxref("FocusEvent.FocusEvent", "FocusEvent()")}}
   - : Creates a `FocusEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent {{domxref("UIEvent")}}, and indirectly from {{domxref("Event")}}_.
 
 - {{domxref("FocusEvent.relatedTarget")}}
   - : An {{domxref("EventTarget")}} representing a secondary target for this event. In some cases (such as when tabbing in or out a page), this property may be set to `null` for security reasons.
 
-## Methods
+## Instance methods
 
 _This interface has no specific methods. It inherits methods from its parent {{domxref("UIEvent")}}, and indirectly from {{domxref("Event")}}._
 

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -25,7 +25,7 @@ For URL font sources it allows authors to trigger when the remote font is fetche
 - {{domxref("FontFace.FontFace", "FontFace()")}}
   - : Constructs and returns a new `FontFace` object, built from an external resource described by a URL or from an {{jsxref("ArrayBuffer")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("FontFace.ascentOverride")}}
   - : A string that retrieves or sets the _ascent metric_ of the font. It is equivalent to the {{cssxref("@font-face/ascent-override", "ascent-override")}} descriptor.

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -20,7 +20,7 @@ This property is available as {{domxref("Document.fonts")}}, or `self.fonts` in 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("FontFaceSet.status")}} {{ReadOnlyInline}}
   - : Indicates the font-face's loading status. It will be one of `'loading'` or `'loaded'`.
@@ -38,7 +38,7 @@ This property is available as {{domxref("Document.fonts")}}, or `self.fonts` in 
 - {{domxref("FontFaceSet.loadingerror_event", "loadingerror")}}
   - : Fires when an error occurred whilst loading a font-face set.
 
-## Methods
+## Instance methods
 
 - {{domxref("FontFaceSet.add","FontFaceSet.add()")}}
   - : Adds a font to the font set.

--- a/files/en-us/web/api/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/index.md
@@ -27,7 +27,7 @@ Events are fired when font loading starts ([`loading`](/en-US/docs/Web/API/FontF
 - {{domxref("FontFaceSetLoadEvent.FontFaceSetLoadEvent","FontFaceSetLoadEvent()")}}
   - : Creates a new `FontFaceSetLoadEvent` object.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
@@ -35,7 +35,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
   - : Returns an array of {{domxref("FontFace")}} instances.
     Depending on the event, the array will contain font faces that are loading (`loading`), have successfully loaded (`loadingdone`), or have failed to load (`loadingerror`).
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/formdata/index.md
+++ b/files/en-us/web/api/formdata/index.md
@@ -26,7 +26,7 @@ An object implementing `FormData` can directly be used in a {{jsxref("Statements
 - {{domxref("FormData.FormData","FormData()")}}
   - : Creates a new `FormData` object.
 
-## Methods
+## Instance methods
 
 - {{domxref("FormData.append()")}}
   - : Appends a new value onto an existing key inside a `FormData` object, or adds the key if it does not already exist.

--- a/files/en-us/web/api/formdataevent/index.md
+++ b/files/en-us/web/api/formdataevent/index.md
@@ -24,14 +24,14 @@ This allows a {{domxref("FormData")}} object to be quickly obtained in response 
 - {{domxref("FormDataEvent.FormDataEvent","FormDataEvent()")}}
   - : Creates a new `FormDataEvent` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent interface, {{domxref("Event")}}._
 
 - {{domxref("FormDataEvent.formData")}}
   - : Contains the {{domxref("FormData")}} object representing the data contained in the form when the event was fired.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -37,21 +37,21 @@ See the article [Guide to the Fullscreen API](/en-US/docs/Web/API/Fullscreen_API
 
 _The Fullscreen API has no interfaces of its own. Instead, it augments several other interfaces to add the methods, properties, and event handlers needed to provide fullscreen functionality. These are listed in the following sections._
 
-## Methods
+## Instance methods
 
 The Fullscreen API adds methods to the {{DOMxRef("Document")}} and {{DOMxRef("Element")}} interfaces to allow turning off and on fullscreen mode.
 
-### Methods on the Document interface
+### Instance methods on the Document interface
 
 - {{DOMxRef("Document.exitFullscreen()")}}
   - : Requests that the {{Glossary("user agent")}} switch from fullscreen mode back to windowed mode. Returns a {{jsxref("Promise")}} which is resolved once fullscreen mode has been completely shut off.
 
-### Methods on the Element interface
+### Instance methods on the Element interface
 
 - {{DOMxRef("Element.requestFullscreen()")}}
   - : Asks the user agent to place the specified element (and, by extension, its descendants) into fullscreen mode, removing all of the browser's UI elements as well as all other applications from the screen. Returns a {{jsxref("Promise")}} which is resolved once fullscreen mode has been activated.
 
-## Properties
+## Instance properties
 
 _The {{DOMxRef("Document")}} interface provides properties that can be used to determine if fullscreen mode is supported and available, and if fullscreen mode is currently active, which element is using the screen._
 


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with D, E, F

Moved to have consistent headings and ordering.