### PR TITLE
Rewrite Using the User Timing API

### DIFF
--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -9,21 +9,21 @@ tags:
 
 {{DefaultAPISidebar("User Timing API")}}
 
-The **User Timing API** allows you measure the performance of applications using [high-precision timestamps](/en-US/docs/Web/API/DOMHighResTimeStamp) that are part of the browser's performance timeline.
+The **User Timing API** allows you to measure the performance of applications using [high-precision timestamps](/en-US/docs/Web/API/DOMHighResTimeStamp) that are part of the browser's performance timeline.
 There are two types of timing performance entries:
 
 - {{domxref("PerformanceMark")}} entries are marks that you can name and add at any location in an application.
 - {{domxref("PerformanceMeasure")}} entries are time measurements between two marks.
 
-This document explains in detail how to work with the mark and measure performance entry types. If you are already familiar with the API, see also the [User Timing API](/en-US/docs/Web/API/User_Timing_API) overview page, or consult the reference pages.
+This document explains how to work with the mark and measure performance entry types. If you are already familiar with the API, see the [User Timing API](/en-US/docs/Web/API/User_Timing_API) overview page, or consult the reference pages.
 
 ## What is User Timing?
 
-The browser provides certain information (performance entries) to the browser's performance timeline for you. This includes, for example, entries provided by the [Resource Timing API](/en-US/docs/Web/API/Resource_Timing_API) that determine the length of time it takes to fetch a resource like an image.
+The browser provides certain information (called _performance entries_) to the browser's performance timeline for you. This includes, for example, entries provided by the [Resource Timing API](/en-US/docs/Web/API/Resource_Timing_API) that determine the time it takes to fetch a resource like an image.
 
-The browser, however, can not determine what is going on your application. For example, when a user clicks a button or performs a specific task within your application there is no high precision performance measurement. The User Timing API is an extension to the browser's performance timeline and helps you to measure and record performance data that is custom to your application.
+The browser, however, can not determine what is going on in your application. For example, when a user clicks a button or performs a specific task within your application, there is no high-precision performance measurement. The User Timing API is an extension to the browser's performance timeline and helps you to measure and record performance data that is custom to your application.
 
-The advantage of using this API, over calls to {{jsxref("Date.now()")}} or {{domxref("performance.now()")}}, is that you can give the markers a name and that it integrates well with performance tooling. Browser's developer tools can display performance marks in Performance Panels and it also works with other performance APIs like {{domxref("PerformanceObserver")}} objects.
+The advantage of using this API, over calls to {{jsxref("Date.now()")}} or {{domxref("performance.now()")}}, is that you can give the markers a name and that it integrates well with performance tooling. Browser's developer tools can display performance marks in Performance Panels, and it also works with other performance APIs like {{domxref("PerformanceObserver")}} objects.
 
 ## Adding performance markers
 
