### PR TITLE
fix: characters stuck to DD markup

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -164,6 +164,13 @@
           "searchPattern": "/([^\\s>])  ([^\\s|])/g",
           "replace": "$1 $2",
           "skipCode": true
+        },
+        {
+          "name": "stuck-definition",
+          "message": "Character is stuck to definition description marker",
+          "searchPattern": "/- :(\\w)/g",
+          "replace": "- : $1",
+          "skipCode": true
         }
       ]
     }

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -69,7 +69,7 @@ get(options)
     - `publicKey`
       - : An object containing requirements for returned [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) credentials. The available options are:
         - `challenge`
-          - :An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} emitted by the relying party's server and used as a [cryptographic challenge](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication). This value will be signed by the authenticator and the signature will be sent back as part of {{domxref("AuthenticatorAssertionResponse.signature")}}.
+          - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} emitted by the relying party's server and used as a [cryptographic challenge](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication). This value will be signed by the authenticator and the signature will be sent back as part of {{domxref("AuthenticatorAssertionResponse.signature")}}.
         - `timeout` {{optional_inline}}
           - : A numerical hint, in milliseconds, which indicates the time the caller is willing to wait for the retrieval operation to complete. This hint may be overridden by the browser.
         - `rpId` {{optional_inline}}

--- a/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.md
+++ b/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.md
@@ -30,7 +30,7 @@ new SensorErrorEvent(type, options)
 ### Parameters
 
 - `type`
-  - :A string with the name of the event.
+  - : A string with the name of the event.
     It is case-sensitive and browsers always set it to `error`.
 - `options`
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:


### PR DESCRIPTION
Found more of them in the translated content, but I think this is probably a safe pattern to autofix. Think it makes sense to enforce as a rule because it actually breaks rendering. Alternately this could be a Flaw in yari, but this seemed easier to implement