### PR TITLE
Remove browser-extension-template recommendation

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -216,6 +216,4 @@ When approaching a cross-platform extension development, the differences between
 
 The bulk of your cross-platform work is likely to focus on handling variations among the API features supported by the main browsers. Creating your `manifest.json` files should be relatively straightforward and something you can do manually. You will then need to account for the variations in the processes for submitting to each extension store.
 
-You can use [browser-extension-template](https://github.com/fregante/browser-extension-template) to quickly set up a working project for building and publishing a browser extension.
-
 Following the advice in this article, you should be able to create an extension that works well on all of the four main browsers, enabling you to deliver your extension features to more people.


### PR DESCRIPTION
### Description

Remove the [browser-extension-template](https://github.com/fregante/browser-extension-template) recommendation from the [Building a cross-browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension) page.

### Motivation

The [browser-extension-template](https://github.com/fregante/browser-extension-template) has been updated to handle MV3 and is therefore not suitable for inclusion in the [Building a cross-browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension) which only covers MV2.

### Additional details

Suggestion to restore when appropriate: https://github.com/mdn/content/issues/21826

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/21722

