### PR TITLE
Add note regarding the specificity

### DIFF
--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -23,6 +23,8 @@ the h1 and applies the style to h1 */
 h1:has(+ p) { margin-bottom: 0; }
 ```
 
+The `:has()` pseudo-class takes on the [specificity](/en-US/docs/Web/CSS/Specificity) of the most specific selector in its arguments the same way as {{CSSxRef(":is", ":is()")}} and {{CSSxRef(":not", ":not()")}} do.
+
 ## Syntax
 
 ```


### PR DESCRIPTION
Add a note regarding the specificity of the `has()` pseudo-class.  
The same way as it is added on the `is()`, `not()` and `where()` pseudo-classes pages.