### PR TITLE
Web API titles: some sample interfaces

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.autoPictureInPicture
+title: "HTMLVideoElement: autoPictureInPicture property"
+short-title: autoPictureInPicture
 slug: Web/API/HTMLVideoElement/autoPictureInPicture
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.disablePictureInPicture
+title: "HTMLVideoElement: disablePictureInPicture property"
+short-title: disablePictureInPicture
 slug: Web/API/HTMLVideoElement/disablePictureInPicture
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.md
+++ b/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.md
@@ -1,5 +1,6 @@
 ---
-title: 'HTMLVideoElement: enterpictureinpicture event'
+title: "HTMLVideoElement: enterpictureinpicture event"
+short-title: enterpictureinpicture
 slug: Web/API/HTMLVideoElement/enterpictureinpicture_event
 page-type: web-api-event
 tags:
@@ -25,9 +26,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('enterpictureinpicture', (event) => { });
+addEventListener("enterpictureinpicture", (event) => {});
 
-onenterpictureinpicture = (event) => { };
+onenterpictureinpicture = (event) => {};
 ```
 
 ## Event type
@@ -47,25 +48,25 @@ These examples add an event listener for the HTMLVideoElement's `enterpictureinp
 Using `addEventListener()`:
 
 ```js
-const video = document.querySelector('#video');
-const button = document.querySelector('#button');
+const video = document.querySelector("#video");
+const button = document.querySelector("#button");
 
 function onEnterPip() {
   console.log("Picture-in-Picture mode activated!");
 }
 
-video.addEventListener('enterpictureinpicture', onEnterPip, false);
+video.addEventListener("enterpictureinpicture", onEnterPip, false);
 
 button.onclick = () => {
   video.requestPictureInPicture();
-}
+};
 ```
 
 Using the `onenterpictureinpicture` event handler property:
 
 ```js
-const video = document.querySelector('#video');
-const button = document.querySelector('#button');
+const video = document.querySelector("#video");
+const button = document.querySelector("#button");
 
 function onEnterPip() {
   console.log("Picture-in-Picture mode activated!");
@@ -75,7 +76,7 @@ video.onenterpictureinpicture = onEnterPip;
 
 button.onclick = () => {
   video.requestPictureInPicture();
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.getVideoPlaybackQuality()
+title: "HTMLVideoElement: getVideoPlaybackQuality() method"
+short-title: getVideoPlaybackQuality()
 slug: Web/API/HTMLVideoElement/getVideoPlaybackQuality
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.md
+++ b/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.md
@@ -1,5 +1,6 @@
 ---
-title: 'HTMLVideoElement: leavepictureinpicture event'
+title: "HTMLVideoElement: leavepictureinpicture event"
+short-title: leavepictureinpicture
 slug: Web/API/HTMLVideoElement/leavepictureinpicture_event
 page-type: web-api-event
 tags:
@@ -25,9 +26,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('leavepictureinpicture', (event) => { });
+addEventListener("leavepictureinpicture", (event) => {});
 
-onleavepictureinpicture = (event) => { };
+onleavepictureinpicture = (event) => {};
 ```
 
 ## Event type
