### PR TITLE
Web API methods/props sorted to static/instance headings - RS

### DIFF
--- a/files/en-us/web/api/radionodelist/index.md
+++ b/files/en-us/web/api/radionodelist/index.md
@@ -16,14 +16,14 @@ The **`RadioNodeList`** interface represents a collection of radio elements in a
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `RadioNodeList` interface inherits the properties of_ {{domxref("NodeList")}}.
 
 - {{domxref("RadioNodeList.value")}}
   - : If the underlying element collection contains radio buttons, the `value` property represents the checked radio button. On retrieving the `value` property, the `value` of the currently `checked` radio button is returned as a string. If the collection does not contain any radio buttons or none of the radio buttons in the collection is in `checked` state, the empty string is returned. On setting the `value` property, the first radio button input element whose `value` property is equal to the new value will be set to `checked`.
 
-## Methods
+## Instance methods
 
 _The `RadioNodeList` interface inherits the methods of_ {{domxref("NodeList")}}.
 

--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -18,7 +18,7 @@ There also is the {{domxref("Range.Range()", "Range()")}} constructor available.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _There are no inherited properties._
 
@@ -40,7 +40,7 @@ _There are no inherited properties._
 - {{ domxref("Range.Range()", "Range()") }}
   - : Returns a `Range` object with the global {{domxref("Document")}} as its start and end.
 
-## Methods
+## Instance methods
 
 _There are no inherited methods._
 

--- a/files/en-us/web/api/readablebytestreamcontroller/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.md
@@ -39,14 +39,14 @@ Note that even though the controller is primarily used by the underlying byte so
 
 None. `ReadableByteStreamController` instances are automatically created if an `underlyingSource` with the property `type="bytes"` is passed to the [`ReadableStream()` constructor](/en-US/docs/Web/API/ReadableStream/ReadableStream#type).
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableByteStreamController.byobRequest")}} {{ReadOnlyInline}}
   - : Returns the current BYOB pull request, or `null` if there no outstanding request.
 - {{domxref("ReadableByteStreamController.desiredSize")}} {{ReadOnlyInline}}
   - : Returns the desired size required to fill the stream's internal queue.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableByteStreamController.close()")}}
   - : Closes the associated stream.

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -28,12 +28,12 @@ The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_
 - {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}}
   - : Creates and returns a readable stream object from the given handlers.
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableStream.locked")}} {{ReadOnlyInline}}
   - : Returns a boolean indicating whether or not the readable stream is locked to a reader.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableStream.cancel()")}}
   - : Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied `reason` argument will be given to the underlying source, which may or may not use it.

--- a/files/en-us/web/api/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/index.md
@@ -31,12 +31,12 @@ The `read()` method differs in that it provide a view into which data should be 
 - {{domxref("ReadableStreamBYOBReader.ReadableStreamBYOBReader", "ReadableStreamBYOBReader()")}}
   - : Creates and returns a `ReadableStreamBYOBReader` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableStreamBYOBReader.closed")}} {{ReadOnlyInline}}
   - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the stream throws an error or the reader's lock is released. This property enables you to write code that responds to an end to the streaming process.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableStreamBYOBReader.cancel()")}}
   - : Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied `reason` argument will be given to the underlying source, which may or may not use it.

--- a/files/en-us/web/api/readablestreambyobrequest/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/index.md
@@ -35,13 +35,13 @@ Note that a {{domxref("ReadableByteStreamController")}} is only created for unde
 
 None. `ReadableStreamBYOBRequest` instance is created automatically by `ReadableByteStreamController` as needed.
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableStreamBYOBRequest.view")}} {{ReadOnlyInline}}
   - : Returns the current view.
     This is a view on a buffer that will be transferred to the consumer when `ReadableStreamBYOBRequest.respond()` is called.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableStreamBYOBRequest.respond()")}}
   - : Signals the associated readable byte stream that the specified number of bytes were written into the current [`view`](#readablestreambyobrequest.view), which then causes the pending request from the consumer to be resolved.

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.md
@@ -20,12 +20,12 @@ The **`ReadableStreamDefaultController`** interface of the [Streams API](/en-US/
 
 None. `ReadableStreamDefaultController` instances are created automatically during `ReadableStream` construction.
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableStreamDefaultController.desiredSize")}} {{ReadOnlyInline}}
   - : Returns the desired size required to fill the stream's internal queue.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableStreamDefaultController.close()")}}
   - : Closes the associated stream.

--- a/files/en-us/web/api/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.md
@@ -27,12 +27,12 @@ For any other underlying source, the stream will always satisfy read requests wi
 - {{domxref("ReadableStreamDefaultReader.ReadableStreamDefaultReader", "ReadableStreamDefaultReader()")}}
   - : Creates and returns a `ReadableStreamDefaultReader` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("ReadableStreamDefaultReader.closed")}} {{ReadOnlyInline}}
   - : Returns a {{jsxref("Promise")}} that fulfills when the stream closes, or rejects if the stream throws an error or the reader's lock is released. This property enables you to write code that responds to an end to the streaming process.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReadableStreamDefaultReader.cancel()")}}
   - : Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied `reason` argument will be given to the underlying source, which may or may not use it.

--- a/files/en-us/web/api/relativeorientationsensor/index.md
+++ b/files/en-us/web/api/relativeorientationsensor/index.md
@@ -31,11 +31,11 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 - {{domxref("RelativeOrientationSensor.RelativeOrientationSensor", "RelativeOrientationSensor()")}}
   - : Creates a new `RelativeOrientationSensor` object.
 
-## Properties
+## Instance properties
 
 _No specific properties; inherits properties from its ancestors {{domxref('OrientationSensor')}} and {{domxref('Sensor')}}._
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its ancestors {{domxref('OrientationSensor')}} and {{domxref('Sensor')}}._
 