@@ -39,7 +39,7 @@ performance.mark("login-started");
 performance.mark("login-finished");
 ```
 
-If the `name` argument isn't enough, `mark()` is configurable using an options object where you can put additional information in the `detail` property (can be of any type). You can also set a different `startTime` if needed. In the following code, the `startTime` is set to `12.5` and additional information like the html element used is provided with `detail`.
+If the `name` argument isn't enough, `mark()` is configurable using an options object where you can put additional information in the `detail` property, which can be of any type. You can also set a different `startTime` if needed. In the following code, the `startTime` is set to `12.5`, and additional information, like the HTML element used, is provided with `detail`.
 
 ```js
 performance.mark("login-started", {
@@ -50,11 +50,11 @@ performance.mark("login-started", {
 
 ## Measuring duration between markers
 
-Now that you added markers into your application, you can measure the time between the markers.
+Now that you added markers to your application, you can measure the time between them.
 
-The {{domxref("Performance.measure()")}} method is used to create a {{domxref("PerformanceMeasure")}} object. It accepts a name parameter, used to identify the measure, and two marks, start and end, that it should measure between. The following example creates "login-duration" measure and measures between the start and the finish of the login process.
+The {{domxref("Performance.measure()")}} method is used to create a {{domxref("PerformanceMeasure")}} object. It accepts a `name` parameter, used to identify the measure, and two marks, `start` and `end`, that it should measure between. The following example creates a `"login-duration"` measure and measures between the start and the finish of the login process.
 
-The object then has a `duration` property which calculated the end mark timestamp minus the start mark timestamp for you. You can log this value or send it it some analytics end point, for example.
+The object then has a `duration` property which calculates the end mark timestamp minus the start mark timestamp for you. For example, you can log this value or send it to some analytics endpoint.
 
 ```js
 const loginMeasure = performance.measure(
@@ -111,10 +111,10 @@ For more information, see {{domxref("PerformanceObserver")}} and [Using Performa
 
 There are many different performance entries in the browser's performance timeline. Some are added by the browser, and some might be added by you, like the login markers and measures from the examples above.
 
-To retrieve performance marks and measures at a single point in time, the {{domxref("Performance")}} interface provides three methods as shown below.
+To retrieve performance marks and measures at a single point in time, the {{domxref("Performance")}} interface provides three methods, as shown below.
 
-> **Note:** The methods below do not notify you about new performance markers; you will only get markers that have been created at the time you call these methods.
-> See the section [Observing performance measures](#observing_performance_measures) above for receiving notifications about new metrics as they come available using a {{domxref("PerformanceObserver")}}. Usually, using performance observers is the preferred way to get performance markers and measures.
+> **Note:** The methods below do not notify you about new performance markers; you will only get markers that have been created when you call these methods.
+> See the section [Observing performance measures](#observing_performance_measures) above for receiving notifications about new metrics as they become available using a {{domxref("PerformanceObserver")}}. Usually, using performance observers is the preferred way to get performance markers and measures.
 
 The {{domxref("Performance.getEntries","performance.getEntries()")}} method gets all performance entries. You can filter them as needed.
 
@@ -148,7 +148,7 @@ The {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name,
 
 ```js
 // Log all marks named "debug-marks"
-const debugMarks = performance.getEntriesByName("debug-mark","mark");
+const debugMarks = performance.getEntriesByName("debug-mark", "mark");
 debugMarks.forEach((entry) => {
   console.log(`${entry.name}'s startTime: ${entry.startTime}`);
 });

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -9,221 +9,177 @@ tags:
 
 {{DefaultAPISidebar("User Timing API")}}
 
-The **`User Timing`** interface allows the developer to create application specific {{domxref("DOMHighResTimeStamp","timestamps")}} that are part of the browser's _performance timeline_. There are two types of _user_ defined timing entry types: the "`mark`" {{domxref("PerformanceEntry.entryType","entry type")}} and the "`measure`" {{domxref("PerformanceEntry.entryType","entry type")}}.
+The **User Timing API** allows you measure the performance of applications using [high-precision timestamps](/en-US/docs/Web/API/DOMHighResTimeStamp) that are part of the browser's performance timeline.
+There are two types of timing performance entries:
 
-**`mark`** events are _named_ by the application and can be set at any location in an application. **`measure`** events are also _named_ by the application but they are placed between two marks thus they are effectively a _midpoint_ between two marks.
+- {{domxref("PerformanceMark")}} entries are marks that you can name and add at any location in an application.
+- {{domxref("PerformanceMeasure")}} entries are time measurements between two marks.
 
-This document shows how to create `mark` and `measure` {{domxref("PerformanceEntry.entryType","performance entry types")}} and how to use `User Timing` methods (which are extensions of the {{domxref("Performance")}} interface) to retrieve and remove entries from the browser's _performance timeline_.
+This document explains in detail how to work with the mark and measure performance entry types. If you are already familiar with the API, see also the [User Timing API](/en-US/docs/Web/API/User_Timing_API) overview page, or consult the reference pages.
 
-A _live_ version of the examples is available on [GitHub](https://mdn.github.io/dom-examples/performance-apis/Using_the_User_Timing_API.html), as is the [source code](https://github.com/mdn/dom-examples/blob/main/performance-apis/Using_the_User_Timing_API.html). Pull requests, enhancement requests and [bug reports](https://github.com/mdn/dom-examples/issues) are welcome.
+## What is User Timing?
 
-## Performance `marks`
+The browser provides certain information (performance entries) to the browser's performance timeline for you. This includes, for example, entries provided by the [Resource Timing API](/en-US/docs/Web/API/Resource_Timing_API) that determine the length of time it takes to fetch a resource like an image.
 
-A performance **`mark`** is a _named_ {{domxref("PerformanceEntry","performance entry")}} that is created by the application at some location in an application. The mark is a {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance timeline_.
+The browser, however, can not determine what is going on your application. For example, when a user clicks a button or performs a specific task within your application there is no high precision performance measurement. The User Timing API is an extension to the browser's performance timeline and helps you to measure and record performance data that is custom to your application.
 
-### Creating a performance `mark`
+The advantage of using this API, over calls to {{jsxref("Date.now()")}} or {{domxref("performance.now()")}}, is that you can give the markers a name and that it integrates well with performance tooling. Browser's developer tools can display performance marks in Performance Panels and it also works with other performance APIs like {{domxref("PerformanceObserver")}} objects.
 
-The {{domxref("Performance.mark","performance.mark()")}} method is used to create a performance mark. The method takes one argument, the _name_ of the mark, as shown in the following example.
+## Adding performance markers
+
+As a first step to start measuring the performance of your app's functionality, you need to add named performance markers at important places in your code. Ideally, you go through your codebase and determine critical paths and important tasks for which you want to ensure they can be performed fast.
+
+The {{domxref("Performance.mark","performance.mark()")}} method is used to create a {{domxref("PerformanceMark")}}. The method takes one argument, the `name` of the mark, as shown in the following example.
 
 ```js
-function create_marks(ev) {
-  if (performance.mark === undefined) {
-    log("Create Marks: performance.mark Not supported", 0);
-    return;
-  } else {
-    log("Create marks", 0);
-    // Create several performance marks including two with the same name
-    performance.mark("mark-1");
-    do_work(50000);
-    performance.mark("mark-2");
-    do_work(50000);
-    performance.mark("mark-2");
-    const marks = ["mark-1", "mark-2", "mark-2"];
-    marks.forEach((mark) => {
-      log(`... Created mark = ${mark}`, 0);
-    });
-  }
-}
+// Place at a location in the code that starts login 
+performance.mark("login-started");
+
+// Place at a location in the code that finishes login 
+performance.mark("login-finished");
 ```
 
-### Retrieving performance `marks`
-
-The {{domxref("Performance")}} interface has three methods to retrieve marks. The following examples shows how to use each of these methods ({{domxref("Performance.getEntries","performance.getEntries()")}}, {{domxref("Performance.getEntriesByType","performance.getEntriesByType(entryType)")}}, and {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name, entryType)")}} ) to retrieve one or more marks.
+If the `name` argument isn't enough, `mark()` is configurable using an options object where you can put additional information in the `detail` property (can be of any type). You can also set a different `startTime` if needed. In the following code, the `startTime` is set to `12.5` and additional information like the html element used is provided with `detail`.
 
 ```js
-function display_marks(ev) {
-  if (performance.getEntries === undefined) {
-    log("Display Marks: performance.getEntries Not supported", 0);
-    return;
-  }
-  log("Display marks", 0);
+performance.mark("login-started", {
+  startTime: 12.5,
+  detail: { htmlElement: myElement.id }
+});
+```
 
-  // Display each mark using getEntries()
-  let entries = performance.getEntries();
-  let j=0;
-  entries.forEach((entry, i) => {
+## Measuring duration between markers
+
+Now that you added markers into your application, you can measure the time between the markers.
+
+The {{domxref("Performance.measure()")}} method is used to create a {{domxref("PerformanceMeasure")}} object. It accepts a name parameter, used to identify the measure, and two marks, start and end, that it should measure between. The following example creates "login-duration" measure and measures between the start and the finish of the login process.
+
+The object then has a `duration` property which calculated the end mark timestamp minus the start mark timestamp for you. You can log this value or send it it some analytics end point, for example.
+
+```js
+const loginMeasure = performance.measure(
+  "login-duration",
+  "login-started",
+  "login-finished"
+);
+
+console.log(loginMeasure.duration);
+```
+
+The {{domxref("Performance.measure()")}} method is also configurable using an options object, so you can do more advanced measurements or provide additional information using the `detail` property.
+
+For example, you can use the [`event.timestamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) to know exactly when a user clicked login and measure that to the point in time when the UI was updated and the user sees they are logged in (which is the `"login-finished"` marker here).
+
+```js
+loginButton.addEventListener('click', (clickEvent) => {
+  fetch(loginURL).then(data => {
+    renderLoggedInUser(data);
+
+    const marker = performance.mark("login-finished");
+
+    performance.measure("login-click", {
+      detail: { htmlElement: myElement.id },
+      start: clickEvent.timeStamp,
+      end: marker.startTime,
+    });
+  });
+});
+```
+
+## Observing performance measures
+
+The preferred way to get notified about your custom performance measures is the use of {{domxref("PerformanceObserver")}} objects. Performance observers allow you to subscribe passively to performance marks and measures as they happen.
+
+```js
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) =>  {
     if (entry.entryType === "mark") {
-      if (j === 0) { log("= getEntries()", 0); j++ }
-      log(`... [${i}] = ${entry.name}`, 0);
+      console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+    };
+    if (entry.entryType === "measure") {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
     };
   });
-
-  // Display each mark using getEntriesByType()
-  entries = performance.getEntriesByType("mark");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByType('mark')", 0);
-    log(`... [${i}] = ${entry.name}`, 0);
-  });
-
-  // Display each mark using getEntriesName(); must look for each mark separately
-  entries = performance.getEntriesByName("mark-1","mark");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByName('mark-1', 'mark')", 0);
-    log(`... ${entry.name}`, 0);
-  });
-  entries = performance.getEntriesByName("mark-2","mark");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByName('mark-2', 'mark')", 0);
-    log(`... ${entry.name}`, 0);
-  });
 }
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
-### Removing performance `marks`
+For more information, see {{domxref("PerformanceObserver")}} and [Using Performance Timeline](https://developer.mozilla.org/en-US/docs/Web/API/Performance_Timeline/Using_Performance_Timeline).
 
-The {{domxref("Performance.clearMarks","performance.clearMarks()")}} method is used to remove one or more marks from the browser's performance timeline. If a specific mark _name_ is given to this method, only the mark(s) with that name will be removed. However, if no argument is given, then all {{domxref("PerformanceEntry","performance entries")}} of type "`mark`" will be removed from the performance timeline. The following example demonstrates both uses of this method.
+## Retrieving markers and measures
+
+There are many different performance entries in the browser's performance timeline. Some are added by the browser, and some might be added by you, like the login markers and measures from the examples above.
+
+To retrieve performance marks and measures at a single point in time, the {{domxref("Performance")}} interface provides three methods as shown below.
+
+> **Note:** The methods below do not notify you about new performance markers; you will only get markers that have been created at the time you call these methods.
+> See the section [Observing performance measures](#observing_performance_measures) above for receiving notifications about new metrics as they come available using a {{domxref("PerformanceObserver")}}. Usually, using performance observers is the preferred way to get performance markers and measures.
+
+The {{domxref("Performance.getEntries","performance.getEntries()")}} method gets all performance entries. You can filter them as needed.
 
 ```js
-function clear_marks(obj) {
-  if (performance.clearMarks === undefined) {
-    log("Clear Marks: performance.clearMarks Not supported", 0);
-    return;
-  }
-  log("Clear marks", 0);
-
-  if (typeof obj === "string") {
-    log(`... cleared '${obj}' mark(s)`, 0);
-    performance.clearMarks(obj);
-  } else {
-    // No argument specified so clear all marks
-    log("... cleared All marks", 0);
-    performance.clearMarks();
-  }
-}
+const entries = performance.getEntries();
+entries.forEach((entry) => {
+  if (entry.entryType === "mark") {
+    console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+  };
+  if (entry.entryType === "measure") {
+    console.log(`${entry.name}'s duration: ${entry.duration}`);
+  };
+});
 ```
 
-## Performance `measures`
-
-A **`measure`** performance entry type is _named_ by the application and its {{domxref("DOMHighResTimeStamp","timestamp")}} is placed between two _named_ marks thus a measure is effectively a _midpoint_ between two marks in the browser's performance timeline.
-
-### Creating a performance `measure`
-
-A `measure` is created by calling `performance.measure(measureName, startMarkName, endMarkName)` where `measureName` is the measure's name and `startMarkName` and `endMarkName` are the start and end names, respectively, of the marks the measure will be placed between (in the performance timeline).
+The {{domxref("Performance.getEntriesByType","performance.getEntriesByType(entryType)")}} method filters the entries by type already.
 
 ```js
