### PR TITLE
PerformanceObserver.supportedEntryTypes is static

### DIFF
--- a/files/en-us/web/api/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/index.md
@@ -24,7 +24,7 @@ The **`PerformanceObserver`** interface is used to _observe_ performance measure
 - {{domxref("PerformanceObserver.PerformanceObserver","PerformanceObserver()")}}
   - : Creates and returns a new `PerformanceObserver` object.
 
-## Instance properties
+## Static properties
 
 - {{domxref("PerformanceObserver.supportedEntryTypes")}} {{ReadOnlyInline}}
   - : Returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
@@ -1,7 +1,7 @@
 ---
 title: PerformanceObserver.supportedEntryTypes
 slug: Web/API/PerformanceObserver/supportedEntryTypes
-page-type: web-api-instance-property
+page-type: web-api-static-property
 tags:
   - API
   - Property
@@ -14,7 +14,7 @@ browser-compat: api.PerformanceObserver.supportedEntryTypes
 
 {{APIRef("Performance Timeline API")}}
 
-The **`supportedEntryTypes`** read-only property of the
+The static **`supportedEntryTypes`** read-only property of the
 {{domxref("PerformanceObserver")}} interface returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.
 
 As the list of supported entries varies per browser and is evolving, this property allows web developers to check which are available.


### PR DESCRIPTION
### Description

It's static, see https://w3c.github.io/performance-timeline/#ref-for-dom-performanceobserver-supportedentrytypes-3

### Motivation

Bugfix.

### Additional details

None.

### Related issues and pull requests

None.
