### PR TITLE
Fix typo: replace "exits" with "exist"

### DIFF
--- a/files/en-us/web/exslt/set/intersection/index.md
+++ b/files/en-us/web/exslt/set/intersection/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}
 
-`set:intersection()` returns the intersection of two node-sets. In other words, it returns a node-set containing all the nodes that exits in both `nodeSet1` and `nodeSet2`.
+`set:intersection()` returns the intersection of two node-sets. In other words, it returns a node-set containing all the nodes that exist in both `nodeSet1` and `nodeSet2`.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed minor typo: replaced "exits" with "exist".

### Motivation

Typo correction improves clarity.

### Additional details

N/A

### Related issues and pull requests

N/A