### PR TITLE
Doc trailing whitespace stripping for parse functions

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -25,7 +25,7 @@ Number.parseFloat(string)
 ### Parameters
 
 - `string`
-  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
+  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument is ignored.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -25,7 +25,7 @@ Number.parseFloat(string)
 ### Parameters
 
 - `string`
-  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading {{glossary("whitespace")}} in this argument is ignored.
+  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
@@ -27,7 +27,7 @@ Number.parseInt(string, radix)
 ### Parameters
 
 - `string`
-  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading whitespace in this argument is ignored.
+  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing whitespace in this argument is ignored.
 - `radix` {{optional_inline}}
 
   - : An integer between `2` and `36` that represents the

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -23,7 +23,7 @@ parseFloat(string)
 ### Parameters
 
 - `string`
-  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
+  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument is ignored.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -23,7 +23,7 @@ parseFloat(string)
 ### Parameters
 
 - `string`
-  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading {{glossary("whitespace")}} in this argument is ignored.
+  - : The value to parse, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
 
 ### Return value
 
@@ -37,7 +37,7 @@ The `parseFloat` function converts its first argument to a string, parses that s
 
 - The characters accepted by `parseFloat()` are plus sign (`+`), minus sign (`-` U+002D HYPHEN-MINUS), decimal digits (`0`–`9`), decimal point (`.`), exponent indicator (`e` or `E`), and the `"Infinity"` literal.
 - The `+`/`-` signs can only appear strictly at the beginning of the string, or immediately following the `e`/`E` character. The decimal point can only appear once, and only before the `e`/`E` character. The `e`/`E` character can only appear once, and only if there is at least one digit before it.
-- Leading spaces in the argument are trimmed and ignored.
+- Leading and trailing spaces in the argument are trimmed and ignored.
 - `parseFloat()` can also parse and return {{jsxref("Infinity")}} or `-Infinity` if the string starts with `"Infinity"` or `"-Infinity"` preceded by none or more white spaces.
 - `parseFloat()` picks the longest substring starting from the beginning that generates a valid number literal. If it encounters an invalid character, it returns the number represented up to that point, ignoring the invalid character and all characters following it.
 - If the argument's first character can't start a legal number literal per the syntax above, `parseFloat` returns {{jsxref("NaN")}}.

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -25,7 +25,7 @@ parseInt(string, radix)
 ### Parameters
 
 - `string`
-  - : A string starting with an integer. Leading {{glossary("whitespace")}} in this argument is ignored.
+  - : A string starting with an integer. Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
 - `radix` {{optional_inline}}
 
   - : An integer between `2` and `36` that represents the _radix_ (the base in mathematical numeral systems) of the `string`. It is converted to a [32-bit integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#fixed-width_number_conversion); if it's outside the range of \[2, 36] after conversion, the function will always return `NaN`. If `0` or not provided, the radix will be inferred based on `string`'s value. Be careful — this does NOT always default to `10`! The [description below](#description) explains in more detail what happens when `radix` is not provided.
@@ -90,6 +90,7 @@ parseInt("15 * 3", 10);
 parseInt("15e2", 10);
 parseInt("15px", 10);
 parseInt("12", 13);
+parseInt("   15 ");
 ```
 
 The following examples all return `NaN`:
@@ -97,6 +98,7 @@ The following examples all return `NaN`:
 ```js
 parseInt("Hello", 8); // Not a number at all
 parseInt("546", 2); // Digits other than 0 or 1 are invalid for binary radix
+parseInt("   "); // At least one digit required
 ```
 
 The following examples all return `-15`:

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -25,7 +25,7 @@ parseInt(string, radix)
 ### Parameters
 
 - `string`
-  - : A string starting with an integer. Leading and trailing {{glossary("whitespace")}} in this argument are ignored.
+  - : A string starting with an integer. Leading and trailing {{glossary("whitespace")}} in this argument is ignored.
 - `radix` {{optional_inline}}
 
   - : An integer between `2` and `36` that represents the _radix_ (the base in mathematical numeral systems) of the `string`. It is converted to a [32-bit integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#fixed-width_number_conversion); if it's outside the range of \[2, 36] after conversion, the function will always return `NaN`. If `0` or not provided, the radix will be inferred based on `string`'s value. Be careful — this does NOT always default to `10`! The [description below](#description) explains in more detail what happens when `radix` is not provided.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

The ECMA standard indicates abstract function TrimString is applied to parse function inputs and that indicate leading and tariling whitespace stripping but the current doc only indiates leading whitespace stripping.

<!-- ✍️ Summarize your changes in one or two sentences -->

Add the phrase "and trailing" to the whitespace qualifier in a few places and add a couple of examples.

<!-- ❓ Why are you making these changes and how do they help readers? -->

So readers don't have to experiment with trailing spaces in piuzzlement. 

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
