### PR TITLE
Example fix to work as expected in browsers and NodeJs

### DIFF
--- a/files/en-us/web/api/console/assert/index.md
+++ b/files/en-us/web/api/console/assert/index.md
@@ -60,7 +60,7 @@ assertion:
 const errorMsg = "the # is not even";
 for (let number = 2; number <= 5; number++) {
   console.log(`the # is ${number}`);
-  console.assert(number % 2 === 0, { number, errorMsg });
+  console.assert(number % 2 === 0, '%o', { number, errorMsg });
 }
 // output:
 // the # is 2


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Turned `assert(assertion, obj)` into `assert(assertion, msg, subst1)` to work as declared in browsers and NodeJs

<!-- ✍️ Summarize your changes in one or two sentences -->

Updated example to `console.assert(number % 2 === 0, '%o', { number, errorMsg })` to achieve declared `Assertion failed: {number: 3, errorMsg: "the # is not even"}` in NodeJs since `console.assert(number % 2 === 0, { number, errorMsg })` works as expected in browsers but gives `Assertion failed: [object Object]` in NodeJs

<!-- ❓ Why are you making these changes and how do they help readers? -->

NodeJs v19.0.0
