### PR TITLE
Update the HTTP/1.1 status code definitions site

### DIFF
--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -31,4 +31,4 @@ The HyperText Transfer Protocol (HTTP) **`502 Bad Gateway`** server error respon
 ## See also
 
 - {{HTTPStatus(504)}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP/1.1: Status Code Definitions]([https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes))


### PR DESCRIPTION
### Description

I changed the HTTP/1.1 status code to the correct one. 

The old one is out of date:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
![image](https://user-images.githubusercontent.com/53285116/197685585-cf12f24e-5cdc-4d6e-b2c1-f5286101428b.png)

The new one is the current document.


### Motivation

It gives the most up to date version. 

### Additional details


### Related issues and pull requests
If there are other error code pages that have this URL, it should be changed. 

