### PR TITLE
transform content updates

### DIFF
--- a/files/en-us/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-2d/index.md
@@ -14,7 +14,7 @@ browser-compat: css.at-rules.media.-webkit-transform-2d
 
 {{ Non-standard_header }}
 
-> **Note:** All browsers support the [`transition`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-transition-2d` media feature. No browsers support `transition`, without the prefix or `2d` extension, as a media query. Use the [`@supports (transition)`](/en-US/docs/Web/CSS/@supports) feature query instead.
+> **Note:** All browsers support the [`transform`](/en-US/docs/Web/CSS/transform#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-transform-2d` media feature. No browsers support `transform`, without the prefix or `2d` extension, as a media query. Use the [`@supports (transform)`](/en-US/docs/Web/CSS/@supports) feature query instead.
 
 The **`-webkit-transform-2d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 2D {{cssxref("transform")}}s and non-standard vendor-prefixed media queries are supported.
 
@@ -43,7 +43,7 @@ Apple has [a description in Safari CSS Reference](https://developer.apple.com/li
 }
 ```
 
-This media feature is only supported by WebKit. If possible, use an {{cssxref("@supports")}} feature query instead:
+This media feature is only supported by WebKit. The unprefixed [`transform`](/en-US/docs/Web/CSS/transform) property is supported in all modern browsers. If possible, use an {{cssxref("@supports")}} feature query instead:
 
 ```css
 @supports (-webkit-transform: translate(100px, 100px)) {

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -14,9 +14,15 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/CSS/@media/")}}
 
+> **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
+
 The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is used to detect if the user has requested that the system minimize the amount of non-essential motion it uses.
 
-> **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
+```css
+@media (prefers-reduced-motion) {
+  /* styles to apply if the user's settings are set to reduced motion */
+}
+```
 
 ## Syntax
 
@@ -62,7 +68,7 @@ This example has a scaling animation by default. If Reduce Motion is enabled in 
 /* Tone down the animation to avoid vestibular motion triggers like scaling or panning large objects. */
 @media (prefers-reduced-motion) {
   .animation {
-    animation-name: dissolve;
+    animation: dissolve 2s linear infinite both;
   }
 }
 ```

--- a/files/en-us/web/css/@media/update-frequency/index.md
+++ b/files/en-us/web/css/@media/update-frequency/index.md
@@ -14,7 +14,13 @@ browser-compat: css.at-rules.media.update
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`update`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) can be used to test how frequently (if at all) the output device is able to modify the appearance of content.
+The **`update`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) can be used to test how frequently (if at all) the output device is able to modify the appearance of content once rendered.
+
+```css
+@media (update: < none | slow | fast >) {
+  /* styles to apply if the update frequency of the output device is a match */
+}
+```
 
 ## Syntax
 
@@ -32,7 +38,7 @@ The `update` feature is specified as a single keyword value chosen from the list
 ### HTML
 
 ```html
-<p>If this text animates for you, you are using a fast-updating device.</p>
+<p>If this text animates for you, your browser supports `update` and you are using a fast-updating device.</p>
 ```
 
 ### CSS

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -45,8 +45,8 @@ Here is the MDN logo rotated 90 degrees from its bottom-left corner.
 
 ```html
 <img
-  style="transform: rotate(90deg);
-            transform-origin: bottom left;"
+  style="rotate: 90deg;
+      transform-origin: bottom left;"
   src="logo.png"
   alt="MDN Logo" />
 ```

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -26,7 +26,7 @@ CSS transforms are implemented using a set of CSS properties that let you apply 
 
 ## CSS transforms properties
 
-Two major properties are used to define CSS transforms: {{cssxref("transform")}} and {{cssxref("transform-origin")}}
+Two major properties are used to define CSS transforms: {{cssxref("transform")}} (or the individual {{cssxref('translate')}}, {{cssxref('rotate')}}), and {{cssxref('scale')}} properties) and {{cssxref("transform-origin")}}
 
 - {{cssxref("transform-origin")}}
   - : Specifies the position of the origin. By default, it is at the center of the element and can be moved. It is used by several transforms, like rotations, scaling or skewing, that need a specific point as a parameter.
@@ -544,6 +544,8 @@ Once you have done this, you can work on the element in the 3D space.
 
 ## See also
 
+- The [CSS `transform` property](/en-US/docs/Web/CSS/transform) and the [CSS `<transform-function>` data types](/en-US/docs/Web/CSS/transform-function)
+- The individual tranforms properties: {{cssxref('translate')}}, {{cssxref('rotate')}}), and {{cssxref('scale')}} (There is no `skew` property)
 - [Using device orientation with 3D Transforms](/en-US/docs/Web/API/Device_orientation_events/Using_device_orientation_with_3D_transforms)
 - [Intro to CSS 3D transforms](https://3dtransforms.desandro.com/) (Blog post by David DeSandro)
 - [CSS Transform Playground](https://css-transform.moro.es/) (Online tool to visualize CSS Transform functions)

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -47,7 +47,8 @@ Here is the MDN logo rotated 90 degrees from its bottom-left corner.
 <img
   style="transform: rotate(90deg);
             transform-origin: bottom left;"
-  src="logo.png" />
+  src="logo.png"
+  alt="MDN Logo" />
 ```
 
 {{EmbedLiveSample('Rotating', 'auto', 240) }}
@@ -60,7 +61,8 @@ Here is the MDN logo, skewed by 10 degrees and translated by 150 pixels on the X
 <img
   style="transform: skewx(10deg) translatex(150px);
             transform-origin: bottom left;"
-  src="logo.png" />
+  src="logo.png"
+  alt="MDN logo" />
 ```
 
 {{EmbedLiveSample('Skewing_and_translating') }}

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -99,7 +99,7 @@ This example performs a four-second font size transition with a two-second delay
   background-color: #ffcccc;
   width: 200px;
   height: 200px;
-  transform: rotate(180deg);
+  rotate: 180deg;
 }
 ```
 

--- a/files/en-us/web/css/element/index.md
+++ b/files/en-us/web/css/element/index.md
@@ -51,7 +51,7 @@ This example uses a hidden {{HTMLElement("div")}} as a background. The backgroun
   <div
     id="myBackground1"
     style="width:1024px; height:1024px; background-image: linear-gradient(to right, red, orange, yellow, white);">
-    <p style="transform-origin:0 0; transform: rotate(45deg); color:white;">
+    <p style="transform-origin:0 0; rotate: 45deg; color:white;">
       This text is part of the background. Cool, huh?
     </p>
   </div>

--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -138,4 +138,5 @@ Please see [Using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_t
 
 - [Using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
 - {{cssxref("&lt;transform-function&gt;")}} data type with all the transform functions explained.
+- Individual CSS properties: {{cssxref('translate')}}, {{cssxref('rotate')}}), and {{cssxref('scale')}} (there is no `skew` property).
 - Online tool to visualize CSS Transform functions: [CSS Transform Playground](https://css-transform.moro.es/)


### PR DESCRIPTION
* found an issue where transform and transition were confused. 
* added the individual transform properties as links / more info.
* changed a few examples to show use cases for `scale` and `rotate` properties
per https://github.com/openwebdocs/project/issues/140