### PR TITLE
fix: updated description for positional properties

### DIFF
--- a/files/en-us/web/css/left/index.md
+++ b/files/en-us/web/css/left/index.md
@@ -63,7 +63,7 @@ left: unset;
 
 The effect of `left` depends on how the element is positioned (i.e., the value of the {{cssxref("position")}} property):
 
-- When `position` is set to `absolute` or `fixed`, the `left` property specifies the distance between the element's left edge and the left edge of its containing block. (The containing block is the ancestor to which the element is relatively positioned.)
+- When `position` is set to `absolute` or `fixed`, the `left` property specifies the distance between the element's outer margin of left edge and the inner border of left edge of its containing block. (The containing block is the ancestor to which the element is relatively positioned.)
 - When `position` is set to `relative`, the `left` property specifies the distance the element's left edge is moved to the right from its normal position.
 - When `position` is set to `sticky`, the `left` property is used to compute the sticky-constraint rectangle.
 - When `position` is set to `static`, the `left` property has _no effect_.

--- a/files/en-us/web/css/right/index.md
+++ b/files/en-us/web/css/right/index.md
@@ -65,7 +65,7 @@ right: unset;
 
 The effect of `right` depends on how the element is positioned (i.e., the value of the {{cssxref("position")}} property):
 
-- When `position` is set to `absolute` or `fixed`, the `right` property specifies the distance between the element's right edge and the right edge of its containing block.
+- When `position` is set to `absolute` or `fixed`, the `right` property specifies the distance between the element's outer margin of right edge and the inner border of the right edge of its containing block.
 - When `position` is set to `relative`, the `right` property specifies the distance the element's right edge is moved to the left from its normal position.
 - When `position` is set to `sticky`, the `right` property is used to compute the sticky-constraint rectangle.
 - When `position` is set to `static`, the `right` property has _no effect_.


### PR DESCRIPTION
### Description

Updated description for positional properties (`left` and `right`) with more specific information.

### Motivation

Closing #15862 issue

### Additional details

In corresponding issue were mentioned required updates also for the `bottom` property but it's already fixed, so it's not relevant anymore.

### Related issues and pull requests

🔨 Fixes #15862