### PR TITLE
fix: casing in "ARIA: navigation role" title

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/navigation_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/navigation_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: navigation Role"
+title: "ARIA: navigation role"
 slug: Web/Accessibility/ARIA/Roles/navigation_role
 tags:
   - ARIA


### PR DESCRIPTION
### Description

In the sidebar of <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role>,
the "ARIA: navigation Role" was the only entry with a capitalised "Role" word.

### Motivation

Consistency.
