### PR TITLE
Document deprecated MathML attributes superscriptshift/subscriptshift

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -407,6 +407,28 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       </td>
     </tr>
     <tr>
+      <td><code>subscriptshift</code> {{deprecated_inline}}</td>
+      <td>
+        {{ MathMLElement("msub") }},
+        {{ MathMLElement("msubsup") }},
+        {{ MathMLElement("mmultiscripts") }}
+      </td>
+      <td>
+        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the subscript down.
+      </td>
+    </tr>
+    <tr>
+      <td><code>superscriptshift</code> {{deprecated_inline}}</td>
+      <td>
+        {{ MathMLElement("msup") }},
+        {{ MathMLElement("msubsup") }},
+        {{ MathMLElement("mmultiscripts") }}
+      </td>
+      <td>
+        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the superscript up.
+      </td>
+    </tr>
+    <tr>
       <td><code>symmetric</code></td>
       <td>{{ MathMLElement("mo") }}</td>
       <td>

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -34,7 +34,14 @@ MathML uses the syntax below, that is a base expression, followed by an arbitrar
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
+
+- `subscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+- `superscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+
+> **Note:** For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -17,7 +17,12 @@ It uses the following syntax: `<msub> base subscript </msub>`.
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attribute:
+
+- `subscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+
+> **Note:** For the `subscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -17,7 +17,14 @@ It uses the following syntax: `<msubsup> base subscript superscript </msubsup>`.
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
+
+- `subscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+- `superscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+
+> **Note:** For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -17,7 +17,12 @@ It uses the following syntax: `<msup> base superscript </msup>`.
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attribute:
+
+- `superscriptshift` {{deprecated_inline}}
+  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+
+> **Note:** For the `superscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Document deprecated MathML attributes superscriptshift/subscriptshift.

### Motivation

 These were incorrectly removed in [3]. Actually, they were disabled in Firefox in [1] and implemented in WebKit in [2]. See also [4].

### Additional details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1664488
[2] https://commits.webkit.org/139551@main
[3] https://github.com/mdn/content/commit/21f8488aec18b17688d7051b2e9f5cdcc811d71b

### Related issues and pull requests

[4] https://github.com/mdn/browser-compat-data/pull/17962