-function create_measures(ev) {
-  if (performance.measure === undefined) {
-    log("Create Measures: performance.measure Not supported", 1);
-    return;
-  }
-  log("Create measures", 1);
+const marks = performance.getEntriesByType("mark");
+marks.forEach((entry) => {
+  console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+});
 
-  // Create several performance marks
-  performance.mark("mark-A");
-  do_work(50000);
-  performance.mark("mark-B");
-
-  performance.mark("mark-C");
-  do_work(50000);
-  performance.mark("mark-D");
-
-  // Create some measures
-  performance.measure("measure-1", "mark-A", "mark-B");
-  performance.measure("measure-2", "mark-C", "mark-D");
-
-  // Log the marks and measures
-  const marks = ["mark-A", "mark-B", "mark-C", "mark-D"];
-  marks.forEach((mark) => {
-    log(`... Created mark = ${mark}`, 1);
-  });
-  const measures = ["measures-1", "measures-2"];
-  measures.forEach((measure) => {
-    log(`... Created measure = ${measure}`, 1);
-  });
-}
+const measures = performance.getEntriesByType("measure");
+measures.forEach((entry) => {
+  console.log(`${entry.name}'s duration: ${entry.duration}`);
+});
 ```
 
-### Retrieving performance `measures`
-
-The {{domxref("Performance")}} interface has three methods to retrieve measures. The following examples shows how to use each of these methods ({{domxref("Performance.getEntries","performance.getEntries()")}}, {{domxref("Performance.getEntriesByType","performance.getEntriesByType(entryType)")}}, and {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name, entryType)")}}) to retrieve one or more measures.
+The {{domxref("Performance.getEntriesByName","performance.getEntriesByName(name, entryType)")}} method allows you to get specific marks or measures by name.
 
 ```js
