### PR TITLE
Strict-Transport-Security: Use valid preload STS header in the syntax description

### DIFF
--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -44,7 +44,7 @@ Strict-Transport-Security: max-age=<expire-time>; includeSubDomains; preload
 - `includeSubDomains` {{optional_inline}}
   - : If this optional parameter is specified, this rule applies to all of the site's subdomains as well.
 - `preload` {{optional_inline}} {{non-standard_inline}}
-  - : See [Preloading Strict Transport Security](#preloading_strict_transport_security) for details.
+  - : See [Preloading Strict Transport Security](#preloading_strict_transport_security) for details. When using `preload`, the `max-age` directive must be at least `31536000` (1 year), and the `includeSubDomains` directive must be present.
     Not part of the specification.
 
 ## Description

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -34,7 +34,7 @@ The HTTP **`Strict-Transport-Security`** response header (often abbreviated as {
 ```http
 Strict-Transport-Security: max-age=<expire-time>
 Strict-Transport-Security: max-age=<expire-time>; includeSubDomains
-Strict-Transport-Security: max-age=<expire-time>; preload
+Strict-Transport-Security: max-age=<expire-time>; includeSubDomains; preload
 ```
 
 ## Directives


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the syntax examples of the STS header to include a valid use of the preload directive.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Several websites use the preload directive without specifying the necessary includeSubDomains directive. 
It might be that they copied the syntax from this MDN page without reading the requirements.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Requirements: https://hstspreload.org/
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
