### PR TITLE
more explicit link text

### DIFF
--- a/files/en-us/glossary/cross-site_scripting/index.md
+++ b/files/en-us/glossary/cross-site_scripting/index.md
@@ -15,7 +15,7 @@ These attacks succeed if the Web app does not employ enough validation or encodi
 
 ## See also
 
-- [Type of Attacks : Cross-site scripting (XSS)](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)
+- [Type of Attacks: Cross-site scripting (XSS)](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)
 - [Cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) on Wikipedia
 - [Cross-site scripting on OWASP](https://owasp.org/www-community/attacks/xss/)
 - [Another article about Cross-site scripting](https://www.acunetix.com/blog/articles/dom-xss-explained/)

--- a/files/en-us/glossary/cross-site_scripting/index.md
+++ b/files/en-us/glossary/cross-site_scripting/index.md
@@ -15,7 +15,7 @@ These attacks succeed if the Web app does not employ enough validation or encodi
 
 ## See also
 
-- [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)
+- [Type of Attacks : Cross-site scripting (XSS)](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)
 - [Cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) on Wikipedia
 - [Cross-site scripting on OWASP](https://owasp.org/www-community/attacks/xss/)
 - [Another article about Cross-site scripting](https://www.acunetix.com/blog/articles/dom-xss-explained/)


### PR DESCRIPTION
### Description

More explicit link text.

### Motivation

Prevents link text and current page name to be identical. 

Avoid confusion, as the link doesn't point to the current page.

### Additional details

None

### Related issues and pull requests

None