### PR TITLE
Web/HTML: Add/correct sidebars

### DIFF
--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -14,7 +14,7 @@ tags:
   - Web
 ---
 
-{{HTMLSidebar}}
+{{HTMLSidebar("Attributes")}}
 
 Elements in HTML have **attributes**; these are additional values that configure the elements or adjust their behavior in various ways to meet the criteria the users want.
 
@@ -1172,7 +1172,7 @@ Elements in HTML have **attributes**; these are additional values that configure
       <td>{{ HTMLElement("ol") }}</td>
       <td>
         Indicates whether the list should be displayed in a descending order
-        instead of a ascending.
+        instead of an ascending order.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/block-level_elements/index.md
+++ b/files/en-us/web/html/block-level_elements/index.md
@@ -9,6 +9,8 @@ tags:
   - Web
 ---
 
+{{HTMLSidebar}}
+
 In this article, we'll examine HTML block-level elements and how they differ from [inline-level elements](/en-US/docs/Web/HTML/Inline_elements).
 
 HTML (**HyperText Markup Language**) elements historically were categorized as either "block-level" elements or "inline-level" elements. Since this is a presentational characteristic it is nowadays specified by CSS in the [Flow Layout](/en-US/docs/Web/CSS/CSS_Flow_Layout). A Block-level element occupies the entire horizontal space of its parent element (container), and vertical space equal to the height of its contents, thereby creating a "block".
@@ -53,7 +55,7 @@ There are a couple of key differences between block-level elements and inline el
 - Default formatting
   - : By default, block-level elements begin on new lines, but inline elements can start anywhere in a line.
 
-The distinction of block-level vs. inline elements was used in HTML specifications up to 4.01. Later, this binary distinction is replaced with a more complex set of [content categories](/en-US/docs/Web/Guide/HTML/Content_categories). While the "inline" category roughly corresponds to the category of [phrasing content](/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content), the "block-level" category doesn't directly correspond to any HTML content category, but _"block-level" and "inline" elements combined together_ correspond to the [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) in HTML. There are also additional categories, e.g. [interactive content](/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content).
+The distinction of block-level vs. inline elements was used in HTML specifications up to 4.01. Later, this binary distinction is replaced with a more complex set of [content categories](/en-US/docs/Web/Guide/HTML/Content_categories). While the "inline" category roughly corresponds to the category of [phrasing content](/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content), the "block-level" category doesn't directly correspond to any HTML content category, but _"block-level" and "inline" elements combined_ correspond to the [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) in HTML. There are also additional categories, e.g. [interactive content](/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content).
 
 ## Elements
 
