### PR TITLE
Recommend secure instanceof checks

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -248,6 +248,20 @@ new ClassWithPrivateAccessor();
 // 🎬hello world🛑
 ```
 
+Unlike public methods, private methods are not accessible on `Class.prototype`.
+
+```js
+class C {
+  #method() {}
+  static getMethod(x) {
+    return x.#method;
+  }
+}
+
+console.log(C.getMethod(new C())); // [Function: #method]
+console.log(C.getMethod(C.prototype)); // Object must be an instance of class C
+```
+
 #### Private static methods
 
 Like their public equivalent, private static methods are called on the class itself, not instances of the class. Like private static fields, they are only accessible from inside the class declaration.

--- a/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -41,7 +41,7 @@ A boolean indicating whether the calling object (`this`) lies in the prototype c
 
 ## Description
 
-All objects that inherit from `Object.prototype` (that is, all except [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype)) inherit the `isPrototypeOf()` method. This method allows you to check whether or not the object exists within another object's prototype chain. If the `object` passed as parameter is not an object (i.e. a primitive), the method directly returns `false`. Otherwise, the `this` value is [converted to an object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion), and the prototype chain of `object` is searched for the `this` value, until the end of the chain is reached or the `this` value is found.
+All objects that inherit from `Object.prototype` (that is, all except [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype)) inherit the `isPrototypeOf()` method. This method allows you to check whether or not the object exists within another object's prototype chain. If the `object` passed as the parameter is not an object (i.e. a primitive), the method directly returns `false`. Otherwise, the `this` value is [converted to an object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion), and the prototype chain of `object` is searched for the `this` value, until the end of the chain is reached or the `this` value is found.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -13,15 +13,11 @@ browser-compat: javascript.builtins.Object.isPrototypeOf
 
 {{JSRef}}
 
-The **`isPrototypeOf()`** method checks if an object exists in
-another object's prototype chain.
+The **`isPrototypeOf()`** method checks if an object exists in another object's prototype chain.
+
+> **Note:** `isPrototypeOf()` differs from the [`instanceof`](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) operator. In the expression `object instanceof AFunction`, `object`'s prototype chain is checked against `AFunction.prototype`, not against `AFunction` itself.
 
 {{EmbedInteractiveExample("pages/js/object-prototype-isprototypeof.html")}}
-
-> **Note:** `isPrototypeOf()` differs from the {{jsxref("Operators/instanceof", "instanceof")}} operator. In the expression
-> `object instanceof AFunction`, the `object` prototype chain is
-> checked against `AFunction.prototype`, not against `AFunction`
-> itself.
 
 ## Syntax
 
@@ -36,44 +32,36 @@ isPrototypeOf(object)
 
 ### Return value
 
-A {{jsxref("Boolean")}} indicating whether the calling object lies in the prototype
-chain of the specified object.
+A boolean indicating whether the calling object (`this`) lies in the prototype chain of `object`. Directly returns `false` when `object` is not an object (i.e. a primitive).
 
 ### Errors thrown
 
 - {{jsxref("TypeError")}}
-  - : A {{jsxref("TypeError")}} is thrown if `prototypeObj` is
-    undefined or null.
+  - : Thrown if `this` is `null` or `undefined` (because it can't be [converted to an object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion)).
 
 ## Description
 
-The `isPrototypeOf()` method allows you to check whether or not an object
-exists within another object's prototype chain.
+All objects that inherit from `Object.prototype` (that is, all except [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype)) inherit the `isPrototypeOf()` method. This method allows you to check whether or not the object exists within another object's prototype chain. If the `object` passed as parameter is not an object (i.e. a primitive), the method directly returns `false`. Otherwise, the `this` value is [converted to an object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion), and the prototype chain of `object` is searched for the `this` value, until the end of the chain is reached or the `this` value is found.
 
 ## Examples
 
-### Using isPrototypeOf
+### Using isPrototypeOf()
 
-This example demonstrates that `Baz.prototype`,
-`Bar.prototype`, `Foo.prototype` and `Object.prototype`
-exist in the prototype chain for object `baz`:
+This example demonstrates that `Baz.prototype`, `Bar.prototype`, `Foo.prototype` and `Object.prototype` exist in the prototype chain for object `baz`:
 
 ```js
-function Foo() {}
-function Bar() {}
-function Baz() {}
-
-Bar.prototype = Object.create(Foo.prototype);
-Baz.prototype = Object.create(Bar.prototype);
+class Foo {}
+class Bar extends Foo {}
+class Baz extends Bar {}
 
 const foo = new Foo();
 const bar = new Bar();
 const baz = new Baz();
 
 // prototype chains:
-// foo: Foo <- Object
-// bar: Bar <- Foo <- Object
-// baz: Baz <- Bar <- Foo <- Object
+// foo: Foo --> Object
+// bar: Bar --> Foo --> Object
+// baz: Baz --> Bar --> Foo --> Object
 console.log(Baz.prototype.isPrototypeOf(baz));    // true
 console.log(Baz.prototype.isPrototypeOf(bar));    // false
 console.log(Baz.prototype.isPrototypeOf(foo));    // false
