### PR TITLE
Add missing space for consistency on Path2D() example

### DIFF
--- a/files/en-us/web/api/path2d/path2d/index.md
+++ b/files/en-us/web/api/path2d/path2d/index.md
@@ -52,7 +52,7 @@ const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 
 let path1 = new Path2D();
-path1.rect(10, 10, 100,100);
+path1.rect(10, 10, 100, 100);
 
 let path2 = new Path2D(path1);
 path2.moveTo(220, 60);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The third parameter in `path1.rect()` is missing a trailing space after the comma to be consistent with the other examples.

Page: https://developer.mozilla.org/en-US/docs/Web/API/Path2D/Path2D

### Screenshots
![Screen Shot 2022-10-22 at 6 00 07 PM](https://user-images.githubusercontent.com/48612525/197368132-f6bde841-f023-4fdb-82f8-45eb16f854b2.png)

