### PR TITLE
Changed double to single quotes in code examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Symbol
 
 **`Symbol`** is a built-in object whose constructor returns a `symbol` [primitive](/en-US/docs/Glossary/Primitive) — also called a **Symbol value** or just a **Symbol** — that's guaranteed to be unique. Symbols are often used to add unique property keys to an object that won't collide with keys any other code might add to the object, and which are hidden from any mechanisms other code will typically use to access the object. That enables a form of weak {{Glossary("encapsulation")}}, or a weak form of [information hiding](https://en.wikipedia.org/wiki/Information_hiding).
 
-Every `Symbol()` call is guaranteed to return a unique Symbol. Every `Symbol.for("key")` call will always return the same Symbol for a given value of `"key"`. When `Symbol.for("key")` is called, if a Symbol with the given key can be found in the global Symbol registry, that Symbol is returned. Otherwise, a new Symbol is created, added to the global Symbol registry under the given key, and returned.
+Every `Symbol()` call is guaranteed to return a unique Symbol. Every `Symbol.for('key')` call will always return the same Symbol for a given value of `'key'`. When `Symbol.for('key')` is called, if a Symbol with the given key can be found in the global Symbol registry, that Symbol is returned. Otherwise, a new Symbol is created, added to the global Symbol registry under the given key, and returned.
 
 ## Description
 
@@ -26,7 +26,7 @@ const sym2 = Symbol('foo');
 const sym3 = Symbol('foo');
 ```
 
-The above code creates three new Symbols. Note that `Symbol("foo")` does not coerce the string `"foo"` into a Symbol. It creates a new Symbol each time:
+The above code creates three new Symbols. Note that `Symbol('foo')` does not coerce the string `'foo'` into a Symbol. It creates a new Symbol each time:
 
 ```js
 Symbol('foo') === Symbol('foo')  // false
@@ -147,7 +147,7 @@ Some things to note when working with type conversion of Symbols.
 - When trying to convert a Symbol to a number, a {{jsxref("TypeError")}} will be thrown
   (e.g. `+sym` or `sym | 0`).
 - When using loose equality, `Object(sym) == sym` returns `true`.
-- `Symbol("foo") + "bar"` throws a {{jsxref("TypeError")}} (can't convert Symbol to string). This prevents you from silently creating a new string property name from a Symbol, for example.
+- `Symbol('foo') + 'bar'` throws a {{jsxref("TypeError")}} (can't convert Symbol to string). This prevents you from silently creating a new string property name from a Symbol, for example.
 - The ["safer" `String(sym)` conversion](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_conversion) works like a call to {{jsxref("Symbol.prototype.toString()")}} with Symbols, but note that `new String(sym)` will throw.
 
 ### Symbols and for...in iteration


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I've left the `jsxref` examples in double quotes — not sure if that's idiomatic.


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Standardise use of quotes.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
