### PR TITLE
fix: Remove CODE tags from macros

### DIFF
--- a/files/en-us/web/api/htmlparamelement/index.md
+++ b/files/en-us/web/api/htmlparamelement/index.md
@@ -28,7 +28,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLParamElement.type")}} {{Deprecated_Inline}}
   - : A string containing the type of the parameter when `valueType` has the `"ref"` value. It reflects the {{htmlattrxref("type", "param")}} attribute.
 - {{domxref("HTMLParamElement.valueType")}} {{Deprecated_Inline}}
-  - : A string containing the type of the `value`. It reflects the {{htmlattrxref("<code>valuetype</code>", "param")}} attribute and has one of the values: `"data"`, `"ref"`, or `"object"`.
+  - : A string containing the type of the `value`. It reflects the [valuetype](/en-US/docs/Web/HTML/Element/param#attr-valuetype) attribute and has one of the values: `"data"`, `"ref"`, or `"object"`.
 
 ## Instance methods
 

--- a/files/en-us/web/api/rtcsctptransport/index.md
+++ b/files/en-us/web/api/rtcsctptransport/index.md
@@ -27,7 +27,7 @@ Possibly the most useful property on this interface is its {{DOMxRef("RTCSctpTra
 _Also inherits properties from: {{DOMxRef("EventTarget")}}_.
 
 - {{DOMxRef("RTCSctpTransport.maxChannels")}} {{ReadOnlyInline}}
-  - : An integer value indicating the maximum number of [`RTCDataChannel`s](/en-US/docs/Web/API/RTCDataChannel) that can be open simultaneously.
+  - : An integer value indicating the maximum number of [`RTCDataChannel`](/en-US/docs/Web/API/RTCDataChannel) objects that can be opened simultaneously.
 - {{DOMxRef("RTCSctpTransport.maxMessageSize")}} {{ReadOnlyInline}}
   - : An integer value indicating the maximum size, in bytes, of a message which can be sent using the {{DOMxRef("RTCDataChannel.send()")}} method.
 - {{DOMxRef("RTCSctpTransport.state")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/rtcsctptransport/index.md
+++ b/files/en-us/web/api/rtcsctptransport/index.md
@@ -27,7 +27,7 @@ Possibly the most useful property on this interface is its {{DOMxRef("RTCSctpTra
 _Also inherits properties from: {{DOMxRef("EventTarget")}}_.
 
 - {{DOMxRef("RTCSctpTransport.maxChannels")}} {{ReadOnlyInline}}
-  - : An integer value indicating the maximum number of {{DOMxRef("RTCDataChannel", "<code>RTCDataChannel</code>s", "", 1)}} that can be open simultaneously.
+  - : An integer value indicating the maximum number of [`RTCDataChannel`s](/en-US/docs/Web/API/RTCDataChannel) that can be open simultaneously.
 - {{DOMxRef("RTCSctpTransport.maxMessageSize")}} {{ReadOnlyInline}}
   - : An integer value indicating the maximum size, in bytes, of a message which can be sent using the {{DOMxRef("RTCDataChannel.send()")}} method.
 - {{DOMxRef("RTCSctpTransport.state")}} {{ReadOnlyInline}}

--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -21,7 +21,7 @@ The **`-moz-force-broken-image-icon`** extended CSS property can be used to forc
 ### Values
 
 - {{cssxref("&lt;integer&gt;")}}
-  - : A value of `1` means that the broken image icon is shown even if the image has an {{HTMLElement("img", "<code>alt</code>", "#attr-alt")}} attribute. When the value `0` is used the image will act as usual and only display the `alt` attribute.
+  - : A value of `1` means that the broken image icon is shown even if the image has an [`alt` attribute](/en-US/docs/Web/HTML/Element/img#attr-alt). When the value `0` is used the image will act as usual and only display the `alt` attribute.
 
 > **Note:** Even if the value is set to `1` the `alt` attribute will still be displayed, alongside the broken image icon.
 

--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -21,7 +21,7 @@ The **`-moz-force-broken-image-icon`** extended CSS property can be used to forc
 ### Values
 
 - {{cssxref("&lt;integer&gt;")}}
-  - : A value of `1` means that the broken image icon is shown even if the image has an [`alt` attribute](/en-US/docs/Web/HTML/Element/img#attr-alt). When the value `0` is used the image will act as usual and only display the `alt` attribute.
+  - : A value of `1` means that the broken image icon is shown even if the image has an [`alt`](/en-US/docs/Web/HTML/Element/img#attr-alt) attribute. When the value `0` is used, the image will act as usual and only display the `alt` attribute.
 
 > **Note:** Even if the value is set to `1` the `alt` attribute will still be displayed, alongside the broken image icon.
 

--- a/files/en-us/web/http/feature_policy/index.md
+++ b/files/en-us/web/http/feature_policy/index.md
@@ -51,7 +51,7 @@ A policy is described using a set of individual policy directives. A policy dire
 Feature Policy provides two ways to specify policies to control features:
 
 - The {{httpheader("Feature-Policy")}} HTTP header.
-- The [`allow` attribute](/en-US/docs/Web/HTML/Element/iframe#attributes) on iframes.
+- The [`allow`](/en-US/docs/Web/HTML/Element/iframe#attributes) attribute on iframes.
 
 The primary difference between the HTTP header and the `allow` attribute is that the allow attribute only controls features within an iframe. The header controls features in the response and any embedded content within the page.
 

--- a/files/en-us/web/http/feature_policy/index.md
+++ b/files/en-us/web/http/feature_policy/index.md
@@ -51,7 +51,7 @@ A policy is described using a set of individual policy directives. A policy dire
 Feature Policy provides two ways to specify policies to control features:
 
 - The {{httpheader("Feature-Policy")}} HTTP header.
-- The {{HTMLElement("iframe","<code>allow</code>","#Attributes")}} attribute on iframes.
+- The [`allow` attribute](/en-US/docs/Web/HTML/Element/iframe#attributes) on iframes.
 
 The primary difference between the HTTP header and the `allow` attribute is that the allow attribute only controls features within an iframe. The header controls features in the response and any embedded content within the page.
 
@@ -134,7 +134,7 @@ The features include (see [Features list](/en-US/docs/Web/HTTP/Headers/Feature-P
 
 - [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
 - {{HTTPHeader("Feature-Policy")}} HTTP header
-- {{HTMLElement("iframe","<code>allow</code>","#Attributes")}} attribute on iframes
+- {{HTMLElement("iframe", "allow", "#Attributes")}} attribute on iframes
 - [Introduction to Feature Policy](https://developer.chrome.com/blog/feature-policy/)
 - [Feature policies on www.chromestatus.com](https://chromestatus.com/features#component%3A%20Blink%3EFeaturePolicy)
 - [Feature-Policy Tester (Chrome Developer Tools extension)](https://chrome.google.com/webstore/detail/feature-policy-tester-dev/pchamnkhkeokbpahnocjaeednpbpacop)


### PR DESCRIPTION
Current version works as-is, but works just as well with the native Markdown