### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -88,7 +88,7 @@ const wisenArray = Array.of(9.3); // wisenArray contains only one element 9.3
 
 ## Referring to array elements
 
-Because elements are also properties, you can access the using [property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors). Suppose you define the following array:
+Because elements are also properties, you can access them using [property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors). Suppose you define the following array:
 
 ```js
 const myArray = ['Wind', 'Rain', 'Fire'];


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I am reading about JavaScript array to have better understanding and I found a small typo in the material. There is a typo in Referring to array elements part. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The current version writes as follows: 
Because elements are also properties, you can access the using property accessors. Suppose you define the following array:

The updated version should be as follows: 
Because elements are also properties, you can access them using property accessors. Suppose you define the following array:
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #123
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
