### PR TITLE
Add Event Timing info to PerformanceEntry pages

### DIFF
--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -21,6 +21,8 @@ The **`duration`** property returns a
 The value returned by this property depends on the performance entry's
 {{domxref("PerformanceEntry.entryType","type")}}:
 
+- `"event"` - returns a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
+- `"first-input"` - returns a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
 - "`frame`" - returns a {{domxref("DOMHighResTimeStamp","timestamp")}}
   indicating the difference between the `startTime`s of two successive
   frames.

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -45,6 +45,18 @@ table below.
       <td>Reports load time of elements.</td>
     </tr>
     <tr>
+      <td><code>event</code></td>
+      <td>{{domxref('PerformanceEventTiming')}}</td>
+      <td>string</td>
+      <td>Reports event latencies.</td>
+    </tr>
+    <tr>
+      <td><code>first-input</code></td>
+      <td>{{domxref('PerformanceEventTiming')}}</td>
+      <td>string</td>
+      <td>Reports the {{Glossary("first input delay")}}.</td>
+    </tr>
+    <tr>
       <td><code>navigation</code></td>
       <td>
         {{domxref('PerformanceNavigationTiming')}}

--- a/files/en-us/web/api/performanceentry/index.md
+++ b/files/en-us/web/api/performanceentry/index.md
@@ -20,6 +20,7 @@ The **`PerformanceEntry`** object encapsulates a single performance metric that 
 
 - {{domxref("PerformanceMark")}}
 - {{domxref("PerformanceMeasure")}}
+- {{domxref("PerformanceEventTiming")}}
 - {{domxref("PerformanceNavigationTiming")}}
 - {{domxref("PerformanceResourceTiming")}}
 - {{domxref("PerformancePaintTiming")}}

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -35,6 +35,14 @@ the value of {{domxref("PerformanceEntry.entryType")}}, as shown by the table be
   </thead>
   <tbody>
     <tr>
+      <td>string</td>
+      <td>
+        {{domxref('PerformanceEventTiming')}}
+      </td>
+      <td><code>event</code>, <code>first-input</code></td>
+      <td>The associated event's type.</td>
+    </tr>
+    <tr>
       <td>{{domxref("URL")}}</td>
       <td>
         {{domxref('PerformanceNavigationTiming')}}

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -21,17 +21,19 @@ The **`startTime`** property returns the first recorded
 The value returned by this property depends on the performance entry's
 {{domxref("PerformanceEntry.entryType","type")}}:
 
-- "`frame`" - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
+- `"event"` - returns a {{domxref("DOMHighResTimeStamp")}} representing the associated event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property. This is the time the event was created.
+- `"first-input"` - returns a {{domxref("DOMHighResTimeStamp")}} representing the associated event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property. This is the time the first input event was created.
+- `"frame"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
   when the frame was started.
-- "`mark`" - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
+- `"mark"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
   when the mark was created by a call to
   {{domxref("Performance.mark","performance.mark()")}}.
-- "`measure`" - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
+- `"measure"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
   when the measure was created by a call to
   {{domxref("Performance.measure","performance.measure()")}}.
-- "`navigation`" - returns the
+- `"navigation"` - returns the
   {{domxref("DOMHighResTimeStamp","timestamp")}} with a value of "`0`".
-- "`resource`" - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
+- `"resource"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
   immediately before the browser {{domxref("PerformanceResourceTiming/fetchStart","starts
     fetching the resource")}}.
 


### PR DESCRIPTION
### Description

This PR adds information from the Event Timing API (`PerformanceEventTiming`) to its parent `PerformanceEntry`.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I think we want to take a closer look at the `PerformanceEntry` pages at a later stage. It seems it is an abstract interface for many performance APIs and we should see how to improve these pages. This PR just adds to what the current structures offer. 

### Related issues and pull requests

https://github.com/mdn/content/pull/21531 documents these properties in a "Instance properties" section as well. 