### PR TITLE
fix(example): extract pemContents

### DIFF
--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -267,7 +267,7 @@ function importPrivateKey(pem) {
   // fetch the part of the PEM string between header and footer
   const pemHeader = "-----BEGIN PRIVATE KEY-----";
   const pemFooter = "-----END PRIVATE KEY-----";
-  const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length);
+  const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length - 1).trim();
   // base64 decode the string to get the binary data
   const binaryDerString = window.atob(pemContents);
   // convert from a binary string to an ArrayBuffer


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Import a PEM encoded RSA private key function importPrivateKey(pem) did not properly extract the pemContents.
<!-- ✍️ Summarize your changes in one or two sentences -->

Corrected length -1 and added trim() to remove newline/whitespace if present.

### Motivation
Wanted to correct example.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