@@ -47,8 +48,8 @@ These examples add an event listener for the HTMLVideoElement's `leavepictureinp
 Using `addEventListener()`:
 
 ```js
-const video = document.querySelector('#video');
-const button = document.querySelector('#button');
+const video = document.querySelector("#video");
+const button = document.querySelector("#button");
 
 function onExitPip() {
   console.log("Picture-in-Picture mode deactivated!");
@@ -60,14 +61,14 @@ button.onclick = () => {
   if (document.pictureInPictureElement) {
     document.exitPictureInPicture();
   }
-}
+};
 ```
 
 Using the `onleavepictureinpicture` event handler property:
 
 ```js
-const video = document.querySelector('#video');
-const button = document.querySelector('#button');
+const video = document.querySelector("#video");
+const button = document.querySelector("#button");
 
 function onExitPip() {
   console.log("Picture-in-Picture mode deactivated!");
@@ -79,7 +80,7 @@ button.onclick = () => {
   if (document.pictureInPictureElement) {
     document.exitPictureInPicture();
   }
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlvideoelement/msframestep/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msframestep/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msFrameStep()
+title: "HTMLVideoElement: msFrameStep() method"
+short-title: msFrameStep()
 slug: Web/API/HTMLVideoElement/msFrameStep
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msHorizontalMirror
+title: "HTMLVideoElement: msHorizontalMirror property"
+short-title: msHorizontalMirror
 slug: Web/API/HTMLVideoElement/msHorizontalMirror
 page-type: web-api-instance-property
 tags:
@@ -30,18 +31,18 @@ when user moves left, their representation on-screen would move left as well).
 ## Examples
 
 ```js
-       const myVideo = document.getElementById("videoTag1");
-       myVideo.msHorizontalMirror = true;
-       myVideo.play();
+const myVideo = document.getElementById("videoTag1");
+myVideo.msHorizontalMirror = true;
+myVideo.play();
 ```
 
 Example #2:
 
 ```js
-    const flip = document.querySelector('#flip');
-    flip.addEventListener('click', function() {
-      video.msHorizontalMirror = true;
-    });
+const flip = document.querySelector("#flip");
+flip.addEventListener("click", function () {
+  video.msHorizontalMirror = true;
+});
 ```
 
 ## See also

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msInsertVideoEffect()
+title: "HTMLVideoElement: msInsertVideoEffect() method"
+short-title: msInsertVideoEffect()
 slug: Web/API/HTMLVideoElement/msInsertVideoEffect
 page-type: web-api-instance-method
 tags:
@@ -44,7 +45,11 @@ None ({{jsxref("undefined")}}).
 
 ```js
 const oVideo1 = document.getElementById("video1");
-oVideo1.msInsertVideoEffect("Windows.Media.VideoEffects.VideoStabilization", true, null);
+oVideo1.msInsertVideoEffect(
+  "Windows.Media.VideoEffects.VideoStabilization",
+  true,
+  null
+);
 ```
 
 ## See also

--- a/files/en-us/web/api/htmlvideoelement/msisboxed/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msisboxed/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msIsBoxed
+title: "HTMLVideoElement: msIsBoxed property"
+short-title: msIsBoxed
 slug: Web/API/HTMLVideoElement/msIsBoxed
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msIsLayoutOptimalForPlayback
+title: "HTMLVideoElement: msIsLayoutOptimalForPlayback property"
+short-title: msIsLayoutOptimalForPlayback
 slug: Web/API/HTMLVideoElement/msIsLayoutOptimalForPlayback
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msIsStereo3D
+title: "HTMLVideoElement: msIsStereo3D property"
+short-title: msIsStereo3D
 slug: Web/API/HTMLVideoElement/msIsStereo3D
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msSetVideoRectangle
+title: "HTMLVideoElement: msSetVideoRectangle property"
+short-title: msSetVideoRectangle
 slug: Web/API/HTMLVideoElement/msSetVideoRectangle
 page-type: web-api-instance-property
 tags:
@@ -43,7 +44,7 @@ HTMLVideoElement.msSetVideoRectangle(
   2, // left
   0, // top
   4, // right
-  4, // bottom
+  4 // bottom
 );
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msStereo3DPackingMode
+title: "HTMLVideoElement: msStereo3DPackingMode property"
+short-title: msStereo3DPackingMode
 slug: Web/API/HTMLVideoElement/msStereo3DPackingMode
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msStereo3DRenderMode
+title: "HTMLVideoElement: msStereo3DRenderMode property"
+short-title: msStereo3DRenderMode
 slug: Web/API/HTMLVideoElement/msStereo3DRenderMode
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/mszoom/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mszoom/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.msZoom
+title: "HTMLVideoElement: msZoom property"
+short-title: msZoom
 slug: Web/API/HTMLVideoElement/msZoom
 page-type: web-api-instance-property
 tags:
@@ -45,9 +46,9 @@ space of the video object.
 This examples gets a Video object and sets the `msZoom` property to true.
 
 ```js
