### PR TITLE
Mention fetch() keepalive in the navigator.sendBeacon() article

### DIFF
--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -25,6 +25,8 @@ sending analytics data to a web server, and avoids some of the problems with
 legacy techniques for sending analytics, such as the use of
 {{domxref("XMLHttpRequest","XMLHttpRequest")}}.
 
+> **Note:** The sendBeacon() method can make POST requests only. It does not provide ability to customize the request method, provide custom request headers, or change other processing properties of the request and response. Applications that need such requests should use the fetch API with the [keepalive](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) parameter set to true. This feature was added to fetch API to obsolete the need for sendBeacon().
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -25,7 +25,7 @@ sending analytics data to a web server, and avoids some of the problems with
 legacy techniques for sending analytics, such as the use of
 {{domxref("XMLHttpRequest","XMLHttpRequest")}}.
 
-> **Note:** The `sendBeacon()` method can make POST requests only. It does not provide ability to customize the request method, provide custom request headers, or change other processing properties of the request and response. Applications that need such requests should use the fetch API with the [`keepalive`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) parameter set to true. This feature was added to fetch API to obsolete the need for `sendBeacon()`.
+> **Note:** `sendBeacon()` is limited to sending `POST` requests only, and does not provide any ability to add custom request headers, nor to change any properties of the request, and does not enable any access to the server response. For use cases that need the ability to send requests with methods other than `POST`, or to change any request properties, or that need access to the server response, instead use the [Fetch API](/en-US/docs/Web/API/Fetch_API) with the [`keepalive`](/en-US/docs/Web/API/fetch#keepalive) parameter set to true.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -25,7 +25,7 @@ sending analytics data to a web server, and avoids some of the problems with
 legacy techniques for sending analytics, such as the use of
 {{domxref("XMLHttpRequest","XMLHttpRequest")}}.
 
-> **Note:** `sendBeacon()` is limited to sending `POST` requests only, and does not provide any ability to add custom request headers, nor to change any properties of the request, and does not enable any access to the server response. For use cases that need the ability to send requests with methods other than `POST`, or to change any request properties, or that need access to the server response, instead use the [Fetch API](/en-US/docs/Web/API/Fetch_API) with the [`keepalive`](/en-US/docs/Web/API/fetch#keepalive) parameter set to true.
+> **Note:** For use cases that need the ability to send requests with methods other than `POST`, or to change any request properties, or that need access to the server response, instead use the [Fetch API](/en-US/docs/Web/API/Fetch_API) with [`keepalive`](/en-US/docs/Web/API/fetch#keepalive) set to true.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -25,7 +25,7 @@ sending analytics data to a web server, and avoids some of the problems with
 legacy techniques for sending analytics, such as the use of
 {{domxref("XMLHttpRequest","XMLHttpRequest")}}.
 
-> **Note:** For use cases that need the ability to send requests with methods other than `POST`, or to change any request properties, or that need access to the server response, instead use the [Fetch API](/en-US/docs/Web/API/Fetch_API) with [`keepalive`](/en-US/docs/Web/API/fetch#keepalive) set to true.
+> **Note:** For use cases that need the ability to send requests with methods other than `POST`, or to change any request properties, or that need access to the server response, instead use the [`fetch()`](/en-US/docs/Web/API/fetch) method with [`keepalive`](/en-US/docs/Web/API/fetch#keepalive) set to true.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -25,7 +25,7 @@ sending analytics data to a web server, and avoids some of the problems with
 legacy techniques for sending analytics, such as the use of
 {{domxref("XMLHttpRequest","XMLHttpRequest")}}.
 
-> **Note:** The sendBeacon() method can make POST requests only. It does not provide ability to customize the request method, provide custom request headers, or change other processing properties of the request and response. Applications that need such requests should use the fetch API with the [keepalive](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) parameter set to true. This feature was added to fetch API to obsolete the need for sendBeacon().
+> **Note:** The `sendBeacon()` method can make POST requests only. It does not provide ability to customize the request method, provide custom request headers, or change other processing properties of the request and response. Applications that need such requests should use the fetch API with the [`keepalive`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) parameter set to true. This feature was added to fetch API to obsolete the need for `sendBeacon()`.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Adds a note to mention fetch API's `keepalive` method as a replacement for sendBeacon()

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Many people might wonder how they can use other HTTP methods using the sendBeacon method, but this is not possible with the sendBeacon() method and instead the `keepalive` flag has been added to the fetch API to accomplish this. I've added a note to mention this.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
