### PR TITLE
Correct apparent copypaste error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/index.md
@@ -74,7 +74,7 @@ function getUint64BigInt(dataview, byteOffset, littleEndian) {
 - {{jsxref("DataView.prototype.buffer")}}
   - : The {{jsxref("ArrayBuffer")}} referenced by this view. Fixed at construction time and thus **read only.**
 - {{jsxref("DataView.prototype.byteLength")}}
-  - : The length (in bytes) of this view from the start of its {{jsxref("ArrayBuffer")}}. Fixed at construction time and thus **read only.**
+  - : The length (in bytes) of this view. Fixed at construction time and thus **read only.**
 - {{jsxref("DataView.prototype.byteOffset")}}
   - : The offset (in bytes) of this view from the start of its {{jsxref("ArrayBuffer")}}. Fixed at construction time and thus **read only.**
 


### PR DESCRIPTION
The previous description implies that this value reflects not just its size, but its position in ArrayBuffer.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
removed reference to "start of ArrayBuffer"



### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
i love mdn, i hate sloppy language

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
