### PR TITLE
Fix `detectedBarcode` object `rawData` property in the example

### DIFF
--- a/files/en-us/web/api/barcodedetector/index.md
+++ b/files/en-us/web/api/barcodedetector/index.md
@@ -76,7 +76,7 @@ This example uses the `detect()` method to detect the barcodes within the given 
 barcodeDetector
   .detect(imageEl)
   .then((barcodes) => {
-    barcodes.forEach((barcode) => console.log(barcode.rawData));
+    barcodes.forEach((barcode) => console.log(barcode.rawValue));
   })
   .catch((err) => {
     console.log(err);


### PR DESCRIPTION
### Description

In the example, there is typo (most probably). The `detectedBarcode` object contains a `rawValue` property and not a `rawData` property.