### PR TITLE
Web API methods/props sorted to static/instance headings - OPQ

### DIFF
--- a/files/en-us/web/api/oes_vertex_array_object/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/index.md
@@ -25,7 +25,7 @@ This extension exposes one new constant, which can be used in the {{domxref("Web
 - `ext.VERTEX_ARRAY_BINDING_OES`
   - : Returns a {{domxref("WebGLVertexArrayObject")}} object when used in the {{domxref("WebGLRenderingContext.getParameter()", "gl.getParameter()")}} method as the `pname` parameter.
 
-## Methods
+## Instance methods
 
 This extension exposes four new methods.
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.md
@@ -24,14 +24,14 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `OfflineAudioCompletionEv
 - {{domxref("OfflineAudioCompletionEvent.OfflineAudioCompletionEvent", "OfflineAudioCompletionEvent()")}}
   - : Creates a new `OfflineAudioCompletionEvent` object instance.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent, {{domxref("Event")}}_.
 
 - {{domxref("OfflineAudioCompletionEvent.renderedBuffer")}} {{ReadOnlyInline}}
   - : An {{domxref("AudioBuffer")}} containing the result of processing an {{domxref("OfflineAudioContext")}}.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/index.md
@@ -23,14 +23,14 @@ The `OfflineAudioContext` interface is an {{domxref("AudioContext")}} interface 
 - {{domxref("OfflineAudioContext.OfflineAudioContext()", "OfflineAudioContext()")}}
   - : Creates a new `OfflineAudioContext` instance.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent interface, {{domxref("BaseAudioContext")}}._
 
 - {{domxref('OfflineAudioContext.length')}} {{ReadOnlyInline}}
   - : An integer representing the size of the buffer in sample-frames.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from its parent interface, {{domxref("BaseAudioContext")}}._
 

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -29,14 +29,14 @@ Rendering operations can also be run inside a [worker](/en-US/docs/Web/API/Web_W
 - {{domxref("OffscreenCanvas.OffscreenCanvas", "OffscreenCanvas()")}}
   - : `OffscreenCanvas` constructor. Creates a new `OffscreenCanvas` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("OffscreenCanvas.height")}}
   - : The height of the offscreen canvas.
 - {{domxref("OffscreenCanvas.width")}}
   - : The width of the offscreen canvas.
 
-## Methods
+## Instance methods
 
 - {{domxref("OffscreenCanvas.getContext()")}}
   - : Returns a rendering context for the offscreen canvas.

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -48,7 +48,7 @@ The **`OscillatorNode`** interface represents a periodic waveform, such as a sin
 - {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
   - : Creates a new instance of an `OscillatorNode` object, optionally providing an object specifying default values for the node's [properties](#properties). As an alternative, you can use the {{domxref("BaseAudioContext.createOscillator()")}} factory method; see [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioScheduledSourceNode")}}, and adds the following properties:_
 
@@ -64,7 +64,7 @@ _Inherits properties from its parent, {{domxref("AudioScheduledSourceNode")}}, a
 - {{domxref("OscillatorNode.onended")}}
   - : Sets the event handler for the {{domxref("AudioScheduledSourceNode/ended_event", "ended")}} event, which fires when the tone has stopped playing.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}, and adds the following:_
 

--- a/files/en-us/web/api/otpcredential/index.md
+++ b/files/en-us/web/api/otpcredential/index.md
@@ -17,7 +17,7 @@ The **`OTPCredential`** interface of the {{domxref('WebOTP API','','',' ')}} con
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from {{domxref("Credential")}}._
 
@@ -28,7 +28,7 @@ _This interface also inherits properties from {{domxref("Credential")}}._
 
 None.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/index.md
@@ -26,7 +26,7 @@ The **`OverconstrainedError`** interface of the [Media Capture and Streams API](
 - {{domxref("OverconstrainedError.OverconstrainedError", "OverconstrainedError()")}}
   - : Creates a new `OverconstrainedError` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("OverconstrainedError.constraint")}} {{ReadOnlyInline}}
   - : Returns the constraint that was supplied in the constructor, meaning the constraint that was not satisfied.
@@ -35,7 +35,7 @@ The **`OverconstrainedError`** interface of the [Media Capture and Streams API](
 - {{domxref("DOMException.name")}} {{ReadOnlyInline}}
   - : Will always return `OverconstrainedError`.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/ovr_multiview2/index.md
+++ b/files/en-us/web/api/ovr_multiview2/index.md
@@ -42,7 +42,7 @@ This extension exposes 4 constants that can be used in [`getParameter()`](/en-US
 - `FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR`
   - : If baseViewIndex is not the same for all framebuffer attachment points where the value of `FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE` is not `NONE`, the framebuffer is considered incomplete. Calling [`checkFramebufferStatus`](/en-US/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus) for a framebuffer in this state returns `FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR`.
 
-## Methods
+## Instance methods
 
 - [`framebufferTextureMultiviewOVR()`](/en-US/docs/Web/API/OVR_multiview2/framebufferTextureMultiviewOVR)
   - : Simultaneously renders to multiple elements of a 2D texture array.

--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -115,7 +115,7 @@ if (typeof document.addEventListener === "undefined" || hidden === undefined) {
 }
 ```
 
-## Properties added to the Document interface
+## Instance properties added to the Document interface
 
 The Page Visibility API adds the following properties to the {{domxref("Document")}} interface:
 

--- a/files/en-us/web/api/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/index.md
@@ -16,7 +16,7 @@ The **`PageTransitionEvent`** event object is available inside handler functions
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/paintworklet/index.md
+++ b/files/en-us/web/api/paintworklet/index.md
@@ -26,7 +26,7 @@ To avoid leaking visited links, this feature is currently disabled in Chrome-bas
 - The CSS Painting API [Privacy Considerations section](https://drafts.css-houdini.org/css-paint-api/#privacy-considerations)
 - The CSS Painting API spec issue ["CSS Paint API leaks browsing history"](https://github.com/w3c/css-houdini-drafts/issues/791)
 
-## Properties
+## Instance properties
 
 - {{domxref('PaintWorklet.devicePixelRatio')}}
   - : Returns the current device's ratio of physical pixels to logical pixels.
@@ -35,7 +35,7 @@ To avoid leaking visited links, this feature is currently disabled in Chrome-bas
 
 None.
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from {{domxref('Worklet')}}._
 

--- a/files/en-us/web/api/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/index.md
@@ -51,7 +51,7 @@ A `PannerNode` always has exactly one input and one output: the input can be _mo
 - {{domxref("PannerNode.PannerNode", "PannerNode()")}}
   - : Creates a new `PannerNode` object instance.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
@@ -86,7 +86,7 @@ _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 - {{domxref("PannerNode.rolloffFactor")}}
   - : A double value describing how quickly the volume is reduced as the source moves away from the listener. This value is used by all distance models.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/index.md
@@ -26,7 +26,7 @@ The interface of the [Credential Management API](/en-US/docs/Web/API/Credential_
 - {{domxref("PasswordCredential.PasswordCredential()","PasswordCredential()")}} {{securecontext_inline}} {{Experimental_Inline}}
   - : Creates a new `PasswordCredential` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
@@ -41,7 +41,7 @@ _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 None.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/path2d/index.md
+++ b/files/en-us/web/api/path2d/index.md
@@ -20,7 +20,7 @@ The **`Path2D`** interface of the Canvas 2D API is used to declare a path that c
 - {{domxref("Path2D.Path2D", "Path2D()")}}
   - : `Path2D` constructor. Creates a new `Path2D` object.
 
-## Methods
+## Instance methods
 
 - {{domxref("Path2D.addPath()")}}
   - : Adds a path to the current path.

--- a/files/en-us/web/api/paymentaddress/index.md
+++ b/files/en-us/web/api/paymentaddress/index.md
@@ -21,7 +21,7 @@ The **`PaymentAddress`** interface of the [Payment Request API](/en-US/docs/Web/
 
 It may be useful to refer to the Universal Postal Union web site's [Addressing S42 standard](https://www.upu.int/en/Postal-Solutions/Programmes-Services/Addressing-Solutions#addressing-s42-standard) materials, which provide information about international standards for postal addresses.
 
-## Properties
+## Instance properties
 
 - {{domxref('PaymentAddress.addressLine')}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : An array of strings providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.
@@ -46,7 +46,7 @@ It may be useful to refer to the Universal Postal Union web site's [Addressing S
 
 > **Note:** Properties for which values were not specified contain empty strings.
 
-## Methods
+## Instance methods
 
 - {{domxref('PaymentAddress.toJSON()')}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : A standard serializer that returns a JSON representation of the `PaymentAddress` object's properties.

--- a/files/en-us/web/api/paymentmethodchangeevent/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.md
@@ -26,7 +26,7 @@ The **`PaymentMethodChangeEvent`** interface of the [Payment Request API](/en-US
 - {{domxref("PaymentMethodChangeEvent.PaymentMethodChangeEvent", "PaymentMethodChangeEvent()")}}
   - : Creates and returns a new `PaymentMethodChangeEvent` object, optionally initialized with values taken from a given {{domxref("PaymentMethodChangeEventInit")}} dictionary.
 
-## Properties
+## Instance properties
 
 _In addition to the properties below, this interface includes properties inherited from {{domxref("PaymentRequestUpdateEvent")}}._
 
@@ -35,7 +35,7 @@ _In addition to the properties below, this interface includes properties inherit
 - {{domxref("PaymentMethodChangeEvent.methodName", "methodName")}} {{ReadOnlyInline}} {{securecontext_inline}}
   - : A string containing the payment method identifier, a string which uniquely identifies a particular payment method. This identifier is usually a URL used during the payment process, but may be a standardized non-URL string as well, such as `basic-card`. The default value is the empty string, `""`.
 
-## Methods
+## Instance methods
 
 _This interface includes methods inherited from {{domxref("PaymentRequestUpdateEvent")}}._
 

--- a/files/en-us/web/api/paymentrequest/index.md
+++ b/files/en-us/web/api/paymentrequest/index.md
@@ -28,7 +28,7 @@ The [Payment Request API's](/en-US/docs/Web/API/Payment_Request_API) **`PaymentR
 - {{domxref('PaymentRequest.PaymentRequest()','PaymentRequest()')}} {{SecureContext_Inline}}
   - : Creates a new `PaymentRequest` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('PaymentRequest.id')}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : An unique identifier for a particular `PaymentRequest`, which can be set via `details.id`. When none is set, it defaults to a UUID.
@@ -39,7 +39,7 @@ The [Payment Request API's](/en-US/docs/Web/API/Payment_Request_API) **`PaymentR
 - {{domxref('PaymentRequest.shippingType')}} {{ReadOnlyInline}} {{SecureContext_Inline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns the type of shipping used to fulfill the transaction. This will be one of `shipping`, `delivery`, `pickup`, or `null` if a value was not provided in the constructor.
 
-## Methods
+## Instance methods
 
 - {{domxref('PaymentRequest.canMakePayment()')}} {{SecureContext_Inline}}
   - : Indicates whether the `PaymentRequest` object can make a payment before calling `show()`.

--- a/files/en-us/web/api/paymentrequestevent/index.md
+++ b/files/en-us/web/api/paymentrequestevent/index.md
@@ -24,7 +24,7 @@ The **`PaymentRequestEvent`** interface of the [Payment Request API](/en-US/docs
 - {{domxref("PaymentRequestEvent.PaymentRequestEvent","PaymentRequestEvent()")}} {{Experimental_Inline}}
   - : Creates a new `PaymentRequestEvent` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("PaymentRequestEvent.instrumentKey","instrumentKey")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns a {{domxref("PaymentInstrument")}} object reflecting the payment instrument selected by the user or an empty string if the user has not registered or chosen a payment instrument.
@@ -41,7 +41,7 @@ The **`PaymentRequestEvent`** interface of the [Payment Request API](/en-US/docs
 - {{domxref("PaymentRequestEvent.total","total")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the total amount being requested for payment.
 
-## Methods
+## Instance methods
 
 - {{domxref("PaymentRequestEvent.openWindow","openWindow()")}} {{Experimental_Inline}}
   - : Opens the specified URL in a new window, if and only if the given URL is on the same origin as the calling page. It returns a {{jsxref("Promise")}} that resolves with a reference to a {{domxref("WindowClient")}}.

--- a/files/en-us/web/api/paymentrequestupdateevent/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/index.md
@@ -29,11 +29,11 @@ The **`PaymentRequestUpdateEvent`** interface is used for events sent to a {{dom
 - {{domxref("PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()","PaymentRequestUpdateEvent()")}} {{securecontext_inline}}
   - : Creates a new `PaymentRequestUpdateEvent` object.
 
-## Properties
+## Instance properties
 
 _Provides only the properties inherited from its parent interface, {{domxref("Event")}}._
 
-## Methods
+## Instance methods
 
 _In addition to methods inherited from the parent interface, {{domxref("Event")}}, `PaymentRequestUpdateEvent` offers the following methods:_
 

--- a/files/en-us/web/api/paymentresponse/index.md
+++ b/files/en-us/web/api/paymentresponse/index.md
@@ -18,7 +18,7 @@ The **`PaymentResponse`** interface of the [Payment Request API](/en-US/docs/Web
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref('PaymentResponse.details')}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : Returns a JSON-serializable object that provides a payment method specific message used by the merchant to process the transaction and determine successful fund transfer. The contents of the object depend on the payment method being used. Developers need to consult whomever controls the URL for the expected shape of the details object.
@@ -37,7 +37,7 @@ The **`PaymentResponse`** interface of the [Payment Request API](/en-US/docs/Web
 - {{domxref('PaymentResponse.shippingOption')}} {{ReadOnlyInline}} {{SecureContext_Inline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns the ID attribute of the shipping option selected by the user. This option is only present when the `requestShipping` option is set to `true` in the `options` parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.
 
-## Methods
+## Instance methods
 
 - {{domxref('PaymentResponse.retry()')}} {{SecureContext_Inline}}
   - : If something is wrong with the payment response's data (and there is a recoverable error), this method allows a merchant to request that the user retry the payment. The method takes an object as argument, which is used to signal to the user exactly what is wrong with the payment response so they can try to correct any issues.

--- a/files/en-us/web/api/pbkdf2params/index.md
+++ b/files/en-us/web/api/pbkdf2params/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params
 
 The **`Pbkdf2Params`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when using the [PBKDF2](/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2) algorithm.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `PBKDF2`.

--- a/files/en-us/web/api/performance/index.md
+++ b/files/en-us/web/api/performance/index.md
@@ -22,7 +22,7 @@ An object of this type can be obtained by calling the {{domxref("window.performa
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `Performance` interface doesn't inherit any properties._
 
@@ -43,7 +43,7 @@ _The `Performance` interface doesn't inherit any properties._
 - {{domxref("Performance.timeOrigin")}} {{ReadOnlyInline}}
   - : Returns the high resolution timestamp of the start time of the performance measurement.
 
-## Methods
+## Instance methods
 
 _The `Performance` interface doesn't inherit any methods._
 

--- a/files/en-us/web/api/performance_api/index.md
+++ b/files/en-us/web/api/performance_api/index.md
@@ -28,13 +28,13 @@ The {{domxref("DOMHighResTimeStamp")}} type, as its name implies, represents a h
 
 The unit of `DOMHighResTimeStamp` is milliseconds and should be accurate to 5 µs (microseconds). However, If the browser is unable to provide a time value accurate to 5 microseconds (because, for example, due to hardware or software constraints), the browser can represent the value as a time in milliseconds accurate to a millisecond.
 
-## Methods
+## Instance methods
 
 The {{domxref("Performance")}} interface has two methods. The {{domxref("Performance.now","now()")}} method returns a {{domxref("DOMHighResTimeStamp")}} whose value that depends on the {{domxref("PerformanceTiming.navigationStart","navigation start")}} and scope. If the scope is a window, the value is the time the browser context was created and if the scope is a {{domxref("Worker","worker")}}, the value is the time the worker was created.
 
 The {{domxref("Performance.toJSON","toJSON()")}} method returns a serialization of the {{domxref("Performance")}} object, for those attributes that can be serialized.
 
-## Properties
+## Instance properties
 
 The {{domxref("Performance")}} interface has two properties. The {{domxref("Performance.timing","timing")}} property returns a {{domxref("PerformanceTiming")}} object containing latency-related performance information such as the start of navigation time, start and end times for redirects, start and end times for responses, etc.
 

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -17,7 +17,7 @@ The **`PerformanceElementTiming`** interface of the {{domxref('Element Timing AP
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PerformanceElementTiming.element")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An {{domxref("Element")}} representing the element we are returning information about.
@@ -38,7 +38,7 @@ The **`PerformanceElementTiming`** interface of the {{domxref('Element Timing AP
 - {{domxref("PerformanceElementTiming.url")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string which is the initial URL of the resources request for images, 0 for text.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceElementTiming.toJSON()")}} {{Experimental_Inline}}
   - : Generates a JSON description of the object.

--- a/files/en-us/web/api/performanceentry/index.md
+++ b/files/en-us/web/api/performanceentry/index.md
@@ -27,7 +27,7 @@ The **`PerformanceEntry`** object encapsulates a single performance metric that 
 
 {{AvailableInWorkers}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PerformanceEntry.name")}} {{ReadOnlyInline}}
   - : A value that further specifies the value returned by the {{domxref("PerformanceEntry.entryType")}} property. The value of both depends on the subtype. See property page for valid values.
@@ -38,7 +38,7 @@ The **`PerformanceEntry`** object encapsulates a single performance metric that 
 - {{domxref("PerformanceEntry.duration")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} representing the time value of the duration of the performance event.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceEntry.toJSON","PerformanceEntry.toJSON()")}}
   - : Returns a JSON representation of the `PerformanceEntry` object.

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -56,7 +56,7 @@ The `PerformanceEventTiming` interface of the Event Timing API provides timing i
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PerformanceEventTiming.processingStart")}}
   - : Returns the time at which event dispatch started.
@@ -67,7 +67,7 @@ The `PerformanceEventTiming` interface of the Event Timing API provides timing i
 - {{domxref("PerformanceEventTiming.target")}}
   - : Returns the associated event's last target, if it is not removed.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceEventTiming.toJSON()")}}
   - : Converts the PerformanceEventTiming object to JSON.

--- a/files/en-us/web/api/performancelongtasktiming/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/index.md
@@ -18,7 +18,7 @@ The **`PerformanceLongTaskTiming`** interface of the [Long Tasks API](/en-US/doc
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PerformanceLongTaskTiming.attribution")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a sequence of {{domxref('TaskAttributionTiming')}} instances.

--- a/files/en-us/web/api/performancemark/index.md
+++ b/files/en-us/web/api/performancemark/index.md
@@ -19,7 +19,7 @@ browser-compat: api.PerformanceMark
 
 {{AvailableInWorkers}}
 
-## Properties
+## Instance properties
 
 This interface has no properties but it extends the following {{domxref("PerformanceEntry")}} properties by qualifying/constraining the properties as follows:
 
@@ -32,7 +32,7 @@ This interface has no properties but it extends the following {{domxref("Perform
 - {{domxref("PerformanceEntry.duration")}}
   - : Returns "`0`". (A mark has no _duration_.)
 
-## Methods
+## Instance methods
 
 This interface has no methods.
 

--- a/files/en-us/web/api/performancemeasure/index.md
+++ b/files/en-us/web/api/performancemeasure/index.md
@@ -19,7 +19,7 @@ browser-compat: api.PerformanceMeasure
 
 {{AvailableInWorkers}}
 
-## Properties
+## Instance properties
 
 This interface defines:
 
@@ -38,7 +38,7 @@ In addition, it extends the following {{domxref("PerformanceEntry")}} properties
 - {{domxref("PerformanceEntry.duration")}}
   - : Returns a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure (typically, the measure's end mark timestamp minus its start mark timestamp).
 
-## Methods
+## Instance methods
 
 This interface has no methods.
 

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -26,7 +26,7 @@ The legacy **`PerformanceNavigation`** interface represents information about ho
 
 An object of this type can be obtained by calling the {{domxref("Performance.navigation")}} read-only attribute.
 
-## Properties
+## Instance properties
 
 _The `PerformanceNavigation` interface doesn't inherit any properties._
 
@@ -46,7 +46,7 @@ _The `PerformanceNavigation` interface doesn't inherit any properties._
 - {{domxref("PerformanceNavigation.redirectCount")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : An `unsigned short` representing the number of REDIRECTs done before reaching the page.
 
-## Methods
+## Instance methods
 
 _The `Performance` interface doesn't inherit any methods._
 

--- a/files/en-us/web/api/performancenavigationtiming/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/index.md
@@ -18,7 +18,7 @@ The **`PerformanceNavigationTiming`** interface provides methods and properties 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 This interface extends the following {{domxref('PerformanceEntry')}} properties for navigation performance entry types by qualifying and constraining them as follows:
 
@@ -67,7 +67,7 @@ The interface also supports the following properties:
 - {{domxref('PerformanceNavigationTiming.unloadEventStart')}} {{ReadOnlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} representing the time value equal to the time immediately before the user agent starts the unload event of the previous document.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceNavigationTiming.toJSON()")}}
   - : Returns a string that is the JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.

--- a/files/en-us/web/api/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/index.md
@@ -24,12 +24,12 @@ The **`PerformanceObserver`** interface is used to _observe_ performance measure
 - {{domxref("PerformanceObserver.PerformanceObserver","PerformanceObserver()")}}
   - : Creates and returns a new `PerformanceObserver` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("PerformanceObserver.supportedEntryTypes")}} {{ReadOnlyInline}}
   - : Returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceObserver.observe","PerformanceObserver.observe()")}}
   - : Specifies the set of {{domxref("PerformanceEntry.entryType","entry types")}} to observe. The performance observer's callback function will be invoked when a {{domxref("PerformanceEntry","performance entry")}} is recorded for one of the specified `entryTypes`

--- a/files/en-us/web/api/performanceobserverentrylist/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/index.md
@@ -16,7 +16,7 @@ The **`PerformanceObserverEntryList`** interface is a list of {{domxref("Perform
 
 Note: this interface is exposed to {{domxref("Window")}} and {{domxref("Worker")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceObserverEntryList.getEntries","PerformanceObserverEntryList.getEntries()")}}
   - : Returns a list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects based on the given _filter_.

--- a/files/en-us/web/api/performancepainttiming/index.md
+++ b/files/en-us/web/api/performancepainttiming/index.md
@@ -21,7 +21,7 @@ An application can register a {{domxref("PerformanceObserver")}} for "`paint`" {
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 This interface has no properties but it extends the following {{domxref("PerformanceEntry")}} properties (for "`paint`" {{domxref ("PerformanceEntry.entryType","performance entry types")}}) by qualifying and constraining the properties as follows:
 
@@ -34,7 +34,7 @@ This interface has no properties but it extends the following {{domxref("Perform
 - {{domxref("PerformanceEntry.duration")}}
   - : Returns 0.
 
-## Methods
+## Instance methods
 
 This interface has no methods.
 

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -20,7 +20,7 @@ The interface's properties create a _resource loading timeline_ with {{domxref("
 
 {{AvailableInWorkers}}
 
-## Properties
+## Instance properties
 
 This interface extends the following {{domxref("PerformanceEntry")}} properties for resource performance entry types by qualifying and constraining them as follows:
 
@@ -72,7 +72,7 @@ The interface also supports the following properties which are listed in the ord
 - {{domxref('PerformanceResourceTiming.serverTiming')}} {{ReadOnlyInline}}
   - : An array of {{domxref("PerformanceServerTiming")}} entries containing server timing metrics.
 
-## Methods
+## Instance methods
 
 - {{domxref("PerformanceResourceTiming.toJSON()")}}
   - : Returns a string that is the JSON representation of the {{domxref("PerformanceResourceTiming")}} object.

--- a/files/en-us/web/api/performanceservertiming/index.md
+++ b/files/en-us/web/api/performanceservertiming/index.md
@@ -16,7 +16,7 @@ The **`PerformanceServerTiming`** interface surfaces server metrics that are sen
 
 This interface is restricted to the same origin, but you can use the {{HTTPHeader("Timing-Allow-Origin")}} header to specify the domains that are allowed to access the server metrics. Note that this interface is only available in secure contexts (HTTPS) in some browsers.
 
-## Properties
+## Instance properties
 
 - {{domxref('PerformanceServerTiming.description')}} {{ReadOnlyInline}}
   - : A string value of the server-specified metric description, or an empty string.
@@ -25,7 +25,7 @@ This interface is restricted to the same origin, but you can use the {{HTTPHeade
 - {{domxref('PerformanceServerTiming.name')}} {{ReadOnlyInline}}
   - : A string value of the server-specified metric name.
 
-## Methods
+## Instance methods
 
 - {{domxref('PerformanceServerTiming.toJSON()')}}
   - : Returns a string that is the JSON representation of the `PerformanceServerTiming` object.

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -23,7 +23,7 @@ browser-compat: api.PerformanceTiming
 
 The **`PerformanceTiming`** interface is a legacy interface kept for backwards compatibility and contains properties that offer performance timing information for various events which occur during the loading and use of the current page. You get a `PerformanceTiming` object describing your page using the {{domxref("Performance.timing", "window.performance.timing")}} property.
 
-## Properties
+## Instance properties
 
 _The `PerformanceTiming` interface doesn't inherit any properties._
 
@@ -76,7 +76,7 @@ These properties are listed in the order in which they occur during the navigati
 - {{domxref("PerformanceTiming.loadEventEnd")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : When the {{domxref("Window/load_event", "load")}} event handler terminated, that is when the load event is completed. If this event has not yet been sent, or is not yet completed, it returns `0.`
 
-## Methods
+## Instance methods
 
 _The `PerformanceTiming`_ _interface doesn't inherit any methods._
 

--- a/files/en-us/web/api/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/index.md
@@ -28,12 +28,12 @@ An instance of this event is passed to the {{domxref('ServiceWorkerGlobalScope.p
 - {{domxref("PeriodicSyncEvent.PeriodicSyncEvent()")}} {{Experimental_Inline}}
   - : Creates a new `PeriodicSyncEvent` object. This constructor is not typically used. The browser creates these objects itself and provides them to {{domxref('ServiceWorkerGlobalScope.periodicsync_event', 'onperiodicsync')}} callback.
 
-## Properties
+## Instance properties
 
 - {{domxref('PeriodicSyncEvent.tag')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the developer-defined identifier for this `PeriodicSyncEvent`. Multiple tags can be used by the web app to run different periodic tasks at different frequencies.
 
-## Methods
+## Instance methods
 
 Inherits methods from its parent {{domxref('ExtendableEvent')}}.
 

--- a/files/en-us/web/api/periodicsyncmanager/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/index.md
@@ -19,11 +19,11 @@ browser-compat: api.PeriodicSyncManager
 
 The **`PeriodicSyncManager`** interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to register tasks to be run in a service worker at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests. Access `PeriodicSyncManager` through the {{domxref('ServiceWorkerRegistration.periodicSync')}}.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref('PeriodicSyncManager.register')}} {{Experimental_Inline}}
   - : Registers a periodic sync request with the browser with the specified tag and options. Returns a {{jsxref('Promise')}} that resolves when the registration completes.

--- a/files/en-us/web/api/periodicwave/index.md
+++ b/files/en-us/web/api/periodicwave/index.md
@@ -26,11 +26,11 @@ The **`PeriodicWave`** interface defines a periodic waveform that can be used to
 - {{domxref("PeriodicWave.PeriodicWave", "PeriodicWave()")}}
   - : Creates a new `PeriodicWave` object instance using the default values for all properties. If you wish to establish custom property values at the outset, use the {{domxref("BaseAudioContext.createPeriodicWave")}} factory method instead.
 
-## Properties
+## Instance properties
 
 None; also, `PeriodicWave` doesn't inherit any properties.
 
-## Methods
+## Instance methods
 
 None; also, `PeriodicWave` doesn't inherit any methods.
 

--- a/files/en-us/web/api/permissions/index.md
+++ b/files/en-us/web/api/permissions/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Permissions
 
 The Permissions interface of the [Permissions API](/en-US/docs/Web/API/Permissions_API) provides the core Permission API functionality, such as methods for querying and revoking permissions
 
-## Methods
+## Instance methods
 
 - {{domxref("Permissions.query","Permissions.query()")}}
   - : Returns the user permission status for a given API.

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -18,7 +18,7 @@ The **`PermissionStatus`** interface of the [Permissions API](/en-US/docs/Web/AP
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PermissionStatus.name")}} {{ReadOnlyInline}}
   - : Returns the name of a requested permission, identical to the `name` passed to {{domxref("Permissions.query")}}.

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -26,37 +26,37 @@ The **Picture-in-Picture API** allow websites to create a floating video window 
 - {{DOMxRef("PictureInPictureWindow")}}
   - : Represents the floating video window; contains {{domxref("PictureInPictureWindow/width", "width")}} and {{domxref("PictureInPictureWindow/height", "height")}} properties, and an {{domxref("PictureInPictureWindow/onresize", "onresize")}} event handler property.
 
-## Methods
+## Instance methods
 
 The Picture-in-Picture API adds methods to the {{DOMxRef("HTMLVideoElement")}} and {{DOMxRef("Document")}} interfaces to allow toggling of the floating video window.
 
-### Methods on the HTMLVideoElement interface
+### Instance methods on the HTMLVideoElement interface
 
 - {{DOMxRef("HTMLVideoElement.requestPictureInPicture()")}}
   - : Requests that the user agent enters the video into picture-in-picture mode
 
-### Methods on the Document interface
+### Instance methods on the Document interface
 
 - {{DOMxRef("Document.exitPictureInPicture()")}}
   - : Requests that the user agent returns the element in picture-in-picture mode back into its original box.
 
-## Properties
+## Instance properties
 
 The Picture-in-Picture API augments the {{DOMxRef("HTMLVideoElement")}}, {{DOMxRef("Document")}}, and {{DOMxRef("ShadowRoot")}} interfaces with properties that can be used to determine if the floating video window mode is supported and available, if picture-in-picture mode is currently active, and which video is floating.
 
-### Properties on the HTMLVideoElement interface
+### Instance properties on the HTMLVideoElement interface
 
 - {{DOMxRef("HTMLVideoElement.autoPictureInPicture")}}
   - : The `autoPictureInPicture` property will automatically enter and leave the picture-in-picture mode for a video element when the user switches tab and/or applications.
 - {{DOMxRef("HTMLVideoElement.disablePictureInPicture")}}
   - : The `disablePictureInPicture` property will provide a hint to the user agent to not suggest the picture-in-picture to users or to request it automatically.
 
-### Properties on the Document interface
+### Instance properties on the Document interface
 
 - {{DOMxRef("Document.pictureInPictureEnabled")}}
   - : The `pictureInPictureEnabled` property tells you whether or not it is possible to engage picture-in-picture mode. This is `false` if picture-in-picture mode is not available for any reason (e.g. the [`"picture-in-picture"` feature](/en-US/docs/Web/HTTP/Headers/Feature-Policy/picture-in-picture) has been disallowed, or picture-in-picture mode is not supported).
 
-### Properties on the Document or ShadowRoot interfaces
+### Instance properties on the Document or ShadowRoot interfaces
 
 - {{DOMxRef("Document.pictureInPictureElement")}} / {{DOMxRef("ShadowRoot.pictureInPictureElement")}}
   - : The `pictureInPictureElement` property tells you which {{DOMxRef("Element")}} is currently being displayed in the floating window (or in the shadow DOM). If this is `null`, the document (or shadow DOM) has no node currently in picture-in-picture mode.

--- a/files/en-us/web/api/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/index.md
@@ -22,14 +22,14 @@ The **`PictureInPictureEvent`** interface represents picture-in-picture-related 
 - {{domxref("PictureInPictureEvent.PictureInPictureEvent", "PictureInPictureEvent()")}}
   - : Creates a `PictureInPictureEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("PictureInPictureEvent.pictureInPictureWindow")}}
   - : Returns the {{domxref("PictureInPictureWindow")}} the event relates to.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/pictureinpicturewindow/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/index.md
@@ -22,7 +22,7 @@ An object with this interface is obtained using the {{domxref("HTMLVideoElement.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `PictureInPictureWindow` interface doesn't inherit any properties._
 
@@ -31,7 +31,7 @@ _The `PictureInPictureWindow` interface doesn't inherit any properties._
 - {{domxref("PictureInPictureWindow.height")}} {{ReadOnlyInline}}
   - : Determines the height of the floating video window.
 
-## Methods
+## Instance methods
 
 _The `PictureInPictureWindow` interface doesn't inherit any methods._
 

--- a/files/en-us/web/api/plugin/index.md
+++ b/files/en-us/web/api/plugin/index.md
@@ -19,7 +19,7 @@ The `Plugin` interface provides information about a browser plugin.
 
 > **Note:** Own properties of `Plugin` objects are no longer enumerable in the latest browser versions.
 
-## Properties
+## Instance properties
 
 - {{domxref("Plugin.description")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : A human readable description of the plugin.
@@ -30,7 +30,7 @@ The `Plugin` interface provides information about a browser plugin.
 - {{domxref("Plugin.version")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : The plugin's version number string.
 
-## Methods
+## Instance methods
 
 - {{domxref("Plugin.item")}} {{Deprecated_Inline}}
   - : Returns the MIME type of a supported content type, given the index number into a list of supported types.

--- a/files/en-us/web/api/pluginarray/index.md
+++ b/files/en-us/web/api/pluginarray/index.md
@@ -18,12 +18,12 @@ The `PluginArray` interface is used to store a list of {{DOMxRef("Plugin")}} obj
 
 > **Note:** Own properties of `PluginArray` objects are no longer enumerable in the latest browser versions.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("PluginArray.length")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : The number of plugins in the array.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("PluginArray.item")}} {{Deprecated_Inline}}
   - : Returns the {{DOMxRef("Plugin")}} at the specified index into the array.

--- a/files/en-us/web/api/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/index.md
@@ -28,7 +28,7 @@ A pointer's _hit test_ is the process a browser uses to determine the target ele
 - {{domxref("PointerEvent.PointerEvent", "PointerEvent()")}}
   - : Creates a synthetic—and untrusted—`PointerEvent`.
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref("Event")}}._
 
@@ -53,7 +53,7 @@ _This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref
 - {{ domxref('PointerEvent.isPrimary')}} {{ReadOnlyInline}}
   - : Indicates if the pointer represents the primary pointer of this pointer type.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef('PointerEvent.getCoalescedEvents()')}}
   - : Returns a sequence of all `PointerEvent` instances that were coalesced into the dispatched {{domxref("HTMLElement/pointermove_event", "pointermove")}} event.

--- a/files/en-us/web/api/popstateevent/index.md
+++ b/files/en-us/web/api/popstateevent/index.md
@@ -26,14 +26,14 @@ event's `state` property contains a copy of the history entry's state object.
 - {{domxref("PopStateEvent.PopStateEvent", "PopStateEvent()")}}
   - : Creates a new `PopStateEvent` object.
 
-## Properties
+## Instance properties
 
 _This interface also inherits the properties of its parent, {{domxref("Event")}}._
 
 - {{domxref("PopStateEvent.state")}} {{ReadOnlyInline}}
   - : Returns a copy of the information that was provided to `pushState()` or `replaceState()`.
 
-## Methods
+## Instance methods
 
 _This interface has no methods of its own, but inherits the methods of its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/positionsensorvrdevice/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/index.md
@@ -19,7 +19,7 @@ browser-compat: api.PositionSensorVRDevice
 
 The **`PositionSensorVRDevice`** interface of the [WebVR API](/en-US/docs/Web/API/WebVR_API) represents VR hardware's position sensor. You can access information such as the current position and orientation of the sensor in relation to the head mounted display through the {{domxref("PositionSensorVRDevice.getState()")}} method.
 
-## Methods
+## Instance methods
 
 - {{domxref("PositionSensorVRDevice.getState()")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns the current state of the position sensor for the current frame (e.g. within the current {{domxref("window.requestAnimationFrame")}} callback) or for the previous frame, contained with a {{domxref("VRPose")}} object. This is the method you'd normally want to use, versus `getImmediateState()`.
@@ -28,7 +28,7 @@ The **`PositionSensorVRDevice`** interface of the [WebVR API](/en-US/docs/Web/AP
 - {{domxref("PositionSensorVRDevice.resetSensor()")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : _Can be used to reset the sensor if desired, returning the_ position and orientation values to zero.
 
-## Properties
+## Instance properties
 
 _This interface doesn't define any properties of its own, but it does inherit the properties of its parent interface, {{domxref("VRDisplay")}}._
 

--- a/files/en-us/web/api/presentation/index.md
+++ b/files/en-us/web/api/presentation/index.md
@@ -18,14 +18,14 @@ The **`Presentation`** can be defined as two possible user agents in the context
 
 In controlling browsing context, the `Presentation` interface provides a mechanism to override the browser default behavior of launching presentation to external screen. In receiving browsing context, `Presentation` interface provides the access to the available presentation connections.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("Presentation.defaultRequest")}} {{Experimental_Inline}}
   - : In a [controlling user agent](https://www.w3.org/TR/presentation-api/#dfn-controlling-user-agent), the `defaultRequest` attribute _MUST_ return the [default presentation request](https://www.w3.org/TR/presentation-api/#dfn-default-presentation-request) if any, `null` otherwise. In a [receiving browsing context](https://www.w3.org/TR/presentation-api/#dfn-receiving-browsing-context), it _MUST_ return `null`.
 - {{DOMxRef("Presentation.receiver")}} {{Experimental_Inline}}
   - : In a [receiving user agent](https://www.w3.org/TR/presentation-api/#dfn-receiving-user-agent), the `receiver` attribute _MUST_ return the {{DOMxRef("PresentationReceiver")}} instance associated with the [receiving browsing context](https://www.w3.org/TR/presentation-api/#dfn-receiving-browsing-context) and created by the [receiving user agent](https://www.w3.org/TR/presentation-api/#dfn-receiving-user-agent) when the [receiving browsing context](https://www.w3.org/TR/presentation-api/#dfn-receiving-browsing-context) is created.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/presentationavailability/index.md
+++ b/files/en-us/web/api/presentationavailability/index.md
@@ -22,7 +22,7 @@ The `onchange` attribute is an [event handler](https://www.w3.org/TR/presentatio
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PresentationAvailability.value")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A boolean value indicating whether the given presentation display is available. The `value` attribute _MUST_ return the last value it was set to.
@@ -32,7 +32,7 @@ The `onchange` attribute is an [event handler](https://www.w3.org/TR/presentatio
 - {{domxref("PresentationAvailability.change_event", "change")}} {{Experimental_Inline}}
   - : Indicates that the availability of the presentation display has changed.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/presentationconnection/index.md
+++ b/files/en-us/web/api/presentationconnection/index.md
@@ -18,7 +18,7 @@ The **`PresentationConnection`** interface of the [Presentation API](/en-US/docs
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("PresentationConnection.binaryType")}} {{Experimental_Inline}}
   - : Returns either blob or arrayBuffer. When a `PresentationConnection` object is created, its [`binaryType`](https://www.w3.org/TR/presentation-api/#idl-def-presentationconnection-binarytype) IDL attribute _MUST_ be set to the string " [`arraybuffer`](https://www.w3.org/TR/presentation-api/#dom-binarytype-arraybuffer)".
@@ -40,7 +40,7 @@ The **`PresentationConnection`** interface of the [Presentation API](/en-US/docs
 - {{domxref("PresentationConnection.onterminated")}}
   - : Fired when there is a call to {{DOMxRef("PresentationConnection.terminate", "PresentationConnection.terminate()")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("PresentationConnection.close()")}} {{Experimental_Inline}}
   - : Closes the current connection and sends a {{domxref("PresentationConnectionCloseEvent")}} to {{DOMxRef("PresentationConnection.onclosed")}}.

--- a/files/en-us/web/api/presentationconnectionavailableevent/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/index.md
@@ -26,7 +26,7 @@ A [controlling user agent](https://www.w3.org/TR/presentation-api/#dfn-controlli
 - {{domxref("PresentationConnectionAvailableEvent.PresentationConnectionAvailableEvent", "PresentationConnectionAvailableEvent()")}} {{Experimental_Inline}}
   - : Creates a new PresentationConnectionAvailableEvent.
 
-## Properties
+## Instance properties
 
 - {{domxref("PresentationConnectionAvailableEvent.connection")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a references to the {{domxref("PresentationConnection")}} object that fired the event.

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.md
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.md
@@ -24,7 +24,7 @@ The **`PresentationConnectionCloseEvent`** interface of the [Presentation API](/
 - {{domxref("PresentationConnectionCloseEvent.PresentationConnectionCloseEvent", "PresentationConnectionCloseEvent()")}} {{Experimental_Inline}}
   - : Creates a new PresentationConnectionCloseEvent.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("PresentationConnectionCloseEvent.message")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A human-readable message that provides more information about why the connection was closed.

--- a/files/en-us/web/api/presentationconnectionlist/index.md
+++ b/files/en-us/web/api/presentationconnectionlist/index.md
@@ -19,7 +19,7 @@ browser-compat: api.PresentationConnectionList
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref('PresentationConnectionList.connections')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the non-terminated set of {{DOMxRef("PresentationConnection")}}s in the [set of presentation controllers](https://www.w3.org/TR/presentation-api/#dfn-set-of-presentation-controllers).

--- a/files/en-us/web/api/presentationreceiver/index.md
+++ b/files/en-us/web/api/presentationreceiver/index.md
@@ -17,7 +17,7 @@ browser-compat: api.PresentationReceiver
 
 The **`PresentationReceiver`** interface of the [Presentation API](/en-US/docs/Web/API/Presentation_API) provides a means for a receiving browsing context to access controlling browsing contexts and communicate with them.
 
-## Properties
+## Instance properties
 
 - {{domxref('PresentationReceiver.connectionList')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{jsxref('Promise')}} that resolves with a {{domxref('PresentationConnectionList')}} object containing a list of _incoming presentation connections._

--- a/files/en-us/web/api/presentationrequest/index.md
+++ b/files/en-us/web/api/presentationrequest/index.md
@@ -25,7 +25,7 @@ When a `PresentationRequest` is constructed, the given `urls` _MUST_ be used as 
 - {{domxref("PresentationRequest.PresentationRequest","PresentationRequest()")}} {{Experimental_Inline}}
   - : Creates a `PresentationRequest`.
 
-## Properties
+## Instance properties
 
 None
 
@@ -34,7 +34,7 @@ None
 - {{domxref("PresentationRequest.onconnectionavailable")}} {{Experimental_Inline}}
   - : Fires on a successful call to {{DOMxRef("PresentationRequest.start","PresentationRequest.start()")}} or {{DOMxRef("PresentationRequest.join","PresentationRequest.join()")}}. This method provides a object with a reference to the created or joined object.
 
-## Methods
+## Instance methods
 
 - {{domxref("PresentationRequest.start()")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Promise")}} that resolves with a {{DOMxRef("PresentationConnection")}} after the user agent prompts the user to select a display and grant permission to use that display.

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -28,14 +28,14 @@ is a processing instruction whose `target` is `xml`.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
 - {{domxref("ProcessingInstruction.target")}} {{ReadOnlyInline}}
   - : A name identifying the application to which the instruction is targeted.
 
-## Methods
+## Instance methods
 
 _This interface doesn't have any specific method, but inherits methods from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/index.md
@@ -22,7 +22,7 @@ The **`ProgressEvent`** interface represents events measuring progress of an und
 - {{domxref("ProgressEvent.ProgressEvent", "ProgressEvent()")}}
   - : Creates a `ProgressEvent` event with the given parameters.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
@@ -33,7 +33,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
 - {{domxref("ProgressEvent.total")}} {{ReadOnlyInline}}
   - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/promiserejectionevent/index.md
+++ b/files/en-us/web/api/promiserejectionevent/index.md
@@ -27,7 +27,7 @@ For details on promise rejection events, see {{SectionOnPage("/en-US/docs/Web/Ja
 - {{domxref("PromiseRejectionEvent.PromiseRejectionEvent", "PromiseRejectionEvent()")}}
   - : Creates a `PromiseRejectionEvent` event, given the type of event ([`unhandledrejection`](/en-US/docs/Web/API/Window/unhandledrejection_event) or [`rejectionhandled`](/en-US/docs/Web/API/Window/rejectionhandled_event)) and other details.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
@@ -36,7 +36,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
 - {{domxref("PromiseRejectionEvent.reason")}} {{ReadOnlyInline}}
   - : A value or {{jsxref("Object")}} indicating why the promise was rejected, as passed to {{jsxref("Promise.reject()")}}.
 
-## Methods
+## Instance methods
 
 _This interface has no unique methods; inherits methods from its parent {{domxref("Event")}}_.
 

--- a/files/en-us/web/api/publickeycredential/index.md
+++ b/files/en-us/web/api/publickeycredential/index.md
@@ -21,7 +21,7 @@ The **`PublicKeyCredential`** interface provides information about a public key 
 
 > **Note:** This API is restricted to top-level contexts. Use from within an {{HTMLElement("iframe")}} element will not have any effect.
 
-## Properties
+## Instance properties
 
 - `PublicKeyCredential.type` {{ReadOnlyInline()}} {{securecontext_inline}}
   - : Inherited from {{domxref("Credential")}}. Always set to `public-key` for `PublicKeyCredential` instances.
@@ -32,12 +32,15 @@ The **`PublicKeyCredential`** interface provides information about a public key 
 - {{domxref("PublicKeyCredential.response")}} {{ReadOnlyInline()}} {{securecontext_inline}}
   - : An instance of an {{domxref("AuthenticatorResponse")}} object. It is either of type {{domxref("AuthenticatorAttestationResponse")}} if the `PublicKeyCredential` was the results of a {{domxref("CredentialsContainer.create()","navigator.credentials.create()")}} call, or of type {{domxref("AuthenticatorAssertionResponse")}} if the `PublicKeyCredential` was the result of a {{domxref("CredentialsContainer.get()","navigator.credentials.get()")}} call.
 
-## Methods
+## Static methods
+
+- {{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}} {{securecontext_inline}}
+  - : A static method returning a {{jsxref("Promise")}} which resolves to `true` if an authenticator bound to the platform is capable of _verifying_ the user.
+
+## Instance methods
 
 - {{domxref("PublicKeyCredential.getClientExtensionResults()")}} {{securecontext_inline}}
   - : If any extensions were requested, this method will return the results of processing those extensions.
-- {{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}} {{securecontext_inline}}
-  - : A static method returning a {{jsxref("Promise")}} which resolves to `true` if an authenticator bound to the platform is capable of _verifying_ the user.
 
 ## Examples
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.md
@@ -16,7 +16,7 @@ browser-compat: api.PublicKeyCredentialRequestOptions
 
 The **`PublicKeyCredentialRequestOptions`** dictionary of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) holds the options passed to {{domxref("CredentialsContainer.get()","navigator.credentials.get()")}} in order to fetch a given {{domxref("PublicKeyCredential")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("PublicKeyCredentialRequestOptions.challenge")}}
   - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}}, emitted by the relying party's server and used as a [cryptographic challenge](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication). This value will be signed by the authenticator and the signature will be sent back as part of {{domxref("AuthenticatorAssertionResponse.signature")}}.
@@ -31,7 +31,7 @@ The **`PublicKeyCredentialRequestOptions`** dictionary of the [Web Authenticatio
 - {{domxref("PublicKeyCredentialRequestOptions.extensions")}} {{optional_inline}}
   - : An object with several client extensions' inputs. Those extensions are used to request additional processing (e.g. dealing with legacy FIDO APIs credentials, prompting a specific text on the authenticator, etc.).
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/index.md
@@ -26,14 +26,14 @@ The **`PushEvent`** interface of the [Push API](/en-US/docs/Web/API/Push_API) re
 - {{domxref("PushEvent.PushEvent", "PushEvent()")}}
   - : Creates a new `PushEvent` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("ExtendableEvent")}}. Additional properties:_
 
 - {{domxref("PushEvent.data")}} {{ReadOnlyInline}}
   - : Returns a reference to a {{domxref("PushMessageData")}} object containing data sent to the {{domxref("PushSubscription")}}.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("ExtendableEvent")}}_.
 

--- a/files/en-us/web/api/pushmanager/index.md
+++ b/files/en-us/web/api/pushmanager/index.md
@@ -18,12 +18,12 @@ The **`PushManager`** interface of the [Push API](/en-US/docs/Web/API/Push_API) 
 
 This interface is accessed via the {{domxref("ServiceWorkerRegistration.pushManager")}} property.
 
-## Properties
+## Instance properties
 
 - {{domxref("PushManager.supportedContentEncodings")}}
   - : Returns an array of supported content codings that can be used to encrypt the payload of a push message.
 
-## Methods
+## Instance methods
 
 - {{domxref("PushManager.getSubscription()")}}
   - : Retrieves an existing push subscription. It returns a {{jsxref("Promise")}} that resolves to a {{domxref("PushSubscription")}} object containing details of an existing subscription. If no existing subscription exists, this resolves to a `null` value.

--- a/files/en-us/web/api/pushmessagedata/index.md
+++ b/files/en-us/web/api/pushmessagedata/index.md
@@ -21,11 +21,11 @@ Unlike the similar methods in the [Fetch API](/en-US/docs/Web/API/Fetch_API), wh
 
 Messages received through the Push API are sent encrypted by push services and then automatically decrypted by browsers before they are made accessible through the methods of the `PushMessageData` interface.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("PushMessageData.arrayBuffer()")}}
   - : Extracts the data as an {{jsxref("ArrayBuffer")}} object.

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -19,7 +19,7 @@ The `PushSubscription` interface of the [Push API](/en-US/docs/Web/API/Push_API)
 
 An instance of this interface can be serialized.
 
-## Properties
+## Instance properties
 
 - {{domxref("PushSubscription.endpoint")}} {{ReadOnlyInline}}
   - : A string containing the endpoint associated with the push subscription.
@@ -30,7 +30,7 @@ An instance of this interface can be serialized.
 - {{domxref("PushSubscription.subscriptionId")}} {{deprecated_inline}} {{ReadOnlyInline}}
   - : A string containing the subscription ID associated with the push subscription.
 
-## Methods
+## Instance methods
 
 - {{domxref("PushSubscription.getKey()")}}
   - : Returns an {{jsxref("ArrayBuffer")}} which contains the client's public key, which can then be sent to a server and used in encrypting push message data.

--- a/files/en-us/web/api/pushsubscriptionoptions/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.md
@@ -16,7 +16,7 @@ The **`PushSubscriptionOptions`** interface of the {{domxref('Push API','','',' 
 
 The read-only `PushSubscriptionOptions` object is returned by calling {{domxref("PushSubscription.options")}} on a {{domxref("PushSubscription")}}. This interface has no constructor of its own.
 
-## Properties
+## Instance properties
 
 - {{domxref("PushSubscriptionOptions.userVisibleOnly")}} {{ReadOnlyInline}}
   - : A boolean value indicating that the returned push


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with O to Q

Moved to have consistent headings and ordering.