### PR TITLE
fix: use Q tag with lang for non-English

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -82,6 +82,7 @@
         "ol",
         "p",
         "pre",
+        "q",
         "section",
         "semantics",
         "strong",

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -15,7 +15,7 @@ browser-compat: css.properties.text-combine-upright
 
 The **`text-combine-upright`** [CSS](/en-US/docs/Web/CSS) property sets the combination of characters into the space of a single character. If the combined text is wider than 1em, the user agent must fit the contents within 1em. The resulting composition is treated as a single upright glyph for layout and decoration. This property only has an effect in vertical writing modes.
 
-This is used to produce an effect that is known as tate-chū-yoko <q lang="ja">縦中横</q> in Japanese, or as <q lang="zh-cn">直書橫向</q> in Chinese.
+This is used to produce an effect that is known as tate-chū-yoko <q lang="ja">縦中横</q> in Japanese, or as <q lang="zh-Hant">橫向文字</q> in Chinese.
 
 {{EmbedInteractiveExample("pages/css/text-combine-upright.html")}}
 

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -15,7 +15,7 @@ browser-compat: css.properties.text-combine-upright
 
 The **`text-combine-upright`** [CSS](/en-US/docs/Web/CSS) property sets the combination of characters into the space of a single character. If the combined text is wider than 1em, the user agent must fit the contents within 1em. The resulting composition is treated as a single upright glyph for layout and decoration. This property only has an effect in vertical writing modes.
 
-This is used to produce an effect that is known as tate-chū-yoko (縦中横) in Japanese, or as 直書橫向 in Chinese.
+This is used to produce an effect that is known as tate-chū-yoko <q lang="ja">縦中横</q> in Japanese, or as <q lang="zh-cn">直書橫向</q> in Chinese.
 
 {{EmbedInteractiveExample("pages/css/text-combine-upright.html")}}
 


### PR DESCRIPTION
Downstream in the translated content there are a few tags used for this. The French content uses a mix of `<i>` and `<q>` instead of `<span>`, so I picked `<q>` here and added it as allowed in Markdownlint