### PR TITLE
remove brackets

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -117,7 +117,7 @@ console.info("My first car was a", car, ". The object is:", someObject);
 The output will look like this:
 
 ```bash
-My first car was a Dodge Charger. The object is: ({str:"Some text", id:5})
+My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 ```
 
 #### Using string substitutions


### PR DESCRIPTION
Removes brackets from the bash output on MDN web docs for console api

For the following section:

```
Outputting multiple objects
You can also output multiple objects by listing them when calling the logging method, like this:

const car = "Dodge Charger";
const someObject = { str: "Some text", id: 5 };
console.info("My first car was a", car, ". The object is:", someObject);
```
The output will look like this:
```
My first car was a Dodge Charger. The object is: ({str:"Some text", id:5})
```

Output in console should be:
```
My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
```