### PR TITLE
Document PerformanceEventTiming members

### DIFF
--- a/files/en-us/web/api/performanceeventtiming/cancelable/index.md
+++ b/files/en-us/web/api/performanceeventtiming/cancelable/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceEventTiming.cancelable
 
 {{APIRef}}
 
-The read-only **`cancelable`** property returns the associated event's [`cancelable`](/en-US/docs/Web/API/Event/cancelable) property indicating whether the event can be canceled.
+The read-only **`cancelable`** property returns the associated event's [`cancelable`](/en-US/docs/Web/API/Event/cancelable) property, indicating whether the event can be canceled.
 
 ## Value
 
@@ -22,7 +22,7 @@ A boolean. `true` if the associated event is cancelable, `false` otherwise.
 
 ### Observing non-cancelable events
 
-The `cancelable` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure non-cancelable events only.
+The `cancelable` property can be used when observing event-timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure non-cancelable events only.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceeventtiming/cancelable/index.md
+++ b/files/en-us/web/api/performanceeventtiming/cancelable/index.md
@@ -1,0 +1,47 @@
+---
+title: PerformanceEventTiming.cancelable
+slug: Web/API/PerformanceEventTiming/cancelable
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.cancelable
+---
+
+{{APIRef}}
+
+The read-only **`cancelable`** property returns the associated event's [`cancelable`](/en-US/docs/Web/API/Event/cancelable) property indicating whether the event can be canceled.
+
+## Value
+
+A boolean. `true` if the associated event is cancelable, `false` otherwise.
+
+## Examples
+
+### Observing non-cancelable events
+
+The `cancelable` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure non-cancelable events only.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    if (!entry.cancelable) {
+      const delay = entry.processingStart - entry.startTime;
+      console.log(entry.name, delay);
+    }
+  });
+});
+
+// Register the observer for events
+observer.observe({entryTypes: ["event"]});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/performanceeventtiming/interactionid/index.md
+++ b/files/en-us/web/api/performanceeventtiming/interactionid/index.md
@@ -1,0 +1,67 @@
+---
+title: PerformanceEventTiming.interactionId
+slug: Web/API/PerformanceEventTiming/interactionId
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.interactionId
+---
+
+{{APIRef}}
+
+The read-only **`interactionId`** property returns an ID that uniquely identifies a user interaction which triggered a series of associated events.
+
+## Description
+
+When a user interacts with a web page, a user interaction (for example a click) usually triggers a sequence of events, such as `pointerdown`,`pointerup`, and `click` events. To measure the latency of this series of events, the events share the same `interactionId`.
+
+An `interactionId` is only computed for the following event types belonging to a user interaction. It is `0` otherwise.
+
+| Event types | User interaction |
+| --- | --- |
+| {{domxref("Element/pointerdown_event", "pointerdown")}}, {{domxref("Element/pointerup_event", "pointerup")}}, {{domxref("Element/click_event", "click")}} | click / tap / drag  |
+| {{domxref("Element/keydown_event", "keydown")}}, {{domxref("Element/keyup_event", "keyup")}} | key press |
+
+## Value
+
+A number.
+
+## Examples
+
+### Using interactionId
+
+The following example collects event duration for all events corresponding to an interaction. The `eventLatencies` map can then be used to find events with maximum duration for a user interaction, for example.
+
+```js
+// The key is the interaction ID.
+let = eventLatencies = {};
+
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    if (entry.interactionId > 0) {
+      const interactionId = entry.interactionId;
+      if (!eventLatencies.has(interactionId)) {
+        eventLatencies[interactionId] = [];
+      }
+       eventLatencies[interactionId].push(entry.duration);
+  });
+});
+
+observer.observe({entryTypes: ["event"]}); 
+
+// Log events with maximum event duration for a user interaction
+Object.entries(eventLatencies).forEach(([k, v]) => {
+    console.log(Math.max(...v));
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/performanceeventtiming/processingend/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingend/index.md
@@ -24,7 +24,7 @@ A {{domxref("DOMHighResTimeStamp")}} timestamp.
 
 ### Using the processingEnd property
 
-The `processingEnd` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to calculate input delay or event processing times.
+The `processingEnd` property can be used when observing event-timing entries ({{domxref("PerformanceEventTiming")}}). For example, to calculate input delay or event processing times.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceeventtiming/processingend/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingend/index.md
@@ -1,0 +1,55 @@
+---
+title: PerformanceEventTiming.processingEnd
+slug: Web/API/PerformanceEventTiming/processingEnd
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.processingEnd
+---
+
+{{APIRef}}
+
+The read-only **`processingEnd`** property returns the time the last event handler finished executing.
+
+It's equal to {{domxref("PerformanceEventTiming.processingStart")}} when there are no such event handlers.
+
+## Value
+
+A {{domxref("DOMHighResTimeStamp")}} timestamp.
+
+## Examples
+
+### Using the processingEnd property
+
+The `processingEnd` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to calculate input delay or event processing times.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    // Full duration
+     const duration = entry.duration;
+     // Input delay (before processing event)
+     const delay = entry.processingStart - entry.startTime;
+     // Synchronous event processing time 
+     // (between start and end dispatch)
+     const time = entry.processingEnd - entry.processingStart;
+  });
+});
+// Register the observer for events
+observer.observe({entryTypes: ["event"]});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("PerformanceEventTiming.processingStart")}}

--- a/files/en-us/web/api/performanceeventtiming/processingstart/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingstart/index.md
@@ -1,0 +1,53 @@
+---
+title: PerformanceEventTiming.processingStart
+slug: Web/API/PerformanceEventTiming/processingStart
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.processingStart
+---
+
+{{APIRef}}
+
+The read-only **`processingStart`** property returns the time at which event dispatch started. This is when event handlers are about to be executed.
+
+## Value
+
+A {{domxref("DOMHighResTimeStamp")}} timestamp.
+
+## Examples
+
+### Using the processingStart property
+
+The `processingStart` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to calculate input delay or event processing times.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    // Full duration
+     const duration = entry.duration;
+     // Input delay (before processing event)
+     const delay = entry.processingStart - entry.startTime;
+     // Synchronous event processing time 
+     // (between start and end dispatch)
+     const time = entry.processingEnd - entry.processingStart;
+  });
+});
+// Register the observer for events
+observer.observe({entryTypes: ["event"]});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("PerformanceEventTiming.processingEnd")}}

--- a/files/en-us/web/api/performanceeventtiming/target/index.md
+++ b/files/en-us/web/api/performanceeventtiming/target/index.md
@@ -24,7 +24,7 @@ Or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the `Node` i
 
 ### Observing events with a specific last target
 
-The `target` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure events for a given last target only.
+The `target` property can be used when observing event-timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure events for a given last target only.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceeventtiming/target/index.md
+++ b/files/en-us/web/api/performanceeventtiming/target/index.md
@@ -1,0 +1,49 @@
+---
+title: PerformanceEventTiming.target
+slug: Web/API/PerformanceEventTiming/target
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.target
+---
+
+{{APIRef}}
+
+The read-only **`target`** property returns the associated event's last [`target`](/en-US/docs/Web/API/Event/target) which is the node onto which the event was last dispatched.
+
+## Value
+
+A {{domxref("Node")}} onto which the event was last dispatched.
+
+Or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the `Node` is disconnected from the document's DOM or is in the [shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM).
+
+## Examples
+
+### Observing events with a specific last target
+
+The `target` property can be used when observing event timing entries ({{domxref("PerformanceEventTiming")}}). For example, to log and measure events for a given last target only.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    if (entry.target && entry.target.id === "myNode") {
+      const delay = entry.processingStart - entry.startTime;
+      console.log(entry.name, delay);
+    }
+  });
+});
+
+// Register the observer for events
+observer.observe({entryTypes: ["event"]});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -1,0 +1,74 @@
+---
+title: PerformanceEventTiming.toJSON()
+slug: Web/API/PerformanceEventTiming/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceEventTiming.toJSON
+---
+
+{{APIRef}}
+
+The **`toJSON()`** method is a _serializer_; it returns a JSON representation of the {{domxref("PerformanceEventTiming","performance event timing entry")}} object.
+
+Note that it doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property given it is of type {{domxref("Node")}} which doesn't provide a `toJSON()` operation.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A JSON object that is the serialization of the {{domxref("PerformanceEventTiming")}} object.
+
+## Examples
+
+### Using the toJSON method
+
+The following example shows the use of the `toJSON()` method.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+// Register the observer for events
+observer.observe({entryTypes: ["event"]});
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "dragover",
+  "entryType": "event",
+  "startTime": 67090751.599999905,
+  "duration": 128,
+  "processingStart": 67090751.70000005,
+  "processingEnd": 67090751.900000095,
+  "cancelable": true
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PerformanceEventTiming.toJSON
 
 The **`toJSON()`** method is a _serializer_; it returns a JSON representation of the {{domxref("PerformanceEventTiming","performance event timing entry")}} object.
 
-Note that it doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property given it is of type {{domxref("Node")}} which doesn't provide a `toJSON()` operation.
+Note that it doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property, given it is of type {{domxref("Node")}} (which doesn't provide a `toJSON()` operation).
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR documents the `PerformanceEventTiming` API members. 

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I think very often it is hard to come up with good and sensible content for property pages. In fact, I think many MDN API property pages are thin. I tried to provide examples here for everything, though. I hope it doesn't look all too constructed. I think it just tells that I sometimes don't exactly know the precise use case for a property. If you have better use cases or ideas, let me know and I'm happy to make the example code better. 

### Related issues and pull requests

https://github.com/mdn/content/pull/21531 is the PR that updates the `PerformanceEventTiming` interface page. @wbamberg is reviewing it and it might be nice to get his review on this one as well but I won't require it :)