### PR TITLE
remove word-spacing percentage value

### DIFF
--- a/files/en-us/web/css/word-spacing/index.md
+++ b/files/en-us/web/css/word-spacing/index.md
@@ -27,10 +27,6 @@ word-spacing: normal;
 word-spacing: 3px;
 word-spacing: 0.3em;
 
-/* <percentage> values */
-word-spacing: 50%;
-word-spacing: 200%;
-
 /* Global values */
 word-spacing: inherit;
 word-spacing: initial;
@@ -45,8 +41,6 @@ word-spacing: unset;
   - : The normal inter-word spacing, as defined by the current font and/or the browser.
 - {{cssxref("length")}}
   - : Specifies extra spacing in addition to the intrinsic inter-word spacing defined by the font.
-- {{cssxref("percentage")}}
-  - : Specifies extra spacing as a percentage of the affected character's advance width.
 
 ## Examples
 


### PR DESCRIPTION
Cannot use word-spacing percentage value any longer.  The "Try it" section example on line 4, word-spacing: 120%;, does not do anything different from the example on line 1, word-spacing: normal;, and when you change it manually, even back to 120%, you get an error.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
