### PR TITLE
Fix typo in private class Stamper example

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -151,7 +151,7 @@ new Stamper(obj);
 // now the `this` value. `Stamper` then defines `#stamp` on `obj`
 
 console.log(obj); // In some dev tools, it shows {#stamp: 42}
-console.log(getStamp(obj)); // 42
+console.log(Stamper.getStamp(obj)); // 42
 console.log(obj instanceof Stamper); // false
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This fixes a minor typo: `getStamp` is a static method on the Stamper class, not a global.

### Motivation

`Uncaught ReferenceError: getStamp is not defined`