### PR TITLE
The letter "y" is not a vowel.

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -373,10 +373,10 @@ console.table(nonEnglishText.match(regexpBMPWord));
 
 ```js
 const aliceExcerpt = "There was a long silence after this, and Alice could only hear whispers now and then.";
-const regexpVowels = /[AEIOUYaeiouy]/g;
+const regexpVowels = /[AEIOUaeiou]/g;
 
 console.log("Number of vowels:", aliceExcerpt.match(regexpVowels).length);
-// Number of vowels: 26
+// Number of vowels: 25
 ```
 
 ## See also


### PR DESCRIPTION
If the title is "Counting vowels", the regular expression should not include the letter "y".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
