### PR TITLE
Add MediaStreamTrack.contentHint

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/contenthint/index.md
+++ b/files/en-us/web/api/mediastreamtrack/contenthint/index.md
@@ -12,8 +12,6 @@ tags:
 browser-compat: api.MediaStreamTrack.contentHint
 ---
 
-{{MDNSidebar}}
-
 {{APIRef("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.contentHint`** property returns and sets a string that may be used by the web application to provide a hint as to what type of content the track contains to guide how it should be treated by API consumers. Allowable values depend on the value of the {{domxref("MediaStreamTrack.kind")}} property.

--- a/files/en-us/web/api/mediastreamtrack/contenthint/index.md
+++ b/files/en-us/web/api/mediastreamtrack/contenthint/index.md
@@ -1,0 +1,68 @@
+---
+title: MediaStreamTrack.contentHint
+slug: Web/API/MediaStreamTrack/contentHint
+page-type: web-api-instance-property
+tags:
+  - Media Capture and Streams
+  - MediaStreamTrack
+  - Property
+  - Read-only
+  - Reference
+  - WebRTC
+browser-compat: api.MediaStreamTrack.contentHint
+---
+
+{{MDNSidebar}}
+
+{{APIRef("Media Capture and Streams")}}
+
+The **`MediaStreamTrack.contentHint`** property returns and sets a string that may be used by the web application to provide a hint as to what type of content the track contains to guide how it should be treated by API consumers. Allowable values depend on the value of the {{domxref("MediaStreamTrack.kind")}} property.
+
+## Value
+
+A string with one of the following values:
+
+- `""`
+  - : No `contentHint` has been set.
+- `"speech"`
+  - : The track should be treated as if it contains speech data. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"audio"`.
+- `"speech-recognition"`
+  - : The track should be treated as if it contains data for the purpose of speech recognition by a machine. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"audio"`.
+- `"music"`
+  - : The track should be treated as if it contains music. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"audio"`.
+- `"motion"`
+  - : The track should be treated as if it contains video where motion is important. For example, webcam video, movies or video games. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"video"`.
+- `"detail"`
+  - : The track should be treated as if video details are extra important. For example, presentations or web pages with text content, painting or line art. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"video"`.
+- `"text"`
+  - : The track should be treated as if video details are extra important, and that significant sharp edges and areas of consistent color can occur frequently. For example, presentations or web pages with text content. When setting this value, the value of {{domxref("MediaStreamTrack.kind")}} must be `"video"`.
+
+## Examples
+
+### A function that sets the contentHint
+
+This function takes a stream and a `contentHint` value, and applies the hint to each track. [See the full example here](https://webrtc.github.io/samples/src/content/capture/video-contenthint/), showing how different `contentHint` values change how the tracks display.
+
+```js
+function setVideoTrackContentHints(stream, hint) {
+  const tracks = stream.getVideoTracks();
+  tracks.forEach(track => {
+    if ('contentHint' in track) {
+      track.contentHint = hint;
+      if (track.contentHint !== hint) {
+        console.log('Invalid video track contentHint: \'' + hint + '\'');
+      }
+    } else {
+      console.log('MediaStreamTrack contentHint attribute not supported');
+    }
+  });
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mediastreamtrack/contenthint/index.md
+++ b/files/en-us/web/api/mediastreamtrack/contenthint/index.md
@@ -46,14 +46,14 @@ This function takes a stream and a `contentHint` value, and applies the hint to 
 ```js
 function setVideoTrackContentHints(stream, hint) {
   const tracks = stream.getVideoTracks();
-  tracks.forEach(track => {
-    if ('contentHint' in track) {
+  tracks.forEach((track) => {
+    if ("contentHint" in track) {
       track.contentHint = hint;
       if (track.contentHint !== hint) {
-        console.log('Invalid video track contentHint: \'' + hint + '\'');
+        console.log(`Invalid video track contentHint: "${hint}"`);
       }
     } else {
-      console.log('MediaStreamTrack contentHint attribute not supported');
+      console.log("MediaStreamTrack contentHint attribute not supported");
     }
   });
 }

--- a/files/en-us/web/api/mediastreamtrack/contenthint/index.md
+++ b/files/en-us/web/api/mediastreamtrack/contenthint/index.md
@@ -48,10 +48,10 @@ function setVideoTrackContentHints(stream, hint) {
     if ("contentHint" in track) {
       track.contentHint = hint;
       if (track.contentHint !== hint) {
-        console.log(`Invalid video track contentHint: "${hint}"`);
+        console.error(`Invalid video track contentHint: "${hint}"`);
       }
     } else {
-      console.log("MediaStreamTrack contentHint attribute not supported");
+      console.error("MediaStreamTrack contentHint attribute not supported");
     }
   });
 }

--- a/files/en-us/web/api/mediastreamtrack/contenthint/index.md
+++ b/files/en-us/web/api/mediastreamtrack/contenthint/index.md
@@ -14,7 +14,7 @@ browser-compat: api.MediaStreamTrack.contentHint
 
 {{APIRef("Media Capture and Streams")}}
 
-The **`MediaStreamTrack.contentHint`** property returns and sets a string that may be used by the web application to provide a hint as to what type of content the track contains to guide how it should be treated by API consumers. Allowable values depend on the value of the {{domxref("MediaStreamTrack.kind")}} property.
+The **`MediaStreamTrack.contentHint`** property is a string that hints at the type of content the track contains. Allowable values depend on the value of the {{domxref("MediaStreamTrack.kind")}} property.
 
 ## Value
 


### PR DESCRIPTION
### Description

Adding the missing MediaStreamTrack.contentHint property.

### Motivation

This property was missing from the docs, though already has accurate compat data.

### Additional details

https://w3c.github.io/mst-content-hint/#mediastreamtrack-extension