-function display_measures(ev) {
-  if (performance.getEntries === undefined) {
-    log("Display Measures: performance.getEntries Not supported", 1);
-    return;
-  }
-  log("Display measures", 1);
-
-  // Display each measure using getEntries()
-  let entries = performance.getEntries();
-  let j=0;
-  entries.forEach((entry, i) => {
-    if (entry.entryType === "measure") {
-      if (j === 0) { log("= getEntries()", 1); j++ }
-      log(`... [${i}] = ${entry.name}`, 1);
-    }
-  });
-
-  // Display each measure using getEntriesByType
-  entries = performance.getEntriesByType("measure");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByType('measure')", 1);
-    log(`... [${i}] = ${entry.name}`, 1);
-  });
-
-  // Display each measure using getEntriesName() - have to look for each measure separately
-  entries = performance.getEntriesByName("measure-1","measure");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByName('measure-1', 'measure')", 1);
-    log(`... ${entry.name}`, 1);
-  });
-  entries = performance.getEntriesByName("measure-2","measure");
-  entries.forEach((entry, i) => {
-    if (i === 0) log("= getEntriesByName('measure-2', 'measure')", 1);
-    log(`... ${entry.name}`, 1);
-  });
-}
+// Log all marks named "debug-marks"
+const debugMarks = performance.getEntriesByName("debug-mark","mark");
+debugMarks.forEach((entry) => {
+  console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+});
 ```
 
-### Removing performance `measures`
+## Removing markers and measures
 
-The {{domxref("Performance.clearMeasures","performance.clearMeasures()")}} method is used to remove _measures_ from the browser's performance timeline. If the method is called with a specific measure name, all measures with that name will be removed from the timeline. If the method is called with no arguments, all {{domxref("PerformanceEntry","performance entries")}} with a type of "`measure`" will be removed from the timeline. The following examples shows both uses of this method.
+To clean up all performance marks or measures, or just specific entries, the following methods are available:
+
+- [`performance.clearMarks()`](/en-US/docs/Web/API/Performance/clearMarks)
+- [`performance.clearMeasures()`](/en-US/docs/Web/API/Performance/clearMeasures)
 
 ```js
