### PR TITLE
fix play rejection description

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -45,7 +45,7 @@ rejected if for any reason playback cannot be started.
 
 ### Exceptions
 
-The promise's **rejection handler** is called with an exception name
+The promise's **rejection handler** is called with an exception {{domxref("DOMException")}}
 passed in as its sole input parameter (as opposed to a traditional exception being
 thrown). Possible errors include:
 

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -45,7 +45,7 @@ rejected if for any reason playback cannot be started.
 
 ### Exceptions
 
-The promise's **rejection handler** is called with an exception {{domxref("DOMException")}}
+The promise's **rejection handler** is called with a {{domxref("DOMException")}} object
 passed in as its sole input parameter (as opposed to a traditional exception being
 thrown). Possible errors include:
 


### PR DESCRIPTION
### Description

Fixed description for HTMLMediaElement play rejection payload

### Motivation

Current documentation says that Exception name passed to catch method as a sole argument. This is not name. The whole DOMException passed

### Additional details
https://html.spec.whatwg.org/multipage/media.html#dom-media-play
