### PR TITLE
fix: MD052 Reference links and images should use a label that is defined

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -117,8 +117,6 @@
     // MD051 - Link fragments should be valid.
     // -> Disabled, as yari generates link fragments by replacing spaces with underscores, not dashes.
     "MD051": false,
-    // Incompatible with brackets in macros like MD042
-    "MD052": false,
     "search-replace": {
       "rules": [
         {

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -102,7 +102,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("height")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -123,7 +123,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -156,7 +156,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("padding")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -333,7 +333,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border-radius")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -1280,10 +1280,10 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and `{{htmlel
         {{cssxref("text-indent")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td>
         <ol>
@@ -1311,10 +1311,10 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and `{{htmlel
         {{cssxref("text-shadow")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1][2]</sup>
+        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
       </td>
       <td>
         <ol>

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -102,7 +102,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("height")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -123,7 +123,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -156,7 +156,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("padding")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -333,7 +333,7 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border-radius")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
         ✅ Yes
@@ -1280,10 +1280,10 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and `{{htmlel
         {{cssxref("text-indent")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1311,10 +1311,10 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and `{{htmlel
         {{cssxref("text-shadow")}}
       </th>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td style="text-align: center; vertical-align: top">
-        ⚠️ Partial<sup>[1]</sup><sup>[2]</sup>
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -89,7 +89,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 
 ## Uniforms and attributes
 
-- ["WebGL2RenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
+- [`WebGL2RenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Methods specifying values of uniform variables.
 - {{domxref("WebGL2RenderingContext.uniformMatrix()", "WebGL2RenderingContext.uniformMatrix[234]x[234]fv()")}}
   - : Methods specifying matrix values for uniform variables.

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -89,7 +89,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 
 ## Uniforms and attributes
 
-- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]()")}}
+- ["WebGL2RenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Methods specifying values of uniform variables.
 - {{domxref("WebGL2RenderingContext.uniformMatrix()", "WebGL2RenderingContext.uniformMatrix[234]x[234]fv()")}}
   - : Methods specifying matrix values for uniform variables.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -33,11 +33,11 @@ inputs:
 
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- [`WebGLRenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
+- [`WebGLRenderingContext.uniform[1234][fi][v]()`](/en-US/docs/Web/API/WebGLRenderingContext/uniform)
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- [`WebGLRenderingContext.uniformMatrix[234][fv]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniformMatrix)
+- [`WebGLRenderingContext.uniformMatrix[234][fv]()`](/en-US/docs/Web/API/WebGLRenderingContext/uniformMatrix)
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -33,11 +33,11 @@ inputs:
 
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- ["WebGLRenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
+- [`WebGLRenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- [WebGLRenderingContext.uniformMatrix\[234\]\[fv\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniformMatrix)
+- [`WebGLRenderingContext.uniformMatrix[234][fv]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniformMatrix)
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -33,11 +33,11 @@ inputs:
 
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]()")}}
+- ["WebGLRenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]()")}}
+- [WebGLRenderingContext.uniformMatrix\[234\]\[fv\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniformMatrix)
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -278,7 +278,7 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- [`WebGLRenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
+- [`WebGLRenderingContext.uniform[1234][fi][v]()`](/en-US/docs/Web/API/WebGLRenderingContext/uniform)
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -278,7 +278,7 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- ["WebGLRenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
+- [`WebGLRenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -278,7 +278,7 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]()")}}
+- ["WebGLRenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform)
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -22,7 +22,7 @@ object, when they are once again initialized to 0.
 
 > **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
-> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]()")}}.
+> ["WebGL2RenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform).
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -22,7 +22,7 @@ object, when they are once again initialized to 0.
 
 > **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
-> ["WebGL2RenderingContext.uniform\[1234\]\[uif\]\[v\]()](/en-US/docs/Web/API/WebGL2RenderingContext/uniform).
+> [`WebGL2RenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform).
 
 ## Syntax
 


### PR DESCRIPTION
No true failures, but has some macros that collided so I updated to regular MD links. The document titles do seem a little odd with these brackets, but that may just be how the API is