-function clear_measures(obj) {
-  if (performance.clearMeasures === undefined) {
-    log("Clear Measures: performance.clearMeasures Not supported", 1);
-    return;
-  }
-  log("Clear measures", 1);
+// Clear all marks
+performance.clearMarks();
 
-  if (typeof obj === "string") {
-    log(`... cleared '${obj}' measure(s)`, 1);
-    performance.clearMeasures(obj);
-  } else {
-    // No argument specified so clear all measures
-    log("... cleared All measures", 1);
-    performance.clearMeasures();
-  }
-}
+// Removes the marker with the name "myMarker"
+performance.clearMarks("myMarker");
+
+// Clear all measures
+performance.clearMeasures();
+
+// Removes the measure with the name "myMeasure"
+performance.clearMeasures("myMeasure");
 ```
-
-## Interoperability
-
-As shown in the {{domxref("Performance")}} interface's [Browser Compatibility](/en-US/docs/Web/API/Performance#browser_compatibility) table, the `User Timing` methods are broadly implemented by desktop and mobile browsers (the only exceptions are no support for Desktop Safari and Mobile Safari).
 
 ## See also
 
-- [User Timing Standard](https://w3c.github.io/user-timing/); W3C Editor's Draft
-- [A Primer for Web Performance Timing APIs](https://siusin.github.io/perf-timing-primer/); Xiaoqian Wu; W3C Editor's Draft
+- [User Timing API overview](/en-US/docs/Web/API/User_Timing_API)
+- {{domxref("Performance")}}
+- {{domxref("PerformanceMark")}}
+- {{domxref("PerformanceMeasure")}}
+- {{domxref("PerformanceEntry")}}
+- {{domxref("PerformanceObserver")}}

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -105,7 +105,7 @@ const observer = new PerformanceObserver(perfObserver);
 observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
-For more information, see {{domxref("PerformanceObserver")}} and [Using Performance Timeline](https://developer.mozilla.org/en-US/docs/Web/API/Performance_Timeline/Using_Performance_Timeline).
+For more information, see {{domxref("PerformanceObserver")}} and [Using Performance Timeline](/en-US/docs/Web/API/Performance_Timeline/Using_Performance_Timeline).
 
 ## Retrieving markers and measures
 

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -68,7 +68,7 @@ console.log(loginMeasure.duration);
 
 The {{domxref("Performance.measure()")}} method is also configurable using an options object, so you can do more advanced measurements or provide additional information using the `detail` property.
 
-For example, you can use the [`event.timestamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) to know exactly when a user clicked login and measure that to the point in time when the UI was updated and the user sees they are logged in (which is the `"login-finished"` marker here).
+For example, you can use the [`event.timestamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) to know exactly when a user clicked login and measure that to the point in time when the UI was updated, which is the `"login-finished"` marker here.
 
 ```js
 loginButton.addEventListener('click', (clickEvent) => {


### PR DESCRIPTION
### Description

This PR rewrites https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API/Using_the_User_Timing_API.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I ended up completely rewriting this page. I don't think its current structure nor the code examples are particularly useful. It also references stuff on GitHub which I think should be removed. https://github.com/mdn/dom-examples/blob/main/performance-apis/

### Related issues and pull requests

https://github.com/mdn/content/pull/21853 rewrites the corresponding overview page for this API.