@@ -121,5 +123,3 @@ The following is a complete list of all HTML "block-level" elements (although "b
 - [Inline elements](/en-US/docs/Web/HTML/Inline_elements)
 - {{cssxref("display")}}
 - [Block and Inline Layout in Normal Flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/HTML/")}}

--- a/files/en-us/web/html/cors_enabled_image/index.md
+++ b/files/en-us/web/html/cors_enabled_image/index.md
@@ -13,6 +13,8 @@ tags:
   - data
 ---
 
+{{HTMLSidebar}}
+
 HTML provides a {{ htmlattrxref("crossorigin", "img") }} attribute for images that, in combination with an appropriate {{Glossary("CORS")}} header, allows images defined by the {{ HTMLElement("img") }} element that are loaded from foreign origins to be used in a {{HTMLElement("canvas")}} as if they had been loaded from the current origin.
 
 See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details on how the `crossorigin` attribute is used.
@@ -32,11 +34,11 @@ Calling any of the following on a tainted canvas will result in an error:
 - Calling {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}} on the canvas's context
 - Calling {{domxref("HTMLCanvasElement.toBlob", "toBlob()")}}, {{domxref("HTMLCanvasElement.toDataURL", "toDataURL()")}} or {{domxref("HTMLCanvasElement.captureStream", "captureStream()")}} on the {{HTMLElement("canvas")}} element itself
 
-Attempting any of these when the canvas is tainted will cause a `SecurityError` to be thrown. This protects users from having private data exposed by using images to pull information from remote web sites without permission.
+Attempting any of these when the canvas is tainted will cause a `SecurityError` to be thrown. This protects users from having private data exposed by using images to pull information from remote websites without permission.
 
 ## Storing an image from a foreign origin
 
-In this example, we wish to permit images from a foreign origin to be retrieved and saved to local storage. Implementing this requires configuring the server as well as writing code for the web site itself.
+In this example, we wish to permit images from a foreign origin to be retrieved and saved to local storage. Implementing this requires configuring the server as well as writing code for the website itself.
 
 ### Web server configuration
 
@@ -119,5 +121,3 @@ Now it's time to actually save the image locally. To do this, we use the Web Sto
 - [Using Cross-domain images in WebGL and Chrome 13](https://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html)
 - [HTML Specification - the `crossorigin` attribute](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin)
 - [Web Storage API](/en-US/docs/Web/API/Web_Storage_API)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/HTML/")}}

--- a/files/en-us/web/html/date_and_time_formats/index.md
+++ b/files/en-us/web/html/date_and_time_formats/index.md
@@ -20,7 +20,7 @@ tags:
   - week-year
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Certain HTML elements use date and/or time values. The formats of the strings that specify these values are described in this article.
 

--- a/files/en-us/web/html/element/index.md
+++ b/files/en-us/web/html/element/index.md
@@ -10,7 +10,7 @@ tags:
   - "l10n:priority"
 ---
 
-{{HTMLSidebar("Elements")}}
+{{HTMLSidebar("HTML_Elements")}}
 
 This page lists all the {{Glossary("HTML")}} {{Glossary("Element","elements")}}, which are created using {{Glossary("Tag", "tags")}}.
 
@@ -117,7 +117,7 @@ The elements here are used to create and handle tabular data.
 
 ## Forms
 
-HTML provides a number of elements which can be used together to create forms which the user can fill out and submit to the Web site or application. There's a great deal of further information about this available in the [HTML forms guide](/en-US/docs/Learn/Forms).
+HTML provides a number of elements which can be used together to create forms which the user can fill out and submit to the Website or application. There's a great deal of further information about this available in the [HTML forms guide](/en-US/docs/Learn/Forms).
 
 {{HTMLRefTable({"include": ["HTML forms"], "exclude":["Deprecated"]})}}
 

--- a/files/en-us/web/html/element/index.md
+++ b/files/en-us/web/html/element/index.md
@@ -117,7 +117,7 @@ The elements here are used to create and handle tabular data.
 
 ## Forms
 
-HTML provides a number of elements which can be used together to create forms which the user can fill out and submit to the Website or application. There's a great deal of further information about this available in the [HTML forms guide](/en-US/docs/Learn/Forms).
+HTML provides a number of elements which can be used together to create forms which the user can fill out and submit to the website or application. There's a great deal of further information about this available in the [HTML forms guide](/en-US/docs/Learn/Forms).
 
 {{HTMLRefTable({"include": ["HTML forms"], "exclude":["Deprecated"]})}}
 

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -15,7 +15,7 @@ tags:
 browser-compat: html.elements.input
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<input>`** [HTML](/en-US/docs/Web/HTML) element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and {{Glossary("user agent")}}. The `<input>` element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes.
 
@@ -619,7 +619,7 @@ The following non-standard attributes are also available on some browsers. As a 
     <tr>
       <td><a href="#autocorrect"><code>autocorrect</code></a></td>
       <td>
-        A string indicating whether or not autocorrect is <code>on</code> or <code>off</code>. <strong>Safari only.</strong>
+        A string indicating whether autocorrect is <code>on</code> or <code>off</code>. <strong>Safari only.</strong>
       </td>
     </tr>
     <tr>
@@ -657,7 +657,7 @@ The following non-standard attributes are also available on some browsers. As a 
         <a href="#webkitdirectory"><code>webkitdirectory</code></a>
       </td>
       <td>
-        A Boolean indicating whether or not to only allow the user to choose a directory (or directories, if <a href="#multiple"><code>multiple</code></a> is also present)
+        A Boolean indicating whether to only allow the user to choose a directory (or directories, if <a href="#multiple"><code>multiple</code></a> is also present)
       </td>
     </tr>
   </tbody>
@@ -764,7 +764,7 @@ Inputs, being replaced elements, have a few features not applicable to non form 
       <td>{{Cssxref(":placeholder-shown")}}</td>
       <td>
         Element that is currently displaying <a href="#placeholder"><code>placeholder</code> text</a>,
-        including <code>&#x3C;input></code> and {{HTMLElement("textarea")}} elements with the <a href="#placeholder"><code>placeholder</code></a> attribute present that has, as of yet, no value.
+        including <code>&#x3C;input></code> and {{HTMLElement("textarea")}} elements with the <a href="#placeholder"><code>placeholder</code></a> attribute present that has, as yet, no value.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -11,6 +11,8 @@ tags:
   - Reference
 ---
 
+{{HTMLSidebar}}
+
 In this article, we'll examine HTML inline-level elements and how they differ from [block-level elements](/en-US/docs/Web/HTML/Block-level_elements).
 
 HTML (**HyperText Markup Language**) elements historically were categorized as either "block-level" elements or "inline-level" elements. Since this is a presentational characteristic it is nowadays specified by CSS in the [Flow Layout](/en-US/docs/Web/CSS/CSS_Flow_Layout).
@@ -171,5 +173,3 @@ The following elements are inline by default (although block and inline elements
 - {{cssxref("display")}}
 - [Content categories](/en-US/docs/Web/Guide/HTML/Content_categories)
 - [Block and Inline Layout in Normal Flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/HTML/")}}

--- a/files/en-us/web/html/link_types/index.md
+++ b/files/en-us/web/html/link_types/index.md
@@ -341,7 +341,7 @@ In HTML, link types indicate the relationship between two documents, in which on
       </td>
       <td>
         Indicates that the current document is represented by the person to which
-        the me value links. The me value is commonly used in distributed forms
+        the `me` value links. The `me` value is commonly used in distributed forms
         of verification such as <a href="https://microformats.org/wiki/RelMeAuth">
         RelMeAuth</a>.
       </td>
@@ -504,7 +504,7 @@ In HTML, link types indicate the relationship between two documents, in which on
       </td>
       <td>
         Provides a hint to the browser suggesting that it open a connection to
-        the linked web site in advance, without disclosing any private
+        the linked website in advance, without disclosing any private
         information or downloading any content, so that when the link is
         followed the linked content can be fetched more quickly.
       </td>

--- a/files/en-us/web/html/microdata/index.md
+++ b/files/en-us/web/html/microdata/index.md
@@ -11,6 +11,8 @@ tags:
   - Search
 ---
 
+{{HTMLSidebar}}
+
 Microdata is part of the {{glossary("WHATWG")}} HTML Standard and is used to nest metadata within existing content on web pages. Search engines and web crawlers can extract and process microdata from a web page and use it to provide a richer browsing experience for users. Search engines benefit greatly from direct access to this structured data because it allows search engines to understand the information on web pages and provide more relevant results to users. Microdata uses a supporting vocabulary to describe an item and name-value pairs to assign values to its properties. Microdata is an attempt to provide a simpler way of annotating HTML elements with machine-readable tags than the similar approaches of using RDFa and classic microformats.
 
 At a high level, microdata consists of a group of name-value pairs. The groups are called items, and each name-value pair is a property. Items and properties are represented by regular elements.
@@ -159,5 +161,3 @@ Supported in Firefox 16. Removed in Firefox 49.
 ## See also
 
 - [Global Attributes](/en-US/docs/Web/HTML/Global_attributes)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/HTML")}}

--- a/files/en-us/web/html/microformats/index.md
+++ b/files/en-us/web/html/microformats/index.md
@@ -27,7 +27,7 @@ There are [open source parsing libraries for most languages](https://microformat
 
 ## How Microformats Work
 
-An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use a [h-card](https://microformats.org/wiki/h-card) such as:
+An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use an [h-card](https://microformats.org/wiki/h-card) such as:
 
 ### HTML Example
 

--- a/files/en-us/web/html/microformats/index.md
+++ b/files/en-us/web/html/microformats/index.md
@@ -12,6 +12,8 @@ tags:
   - Search
 ---
 
+{{HTMLSidebar}}
+
 [_Microformats_](https://microformats.org/) are standards used to embed semantics and structured data in HTML, and provide an API to be used by social web applications, search engines, aggregators, and other tools. These minimal patterns of HTML are used for marking up entities that range from fundamental to domain-specific information, such as people, organizations, events, and locations.
 
 - To create a microformats object, h-\* class names are used in the class attribute.
@@ -25,7 +27,7 @@ There are [open source parsing libraries for most languages](https://microformat
 
 ## How Microformats Work
 
-An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use an [h-card](https://microformats.org/wiki/h-card) such as:
+An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use a [h-card](https://microformats.org/wiki/h-card) such as:
 
 ### HTML Example
 
@@ -51,7 +53,7 @@ In addition to being machine-readable, microformats are designed to be easily re
 
 All microformats consist of a root, and a collection of properties. Properties are all optional and potentially multivalued - applications needing a singular value may use the first instance of a property. Hierarchical data is represented with nested microformats, typically as property values themselves.
 
-All microformats class names use prefixes. Prefixes are **syntax independent from vocabularies**, which are developed separately.
+All microformats class names use prefixes. Prefixes are **syntax independent of vocabularies**, which are developed separately.
 
 - **"h-\*" for root class names**, e.g. "h-card", "h-entry", "h-feed", and many more. These top-level root classes usually indicate a type and corresponding expected vocabulary of properties. For example:
 
@@ -187,6 +189,7 @@ Example h-entry as a blog post:
       <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">
         <img
           class="u-photo"
+          alt="Greg McVerry"
           src="https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg" />
       </a>
       <a
@@ -225,10 +228,18 @@ Example h-entry as a blog post:
     {
       "type": [ "h-entry" ],
       "properties": {
-        "in-reply-to": [ "https://developer.mozilla.org/en-US/docs/Web/HTML/microformats" ],
-        "name": [ "Hey thanks for making this microformats resource" ],
-        "url": [ "https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource" ],
-        "published": [ "2019-05-31T14:19:09+0000" ],
+        "in-reply-to": [
+          "https://developer.mozilla.org/en-US/docs/Web/HTML/microformats"
+        ],
+        "name": [
+          "Hey thanks for making this microformats resource"
+        ],
+        "url": [
+          "https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource"
+        ],
+        "published": [
+          "2019-05-31T14:19:09+0000"
+        ],
         "content": [
           {
             "html": "Hey thanks for making this microformats resource",
@@ -241,8 +252,12 @@ Example h-entry as a blog post:
             "type": [ "h-card" ],
             "properties": {
               "name": [ "Greg McVerry" ],
-              "photo": [ "https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg" ],
-              "url": [ "https://quickthoughts.jgregorymcverry.com/profile/jgmac1106" ]
+              "photo": [
+                "https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg"
+              ],
+              "url": [
+                "https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
+              ]
             },
             "lang": "en",
             "value": "Greg McVerry"
@@ -251,6 +266,8 @@ Example h-entry as a blog post:
       },
       "lang": "en"
     }
+  ]
+}
 ```
 
 ### h-feed
@@ -364,24 +381,42 @@ The `h-event` is for events on the web. h-event is often used with both event li
 {
   "items": [
     {
-      "type": [ "h-event" ],
+      "type": [
+        "h-event"
+      ],
       "properties": {
-        "name": [ "IndieWeb Summit" ],
-        "url": [ "https://aaronparecki.com/2019/06/29/1/" ],
+        "name": [
+          "IndieWeb Summit"
+        ],
+        "url": [
+          "https://aaronparecki.com/2019/06/29/1/"
+        ],
         "author": [
           {
-            "type": [ "h-card" ],
+            "type": [
+              "h-card"
+            ],
             "properties": {
-              "name": [ "Aaron Parecki" ],
-              "url": [ "https://aaronparecki.com"]
+              "name": [
+                "Aaron Parecki"
+              ],
+              "url": [
+                "https://aaronparecki.com"
+              ]
             },
             "lang": "en",
             "value": "Aaron Parecki"
           }
         ],
-        "start": [ "2019-06-29T09:00:00-07:00" ],
-        "end": [ "2019-06-30T18:00:00-07:00" ],
-        "published": [ "2019-05-25T18:00:00-07:00" ],
+        "start": [
+          "2019-06-29T09:00:00-07:00"
+        ],
+        "end": [
+          "2019-06-30T18:00:00-07:00"
+        ],
+        "published": [
+          "2019-05-25T18:00:00-07:00"
+        ],
         "content": [
           {
             "html": "Come join us",
@@ -391,15 +426,31 @@ The `h-event` is for events on the web. h-event is often used with both event li
         ],
         "location": [
           {
-            "type": [ "h-card" ],
+            "type": [
+              "h-card"
+            ],
             "properties": {
-              "name": [ "Mozilla" ],
-              "p-street-address": [ "1120 NW Couch St" ]
-              "locality": [ "Portland" ],
-              "region": [ "Oregon" ],
-              "country": [ "US" ],
-              "latitude": [ "45.52345" ],
-              "longitude": [ "-122.682677" ]
+              "name": [
+                "Mozilla"
+              ],
+              "p-street-address": [
+                "1120 NW Couch St"
+              ],
+              "locality": [
+                "Portland"
+              ],
+              "region": [
+                "Oregon"
+              ],
+              "country": [
+                "US"
+              ],
+              "latitude": [
+                "45.52345"
+              ],
+              "longitude": [
+                "-122.682677"
+              ]
             },
             "lang": "en",
             "value": "Mozilla"
@@ -408,7 +459,8 @@ The `h-event` is for events on the web. h-event is often used with both event li
       },
       "lang": "en"
     }
-  ],
+  ]
+}
 ```
 
 ## Microformats rel property examples
@@ -441,7 +493,7 @@ This attribute states that the linked document should not be given any weight by
 
 ## Browser compatibility
 
-Supported in all browsers's support for the class attribute and its DOM API.
+Supported in all browsers' support for the class attribute and its DOM API.
 
 ## See also
 

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -11,7 +11,7 @@ tags:
   - XHTML
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 In the old days of the web, pages were typically written in two versions: One for Netscape Navigator, and one for Microsoft Internet Explorer. When the web standards were made at W3C, browsers could not just start using them, as doing so would break most existing sites on the web. Browsers therefore introduced two modes to treat new standards compliant sites differently from old legacy sites.
 
@@ -42,7 +42,7 @@ See also a detailed description of [when different browsers choose various modes
 
 ### XHTML
 
-If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use full standards mode. Note however that serving your pages as `application/xhtml+xml` will cause Internet Explorer 8 to show a download dialog box for an unknown format instead of displaying your page, as the first version of Internet Explorer with support for XHTML is Internet Explorer 9.
+If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use 'full standards mode'. Note however that serving your pages as `application/xhtml+xml` will cause Internet Explorer 8 to show a download dialog box for an unknown format instead of displaying your page, as the first version of Internet Explorer with support for XHTML is Internet Explorer 9.
 
 If you serve XHTML-like content using the `text/html` MIME type, browsers will read it as HTML, and you will need the DOCTYPE to use standards mode.
 

--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -52,7 +52,7 @@ The basic properties of the "viewport" `<meta>` tag include:
 
 ## Screen density
 
-Screen resolutions have risen to the size that individual pixels are indistinguishable by the human eye. For example, smartphones often have small screens with resolutions upwards of 1920—1080 pixels (\~400 dpi). Because of this, many browsers can display their pages in a smaller physical size by translating multiple hardware pixels for each CSS "pixel". Initially, this caused usability and readability problems on many touch-optimized web sites.
+Screen resolutions have risen to the size that individual pixels are indistinguishable by the human eye. For example, smartphones often have small screens with resolutions upwards of 1920—1080 pixels (\~400 dpi). Because of this, many browsers can display their pages in a smaller physical size by translating multiple hardware pixels for each CSS "pixel". Initially, this caused usability and readability problems on many touch-optimized websites.
 
 On high dpi screens, pages with `initial-scale=1` will effectively be zoomed by browsers. Their text will be smooth and crisp, but their bitmap images may not take advantage of the full screen resolution. To get sharper images on these screens, web developers may want to design images – or whole layouts – at a higher scale than their final size and then scale them down using CSS or viewport properties.
 


### PR DESCRIPTION
The PR
- adds missing sidebar to microformats page
- replaces `QuickLinksWithSubpages` with `ListSubpages`. The quicklinks macro is adding a lot of uncollapsible stuff to the sidebars making them less reader friendly. With `ListSubpages` macro the sidebars are conscise.
- fixes syntax errors in json code blocks
- fixes typos