### PR TITLE
Change label attribute on color type example

### DIFF
--- a/files/en-us/web/html/element/datalist/index.md
+++ b/files/en-us/web/html/element/datalist/index.md
@@ -146,7 +146,7 @@ The recommended values in the {{HTMLElement("input/range", "range")}} type will 
 The {{HTMLElement("input/color", "color")}} type can show predefined colors in a browser-provided interface.
 
 ```html
-<label id="colors">Pick a color (preferably a red tone):</label>
+<label for="colors">Pick a color (preferably a red tone):</label>
 <input type="color" list="redColors" id="colors" />
 <datalist id="redColors">
   <option value="#800000"></option>


### PR DESCRIPTION
Changed attribute from id to for on the label element in the color type example.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Using the for attribute links the label to the input. Looks like a typo.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I've never contributed to any project before, lacking the requisite knowledge to correct anything, but this looked like something I could handle. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Nothing to add here.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
