### PR TITLE
Add a link to the source code for WebGL example

### DIFF
--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
@@ -20,4 +20,6 @@ This example demonstrates how to use video files as textures for WebGL surfaces.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
+The source code of this example is available on [GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8).
+
 {{Previous("Learn/WebGL/By_example/Textures_from_code")}}


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/21414.

I didn't think it was a good idea pasting in the code from GitHub, but I added a link to the files in the repo.