### PR TITLE
flesh out details:  how to pre-load WASM

### DIFF
--- a/files/en-us/web/html/link_types/preload/index.md
+++ b/files/en-us/web/html/link_types/preload/index.md
@@ -82,7 +82,7 @@ Many different content types can be preloaded. The possible `as` attribute value
 
 > **Note:** `video` preloading is included in the Preload spec, but is not currently implemented by browsers.
 
-> **Note:** `font` and `fetch` preloading requires the `crossorigin` attribute to be set, see [CORS-enabled fetches](#cors-enabled_fetches) below.
+> **Note:** `font` and `fetch` preloading requires the `crossorigin` attribute to be set; see [CORS-enabled fetches](#cors-enabled_fetches) below.
 
 > **Note:** There's more detail about these values and the web features they expect to be consumed by in the Preload spec — see [link element extensions](https://w3c.github.io/preload/#link-element-extensions). Also note that the full list of values the `as` attribute can take is governed by the Fetch spec — see [request destinations](https://fetch.spec.whatwg.org/#concept-request-destination).
 

--- a/files/en-us/web/html/link_types/preload/index.md
+++ b/files/en-us/web/html/link_types/preload/index.md
@@ -70,7 +70,7 @@ Many different content types can be preloaded. The possible `as` attribute value
 - `audio`: Audio file, as typically used in {{htmlelement("audio")}}.
 - `document`: An HTML document intended to be embedded by a {{htmlelement("frame")}} or {{htmlelement("iframe")}}.
 - `embed`: A resource to be embedded inside an {{htmlelement("embed")}} element.
-- `fetch`: Resource to be accessed by a fetch or XHR request, such as an ArrayBuffer or JSON file.
+- `fetch`: Resource to be accessed by a fetch or XHR request, such as an ArrayBuffer, WebAssembly/WASM binary, or JSON file.
 - `font`: Font file.
 - `image`: Image file.
 - `object`: A resource to be embedded inside an {{htmlelement("object")}} element.
@@ -81,6 +81,8 @@ Many different content types can be preloaded. The possible `as` attribute value
 - `video`: Video file, as typically used in {{htmlelement("video")}}.
 
 > **Note:** `video` preloading is included in the Preload spec, but is not currently implemented by browsers.
+
+> **Note:** `font` and `fetch` preloading requires the `crossorigin` attribute to be set, see [CORS-enabled fetches](#cors-enabled_fetches) below.
 
 > **Note:** There's more detail about these values and the web features they expect to be consumed by in the Preload spec — see [link element extensions](https://w3c.github.io/preload/#link-element-extensions). Also note that the full list of values the `as` attribute can take is governed by the Fetch spec — see [request destinations](https://fetch.spec.whatwg.org/#concept-request-destination).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I was searching for information on how to pre-load a webassembly binary file so that when it's `fetch()`'d by a JavaScript later, its download will already be in progress or completed.   By using Ctrl-F (text search within [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload)), I was not able to find any information regarding this.  Quickly  i returned to google search results and got my answer from another place, from someones anecdote here: 

https://github.com/thedodd/trunk/issues/145

> Preloading can be set up by simply adding one line to the generated `index.html` file, as in the following example:
> .
> ```
> <head>
>   <link rel="preload" href="/index-43bbc68f2f0a6cd7_bg.wasm" as="fetch" crossorigin>
>   <script type="module">import init from '/index-43bbc68f2f0a6cd7.js'; init('/index-43bbc68f2f0a6cd7_bg.wasm');</script>
> ```

I tested it out in my own project: 

```
<head>
  <link rel="preload" href='/test.wasm'  as="fetch" crossorigin>
  
  ...
 
  <script src="wasm_exec.js" defer></script>
  <script>
    ...
    window.onload = () => {
      	WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject).then(function (obj) {

```

And it worked in firefox,  wasm starts downloading early and its not downloaded twice.

### Motivation

I made this change so that the next person coming to this page and searching for "webassembly" or "WASM" is not left empty handed like I was :slightly_smiling_face: 

Yes technically this information _was_ already present in the docs  however it was not accessible via ctrl-f (text search)   

so for people like me who refuse to read walls of text for minutes at a time and would rather go directly to the specific reference or example via search,   I believe this change will make the docs more accessible. 

