### PR TITLE
FF107 Release note: SVGSVGElement.useCurrentView removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -44,6 +44,9 @@ This article provides information about the changes in Firefox 107 that will aff
 
 #### Removals
 
+- The non-standard and deprecated [`SVGSVGElement.useCurrentView`](/en-US/docs/Web/API/SVGSVGElement#svgsvgelement.usecurrentview) property has been removed.
+  (See {{bug(1174097)}} for more details.)
+
 ### WebAssembly
 
 #### Removals


### PR DESCRIPTION
FF107 removes the non-standard deprecated `SVGSVGElement.useCurrentView` in https://bugzilla.mozilla.org/show_bug.cgi?id=1174097

This is release note.

Other docs work for this can be tracked in #21539