### PR TITLE
fix: typo in svg/attribute/href/index.md

### DIFF
--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -11,7 +11,7 @@ browser-compat: svg.attributes.href
 
 The **`href`** attribute defines a link to a resource as a reference [URL](/en-US/docs/Web/SVG/Content_type#url). The exact meaning of that link depends on the context of each element using it.
 
-> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute. If you need to support earlier browser versions, the deprecated `xlink:href` attribute can be used as a fallback in addition to the `href` attribute, e.g. `<use href="some-id" xlink:href="some-id x="5" y="5" />`.
+> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute. If you need to support earlier browser versions, the deprecated `xlink:href` attribute can be used as a fallback in addition to the `href` attribute, e.g. `<use href="some-id" xlink:href="some-id" x="5" y="5" />`.
 
 You can use this attribute with the following SVG elements:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The first example of `href` and `xlink:href` being used together was missing a quote from one of the attribute values, so I tacked one on.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Improve the readability for users and maintain the MDN reputation for quality docs. Beyond that, typos **seriously** trigger my OCD, so I'm also fixing this with slightly self-serving motives 😅

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

N/A

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
