### PR TITLE
ci: skip Husky install for cleanup job

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -19,6 +19,8 @@ jobs:
           cache: yarn
 
       - name: Install all yarn packages
+        env:
+          HUSKY: 0
         run: |
           yarn --frozen-lockfile
 


### PR DESCRIPTION
As mentioned https://github.com/mdn/content/pull/21736#issuecomment-1287757915 when the auto-cleanup job can only partially fix a file, it runs into an issue when husky runs lint-stage and still hits a Markdownlint issue on the file. This skips the husky install, so the hook is never installed and the partially cleaned file can be committed https://github.com/nschonni/mdn-content/actions/runs/3305340915/jobs/5455379116