### PR TITLE
Title update: remove single colon from title

### DIFF
--- a/files/en-us/web/css/_doublecolon_after/index.md
+++ b/files/en-us/web/css/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::after (:after)'
+title: '::after'
 slug: Web/CSS/::after
 page-type: css-pseudo-element
 tags:

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::before (:before)"
+title: "::before"
 slug: Web/CSS/::before
 page-type: css-pseudo-element
 tags:

--- a/files/en-us/web/css/_doublecolon_first-letter/index.md
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-letter (:first-letter)'
+title: '::first-letter'
 slug: Web/CSS/::first-letter
 page-type: css-pseudo-element
 tags:

--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-line (:first-line)'
+title: '::first-line'
 slug: Web/CSS/::first-line
 page-type: css-pseudo-element
 tags:

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -44,12 +44,12 @@ Pseudo-elements defined by a set of CSS specifications include the following:
 
 A
 
-- {{CSSxRef("::after", "::after (:after)")}}
+- {{CSSxRef("::after")}}
 
 B
 
 - {{CSSxRef("::backdrop")}}
-- {{CSSxRef("::before", "::before (:before)")}}
+- {{CSSxRef("::before")}}
 
 C
 
@@ -58,8 +58,8 @@ C
 
 F
 
-- {{CSSxRef("::first-letter", "::first-letter (:first-letter)")}}
-- {{CSSxRef("::first-line", "::first-line (:first-line)")}}
+- {{CSSxRef("::first-letter")}}
+- {{CSSxRef("::first-line")}}
 - {{CSSxRef("::file-selector-button")}}
 
 G


### PR DESCRIPTION
Changed the title for these four as double colon notation is the correct way to do it and has been supported for about 20 years. The text includes a comment about the history of single colon notation. It does not need to be part of the title.