### PR TITLE
fix: typo in regexp/flags/index.md

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -25,7 +25,7 @@ The **`flags`** accessor property represents the [flags](/en-US/docs/Web/JavaScr
 
 All built-in functions read the `flags` property instead of reading individual flag accessors.
 
-The set accessor of `flag` is `undefined`. You cannot change this property directly.
+The set accessor of `flags` is `undefined`. You cannot change this property directly.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Just a minuscule typo fix in the Regexp.prototype.flags page - docs made reference to `flag` when it should really be `flags`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Improving readability and consistency for other readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N/A

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
