### PR TITLE
Fix some link flaws in "Firefox 18 for developers"

### DIFF
--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -30,10 +30,10 @@ Firefox 18 was released on January 8, 2013. This article lists key changes that 
 - `navigator.mozPay` has been landed. ({{bug("767818")}})
 - `window.devicePixelRatio` has been landed. ({{bug("564815")}})
 - The MacOS X backend for `window.navigator.battery` has been implemented. ({{bug("696045")}})
-- {{domxref("BlobBuilder", "MozBlobBuilder")}} is removed. Developers need to use {{domxref("Blob")}} constructor for creating a `Blob` object. ({{bug("744907")}})
+- `MozBlobBuilder` is removed. Developers need to use {{domxref("Blob")}} constructor for creating a `Blob` object. ({{bug("744907")}})
 - The {{domxref("document.visibilitychange_event", "visibilitychange")}} event and the [Page Visibility API](/en-US/docs/Web/API/Page_Visibility_API) has been unprefixed ({{bug("812086")}}).
 - {{domxref("TextDecoder")}} and {{domxref("TextEncoder")}} have been added. Note that the implementation and spec of these evolved and have been changed in Firefox 19 ({{bug("764234")}}).
-- `HTMLMediaElement.src` has been separate in two properties: the standard `src` property, dealing with strings, and the prefixed `mozSrcObject` property, dealing with [media streams](/en-US/docs/Web/API/Media_Streams_API) ({{bug("792665")}}).
+- `HTMLMediaElement.src` has been separate in two properties: the standard `src` property, dealing with strings, and the prefixed `mozSrcObject` property, dealing with [media streams](/en-US/docs/Web/API/Media_Capture_and_Streams_API) ({{bug("792665")}}).
 - Support for [transferable objects.](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#passing_data_by_transferring_.c2.a0ownership_%28transferable_objects%29)
 - The {{domxref("Screen.lockOrientation()")}} method now supports an `Array` of strings as argument ({{bug("784549")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Remove `MozBlobBuilder` which no longer has any specific documentation.
- Fix a link to Media Capture and Streams API.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
