### PR TITLE
Add `window-controls-overlay` to the `display-mode` media query

### DIFF
--- a/files/en-us/web/css/@media/display-mode/index.md
+++ b/files/en-us/web/css/@media/display-mode/index.md
@@ -30,6 +30,7 @@ The `display-mode` feature is specified as a keyword value chosen from the list 
 | `standalone` | The application will look and feel like a standalone application. This can include the application having a different window, its own icon in the application launcher, etc. In this mode, the user agent will exclude UI elements for controlling navigation, but can include other UI elements such as a status bar. | `minimal-ui`          |
 | `minimal-ui` | The application will look and feel like a standalone application, but will have a minimal set of UI elements for controlling navigation. The elements will vary by browser.                                                                                                                                            | `browser`             |
 | `browser`    | The application opens in a conventional browser tab or new window, depending on the browser and platform.                                                                                                                                                                                                              | (none)                |
+| `window-controls-overlay` | In this mode, the application looks and feels like a standalone desktop application, and the [Window Controls Overlay](/en-US/docs/Web/API/Window_Controls_Overlay_API) feature is enabled. |
 
 ## Examples
 

--- a/files/en-us/web/css/@media/display-mode/index.md
+++ b/files/en-us/web/css/@media/display-mode/index.md
@@ -30,7 +30,7 @@ The `display-mode` feature is specified as a keyword value chosen from the list 
 | `standalone` | The application will look and feel like a standalone application. This can include the application having a different window, its own icon in the application launcher, etc. In this mode, the user agent will exclude UI elements for controlling navigation, but can include other UI elements such as a status bar. | `minimal-ui`          |
 | `minimal-ui` | The application will look and feel like a standalone application, but will have a minimal set of UI elements for controlling navigation. The elements will vary by browser.                                                                                                                                            | `browser`             |
 | `browser`    | The application opens in a conventional browser tab or new window, depending on the browser and platform.                                                                                                                                                                                                              | (none)                |
-| `window-controls-overlay` | In this mode, the application looks and feels like a standalone desktop application, and the [Window Controls Overlay](/en-US/docs/Web/API/Window_Controls_Overlay_API) feature is enabled. |
+| `window-controls-overlay` | In this mode, the application looks and feels like a standalone desktop application, and the [Window Controls Overlay](/en-US/docs/Web/API/Window_Controls_Overlay_API) feature is enabled. | (none) |
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The Window Controls Overlay (WCO) feature allows installed web apps to look and feel like standalone applications and makes it possible for them to style the title bar area.

For this to work, the `window-controls-overlay` was added as a web app manifest `display` value (in fact, it needs to be set as part of the `display_override` member).

Therefore, this value is also available as one of the `display-mode` media query values too. 

This PR adds the value to the `display-mode` media query docs.

### Motivation

Users of the WCO feature may need to define media queries based on this value to control the layout of their apps.

### Additional details

See https://web.dev/window-controls-overlay/ for a code example.

### Related issues and pull requests

Relates to #10620 and #11368.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
