### PR TITLE
relnote(106) Add details of HTMLMetaElement.media DOM API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -41,8 +41,8 @@ This article provides information about the changes in Firefox 106 that will aff
 
 #### DOM
 
-- The [`HTMLMetaElement.media`](/en-US/docs/Web/API/HTMLMetaElement/media) property is now supported which enables setting different theme colors based on `media` values (e.g. `max-width: 600px`).
-  Meta elements with `media` properties allows the browser to use the `content` value in conjunction with `theme-color` to set the page or UI colors for a given media query ({{bug(1706179)}}).
+- The [`HTMLMetaElement.media`](/en-US/docs/Web/API/HTMLMetaElement/media) property is now supported. This property enables you to set different theme colors based on `media` values (e.g. `max-width: 600px`).
+  Meta elements with `media` properties allow the browser to use the `content` value in conjunction with `theme-color` to set the page or UI colors for a given media query ({{bug(1706179)}}).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -42,7 +42,7 @@ This article provides information about the changes in Firefox 106 that will aff
 #### DOM
 
 - The [`HTMLMetaElement.media`](/en-US/docs/Web/API/HTMLMetaElement/media) property is now supported which enables setting different theme colors based on `media` values (e.g. `max-width: 600px`).
-  Meta elements with `media` properties allows the browser to use the `content` value as a theme color for the page or UI for the given media query ({{bug(1706179)}}).
+  Meta elements with `media` properties allows the browser to use the `content` value in conjunction with `theme-color` to set the page or UI colors for a given media query ({{bug(1706179)}}).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -41,6 +41,9 @@ This article provides information about the changes in Firefox 106 that will aff
 
 #### DOM
 
+- The [`HTMLMetaElement.media`](/en-US/docs/Web/API/HTMLMetaElement/media) property is now supported which enables setting different theme colors based on `media` values (e.g. `max-width: 600px`).
+  Meta elements with `media` properties allows the browser to use the `content` value as a theme color for the page or UI for the given media query ({{bug(1706179)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
DOM API support for `HTMLMetaElement.media` added in Fx 106. Access to get and set:

```html
<meta content="#ffffff" media="(max-width: 600px)" name="theme-color" />
```



### Related issues

- [x] Parent issue: https://github.com/mdn/content/issues/20928