### PR TITLE
Updated description about case-insensitive thing for `charset` field

### DIFF
--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -53,7 +53,7 @@ In requests, (such as {{HTTPMethod("POST")}} or {{HTTPMethod("PUT")}}), the clie
 ## Syntax
 
 ```http
-Content-Type: text/html; charset=UTF-8
+Content-Type: text/html; charset=utf-8
 Content-Type: multipart/form-data; boundary=something
 ```
 
@@ -62,7 +62,7 @@ Content-Type: multipart/form-data; boundary=something
 - `media-type`
   - : The [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the resource or the data.
 - charset
-  - : The character encoding standard.
+  - : The character encoding standard. Case insensitive, lowercase is preferred.
 - boundary
   - : For multipart entities the `boundary` directive is required. The directive consists of 1 to 70 characters from a set of characters (and not ending with white space) known to be very robust through email gateways. It is used to encapsulate the boundaries of the multiple parts of the message. Often, the header boundary is prepended with two dashes and the final boundary has two dashes appended at the end.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the value of `charset` field to lowercase, and added a description, to fit the preferred writing in the specification.

> For example, the following media types are equivalent in describing HTML text data encoded in the UTF-8 character encoding scheme, but the first is preferred for consistency (the "charset" parameter value is defined as being case-insensitive in [[RFC2046]](https://httpwg.org/specs/rfc9110.html#RFC2046), [Section 4.1.2](https://www.rfc-editor.org/rfc/rfc2046.html#section-4.1.2)):
> 
> ```
> text/html;charset=utf-8
> Text/HTML;Charset="utf-8"
> text/html; charset="utf-8"
> text/html;charset=UTF-8
> ```

Via https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