-    const myVideo = document.getElementById("videoTag1");
-       myVideo.msZoom = true;
-       myVideo.play();
+const myVideo = document.getElementById("videoTag1");
+myVideo.msZoom = true;
+myVideo.play();
 ```
 
 ## See also

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.onMSVideoFormatChanged
+title: "HTMLVideoElement: onMSVideoFormatChanged property"
+short-title: onMSVideoFormatChanged
 slug: Web/API/HTMLVideoElement/onMSVideoFormatChanged
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.onMSVideoFrameStepCompleted
+title: "HTMLVideoElement: onMSVideoFrameStepCompleted property"
+short-title: onMSVideoFrameStepCompleted
 slug: Web/API/HTMLVideoElement/onMSVideoFrameStepCompleted
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.onMSVideoOptimalLayoutChanged
+title: "HTMLVideoElement: onMSVideoOptimalLayoutChanged property"
+short-title: onMSVideoOptimalLayoutChanged
 slug: Web/API/HTMLVideoElement/onMSVideoOptimalLayoutChanged
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.requestPictureInPicture()
+title: "HTMLVideoElement: requestPictureInPicture() method"
+short-title: requestPictureInPicture()
 slug: Web/API/HTMLVideoElement/requestPictureInPicture
 page-type: web-api-instance-method
 tags:
@@ -53,10 +54,13 @@ listener to handle the floating window resizing.
 
 ```js
 function enterPictureInPicture() {
-  videoElement.requestPictureInPicture()
-    .then((pictureInPictureWindow) => {
-      pictureInPictureWindow.addEventListener("resize", () => onPipWindowResize(), false);
-    })
+  videoElement.requestPictureInPicture().then((pictureInPictureWindow) => {
+    pictureInPictureWindow.addEventListener(
+      "resize",
+      () => onPipWindowResize(),
+      false
+    );
+  });
 }
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/videoheight/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videoheight/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.videoHeight
+title: "HTMLVideoElement: videoHeight property"
+short-title: videoHeight
 slug: Web/API/HTMLVideoElement/videoHeight
 page-type: web-api-instance-property
 tags:
