### PR TITLE
Link to WebAssembly/Reference instead of a sub path

### DIFF
--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -43,8 +43,8 @@ And what's even better is that it is being developed as a web standard via the [
 
 ## API reference
 
-- [WebAssembly control flow](/en-US/docs/WebAssembly/Reference/Control_flow)
-  - : Reference documentation for the set of WebAssembly control-flow operators.
+- [WebAssembly language reference](/en-US/docs/WebAssembly/Reference)
+  - : Reference documentation with interactive samples for the set of WebAssembly operators.
 - [WebAssembly JavaScript interface](/en-US/docs/WebAssembly/JavaScript_interface)
   - : This object acts as the namespace for all WebAssembly related functionality.
 - [`WebAssembly.Global()`](/en-US/docs/WebAssembly/JavaScript_interface/Global)


### PR DESCRIPTION
The existing link is to the Control_flow docs, but this is only one
of the useful pages at /WebAssembly/Reference (which I couldn't find
a link for in the whole site), so it's better to link to the parent
resource.