@@ -91,6 +79,44 @@ For example, to execute some code that's only safe to run if a `baz` object has 
 ```js
 if (Foo.prototype.isPrototypeOf(baz)) {
   // do something safe
+}
+```
+
+However, `Foo.prototype` existing in `baz`'s prototype chain doesn't imply `baz` was created using `Foo` as its constructor. For example, `baz` could be directly assigned with `Foo.prototype` as its prototype. In this case, if your code reads [private fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) of `Foo` from `baz`, it would still fail:
+
+```js
+class Foo {
+  #value = "foo";
+  static getValue(x) {
+    return x.#value;
+  }
+}
+
+const baz = { __proto__: Foo.prototype };
+
+if (Foo.prototype.isPrototypeOf(baz)) {
+  console.log(Foo.getValue(baz)); // TypeError: Cannot read private member #value from an object whose class did not declare it
+}
+```
+
+The same applies to [`instanceof`](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof). If you need to read private fields in a secure way, offer a branded check method using [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) instead.
+
+```js
+class Foo {
+  #value = "foo";
+  static getValue(x) {
+    return x.#value;
+  }
+  static isFoo(x) {
+    return #value in x;
+  }
+}
+
+const baz = { __proto__: Foo.prototype };
+
+if (Foo.isFoo(baz)) {
+  // Doesn't run, because baz is not a Foo
+  console.log(Foo.getValue(baz));
 }
 ```
 

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -243,6 +243,32 @@ p1.ageDifference(p2); // TypeError: Cannot read private member #age from an obje
 
 Without the `in` operator, you would have to use a `try...catch` block to check if the object has the private property.
 
+You can also implement this as a [`@@hasInstance`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) method of the class, so that you can use the [`instanceof`](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) operator to perform the same check (which, by default, only checks for the existence of `Person.prototype` in the object's prototype chain).
+
+```js
+class Person {
+  #age;
+  constructor(age) {
+    this.#age = age;
+  }
+  static [Symbol.hasInstance](o) {
+    // Testing `this` to prevent false-positives when
+    // calling `instanceof SubclassOfPerson`
+    return this === Person && #age in o;
+  }
+  ageDifference(other) {
+    return this.#age - other.#age;
+  }
+}
+
+const p1 = new Person(20);
+const p2 = new Person(30);
+
+if (p1 instanceof Person && p2 instanceof Person) {
+  console.log(p1.ageDifference(p2)); // -10
+}
+```
+
 For more examples, see [Private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) and the [class guide](/en-US/docs/Web/JavaScript/Guide/Using_Classes#private_fields).
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -38,7 +38,7 @@ object instanceof constructor
 
 ## Description
 
-The `instanceof` operator tests the presence of `constructor.prototype` in `object`'s prototype chain. This usually means `object` was constructed with `constructor`.
+The `instanceof` operator tests the presence of `constructor.prototype` in `object`'s prototype chain. This usually (though [not always](#overriding_the_behavior_of_instanceof)) means `object` was constructed with `constructor`.
 
 ```js
 // defining constructors
@@ -94,6 +94,16 @@ o2 instanceof A;
 o2 instanceof B;
 ```
 
+For [bound functions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind), `instanceof` looks up for the `prototype` property on the target function, since bound functions don't have `prototype`.
+
+```js
+class Base {}
+const BoundBase = Base.bind(null, 1, 2);
+console.log(new Base() instanceof BoundBase); // true
+```
+
+### instanceof and @@hasInstance
+
 If `constructor` has a [`Symbol.hasInstance`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) method, the method will be called in priority, with `object` as its only argument and `constructor` as `this`.
 
 ```js
@@ -109,14 +119,6 @@ class Forgeable {
 
 const obj = { [Forgeable.isInstanceFlag]: true };
 console.log(obj instanceof Forgeable); // true
-```
-
-For [bound functions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind), `instanceof` looks up for the `prototype` property on the target function, since bound functions don't have `prototype`.
-
-```js
-class Base {}
-const BoundBase = Base.bind(null, 1, 2);
-console.log(new Base() instanceof BoundBase); // true
 ```
 
 ### instanceof and multiple realms
@@ -224,6 +226,72 @@ if (!mycar instanceof Car) {
 ```
 
 This will always be `false`. (`!mycar` will be evaluated before `instanceof`, so you always try to know if a boolean is an instance of `Car`).
+
+### Overriding the behavior of instanceof
+
+A common pitfall of using `instanceof` is believing that, if `x instanceof C`, then `x` was created using `C` as constructor. This is not true, because `x` could be directly assigned with `C.prototype` as its prototype. In this case, if your code reads [private fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) of `C` from `x`, it would still fail:
+
+```js
+class C {
+  #value = "foo";
+  static getValue(x) {
+    return x.#value;
+  }
+}
+
+const x = { __proto__: C.prototype };
+
+if (x instanceof C) {
+  console.log(C.getValue(x)); // TypeError: Cannot read private member #value from an object whose class did not declare it
+}
+```
+
+To avoid this, you can override the behavior of `instanceof` by adding a `Symbol.hasInstance` method to `C`, so that it does a branded check with [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in):
+
+```js
+class C {
+  #value = "foo";
+
+  static [Symbol.hasInstance](x) {
+    return #value in x;
+  }
+
+  static getValue(x) {
+    return x.#value;
+  }
+}
+
+const x = { __proto__: C.prototype };
+
+if (x instanceof C) {
+  // Doesn't run, because x is not a C
+  console.log(C.getValue(x));
+}
+```
+
+Note that you may want to limit this behavior to the current class; otherwise, it could lead to false positives for subclasses:
+
+```js
+class D extends C {}
+console.log(new C() instanceof D); // true; because D inherits @@hasInstance from C
+```
+
+You could do this by checking that `this` is the current constructor:
+
+```js
+class C {
+  #value = "foo";
+
+  static [Symbol.hasInstance](x) {
+    return this === C && #value in x;
+  }
+}
+
+class D extends C {}
+console.log(new C() instanceof D); // false
+console.log(new C() instanceof C); // true
+console.log({ __proto__: C.prototype } instanceof C); // false
+```
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Docs recommend using `isPrototypeOf` and the base `instanceof` to test if `x` is an instance of a constructor; this is not safe because instance fields could be missing. Added examples of how this can be worked around.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
