### PR TITLE
remove instant as ScrollBehavior type

### DIFF
--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -42,7 +42,7 @@ scroll(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`) or happen instantly in a single jump (`auto`, default).
 
 ### Return value
 


### PR DESCRIPTION
originally, instant scrolling was specified with the "instant", however, it was later renamed to auto. Currently, the only possible values for ScrollBehavior are "auto" and "smooth"
the change note: https://w3c.github.io/csswg-drafts/cssom-view/#changes-from-2013-12-17:~:text=The%20instant%20value%20of%20scroll%2Dbehavior%20was%20renamed%20to%20auto.
the scrollbehavior enum: https://w3c.github.io/csswg-drafts/cssom-view/#extensions-to-the-window-interface:~:text=the%20Window%20Interface-,enum%20ScrollBehavior%20%7B%20%22auto%22%2C%20%22smooth%22%20%7D%3B,-dictionary%20ScrollOptions%20%7B

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