@@ -55,15 +56,19 @@ This example creates a handler for the {{domxref("HTMLVideoElement.resize", "res
 ```js
 let v = document.getElementById("myVideo");
 
-v.addEventListener("resize", (ev) => {
-  let w = v.videoWidth;
-  let h = v.videoHeight;
+v.addEventListener(
+  "resize",
+  (ev) => {
+    let w = v.videoWidth;
+    let h = v.videoHeight;
 
-  if (w && h) {
-    v.style.width = w;
-    v.style.height = h;
-  }
-}, false);
+    if (w && h) {
+      v.style.width = w;
+      v.style.height = h;
+    }
+  },
+  false
+);
 ```
 
 Note that this only applies the change if both the `videoWidth` and the `videoHeight` are non-zero.

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.md
@@ -1,5 +1,6 @@
 ---
-title: HTMLVideoElement.videoWidth
+title: "HTMLVideoElement: videoWidth property"
+short-title: videoWidth
 slug: Web/API/HTMLVideoElement/videoWidth
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/response/arraybuffer/index.md
+++ b/files/en-us/web/api/response/arraybuffer/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.arrayBuffer()
+title: "Response: arrayBuffer() method"
+short-title: arrayBuffer()
 slug: Web/API/Response/arrayBuffer
 page-type: web-api-instance-method
 tags:
@@ -62,7 +63,7 @@ when it is already playing (this would cause an error.)
 function getData() {
   const audioCtx = new AudioContext();
 
-  return fetch('viper.ogg')
+  return fetch("viper.ogg")
     .then((response) => {
       if (!response.ok) {
         throw new Error(`HTTP error, status = ${response.status}`);
@@ -76,16 +77,16 @@ function getData() {
       source.connect(audioCtx.destination);
       return source;
     });
-};
+}
 
 // wire up buttons to stop and play audio
 
 play.onclick = () => {
   getData().then((source) => {
     source.start(0);
-    play.setAttribute('disabled', 'disabled');
+    play.setAttribute("disabled", "disabled");
   });
-}
+};
 ```
 
 ### Reading files

--- a/files/en-us/web/api/response/blob/index.md
+++ b/files/en-us/web/api/response/blob/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.blob()
+title: "Respons: blob() method"
+short-title: blob()
 slug: Web/API/Response/blob
 page-type: web-api-instance-method
 tags:
@@ -48,9 +49,9 @@ out of the response using `blob()`, put it into an object URL using
 {{htmlelement("img")}} element to display the image.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest)
   .then((response) => response.blob())

--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.body
+title: "Response: body property"
+short-title: body
 slug: Web/API/Response/body
 page-type: web-api-instance-property
 tags:
@@ -29,40 +30,40 @@ expose the response's stream using `response.body`, create a reader using {{domx
 then enqueue that stream's chunks into a second, custom readable stream — effectively creating an identical copy of the image.
 
 ```js
-const image = document.getElementById('target');
+const image = document.getElementById("target");
 
 // Fetch the original image
-fetch('./tortoise.png')
-// Retrieve its body as ReadableStream
-.then((response) => response.body)
-.then((body) => {
-  const reader = body.getReader();
+fetch("./tortoise.png")
+  // Retrieve its body as ReadableStream
+  .then((response) => response.body)
+  .then((body) => {
+    const reader = body.getReader();
 
-  return new ReadableStream({
-    start(controller) {
-      return pump();
+    return new ReadableStream({
+      start(controller) {
+        return pump();
 
-      function pump() {
-        return reader.read().then(({ done, value }) => {
-          // When no more data needs to be consumed, close the stream
-          if (done) {
-            controller.close();
-            return;
-          }
+        function pump() {
+          return reader.read().then(({ done, value }) => {
+            // When no more data needs to be consumed, close the stream
+            if (done) {
+              controller.close();
+              return;
+            }
 
-          // Enqueue the next data chunk into our target stream
-          controller.enqueue(value);
-          return pump();
-        });
-      }
-    }
+            // Enqueue the next data chunk into our target stream
+            controller.enqueue(value);
+            return pump();
+          });
+        }
+      },
+    });
   })
-})
-.then((stream) => new Response(stream))
-.then((response) => response.blob())
-.then((blob) => URL.createObjectURL(blob))
-.then((url) => console.log(image.src = url))
-.catch((err) => console.error(err));
+  .then((stream) => new Response(stream))
+  .then((response) => response.blob())
+  .then((blob) => URL.createObjectURL(blob))
+  .then((url) => console.log((image.src = url)))
+  .catch((err) => console.error(err));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.bodyUsed
+title: "Response: bodyUsed property"
+short-title: bodyUsed
 slug: Web/API/Response/bodyUsed
 page-type: web-api-instance-property
 tags:
@@ -41,8 +42,8 @@ This returns `false` before and `true` afterwards, as at that point the body has
 ### JavaScript Content
 
 ```js
-const myImage = document.querySelector('.my-image');
-fetch('https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg')
+const myImage = document.querySelector(".my-image");
+fetch("https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg")
   .then((response) => {
     console.log(response.bodyUsed);
     const res = response.blob();

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.clone()
+title: "Response: clone() method"
+short-title: clone()
 slug: Web/API/Response/clone
 page-type: web-api-instance-method
 tags:
@@ -56,10 +57,10 @@ When the fetch resolves successfully, we clone it, extract a blob from both resp
 {{domxref("URL.createObjectURL")}}, and display them in two separate {{htmlelement("img")}} elements.
 
 ```js
-const image1 = document.querySelector('.img1');
-const image2 = document.querySelector('.img2');
+const image1 = document.querySelector(".img1");
+const image2 = document.querySelector(".img2");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   const response2 = response.clone();

--- a/files/en-us/web/api/response/error/index.md
+++ b/files/en-us/web/api/response/error/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.error()
+title: "Response: error() static method"
+short-title: error()
 slug: Web/API/Response/error
 page-type: web-api-static-method
 tags:

--- a/files/en-us/web/api/response/formdata/index.md
+++ b/files/en-us/web/api/response/formdata/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.formData()
+title: "Response: formData() method"
+short-title: formData()
 slug: Web/API/Response/formData
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/response/headers/index.md
+++ b/files/en-us/web/api/response/headers/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.headers
+title: "Response: headers property"
+short-title: headers
 slug: Web/API/Response/headers
 page-type: web-api-instance-property
 tags:
@@ -32,9 +33,9 @@ create an object URL out of it using {{domxref("URL.createObjectURL")}}, and dis
 Note that at the top of the `fetch()` block, we log the response headers to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   // for each response header, log an array with header name as key

--- a/files/en-us/web/api/response/json/index.md
+++ b/files/en-us/web/api/response/json/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.json()
+title: "Response: json() method"
+short-title: json()
 slug: Web/API/Response/json
 page-type: web-api-instance-method
 tags:
@@ -44,24 +45,19 @@ values out of the resulting objects as you'd expect and insert them into list it
 display our product data.
 
 ```js
-const myList = document.querySelector('ul');
-const myRequest = new Request('products.json');
+const myList = document.querySelector("ul");
+const myRequest = new Request("products.json");
 
 fetch(myRequest)
   .then((response) => response.json())
   .then((data) => {
     for (const product of data.products) {
-      const listItem = document.createElement('li');
+      const listItem = document.createElement("li");
+      listItem.appendChild(document.createElement("strong")).textContent =
+        product.Name;
+      listItem.append(` can be found in ${product.Location}. Cost: `);
       listItem.appendChild(
-        document.createElement('strong')
-      ).textContent = product.Name;
-      listItem.append(
-        ` can be found in ${
-          product.Location
-        }. Cost: `
-      );
-      listItem.appendChild(
-        document.createElement('strong')
+        document.createElement("strong")
       ).textContent = `£${product.Price}`;
       myList.appendChild(listItem);
     }

--- a/files/en-us/web/api/response/ok/index.md
+++ b/files/en-us/web/api/response/ok/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.ok
+title: "Response: ok property"
+short-title: ok
 slug: Web/API/Response/ok
 page-type: web-api-instance-property
 tags:
@@ -29,9 +30,9 @@ We then fetch this request using {{domxref("fetch()")}}, extract a blob from the
 > **Note:** at the top of the `fetch()` block we log the response `ok` value to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   console.log(response.ok); // returns true if the response returned successfully

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.redirect()
+title: "Response: redirect() static method"
+short-title: redirect()
 slug: Web/API/Response/redirect
 page-type: web-api-static-method
 tags:
@@ -48,7 +49,7 @@ A {{domxref("Response")}} object.
 ## Examples
 
 ```js
-Response.redirect('https://www.example.com', 302);
+Response.redirect("https://www.example.com", 302);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.redirected
+title: "Response: redirected property"
+short-title: redirected
 slug: Web/API/Response/redirected
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/response/response/index.md
+++ b/files/en-us/web/api/response/response/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response()
+title: "Response: Response() constructor"
+short-title: Response()
 slug: Web/API/Response/Response
 page-type: web-api-constructor
 tags:
@@ -62,7 +63,7 @@ we create a new `Response` object using the constructor, passing it a new {{domx
 
 ```js
 const myBlob = new Blob();
-const myOptions = { status: 200, statusText: 'SuperSmashingGreat!' };
+const myOptions = { status: 200, statusText: "SuperSmashingGreat!" };
 const myResponse = new Response(myBlob, myOptions);
 ```
 

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.status
+title: "Response: status property"
+short-title: status
 slug: Web/API/Response/status
 page-type: web-api-instance-property
 tags:
@@ -32,9 +33,9 @@ We then fetch this request using {{domxref("fetch()")}}, extract a blob from the
 Note that at the top of the `fetch()` block we log the response `status` value to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   console.log(response.status); // returns 200

--- a/files/en-us/web/api/response/statustext/index.md
+++ b/files/en-us/web/api/response/statustext/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.statusText
+title: "Response: statusText property"
+short-title: statusText
 slug: Web/API/Response/statusText
 page-type: web-api-instance-property
 tags:
@@ -34,9 +35,9 @@ We then fetch this request using {{domxref("fetch()")}}, extract a blob from the
 Note that at the top of the `fetch()` block we log the response `statusText` value to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   console.log(response.statusText); // returns "OK" if the response returned successfully

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.text()
+title: "Response: text() method"
+short-title: text()
 slug: Web/API/Response/text
 page-type: web-api-instance-method
 tags:
@@ -41,13 +42,13 @@ When `getData()` is run, we create a new request using the {{domxref("Request.Re
 When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element equal to the text object.
 
 ```js
-const myArticle = document.querySelector('article');
-const myLinks = document.querySelectorAll('ul a');
+const myArticle = document.querySelector("article");
+const myLinks = document.querySelectorAll("ul a");
 
 for (const link of myLinks) {
   link.onclick = (e) => {
     e.preventDefault();
-    const linkData = e.target.getAttribute('data-page');
+    const linkData = e.target.getAttribute("data-page");
     getData(linkData);
   };
 }

--- a/files/en-us/web/api/response/type/index.md
+++ b/files/en-us/web/api/response/type/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.type
+title: "Response: type property"
+short-title: type
 slug: Web/API/Response/type
 page-type: web-api-instance-property
 tags:
@@ -42,9 +43,9 @@ We then fetch this request using {{domxref("fetch()")}}, extract a blob from the
 Note that at the top of the `fetch()` block we log the response `type` to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   console.log(response.type); // returns basic by default

--- a/files/en-us/web/api/response/url/index.md
+++ b/files/en-us/web/api/response/url/index.md
@@ -1,5 +1,6 @@
 ---
-title: Response.url
+title: "Response: url property"
+short-title: url
 slug: Web/API/Response/url
 page-type: web-api-instance-property
 tags:
@@ -29,9 +30,9 @@ We then fetch this request using {{domxref("fetch()")}}, extract a blob from the
 Note that at the top of the `fetch()` block we log the response `URL` to the console.
 
 ```js
-const myImage = document.querySelector('img');
+const myImage = document.querySelector("img");
 
-const myRequest = new Request('flowers.jpg');
+const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest).then((response) => {
   console.log(response.url); // returns https://developer.mozilla.org/en-US/docs/Web/API/Response/flowers.jpg

--- a/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.createCubeLayer()
+title: "XRWebGLBinding: createCubeLayer() method"
+short-title: createCubeLayer()
 slug: Web/API/XRWebGLBinding/createCubeLayer
 page-type: web-api-instance-method
 tags:
@@ -95,10 +96,10 @@ function onXRSessionStarted(xrSession) {
   const cubeLayer = xrGlBinding.createCubeLayer({
     space: xrReferenceSpace,
     viewPixelHeight: 512,
-    viewPixelWidth: 512
+    viewPixelWidth: 512,
   });
   xrSession.updateRenderState({
-    layers: [cubeLayer]
+    layers: [cubeLayer],
   });
 }
 ```

--- a/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.createCylinderLayer()
+title: "XRWebGLBinding: createCylinderLayer() method"
+short-title: createCylinderLayer()
 slug: Web/API/XRWebGLBinding/createCylinderLayer
 page-type: web-api-instance-method
 tags:
@@ -114,14 +115,14 @@ function onXRSessionStarted(xrSession) {
     space: xrReferenceSpace,
     viewPixelWidth: 1200,
     viewPixelHeight: 600,
-    centralAngle : 60 * Math.PI / 180,
-    aspectRatio : 2,
-    radius : 2,
-    transform : new XRRigidTransform(/* … */),
+    centralAngle: (60 * Math.PI) / 180,
+    aspectRatio: 2,
+    radius: 2,
+    transform: new XRRigidTransform(/* … */),
   });
 
   xrSession.updateRenderState({
-    layers: [cylinderLayer]
+    layers: [cylinderLayer],
   });
 }
 ```

--- a/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.createEquirectLayer()
+title: "XRWebGLBinding: createEquirectLayer() method"
+short-title: createEquirectLayer()
 slug: Web/API/XRWebGLBinding/createEquirectLayer
 page-type: web-api-instance-method
 tags:
@@ -121,11 +122,11 @@ function onXRSessionStarted(xrSession) {
     centralHorizontalAngle: 2 * Math.PI,
     upperVerticalAngle: Math.PI / 2.0,
     lowerVerticalAngle: -Math.PI / 2.0,
-    radius: 0
+    radius: 0,
   });
 
   xrSession.updateRenderState({
-    layers: [equirectLayer]
+    layers: [equirectLayer],
   });
 }
 ```

--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.createProjectionLayer()
+title: "XRWebGLBinding: createProjectionLayer() method"
+short-title: createProjectionLayer()
 slug: Web/API/XRWebGLBinding/createProjectionLayer
 page-type: web-api-instance-method
 tags:
@@ -75,12 +76,12 @@ function onXRSessionStarted(xrSession) {
   const gl = glCanvas.getContext("webgl2", { xrCompatible: true });
   const xrGlBinding = new XRWebGLBinding(xrSession, gl);
   const projectionLayer = xrGlBinding.createProjectionLayer({
-    textureType: "texture-array"
+    textureType: "texture-array",
   });
   xrSession.updateRenderState({
-    layers: [projectionLayer]
+    layers: [projectionLayer],
   });
- }
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.createQuadLayer()
+title: "XRWebGLBinding: createQuadLayer() method"
+short-title: createQuadLayer()
 slug: Web/API/XRWebGLBinding/createQuadLayer
 page-type: web-api-instance-method
 tags:
@@ -114,10 +115,10 @@ function onXRSessionStarted(xrSession) {
     space: xrReferenceSpace,
     viewPixelHeight: 512,
     viewPixelWidth: 512,
-    transform: new XRRigidTransform({z: -2})
+    transform: new XRRigidTransform({ z: -2 }),
   });
   xrSession.updateRenderState({
-    layers: [quadLayer]
+    layers: [quadLayer],
   });
 }
 ```

--- a/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.getDepthInformation()
+title: "XRWebGLBinding: getDepthInformation() method"
+short-title: getDepthInformation()
 slug: Web/API/XRWebGLBinding/getDepthInformation
 page-type: web-api-instance-method
 tags:
@@ -55,8 +56,8 @@ const session = navigator.xr.requestSession("immersive-ar", {
   requiredFeatures: ["depth-sensing"],
   depthSensing: {
     usagePreference: ["gpu-optimized"],
-    formatPreference: ["luminance-alpha"]
-  }
+    formatPreference: ["luminance-alpha"],
+  },
 });
 
 const glBinding = new XRWebGLBinding(session, gl);

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.getReflectionCubeMap()
+title: "XRWebGLBinding: getReflectionCubeMap() method"
+short-title: getReflectionCubeMap()
 slug: Web/API/XRWebGLBinding/getReflectionCubeMap
 page-type: web-api-instance-method
 tags:
@@ -42,10 +43,10 @@ If the `rgba16f` format is used, enable the {{domxref("OES_texture_half_float")}
 
 ```js
 const glBinding = new XRWebGLBinding(xrSession, gl);
-gl.getExtension('OES_texture_half_float'); // if rgba16f is the preferredReflectionFormat
+gl.getExtension("OES_texture_half_float"); // if rgba16f is the preferredReflectionFormat
 
 xrSession.requestLightProbe().then((lightProbe) => {
-  lightProbe.addEventListener('reflectionchange', () => {
+  lightProbe.addEventListener("reflectionchange", () => {
     glBinding.getReflectionCubeMap(lightProbe);
   });
 });

--- a/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.getSubImage()
+title: "XRWebGLBinding: getSubImage() method"
+short-title: getSubImage()
 slug: Web/API/XRWebGLBinding/getSubImage
 page-type: web-api-instance-method
 tags:
@@ -64,11 +65,11 @@ const xrGlBinding = new XRWebGLBinding(xrSession, gl);
 const quadLayer = xrGlBinding.createQuadLayer({
   space: xrReferenceSpace,
   viewPixelWidth: 512,
-  viewPixelHeight: 512
+  viewPixelHeight: 512,
 });
 
 // Position 2 meters away from the origin with a width and height of 1.5 meters
-quadLayer.transform = new XRRigidTransform({z: -2});
+quadLayer.transform = new XRRigidTransform({ z: -2 });
 quadLayer.width = 1.5;
 quadLayer.height = 1.5;
 
@@ -81,7 +82,12 @@ function onXRFrame(time, xrFrame) {
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
   let subImage = xrGlBinding.getSubImage(quadLayer, xrFrame);
-  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, subImage.colorTexture, 0);
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    subImage.colorTexture,
+    0
+  );
   let viewport = subImage.viewport;
   gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
 

--- a/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.getViewSubImage()
+title: "XRWebGLBinding: getViewSubImage() method"
+short-title: getViewSubImage()
 slug: Web/API/XRWebGLBinding/getViewSubImage
 page-type: web-api-instance-method
 tags:
@@ -61,10 +62,20 @@ function onXRFrame(time, xrFrame) {
 
   for (const view in xrViewerPose.views) {
     const subImage = xrGlBinding.getViewSubImage(layer, view);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
-      gl.TEXTURE_2D, subImage.colorTexture, 0);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,
-      gl.TEXTURE_2D, subImage.depthStencilTexture, 0);
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.COLOR_ATTACHMENT0,
+      gl.TEXTURE_2D,
+      subImage.colorTexture,
+      0
+    );
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.DEPTH_ATTACHMENT,
+      gl.TEXTURE_2D,
+      subImage.depthStencilTexture,
+      0
+    );
     const viewport = subImage.viewport;
     gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
 

--- a/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
+++ b/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding.nativeProjectionScaleFactor
+title: "XRWebGLBinding: nativeProjectionScaleFactor property"
+short-title: nativeProjectionScaleFactor
 slug: Web/API/XRWebGLBinding/nativeProjectionScaleFactor
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -1,5 +1,6 @@
 ---
-title: XRWebGLBinding()
+title: "XRWebGLBinding: XRWebGLBinding() constructor"
+short-title: XRWebGLBinding()
 slug: Web/API/XRWebGLBinding/XRWebGLBinding
 page-type: web-api-constructor
 tags:


### PR DESCRIPTION
This draft PR is to show what page titles based on https://github.com/orgs/mdn/discussions/248#discussioncomment-3797416 would look like. It updates the title and adds `short-title` for three interfaces:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement
https://developer.mozilla.org/en-US/docs/Web/API/Response
https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLBinding

I chose `Response` because it's very commonly referenced and has some statics, the other two because they contain some quite long titles.

Note that the sidebars will look a bit silly unless you run this with the Yari from https://github.com/wbamberg/yari/tree/apiref-short-title, which contains the update to make APIRef use `short-title` if it's available.

