### PR TITLE
chore(HTML): revert Prettier formatting changes on example

### DIFF
--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -1511,7 +1511,7 @@ Some content attributes (e.g. `required`, `readonly`, `disabled`) are called [bo
 
 HTML defines restrictions on the allowed values of boolean attributes: If the attribute is present, its value must either be the empty string (equivalently, the attribute may have an unassigned value), or a value that is an ASCII case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace. The following examples are valid ways to mark up a boolean attribute:
 
-```html
+```html-nolint
 <div itemscope>This is valid HTML but invalid XML.</div>
 <div itemscope=itemscope>This is also valid HTML but invalid XML.</div>
 <div itemscope="">This is valid HTML and also valid XML.</div>

--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -1513,7 +1513,7 @@ HTML defines restrictions on the allowed values of boolean attributes: If the at
 
 ```html
 <div itemscope>This is valid HTML but invalid XML.</div>
-<div itemscope="itemscope">This is also valid HTML but invalid XML.</div>
+<div itemscope=itemscope>This is also valid HTML but invalid XML.</div>
 <div itemscope="">This is valid HTML and also valid XML.</div>
 <div itemscope="itemscope">
   This is also valid HTML and XML, but perhaps a bit verbose.


### PR DESCRIPTION
The example shows HTML with an attribute not enclosed in quotation marks. This PR reverts the changes.

```html
<div itemscope=itemscope>This is also valid HTML but invalid XML.</div>
<div itemscope="itemscope">
```

Note that I've added the `html-nolint` language tag.