### PR TITLE
Expand possible syntax to `rgba()` function

### DIFF
--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -25,7 +25,7 @@ The **`rgba()`** functional notation expresses a color according to its red, gre
 
 ```css
 rgba(255, 255, 255) /* white */
-rgba(255, 255, 255, .5) /* white with 50% opacity */
+rgba(255, 255, 255, 0.5) /* white with 50% opacity */
 rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
 rgba(255 255 255 / 50%); /* CSS Colors 4 space-separated values by percentage */
 

--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -27,6 +27,8 @@ The **`rgba()`** functional notation expresses a color according to its red, gre
 rgba(255, 255, 255) /* white */
 rgba(255, 255, 255, .5) /* white with 50% opacity */
 rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
+rgba(255 255 255 / 50%); /* CSS Colors 4 space-separated values by percentage */
+
 ```
 
 ### Values

--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -28,7 +28,6 @@ rgba(255, 255, 255) /* white */
 rgba(255, 255, 255, 0.5) /* white with 50% opacity */
 rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
 rgba(255 255 255 / 50%); /* CSS Colors 4 space-separated values by percentage */
-
 ```
 
 ### Values


### PR DESCRIPTION
### Description

Expands the `rgba()` function to show the possible syntax of using an alpha percentage with space-separated values.
Also adds a leading zero to a previous `rgba()` function for the alpha when it is a floating point number. 

### Motivation

This notation was missing as I was doing my own research and I wanted to expand the definitions.

### Additional details

![Screen Shot 2022-10-28 at 08 59 04](https://user-images.githubusercontent.com/1946020/198595039-f7b202e5-a52e-4d3b-829d-3e116a0b1cb7.png)

### Related issues and pull requests

None.
