### PR TITLE
Fix live sample height to avoid a scrollbar

### DIFF
--- a/files/en-us/web/html/attributes/disabled/index.md
+++ b/files/en-us/web/html/attributes/disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'HTML attribute: disabled'
+title: "HTML attribute: disabled"
 slug: Web/HTML/Attributes/disabled
 tags:
   - Attribute
@@ -118,7 +118,7 @@ When form controls are disabled, many browsers will display them in a lighter, g
 </fieldset>
 ```
 
-{{EmbedLiveSample('Examples', 500, 300)}}
+{{EmbedLiveSample('Examples', 500, 450)}}
 
 ## Specifications
 


### PR DESCRIPTION
The live sample height was too small, giving us a scrollbar: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#examples.