### PR TITLE
Document durationThreshold in PerfObserver.observe()

### DIFF
--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -37,9 +37,14 @@ observe(options)
 
 - `options`
 
-  - : A `PerformanceObserverInit` dictionary with the following possible
-    members:
+  - : An object with the following possible members:
 
+    - `buffered`
+      - : A boolean flag to indicate whether buffered
+        entries should be queued into the observer's buffer. Must be used only with the
+        "`type`" option.
+    - `durationThreshold`
+      - : A {{domxref("DOMHighResTimeStamp")}} defining the threshold for {{domxref("PerformanceEventTiming")}} entries. Defaults to 104ms and is rounded to the nearest of 8ms. Lowest possible threshold is 16ms.
     - `entryTypes`
       - : An array of string objects, each
         specifying one performance entry type to observe. May not be used together with
@@ -48,10 +53,6 @@ observe(options)
       - : A single string specifying exactly one
         performance entry type to observe. May not be used together with the
         `entryTypes` option.
-    - `buffered`
-      - : A boolean flag to indicate whether buffered
-        entries should be queued into the observer's buffer. Must be used only with the
-        "`type`" option.
 
     See {{domxref("PerformanceEntry.entryType")}} for a list of valid performance entry
     type names. Unrecognized types are ignored, though the browser may output a warning


### PR DESCRIPTION
### Description

This PR updates https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe to add the `durationThreshold` option from the Event Timing API.

Spec: https://w3c.github.io/event-timing/#sec-modifications-perf-timeline

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I also ordered the options list alphabetically and removed explicit mention of "`PerformanceObserverInit` dictionary" because I believe we don't document dictionaries anymore and all we want readers to know is that it is an options object.

### Related issues and pull requests

In https://github.com/mdn/content/pull/21531 I'm adding more text to talk about `durationThreshold` and I've added an example about it on the `PerformanceEventTiming` page.