### PR TITLE
relnote(106) Add details for font-tech() and font-format() functions

### DIFF
--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -20,6 +20,9 @@ This article provides information about the changes in Firefox 106 that will aff
 
 ### CSS
 
+- The [@supports](/en-US/docs/Web/CSS/@supports) at-rule now supports the `font-tech()` and `font-format()` functions.
+  These functions can be used to test whether a browser supports a given font technology or format and CSS styles can be applied based on the result ({{bug(1786493)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
`@supports` now has support in Fx 106 for:

* `font-tech()` does a user agent support a specific [font technology](https://www.w3.org/TR/css-fonts-4/#font-tech-definitions)?
* `font-format()` does the user agent support certain [font formats](https://www.w3.org/TR/css-fonts-4/#font-format-definitions)?


### Related issues

- [ ] Parent issue: https://github.com/mdn/content/issues/20917