### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -225,7 +225,7 @@ nonsparseArray.forEach((element) => {
 // fourth
 ```
 
-Since JavaScript elements are saved as standard object properties, it is not advisable to iterate through JavaScript arrays using {{jsxref("Statements/for...in","for...in")}} loops, because normal elements and all enumerable properties will be listed.
+Since JavaScript array elements are saved as standard object properties, it is not advisable to iterate through JavaScript arrays using {{jsxref("Statements/for...in","for...in")}} loops, because normal elements and all enumerable properties will be listed.
 
 ### Array methods
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Missing word array in line 228. 
I have now added that word to make better sense. Since all JavaScript elements are not objects, we should explicitly write JavaScript array elements are saved as standard object properties and not JavaScript elements are saved as standard object properties. Because this makes reader confusing. 

The current version is as follows: 
Since JavaScript elements are saved as standard object properties

The updated version is as follows: 
Since JavaScript array elements are saved as standard object properties
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I am reading and understanding JavaScript array and a small typo in reading sometimes misleads the understanding. 
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #123
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
