### PR TITLE
Fix grammar on line 107

### DIFF
--- a/files/en-us/web/api/file/lastmodified/index.md
+++ b/files/en-us/web/api/file/lastmodified/index.md
@@ -104,7 +104,7 @@ someFile.lastModified;
 // …
 ```
 
-In Firefox, you can also enabled `privacy.resistFingerprinting`, the
+In Firefox, if you enable `privacy.resistFingerprinting`, the
 precision will be 100ms or the value of
 `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever
 is larger.


### PR DESCRIPTION
"you can also enabled privacy.resistFingerprinting" --> "if you enable privacy.resistFingerprinting"

### Description

Changed "you can also enabled `privacy.resistFingerprinting`" to "if you enable `privacy.resistFingerprinting`".

Original text in context:
> In Firefox, you can also enabled `privacy.resistFingerprinting`, the
precision will be 100ms or the value of
`privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever
is larger.

### Motivation

The previous text is hard to understand, as it is not grammatically correct.