--- a/files/en-us/web/api/remoteplayback/index.md
+++ b/files/en-us/web/api/remoteplayback/index.md
@@ -16,7 +16,7 @@ The **`RemotePlayback`** interface of the {{domxref('Remote Playback API','','',
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("RemotePlayback.state")}} {{ReadOnlyInline}}
 
@@ -29,7 +29,7 @@ The **`RemotePlayback`** interface of the {{domxref('Remote Playback API','','',
     - `"disconnected"`
       - : The remote playback has not been initiated, has failed to initiate, or has been stopped.
 
-## Methods
+## Instance methods
 
 - {{domxref("RemotePlayback.watchAvailability()")}}
   - : A {{jsxref("Promise")}} that resolves with a `callbackId` of an available remote playback device.

--- a/files/en-us/web/api/report/index.md
+++ b/files/en-us/web/api/report/index.md
@@ -22,7 +22,7 @@ Reports can be accessed in a number of ways:
 - Via the `reports` parameter of the callback function passed into the [`ReportingObserver()`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver) constructor upon creation of a new observer instance. This contains the list of reports currently contained in the observer's report queue.
 - By sending requests to the endpoints defined via the {{httpheader("Report-To")}} HTTP header.
 
-## Properties
+## Instance properties
 
 - {{domxref("Report.body")}} {{experimental_inline}} {{ReadOnlyInline}}
   - : The body of the report, which is a `ReportBody` object containing the detailed report information.
@@ -31,7 +31,7 @@ Reports can be accessed in a number of ways:
 - {{domxref("Report.url")}} {{experimental_inline}} {{ReadOnlyInline}}
   - : The URL of the document that generated the report.
 
-## Methods
+## Instance methods
 
 _This interface has no methods defined on it._
 

--- a/files/en-us/web/api/reportbody/index.md
+++ b/files/en-us/web/api/reportbody/index.md
@@ -23,7 +23,7 @@ The **`ReportBody`** interface of the {{domxref('Reporting API','','',' ')}} rep
 
 An instance of `ReportBody` is returned as the value of {{domxref("Report.body")}}. The interface has no constructor.
 
-## Methods
+## Instance methods
 
 - {{domxref("ReportBody.toJSON()")}} {{experimental_inline}}
   - : A _serializer_ which returns a JSON representation of the `ReportBody` object.

--- a/files/en-us/web/api/reportingobserver/index.md
+++ b/files/en-us/web/api/reportingobserver/index.md
@@ -21,11 +21,11 @@ The `ReportingObserver` interface of the [Reporting API](/en-US/docs/Web/API/Rep
 - {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}} {{Experimental_Inline}}
   - : Creates a new `ReportingObserver` object instance, which can be used to collect and access reports.
 
-## Properties
+## Instance properties
 
 _This interface has no properties defined on it._
 
-## Methods
+## Instance methods
 
 - {{domxref("ReportingObserver.disconnect()")}} {{Experimental_Inline}}
   - : Stops a reporting observer that had previously started observing from collecting reports.

--- a/files/en-us/web/api/reportingobserveroptions/index.md
+++ b/files/en-us/web/api/reportingobserveroptions/index.md
@@ -16,7 +16,7 @@ browser-compat: api.ReportingObserverOptions
 
 The `ReportingObserverOptions` dictionary of the [Reporting API](/en-US/docs/Web/API/Reporting_API) allows options to be set in the constructor when creating a {{domxref("ReportingObserver")}}.
 
-## Properties
+## Instance properties
 
 - `types`
   - : An array of strings representing the types of report to be collected by this observer. Available types include `deprecation`, `intervention`, and `crash`.

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -24,7 +24,7 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
 - {{domxref("Request.Request","Request()")}}
   - : Creates a new `Request` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("Request.body")}} {{ReadOnlyInline}}
   - : A {{domxref("ReadableStream")}} of the body contents.
@@ -55,7 +55,7 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
 - {{domxref("Request.url")}} {{ReadOnlyInline}}
   - : Contains the URL of the request.
 
-## Methods
+## Instance methods
 
 - {{domxref("Request.arrayBuffer()")}}
   - : Returns a promise that resolves with an {{jsxref("ArrayBuffer")}} representation of the request body.

--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -27,11 +27,11 @@ The **`ResizeObserver`** interface reports changes to the dimensions of an {{dom
 - {{domxref("ResizeObserver.ResizeObserver", "ResizeObserver()")}}
   - : Creates and returns a new `ResizeObserver` object.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref('ResizeObserver.disconnect()')}}
   - : Unobserves all observed {{domxref('Element')}} targets of a particular observer.

--- a/files/en-us/web/api/resizeobserverentry/index.md
+++ b/files/en-us/web/api/resizeobserverentry/index.md
@@ -19,7 +19,7 @@ browser-compat: api.ResizeObserverEntry
 
 The **`ResizeObserverEntry`** interface represents the object passed to the {{domxref('ResizeObserver.ResizeObserver','ResizeObserver()')}} constructor's callback function, which allows you to access the new dimensions of the {{domxref("Element")}} or {{domxref("SVGElement")}} being observed.
 
-## Properties
+## Instance properties
 
 - {{domxref('ResizeObserverEntry.borderBoxSize')}} {{ReadOnlyInline}}
   - : An object containing the new border box size of the observed element when the callback is run.
@@ -34,7 +34,7 @@ The **`ResizeObserverEntry`** interface represents the object passed to the {{do
 
 > **Note:** The content box is the box in which content can be placed, meaning the border box minus the padding and border width. The border box encompasses the content, padding, and border. See [The box model](/en-US/docs/Learn/CSS/Building_blocks/The_box_model) for further explanation.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/resizeobserversize/index.md
+++ b/files/en-us/web/api/resizeobserversize/index.md
@@ -16,7 +16,7 @@ The **`ResizeObserverSize`** interface of the {{domxref('Resize Observer API')}}
 
 > **Note:** In [multi-column layout](/en-US/docs/Web/CSS/CSS_Columns), which is a fragmented context, the sizing returned by `ResizeObserverSize` will be the size of the first column.
 
-## Properties
+## Instance properties
 
 - {{domxref("ResizeObserverSize.blockSize")}} {{ReadOnlyInline}}
   - : The length of the observed element's border box in the block dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or width.

--- a/files/en-us/web/api/resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/index.md
@@ -58,7 +58,7 @@ The {{domxref('PerformanceResourceTiming.initiatorType','initiatorType')}} prope
 
 If the current context is a {{domxref("Worker","worker")}}, the {{domxref('PerformanceResourceTiming.workerStart','workerStart')}} property can be used to obtain a {{domxref("DOMHighResTimeStamp")}} when the worker was started.
 
-## Methods
+## Instance methods
 
 The Resource Timing API includes two methods that extend the {{domxref("Performance")}} interface. The {{domxref("Performance.clearResourceTimings","clearResourceTimings()")}} method removes all "`resource`" type performance entries from the browser's _resource_ performance entry buffer. The {{domxref("Performance.setResourceTimingBufferSize","setResourceTimingBufferSize()")}} method sets the resource performance entry buffer size to the specified number of resource {{domxref("PerformanceEntry","performance entries")}}.
 

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -23,7 +23,7 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 - {{domxref("Response.Response","Response()")}}
   - : Creates a new `Response` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("Response.body")}} {{ReadOnlyInline}}
   - : A {{domxref("ReadableStream")}} of the body contents.
@@ -46,7 +46,7 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 - {{domxref("Response.url")}} {{ReadOnlyInline}}
   - : The URL of the response.
 
-## Methods
+## Instance methods
 
 - {{domxref("Response.arrayBuffer()")}}
   - : Returns a promise that resolves with an {{jsxref("ArrayBuffer")}} representation of the response body.

--- a/files/en-us/web/api/rsahashedimportparams/index.md
+++ b/files/en-us/web/api/rsahashedimportparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaHashedImportParams
 
 The **`RsaHashedImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when importing any RSA-based key pair: that is, when the algorithm is identified as any of [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep).
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `RSASSA-PKCS1-v1_5`, `RSA-PSS`, or `RSA-OAEP`, depending on the algorithm you want to use.

--- a/files/en-us/web/api/rsahashedkeygenparams/index.md
+++ b/files/en-us/web/api/rsahashedkeygenparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyGenParams
 
 The **`RsaHashedKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating any RSA-based key pair: that is, when the algorithm is identified as any of [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep).
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `RSASSA-PKCS1-v1_5`, `RSA-PSS`, or `RSA-OAEP`, depending on the algorithm you want to use.

--- a/files/en-us/web/api/rsaoaepparams/index.md
+++ b/files/en-us/web/api/rsaoaepparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaOaepParams
 
 The **`RsaOaepParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.encrypt()")}}, {{domxref("SubtleCrypto.decrypt()")}}, {{domxref("SubtleCrypto.wrapKey()")}}, or {{domxref("SubtleCrypto.unwrapKey()")}}, when using the [RSA_OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep) algorithm.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `RSA-OAEP`.

--- a/files/en-us/web/api/rsapssparams/index.md
+++ b/files/en-us/web/api/rsapssparams/index.md
@@ -15,7 +15,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaPssParams
 
 The **`RsaPssParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.sign()")}} or {{domxref("SubtleCrypto.verify()")}}, when using the [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss) algorithm.
 
-## Properties
+## Instance properties
 
 - `name`
   - : A string. This should be set to `RSA-PSS`.

--- a/files/en-us/web/api/rtccertificate/index.md
+++ b/files/en-us/web/api/rtccertificate/index.md
@@ -16,7 +16,7 @@ browser-compat: api.RTCCertificate
 
 The interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides an object represents a certificate that an {{domxref("RTCPeerConnection")}} uses to authenticate.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCCertificate.expires")}} {{ReadOnlyInline}}
   - : Returns the expiration date of the certificate.

--- a/files/en-us/web/api/rtcdatachannel/index.md
+++ b/files/en-us/web/api/rtcdatachannel/index.md
@@ -26,7 +26,7 @@ To create a data channel and ask a remote peer to join you, call the {{DOMxRef("
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from {{DOMxRef("EventTarget")}}._
 
@@ -85,7 +85,7 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
 - {{DOMxRef("RTCDataChannel.reliable", "reliable")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Indicates whether or not the data channel is _reliable_.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/rtcdatachannelevent/index.md
+++ b/files/en-us/web/api/rtcdatachannelevent/index.md
@@ -24,7 +24,7 @@ represents an event related to a specific {{DOMxRef("RTCDataChannel")}}.
 - {{DOMxRef("RTCDataChannelEvent.RTCDataChannelEvent", "RTCDataChannelEvent()")}}
   - : Creates a new `RTCDataChannelEvent`.
 
-## Properties
+## Instance properties
 
 _Also inherits properties from {{DOMxRef("Event")}}._
 

--- a/files/en-us/web/api/rtcdtlstransport/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/index.md
@@ -23,7 +23,7 @@ Features of the DTLS transport include the addition of security to the underlyin
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from {{DOMxRef("EventTarget")}}._
 
@@ -46,7 +46,7 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
     which specifies a function the browser calls
     when the {{DOMxRef("RTCDtlsTransport.statechange_event", "statechange")}} event is received.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/rtcdtmfsender/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/index.md
@@ -25,12 +25,12 @@ The primary purpose for WebRTC's DTMF support is to allow WebRTC-based communica
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCDTMFSender.toneBuffer")}} {{ReadOnlyInline}}
   - : A string which contains the list of DTMF tones currently in the queue to be transmitted (tones which have already been played are no longer included in the string). See {{domxref("RTCDTMFSender.toneBuffer", "toneBuffer")}} for details on the format of the tone buffer.
 
-## Methods
+## Instance methods
 
 - {{domxref("RTCDTMFSender.insertDTMF()")}}
   - : Given a string describing a set of DTMF codes and, optionally, the duration of and inter-tone gap between the tones, `insertDTMF()` starts sending the specified tones. Calling `insertDTMF()` replaces any already-pending tones from the `toneBuffer`. You can abort sending queued tones by specifying an empty string (`""`) as the set of tones to play.

--- a/files/en-us/web/api/rtcdtmftonechangeevent/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/index.md
@@ -18,7 +18,7 @@ The **`RTCDTMFToneChangeEvent`** interface represents events sent to indicate th
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _In addition to the properties of {{domxref("Event")}}, this interface offers the following:_
 
@@ -30,7 +30,7 @@ _In addition to the properties of {{domxref("Event")}}, this interface offers th
 - {{domxref("RTCDTMFToneChangeEvent.RTCDTMFToneChangeEvent()", "RTCDTMFToneChangeEvent()")}}
   - : Returns a new `RTCDTMFToneChangeEvent`. It takes two parameters, the first being a string representing the type of the event (always `"tonechange"`); the second a dictionary containing the initial state of the properties of the event.
 
-## Methods
+## Instance methods
 
 _Supports the methods defined in {{domxref("Event")}}. There are no additional methods._
 

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -29,7 +29,7 @@ The **`RTCError`** interface describes an error which has occurred while handlin
 - {{domxref("RTCError.RTCError", "RTCError()")}}
   - : Creates and returns a new `RTCError` object initialized with the different parameters and, optionally, a string to use as the value of the error's {{domxref("DOMException.message", "message")}} property.
 
-## Properties
+## Instance properties
 
 _In addition to the properties defined by the parent interface, {{domxref("DOMException")}}, `RTCError` includes the following properties:_
 

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -27,14 +27,14 @@ The WebRTC API's **`RTCErrorEvent`** interface represents an error sent to a Web
 - {{domxref("RTCErrorEvent.RTCErrorEvent", "RTCErrorEvent()")}}
   - : Creates and returns a new `RTCErrorEvent` object.
 
-## Properties
+## Instance properties
 
 _In addition to the standard properties available on the {{domxref("Event")}} interface, `RTCErrorEvent` also includes the following:_
 
 - {{domxref("RTCErrorEvent.error", "error")}} {{ReadOnlyInline}}
   - : An {{domxref("RTCError")}} object specifying the error which occurred; this object includes the type of error that occurred, information about where the error occurred (such as which line number in the {{Glossary("SDP")}} or what {{Glossary("SCTP")}} cause code was at issue).
 
-## Methods
+## Instance methods
 
 _No additional methods are provided beyond any found on the parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/rtcicecandidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/index.md
@@ -35,7 +35,7 @@ For details on how the ICE process works, see [Lifetime of a WebRTC session](/en
 
     > **Note:** For backwards compatibility, the constructor also accepts as input a string containing the value of the {{domxref("RTCIceCandidate.candidate", "candidate")}} property instead of the configuration object.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCIceCandidate.address", "address")}} {{ReadOnlyInline}}
   - : A string containing the IP address of the candidate.
@@ -66,7 +66,7 @@ For details on how the ICE process works, see [Lifetime of a WebRTC session](/en
 - {{domxref("RTCIceCandidate.usernameFragment", "usernameFragment")}} {{ReadOnlyInline}}
   - : A string containing a randomly-generated username fragment ("ice-ufrag") which ICE uses for message integrity along with a randomly-generated password ("ice-pwd"). You can use this string to verify generations of ICE generation; each generation of the same ICE process will use the same `usernameFragment`, even across ICE restarts.
 
-## Methods
+## Instance methods
 
 - {{domxref("RTCIceCandidate.toJSON", "toJSON()")}}
   - : Returns a {{Glossary("JSON")}} representation of the `RTCIceCandidate`'s current configuration.

--- a/files/en-us/web/api/rtcicecandidatepair/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/index.md
@@ -21,7 +21,7 @@ browser-compat: api.RTCIceCandidatePair
 
 The **`RTCIceCandidatePair`** dictionary describes a pair of ICE candidates which together comprise a description of a viable connection between two WebRTC endpoints. It is used as the return value from {{domxref("RTCIceTransport.getSelectedCandidatePair()")}} to identify the currently-selected candidate pair identified by the ICE agent.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCIceCandidatePair.local", "local")}}
   - : An {{domxref("RTCIceCandidate")}} describing the configuration of the local end of the connection.

--- a/files/en-us/web/api/rtcicecandidatepairstats/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/index.md
@@ -29,7 +29,7 @@ The WebRTC **`RTCIceCandidatePairStats`** dictionary reports statistics which pr
 
 If a {{domxref("RTCStats")}}-based object's {{domxref("RTCStats.type", "type")}} is `candidate-pair`, it's an `RTCIceCandidatePairStats` object.
 
-## Properties
+## Instance properties
 
 _`RTCIceCandidatePairStats` is based upon {{domxref("RTCStats")}} and inherits its properties. In addition, it adds the following new properties:_
 

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -22,7 +22,7 @@ browser-compat: api.RTCIceCandidateStats
 
 The WebRTC API's **`RTCIceCandidateStats`** dictionary provides statistics related to an {{domxref("RTCIceCandidate")}}.
 
-## Properties
+## Instance properties
 
 `RTCIceCandidateStats` is based upon the {{domxref("RTCStats")}} dictionary, so it includes those properties in addition to the ones below.
 

--- a/files/en-us/web/api/rtciceparameters/index.md
+++ b/files/en-us/web/api/rtciceparameters/index.md
@@ -27,7 +27,7 @@ The **`RTCIceParameters`** dictionary specifies the username fragment and passwo
 
 During ICE negotiation, each peer's username fragment and password are recorded in an `RTCIceParameters` object, which can be obtained from the {{domxref("RTCIceTransport")}} by calling its {{domxref("RTCIceTransport.getLocalParameters", "getLocalParameters()")}} or {{domxref("RTCIceTransport.getRemoteParameters", "getRemoteParameters()")}} method, depending on which end interests you.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCIceParameters.usernameFragment", "usernameFragment")}}
   - : A string specifying the value of the ICE session's username fragment field, `ufrag`.

--- a/files/en-us/web/api/rtciceserver/index.md
+++ b/files/en-us/web/api/rtciceserver/index.md
@@ -16,7 +16,7 @@ browser-compat: api.RTCIceServer
 
 The **`RTCIceServer`** dictionary defines how to connect to a single ICE server (such as a {{Glossary("STUN")}} or {{Glossary("TURN")}} server). Objects of this type are provided in the [configuration](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#parameters) of an {{domxref("RTCPeerConnection")}}, in the `iceServers` array.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCIceServer.credential", "credential")}} {{optional_inline}}
   - : The credential to use when logging into the server. This is only used if the `RTCIceServer` represents a TURN server.

--- a/files/en-us/web/api/rtcicetransport/index.md
+++ b/files/en-us/web/api/rtcicetransport/index.md
@@ -23,7 +23,7 @@ This is particularly useful if you need to access state information about the co
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `RTCIceTransport` interface inherits properties from its parent, {{domxref("EventTarget")}}. It also offers the following properties:_
 
@@ -36,7 +36,7 @@ _The `RTCIceTransport` interface inherits properties from its parent, {{domxref(
 - {{domxref("RTCIceTransport.state", "state")}} {{ReadOnlyInline}}
   - : A string indicating what the current state of the ICE agent is. The value of `state` can be used to determine whether the ICE agent has made an initial connection using a viable candidate pair (`"connected"`), made its final selection of candidate pairs (`"completed"`), or in an error state (`"failed"`), among other states.
 
-## Methods
+## Instance methods
 
 _Also includes methods from {{domxref("EventTarget")}}, the parent interface._
 

--- a/files/en-us/web/api/rtcidentityassertion/index.md
+++ b/files/en-us/web/api/rtcidentityassertion/index.md
@@ -17,7 +17,7 @@ browser-compat: api.RTCIdentityAssertion
 
 The **`RTCIdentityAssertion`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents the identity of a remote peer of the current connection. If no peer has yet been set and verified, then this interface returns `null`. Once set it can't be changed.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCIdentityAssertion.idp")}} {{Experimental_Inline}}
   - : Indicates the provider of the identity assertion.

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
@@ -19,7 +19,7 @@ browser-compat: api.RTCInboundRtpStreamStats
 
 The [WebRTC API](/en-US/docs/Web/API/WebRTC_API)'s **`RTCInboundRtpStreamStats`** dictionary, based upon {{domxref("RTCReceivedRtpStreamStats")}} and {{domxref("RTCStats")}}, contains statistics related to the receiving end of an RTP stream on the local end of the {{domxref("RTCPeerConnection")}}.
 
-## Properties
+## Instance properties
 
 The `RTCInboundRtpStreamStats` dictionary is based on the {{domxref("RTCReceivedRtpStreamStats")}} dictionary, whose properties are also available.
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
@@ -22,7 +22,7 @@ browser-compat: api.RTCOutboundRtpStreamStats
 
 The **`RTCOutboundRtpStreamStats`** dictionary is the {{domxref("RTCStats")}}-based object which provides metrics and statistics related to an outbound {{Glossary("RTP")}} stream being sent by an {{domxref("RTCRtpSender")}}.
 
-## Properties
+## Instance properties
 
 _The `RTCOutboundRtpStreamStats` dictionary includes the following properties in addition to those it inherits from {{domxref("RTCSentRtpStreamStats")}}, {{domxref("RTCRtpStreamStats")}}, and {{domxref("RTCStats")}}._
 

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -31,13 +31,7 @@ The **`RTCPeerConnection`** interface represents a WebRTC connection between the
   - : Returns a newly-created `RTCPeerConnection`,
     which represents a connection between the local device and a remote peer.
 
-## Static methods
-
-- {{DOMxRef("RTCPeerConnection.generateCertificate", "generateCertificate()")}}
-  - : Creates an X.509 certificate and its corresponding private key,
-    returning a {{jsxref("Promise")}} that resolves with the new {{DOMxRef("RTCCertificate")}} once it is generated.
-
-## Properties
+## Instance properties
 
 _Also inherits properties from {{DOMxRef("EventTarget")}}._
 
@@ -120,7 +114,13 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
     `stable`, `have-local-offer`, `have-remote-offer`,
     `have-local-pranswer`, `have-remote-pranswer`, or `closed`.
 
-## Methods
+## Static methods
+
+- {{DOMxRef("RTCPeerConnection.generateCertificate", "generateCertificate()")}}
+  - : Creates an X.509 certificate and its corresponding private key,
+    returning a {{jsxref("Promise")}} that resolves with the new {{DOMxRef("RTCCertificate")}} once it is generated.
+
+## Instance methods
 
 _Also inherits methods from {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -31,7 +31,7 @@ The **`RTCPeerConnectionIceErrorEvent`** interface—based upon the {{domxref("E
 - {{domxref("RTCPeerConnectionIceErrorEvent.RTCPeerConnectionIceErrorEvent", "RTCPeerConnectionIceErrorEvent()")}}
   - : Creates and returns a new `RTCPeerConnectionIceErrorEvent` object, with its `type` and other properties initialized as specified in the parameters. You will not normally create an object of this type yourself.
 
-## Properties
+## Instance properties
 
 _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on the {{domxref("Event")}} interface, as well as the following properties:_
 
@@ -46,7 +46,7 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
 
-## Methods
+## Instance methods
 
 _`RTCPeerConnectionIceErrorEvent` has no methods other than any provided by the parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
@@ -19,7 +19,7 @@ Only one event is of this type: {{domxref("RTCPeerConnection.icecandidate_event"
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _A {{domxref("RTCPeerConnectionIceEvent")}} being an {{domxref("Event")}}, this event also implements these properties_.
 
@@ -31,7 +31,7 @@ _A {{domxref("RTCPeerConnectionIceEvent")}} being an {{domxref("Event")}}, this 
 - {{domxref("RTCPeerConnectionIceEvent.RTCPeerConnectionIceEvent()", "RTCPeerConnectionIceEvent()")}}
   - : Returns a new `RTCPeerConnectionIceEvent`. It takes two parameters, the first being a string representing the type of the event; the second a dictionary containing the {{domxref("RTCIceCandidate")}} it refers to.
 
-## Methods
+## Instance methods
 
 _A {{domxref("RTCPeerConnectionIceEvent")}} being an {{domxref("Event")}}, this event also implements these properties. There is no specific {{domxref("RTCDataChannelEvent")}} method._
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.md
@@ -26,7 +26,7 @@ browser-compat: api.RTCRemoteOutboundRtpStreamStats
 
 The WebRTC statistics model's **`RTCRemoteOutboundRtpStreamStats`** dictionary extends the underlying {{domxref("RTCSentRtpStreamStats")}} dictionary with properties measuring metrics specific to outgoing {{Glossary("RTP")}} streams.
 
-## Properties
+## Instance properties
 
 _In addition to the properties defined by {{domxref("RTCSentRtpStreamStats")}} and its underlying {{domxref("RTCRtpStreamStats")}} and {{domxref("RTCStats")}} dictionaries, `RTCRemoteOutboundRtpStreamStats` defines the following properties._
 

--- a/files/en-us/web/api/rtcrtcpparameters/index.md
+++ b/files/en-us/web/api/rtcrtcpparameters/index.md
@@ -21,7 +21,7 @@ browser-compat: api.RTCRtcpParameters
 
 The **`RTCRtcpParameters`** dictionary provides parameters of an {{Glossary("RTCP")}} connection. It's used as the value of the {{domxref("RTCRtpParameters.rtcp", "rtcp")}} property of the [parameters](/en-US/docs/Web/API/RTCRtpParameters) of an {{domxref("RTCRtpSender")}} or {{domxref("RTCRtpReceiver")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtcpParameters.cname", "cname")}}
   - : The Canonical Name (CNAME) being used by RTCP. This is used, for example, in SDES (SDP security descriptions) messages, described in {{RFC(4568)}}. This property cannot be changed once initialized.

--- a/files/en-us/web/api/rtcrtpcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.md
@@ -25,7 +25,7 @@ The **`RTCRtpCapabilities`** dictionary is a data type used to describe the capa
 
 An `RTCRtpCapabilities` object contains an array of objects conforming to {{domxref("RTCRtpCodecCapability")}} (each describing the capabilities of one codec) and an array of the supported {{Glossary("RTP")}} [header extensions](https://datatracker.ietf.org/doc/html/rfc3550#section-5.3.1) for that codec.
 
-## Properties
+## Instance properties
 
 - `codecs`
   - : An array of {{domxref("RTCRtpCodecCapability")}} objects, each describing one of the codecs supported by the {{domxref("RTCRtpSender")}} or {{domxref("RTCRtpReceiver")}}. There are some special entries in this array, described below in the section [The codecs array](#the_codecs_array).

--- a/files/en-us/web/api/rtcrtpcodeccapability/index.md
+++ b/files/en-us/web/api/rtcrtpcodeccapability/index.md
@@ -22,7 +22,7 @@ browser-compat: api.RTCRtpCodecCapability
 
 The [WebRTC API's](/en-US/docs/Web/API/WebRTC_API) **`RTCRtpCodecCapability`** dictionary provides information describing the capabilities of a single [media codec](/en-US/docs/Web/Media/Formats/WebRTC_codecs).
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpCodecCapability.channels", "channels")}} {{optional_inline}}
   - : An unsigned integer value indicating the maximum number of channels supported by the codec; for example, a codec that supports only mono sound would have a value of 1; stereo codecs would have a 2, etc.

--- a/files/en-us/web/api/rtcrtpcodecparameters/index.md
+++ b/files/en-us/web/api/rtcrtpcodecparameters/index.md
@@ -29,7 +29,7 @@ In addition to being the type of the {{domxref("RTCRtpParameters.codecs")}} prop
 
 Most of the fields in this property take values which are defined and maintained by the Internet Assigned Numbers Authority (IANA). References to relevant IANA documents are provided in the [see also](#see_also) section at the end of this article.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpCodecParameters.payloadType", "payloadType")}} {{optional_inline}}
   - : The [RTP payload type](https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1) used to identify this codec.

--- a/files/en-us/web/api/rtcrtpcontributingsource/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/index.md
@@ -21,7 +21,7 @@ The **`RTCRtpContributingSource`** dictionary of the [WebRTC API](/en-US/docs/We
 
 The information provided is based on the last ten seconds of media received.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpContributingSource.audioLevel", "audioLevel")}} {{optional_inline}}
   - : A double-precision floating-point value between 0 and 1 specifying the audio level contained in the last RTP packet played from this source.

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.md
@@ -24,7 +24,7 @@ An instance of the [WebRTC](/en-US/docs/Web/API/WebRTC_API) API's **`RTCRtpEncod
 
 This dictionary is used in the {{domxref("RTCRtpSendParameters")}} describing the configuration of an RTP sender's {{domxref("RTCRtpSendParameters.encodings", "encodings")}}; {{domxref("RTCRtpDecodingParameters")}} is used to describe the configuration of an RTP receiver's {{domxref("RTCRtpReceiveParameters", "encodings")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpEncodingParameters.active", "active")}}
   - : If `true`, the described encoding is currently actively being used. That is, for RTP senders, the encoding is currently being used to send data, while for receivers, the encoding is being used to decode received data. The default value is `true`.

--- a/files/en-us/web/api/rtcrtpparameters/index.md
+++ b/files/en-us/web/api/rtcrtpparameters/index.md
@@ -28,7 +28,7 @@ To obtain the parameters of a sender or receiver, call its `getParameters()` met
 - {{domxref("RTCRtpSender.getParameters", "getParameters()")}}
 - {{domxref("RTCRtpReceiver.getParameters", "getParameters()")}}
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpParameters.codecs", "codecs")}}
   - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the sender or receiver will choose. This parameter cannot be changed once initially set.

--- a/files/en-us/web/api/rtcrtpreceiveparameters/index.md
+++ b/files/en-us/web/api/rtcrtpreceiveparameters/index.md
@@ -22,7 +22,7 @@ browser-compat: api.RTCRtpReceiveParameters
 
 The **`RTCRtpReceiveParameters`** dictionary, based upon the {{domxref("RTCRtpParameters")}} dictionary, is returned by the {{domxref("RTCRtpReceiver")}} method {{domxref("RTCRtpReceiver.getParameters", "getParameters()")}}. It describes the parameters being used by the receiver's {{Glossary("RTP")}} connection to the remote peer.
 
-## Properties
+## Instance properties
 
 _This dictionary currently has no properties of its own; it exists for future expansion. It inherits all of the properties of its parent, {{domxref("RTCRtpParameters")}}._
 

--- a/files/en-us/web/api/rtcrtpreceiver/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/index.md
@@ -18,7 +18,7 @@ browser-compat: api.RTCRtpReceiver
 
 The **`RTCRtpReceiver`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) manages the reception and decoding of data for a {{domxref("MediaStreamTrack")}} on an {{domxref("RTCPeerConnection")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpReceiver.track")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("MediaStreamTrack")}} associated with the current `RTCRtpReceiver` instance.
@@ -30,7 +30,12 @@ The **`RTCRtpReceiver`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRT
 - `rtcpTransport` {{deprecated_inline}}
   - : This property has been removed; the RTP and RTCP transports have been combined into a single transport. Use the {{domxref("RTCRtpReceiver.transport", "transport")}} property instead.
 
-## Methods
+## Static methods
+
+- {{domxref("RTCRtpReceiver.getCapabilities()")}}
+  - : Returns the most optimistic view of the capabilities of the system for receiving media of the given kind.
+
+## Instance methods
 
 - {{domxref("RTCRtpReceiver.getContributingSources()")}}
   - : Returns an array of {{domxref("RTCRtpContributingSource")}} instances for each unique CSRC (contributing source) identifier received by the current `RTCRtpReceiver` in the last ten seconds.
@@ -40,11 +45,6 @@ The **`RTCRtpReceiver`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRT
   - : Returns a {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref("RTCStatsReport")}} which contains statistics about the incoming streams and their dependencies.
 - {{domxref("RTCRtpReceiver.getSynchronizationSources()")}}
   - : Returns an array including one {{domxref("RTCRtpSynchronizationSource")}} instance for each unique SSRC (synchronization source) identifier received by the current `RTCRtpReceiver` in the last ten seconds.
-
-## Static methods
-
-- {{domxref("RTCRtpReceiver.getCapabilities()")}}
-  - : Returns the most optimistic view of the capabilities of the system for receiving media of the given kind.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcrtpsender/index.md
+++ b/files/en-us/web/api/rtcrtpsender/index.md
@@ -26,7 +26,7 @@ The **`RTCRtpSender`** interface provides the ability to control and obtain deta
 
 With it, you can configure the encoding used for the corresponding track, get information about the device's media capabilities, and so forth. You can also obtain access to an {{domxref("RTCDTMFSender")}} which can be used to send {{Glossary("DTMF")}} codes (to simulate the user pressing buttons on a telephone's dial pad) to the remote peer.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpSender.dtmf")}} {{ReadOnlyInline}}
   - : An {{domxref("RTCDTMFSender")}} which can be used to send {{Glossary("DTMF")}} tones using `telephone-event` payloads on the {{Glossary("RTP")}} session represented by the `RTCRtpSender` object. If `null`, the track and/or the connection doesn't support DTMF. Only audio tracks can support DTMF.
@@ -40,7 +40,12 @@ With it, you can configure the encoding used for the corresponding track, get in
 - `rtcpTransport` {{deprecated_inline}}
   - : This property has been removed; the RTP and RTCP transports have been combined into a single transport. Use the {{domxref("RTCRtpSender.transport", "transport")}} property instead.
 
-## Methods
+## Static methods
+
+- {{domxref("RTCRtpSender.getCapabilities()")}}
+  - : Returns an {{domxref("RTCRtpCapabilities")}} object describing the system's capabilities for sending a specified kind of media data.
+
+## Instance methods
 
 - {{domxref("RTCRtpSender.getParameters()")}}
   - : Returns a {{domxref("RTCRtpParameters")}} object describing the current configuration for the encoding and transmission of media on the `track`.
@@ -52,11 +57,6 @@ With it, you can configure the encoding used for the corresponding track, get in
   - : Sets the {{domxref("MediaStream")}}(s) associated with the {{domxref("RTCRtpSender.track", "track")}} being transmitted by this sender.
 - {{domxref("RTCRtpSender.replaceTrack()")}}
   - : Attempts to replace the track currently being sent by the `RTCRtpSender` with another track, without performing renegotiation. This method can be used, for example, to toggle between the front- and rear-facing cameras on a device.
-
-## Static methods
-
-- {{domxref("RTCRtpSender.getCapabilities()")}}
-  - : Returns an {{domxref("RTCRtpCapabilities")}} object describing the system's capabilities for sending a specified kind of media data.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcrtpsendparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsendparameters/index.md
@@ -26,7 +26,7 @@ browser-compat: api.RTCRtpSendParameters
 
 The WebRTC API's **`RTCRtpSendParameters`** dictionary is used to specify the parameters for an {{domxref("RTCRtpSender")}} when calling its {{domxref("RTCRtpSender.setParameters", "setParameters()")}} method.
 
-## Properties
+## Instance properties
 
 _In addition to the properties below, `RTCRtpSendParameters` inherits the properties from the {{domxref("RTCRtpParameters")}} interface._
 

--- a/files/en-us/web/api/rtcrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/index.md
@@ -27,7 +27,7 @@ While the dictionary has a base set of properties that are present in each of th
 
 > **Note:** This interface was called `RTCRTPStreamStats` until a specification update in the spring of 2017. Check the [Browser compatibility](#browser_compatibility) table to know if and when the name change was implemented in specific browsers.
 
-## Properties
+## Instance properties
 
 _The `RTCRtpStreamStats` dictionary is based on {{domxref("RTCStats")}}, and inherits its properties. In addition, some or all of the following properties are available._
 

--- a/files/en-us/web/api/rtcrtptransceiver/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/index.md
@@ -24,7 +24,7 @@ Each {{Glossary("SDP")}} media section describes one bidirectional SRTP ("Secure
 
 A transceiver is uniquely identified using its {{domxref("RTCRtpTransceiver.mid", "mid")}} property, which is the same as the media ID (`mid`) of its corresponding m-line. An `RTCRtpTransceiver` is **associated** with an m-line if its `mid` is non-null; otherwise it's considered disassociated.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}} {{ReadOnlyInline}}
   - : A read-only string which indicates the transceiver's current directionality, or `null` if the transceiver is stopped or has never participated in an exchange of offers and answers. To change the transceiver's directionality, set the value of the {{domxref("RTCRtpTransceiver.direction", "direction")}} property.
@@ -39,7 +39,7 @@ A transceiver is uniquely identified using its {{domxref("RTCRtpTransceiver.mid"
 - {{domxref("RTCRtpTransceiver.stopped", "stopped")}} {{Deprecated_Inline}}
   - : Indicates whether or not sending and receiving using the paired `RTCRtpSender` and `RTCRtpReceiver` has been permanently disabled, either due to SDP offer/answer, or due to a call to {{domxref("RTCRtpTransceiver.stop", "stop()")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("RTCRtpTransceiver.setCodecPreferences", "setCodecPreferences()")}}
   - : A list of {{domxref("RTCRtpCodecParameters")}} objects which override the default preferences used by the {{Glossary("user agent")}} for the transceiver's codecs.

--- a/files/en-us/web/api/rtcsctptransport/index.md
+++ b/files/en-us/web/api/rtcsctptransport/index.md
@@ -22,7 +22,7 @@ Possibly the most useful property on this interface is its {{DOMxRef("RTCSctpTra
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from: {{DOMxRef("EventTarget")}}_.
 
@@ -40,7 +40,7 @@ _Also inherits properties from: {{DOMxRef("EventTarget")}}_.
 - {{DOMxRef("RTCSctpTransport.onstatechange")}}
   - : Fired when the {{DOMxRef("RTCSctpTransport.state")}} changes.
 
-## Methods
+## Instance methods
 
 _This interface has no methods, but inherits methods from: {{DOMxRef("EventTarget")}}._
 

--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -20,7 +20,7 @@ The **`RTCSessionDescription`** interface describes one end of a connection—or
 
 The process of negotiating a connection between two peers involves exchanging `RTCSessionDescription` objects back and forth, with each description suggesting one combination of connection configuration options that the sender of the description supports. Once the two peers agree upon a configuration for the connection, negotiation is complete.
 
-## Properties
+## Instance properties
 
 _The `RTCSessionDescription` interface doesn't inherit any properties._
 
@@ -29,7 +29,7 @@ _The `RTCSessionDescription` interface doesn't inherit any properties._
 - {{domxref("RTCSessionDescription.sdp")}} {{ReadOnlyInline}}
   - : A string containing the {{Glossary("SDP")}} describing the session.
 
-## Methods
+## Instance methods
 
 _The `RTCSessionDescription` doesn't inherit any methods._
 

--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -21,7 +21,7 @@ The **`RTCStats`** dictionary is the basic statistics object used by WebRTC's st
 
 Specific classes of statistic are defined as dictionaries based on `RTCStats`. For example, statistics about a received {{Glossary("RTP")}} stream are represented by {{domxref("RTCReceivedRtpStreamStats")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("RTCStats.id", "id")}}
   - : A string which uniquely identifies the object which was inspected to produce this object based on `RTCStats`.

--- a/files/en-us/web/api/rtcstatsreport/index.md
+++ b/files/en-us/web/api/rtcstatsreport/index.md
@@ -27,7 +27,7 @@ Calling `getStats()` on an {{domxref("RTCPeerConnection")}} lets you specify whe
 
 For each category of statistic information, there is a dictionary whose properties provide the relevant information.
 
-### Properties common to all statistic categories
+### Instance properties common to all statistic categories
 
 All WebRTC statistics objects are fundamentally based on the {{domxref("RTCStats")}} dictionary, which provides the most fundamental information: the timestamp, the statistic type string, and an ID uniquely identifying the source of the data.
 

--- a/files/en-us/web/api/rtctrackevent/index.md
+++ b/files/en-us/web/api/rtctrackevent/index.md
@@ -31,7 +31,7 @@ This event is sent by the WebRTC layer to the web site or application, so you wi
 - {{domxref("RTCTrackEvent.RTCTrackEvent", "RTCTrackEvent()")}}
   - : Creates and returns a new `RTCTrackEvent` object, initialized with properties taken from the specified {{domxref("RTCTrackEventInit")}} dictionary. You will probably not need to create new track events yourself, since they're typically created by the WebRTC infrastructure and sent to the connection's {{domxref("RTCPeerConnection.track_event", "ontrack")}} event handler.
 
-## Properties
+## Instance properties
 
 _Since `RTCTrackEvent` is based on {{domxref("Event")}}, its properties are also available._
 

--- a/files/en-us/web/api/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/index.md
@@ -25,7 +25,7 @@ This configuration may be customized using constructor options.
 - {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}} {{Experimental_Inline}}
   - : Creates and returns a `Sanitizer` object, optionally with custom sanitization behavior.
 
-## Methods
+## Instance methods
 
 - {{domxref('Sanitizer.sanitize()')}} {{Experimental_Inline}}
 

--- a/files/en-us/web/api/scheduler/index.md
+++ b/files/en-us/web/api/scheduler/index.md
@@ -15,11 +15,11 @@ The **`Scheduler`** interface of the [Prioritized Task Scheduling API](/en-US/do
 
 A `Scheduler` can be accessed from the global object {{domxref("Window")}} or {{domxref("WorkerGlobalScope")}} (`this.scheduler`).
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref('Scheduler.postTask()')}}
   - : Adds a task to the scheduler as a callback, optionally specifying a priority, delay, and/or a signal for aborting the task.

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -18,7 +18,7 @@ Note that browsers determine which screen to report as current by detecting whic
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from its parent {{domxref("EventTarget")}}_.
 
@@ -49,7 +49,7 @@ _Also inherits properties from its parent {{domxref("EventTarget")}}_.
 - {{DOMxRef("Screen.mozBrightness")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Controls the brightness of a device's screen. A double between 0 and 1.0 is expected.
 
-## Methods
+## Instance methods
 
 _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -20,7 +20,7 @@ A **`ScreenOrientation`** instance object can be retrieved using the {{domxref("
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("ScreenOrientation.type")}} {{ReadOnlyInline}}
   - : Returns the document's current orientation type, one of "portrait-primary", "portrait-secondary", "landscape-primary", or "landscape-secondary".
@@ -32,7 +32,7 @@ A **`ScreenOrientation`** instance object can be retrieved using the {{domxref("
 - {{DOMxRef("ScreenOrientation.onchange")}}
   - : The [event handler](/en-US/docs/Web/Events/Event_handlers) called whenever the screen changes orientation.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("ScreenOrientation.lock()")}}
   - : Locks the orientation of the containing document to its default orientation and returns a {{JSxRef("Promise")}}.

--- a/files/en-us/web/api/scriptprocessornode/index.md
+++ b/files/en-us/web/api/scriptprocessornode/index.md
@@ -53,14 +53,14 @@ If the buffer size is not defined, which is recommended, the browser will pick o
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
 - {{domxref("ScriptProcessorNode.bufferSize")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : Returns an integer representing both the input and output buffer size. Its value can be a power of 2 value in the range `256`–`16384`.
 
-## Methods
+## Instance methods
 
 _No specific methods; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.md
@@ -24,7 +24,7 @@ The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event"
 - {{domxref("SecurityPolicyViolationEvent.SecurityPolicyViolationEvent","SecurityPolicyViolationEvent()")}}
   - : Creates a new `SecurityPolicyViolationEvent` object instance.
 
-## Properties
+## Instance properties
 
 - {{domxref("SecurityPolicyViolationEvent.blockedURI")}} {{ReadOnlyInline}}
   - : A string representing the URI of the resource that was blocked because it violates a policy.

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -18,7 +18,7 @@ A user may make a selection from left to right (in document order) or right to l
 
 > **Note:** _Anchor_ and _focus_ should not be confused with the _start_ and _end_ positions of a selection. The anchor can be placed before the focus or vice versa, depending on the direction you made your selection.
 
-## Properties
+## Instance properties
 
 - {{DOMxRef("Selection.anchorNode")}} {{ReadOnlyInline}}
   - : Returns the {{DOMxRef("Node")}} in which the selection begins. Can return `null` if selection never existed in the document (e.g., an iframe that was never clicked on).
@@ -35,7 +35,7 @@ A user may make a selection from left to right (in document order) or right to l
 - {{DOMxRef("Selection.type")}} {{ReadOnlyInline}}
   - : Returns a string describing the type of the current selection.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("Selection.addRange()")}}
   - : A {{DOMxRef("Range")}} object that will be added to the selection.

--- a/files/en-us/web/api/sensorerrorevent/index.md
+++ b/files/en-us/web/api/sensorerrorevent/index.md
@@ -26,7 +26,7 @@ The **`SensorErrorEvent`** interface of the [Sensor APIs](/en-US/docs/Web/API/Se
 - {{domxref("SensorErrorEvent.SensorErrorEvent", "SensorErrorEvent()")}}
   - : Creates a new `SensorErrorEvent` object.
 
-## Properties
+## Instance properties
 
 - {{domxref('SensorErrorEvent.error')}} {{ReadOnlyInline}}
   - : Returns the {{domxref('DOMException')}} object passed in the event's constructor.

--- a/files/en-us/web/api/serial/index.md
+++ b/files/en-us/web/api/serial/index.md
@@ -17,7 +17,7 @@ The `Serial` interface of the {{domxref("Web_Serial_API", "Web Serial API")}} pr
 
 {{InheritanceDiagram}}
 
-## Methods
+## Instance methods
 
 - {{domxref("Serial.requestPort()")}} {{Experimental_Inline}}
 

--- a/files/en-us/web/api/serialport/index.md
+++ b/files/en-us/web/api/serialport/index.md
@@ -21,14 +21,14 @@ The `SerialPort` interface of the {{domxref("Web_Serial_API", "Web Serial API")}
 
 Instances of this interface may be obtained by calling methods of the {{domxref("Serial")}} interface, therefore it has no constructor of its own.
 
-## Properties
+## Instance properties
 
 - {{domxref("SerialPort.readable")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port.
 - {{domxref("SerialPort.writable")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref("WritableStream")}} for sending data to the device connected to the port.
 
-## Methods
+## Instance methods
 
 - {{domxref("SerialPort.getInfo()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with an object containing properties of the port.

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -23,7 +23,7 @@ The `ServiceWorker` interface is dispatched a set of lifecycle events — `insta
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The `ServiceWorker` interface inherits properties from its parent, {{domxref("EventTarget")}}._
 
@@ -32,7 +32,7 @@ _The `ServiceWorker` interface inherits properties from its parent, {{domxref("E
 - {{domxref("ServiceWorker.state")}} {{ReadOnlyInline}}
   - : Returns the state of the service worker. It returns one of the following values: `parsed`, `installing`, `installed,` `activating`, `activated`, or `redundant`.
 
-## Methods
+## Instance methods
 
 _The `ServiceWorker` interface inherits methods from its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/serviceworkercontainer/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/index.md
@@ -23,7 +23,7 @@ Most importantly, it exposes the {{domxref("ServiceWorkerContainer.register", "S
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("ServiceWorkerContainer.controller")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("ServiceWorker")}} object if its state is `activating` or `activated` (the same object returned by {{domxref("ServiceWorkerRegistration.active")}}). This property returns `null` during a force-refresh request (_Shift_ + refresh) or if there is no active worker.
@@ -39,7 +39,7 @@ Most importantly, it exposes the {{domxref("ServiceWorkerContainer.register", "S
 - [`message`](/en-US/docs/Web/API/ServiceWorkerContainer/message_event)
   - : Occurs when incoming messages are received by the {{domxref("ServiceWorkerContainer")}} object (e.g. via a {{domxref("MessagePort.postMessage()")}} call).
 
-## Methods
+## Instance methods
 
 - {{domxref("ServiceWorkerContainer.register", "ServiceWorkerContainer.register()")}}
   - : Creates or updates a {{domxref("ServiceWorkerRegistration")}} for the given `scriptURL`.

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -26,7 +26,7 @@ This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("ServiceWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("CacheStorage")}} object associated with the service worker.
@@ -60,7 +60,7 @@ This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and
 - {{domxref("ServiceWorkerGlobalScope/pushsubscriptionchange_event", "pushsubscriptionchange")}}
   - : Occurs when a push subscription has been invalidated, or is about to be invalidated (e.g. when a push service sets an expiration time).
 
-## Methods
+## Instance methods
 
 - {{domxref("ServiceWorkerGlobalScope.skipWaiting()")}}
   - : Allows the current service worker registration to progress from waiting to active state while service worker clients are using it.

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -24,7 +24,7 @@ The lifetime of a service worker registration is beyond that of the `ServiceWork
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also implements properties from its parent interface,_ {{domxref("EventTarget")}}.
 
@@ -47,7 +47,7 @@ _Also implements properties from its parent interface,_ {{domxref("EventTarget")
 - {{domxref("ServiceWorkerRegistration.updateViaCache")}} {{ReadOnlyInline}}
   - : Returns a string indicating what is the cache strategy to use when updating the service worker scripts. It can be one of the following: `imports`, `all`, or `none`.
 
-## Methods
+## Instance methods
 
 _Also implements methods from its parent interface,_ {{domxref("EventTarget")}}.
 

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -20,7 +20,7 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("ShadowRoot.activeElement")}} {{ReadOnlyInline}}
   - : Returns the {{domxref('Element')}} within the shadow tree that has focus.
@@ -46,7 +46,7 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
 - {{domxref("ShadowRoot.styleSheets")}} {{ReadOnlyInline}}
   - : Returns a {{domxref('StyleSheetList')}} of {{domxref('CSSStyleSheet')}} objects for stylesheets explicitly linked into, or embedded in a shadow tree.
 
-## Methods
+## Instance methods
 
 - {{DOMxRef("ShadowRoot.getAnimations()")}}
   - : Returns an array of all {{DOMxRef("Animation")}} objects currently in effect, whose target elements are descendants of the shadow tree.

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -25,7 +25,7 @@ The **`SharedWorker`** interface represents a specific kind of worker that can b
 - {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}}
   - : Creates a shared web worker that executes the script at the specified URL.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("EventTarget")}}._
 
@@ -37,7 +37,7 @@ _Inherits properties from its parent, {{domxref("EventTarget")}}._
 - {{domxref("SharedWorker.error_event", "error")}}
   - : Fires when an error occurs in the shared worker.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -17,7 +17,7 @@ The **`SharedWorkerGlobalScope`** object (the {{domxref("SharedWorker")}} global
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 
@@ -26,7 +26,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("SharedWorkerGlobalScope.applicationCache")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : This property returns the {{domxref("ApplicationCache")}} object for the worker.
 
-### Properties inherited from WorkerGlobalScope
+### Instance properties inherited from WorkerGlobalScope
 
 - {{domxref("WorkerGlobalScope.self")}}
   - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
@@ -39,7 +39,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
 
-## Methods
+## Instance methods
 
 _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/sourcebuffer/index.md
+++ b/files/en-us/web/api/sourcebuffer/index.md
@@ -20,7 +20,7 @@ The **`SourceBuffer`** interface represents a chunk of media to be passed into a
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("SourceBuffer.appendWindowEnd")}}
   - : Controls the timestamp for the end of the append window.
@@ -41,7 +41,7 @@ The **`SourceBuffer`** interface represents a chunk of media to be passed into a
 - {{domxref("SourceBuffer.videoTracks")}} {{ReadOnlyInline}}
   - : A list of the video tracks currently contained inside the `SourceBuffer`.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/sourcebufferlist/index.md
+++ b/files/en-us/web/api/sourcebufferlist/index.md
@@ -24,12 +24,12 @@ The individual source buffers can be accessed using the [array operator](/en-US/
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("SourceBufferList.length")}} {{ReadOnlyInline}}
   - : Returns the number of {{domxref("SourceBuffer")}} objects in the list.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/speechgrammar/index.md
+++ b/files/en-us/web/api/speechgrammar/index.md
@@ -25,7 +25,7 @@ Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (
 - {{domxref("SpeechGrammar.SpeechGrammar()", "SpeechGrammar()")}} {{Non-standard_Inline}} {{Experimental_Inline}}
   - : Creates a new `SpeechGrammar` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechGrammar.src")}} {{Experimental_Inline}}
   - : Sets and returns a string containing the grammar from within in the `SpeechGrammar` object instance.

--- a/files/en-us/web/api/speechgrammarlist/index.md
+++ b/files/en-us/web/api/speechgrammarlist/index.md
@@ -25,12 +25,12 @@ Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (
 - {{domxref("SpeechGrammarList.SpeechGrammarList", "SpeechGrammarList()")}} {{Experimental_Inline}}
   - : Creates a new `SpeechGrammarList` object.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechGrammarList.length")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the number of {{domxref("SpeechGrammar")}} objects contained in the `SpeechGrammarList`.
 
-## Methods
+## Instance methods
 
 - {{domxref("SpeechGrammarList.item()")}} {{Experimental_Inline}}
   - : Standard getter — allows individual {{domxref("SpeechGrammar")}} objects to be retrieved from the `SpeechGrammarList` using array syntax.

--- a/files/en-us/web/api/speechrecognition/index.md
+++ b/files/en-us/web/api/speechrecognition/index.md
@@ -26,7 +26,7 @@ The **`SpeechRecognition`** interface of the [Web Speech API](/en-US/docs/Web/AP
 - {{domxref("SpeechRecognition.SpeechRecognition", "SpeechRecognition()")}}
   - : Creates a new `SpeechRecognition` object.
 
-## Properties
+## Instance properties
 
 _`SpeechRecognition` also inherits properties from its parent interface, {{domxref("EventTarget")}}._
 
@@ -41,7 +41,7 @@ _`SpeechRecognition` also inherits properties from its parent interface, {{domxr
 - {{domxref("SpeechRecognition.maxAlternatives")}}
   - : Sets the maximum number of {{domxref("SpeechRecognitionAlternative")}}s provided per result. The default value is 1.
 
-## Methods
+## Instance methods
 
 _`SpeechRecognition` also inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/speechrecognitionalternative/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/index.md
@@ -17,7 +17,7 @@ browser-compat: api.SpeechRecognitionAlternative
 
 The **`SpeechRecognitionAlternative`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a single word that has been recognized by the speech recognition service.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechRecognitionAlternative.transcript")}} {{ReadOnlyInline}}
   - : Returns a string containing the transcript of the recognized word.

--- a/files/en-us/web/api/speechrecognitionerrorevent/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/index.md
@@ -11,7 +11,7 @@ The **`SpeechRecognitionErrorEvent`** interface of the [Web Speech API](/en-US/d
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _`SpeechRecognitionErrorEvent` also inherits properties from its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/speechrecognitionevent/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/index.md
@@ -20,7 +20,7 @@ The **`SpeechRecognitionEvent`** interface of the [Web Speech API](/en-US/docs/W
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _`SpeechRecognitionEvent` also inherits properties from its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/speechrecognitionresult/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/index.md
@@ -17,14 +17,14 @@ browser-compat: api.SpeechRecognitionResult
 
 The **`SpeechRecognitionResult`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a single recognition match, which may contain multiple {{domxref("SpeechRecognitionAlternative")}} objects.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechRecognitionResult.isFinal")}} {{ReadOnlyInline}}
   - : A boolean value that states whether this result is final (true) or not (false) — if so, then this is the final time this result will be returned; if not, then this result is an interim result, and may be updated later on.
 - {{domxref("SpeechRecognitionResult.length")}} {{ReadOnlyInline}}
   - : Returns the length of the "array" — the number of {{domxref("SpeechRecognitionAlternative")}} objects contained in the result (also referred to as "n-best alternatives".)
 
-## Methods
+## Instance methods
 
 - {{domxref("SpeechRecognitionResult.item")}}
   - : A standard getter that allows {{domxref("SpeechRecognitionAlternative")}} objects within the result to be accessed via array syntax.

--- a/files/en-us/web/api/speechrecognitionresultlist/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.md
@@ -17,12 +17,12 @@ browser-compat: api.SpeechRecognitionResultList
 
 The **`SpeechRecognitionResultList`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a list of {{domxref("SpeechRecognitionResult")}} objects, or a single one if results are being captured in {{domxref("SpeechRecognition.continuous","continuous")}} mode.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechRecognitionResultList.length")}} {{ReadOnlyInline}}
   - : Returns the length of the "array" — the number of {{domxref("SpeechRecognitionResult")}} objects in the list.
 
-## Methods
+## Instance methods
 
 - {{domxref("SpeechRecognitionResultList.item")}}
   - : A standard getter that allows {{domxref("SpeechRecognitionResult")}} objects in the list to be accessed via array syntax.

--- a/files/en-us/web/api/speechsynthesis/index.md
+++ b/files/en-us/web/api/speechsynthesis/index.md
@@ -19,7 +19,7 @@ The **`SpeechSynthesis`** interface of the [Web Speech API](/en-US/docs/Web/API/
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _`SpeechSynthesis` also inherits properties from its parent interface, {{domxref("EventTarget")}}._
 
@@ -30,7 +30,7 @@ _`SpeechSynthesis` also inherits properties from its parent interface, {{domxref
 - {{domxref("SpeechSynthesis.speaking")}} {{ReadOnlyInline}}
   - : A boolean value that returns `true` if an utterance is currently in the process of being spoken — even if `SpeechSynthesis` is in a paused state.
 
-## Methods
+## Instance methods
 
 _`SpeechSynthesis` also inherits methods from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.md
@@ -19,14 +19,14 @@ The **`SpeechSynthesisErrorEvent`** interface of the [Web Speech API](/en-US/doc
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _`SpeechSynthesisErrorEvent` extends the {{domxref("SpeechSynthesisEvent")}} interface, which inherits properties from its parent interface, {{domxref("Event")}}._
 
 - {{domxref("SpeechSynthesisErrorEvent.error")}} {{ReadOnlyInline}}
   - : Returns an error code indicating what has gone wrong with a speech synthesis attempt.
 
-## Methods
+## Instance methods
 
 _`SpeechSynthesisErrorEvent` extends the {{domxref("SpeechSynthesisEvent")}} interface, which inherits methods from its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -19,7 +19,7 @@ The **`SpeechSynthesisEvent`** interface of the [Web Speech API](/en-US/docs/Web
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from its parent interface, {{domxref("Event")}}._
 
@@ -32,7 +32,7 @@ _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from
 - {{domxref("SpeechSynthesisEvent.utterance")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("SpeechSynthesisUtterance")}} instance that the event was triggered on.
 
-## Methods
+## Instance methods
 
 _The {{domxref("SpeechSynthesisEvent")}} interface also inherits methods from its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/index.md
@@ -25,7 +25,7 @@ It contains the content the speech service should read and information about how
 - {{domxref("SpeechSynthesisUtterance.SpeechSynthesisUtterance", "SpeechSynthesisUtterance()")}}
   - : Returns a new `SpeechSynthesisUtterance` object instance.
 
-## Properties
+## Instance properties
 
 _`SpeechSynthesisUtterance` also inherits properties from its parent interface, {{domxref("EventTarget")}}._
 

--- a/files/en-us/web/api/speechsynthesisvoice/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/index.md
@@ -18,7 +18,7 @@ browser-compat: api.SpeechSynthesisVoice
 The **`SpeechSynthesisVoice`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a voice that the system supports.
 Every `SpeechSynthesisVoice` has its own relative speech service including information about language, name and URI.
 
-## Properties
+## Instance properties
 
 - {{domxref("SpeechSynthesisVoice.default")}} {{ReadOnlyInline}}
   - : A boolean value indicating whether the voice is the default voice for the current app language (`true`), or not (`false`.)

--- a/files/en-us/web/api/staticrange/index.md
+++ b/files/en-us/web/api/staticrange/index.md
@@ -30,7 +30,7 @@ This interface offers the same set of properties and methods as `AbstractRange`.
 - {{domxref("StaticRange.StaticRange", "StaticRange()")}}
   - : Creates a new `StaticRange` object given the {{domxref("StaticRangeInit")}} dictionary specifying the default values for its properties.
 
-## Properties
+## Instance properties
 
 _The properties below are inherited from its parent interface, {{domxref("AbstractRange")}}._
 

--- a/files/en-us/web/api/stereopannernode/index.md
+++ b/files/en-us/web/api/stereopannernode/index.md
@@ -52,14 +52,14 @@ The {{domxref("StereoPannerNode.pan", "pan")}} property takes a unitless value b
 - {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
   - : Creates a new instance of a `StereoPannerNode` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
 - {{domxref("StereoPannerNode.pan")}} {{ReadOnlyInline}}
   - : An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the amount of panning to apply.
 
-## Methods
+## Instance methods
 
 _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_.
 

--- a/files/en-us/web/api/storage/index.md
+++ b/files/en-us/web/api/storage/index.md
@@ -18,12 +18,12 @@ The **`Storage`** interface of the [Web Storage API](/en-US/docs/Web/API/Web_Sto
 
 To manipulate, for instance, the session storage for a domain, a call to {{domxref("Window.sessionStorage")}} is made; whereas for local storage the call is made to {{domxref("Window.localStorage")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("Storage.length")}} {{ReadOnlyInline}}
   - : Returns an integer representing the number of data items stored in the `Storage` object.
 
-## Methods
+## Instance methods
 
 - {{domxref("Storage.key()")}}
   - : When passed a number `n`, this method will return the name of the nth key in the storage.

--- a/files/en-us/web/api/storageevent/index.md
+++ b/files/en-us/web/api/storageevent/index.md
@@ -24,7 +24,7 @@ when a storage area the window has access to is changed within the context of an
 - {{domxref("StorageEvent.StorageEvent()", "StorageEvent()")}}
   - : Returns a newly constructed `StorageEvent` object.
 
-## Properties
+## Instance properties
 
 _In addition to the properties listed below, this interface inherits the properties of its parent interface, {{domxref("Event")}}._
 
@@ -46,7 +46,7 @@ _In addition to the properties listed below, this interface inherits the propert
 - {{domxref("StorageEvent.url", "url")}} {{ReadOnlyInline}}
   - : Returns string with the URL of the document whose `key` changed.
 
-## Methods
+## Instance methods
 
 _In addition to the methods listed below, this interface inherits the methods of its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/storagemanager/index.md
+++ b/files/en-us/web/api/storagemanager/index.md
@@ -20,7 +20,7 @@ browser-compat: api.StorageManager
 
 The **`StorageManager`** interface of the [Storage API](/en-US/docs/Web/API/Storage_API) provides an interface for managing persistence permissions and estimating available storage. You can get a reference to this interface using either {{domxref("navigator.storage")}} or {{domxref("WorkerNavigator.storage")}}.
 
-## Methods
+## Instance methods
 
 - {{domxref("StorageManager.estimate()")}} {{securecontext_inline}}
   - : Returns a {{jsxref('Promise')}} that resolves to an object containing usage and quota numbers for your origin.

--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -19,11 +19,11 @@ The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("StylePropertyMapReadOnly")}}._
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("StylePropertyMapReadOnly")}}._
 

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -17,12 +17,12 @@ browser-compat: api.StylePropertyMapReadOnly
 
 The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) provides a read-only representation of a CSS declaration block that is an alternative to {{domxref("CSSStyleDeclaration")}}. Retrieve an instance of this interface using {{domxref('Element.computedStyleMap','Element.computedStyleMap()')}}.
 
-## Properties
+## Instance properties
 
 - {{domxref('StylePropertyMapReadOnly.size')}} {{Experimental_Inline}}
   - : Returns an unsigned long integer containing the size of the `StylePropertyMapReadOnly` object.
 
-## Methods
+## Instance methods
 
 - {{domxref('StylePropertyMapReadOnly.entries()')}} {{Experimental_Inline}}
   - : Returns an array of a given object's own enumerable property `[key, value]` pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).

--- a/files/en-us/web/api/stylesheet/index.md
+++ b/files/en-us/web/api/stylesheet/index.md
@@ -17,7 +17,7 @@ browser-compat: api.StyleSheet
 
 An object implementing the `StyleSheet` interface represents a single style sheet. CSS style sheets will further implement the more specialized {{domxref("CSSStyleSheet")}} interface.
 
-## Properties
+## Instance properties
 
 - {{domxref("StyleSheet.disabled")}}
   - : A boolean value representing whether the current stylesheet has been applied or not.

--- a/files/en-us/web/api/stylesheetlist/index.md
+++ b/files/en-us/web/api/stylesheetlist/index.md
@@ -15,12 +15,12 @@ The `StyleSheetList` interface represents a list of {{domxref("CSSStyleSheet")}}
 
 It is an array-like object but can't be iterated over using {{jsxref("Array")}} methods. However it can be iterated over in a standard {{jsxref("Statements/for", "for")}} loop over its indices, or converted to an {{jsxref("Array")}}.
 
-## Properties
+## Instance properties
 
 - {{domxref("StyleSheetList.length")}} {{ReadOnlyInline}}
   - : Returns the number of {{domxref("CSSStyleSheet")}} objects in the collection.
 
-## Methods
+## Instance methods
 
 - {{domxref("StyleSheetList.item()")}}
   - : Returns the {{domxref("CSSStyleSheet")}} object at the index passed in, or `null` if no item exists for that index.

--- a/files/en-us/web/api/submitevent/index.md
+++ b/files/en-us/web/api/submitevent/index.md
@@ -27,14 +27,14 @@ The **`SubmitEvent`** interface defines the object used to represent an {{Glossa
 - {{domxref("SubmitEvent.SubmitEvent", "SubmitEvent()")}}
   - : Creates and returns a new `SubmitEvent` object whose {{domxref("Event.type", "type")}} and other options are configured as specified. Note that currently the only valid `type` for a `SubmitEvent` is `submit`.
 
-## Properties
+## Instance properties
 
 _In addition to the properties listed below, this interface inherits the properties of its parent interface, {{domxref("Event")}}._
 
 - {{domxref("SubmitEvent.submitter", "submitter")}} {{ReadOnlyInline}}
   - : An {{domxref("HTMLElement")}} object which identifies the button or other element which was invoked to trigger the form being submitted.
 
-## Methods
+## Instance methods
 
 _While `SubmitEvent` offers no methods of its own, it inherits any specified by its parent interface, {{domxref("Event")}}._
 

--- a/files/en-us/web/api/subtlecrypto/index.md
+++ b/files/en-us/web/api/subtlecrypto/index.md
@@ -26,11 +26,11 @@ The **`SubtleCrypto`** interface of the [Web Crypto API](/en-US/docs/Web/API/Web
 >
 > Please learn and experiment, but don't guarantee or imply the security of your work before an individual knowledgeable in this subject matter thoroughly reviews it. The [Crypto 101 Course](https://www.crypto101.io/) can be a great place to start learning about the design and implementation of secure systems.
 
-## Properties
+## Instance properties
 
 _This interface doesn't inherit any properties, as it has no parent interface._
 
-## Methods
+## Instance methods
 
 _This interface doesn't inherit any methods, as it has no parent interface._
 

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -16,7 +16,7 @@ The **`SVGAElement`** interface provides access to the properties of an {{SVGEle
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}, and implements properties from {{domxref("HTMLHyperlinkElementUtils")}}._
 
@@ -41,7 +41,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.type")}}
   - : A string that reflects the `type` attribute, indicating the MIME type of the linked resource.
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgaltglyphdefelement/index.md
+++ b/files/en-us/web/api/svgaltglyphdefelement/index.md
@@ -19,11 +19,11 @@ The **`SVGAltGlyphDefElement`** interface corresponds to the {{SVGElement("altGl
 
 > **Warning:** This interface was removed in the SVG 2 specification.
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgaltglyphelement/index.md
+++ b/files/en-us/web/api/svgaltglyphelement/index.md
@@ -16,7 +16,7 @@ browser-compat: api.SVGAltGlyphElement
 
 The **`SVGAltGlyphElement`** interface represents an {{ SVGElement("altglyph") }} element. This interface makes it possible to implement more sophisticated and particular glyph characters. For some textual representations as: ligatures (e.g. æ, ß, etc.), special-purpose fonts (e.g. musical symbols) or even alternate glyphs such as Asian text strings it is required that a different set of glyphs be used than the normal given character data.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}._
 
@@ -25,7 +25,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGAltGlyphElement.format")}} {{deprecated_inline}}
   - : It corresponds to the attribute {{ SVGAttr("format") }} on the given element. It's data type is 'String'. This property specifies the format of the given font.
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgaltglyphitemelement/index.md
+++ b/files/en-us/web/api/svgaltglyphitemelement/index.md
@@ -19,11 +19,11 @@ The **`SVGAltGlyphItemElement`** interface corresponds to the {{SVGElement("altG
 
 > **Warning:** This interface was removed in the SVG 2 specification.
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgangle/index.md
+++ b/files/en-us/web/api/svgangle/index.md
@@ -36,7 +36,7 @@ Every `SVGAngle` object operates in one of two modes:
 - `SVG_ANGLETYPE_GRAD`
   - : An {{cssxref("&lt;angle&gt;")}} with a `grad` unit.
 
-## Properties
+## Instance properties
 
 - `unitType`
   - : The type of the value as specified by one of the `SVG_ANGLETYPE_*` constants defined on this interface.
@@ -62,7 +62,7 @@ Every `SVGAngle` object operates in one of two modes:
 
     A {{domxref("DOMException")}} with code `NO_MODIFICATION_ALLOWED_ERR` is raised when the length corresponds to a read-only attribute, or when the object itself is read-only.
 
-## Methods
+## Instance methods
 
 - `newValueSpecifiedUnits`
 

--- a/files/en-us/web/api/svganimatecolorelement/index.md
+++ b/files/en-us/web/api/svganimatecolorelement/index.md
@@ -18,11 +18,11 @@ The **`SVGAnimateColorElement`** interface corresponds to the {{SVGElement("anim
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGAnimationElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGAnimationElement")}}._
 

--- a/files/en-us/web/api/svganimatedangle/index.md
+++ b/files/en-us/web/api/svganimatedangle/index.md
@@ -54,7 +54,7 @@ The `SVGAnimatedAngle` interface is used for attributes of basic type [\<angle>]
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -87,7 +87,7 @@ The `SVGAnimatedAngle` interface is used for attributes of basic type [\<angle>]
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedAngle` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedboolean/index.md
+++ b/files/en-us/web/api/svganimatedboolean/index.md
@@ -50,7 +50,7 @@ The `SVGAnimatedBoolean` interface is used for attributes of type boolean which 
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -81,7 +81,7 @@ The `SVGAnimatedBoolean` interface is used for attributes of type boolean which 
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedBoolean` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -50,7 +50,7 @@ The `SVGAnimatedEnumeration` interface is used for attributes whose value must b
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -81,7 +81,7 @@ The `SVGAnimatedEnumeration` interface is used for attributes whose value must b
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedEnumeration` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedinteger/index.md
+++ b/files/en-us/web/api/svganimatedinteger/index.md
@@ -51,7 +51,7 @@ The `SVGAnimatedInteger` interface is used for attributes of basic type [\<integ
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -82,7 +82,7 @@ The `SVGAnimatedInteger` interface is used for attributes of basic type [\<integ
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedInteger` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedlength/index.md
+++ b/files/en-us/web/api/svganimatedlength/index.md
@@ -13,7 +13,7 @@ browser-compat: api.SVGAnimatedLength
 
 The `SVGAnimatedLength` interface represents attributes of type [\<length>](/en-US/docs/Web/SVG/Content_type#length) which can be animated.
 
-## Properties
+## Instance properties
 
 - {{domxref("baseVal")}} {{ReadOnlyInline}}
   - : A {{domxref("SVGLength")}} representing the base value of the given attribute before applying any animations.
@@ -23,7 +23,7 @@ The `SVGAnimatedLength` interface represents attributes of type [\<length>](/en-
     If the given attribute or property is not currently being animated,
     a {{domxref("SVGLength")}} containing the same value as <code>baseVal</code>.
 
-## Methods
+## Instance methods
 
 _This interface does not implement any specific methods._
 

--- a/files/en-us/web/api/svganimatedlengthlist/index.md
+++ b/files/en-us/web/api/svganimatedlengthlist/index.md
@@ -56,7 +56,7 @@ The `SVGAnimatedLengthList` interface is used for attributes of type {{ domxref(
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -90,7 +90,7 @@ The `SVGAnimatedLengthList` interface is used for attributes of type {{ domxref(
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedLengthList` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatednumber/index.md
+++ b/files/en-us/web/api/svganimatednumber/index.md
@@ -50,7 +50,7 @@ The `SVGAnimatedNumber` interface is used for attributes of basic type [\<Number
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -81,7 +81,7 @@ The `SVGAnimatedNumber` interface is used for attributes of basic type [\<Number
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedNumber` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatednumberlist/index.md
+++ b/files/en-us/web/api/svganimatednumberlist/index.md
@@ -56,14 +56,14 @@ The `SVGAnimatedNumber` interface is used for attributes which take a list of nu
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGAnimatedNumberList.baseVal")}} {{ReadOnlyInline}}
   - : A {{domxref("SVGNumberList")}} that represents the base value of the given attribute before applying any animations.
 - {{domxref("SVGAnimatedNumberList.animVal")}} {{ReadOnlyInline}}
   - : A read only {{ domxref("SVGNumberList") }} that represents the current animated value of the given attribute. If the given attribute is not currently being animated, then the {{ domxref("SVGNumberList") }} will have the same contents as `baseVal`. The object referenced by `animVal` will always be distinct from the one referenced by `baseVal`, even when the attribute is not animated.
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedNumberList` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedpreserveaspectratio/index.md
+++ b/files/en-us/web/api/svganimatedpreserveaspectratio/index.md
@@ -49,14 +49,14 @@ The `SVGAnimatedPreserveAspectRatio` interface is used for attributes of type {{
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGAnimatedPreserveAspectRatio.baseVal")}} {{ReadOnlyInline}}
   - : A {{domxref("SVGPreserveAspectRatio")}} that represents the base value of the given attribute before applying any animations.
 - {{domxref("SVGAnimatedPreserveAspectRatio.animVal")}} {{ReadOnlyInline}}
   - : A {{domxref("SVGPreserveAspectRatio")}} that represents the current animated value of the given attribute. If the given attribute is not currently being animated, then the {{ domxref("SVGPreserveAspectRatio") }} will have the same contents as `baseVal`. The object referenced by `animVal` is always distinct from the one referenced by `baseVal`, even when the attribute is not animated.
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedPreserveAspectRatio` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svganimatedrect/index.md
+++ b/files/en-us/web/api/svganimatedrect/index.md
@@ -52,7 +52,7 @@ The `SVGAnimatedRect` interface is used for attributes of basic {{ domxref("SVGR
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -85,7 +85,7 @@ The `SVGAnimatedRect` interface is used for attributes of basic {{ domxref("SVGR
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 _The `SVGAnimatedRect` interface do not provide any specific methods._
 

--- a/files/en-us/web/api/svganimatedstring/index.md
+++ b/files/en-us/web/api/svganimatedstring/index.md
@@ -15,14 +15,14 @@ browser-compat: api.SVGAnimatedString
 
 The **`SVGAnimatedString`** interface represents string attributes which can be animated from each SVG declaration. You need to create SVG attribute before doing anything else, everything should be declared inside this.
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGAnimatedString.animVal")}} {{ReadOnlyInline}}
   - : This is a string representing the animation value. If the given attribute or property is being animated it contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, it contains the same value as baseVal.
 - {{domxref("SVGAnimatedString.baseVal")}}
   - : This is a string representing the base value. The base value of the given attribute before applying any animations. Setter throws DOMException.
 
-## Methods
+## Instance methods
 
 _The `SVGAnimatedString` interface do not provide any specific methods._
 

--- a/files/en-us/web/api/svganimatedtransformlist/index.md
+++ b/files/en-us/web/api/svganimatedtransformlist/index.md
@@ -55,7 +55,7 @@ The `SVGAnimatedTransformList` interface is used for attributes which take a lis
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -89,7 +89,7 @@ The `SVGAnimatedTransformList` interface is used for attributes which take a lis
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 The `SVGAnimatedTransformList` interface doesn't provide any specific methods.
 

--- a/files/en-us/web/api/svganimateelement/index.md
+++ b/files/en-us/web/api/svganimateelement/index.md
@@ -17,11 +17,11 @@ The **`SVGAnimateElement`** interface corresponds to the {{SVGElement("animate")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGAnimationElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGAnimationElement")}}._
 

--- a/files/en-us/web/api/svganimatemotionelement/index.md
+++ b/files/en-us/web/api/svganimatemotionelement/index.md
@@ -16,11 +16,11 @@ The **`SVGAnimateMotionElement`** interface corresponds to the {{SVGElement("ani
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGAnimationElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGAnimationElement")}}._
 

--- a/files/en-us/web/api/svganimatetransformelement/index.md
+++ b/files/en-us/web/api/svganimatetransformelement/index.md
@@ -17,11 +17,11 @@ The `SVGAnimateTransformElement` interface corresponds to the {{SVGElement("anim
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGAnimationElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGAnimationElement")}}._
 

--- a/files/en-us/web/api/svganimationelement/index.md
+++ b/files/en-us/web/api/svganimationelement/index.md
@@ -17,7 +17,7 @@ The **`SVGAnimationElement`** interface is the base interface for all of the ani
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -28,7 +28,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGAnimationElement.targetElement")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGElement")}} representing the element which is being animated. If no target element is being animated (for example, because the {{SVGAttr("href")}} specifies an unknown element) the value returned is `null`.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgcircleelement/index.md
+++ b/files/en-us/web/api/svgcircleelement/index.md
@@ -18,7 +18,7 @@ The **`SVGCircleElement`** interface is an interface for the {{SVGElement("circl
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
@@ -29,7 +29,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 - {{domxref("SVGCircleElement.r")}} {{ReadOnlyInline}}
   - : This property defines the radius of the `<circle>` element. It is denoted by the {{SVGAttr("r")}} of the element.
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgclippathelement/index.md
+++ b/files/en-us/web/api/svgclippathelement/index.md
@@ -17,14 +17,14 @@ The **`SVGClipPathElement`** interface provides access to the properties of {{SV
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGClipPathElement.clipPathUnits")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("clipPathUnits")}} attribute of the given {{SVGElement("clipPath")}} element. Takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgcomponenttransferfunctionelement/index.md
+++ b/files/en-us/web/api/svgcomponenttransferfunctionelement/index.md
@@ -63,7 +63,7 @@ The **`SVGComponentTransferFunctionElement`** interface defines a base interface
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -82,7 +82,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGComponentTransferFunctionElement.offset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedNumber")}} corresponding to the {{SVGAttr("offset")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgcursorelement/index.md
+++ b/files/en-us/web/api/svgcursorelement/index.md
@@ -18,7 +18,7 @@ The **`SVGCursorElement`** interface provides access to the properties of {{ SVG
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -27,7 +27,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGCursorElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("cursor")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgdefselement/index.md
+++ b/files/en-us/web/api/svgdefselement/index.md
@@ -17,11 +17,11 @@ The **`SVGDefsElement`** interface corresponds to the {{SVGElement("defs")}} ele
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgdescelement/index.md
+++ b/files/en-us/web/api/svgdescelement/index.md
@@ -17,11 +17,11 @@ The **`SVGDescElement`** interface corresponds to the {{SVGElement("desc")}} ele
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgelement/index.md
+++ b/files/en-us/web/api/svgelement/index.md
@@ -19,7 +19,7 @@ All of the SVG DOM interfaces that correspond directly to elements in the SVG la
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _Also inherits properties from: {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("Element")}}, {{DOMxRef("SVGElementInstance")}}._
 
@@ -40,7 +40,7 @@ _Also inherits properties from: {{DOMxRef("DocumentAndElementEventHandlers")}}, 
 - {{DOMxRef("SVGElement.viewportElement")}} {{ReadOnlyInline}}
   - : The {{DOMxRef("SVGElement")}} which established the current viewport. Often the nearest ancestor {{SVGElement("svg")}} element. `null` if the given element is the outermost `<svg>` element.
 
-## Methods
+## Instance methods
 
 _This interface has no methods, but inherits methods from: {{DOMxRef("DocumentAndElementEventHandlers")}}, {{DOMxRef("Element")}}, {{DOMxRef("SVGElementInstance")}}_.
 

--- a/files/en-us/web/api/svgellipseelement/index.md
+++ b/files/en-us/web/api/svgellipseelement/index.md
@@ -16,7 +16,7 @@ The **`SVGEllipseElement`** interface provides access to the properties of {{SVG
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGGeometryElement")}}._
 
@@ -29,7 +29,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGEllipseElement.ry")}} {{ReadOnlyInline}}
   - : This property returns a {{domxref("SVGAnimatedLength")}} reflecting the {{SVGAttr("ry")}} attribute of the given {{SVGElement("ellipse")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgevent/index.md
+++ b/files/en-us/web/api/svgevent/index.md
@@ -13,7 +13,7 @@ tags:
 
 The {{domxref("SVGEvent")}} interface represents the event object for most SVG-related events.
 
-## Properties
+## Instance properties
 
 | Property                        | Type                       | Description                                            |
 | ------------------------------- | -------------------------- | ------------------------------------------------------ |

--- a/files/en-us/web/api/svgfeblendelement/index.md
+++ b/files/en-us/web/api/svgfeblendelement/index.md
@@ -63,7 +63,7 @@ The **`SVGFEBlendElement`** interface corresponds to the {{SVGElement("feBlend")
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -84,7 +84,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEBlendElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfecolormatrixelement/index.md
+++ b/files/en-us/web/api/svgfecolormatrixelement/index.md
@@ -60,7 +60,7 @@ The **`SVGFEColorMatrixElement`** interface corresponds to the {{SVGElement("feC
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -81,7 +81,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEColorMatrixElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}_.
 

--- a/files/en-us/web/api/svgfecomponenttransferelement/index.md
+++ b/files/en-us/web/api/svgfecomponenttransferelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEComponentTransferElement`** interface corresponds to the {{SVGElemen
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEComponentTransferElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfecompositeelement/index.md
+++ b/files/en-us/web/api/svgfecompositeelement/index.md
@@ -68,7 +68,7 @@ The **`SVGFECompositeElement`** interface corresponds to the {{SVGElement("feCom
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -89,7 +89,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFECompositeElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfeconvolvematrixelement/index.md
+++ b/files/en-us/web/api/svgfeconvolvematrixelement/index.md
@@ -53,7 +53,7 @@ The **`SVGFEConvolveMatrixElement`** interface corresponds to the {{SVGElement("
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -92,7 +92,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEConvolveMatrixElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfediffuselightingelement/index.md
+++ b/files/en-us/web/api/svgfediffuselightingelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEDiffuseLightingElement`** interface corresponds to the {{SVGElement(
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -42,7 +42,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEDiffuseLightingElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfedisplacementmapelement/index.md
+++ b/files/en-us/web/api/svgfedisplacementmapelement/index.md
@@ -58,7 +58,7 @@ The **`SVGFEDisplacementMapElement`** interface corresponds to the {{SVGElement(
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -83,7 +83,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEDisplacementMapElement.yChannelSelector")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("yChannelSelect")}} attribute of the given element. It takes one of the `SVG_CHANNEL_*` constants defined on this interface.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfedistantlightelement/index.md
+++ b/files/en-us/web/api/svgfedistantlightelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEDistantLightElement`** interface corresponds to the {{SVGElement("fe
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEDistantLightElement.elevation")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedNumber")}} corresponding to the {{SVGAttr("elevation")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfedropshadowelement/index.md
+++ b/files/en-us/web/api/svgfedropshadowelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEDropShadowElement`** interface corresponds to the {{SVGElement("feDr
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -42,7 +42,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEDropShadowElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfefloodelement/index.md
+++ b/files/en-us/web/api/svgfefloodelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEFloodElement`** interface corresponds to the {{SVGElement("feFlood")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -32,7 +32,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEFloodElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfefuncaelement/index.md
+++ b/files/en-us/web/api/svgfefuncaelement/index.md
@@ -17,11 +17,11 @@ The **`SVGFEFuncAElement`** interface corresponds to the {{SVGElement("feFuncA")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface not provide any specific properties, but inherits properties from its parent interface, {{domxref("SVGComponentTransferFunctionElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGComponentTransferFunctionElement")}}._
 

--- a/files/en-us/web/api/svgfefuncbelement/index.md
+++ b/files/en-us/web/api/svgfefuncbelement/index.md
@@ -17,11 +17,11 @@ The **`SVGFEFuncBElement`** interface corresponds to the {{SVGElement("feFuncB")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface not provide any specific properties, but inherits properties from its parent interface, {{domxref("SVGComponentTransferFunctionElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGComponentTransferFunctionElement")}}._
 

--- a/files/en-us/web/api/svgfefuncgelement/index.md
+++ b/files/en-us/web/api/svgfefuncgelement/index.md
@@ -17,11 +17,11 @@ The **`SVGFEFuncGElement`** interface corresponds to the {{SVGElement("feFuncG")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface not provide any specific properties, but inherits properties from its parent interface, {{domxref("SVGComponentTransferFunctionElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGComponentTransferFunctionElement")}}._
 

--- a/files/en-us/web/api/svgfefuncrelement/index.md
+++ b/files/en-us/web/api/svgfefuncrelement/index.md
@@ -17,11 +17,11 @@ The **`SVGFEFuncRElement`** interface corresponds to the {{SVGElement("feFuncR")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface not provide any specific properties, but inherits properties from its parent interface, {{domxref("SVGComponentTransferFunctionElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGComponentTransferFunctionElement")}}._
 

--- a/files/en-us/web/api/svgfegaussianblurelement/index.md
+++ b/files/en-us/web/api/svgfegaussianblurelement/index.md
@@ -53,7 +53,7 @@ The **`SVGFEGaussianBlurElement`** interface corresponds to the {{SVGElement("fe
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -76,7 +76,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEGaussianBlurElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfeimageelement/index.md
+++ b/files/en-us/web/api/svgfeimageelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEImageElement`** interface corresponds to the {{SVGElement("feImage")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -38,7 +38,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEImageElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfemergeelement/index.md
+++ b/files/en-us/web/api/svgfemergeelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEMergeElement`** interface corresponds to the {{SVGElement("feMerge")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -32,7 +32,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEMergeElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfemergenodeelement/index.md
+++ b/files/en-us/web/api/svgfemergenodeelement/index.md
@@ -17,14 +17,14 @@ The **`SVGFEMergeNodeElement`** interface corresponds to the {{SVGElement("feMer
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGFEMergeNodeElement.in1")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("in")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfemorphologyelement/index.md
+++ b/files/en-us/web/api/svgfemorphologyelement/index.md
@@ -48,7 +48,7 @@ The **`SVGFEMorphologyElement`** interface corresponds to the {{SVGElement("feMo
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -71,7 +71,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEMorphologyElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfeoffsetelement/index.md
+++ b/files/en-us/web/api/svgfeoffsetelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEOffsetElement`** interface corresponds to the {{SVGElement("feOffset
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -38,7 +38,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEOffsetElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfepointlightelement/index.md
+++ b/files/en-us/web/api/svgfepointlightelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFEPointLightElement`** interface corresponds to the {{SVGElement("fePo
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -28,7 +28,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEPointLightElement.z")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedNumber")}} corresponding to the {{SVGAttr("z")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfespecularlightingelement/index.md
+++ b/files/en-us/web/api/svgfespecularlightingelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFESpecularLightingElement`** interface corresponds to the {{SVGElement
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFESpecularLightingElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfespotlightelement/index.md
+++ b/files/en-us/web/api/svgfespotlightelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFESpotLightElement`** interface corresponds to the {{SVGElement("feSpo
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -38,7 +38,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFESpotLightElement.limitingConeAngle")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedNumber")}} corresponding to the {{SVGAttr("limitingConeAngle")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfetileelement/index.md
+++ b/files/en-us/web/api/svgfetileelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFETileElement`** interface corresponds to the {{SVGElement("feTile")}}
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFETileElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfeturbulenceelement/index.md
+++ b/files/en-us/web/api/svgfeturbulenceelement/index.md
@@ -81,7 +81,7 @@ The **`SVGFETurbulenceElement`** interface corresponds to the {{SVGElement("feTu
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -108,7 +108,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFETurbulenceElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfilterelement/index.md
+++ b/files/en-us/web/api/svgfilterelement/index.md
@@ -17,7 +17,7 @@ The **`SVGFilterElement`** interface provides access to the properties of {{SVGE
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGFilterElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("filter")}} element.
@@ -38,7 +38,7 @@ The **`SVGFilterElement`** interface provides access to the properties of {{SVGE
 - {{domxref("SVGFilterElement.filterResY")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : An {{domxref("SVGAnimatedInteger")}} that contains the Y component of the {{SVGAttr("filterRes")}} attribute of the given {{SVGElement("filter")}} element.
 
-## Methods
+## Instance methods
 
 - {{domxref("SVGFilterElement.setFilterRes()")}} {{deprecated_inline}}
   - : Sets the values of the {{SVGAttr("filterRes")}} attribute.

--- a/files/en-us/web/api/svgfontelement/index.md
+++ b/files/en-us/web/api/svgfontelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font")}} element v
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfontfaceelement/index.md
+++ b/files/en-us/web/api/svgfontfaceelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font-face")}} elem
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfontfaceformatelement/index.md
+++ b/files/en-us/web/api/svgfontfaceformatelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font-face-format")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfontfacenameelement/index.md
+++ b/files/en-us/web/api/svgfontfacenameelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font-face-name")}}
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfontfacesrcelement/index.md
+++ b/files/en-us/web/api/svgfontfacesrcelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font-face-src")}} 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgfontfaceurielement/index.md
+++ b/files/en-us/web/api/svgfontfaceurielement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("font-face-uri")}} 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgforeignobjectelement/index.md
+++ b/files/en-us/web/api/svgforeignobjectelement/index.md
@@ -17,7 +17,7 @@ The **`SVGForeignObjectElement`** interface provides access to the properties of
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
@@ -30,7 +30,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGForeignObjectElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("foreignObject")}} element.
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svggelement/index.md
+++ b/files/en-us/web/api/svggelement/index.md
@@ -17,11 +17,11 @@ The **`SVGGElement`** interface corresponds to the {{SVGElement("g")}} element.
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svggeometryelement/index.md
+++ b/files/en-us/web/api/svggeometryelement/index.md
@@ -18,14 +18,14 @@ The `SVGGeometryElement` interface represents SVG elements whose rendering is de
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
 - {{domxref("SVGGeometryElement.pathLength")}} {{ReadOnlyInline}}
   - : This property reflects the {{SVGAttr("pathLength")}} attribute.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgglyphelement/index.md
+++ b/files/en-us/web/api/svgglyphelement/index.md
@@ -21,11 +21,11 @@ Object-oriented access to the attributes of the `<glyph>` element via the SVG DO
 
 > **Warning:** This interface was removed in the SVG 2 specification.
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgglyphrefelement/index.md
+++ b/files/en-us/web/api/svgglyphrefelement/index.md
@@ -17,7 +17,7 @@ The **`SVGGlyphRefElement`** interface corresponds to the {{SVGElement("glyphRef
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGGlyphRefElement.dy")}} {{Deprecated_Inline}}
   - : A float corresponding to the {{SVGAttr("dy")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svggradientelement/index.md
+++ b/files/en-us/web/api/svggradientelement/index.md
@@ -53,7 +53,7 @@ The **`SVGGradient`** interface is a base interface used by {{domxref("SVGLinear
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -66,7 +66,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGGradientElement.spreadMethod")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spreadMethod")}} attribute on the given element. One of the spread method types defined on this interface.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svggraphicselement/index.md
+++ b/files/en-us/web/api/svggraphicselement/index.md
@@ -17,7 +17,7 @@ The **`SVGGraphicsElement`** interface represents SVG elements whose primary pur
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -28,7 +28,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGGraphicsElement.transform")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedTransformList")}} reflecting the computed value of the {{cssxref("transform")}} property and its corresponding {{SVGAttr("transform")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svghkernelement/index.md
+++ b/files/en-us/web/api/svghkernelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("hkern")}} element 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgimageelement/index.md
+++ b/files/en-us/web/api/svgimageelement/index.md
@@ -20,7 +20,7 @@ The **`SVGImageElement`** interface corresponds to the {{SVGElement("image")}} e
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
@@ -41,7 +41,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGImageElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("image")}} element.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent interface, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svglength/index.md
+++ b/files/en-us/web/api/svglength/index.md
@@ -208,7 +208,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -296,7 +296,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/svglengthlist/index.md
+++ b/files/en-us/web/api/svglengthlist/index.md
@@ -96,14 +96,14 @@ An `SVGLengthList` is indexable and can be accessed like an array.
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 | Name                                 | Type          | Description                      |
 | ------------------------------------ | ------------- | -------------------------------- |
 | `numberOfItems`                      | unsigned long | The number of items in the list. |
 | `length` {{ non-standard_inline() }} | unsigned long | The number of items in the list. |
 
-## Methods
+## Instance methods
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/api/svglineargradientelement/index.md
+++ b/files/en-us/web/api/svglineargradientelement/index.md
@@ -17,7 +17,7 @@ The **`SVGLinearGradientElement`** interface corresponds to the {{SVGElement("li
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGradientElement")}}._
 
@@ -30,7 +30,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGradient
 - {{domxref("SVGLinearGradientElement.y2")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y2")}} attribute of the given {{SVGElement("linearGradient")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGradientElement")}}._
 

--- a/files/en-us/web/api/svglineelement/index.md
+++ b/files/en-us/web/api/svglineelement/index.md
@@ -17,7 +17,7 @@ The **`SVGLineElement`** interface provides access to the properties of {{ SVGEl
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
@@ -30,7 +30,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 - {{domxref("SVGLineElement.y2")}} {{ReadOnlyInline}}
   - : Returns an {{domxref("SVGAnimatedLength")}} that corresponds to attribute {{SVGAttr("y2")}} on the given {{SVGElement("line")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgmarkerelement/index.md
+++ b/files/en-us/web/api/svgmarkerelement/index.md
@@ -18,7 +18,7 @@ The **`SVGMarkerElement`** interface provides access to the properties of {{SVGE
 
 The following properties and methods all return, or act on the attributes of the {{SVGElement("marker")}} element represented by `SVGMarkerElement`.
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -59,7 +59,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGMarkerElement.preserveAspectRatio")}} {{ReadOnlyInline}}
   - : Returns an {{domxref("SVGPreserveAspectRatio")}} object which contains the values set by the {{SVGattr("preserveAspectRatio")}} attribute on the {{SVGElement("marker")}} viewport.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgmaskelement/index.md
+++ b/files/en-us/web/api/svgmaskelement/index.md
@@ -17,7 +17,7 @@ The **`SVGMaskElement`** interface provides access to the properties of {{SVGEle
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGMaskElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("mask")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgmatrix/index.md
+++ b/files/en-us/web/api/svgmatrix/index.md
@@ -34,7 +34,7 @@ An **`SVGMatrix`** object can be designated as read only, which means that attem
 
 > **Warning:** SVG 2 replaced the `SVGMatrix` interface by the more general {{domxref("DOMMatrix")}} and {{domxref("DOMMatrixReadOnly")}} interfaces.
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGMatrix.a")}}
   - : A float representing the _a_ component of the matrix.
@@ -49,7 +49,7 @@ An **`SVGMatrix`** object can be designated as read only, which means that attem
 - {{domxref("SVGMatrix.f")}}
   - : A float representing the _f_ component of the matrix.
 
-## Methods
+## Instance methods
 
 - {{domxref("SVGMatrix.multiply()")}}
   - : Performs matrix multiplication. This matrix is post-multiplied by another matrix, returning the resulting new matrix as `SVGMatrix`.

--- a/files/en-us/web/api/svgmetadataelement/index.md
+++ b/files/en-us/web/api/svgmetadataelement/index.md
@@ -17,11 +17,11 @@ The **`SVGMetadataElement`** interface corresponds to the {{SVGElement("metadata
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgmissingglyphelement/index.md
+++ b/files/en-us/web/api/svgmissingglyphelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("missing-glyph")}} 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgmpathelement/index.md
+++ b/files/en-us/web/api/svgmpathelement/index.md
@@ -17,14 +17,14 @@ The **`SVGMPathElement`** interface corresponds to the {{SVGElement("mpath")}} e
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGMPathElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("mpath")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgnumber/index.md
+++ b/files/en-us/web/api/svgnumber/index.md
@@ -17,7 +17,7 @@ The **`SVGNumber`** interface corresponds to the {{cssxref("&lt;number&gt;")}} b
 
 An `SVGNumber` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGNumber.value")}}
 
@@ -25,7 +25,7 @@ An `SVGNumber` object can be designated as read only, which means that attempts 
 
     Note: If the `SVGNumber` is read-only, a {{domxref("DOMException")}} with the code NO_MODIFICATION_ALLOWED_ERR is raised on an attempt to change the value.
 
-## Methods
+## Instance methods
 
 _This interface doesn't provide any specific methods._
 

--- a/files/en-us/web/api/svgnumberlist/index.md
+++ b/files/en-us/web/api/svgnumberlist/index.md
@@ -95,14 +95,14 @@ An `SVGNumberList` is indexable and can be accessed like an array.
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 | Name                                 | Type          | Description                      |
 | ------------------------------------ | ------------- | -------------------------------- |
 | `numberOfItems`                      | unsigned long | The number of items in the list. |
 | `length` {{ non-standard_inline() }} | unsigned long | The number of items in the list. |
 
-## Methods
+## Instance methods
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/api/svgpathelement/index.md
+++ b/files/en-us/web/api/svgpathelement/index.md
@@ -19,11 +19,11 @@ The **`SVGPathElement`** interface corresponds to the {{SVGElement("path")}} ele
 
 > **Note:** In SVG 2 the `getPathSegAtLength()` and `createSVGPathSeg*` methods were removed and the `pathLength` property and the `getTotalLength()` and `getPointAtLength()` methods were moved to {{domxref("SVGGeometryElement")}}.
 
-## Properties
+## Instance properties
 
 _This interface inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgpatternelement/index.md
+++ b/files/en-us/web/api/svgpatternelement/index.md
@@ -17,7 +17,7 @@ The **`SVGPatternElement`** interface corresponds to the {{SVGElement("pattern")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}} and implements the ones from {{domxref("SVGFitToViewBox")}}._
 
@@ -38,7 +38,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGElement"
 - {{domxref("SVGPatternElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("pattern")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}} and implements the ones from {{domxref("SVGFitToViewBox")}}._
 

--- a/files/en-us/web/api/svgpointlist/index.md
+++ b/files/en-us/web/api/svgpointlist/index.md
@@ -16,14 +16,14 @@ The **`SVGPointList`** interface represents a list of {{domxref("SVGPoint")}} ob
 
 An `SVGPointList` can be designated as read-only, which means that attempts to modify the object will result in an exception being thrown.
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGPointList.length")}} {{ReadOnlyInline}}
   - : Returns the number of points in the list.
 - {{domxref("SVGPointList.numberOfItems")}} {{ReadOnlyInline}}
   - : Returns the number of points in the list.
 
-## Methods
+## Instance methods
 
 - {{domxref("SVGPointList.clear()")}}
   - : Removes all items in the list.

--- a/files/en-us/web/api/svgpolygonelement/index.md
+++ b/files/en-us/web/api/svgpolygonelement/index.md
@@ -17,7 +17,7 @@ The **`SVGPolygonElement`** interface provides access to the properties of {{SVG
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 - {{domxref("SVGPolygonElement.points")}}
   - : A {{DOMxRef("SVGPointList")}} representing the base (i.e., static) value of the element's {{SVGAttr("points")}} attribute. Modifications via the {{DOMxRef("SVGPointList")}} object are reflected in the {{SVGAttr("points")}} attribute, and vice versa.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgpolylineelement/index.md
+++ b/files/en-us/web/api/svgpolylineelement/index.md
@@ -17,7 +17,7 @@ The **`SVGPolylineElement`** interface provides access to the properties of {{SV
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 - {{domxref("SVGPolylineElement.points")}}
   - : A {{DOMxRef("SVGPointList")}} representing the base (i.e., static) value of the element's {{SVGAttr("points")}} attribute. Modifications via the {{DOMxRef("SVGPointList")}} object are reflected in the {{SVGAttr("points")}} attribute, and vice versa.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgpreserveaspectratio/index.md
+++ b/files/en-us/web/api/svgpreserveaspectratio/index.md
@@ -256,7 +256,7 @@ An `SVGPreserveAspectRatio` object can be designated as read only, which means t
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -288,7 +288,7 @@ An `SVGPreserveAspectRatio` object can be designated as read only, which means t
 
 **Exceptions on setting:** a [`DOMException`](/en-US/docs/Web/API/DOMException) with code `NO_MODIFICATION_ALLOWED_ERR` is raised on an attempt to change the value of an attribute on a read only object.
 
-## Methods
+## Instance methods
 
 The `SVGPreserveAspectRatio` interface do not provide any specific methods.
 

--- a/files/en-us/web/api/svgradialgradientelement/index.md
+++ b/files/en-us/web/api/svgradialgradientelement/index.md
@@ -16,7 +16,7 @@ The **`SVGRadialGradientElement`** interface corresponds to the {{SVGElement("Ra
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGradientElement")}}._
 
@@ -31,7 +31,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGradient
 - {{domxref("SVGRadialGradientElement.fy")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("fy")}} attribute of the given {{SVGElement("RadialGradient")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGradientElement")}}._
 

--- a/files/en-us/web/api/svgrect/index.md
+++ b/files/en-us/web/api/svgrect/index.md
@@ -16,7 +16,7 @@ The **`SVGRect`** represents a rectangle. Rectangles consist of an `x` and `y` c
 
 An **`SVGRect`** object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGRect.x")}}
   - : The exact effect of this coordinate depends on each element. If the attribute is not specified, the effect is as if a value of `0` were specified.
@@ -27,7 +27,7 @@ An **`SVGRect`** object can be designated as read only, which means that attempt
 - {{SVGAttr("SVGRect.height")}}
   - : This represents the height of the rectangle. A value that is negative results to an error. A value of `0` disables rendering of the element.
 
-## Methods
+## Instance methods
 
 None.
 

--- a/files/en-us/web/api/svgrectelement/index.md
+++ b/files/en-us/web/api/svgrectelement/index.md
@@ -17,7 +17,7 @@ The `SVGRectElement` interface provides access to the properties of {{SVGElement
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 - {{domxref("SVGRectElement.ry")}} {{ReadOnlyInline}}
   - : Returns an {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("ry")}} attribute of the given {{SVGElement("rect")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 

--- a/files/en-us/web/api/svgrenderingintent/index.md
+++ b/files/en-us/web/api/svgrenderingintent/index.md
@@ -65,11 +65,11 @@ The **`SVGRenderingIntent`** interface defines the enumerated list of possible v
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods._
 

--- a/files/en-us/web/api/svgscriptelement/index.md
+++ b/files/en-us/web/api/svgscriptelement/index.md
@@ -17,7 +17,7 @@ The **`SVGScriptElement`** interface corresponds to the SVG {{SVGElement("script
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 - {{domxref("SVGScriptElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("script")}} element.
@@ -26,7 +26,7 @@ The **`SVGScriptElement`** interface corresponds to the SVG {{SVGElement("script
 - {{domxref("SVGScriptElement.crossOrigin")}} {{ReadOnlyInline}}
   - : A string corresponding to the {{SVGAttr("crossorigin")}} attribute of the given {{SVGElement("script")}} element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgsetelement/index.md
+++ b/files/en-us/web/api/svgsetelement/index.md
@@ -17,11 +17,11 @@ The **`SVGSetElement`** interface corresponds to the {{SVGElement("set")}} eleme
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGAnimationElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGAnimationElement")}}._
 

--- a/files/en-us/web/api/svgstopelement/index.md
+++ b/files/en-us/web/api/svgstopelement/index.md
@@ -17,14 +17,14 @@ The **`SVGStopElement`** interface corresponds to the {{SVGElement("stop")}} ele
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGStopElement.offset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedNumber")}} corresponding to the {{SVGAttr("offset")}} of the given element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgstringlist/index.md
+++ b/files/en-us/web/api/svgstringlist/index.md
@@ -82,7 +82,7 @@ An `SVGStringList` object can be designated as read only, which means that attem
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -109,7 +109,7 @@ An `SVGStringList` object can be designated as read only, which means that attem
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -17,7 +17,7 @@ The **`SVGStyleElement`** interface corresponds to the SVG {{SVGElement("style")
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
@@ -40,7 +40,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGStyleElement.disabled")}}
   - : A boolean value indicating whether or not the associated stylesheet is disabled.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgsvgelement/index.md
+++ b/files/en-us/web/api/svgsvgelement/index.md
@@ -17,7 +17,7 @@ The **`SVGSVGElement`** interface provides access to the properties of {{SVGElem
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}} and also implements the ones from {{domxref("SVGFitToViewBox")}}._
 
@@ -70,7 +70,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGSVGElement.currentTranslate")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGPoint")}} representing the translation factor that takes into account user "magnification" corresponding to an outermost {{SVGElement("svg")}} element. The behavior is undefined for `<svg>` elements that are not at the outermost level.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGGraphicsElement")}} and also implements the ones from {{domxref("SVGFitToViewBox")}}._
 

--- a/files/en-us/web/api/svgswitchelement/index.md
+++ b/files/en-us/web/api/svgswitchelement/index.md
@@ -17,11 +17,11 @@ The **`SVGSwitchElement`** interface corresponds to the {{SVGElement("switch")}}
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgsymbolelement/index.md
+++ b/files/en-us/web/api/svgsymbolelement/index.md
@@ -19,11 +19,11 @@ The **`SVGSymbolElement`** interface corresponds to the {{SVGElement("symbol")}}
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}, and implements properties from {{domxref("SVGFitToViewBox")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGraphicsElement")}}, and implements methods from {{domxref("SVGFitToViewBox")}}._
 

--- a/files/en-us/web/api/svgtextcontentelement/index.md
+++ b/files/en-us/web/api/svgtextcontentelement/index.md
@@ -44,7 +44,7 @@ The **`SVGTextContentElement`** interface is implemented by elements that suppor
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
@@ -53,7 +53,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGTextContentElement.lengthAdjust")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} reflecting the {{SVGAttr("lengthAdjust")}} attribute of the given element. The numeric type values represent one of the constant values above.
 
-## Methods
+## Instance methods
 
 _This interface also inherits methods from its parent, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgtextelement/index.md
+++ b/files/en-us/web/api/svgtextelement/index.md
@@ -17,11 +17,11 @@ The **`SVGTextElement`** interface corresponds to the {{SVGElement("text")}} ele
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGTextPositioningElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGTextPositioningElement")}}._
 

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -81,7 +81,7 @@ The **`SVGTextPathElement`** interface corresponds to the {{SVGElement("textPath
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGTextContentElement")}}._
 
@@ -94,7 +94,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGTextPathElement.spacing")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element. It takes one of the `TEXTPATH_SPACINGTYPE_*` constants defined on this interface.
 
-## Methods
+## Instance methods
 
 _This interface does not provide any specific methods, but implements those of its parent, {{domxref("SVGTextContentElement")}}._
 

--- a/files/en-us/web/api/svgtextpositioningelement/index.md
+++ b/files/en-us/web/api/svgtextpositioningelement/index.md
@@ -17,7 +17,7 @@ The **`SVGTextPositioningElement`** interface is implemented by elements that su
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("SVGTextContentElement")}}._
 
@@ -32,7 +32,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGTextCont
 - {{domxref("SVGTextPositioningElement.rotate")}} {{ReadOnlyInline}}
   - : Returns an {{domxref("SVGAnimatedNumberList")}} reflecting the {{SVGAttr("rotate")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't provide any specific methods, but inherits methods from its parent, {{domxref("SVGTextContentElement")}}._
 

--- a/files/en-us/web/api/svgtitleelement/index.md
+++ b/files/en-us/web/api/svgtitleelement/index.md
@@ -17,11 +17,11 @@ The **`SVGTitleElement`** interface corresponds to the {{SVGElement("title")}} e
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties, but inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgtransform/index.md
+++ b/files/en-us/web/api/svgtransform/index.md
@@ -136,7 +136,7 @@ An `SVGTransform` object can be designated as read only, which means that attemp
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 <table class="no-markdown">
   <thead>
@@ -211,7 +211,7 @@ An `SVGTransform` object can be designated as read only, which means that attemp
   </tbody>
 </table>
 
-## Methods
+## Instance methods
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/svgtransformlist/index.md
+++ b/files/en-us/web/api/svgtransformlist/index.md
@@ -106,14 +106,14 @@ An `SVGTransformList` is indexable and can be accessed like an array.
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 | Name                                 | Type          | Description                      |
 | ------------------------------------ | ------------- | -------------------------------- |
 | `numberOfItems`                      | unsigned long | The number of items in the list. |
 | `length` {{ non-standard_inline() }} | unsigned long | The number of items in the list. |
 
-## Methods
+## Instance methods
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/api/svgtrefelement/index.md
+++ b/files/en-us/web/api/svgtrefelement/index.md
@@ -20,11 +20,11 @@ Object-oriented access to the attributes of the {{SVGElement("tref")}} element v
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("</em>SVGTextPositioningElement<em>")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("</em>SVGTextPositioningElement<em>")}}._
 

--- a/files/en-us/web/api/svgtspanelement/index.md
+++ b/files/en-us/web/api/svgtspanelement/index.md
@@ -17,11 +17,11 @@ The **`SVGTSpanElement`** interface represents a {{SVGElement("tspan")}} element
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface doesn't provide any specific properties, but inherits the properties from its parent, {{domxref("SVGTextPositioningElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface doesn't provide any specific methods._
 

--- a/files/en-us/web/api/svgunittypes/index.md
+++ b/files/en-us/web/api/svgunittypes/index.md
@@ -48,11 +48,11 @@ The **`SVGUnitTypes`** interface defines a commonly used set of constants used f
   </tbody>
 </table>
 
-## Properties
+## Instance properties
 
 _This interface doesn't implement any specific properties._
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods._
 

--- a/files/en-us/web/api/svguseelement/index.md
+++ b/files/en-us/web/api/svguseelement/index.md
@@ -19,7 +19,7 @@ The **`SVGUseElement`** interface corresponds to the {{SVGElement("use")}} eleme
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}._
 
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGUseElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given element.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGraphicsElement")}}._
 

--- a/files/en-us/web/api/svgviewelement/index.md
+++ b/files/en-us/web/api/svgviewelement/index.md
@@ -17,14 +17,14 @@ The **`SVGViewElement`** interface provides access to the properties of {{SVGEle
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGViewElement.viewTarget")}} {{deprecated_inline}}
   - : An {{domxref("SVGStringList")}} corresponding to the {{SVGAttr("viewTarget")}} attribute of the given {{SVGElement("view")}} element. A list of string values which contain the names listed in the {{SVGAttr("viewTarget")}} attribute. Each of the string values can be associated with the corresponding element using the {{domxref("Document.getElementById()", "getElementById()")}} method call.
 
-## Methods
+## Instance methods
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/svgvkernelement/index.md
+++ b/files/en-us/web/api/svgvkernelement/index.md
@@ -19,11 +19,11 @@ Object-oriented access to the attributes of the {{SVGElement("vkern")}} element 
 
 {{InheritanceDiagram}}
 
-## Properties
+## Instance properties
 
 _This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
-## Methods
+## Instance methods
 
 _This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 

--- a/files/en-us/web/api/syncevent/index.md
+++ b/files/en-us/web/api/syncevent/index.md
@@ -28,7 +28,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 - {{domxref("SyncEvent.SyncEvent", "SyncEvent()")}} {{Experimental_Inline}}
   - : Creates a new `SyncEvent` object.
 
-## Properties
+## Instance properties
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
@@ -37,7 +37,7 @@ _Inherits properties from its ancestor, {{domxref("Event")}}_.
 - {{domxref("SyncEvent.lastChance")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns `true` if the user agent will not make further synchronization attempts after the current attempt.
 
-## Methods
+## Instance methods
 
 _Inherits methods from its parent, {{domxref("ExtendableEvent")}}_.
 

--- a/files/en-us/web/api/syncmanager/index.md
+++ b/files/en-us/web/api/syncmanager/index.md
@@ -16,11 +16,11 @@ browser-compat: api.SyncManager
 
 The **`SyncManager`** interface of the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API) provides an interface for registering and listing sync registrations.
 
-## Properties
+## Instance properties
 
 None.
 
-## Methods
+## Instance methods
 
 - {{domxref("SyncManager.register")}} {{Experimental_Inline}}
   - : Create a new sync registration and return a {{jsxref("Promise")}}.


### PR DESCRIPTION
Follow on from #21353

This is the Web API items starting with R and S

Moved to have consistent headings and ordering.