### PR TITLE
Fix typo on Credential Management docs

### DIFF
--- a/files/en-us/web/api/credential_management_api/index.md
+++ b/files/en-us/web/api/credential_management_api/index.md
@@ -27,7 +27,7 @@ To address these problems, the Credential Management API provides ways for a web
 
 ### Subdomain-shared credentials
 
-Later version of the spec allow credentials to be retrieved from a different subdomain. For example, a password stored in `login.example.com` may be used to log in to `www.example.com`. To take advantage of this, a password must be explicitly stored by calling {{domxref("CredentialsContainer.store()")}}. This is sometimes referred to as public suffix list (PSL) matching; however the spec only _recommends_ using PSL to determine the effective scope of a credential. It does not require it. Hence browsers may vary in their implementation.
+Later versions of the spec allow credentials to be retrieved from a different subdomain. For example, a password stored in `login.example.com` may be used to log in to `www.example.com`. To take advantage of this, a password must be explicitly stored by calling {{domxref("CredentialsContainer.store()")}}. This is sometimes referred to as public suffix list (PSL) matching; however the spec only _recommends_ using PSL to determine the effective scope of a credential. It does not require it. Hence browsers may vary in their implementation.
 
 ## Interfaces
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fix typo on Credential Management API docs. `Later version` -> `Later versions`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I was reading the documentation and came across this.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
