### PR TITLE
chore: normalize CSSRef macros

### DIFF
--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.properties.-webkit-mask-box-image
 ---
 
-{{ CSSRef() }} {{ Non-standard_header() }}
+{{CSSRef}} {{ Non-standard_header() }}
 
 `-webkit-mask-box-image` sets the mask image for an element's border box.
 

--- a/files/en-us/web/css/-webkit-text-security/index.md
+++ b/files/en-us/web/css/-webkit-text-security/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.properties.-webkit-text-security
 ---
 
-{{ CSSRef() }} {{ Non-standard_header() }}
+{{CSSRef}} {{ Non-standard_header() }}
 
 **`-webkit-text-security`** is a non-standard CSS property that obfuscates characters in a {{HtmlElement("form")}} field (such as {{HtmlElement("input")}} or {{HtmlElement("textarea")}}) by replacing them with a shape. It only affects fields that are _not_ of `type=password`.
 

--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.at-rules.charset
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`@charset`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) specifies the character encoding used in the style sheet. It must be the first element in the style sheet and not be preceded by any character; as it is not a [nested statement](/en-US/docs/Web/CSS/Syntax#nested_statements), it cannot be used inside [conditional group at-rules](/en-US/docs/Web/CSS/At-rule#conditional_group_rules). If several `@charset` at-rules are defined, only the first one is used, and it cannot be used inside a `style` attribute on an HTML element or inside the {{ HTMLElement("style") }} element where the character set of the HTML page is relevant.
 

--- a/files/en-us/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-2d/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.at-rules.media.-webkit-transform-2d
 ---
 
-{{ Non-standard_header }}
+{{CSSRef}} {{ Non-standard_header }}
 
 > **Note:** All browsers support the [`transition`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-transition-2d` media feature. No browsers support `transition`, without the prefix or `2d` extension, as a media query. Use the [`@supports (transition)`](/en-US/docs/Web/CSS/@supports) feature query instead.
 
@@ -70,5 +70,3 @@ Not part of any standard.
 - {{cssxref("transform")}} and [using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
 - {{cssxref("@media")}} and [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
 - {{cssxref("@supports")}} and [using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
-
-{{ CSSRef }}

--- a/files/en-us/web/css/@media/-webkit-transition/index.md
+++ b/files/en-us/web/css/@media/-webkit-transition/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.at-rules.media.-webkit-transition
 ---
 
-{{ CSSRef }} {{deprecated_header}} {{ Non-standard_header }}
+{{CSSRef}} {{deprecated_header}} {{ Non-standard_header }}
 
 > **Note:** All browsers support the [`transition`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers support the `-webkit-transition` media feature. No browsers support `transition` without the prefix as a media query (though some browsers do support - {{cssxref("@media/-webkit-transform-3d", "-webkit-transform-3d")}}). Use the [`@supports (transition)`](/en-US/docs/Web/CSS/@supports) feature query instead.
 

--- a/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
@@ -11,7 +11,7 @@ tags:
   - Selector
 ---
 
-{{ CSSRef }}{{Non-standard_header}}
+{{CSSRef}} {{Non-standard_header}}
 
 The **`:-moz-handler-blocked`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that matches elements that can't be displayed because their handlers have been blocked.
 

--- a/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
@@ -11,7 +11,7 @@ tags:
   - Selector
 ---
 
-{{ CSSRef }}{{Non-standard_header}}
+{{CSSRef}} {{Non-standard_header}}
 
 The **`:-moz-handler-crashed`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that matches elements that can't be displayed because the plugin responsible for drawing them has crashed.
 

--- a/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
@@ -11,7 +11,7 @@ tags:
   - Selector
 ---
 
-{{ CSSRef }}{{Non-standard_header}}
+{{CSSRef}} {{Non-standard_header}}
 
 The **`:-moz-handler-disabled`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that matches elements that can't be displayed because their handlers have been disabled by the user.
 

--- a/files/en-us/web/css/_colon_defined/index.md
+++ b/files/en-us/web/css/_colon_defined/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.selectors.defined
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:defined`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any element that has been defined. This includes any standard element built in to the browser, and custom elements that have been successfully defined (i.e. with the {{domxref("CustomElementRegistry.define()")}} method).
 

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -17,7 +17,7 @@ tags:
 browser-compat: css.selectors.host
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:host`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selects the shadow host of the [shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM) containing the CSS it is used inside — in other words, this allows you to select a custom element from inside its shadow DOM.
 

--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.selectors.hover
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:hover`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches when the user interacts with an element with a pointing device, but does not necessarily activate it. It is generally triggered when the user hovers over an element with the cursor (mouse pointer).
 

--- a/files/en-us/web/css/_colon_left/index.md
+++ b/files/en-us/web/css/_colon_left/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.selectors.left
 ---
 
-{{ CSSRef() }}
+{{CSSRef}}
 
 The **`:left`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), used with the {{cssxref("@page")}} [at-rule](/en-US/docs/Web/CSS/At-rule), represents all left-hand pages of a printed document.
 

--- a/files/en-us/web/css/_colon_link/index.md
+++ b/files/en-us/web/css/_colon_link/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.selectors.link
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:link`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that has not yet been visited. It matches every unvisited {{HTMLElement("a")}} or {{HTMLElement("area")}} element that has an `href` attribute.
 

--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -5,7 +5,7 @@ page-type: css-pseudo-class
 spec-urls: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:local-link`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents a link to the same document. Therefore an element that is the source anchor of a hyperlink whose target's absolute URL matches the element's own document URL.
 

--- a/files/en-us/web/css/_colon_optional/index.md
+++ b/files/en-us/web/css/_colon_optional/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.selectors.optional
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:optional`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element that does not have the {{ htmlattrxref("required", "input") }} attribute set on it.
 

--- a/files/en-us/web/css/_colon_required/index.md
+++ b/files/en-us/web/css/_colon_required/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.selectors.required
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`:required`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element that has the {{ htmlattrxref("required", "input") }} attribute set on it.
 

--- a/files/en-us/web/css/_colon_right/index.md
+++ b/files/en-us/web/css/_colon_right/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.selectors.right
 ---
 
-{{ CSSRef() }}
+{{CSSRef}}
 
 The **`:right`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes), used with the {{cssxref("@page")}} [at-rule](/en-US/docs/Web/CSS/At-rule), represents all right-hand pages of a printed document.
 

--- a/files/en-us/web/css/_doublecolon_slotted/index.md
+++ b/files/en-us/web/css/_doublecolon_slotted/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.selectors.slotted
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`::slotted()`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents any element that has been placed into a slot inside an HTML template (see [Using templates and slots](/en-US/docs/Web/Web_Components/Using_templates_and_slots) for more information).
 

--- a/files/en-us/web/css/angle/index.md
+++ b/files/en-us/web/css/angle/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.types.angle
 ---
 
-{{ CSSRef() }}
+{{CSSRef}}
 
 The **`<angle>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents an angle value expressed in degrees, gradians, radians, or turns. It is used, for example, in {{cssxref("&lt;gradient&gt;")}}s and in some {{cssxref("transform")}} functions.
 

--- a/files/en-us/web/css/column-rule-style/index.md
+++ b/files/en-us/web/css/column-rule-style/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.properties.column-rule-style
 ---
 
-{{ CSSRef}}
+{{CSSRef}}
 
 The **`column-rule-style`** [CSS](/en-US/docs/Web/CSS) property sets the style of the line drawn between columns in a multi-column layout.
 

--- a/files/en-us/web/css/column-rule-width/index.md
+++ b/files/en-us/web/css/column-rule-width/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.properties.column-rule-width
 ---
 
-{{ CSSRef}}
+{{CSSRef}}
 
 The **`column-rule-width`** [CSS](/en-US/docs/Web/CSS) property sets the width of the line drawn between columns in a multi-column layout.
 

--- a/files/en-us/web/css/flex-wrap/index.md
+++ b/files/en-us/web/css/flex-wrap/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.properties.flex-wrap
 ---
 
-{{ CSSRef}}
+{{CSSRef}}
 
 The **`flex-wrap`** [CSS](/en-US/docs/Web/CSS) property sets whether flex items are forced onto one line or can wrap onto multiple lines. If wrapping is allowed, it sets the direction that lines are stacked.
 

--- a/files/en-us/web/css/font-smooth/index.md
+++ b/files/en-us/web/css/font-smooth/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: css.properties.font-smooth
 ---
 
-{{ CSSRef }} {{ Non-standard_header }}
+{{CSSRef}} {{ Non-standard_header }}
 
 The **`font-smooth`** [CSS](/en-US/docs/Web/CSS) property controls the application of anti-aliasing when fonts are rendered.
 

--- a/files/en-us/web/css/text-decoration-color/index.md
+++ b/files/en-us/web/css/text-decoration-color/index.md
@@ -18,7 +18,7 @@ tags:
 browser-compat: css.properties.text-decoration-color
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`text-decoration-color`** [CSS](/en-US/docs/Web/CSS) property sets the color of decorations added to text by {{ cssxref("text-decoration-line") }}.
 

--- a/files/en-us/web/css/transform-origin/index.md
+++ b/files/en-us/web/css/transform-origin/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: css.properties.transform-origin
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 The **`transform-origin`** [CSS](/en-US/docs/Web/CSS) property sets the origin for an element's transformations.
 

--- a/files/en-us/web/guide/css/block_formatting_context/index.md
+++ b/files/en-us/web/guide/css/block_formatting_context/index.md
@@ -11,7 +11,7 @@ tags:
 spec-urls: https://drafts.csswg.org/css-display/#block-formatting-context
 ---
 
-{{ CSSRef }}
+{{CSSRef}}
 
 A **block formatting context** (BFC) is a part of a visual CSS rendering of a web page. It's the region in which the layout of block boxes occurs and in which floats interact with other elements.
 


### PR DESCRIPTION
The should all work, but noticed one of the ones with `()` in the translations so figured I'd see if there were many here