### PR TITLE
Gedit no longer default on Ubuntu 22.10

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -22,7 +22,7 @@ In this article, we'll set you up with the bare minimum — a text editor and so
 
 ### Installing a text editor
 
-You probably already have a basic text editor on your computer. By default Windows includes [Notepad](https://en.wikipedia.org/wiki/Microsoft_Notepad) and macOS comes with [TextEdit](https://en.wikipedia.org/wiki/TextEdit). Linux distros vary; Ubuntu comes with [gedit](https://en.wikipedia.org/wiki/Gedit) by default.
+You probably already have a basic text editor on your computer. By default Windows includes [Notepad](https://en.wikipedia.org/wiki/Microsoft_Notepad) and macOS comes with [TextEdit](https://en.wikipedia.org/wiki/TextEdit). Linux distros vary; Ubuntu comes with [GNOME Text Editor](https://en.wikipedia.org/wiki/GNOME_Text_Editor) by default.
 
 For web development, you can probably do better than Notepad or TextEdit. We recommend starting with [Visual Studio Code](https://code.visualstudio.com/), which is a free editor, that offers live previews and code hints.
 

--- a/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -22,7 +22,7 @@ In this article, we'll set you up with the bare minimum — a text editor and so
 
 ### Installing a text editor
 
-You probably already have a basic text editor on your computer. By default Windows includes [Notepad](https://en.wikipedia.org/wiki/Microsoft_Notepad) and macOS comes with [TextEdit](https://en.wikipedia.org/wiki/TextEdit). Linux distros vary; Ubuntu comes with [GNOME Text Editor](https://en.wikipedia.org/wiki/GNOME_Text_Editor) by default.
+You probably already have a basic text editor on your computer. By default Windows includes [Notepad](https://en.wikipedia.org/wiki/Microsoft_Notepad) and macOS comes with [TextEdit](https://en.wikipedia.org/wiki/TextEdit). Linux distros vary; the Ubuntu 22.04 LTS release comes with [GNOME Text Editor](https://en.wikipedia.org/wiki/GNOME_Text_Editor) by default.
 
 For web development, you can probably do better than Notepad or TextEdit. We recommend starting with [Visual Studio Code](https://code.visualstudio.com/), which is a free editor, that offers live previews and code hints.
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Ubuntu 22.10 is scheduled to be released on October 20, 2022. It comes with a new default text editor, aptly named GNOME Text Editor. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Users who install Ubuntu 22.10 will have difficulty finding gedit, because Ubuntu will not include gedit in the default installation going forward. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
