### PR TITLE
Correct presentation of content_security_policy in release notes 106

### DIFF
--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -72,7 +72,7 @@ This article provides information about the changes in Firefox 106 that will aff
 ## Changes for add-on developers
 
 - The ability to set the [`"background"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background) manifest key property `"persistent"` to `false` for Manifest V2 (to make a background page non-persistent) is now available by default.
-- The `object-src` directive in the `"content-security-policy"` manifest key is now optional ({{bug(1766881)}}). See [object-src directive](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#object-src_directive) on the `"content-security-policy"` manifest key page for more details.
+- The `object-src` directive in the `"content_security_policy"` manifest key is now optional ({{bug(1766881)}}). See [object-src directive](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#object-src_directive) on the `"content_security_policy"` manifest key page for more details.
 
 ### Removals
 


### PR DESCRIPTION
### Description

content_security_policy incorrectly presented as content-security-policy in release notes 106