### PR TITLE
Document beforematch event

### DIFF
--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -95,7 +95,7 @@ document.querySelector("#reset").addEventListener("click", () => {
 
 #### Result
 
-Clicking the "Go to hidden content" button navigates to the hidden until found element. The `beforematch` event fires, the text content is updated, and then the element's content is displayed.
+Clicking the "Go to hidden content" button navigates to the hidden-until-found element. The `beforematch` event fires, the text content is updated, and then the element's content is displayed.
 
 To run the example again, click "Reload".
 

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -1,0 +1,114 @@
+---
+title: "Element: beforematch event"
+slug: Web/API/Element/beforematch_event
+page-type: web-api-event
+tags:
+  - Experimental
+browser-compat: api.Element.beforematch_event
+---
+
+{{APIRef}}
+
+An element receives a **`beforematch`** event when it is in the _hidden until found_ state and the browser is about to reveal its content because the user has found the content through the "find in page" feature or through fragment navigation.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("beforematch", (event) => {});
+
+onbeforematch = (event) => {};
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
+## Usage notes
+
+The HTML [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute accepts a value `until-found`: when this value is specified, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation. When these features cause a scroll to an element in a "hidden until found" subtree, the browser will:
+
+- fire a `beforematch` event on the hidden element
+- remove the `hidden` attribute from the element
+- scroll to the element
+
+## Examples
+
+### Using beforematch
+
+In this example we have:
+
+- Two {{HTMLElement("div")}} elements. The first is not hidden, while the second has `hidden="until-found"`and `id="until-found-box"` attributes.
+- A link whose target is the `"until-found-box"` fragment.
+
+We also have some JavaScript that listens for the `beforematch` event firing on the hidden until found element. The event handler changes the text content of the box.
+
+#### HTML
+
+```html
+<a href="#until-found-box">Go to hidden content</a>
+
+<div>I'm not hidden</div>
+<div id="until-found-box" hidden="until-found">Hidden until found</div>
+```
+
+```html hidden
+<button id="reset">Reset</button>
+```
+
+#### CSS
+
+```css
+div {
+  height: 40px;
+  width: 300px;
+  border: 5px dashed black;
+  margin: 1rem 0;
+  padding: 1rem;
+  font-size: 2rem;
+}
+```
+
+```css hidden
+#until-found-box {
+  scroll-margin-top: 200px;
+}
+```
+
+#### JavaScript
+
+```js
+const untilFound = document.querySelector("#until-found-box");
+untilFound.addEventListener(
+  "beforematch",
+  () => (untilFound.textContent = "I've been revealed!")
+);
+```
+
+```js hidden
+document.querySelector("#reset").addEventListener("click", () => {
+  document.location.hash = "";
+  document.location.reload();
+});
+```
+
+#### Result
+
+Clicking the "Go to hidden content" button navigates to the hidden until found element. The `beforematch` event fires, the text content is updated, and then the element's content is displayed.
+
+To run the example again, click "Reload".
+
+{{EmbedLiveSample("Using beforematch", "", 300)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The HTML [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -300,18 +300,16 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 
 Listen to these events using `addEventListener()` or by assigning an event listener to the `oneventname` property of this interface.
 
+- {{domxref("Element/beforematch_event", "beforematch")}}
+  - : Fires on an element that is in the [_hidden until found_](/en-US/docs/Web/HTML/Global_attributes/hidden) state, when the browser is about to reveal its content because the user has found the content through the "find in page" feature or through fragment navigation.
 - {{domxref("HTMLDialogElement/cancel_event", "cancel")}}
-
   - : Fires on a {{HTMLElement("dialog")}} when the user instructs the browser that they wish to dismiss the current open dialog. For example, the browser might fire this event when the user presses the <kbd>Esc</kbd> key or clicks a "Close dialog" button which is part of the browser's UI.
-
 - {{domxref("Element/error_event", "error")}}
   - : Fired when a resource failed to load, or can't be used. For example, if a script has an execution error or an image can't be found or is invalid.
 - {{domxref("Element/scroll_event", "scroll")}}
   - : Fired when the document view or an element has been scrolled.
 - {{domxref("Element/securitypolicyviolation_event","securitypolicyviolation")}} {{Deprecated_Inline}}
-
   - : Fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
-
 - {{domxref("Element/select_event", "select")}}
   - : Fired when some text has been selected.
 - {{domxref("Element/show_event", "show")}} {{Deprecated_Inline}} {{Non-standard_Inline}}

--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -62,7 +62,7 @@ Web browsers may implement the _hidden_ state using `display: none`, in which ca
 
 In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation. When these features cause a scroll to an element in a _hidden until found_ subtree, the browser will:
 
-- fire a `beforematch` event on the hidden element
+- fire a [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event on the hidden element
 - remove the `hidden` attribute from the element
 - scroll to the element
 
@@ -165,5 +165,6 @@ To run the example again, click "Reload".
 ## See also
 
 - {{DOMxRef("HTMLElement.hidden")}}
-- All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+- All [global attributes](/en-US/docs/Web/HTML/Global_attributes)
 - [`aria-hidden` attribute](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
+- The [`beforematch](/en-US/docs/Web/API/Element/beforematch_event) event


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/21490, which documented the `until-found` value for the `hidden` attribute.

This PR documents the `beforematch` event, which is fired when the browser is about to reveal a `hidden=until-found` element.

BCD PR is at https://github.com/mdn/browser-compat-data/pull/17981.