### PR TITLE
XRWebGLSubImage/textureHeight|Width → colorTextureHeight|Width

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -10201,6 +10201,8 @@
 /en-US/docs/Web/API/XRWebGLLayerInit/framebufferscalefactor	/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer
 /en-US/docs/Web/API/XRWebGLLayerInit/ignoredepthvalues	/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer
 /en-US/docs/Web/API/XRWebGLLayerInit/stencil	/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer
+/en-US/docs/Web/API/XRWebGLSubImage/textureHeight	/en-US/docs/Web/API/XRWebGLSubImage/colorTextureHeight
+/en-US/docs/Web/API/XRWebGLSubImage/textureWidth	/en-US/docs/Web/API/XRWebGLSubImage/colorTextureWidth
 /en-US/docs/Web/API/console.assert	/en-US/docs/Web/API/console/assert
 /en-US/docs/Web/API/console.dir	/en-US/docs/Web/API/console/dir
 /en-US/docs/Web/API/console.error	/en-US/docs/Web/API/console/error

--- a/files/en-us/web/api/xrwebglsubimage/colortextureheight/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/colortextureheight/index.md
@@ -1,6 +1,6 @@
 ---
-title: XRWebGLSubImage.textureHeight
-slug: Web/API/XRWebGLSubImage/textureHeight
+title: XRWebGLSubImage.colorTextureHeight
+slug: Web/API/XRWebGLSubImage/colorTextureHeight
 page-type: web-api-instance-property
 tags:
   - API
@@ -12,12 +12,12 @@ tags:
   - WebXR Device API
   - XR
   - Experimental
-browser-compat: api.XRWebGLSubImage.textureHeight
+browser-compat: api.XRWebGLSubImage.colorTextureHeight
 ---
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The read-only **`textureHeight`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the height in pixels of the GL attachment.
+The read-only **`colorTextureHeight`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the height in pixels of the GL attachment.
 
 ## Value
 

--- a/files/en-us/web/api/xrwebglsubimage/colortexturewidth/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/colortexturewidth/index.md
@@ -1,6 +1,6 @@
 ---
-title: XRWebGLSubImage.textureWidth
-slug: Web/API/XRWebGLSubImage/textureWidth
+title: XRWebGLSubImage.colorTextureWidth
+slug: Web/API/XRWebGLSubImage/colorTextureWidth
 page-type: web-api-instance-property
 tags:
   - API
@@ -12,12 +12,12 @@ tags:
   - WebXR Device API
   - XR
   - Experimental
-browser-compat: api.XRWebGLSubImage.textureWidth
+browser-compat: api.XRWebGLSubImage.colorTextureWidth
 ---
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The read-only **`textureWidth`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the width in pixels of the GL attachment.
+The read-only **`colorTextureWidth`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the width in pixels of the GL attachment.
 
 ## Value
 

--- a/files/en-us/web/api/xrwebglsubimage/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/index.md
@@ -30,9 +30,9 @@ _Inherits properties from its parent, {{domxref("XRSubImage")}}._
   - : A depth/stencil {{domxref("WebGLTexture")}} object for the {{domxref("XRCompositionLayer")}} to render.
 - {{domxref("XRWebGLSubImage.imageIndex")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
-- {{domxref("XRWebGLSubImage.textureWidth")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("XRWebGLSubImage.colorTextureWidth")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A number representing the width in pixels of the GL attachment.
-- {{domxref("XRWebGLSubImage.textureHeight")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("XRWebGLSubImage.colorTextureHeight")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A number representing the height in pixels of the GL attachment.
 
 ## Specifications


### PR DESCRIPTION
https://immersive-web.github.io/layers/#xrwebglsubimagetype

Related BCD PR: https://github.com/mdn/browser-compat-data/pull/17985