### PR TITLE
Web API methods/props sorted to static/instance headings - JKLMN

### DIFF
--- a/files/en-us/web/api/keyboard/index.md
+++ b/files/en-us/web/api/keyboard/index.md
@@ -22,11 +22,11 @@ A list of valid code values is found in the [UI Events KeyboardEvent code Values
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref('Keyboard.getLayoutMap()')}} {{experimental_inline}}
   - : Returns a {{jsxref('Promise')}} that resolves with an instance of {{domxref('KeyboardLayoutMap')}} which is a map-like object with functions for retrieving the strings associated with specific physical keys.

--- a/files/en-us/web/api/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/index.md
@@ -117,7 +117,7 @@ The following constants identify which part of the keyboard the key event origin
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 
@@ -157,7 +157,7 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
   - : Returns a boolean value that is `true` if the <kbd>Shift</kbd> key was active when the key event was generated.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 

--- a/files/en-us/web/api/keyboardlayoutmap/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/index.md
@@ -20,7 +20,7 @@ The **`KeyboardLayoutMap`** interface of the [Keyboard API](/en-US/docs/Web/API/
 
 A list of valid keys is found in the [UI Events KeyboardEvent code Values](https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system) specification.
 
-## Properties
+## Instance properties
 
 - {{domxref('KeyboardLayoutMap.entries')}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns an array of a given object's own enumerable property `[key, value]` pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a `for-in` loop enumerates properties in the prototype chain as well).
@@ -31,7 +31,7 @@ A list of valid keys is found in the [UI Events KeyboardEvent code Values](https
 - {{domxref('KeyboardLayoutMap.values')}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns a new _array iterator_ object that contains the values for each index in the `KeyboardLayoutMap` object.
 
-## Methods
+## Instance methods
 
 - {{domxref('KeyboardLayoutMap.forEach()')}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Executes a provided function once for each element of `KeyboardLayoutMap`.

--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -25,7 +25,7 @@ The **`KeyframeEffect`** interface of the [Web Animations API](/en-US/docs/Web/A
 - {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}
   - : Returns a new `KeyframeEffect` object instance, and also allows you to clone an existing keyframe effect object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("KeyframeEffect.target")}}
   - : Gets and sets the element, or originating element of the pseudo-element, being animated by this object. This may be `null` for animations that do not target a specific element or pseudo-element.
@@ -36,7 +36,7 @@ The **`KeyframeEffect`** interface of the [Web Animations API](/en-US/docs/Web/A
 - {{domxref("KeyframeEffect.composite")}}
   - : Gets and sets the composite operation property for resolving the property value changes between this and other keyframe effects.
 
-## Methods
+## Instance methods
 
 _This interface inherits some of its methods from its parent, {{domxref("AnimationEffect")}}._
 

--- a/files/en-us/web/api/largestcontentfulpaint/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/index.md
@@ -20,7 +20,7 @@ The `LargestContentfulPaint` interface of the {{domxref("Largest Contentful Pain
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("PerformanceEntry")}}._
 
@@ -37,7 +37,7 @@ _This interface also inherits properties from {{domxref("PerformanceEntry")}}._
 - {{domxref("LargestContentfulPaint.url")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : If the element is an image, the request url of the image.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from {{domxref("PerformanceEntry")}}._
 

--- a/files/en-us/web/api/layoutshift/index.md
+++ b/files/en-us/web/api/layoutshift/index.md
@@ -20,7 +20,7 @@ The `LayoutShift` interface of the [Layout Instability API](/en-US/docs/Web/API/
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("LayoutShift.value")}} {{Experimental_Inline}}
   - : Returns the `impact fraction` (fraction of the viewport that was shifted) times the `distance fraction` (distance moved as a fraction of viewport).
@@ -31,7 +31,7 @@ The `LayoutShift` interface of the [Layout Instability API](/en-US/docs/Web/API/
 - {{domxref("LayoutShift.sources")}} {{Experimental_Inline}}
   - : Returns an array of {{domxref('LayoutShiftAttribution')}} objects with information on the elements that were shifted.
 
-## Methods
+## Instance methods
 
 - {{domxref("LayoutShift.toJSON()")}} {{Experimental_Inline}}
   - : Converts the properties to JSON.

--- a/files/en-us/web/api/layoutshiftattribution/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/index.md
@@ -21,7 +21,7 @@ The `LayoutShiftAttribution` interface of the [Layout Instability API](/en-US/do
 
 Instances of `LayoutShiftAttribution` are returned in an array by calling {{domxref("LayoutShift.sources")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("LayoutShiftAttribution.Node")}} {{ReadOnlyInline}}
   - : Returns the element that has shifted (null if it has been removed).
@@ -30,7 +30,7 @@ Instances of `LayoutShiftAttribution` are returned in an array by calling {{domx
 - {{domxref("LayoutShiftAttribution.currentRect")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element after the shift.
 
-## Methods
+## Instance methods
 
 - {{domxref("LayoutShiftAttribution.toJSON()")}} {{Experimental_Inline}}
   - : Returns a JSON representation of the `LayoutShiftAttribution` object.

--- a/files/en-us/web/api/linearaccelerationsensor/index.md
+++ b/files/en-us/web/api/linearaccelerationsensor/index.md
@@ -31,11 +31,11 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 - {{domxref("LinearAccelerationSensor.LinearAccelerationSensor", "LinearAccelerationSensor()")}}
   - : Creates a new `LinearAccelerationSensor` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestors, {{domxref('Accelerometer')}}, {{domxref("Sensor")}}, and {{domxref("EventTarget")}}._
 
-## Methods
+## Instance methods
 
 _`LinearAccelerationSensor` doesn't have own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -110,7 +110,7 @@ document.body.addEventListener('click', (evt) => {
 
 {{EmbedLiveSample('Location anatomy', '85ch', '160px')}}
 
-## Properties
+## Instance properties
 
 - {{domxref("Location.ancestorOrigins")}}
   - : A static {{domxref("DOMStringList")}} containing, in reverse order, the origins of all ancestor browsing contexts of the document associated with the given `Location` object.
@@ -133,7 +133,7 @@ document.body.addEventListener('click', (evt) => {
 - {{domxref("Location.origin")}} {{ReadOnlyInline}}
   - : Returns a string containing the canonical form of the origin of the specific location.
 
-## Methods
+## Instance methods
 
 - {{domxref("Location.assign()")}}
   - : Loads the resource at the URL provided in parameter.

--- a/files/en-us/web/api/lock/index.md
+++ b/files/en-us/web/api/lock/index.md
@@ -16,7 +16,7 @@ browser-compat: api.Lock
 The **`Lock`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides the name and mode of a lock.
 This may be a newly requested lock that is received in the callback to {{domxref('LockManager.request','LockManager.request()')}}, or a record of an active or queued lock returned by {{domxref('LockManager.query()')}}.
 
-## Properties
+## Instance properties
 
 - {{domxref('Lock.mode')}} {{ReadOnlyInline}}
   - : Returns the access mode passed to {{domxref('LockManager.request()')}} when the lock was requested.

--- a/files/en-us/web/api/lockmanager/index.md
+++ b/files/en-us/web/api/lockmanager/index.md
@@ -16,7 +16,7 @@ browser-compat: api.LockManager
 
 The **`LockManager`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing `Lock` object. To get an instance of `LockManager`, call {{domxref('navigator.locks')}}.
 
-## Methods
+## Instance methods
 
 - {{domxref('LockManager.request()')}}
   - : Requests a {{domxref('Lock')}} object with parameters specifying its name and characteristics.

--- a/files/en-us/web/api/magnetometer/index.md
+++ b/files/en-us/web/api/magnetometer/index.md
@@ -30,7 +30,7 @@ If a feature policy blocks use of a feature, it's because your code is inconsist
 - {{domxref("Magnetometer.Magnetometer", "Magnetometer()")}} {{Experimental_Inline}}
   - : Creates a new `Magnetometer` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('Magnetometer.x')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a double containing the magnetic field around the device's x axis.
@@ -39,7 +39,7 @@ If a feature policy blocks use of a feature, it's because your code is inconsist
 - {{domxref('Magnetometer.z')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a double containing the magnetic field around the device's z axis.
 
-## Methods
+## Instance methods
 
 _`Magnetometer` doesn't have own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/mathmlelement/index.md
+++ b/files/en-us/web/api/mathmlelement/index.md
@@ -17,7 +17,7 @@ The **`MathMLElement`** interface represents any [MathML](/en-US/docs/Web/MathML
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from: {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("Element")}}_.
 
@@ -26,7 +26,7 @@ _Also inherits properties from: {{DOMxRef("DocumentAndElementEventHandlers")}}, 
 - {{DOMxRef("MathMLElement.style")}}
   - : A {{DOMxRef("CSSStyleDeclaration")}} representing the declarations of the element's `style` attribute.
 
-## Methods
+## Instance methods
 
 _This interface has no methods, but inherits methods from: {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("Element")}}_.
 

--- a/files/en-us/web/api/mediacapabilities/index.md
+++ b/files/en-us/web/api/mediacapabilities/index.md
@@ -19,7 +19,7 @@ The **`MediaCapabilities`** interface of the [Media Capabilities API](/en-US/doc
 
 The information is accessed through the **`mediaCapabilities`** property of the {{domxref("Navigator")}} interface.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaCapabilities.encodingInfo()")}}
   - : When passed a valid media configuration, it returns a promise with information as to whether the media type is supported, and whether encoding such media would be smooth and power efficient.

--- a/files/en-us/web/api/mediadeviceinfo/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/index.md
@@ -23,7 +23,7 @@ The **`MediaDeviceInfo`** interface contains information that describes a single
 
 The list of devices obtained by calling {{domxref("MediaDevices.enumerateDevices", "navigator.mediaDevices.enumerateDevices()")}} is an array of `MediaDeviceInfo` objects, one per media device.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaDeviceInfo.deviceId")}} {{ReadOnlyInline}}
   - : Returns a string that is an identifier for the represented device that is persisted across sessions. It is un-guessable by other applications and unique to the origin of the calling application. It is reset when the user clears cookies (for Private Browsing, a different identifier is used that is not persisted across sessions).
@@ -36,7 +36,7 @@ The list of devices obtained by calling {{domxref("MediaDevices.enumerateDevices
 
 > **Note:** For security reasons, the `label` field is always blank unless an active media stream exists _or_ the user has granted persistent permission for media device access. The set of device labels could otherwise be used as part of a fingerprinting mechanism to identify a user.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/mediadevices/index.md
+++ b/files/en-us/web/api/mediadevices/index.md
@@ -27,11 +27,11 @@ The **`MediaDevices`** interface provides access to connected media input device
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent interface, {{domxref("EventTarget")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.md
@@ -45,14 +45,14 @@ A `MediaElementAudioSourceNode` has no inputs and exactly one output, and is cre
 - {{domxref("MediaElementAudioSourceNode.MediaElementAudioSourceNode", "MediaElementAudioSourceNode()")}}
   - : Creates a new `MediaElementAudioSourceNode` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
 - {{domxref("MediaElementAudioSourceNode.mediaElement", "mediaElement")}} {{ReadOnlyInline}}
   - : The {{domxref("HTMLMediaElement")}} used when constructing this `MediaStreamAudioSourceNode`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/mediaerror/index.md
+++ b/files/en-us/web/api/mediaerror/index.md
@@ -21,7 +21,7 @@ The **`MediaError`** interface represents an error which occurred while handling
 
 A `MediaError` object describes the error in general terms using a numeric `code` categorizing the kind of error, and a `message`, which provides specific diagnostics about what went wrong.
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any properties._
 
@@ -30,7 +30,7 @@ _This interface doesn't inherit any properties._
 - {{domxref("MediaError.message")}}
   - : A human-readable string which provides _specific diagnostic information_ to help the reader understand the error condition which occurred; specifically, it isn't a summary of what the error code means, but actual diagnostic information to help in understanding what exactly went wrong. This text and its format is not defined by the specification and will vary from one {{Glossary("user agent")}} to another. If no diagnostics are available, or no explanation can be provided, this value is an empty string (`""`).
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement or inherit any methods, and has none of its own._
 

--- a/files/en-us/web/api/mediaimage/index.md
+++ b/files/en-us/web/api/mediaimage/index.md
@@ -11,7 +11,7 @@ The Media Session API's **`MediaImage`** dictionary describes the images associa
 
 Its contents can be displayed by the {{Glossary("user agent")}} in appropriate contexts like in a player interface to show the current playing video or audio track.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaImage.src", "src")}}
   - : The URL from which the user agent fetches the image's data.

--- a/files/en-us/web/api/mediakeymessageevent/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/index.md
@@ -23,7 +23,7 @@ The **`MediaKeyMessageEvent`** interface of the [EncryptedMediaExtensions API](/
 - {{domxref("MediaKeyMessageEvent.MediaKeyMessageEvent","MediaKeyMessageEvent()")}}
   - : Creates a new instance of `MediaKeyMessageEvent`.
 
-## Properties
+## Instance properties
 
 Inherits properties from its parent, {{domxref("Event")}}.
 
@@ -32,7 +32,7 @@ Inherits properties from its parent, {{domxref("Event")}}.
 - {{domxref("MediaKeyMessageEvent.messageType")}} {{ReadOnlyInline}}
   - : Indicates the type of message. May be one of `license-request`, `license-renewal`, `license-release`, or `individualization-request`.
 
-## Methods
+## Instance methods
 
 Inherits methods from its parent, {{domxref("Event")}}.
 

--- a/files/en-us/web/api/mediakeys/index.md
+++ b/files/en-us/web/api/mediakeys/index.md
@@ -19,11 +19,11 @@ browser-compat: api.MediaKeys
 
 The **`MediaKeys`** interface of [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) represents a set of keys that an associated {{domxref("HTMLMediaElement")}} can use for decryption of media data during playback.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaKeys.createSession()")}}
   - : Returns a new {{domxref("MediaKeySession")}} object, which represents a context for message exchange with a content decryption module (CDM).

--- a/files/en-us/web/api/mediakeysession/index.md
+++ b/files/en-us/web/api/mediakeysession/index.md
@@ -21,7 +21,7 @@ The **`MediaKeySession`** interface of the [EncryptedMediaExtensions API](/en-US
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaKeySession.closed")}} {{ReadOnlyInline}}
   - : Returns a {{jsxref("Promise")}} signaling when a `MediaKeySession` closes. This promise can only be fulfilled and is never rejected. Closing a session means that licenses and keys associated with it are no longer valid for decrypting media data.
@@ -39,7 +39,7 @@ The **`MediaKeySession`** interface of the [EncryptedMediaExtensions API](/en-US
 - {{domxref("MediaKeySession.message_event", "message")}}
   - : Fires when the content decryption module has generated a message for the session.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaKeySession.close()")}}
   - : Returns a {{jsxref("Promise")}} after notifying the current media session is no longer needed and that the CDM should release any resources associated with this object and close it.

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -15,12 +15,12 @@ browser-compat: api.MediaKeyStatusMap
 
 The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) is a read-only map of media key statuses by key IDs.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaKeyStatusMap.size")}} {{ReadOnlyInline}}
   - : Returns the number of key/value pairs in the status map.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaKeyStatusMap.entries()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing an array of `[key, value]` for each element in the status map, in insertion order.

--- a/files/en-us/web/api/mediakeysystemaccess/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/index.md
@@ -19,12 +19,12 @@ browser-compat: api.MediaKeySystemAccess
 
 The **`MediaKeySystemAccess`** interface of the [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) provides access to a Key System for decryption and/or a content protection provider. You can request an instance of this object using the {{domxref("Navigator.requestMediaKeySystemAccess","Navigator.requestMediaKeySystemAccess()")}} method.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaKeySystemAccess.keySystem")}} {{ReadOnlyInline}}
   - : Returns a string identifying the key system being used.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaKeySystemAccess.createMediaKeys()")}}
   - : Returns a {{jsxref('Promise')}} that resolves to a new {{domxref("MediaKeys")}} object.

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -17,14 +17,14 @@ The **`MediaList`** interface represents the media queries of a stylesheet, e.g.
 
 > **Note:** `MediaList` is a live list; updating the list using properties or methods listed below will immediately update the behavior of the document.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaList.mediaText")}}
   - : A {{Glossary("stringifier")}} that returns a string representing the `MediaList` as text, and also allows you to set a new `MediaList`.
 - {{domxref("MediaList.length")}} {{ReadOnlyInline}}
   - : Returns the number of media queries in the `MediaList`.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaList.appendMedium()")}}
   - : Adds a media query to the `MediaList`.

--- a/files/en-us/web/api/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/index.md
@@ -23,7 +23,7 @@ The **`MediaMetadata`** interface of the [Media Session API](/en-US/docs/Web/API
 - {{domxref("MediaMetadata.MediaMetadata", "MediaMetadata()")}}
   - : Creates a new `MediaMetaData` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaMetadata.title")}}
   - : Returns or sets the title of the media to be played.

--- a/files/en-us/web/api/mediaquerylist/index.md
+++ b/files/en-us/web/api/mediaquerylist/index.md
@@ -25,7 +25,7 @@ This is very useful for adaptive design, since this makes it possible to observe
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `MediaQueryList` interface inherits properties from its parent interface, {{DOMxRef("EventTarget")}}._
 
@@ -34,7 +34,7 @@ _The `MediaQueryList` interface inherits properties from its parent interface, {
 - {{DOMxRef("MediaQueryList.media", "media")}} {{ReadOnlyInline}}
   - : A string representing a serialized media query.
 
-## Methods
+## Instance methods
 
 _The `MediaQueryList` interface inherits methods from its parent interface, {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -23,7 +23,7 @@ The `MediaQueryListEvent` object stores information on the changes that have hap
 - {{DOMxRef("MediaQueryListEvent.MediaQueryListEvent()", "MediaQueryListEvent()")}}
   - : Creates a new `MediaQueryListEvent` instance.
 
-## Properties
+## Instance properties
 
 _The `MediaQueryListEvent` interface inherits properties from its parent interface, {{DOMxRef("Event")}}._
 
@@ -32,7 +32,7 @@ _The `MediaQueryListEvent` interface inherits properties from its parent interfa
 - {{DOMxRef("MediaQueryListEvent.media")}} {{ReadOnlyInline}}
   - : A string representing a serialized media query.
 
-## Methods
+## Instance methods
 
 _The `MediaQueryListEvent` interface inherits methods from its parent interface, {{DOMxRef("Event")}}._
 

--- a/files/en-us/web/api/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/index.md
@@ -27,7 +27,7 @@ The **`MediaRecorder`** interface of the [MediaStream Recording API](/en-US/docs
 - {{domxref("MediaRecorder.MediaRecorder", "MediaRecorder()")}}
   - : Creates a new `MediaRecorder` object, given a {{domxref("MediaStream")}} to record. Options are available to do things like set the container's MIME type (such as `"video/webm"` or `"video/mp4"`) and the bit rates of the audio and video tracks or a single overall bit rate.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaRecorder.mimeType")}} {{ReadOnlyInline}}
   - : Returns the MIME type that was selected as the recording container for the `MediaRecorder` object when it was created.
@@ -40,7 +40,7 @@ The **`MediaRecorder`** interface of the [MediaStream Recording API](/en-US/docs
 - {{domxref("MediaRecorder.audioBitsPerSecond")}} {{ReadOnlyInline}}
   - : Returns the audio encoding bit rate in use. This may differ from the bit rate specified in the constructor (if it was provided).
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaRecorder.pause()")}}
   - : Pauses the recording of media.

--- a/files/en-us/web/api/mediarecorder/pause_event/index.md
+++ b/files/en-us/web/api/mediarecorder/pause_event/index.md
@@ -58,7 +58,7 @@ mediaRecorder.onresume = () => {
 }
 ```
 
-## Properties
+## Instance properties
 
 None.
 

--- a/files/en-us/web/api/mediarecorder/resume_event/index.md
+++ b/files/en-us/web/api/mediarecorder/resume_event/index.md
@@ -58,7 +58,7 @@ mediaRecorder.onresume = () => {
 }
 ```
 
-## Properties
+## Instance properties
 
 None.
 

--- a/files/en-us/web/api/mediarecorder/start_event/index.md
+++ b/files/en-us/web/api/mediarecorder/start_event/index.md
@@ -49,7 +49,7 @@ mediaRecorder.onstart = () => {
 }
 ```
 
-## Properties
+## Instance properties
 
 None.
 

--- a/files/en-us/web/api/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/index.md
@@ -29,7 +29,7 @@ The `MediaRecorderErrorEvent` interface represents errors returned by the [Media
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent interface, {{domxref("Event")}}_.
 
@@ -41,7 +41,7 @@ _Inherits properties from its parent interface, {{domxref("Event")}}_.
 - {{domxref("MediaRecorderErrorEvent.MediaRecorderErrorEvent", "MediaStreamRecorderEvent()")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Creates and returns a new `MediaRecorderErrorEvent` event object with the given parameters.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -20,14 +20,14 @@ The **`MediaSession`** interface of the [Media Session API](/en-US/docs/Web/API/
 
 For example, a smartphone might have a standard panel in its lock screen that provides controls for media playback and information display. A browser on the device can use `MediaSession` to make browser playback controllable from that standard/global user interface.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaSession.metadata", "metadata")}}
   - : Returns an instance of {{domxref("MediaMetadata")}}, which contains rich media metadata for display in a platform UI.
 - {{domxref("MediaSession.playbackState", "playbackState")}}
   - : Indicates whether the current media session is playing. Valid values are `none`, `paused`, or `playing`.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaSession.setActionHandler", "setActionHandler()")}}
   - : Sets an action handler for a media session action, such as play or pause.

--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -27,7 +27,7 @@ The **`MediaSource`** interface of the [Media Source Extensions API](/en-US/docs
 - {{domxref("MediaSource.MediaSource", "MediaSource()")}}
   - : Constructs and returns a new `MediaSource` object with no associated source buffers.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaSource.sourceBuffers")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("SourceBufferList")}} object containing the list of {{domxref("SourceBuffer")}} objects associated with this `MediaSource`.
@@ -38,7 +38,7 @@ The **`MediaSource`** interface of the [Media Source Extensions API](/en-US/docs
 - {{domxref("MediaSource.duration")}}
   - : Gets and sets the duration of the current media being presented.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 
@@ -53,7 +53,12 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 - {{domxref("MediaSource.setLiveSeekableRange()")}}
   - : Sets the range that the user can seek to in the media element.
 
-### Events
+## Static methods
+
+- {{domxref("MediaSource.isTypeSupported()")}}
+  - : Returns a boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.
+
+## Events
 
 - {{domxref("MediaSource.sourceclose_event", "sourceclose")}}
   - : Fired when the `MediaSource` instance is not attached to a media element anymore.
@@ -61,11 +66,6 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
   - : Fired when the `MediaSource` instance is still attached to a media element, but {{domxref("MediaSource.endOfStream", "endOfStream()")}} has been called.
 - {{domxref("MediaSource.sourceopen_event", "sourceopen")}}
   - : Fired when the `MediaSource` instance has been opened by a media element and is ready for data to be appended to the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}}.
-
-## Static methods
-
-- {{domxref("MediaSource.isTypeSupported()")}}
-  - : Returns a boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.
 
 ## Examples
 

--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -27,7 +27,7 @@ Some user agents subclass this interface to provide more precise information or 
 - {{domxref("MediaStream.MediaStream", "MediaStream()")}}
   - : Creates and returns a new MediaStream object. You can create an empty stream, a stream which is based upon an existing stream, or a stream that contains a specified list of tracks (specified as an array of {{domxref("MediaStreamTrack")}} objects).
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from its parent, {{domxref("EventTarget")}}._
 
@@ -36,7 +36,7 @@ _This interface inherits properties from its parent, {{domxref("EventTarget")}}.
 - {{domxref("MediaStream.id")}} {{ReadOnlyInline}}
   - : A string containing a 36-character universally unique identifier ({{Glossary("UUID")}}) for the object.
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
@@ -50,14 +50,14 @@ It is an {{domxref("AudioNode")}} that acts as an audio destination, created usi
 - {{domxref("MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode", "MediaStreamAudioDestinationNode()")}}
   - : Creates a new `MediaStreamAudioDestinationNode` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
 - {{domxref("MediaStreamAudioDestinationNode.stream")}}
   - : A {{domxref("MediaStream")}} containing a single {{domxref("MediaStreamTrack")}} whose {{domxref("MediaStreamTrack.kind", "kind")}} is `audio` and with the same number of channels as the node. You can use this property to get a stream out of the audio graph and feed it into another construct, such as a [Media Recorder](/en-US/docs/Web/API/MediaStream_Recording_API).
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -60,14 +60,14 @@ The number of channels output by the node matches the number of tracks found in 
 - {{domxref("MediaStreamAudioSourceNode.MediaStreamAudioSourceNode", "new MediaStreamAudioSourceNode()")}}
   - : Creates a new `MediaStreamAudioSourceNode` object instance with the specified options.
 
-## Properties
+## Instance properties
 
 _In addition to the following properties, `MediaStreamAudioSourceNode` inherits the properties of its parent, {{domxref("AudioNode")}}._
 
 - {{domxref("MediaStreamAudioSourceNode.mediaStream", "mediaStream")}} {{ReadOnlyInline}}
   - : The {{domxref("MediaStream")}} used when constructing this `MediaStreamAudioSourceNode`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/mediastreamevent/index.md
+++ b/files/en-us/web/api/mediastreamevent/index.md
@@ -16,7 +16,7 @@ browser-compat: api.MediaStreamEvent
 
 The **`MediaStreamEvent`** interface represents events that occurs in relation to a {{domxref("MediaStream")}}. Two events of this type can be thrown: {{domxref("RTCPeerConnection.addstream_event", "addstream")}} and {{domxref("RTCPeerConnection.removestream_event", "removestream")}}.
 
-## Properties
+## Instance properties
 
 _A {{domxref("MediaStreamEvent")}} being an {{domxref("Event")}}, this event also implements these properties_.
 
@@ -28,7 +28,7 @@ _A {{domxref("MediaStreamEvent")}} being an {{domxref("Event")}}, this event als
 - {{domxref("MediaStreamEvent.MediaStreamEvent()", "MediaStreamEvent()")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns a new `MediaStreamEvent`. It takes two parameters, the first being a string representing the type of the event; the second a dictionary containing the {{domxref("MediaStream")}} it refers to.
 
-## Methods
+## Instance methods
 
 A {{domxref("MediaStreamEvent")}} being an {{domxref("Event")}}, this event also implements these properties. There is no specific {{domxref("MediaStreamEvent")}} method.
 

--- a/files/en-us/web/api/mediastreamtrack/index.md
+++ b/files/en-us/web/api/mediastreamtrack/index.md
@@ -22,7 +22,7 @@ The **`MediaStreamTrack`** interface represents a single media track within a st
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 In addition to the properties listed below, `MediaStreamTrack` has constrainable properties which can be set using {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} and accessed using {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}} and {{domxref("MediaStreamTrack.getSettings", "getSettings()")}}. See [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) to learn how to correctly work with constrainable properties. Not doing so correctly will result in your code being unreliable.
 
@@ -56,7 +56,7 @@ In addition to the properties listed below, `MediaStreamTrack` has constrainable
 - {{domxref("MediaStreamTrack.remote")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns a Boolean with a value of `true` if the track is sourced by a {{domxref("RTCPeerConnection")}}, `false` otherwise.
 
-## Methods
+## Instance methods
 
 - {{domxref("MediaStreamTrack.applyConstraints()")}}
   - : Lets the application specify the ideal and/or ranges of acceptable values for any number of the available constrainable properties of the `MediaStreamTrack`.

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.md
@@ -42,11 +42,11 @@ A `MediaStreamTrackAudioSourceNode` has no inputs and exactly one output, and is
 - {{domxref("MediaStreamTrackAudioSourceNode.MediaStreamTrackAudioSourceNode", "new MediaStreamTrackAudioSourceNode()")}}
   - : Creates a new `MediaStreamTrackAudioSourceNode` object instance with the specified options.
 
-## Properties
+## Instance properties
 
 _The `MediaStreamTrackAudioSourceNode` interface has no properties of its own; however, it inherits the properties of its parent, {{domxref("AudioNode")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/mediastreamtrackevent/index.md
+++ b/files/en-us/web/api/mediastreamtrackevent/index.md
@@ -23,7 +23,7 @@ The **`MediaStreamTrackEvent`** interface represents events which indicate that 
 
 The events based on this interface are {{domxref("MediaStream/addtrack_event", "addtrack")}} and {{domxref("MediaStream/removetrack_event", "removetrack")}}.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent interface, {{domxref("Event")}}._
 
@@ -35,7 +35,7 @@ _Also inherits properties from its parent interface, {{domxref("Event")}}._
 - {{domxref("MediaStreamTrackEvent.MediaStreamTrackEvent", "MediaStreamTrackEvent()")}}
   - : Constructs a new `MediaStreamTrackEvent` with the specified configuration.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from its parent {{domxref("Event")}}._
 

--- a/files/en-us/web/api/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/index.md
@@ -22,14 +22,14 @@ The object consumes a stream of media frames as input, which can be audio or vid
 - {{domxref("MediaStreamTrackGenerator.MediaStreamTrackGenerator", "MediaStreamTrackGenerator()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Creates a new `MediaStreamTrackGenerator` object which accepts either {{domxref("VideoFrame")}} or {{domxref("AudioData")}} objects.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("MediaStreamTrack")}}._
 
 - {{domxref("MediaStreamTrackGenerator.writable")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : A {{domxref("WritableStream")}}.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from {{domxref("MediaStreamTrack")}}._
 

--- a/files/en-us/web/api/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/index.md
@@ -21,7 +21,7 @@ The **`MediaStreamTrackProcessor`** interface of the {{domxref('Insertable Strea
 - {{domxref("MediaStreamTrackProcessor.MediaStreamTrackProcessor", "MediaStreamTrackProcessor()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Creates a new `MediaStreamTrackProcessor` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("MediaStreamTrackProcessor.readable")}} {{Experimental_Inline}}
   - : Returns a {{domxref("ReadableStream")}}.

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -74,18 +74,18 @@ The `ConstrainULong` constraint type is used to specify a constraint for a prope
 - `ideal`
   - : An integer specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
 
-## Properties
+## Instance properties
 
 Some combination—but not necessarily all—of the following properties will exist on the object. This may be because a given browser doesn't support the property, or because it doesn't apply. For example, because {{Glossary("RTP")}} doesn't provide some of these values during negotiation of a WebRTC connection, a track associated with a {{domxref("RTCPeerConnection")}} will not include certain values, such as {{domxref("MediaTrackConstraints.facingMode", "facingMode")}} or {{domxref("MediaTrackConstraints.groupId", "groupId")}}.
 
-### Properties of all media tracks
+### Instance properties of all media tracks
 
 - {{domxref("MediaTrackConstraints.deviceId", "deviceId")}}
   - : A [`ConstrainDOMString`](#constraindomstring) object specifying a device ID or an array of device IDs which are acceptable and/or required.
 - {{domxref("MediaTrackConstraints.groupId", "groupId")}}
   - : A [`ConstrainDOMString`](#constraindomstring) object specifying a group ID or an array of group IDs which are acceptable and/or required.
 
-### Properties of audio tracks
+### Instance properties of audio tracks
 
 - {{domxref("MediaTrackConstraints.autoGainControl", "autoGainControl")}}
   - : A [`ConstrainBoolean`](#constrainboolean) object which specifies whether automatic gain control is preferred and/or required.
@@ -104,7 +104,7 @@ Some combination—but not necessarily all—of the following properties will ex
 - {{domxref("MediaTrackConstraints.volume", "volume")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : A [`ConstrainDouble`](#constraindouble) specifying the volume or range of volumes which are acceptable and/or required.
 
-### Properties of image tracks
+### Instance properties of image tracks
 
 - whiteBalanceMode
   - : A {{jsxref("String")}} specifying one of `"none"`, `"manual"`, `"single-shot"`, or `"continuous"`.
@@ -135,7 +135,7 @@ Some combination—but not necessarily all—of the following properties will ex
 - torch
   - : A boolean value defining whether the fill light is continuously connected, meaning it stays on as long as the track is active.
 
-### Properties of video tracks
+### Instance properties of video tracks
 
 - {{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}}
   - : A [`ConstrainDouble`](#constraindouble) specifying the video aspect ratio or range of aspect ratios which are acceptable and/or required.
@@ -150,7 +150,7 @@ Some combination—but not necessarily all—of the following properties will ex
 - resizeMode
   - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution of a video track. Allowed values are `none` and `crop-and-scale`. `none` means that the user agent uses the resolution provided by the camera, its driver or the OS. `crop-and-scale` means that the user agent can use cropping and downscaling on the camera output in order to satisfy other constraints that affect the resolution.
 
-### Properties of shared screen tracks
+### Instance properties of shared screen tracks
 
 These constraints apply to the `video` property of the object passed into {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} to obtain a stream for screen sharing.
 

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -24,18 +24,18 @@ The **`MediaTrackSettings`** dictionary is used to return the current values con
 
 To learn more about how constraints and settings work, see [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints).
 
-## Properties
+## Instance properties
 
 Some or all of the following will be included in the object, either because it's not supported by the browser or because it's not available due to context. For example, because {{Glossary("RTP")}} doesn't provide some of these values during negotiation of a WebRTC connection, a track associated with a {{domxref("RTCPeerConnection")}} will not include certain values, such as {{domxref("MediaTrackSettings.facingMode", "facingMode")}} or {{domxref("MediaTrackSettings.groupId", "groupId")}}.
 
-### Properties of all media tracks
+### Instance properties of all media tracks
 
 - {{domxref("MediaTrackSettings.deviceId", "deviceId")}}
   - : A string indicating the current value of the {{domxref("MediaTrackConstraints.deviceId", "deviceId")}} property. The device ID is a origin-unique string identifying the source of the track; this is usually a {{Glossary("GUID")}}. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
 - {{domxref("MediaTrackSettings.groupId", "groupId")}}
   - : A string indicating the current value of the {{domxref("MediaTrackConstraints.groupId", "groupId")}} property. The group ID is a browsing session-unique string identifying the source group of the track. Two devices (as identified by the {{domxref("MediaTrackSettings.deviceId", "deviceId")}}) are considered part of the same group if they are from the same physical device. For instance, the audio input and output devices for the speaker and microphone built into a phone would share the same group ID, since they're part of the same physical device. The microphone on a headset would have a different ID, though. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
 
-### Properties of audio tracks
+### Instance properties of audio tracks
 
 - {{domxref("MediaTrackSettings.autoGainControl", "autoGainControl")}}
   - : A Boolean which indicates the current value of the {{domxref("MediaTrackConstraints.autoGainControl", "autoGainControl")}} property, which is `true` if automatic gain control is enabled and is `false` otherwise.
@@ -54,7 +54,7 @@ Some or all of the following will be included in the object, either because it's
 - {{domxref("MediaTrackSettings.volume", "volume")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.volume", "volume")}} property, specifying the volume level of the track. This value will be between 0.0 (silent) to 1.0 (maximum supported volume).
 
-### Properties of video tracks
+### Instance properties of video tracks
 
 - {{domxref("MediaTrackSettings.aspectRatio", "aspectRatio")}}
   - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}} property, specified precisely to 10 decimal places. This is the width of the image in pixels divided by its height in pixels. Common values include 1.3333333333 (for the classic television 4:3 "standard" aspect ratio, also used on tablets such as Apple's iPad), 1.7777777778 (for the 16:9 high-definition widescreen aspect ratio), and 1.6 (for the 16:10 aspect ratio common among widescreen computers and tablets).
@@ -86,7 +86,7 @@ Some or all of the following will be included in the object, either because it's
     - `"crop-and-scale"`
       - : The track's resolution might be the result of the user agent using cropping or downscaling from a higher camera resolution.
 
-### Properties of shared screen tracks
+### Instance properties of shared screen tracks
 
 Tracks containing video shared from a user's screen (regardless of whether the screen data comes from the entire screen or a portion of a screen, like a window or tab) are generally treated like video tracks, with the exception that they also support the following added settings:
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -28,7 +28,7 @@ An actual constraint set is described using an object based on the {{domxref("Me
 
 To learn more about how constraints work, see [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints).
 
-## Properties
+## Instance properties
 
 Some combination—but not necessarily all—of the following properties will exist on the object.
 
@@ -65,7 +65,7 @@ Some combination—but not necessarily all—of the following properties will ex
 - {{domxref("MediaTrackSupportedConstraints.groupId", "groupId")}}
   - : A Boolean value whose value is `true` if the [`groupId`](/en-US/docs/Web/API/MediaTrackConstraints#groupid) constraint is supported in the current environment.
 
-### Properties specific to shared screen tracks
+### Instance properties specific to shared screen tracks
 
 For tracks containing video sources from the user's screen contents, the following additional properties are may be included in addition to those available for video tracks.
 

--- a/files/en-us/web/api/merchantvalidationevent/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/index.md
@@ -29,14 +29,14 @@ To learn more about merchant validation, see {{SectionOnPage("/en-US/docs/Web/AP
 - {{domxref("MerchantValidationEvent.MerchantValidationEvent()","MerchantValidationEvent()")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : Creates a new `MerchantValidationEvent` object describing a {{domxref("PaymentRequest.merchantvalidation_event", "merchantvalidation")}} event that will be sent to the payment handler to request that it validate the merchant.
 
-## Properties
+## Instance properties
 
 - {{domxref("MerchantValidationEvent.methodName")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : A string providing a unique payment method identifier for the payment handler that's requiring validation. This may be either one of the standard payment method identifier strings or a URL that both identifies and handles requests for the payment handler, such as `https://apple.com/apple-pay`.
 - {{domxref("MerchantValidationEvent.validationURL")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : A string specifying a URL from which the site or app can fetch payment handler specific validation information. Once this data is retrieved, the data (or a promise resolving to the validation data) should be passed into {{domxref("MerchantValidationEvent.complete", "complete()")}} to validate that the payment request is coming from an authorized merchant.
 
-## Methods
+## Instance methods
 
 - {{domxref("MerchantValidationEvent.complete()")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : Pass the data retrieved from the URL specified by {{domxref("MerchantValidationEvent.validationURL", "validationURL")}} into `complete()` to complete the validation process for the {{domxref("PaymentRequest")}}.

--- a/files/en-us/web/api/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/index.md
@@ -18,7 +18,7 @@ The **`MessageChannel`** interface of the [Channel Messaging API](/en-US/docs/We
 
 {{AvailableInWorkers}}
 
-## Properties
+## Instance properties
 
 - {{domxref("MessageChannel.port1")}} {{ReadOnlyInline}}
   - : Returns port1 of the channel.

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -38,7 +38,7 @@ The action triggered by this event is defined in a function set as the event han
 - {{domxref("MessageEvent.MessageEvent", "MessageEvent()")}}
   - : Creates a new `MessageEvent`.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("Event")}}._
 
@@ -53,7 +53,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/messageport/index.md
+++ b/files/en-us/web/api/messageport/index.md
@@ -22,7 +22,7 @@ The **`MessagePort`** interface of the [Channel Messaging API](/en-US/docs/Web/A
 
 {{InheritanceDiagram}}
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("EventTarget")}}_.
 

--- a/files/en-us/web/api/metadata/index.md
+++ b/files/en-us/web/api/metadata/index.md
@@ -21,7 +21,7 @@ The **`Metadata`** interface contains information about a file system entry. Thi
 
 > **Note:** This interface isn't available through the global scope; instead, you obtain a `Metadata` object describing a {{domxref("FileSystemEntry")}} using the method {{domxref("FileSystemEntry.getMetadata()")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("Metadata.modificationTime", "modificationTime")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : A {{jsxref("Date")}} object indicating the date and time the entry was modified.

--- a/files/en-us/web/api/midiaccess/index.md
+++ b/files/en-us/web/api/midiaccess/index.md
@@ -16,7 +16,7 @@ The **`MIDIAccess`** interface of the [Web MIDI API](/en-US/docs/Web/API/Web_MID
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("MIDIAccess.inputs")}} {{ReadOnlyInline}}
   - : Returns an instance of {{domxref("MIDIInputMap")}} which provides access to any available MIDI input ports.

--- a/files/en-us/web/api/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/index.md
@@ -24,7 +24,7 @@ The **`MIDIConnectionEvent`** interface of the [Web MIDI API](/en-US/docs/Web/AP
 - {{domxref("MIDIConnectionEvent.MIDIConnectionEvent", "MIDIConnectionEvent()")}}
   - : Creates a new `MIDIConnectionEvent` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("MIDIConnectionEvent.port")}} {{ReadOnlyInline}}
   - : Returns a reference to a {{domxref("MIDIPort")}} instance for a port that has been connected or disconnected."

--- a/files/en-us/web/api/midiinput/index.md
+++ b/files/en-us/web/api/midiinput/index.md
@@ -19,11 +19,11 @@ The **`MIDIInput`** interface of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from {{domxref("MIDIPort")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from {{domxref("MIDIPort")}}._
 

--- a/files/en-us/web/api/midimessageevent/index.md
+++ b/files/en-us/web/api/midimessageevent/index.md
@@ -23,14 +23,14 @@ The **`MIDIMessageEvent`** interface of the [Web MIDI API](/en-US/docs/Web/API/W
 - {{domxref("MIDIMessageEvent.MIDIMessageEvent", "MIDIMessageEvent()")}}
   - : Creates a new `MIDIMessageEvent` object instance.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("Event")}}._
 
 - {{domxref("MIDIMessageEvent.data")}}
   - : A {{jsxref("Uint8Array")}} containing the data bytes of a single MIDI message. See the [MIDI specification](https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message) for more information on its form.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from {{domxref("Event")}}._
 

--- a/files/en-us/web/api/midioutput/index.md
+++ b/files/en-us/web/api/midioutput/index.md
@@ -16,11 +16,11 @@ The **`MIDIOutput`** interface of the {{domxref('Web MIDI API','','',' ')}} prov
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from {{domxref("MIDIPort")}}._
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from {{domxref("MIDIPort")}}._
 

--- a/files/en-us/web/api/midiport/index.md
+++ b/files/en-us/web/api/midiport/index.md
@@ -18,7 +18,7 @@ A `MIDIPort` instance is created when a new MIDI device is connected. Therefore 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("MIDIPort.id")}} {{ReadOnlyInline}}
   - : Returns a string containing the unique ID of the port.
@@ -57,7 +57,7 @@ A `MIDIPort` instance is created when a new MIDI device is connected. Therefore 
     - `"pending"`
       - : The device that this `MIDIPort` represents has been opened but has subsequently disconnected .
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/mimetype/index.md
+++ b/files/en-us/web/api/mimetype/index.md
@@ -15,7 +15,7 @@ browser-compat: api.MimeType
 
 The **`MimeType`** interface provides contains information about a MIME type associated with a particular plugin. {{domxref("Navigator.mimeTypes")}} returns an array of this object.
 
-## Properties
+## Instance properties
 
 - {{domxref("MimeType.type")}} {{Deprecated_Inline}}
   - : Returns the MIME type of the associated plugin.

--- a/files/en-us/web/api/mimetypearray/index.md
+++ b/files/en-us/web/api/mimetypearray/index.md
@@ -15,12 +15,12 @@ browser-compat: api.MimeTypeArray
 
 The **`MimeTypeArray`** interface returns an array of {{domxref('MimeType')}} instances, each of which contains information about a supported browser plugins. This object is returned by {{domxref("Navigator.mimeTypes")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("MimeTypeArray.length")}} {{Deprecated_Inline}}
   - : The number of items in the array.
 
-## Methods
+## Instance methods
 
 - {{domxref("MimeTypeArray.item()")}} {{Deprecated_Inline}}
   - : Returns the `MimeType` object with the specified index.

--- a/files/en-us/web/api/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/index.md
@@ -31,7 +31,7 @@ Several more specific events are based on `MouseEvent`, including {{domxref("Whe
 - {{domxref("MouseEvent.MouseEvent", "MouseEvent()")}}
   - : Creates a `MouseEvent` object.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 
@@ -86,14 +86,14 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 - {{domxref("MouseEvent.y")}} {{ReadOnlyInline}}
   - : Alias for {{domxref("MouseEvent.clientY")}}.
 
-## Constants
+## Static properties
 
 - {{domxref("MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN")}} {{non-standard_inline}} {{ReadOnlyInline}}
   - : Minimum force necessary for a normal click.
 - {{domxref("MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN")}} {{non-standard_inline}} {{ReadOnlyInline}}
   - : Minimum force necessary for a force click.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 

--- a/files/en-us/web/api/mousescrollevent/index.md
+++ b/files/en-us/web/api/mousescrollevent/index.md
@@ -59,7 +59,7 @@ void initMouseScrollEvent(
 | `HORIZONTAL_AXIS` | `0x01` | The event is caused by horizontal wheel operation. |
 | `VERTICAL_AXIS`   | `0x02` | The event is caused by vertical wheel operation.   |
 
-## Methods
+## Instance methods
 
 - `initMouseScrollEvent()`
   - : See `nsIDOMMouseScrollEvent::initMouseScrollEvent()`.

--- a/files/en-us/web/api/msgestureevent/index.md
+++ b/files/en-us/web/api/msgestureevent/index.md
@@ -24,7 +24,7 @@ The **`MSGestureEvent`** is a proprietary interface specific to Internet Explore
 - {{domxref("MSGestureEvent.MSGestureEvent", "MSGestureEvent()")}}
   - : Creates an `MSGestureEvent` object.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 
@@ -49,7 +49,7 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 - {{domxref("MSGestureEvent.velocityY")}} {{ReadOnlyInline}}
   - : Velocity along the direction of the Y-axis.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 

--- a/files/en-us/web/api/msgraphicstrust/index.md
+++ b/files/en-us/web/api/msgraphicstrust/index.md
@@ -17,7 +17,7 @@ that provides properties for info on protected video playback.
 
 This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
-## Properties
+## Instance properties
 
 - `constrictionActive` {{ReadOnlyInline}}
   - : A read-only property which is _true_ when protected media is forced to play in a lower resolution.

--- a/files/en-us/web/api/msmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/index.md
@@ -19,22 +19,26 @@ tags:
 
 This proprietary method is specific to Internet Explorer.
 
-### Events
+## Instance properties
 
-{{domxref("Element/MSManipulationStateChanged_event", "MSManipulationStateChanged")}}: Event fires when the state of an element being manipulated has changed.
+- `currentState` {{ReadOnlyInline}}
+  - : Returns the current state of a manipulation event.
+- `inertiaDestinationX` {{ReadOnlyInline}}
+  - : Represents the predicted horizontal scroll offset after the inertia phase completes.
+- `inertiaDestinationY` {{ReadOnlyInline}}
+  - : Represents the predicted vertical scroll offset after the inertia phase completes.
+- `lastState` {{ReadOnlyInline}}
+  - : Returns the last state after a manipulation change event.
 
-### Methods
+## Instance methods
 
-{{DOMxRef("MSManipulationEvent.initMSManipulationEvent()")}}: Used to create a manipulation event that can be called from JavaScript.
+- {{DOMxRef("MSManipulationEvent.initMSManipulationEvent()")}}
+  - : Used to create a manipulation event that can be called from JavaScript.
 
-### Properties
+## Events
 
-| Property                                 | Description                                                                          |
-| ---------------------------------------- | ------------------------------------------------------------------------------------ |
-| `currentState` {{ReadOnlyInline}}        | Returns the current state of a manipulation event.                                   |
-| `inertiaDestinationX` {{ReadOnlyInline}} | Represents the predicted horizontal scroll offset after the inertia phase completes. |
-| `inertiaDestinationY` {{ReadOnlyInline}} | Represents the predicted vertical scroll offset after the inertia phase completes.   |
-| `lastState` {{ReadOnlyInline}}           | Returns the last state after a manipulation change event.                            |
+- {{domxref("Element/MSManipulationStateChanged_event", "MSManipulationStateChanged")}}:
+  - : Event fires when the state of an element being manipulated has changed.
 
 ## Example
 

--- a/files/en-us/web/api/mssitemodeevent/index.md
+++ b/files/en-us/web/api/mssitemodeevent/index.md
@@ -16,7 +16,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 MSSiteModeEvent
 
-### Methods
+### Instance methods
 
 <table class="no-markdown">
   <thead>
@@ -52,7 +52,7 @@ MSSiteModeEvent
   </tbody>
 </table>
 
-### Properties
+### Instance properties
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/mutationobserver/index.md
+++ b/files/en-us/web/api/mutationobserver/index.md
@@ -26,7 +26,7 @@ The {{domxref("MutationObserver")}} interface provides the ability to watch for 
 - {{domxref("MutationObserver.MutationObserver", "MutationObserver()")}}
   - : Creates and returns a new `MutationObserver` which will invoke a specified callback function when DOM changes occur.
 
-## Methods
+## Instance methods
 
 - {{domxref("MutationObserver.disconnect()", "disconnect()")}}
   - : Stops the `MutationObserver` instance from receiving further notifications until and unless {{domxref("MutationObserver.observe", "observe()")}} is called again.

--- a/files/en-us/web/api/mutationrecord/index.md
+++ b/files/en-us/web/api/mutationrecord/index.md
@@ -16,7 +16,7 @@ browser-compat: api.MutationRecord
 
 A **`MutationRecord`** represents an individual DOM mutation. It is the object that is inside the array passed to {{domxref("MutationObserver")}}'s callback.
 
-## Properties
+## Instance properties
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/api/namednodemap/index.md
+++ b/files/en-us/web/api/namednodemap/index.md
@@ -16,14 +16,14 @@ A `NamedNodeMap` object is _live_ and will thus be auto-updated if changes are m
 
 > **Note:** Although called `NamedNodeMap`, this interface doesn't deal with {{domxref("Node")}} objects but with {{domxref("Attr")}} objects, which are a specialized class of {{domxref("Node")}} objects.
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any property._
 
 - {{domxref("NamedNodeMap.length")}} {{ReadOnlyInline}}
   - : Returns the amount of objects in the map.
 
-## Methods
+## Instance methods
 
 _This interface doesn't inherit any method._
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/index.md
@@ -20,7 +20,7 @@ The **`NavigationPreloadManager`** interface of the [Service Worker API](/en-US/
 If supported, an object of this type is returned by {{domxref("ServiceWorkerRegistration.navigationPreload")}}.
 The result of a preload fetch request is waited on using the promise returned by {{domxref("FetchEvent.preloadResponse")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("NavigationPreloadManager.enable()")}}
   - : Enables navigation preloading, returning a {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -19,7 +19,7 @@ The **`Navigator`** interface represents the state and the identity of the user 
 
 A `Navigator` object can be retrieved using the read-only {{domxref("window.navigator")}} property.
 
-## Properties
+## Instance properties
 
 _Doesn't inherit any properties._
 
@@ -128,7 +128,7 @@ _Doesn't inherit any properties._
 - {{domxref("Navigator.vendorSub")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : Always returns the empty string.
 
-## Methods
+## Instance methods
 
 _Doesn't inherit any method._
 

--- a/files/en-us/web/api/navigatoruadata/index.md
+++ b/files/en-us/web/api/navigatoruadata/index.md
@@ -19,7 +19,7 @@ An instance of this object is returned by calling {{domxref("Navigator.userAgent
 
 > **Note:** The terms _high entropy_ and _low entropy_ refer to the amount of information these values reveal about the browser. The values returned as properties are deemed low entropy, and unlikely to identify a user. The values returned by {{domxref("NavigatorUAData.getHighEntropyValues()")}} could potentially reveal more information. These values are therefore retrieved via a {{jsxref("Promise")}}, allowing time for the browser to request user permission, or make other checks.
 
-## Properties
+## Instance properties
 
 - {{domxref("NavigatorUAData.brands")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an array of brand information containing the browser name and version.
@@ -28,7 +28,7 @@ An instance of this object is returned by calling {{domxref("Navigator.userAgent
 - {{domxref("NavigatorUAData.platform")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the platform brand the user-agent is running on.
 
-## Methods
+## Instance methods
 
 - {{domxref("NavigatorUAData.getHighEntropyValues()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a dictionary object containing the _high entropy_ values the user-agent returns.

--- a/files/en-us/web/api/ndefreader/index.md
+++ b/files/en-us/web/api/ndefreader/index.md
@@ -21,7 +21,7 @@ The **`NDEFReader`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
 - {{DOMxRef("NDEFReader.NDEFReader", "NDEFReader()")}} {{Experimental_Inline}}
   - : Returns a new `NDEFReader` object.
 
-## Methods
+## Instance methods
 
 _The `NDEFReader` interface inherits the methods of {{domxref("EventTarget")}}, its parent interface._
 

--- a/files/en-us/web/api/ndefreadingevent/index.md
+++ b/files/en-us/web/api/ndefreadingevent/index.md
@@ -21,7 +21,7 @@ The **`NDEFReadingEvent`** interface of the [Web NFC API](/en-US/docs/Web/API/We
 - {{DOMxRef("NDEFReadingEvent.NDEFReadingEvent", "NDEFReadingEvent.NDEFReadingEvent()")}} {{Experimental_Inline}}
   - : Creates a new `NDEFReadingEvent`.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("Event")}}_.
 
@@ -30,7 +30,7 @@ _Inherits properties from its parent, {{DOMxRef("Event")}}_.
 - {{DOMxRef("NDEFReadingEvent.serialNumber")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the serial number of the device, which is used for anti-collision and identification, or an empty string if no serial number is available.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("Event")}}_.
 

--- a/files/en-us/web/api/ndefrecord/index.md
+++ b/files/en-us/web/api/ndefrecord/index.md
@@ -19,7 +19,7 @@ The **`NDEFRecord`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
 - {{DOMxRef("NDEFRecord.NDEFRecord", "NDEFRecord()")}} {{Experimental_Inline}}
   - : Returns a new `NDEFRecord`.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("NDEFRecord.recordType")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns the record type of the record. Records must have either a standardized well-known type name such as `"empty"`, `"text"`, `"url"`, `"smart-poster"`, `"absolute-url"`, `"mime"`, or `"unknown"` or else an external type name, which consists of a domain name and custom type name separated by a colon (":").
@@ -35,7 +35,7 @@ The **`NDEFRecord`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_
 - {{DOMxRef("NDEFRecord.lang")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns the language of a textual payload, or `null` if one was not supplied.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("NDEFRecord.toRecords", "NDEFRecord.toRecords()")}} {{Experimental_Inline}}
   - : Converts {{DOMxRef("NDEFRecord.data")}} to a sequence of records. This allows parsing the payloads of record types which may contain nested records, such as smart poster and external type records.

--- a/files/en-us/web/api/networkinformation/index.md
+++ b/files/en-us/web/api/networkinformation/index.md
@@ -21,7 +21,7 @@ The `NetworkInformation` interface cannot be instantiated. It is instead accesse
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties of its parent, {{domxref("EventTarget")}}._
 
@@ -48,7 +48,7 @@ _This interface also inherits properties of its parent, {{domxref("EventTarget")
     - `other`
     - `unknown`
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/node/index.md
+++ b/files/en-us/web/api/node/index.md
@@ -30,10 +30,9 @@ exception.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
-_In addition to the properties below, `Node` inherits properties from its
-parent, {{DOMxRef("EventTarget")}}_.
+_In addition to the properties below, `Node` inherits properties from its parent, {{DOMxRef("EventTarget")}}_.
 
 - {{DOMxRef("Node.baseURI")}} {{ReadOnlyInline}}
   - : Returns a string representing the base URL of the document
@@ -99,31 +98,26 @@ parent, {{DOMxRef("EventTarget")}}_.
 - {{DOMxRef("Node.textContent")}}
   - : Returns / Sets the textual content of an element and all its descendants.
 
-## Methods
+## Instance methods
 
-_In addition to the methods below, `Node` inherits methods from its
-parent, {{DOMxRef("EventTarget")}}._
+_In addition to the methods below, `Node` inherits methods from its parent, {{DOMxRef("EventTarget")}}._
 
 - {{DOMxRef("Node.appendChild()")}}
-  - : Adds the specified `childNode` argument as the last child to
-    the current node.
+  - : Adds the specified `childNode` argument as the last child to the current node.
     If the argument referenced an existing node on the DOM tree, the node will be detached
     from its current position and attached at the new position.
 - {{DOMxRef("Node.cloneNode()")}}
   - : Clone a `Node`, and optionally, all of its contents. By default, it
     clones the content of the node.
 - {{DOMxRef("Node.compareDocumentPosition()")}}
-  - : Compares the position of the current node against another node in any other
-    document.
+  - : Compares the position of the current node against another node in any other document.
 - {{DOMxRef("Node.contains()")}}
   - : Returns `true` or `false` value indicating whether or not a node is a
     descendant of the calling node.
 - {{DOMxRef("Node.getRootNode()")}}
-  - : Returns the context object's root which optionally includes the shadow root if it is
-    available.
+  - : Returns the context object's root which optionally includes the shadow root if it is available.
 - {{DOMxRef("Node.hasChildNodes()")}}
-  - : Returns a boolean value indicating whether or not the element has any child
-    nodes.
+  - : Returns a boolean value indicating whether or not the element has any child nodes.
 - {{DOMxRef("Node.insertBefore()")}}
   - : Inserts a `Node` before the reference node as a child of a specified
     parent node.

--- a/files/en-us/web/api/nodeiterator/index.md
+++ b/files/en-us/web/api/nodeiterator/index.md
@@ -23,7 +23,7 @@ A `NodeIterator` can be created using the
 const nodeIterator = document.createNodeIterator(root, whatToShow, filter);
 ```
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any property._
 
@@ -66,7 +66,7 @@ _This interface doesn't inherit any property._
     {{domxref("NodeIterator")}} is anchored before, the flag being `true`,
     or after, the flag being `false`, the anchor node.
 
-## Methods
+## Instance methods
 
 _This interface doesn't inherit any method._
 

--- a/files/en-us/web/api/nodelist/index.md
+++ b/files/en-us/web/api/nodelist/index.md
@@ -40,12 +40,12 @@ In other cases, the `NodeList` is _static,_ where any changes in the DOM do not 
 
 It's good to keep this distinction in mind when you choose how to iterate over the items in the `NodeList`, and whether you should cache the list's `length`.
 
-## Properties
+## Instance properties
 
 - {{domxref("NodeList.length")}}
   - : The number of nodes in the `NodeList`.
 
-## Methods
+## Instance methods
 
 - {{domxref("NodeList.item()")}}
 

--- a/files/en-us/web/api/notification/index.md
+++ b/files/en-us/web/api/notification/index.md
@@ -24,9 +24,7 @@ These notifications' appearance and specific functionality vary across platforms
 - {{domxref("Notification.Notification", "Notification()")}}
   - : Creates a new instance of the `Notification` object.
 
-## Properties
-
-### Static properties
+## Static properties
 
 These properties are available only on the `Notification` object itself.
 
@@ -41,7 +39,7 @@ These properties are available only on the `Notification` object itself.
 - {{domxref("Notification.maxActions")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : The maximum number of actions supported by the device and the User Agent.
 
-### Instance properties
+## Instance properties
 
 These properties are available only on instances of the `Notification` object.
 
@@ -76,16 +74,14 @@ These properties are available only on instances of the `Notification` object.
 - {{domxref("Notification.vibrate")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Specifies a vibration pattern for devices with vibration hardware to emit.
 
-## Methods
-
-### Static methods
+## Static methods
 
 These methods are available only on the `Notification` object itself.
 
 - {{domxref("Notification.requestPermission()")}}
   - : Requests permission from the user to display notifications.
 
-### Instance methods
+## Instance methods
 
 These properties are available only on an instance of the `Notification` object or through its [`prototype`](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain). The `Notification` object also inherits from the {{domxref("EventTarget")}} interface.
 

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -26,7 +26,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 - {{domxref("NotificationEvent.NotificationEvent","NotificationEvent()")}}
   - : Creates a new `NotificationEvent` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
@@ -35,7 +35,7 @@ _Inherits properties from its ancestor, {{domxref("Event")}}_.
 - {{domxref("NotificationEvent.action")}} {{ReadOnlyInline}}
   - : Returns the string ID of the notification button the user clicked. This value returns an empty string if the user clicked the notification somewhere other than an action button, or the notification does not have a button.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("ExtendableEvent")}}_.
 

--- a/files/en-us/web/api/notifyaudioavailableevent/index.md
+++ b/files/en-us/web/api/notifyaudioavailableevent/index.md
@@ -15,7 +15,7 @@ tags:
 
 The non-standard, obsolete, **`NotifyAudioAvailableEvent`** interface defines the event sent to audio elements when the audio buffer is full.
 
-## Properties
+## Instance properties
 
 - `frameBuffer` {{ReadOnlyInline}}
   - : A {{jsxref("Float32Array")}} containing the raw 32-bit floating-point audio data obtained from decoding the audio (e.g., the raw data being sent to the audio hardware vs. encoded audio). The data is a series of audio samples, each sample containing one 32-bit value per audio channel. All audio frames are normalized to contain 1024 samples by default, but could be any length between 512 and 16384 samples if the user has set a different length using the **`mozFrameBufferLength`** attribute.


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with J to N

Moved to have consistent headings and ordering.