### PR TITLE
Add alt text to image

### DIFF
--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -30,7 +30,7 @@ This is not only best practice — you should not be spamming users with notific
 
 This will spawn a request dialog, along the following lines:
 
-![A browser window with a dialog box asking the user if they will allow notifications from that origin. There are options to never allow or allow notifications.](screen_shot_2019-12-11_at_9.59.14_am.png)
+![A dialog box asking the user to allow notifications from that origin. There are options to never allow or allow notifications.](screen_shot_2019-12-11_at_9.59.14_am.png)
 
 From here the user can choose to allow notifications from this origin, or block them. Once a choice has been made, the setting will generally persist for the current session.
 

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -30,7 +30,7 @@ This is not only best practice — you should not be spamming users with notific
 
 This will spawn a request dialog, along the following lines:
 
-![](screen_shot_2019-12-11_at_9.59.14_am.png)
+![A browser window with a dialog box asking the user if they will allow notifications from that origin. There are options to never allow or allow notifications.](screen_shot_2019-12-11_at_9.59.14_am.png)
 
 From here the user can choose to allow notifications from this origin, or block them. Once a choice has been made, the setting will generally persist for the current session.
 


### PR DESCRIPTION
### Description

Adds alt text to the screen_shot_2019-12-11_at_9.59.14_am.png image on line 33.

### Motivation

To make the image more accessible and promote good web development practices.

### Additional details

### Related issues and pull requests

Relates to #21616 
