### PR TITLE
L10 strings for static and instance methods and properties

### DIFF
--- a/files/jsondata/L10n-Common.json
+++ b/files/jsondata/L10n-Common.json
@@ -55,6 +55,18 @@
     "ru": "Наследование:",
     "zh-CN": "继承"
   },
+  "Instance_methods": {
+    "en-US": "Instance methods",
+    "es": "Métodos de instancia",
+    "fr": "Méthodes d'instance",
+    "zh-CN": "实例方法"
+  },
+  "Instance_properties": {
+    "en-US": "Instance properties",
+    "es": "Propiedades de instancia",
+    "fr": "Propriétés d'instance",
+    "zh-CN": "实例属性"
+  },
   "Interfaces": {
     "en-US": "Interfaces",
     "es": "Interfaces",
@@ -116,6 +128,18 @@
     "pt-BR": "Páginas relacionadas:",
     "ru": "Похожие страницы:",
     "zh-CN": "相关页面："
+  },
+  "Static_methods": {
+    "en-US": "Static methods",
+    "es": "Métodos estáticos",
+    "fr": "Méthodes statiques",
+    "zh-CN": "静态方法"
+  },
+  "Static_properties": {
+    "en-US": "Static properties",
+    "es": "Propiedades estáticas",
+    "fr": "Propriétés statiques",
+    "zh-CN": "静态属性"
   },
   "TranslationCTA": {
     "en-US": "Our volunteers haven't translated this article into your language yet. Join us and help get the job done!",


### PR DESCRIPTION
This is the l10n companion to https://github.com/mdn/yari/pull/7335, and adds the localised strings for static/instance methods/properties en-US, fr, es, zh-CN, so they can be shown in the sidebar. Other languages can be added in follow-up PRs.

To test:
- check out Yari
- check out this branch
- point Yari's CONTENT_ROOT at this branch
- visit some pages under Web/API in various languages:
    - en-US, fr, es, zh-CN should all show translated strings for "Static methods", "Static properties", "Instance methods", "Instance properties" in the sidebar
    - any other locales (e.g. ja, pt-BR) should show en-US strings

(like this: https://github.com/mdn/yari/pull/7335#issuecomment-1286059016)
 
This PR replaces https://github.com/mdn/content/pull/21690, which rotted.