### PR TITLE
ci: add Rebase Needed job from mdn/workflows

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -1,0 +1,14 @@
+name: "PR Needs Rebase"
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  label-rebase-needed:
+    uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
+    with:
+      target-repo: "mdn/content"
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed it being used in the Yari repo and found it useful to get the nudge when a PR got a conflict so I could rebase it. It would be nice if GitHub had a first party why of seeing this, but the job seems to work well