### PR TITLE
Small casing and space fixes for "Web audio spatialization basics"

### DIFF
--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
@@ -439,25 +439,25 @@ Wiring up out control buttons is comparatively simple — now we can listen for 
 // for each of our controls, move the boombox and change the position values
 moveControls.forEach((el) => {
 
-    let moving;
-    el.addEventListener('mousedown', () => {
-        const direction = this.dataset.control;
-        if (moving && moving.frameId) {
-            cancelAnimationFrame(moving.frameId);
-        }
-        moving = moveBoombox(direction);
-    }, false);
+  let moving;
+  el.addEventListener('mousedown', () => {
+    const direction = this.dataset.control;
+    if (moving && moving.frameId) {
+      cancelAnimationFrame(moving.frameId);
+    }
+    moving = moveBoombox(direction);
+  }, false);
 
-    window.addEventListener('mouseup', () => {
-        if (moving && moving.frameId) {
-            cancelAnimationFrame(moving.frameId);
-        }
-    }, false)
+  window.addEventListener('mouseup', () => {
+    if (moving && moving.frameId) {
+      cancelAnimationFrame(moving.frameId);
+    }
+  }, false)
 
 })
 ```
 
-## Connecting Our Graph
+## Connecting our graph
 
 Our HTML contains the audio element we want to be affected by the panner node.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description/Motivation

- Use 2 spaces instead of 4 in code block in accordance with the style guidelines
- Use sentence case for an h2 title (for consistency/to follow guidelines)
