### PR TITLE
Remove reference to "important" in <mark> element intro

### DIFF
--- a/files/en-us/web/html/element/mark/index.md
+++ b/files/en-us/web/html/element/mark/index.md
@@ -16,7 +16,7 @@ browser-compat: html.elements.mark
 
 {{HTMLRef}}
 
-The **`<mark>`** [HTML](/en-US/docs/Web/HTML) element represents text which is **marked** or **highlighted** for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context.
+The **`<mark>`** [HTML](/en-US/docs/Web/HTML) element represents text which is **marked** or **highlighted** for reference or notation purposes due to the marked passage's relevance in the enclosing context.
 
 {{EmbedInteractiveExample("pages/tabbed/mark.html", "tabbed-shorter")}}
 


### PR DESCRIPTION
### Description

According to the HTML Living Standard, mark is not supposed to denote importance, only relevance. Therefore removing the word "importance" from intro paragraph of <mark> element.

### Additional details

See https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element

In particular the final example which, "shows the difference between denoting the importance of a span of text ([strong](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-strong-element)) as opposed to denoting the relevance of a span of text ([mark](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element))."

### Related issues and pull requests

Fixes #21595


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
