### PR TITLE
Fixed a broken link

### DIFF
--- a/files/en-us/glossary/sloppy_mode/index.md
+++ b/files/en-us/glossary/sloppy_mode/index.md
@@ -13,4 +13,4 @@ The normal, non-strict mode of JavaScript is sometimes referred to as **sloppy m
 
 ## See also
 
-- "[Strict Mode](https://exploringjs.com/es5/ch01.html#_strict_mode)" in chapter 7 ("JavaScript Syntax") in the book Speaking _JavaScript_.
+- "[Strict Mode](https://exploringjs.com/es5/ch07.html#_strict_mode)" in chapter 7 ("JavaScript Syntax") in the book Speaking _JavaScript_.

--- a/files/en-us/glossary/sloppy_mode/index.md
+++ b/files/en-us/glossary/sloppy_mode/index.md
@@ -13,4 +13,4 @@ The normal, non-strict mode of JavaScript is sometimes referred to as **sloppy m
 
 ## See also
 
-- "[Strict Mode](http://speakingjs.com/es5/ch07.html#strict_mode)" in chapter 7 ("JavaScript Syntax") in the book Speaking _JavaScript_.
+- "[Strict Mode](https://exploringjs.com/es5/ch01.html#_strict_mode)" in chapter 7 ("JavaScript Syntax") in the book Speaking _JavaScript_.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes a broken link in https://developer.mozilla.org/en-US/docs/Glossary/Sloppy_mode.

SpeakingJS has moved to ExploringJS.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Developers can get confused by the 404. This PR fixes that.

### Additional details

N/A

### Related issues and pull requests

N/A