### PR TITLE
Fix prevunique ordering in IndexedDB docs

### DIFF
--- a/files/en-us/web/api/idbobjectstore/opencursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.md
@@ -53,7 +53,7 @@ openCursor(query, direction)
         in the decreasing order of keys.
     - `prevunique`
       - : The cursor is opened at the start of the store; then, the cursor returns all records, that are not duplicates,
-        in the increasing order of keys.
+        in the decreasing order of keys.
 
 ### Return value
 


### PR DESCRIPTION
Note I haven't tested/verified this, but it seems very likely correct.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description


The ordering for 'prevunique' seems likely wrong.  Please verify this is correct.  Thank you! 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
