### PR TITLE
Fix type check in Error.toString

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
@@ -32,23 +32,22 @@ method inherited by all objects. Its semantics are as follows (assuming
 
 ```js
 Error.prototype.toString = function () {
-  if (this === null || typeof this !== 'object' && typeof this !== 'function') {
+  if (
+    this === null ||
+    (typeof this !== "object" && typeof this !== "function")
+  ) {
     throw new TypeError();
   }
-
   let name = this.name;
-  name = name === undefined ? 'Error' : String(name);
-
+  name = name === undefined ? "Error" : String(name);
   let msg = this.message;
-  msg = msg === undefined ? '' : String(msg);
-
-  if (name === '') {
+  msg = msg === undefined ? "" : String(msg);
+  if (name === "") {
     return msg;
   }
-  if (msg === '') {
+  if (msg === "") {
     return name;
   }
-
   return `${name}: ${msg}`;
 };
 ```
@@ -58,26 +57,26 @@ Error.prototype.toString = function () {
 ### Using toString()
 
 ```js
-const e1 = new Error('fatal error');
-console.log(e1.toString()); // 'Error: fatal error'
+const e1 = new Error("fatal error");
+console.log(e1.toString()); // "Error: fatal error"
 
-const e2 = new Error('fatal error');
+const e2 = new Error("fatal error");
 e2.name = undefined;
-console.log(e2.toString()); // 'Error: fatal error'
+console.log(e2.toString()); // "Error: fatal error"
 
-const e3 = new Error('fatal error');
+const e3 = new Error("fatal error");
 e3.name = '';
-console.log(e3.toString()); // 'fatal error'
+console.log(e3.toString()); // "fatal error"
 
-const e4 = new Error('fatal error');
-e4.name = '';
+const e4 = new Error("fatal error");
+e4.name = "";
 e4.message = undefined;
-console.log(e4.toString()); // ''
+console.log(e4.toString()); // ""
 
-const e5 = new Error('fatal error');
-e5.name = 'hello';
+const e5 = new Error("fatal error");
+e5.name = "hello";
 e5.message = undefined;
-console.log(e5.toString()); // 'hello'
+console.log(e5.toString()); // "hello"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
@@ -39,9 +39,9 @@ Error.prototype.toString = function () {
     throw new TypeError();
   }
   let name = this.name;
-  name = name === undefined ? "Error" : String(name);
+  name = name === undefined ? "Error" : `${name}`;
   let msg = this.message;
-  msg = msg === undefined ? "" : String(msg);
+  msg = msg === undefined ? "" : `${name}`;
   if (name === "") {
     return msg;
   }

--- a/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/tostring/index.md
@@ -32,7 +32,7 @@ method inherited by all objects. Its semantics are as follows (assuming
 
 ```js
 Error.prototype.toString = function () {
-  if (typeof this !== 'object' || typeof this !== 'function') {
+  if (this === null || typeof this !== 'object' && typeof this !== 'function') {
     throw new TypeError();
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes the type check in the sample implementation of Error.prototype.toString to match the ECMAScript specification.

### Motivation

The current implementation always throws a TypeError.

### Additional details

N/A

### Related issues and pull requests

Fixes #21645
