### PR TITLE
WebGL: Fix bitwise calculation isPowerOf2(value), missing parenthesis

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -73,7 +73,7 @@ function loadTexture(gl, url) {
 }
 
 function isPowerOf2(value) {
-  return value & (value - 1) === 0;
+  return (value & (value - 1)) === 0;
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
After using the code example `loadTexture` I noticed that mipmap are not being used. 

<!-- ✍️ Summarize your changes in one or two sentences -->
The issue was in the utility function `isPowerOf2` where it was missing parenthesis `value & (value - 1) === 0` -> `(value & (value - 1)) === 0` making the bool check fail.

### Motivation
It seems that the issue has been resolved in other locales such as `fr` but not in `en-US`. This pull request is created, first to fix the logical problem and keep docs consistent between locales.
