### PR TITLE
Alt attribute: instructions

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -60,6 +60,28 @@ Let's walk through an example:
 6. Now you're ready to create your
    [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
+## Adding alternative text to images
+
+Every `![]` and `<img>` must include `alt` text. Provide short and concise text providing all the relevant information the image conveys to a person who is able to see the image.
+
+Content of `alt` text differ based on the context. For example, if the photo of a dog is the avatar for a Yuckymeat dog food review, `alt="Fluffy"` is appropriate. If the photo is the dog's image on a animal rescue adoption site, the `alt="Fluffy, a tri-color terrier with very short hair, with a tennis ball in her mouth."` is appropriate as image conveys information that is relevant for a prospective dog parent not duplicated in surrounding text. There is rarely a need to describe the image itself. In this scenario, the dog being outdoors with a red collar and a blue leash doesn't add useful information in this context.
+
+Alternative text should include all the information the image conveys that a sighted user can access and is relevant to the context is what needs to be conveyed; nothing more. Keep it short, precise, and useful.
+
+The syntax in markdown:
+
+```html
+![<alt-text>](<url-of-image>)
+<img alt="<alt-text>" src="<url-of-image>">
+```
+
+Examples:
+
+```html
+![OpenWebDocs Logo: Carle the book worm](carle.png)
+<img alt="OpenWebDocs Logo: Carle the book worm" src="carle.png">
+```
+
 ## Compressing images
 
 When you add images to a page on MDN Web Docs, you should make sure that they are compressed as much as possible (without degrading quality) to save on the download size for our readers.

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -81,6 +81,7 @@ Examples:
 ![OpenWebDocs Logo: Carle the book worm](carle.png)
 <img alt="OpenWebDocs Logo: Carle the book worm" src="carle.png">
 ```
+
 While purely decorative images should have an empty `alt`, images added to MDN documentation should have a purpose, and therefore require a non-empty-string description.
 ## Compressing images
 

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -83,6 +83,7 @@ Examples:
 ```
 
 While purely decorative images should have an empty `alt`, images added to MDN documentation should have a purpose, and therefore require a non-empty-string description.
+
 ## Compressing images
 
 When you add images to a page on MDN Web Docs, you should make sure that they are compressed as much as possible (without degrading quality) to save on the download size for our readers.

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -81,7 +81,7 @@ Examples:
 ![OpenWebDocs Logo: Carle the book worm](carle.png)
 <img alt="OpenWebDocs Logo: Carle the book worm" src="carle.png">
 ```
-
+While purely decorative images should have an empty `alt`, images added to MDN documentation should have a purpose, and therefore require a non-empty-string description.
 ## Compressing images
 
 When you add images to a page on MDN Web Docs, you should make sure that they are compressed as much as possible (without degrading quality) to save on the download size for our readers.

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -68,7 +68,7 @@ The content of `alt` text differs based on the context. For example, if the phot
 
 Alternative text should include all the information the image conveys that a sighted user can access and is relevant to the context; nothing more. Keep it short, precise, and useful.
 
-The syntax in markdown:
+The syntax in markdown and HTML:
 
 ```html
 ![<alt-text>](<url-of-image>)

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -62,7 +62,7 @@ Let's walk through an example:
 
 ## Adding alternative text to images
 
-Every `![]` and `<img>` must include `alt` text. Provide short and concise text providing all the relevant information the image conveys to a person who is able to see the image.
+Every image, `![]` and `<img>`, must include `alt` text. Provide short and concise text providing all the relevant information the image conveys. This text is read by those unable to see the image.
 
 Content of `alt` text differ based on the context. For example, if the photo of a dog is the avatar for a Yuckymeat dog food review, `alt="Fluffy"` is appropriate. If the photo is the dog's image on a animal rescue adoption site, the `alt="Fluffy, a tri-color terrier with very short hair, with a tennis ball in her mouth."` is appropriate as image conveys information that is relevant for a prospective dog parent not duplicated in surrounding text. There is rarely a need to describe the image itself. In this scenario, the dog being outdoors with a red collar and a blue leash doesn't add useful information in this context.
 

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -64,7 +64,7 @@ Let's walk through an example:
 
 Every image, `![]` and `<img>`, must include `alt` text. Provide short and concise text providing all the relevant information the image conveys. This text is read by those unable to see the image.
 
-Content of `alt` text differ based on the context. For example, if the photo of a dog is the avatar for a Yuckymeat dog food review, `alt="Fluffy"` is appropriate. If the photo is the dog's image on a animal rescue adoption site, the `alt="Fluffy, a tri-color terrier with very short hair, with a tennis ball in her mouth."` is appropriate as image conveys information that is relevant for a prospective dog parent not duplicated in surrounding text. There is rarely a need to describe the image itself. In this scenario, the dog being outdoors with a red collar and a blue leash doesn't add useful information in this context.
+The content of `alt` text differs based on the context. For example, if the photo of a dog is the avatar for a Yuckymeat dog food review, `alt="Fluffy"` is appropriate. If the photo is the dog's image on an animal rescue adoption site, the `alt="Fluffy, a medium-sized tri-color terrier with very short hair, playing with a chew toy."` is appropriate as the image conveys information relevant for prospective dog parents which is not duplicated in the surrounding text. There is rarely a need to describe the image itself; Fluffy being outdoors with a red collar and a blue leash doesn't add useful information in either context.
 
 Alternative text should include all the information the image conveys that a sighted user can access and is relevant to the context is what needs to be conveyed; nothing more. Keep it short, precise, and useful.
 

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -66,7 +66,7 @@ Every image, `![]` and `<img>`, must include `alt` text. Provide short and conci
 
 The content of `alt` text differs based on the context. For example, if the photo of a dog is the avatar for a Yuckymeat dog food review, `alt="Fluffy"` is appropriate. If the photo is the dog's image on an animal rescue adoption site, the `alt="Fluffy, a medium-sized tri-color terrier with very short hair, playing with a chew toy."` is appropriate as the image conveys information relevant for prospective dog parents which is not duplicated in the surrounding text. There is rarely a need to describe the image itself; Fluffy being outdoors with a red collar and a blue leash doesn't add useful information in either context.
 
-Alternative text should include all the information the image conveys that a sighted user can access and is relevant to the context is what needs to be conveyed; nothing more. Keep it short, precise, and useful.
+Alternative text should include all the information the image conveys that a sighted user can access and is relevant to the context; nothing more. Keep it short, precise, and useful.
 
 The syntax in markdown:
 


### PR DESCRIPTION
Adds how to write a good alt to the MDN writing guidelines.

Fixes https://github.com/mdn/content/issues/20948