### PR TITLE
chore: remove hashes from headings

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -43,7 +43,7 @@ Since JavaScript strings are 16-bit-encoded strings, in most browsers calling `w
 
 Here are the two possible methods.
 
-### Solution #1 – escaping the string before encoding it
+### Solution 1 – escaping the string before encoding it
 
 ```js
 function utf8_to_b64(str) {
@@ -79,7 +79,7 @@ b64EncodeUnicode("✓ à la mode"); // "JUUyJTlDJTkzJTIwJUMzJUEwJTIwbGElMjBtb2Rl
 UnicodeDecodeB64("JUUyJTlDJTkzJTIwJUMzJUEwJTIwbGElMjBtb2Rl"); // "✓ à la mode"
 ```
 
-### Solution #2 – rewriting `atob()` and `btoa()` using `TypedArray`s and UTF-8
+### Solution 2 – rewriting `atob()` and `btoa()` using `TypedArray`s and UTF-8
 
 > **Note:** The following code is also useful to get an [ArrayBuffer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) from a Base64 string and/or vice versa ([see below](#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)).
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -126,13 +126,13 @@ To help improve content discoverability and {{Glossary("SEO")}}, keep the follow
 
 The _name of interface_ extends the following APIs, adding the listed features.
 
-#### Interface #1
+#### Interface 1
 
 - {{domxref("addition1")}}
   - : Description of the feature of Interface#1 that is added to that API by the API you are currently documenting.
     One \*term and definition for each feature. If this API doesn't extend any other interfaces, you can delete these sections.
 
-#### Interface #2
+#### Interface 2
 
 - {{domxref("addition1")}}
   - : Description of the feature of Interface#2 that is added to that API by the API you are currently documenting, etc.

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -122,7 +122,7 @@ single cookie at a time using this method. Consider also that:
 
 ## Examples
 
-### Example #1: Simple usage
+### Example 1: Simple usage
 
 ```js
 // Note that we are setting `SameSite=None;` in this example because the example
@@ -155,7 +155,7 @@ function clearOutputCookies() {
 
 {{EmbedLiveSample('Example_1_Simple_usage', 200, 72)}}
 
-### Example #2: Get a sample cookie named test2
+### Example 2: Get a sample cookie named test2
 
 ```js
 // Note that we are setting `SameSite=None;` in this example because the example
@@ -193,7 +193,7 @@ function clearOutputCookieValue() {
 
 {{EmbedLiveSample('Example_2_Get_a_sample_cookie_named_test2', 200, 72)}}
 
-### Example #3: Do something only once
+### Example 3: Do something only once
 
 In order to use the following code, please replace all occurrences of the word
 `doSomethingOnlyOnce` (the name of the cookie) with a custom name.
@@ -230,7 +230,7 @@ function clearOutputDoOnce() {
 
 {{EmbedLiveSample('Example_3_Do_something_only_once', 200, 72)}}
 
-### Example #4: Reset the previous cookie
+### Example 4: Reset the previous cookie
 
 ```js
 function resetOnce() {
@@ -262,7 +262,7 @@ function clearOutputResetOnce() {
 
 {{EmbedLiveSample('Example_4_Reset_the_previous_cookie', 200, 72)}}
 
-### Example #5: Check a cookie existence
+### Example 5: Check a cookie existence
 
 ```js
 // Note that we are setting `SameSite=None;` in this example because the example
@@ -296,7 +296,7 @@ function clearOutputACookieExists() {
 
 {{EmbedLiveSample('Example_5_Check_a_cookie_existence', 200, 72)}}
 
-### Example #6: Check that a cookie has a specific value
+### Example 6: Check that a cookie has a specific value
 
 ```js
 function checkCookieHasASpecificValue() {

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -306,7 +306,7 @@ The [structured cloning](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_al
 
 ### Passing data examples
 
-#### Example #1: Advanced passing JSON Data and creating a switching system
+#### Example 1: Advanced passing JSON Data and creating a switching system
 
 If you have to pass some complex data and have to call many different functions both on the main page and in the Worker, you can create a system which groups everything together.
 

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -38,7 +38,7 @@ A {{domxref("Location")}} object.
 alert(location); // alerts "https://developer.mozilla.org/en-US/docs/Web/API/Window/location"
 ```
 
-### Example #1: Navigate to a new page
+### Example 1: Navigate to a new page
 
 Whenever a new value is assigned to the location object, a document will be loaded
 using the URL as if `location.assign()` had been called with the modified
@@ -51,13 +51,13 @@ location.assign("http://www.mozilla.org"); // or
 location = "http://www.mozilla.org";
 ```
 
-### Example #2: Reloading the current page
+### Example 2: Reloading the current page
 
 ```js
 location.reload();
 ```
 
-### Example #3
+### Example 3
 
 Consider the following example, which will reload the page by using the [`replace()`](/en-US/docs/Web/API/Location/replace) method to
 insert the value of `location.pathname` into the hash:
@@ -68,7 +68,7 @@ function reloadPageWithHash() {
 }
 ```
 
-### Example #4: Display the properties of the current URL in an alert dialog
+### Example 4: Display the properties of the current URL in an alert dialog
 
 ```js
 function showLoc() {
@@ -82,7 +82,7 @@ function showLoc() {
 // in html: <button onclick="showLoc();">Show location properties</button>
 ```
 
-### Example #5: Send a string of data to the server by modifying the `search` property
+### Example 5: Send a string of data to the server by modifying the `search` property
 
 ```js
 function sendData(data) {
@@ -95,7 +95,7 @@ function sendData(data) {
 The current URL with "?Some%20data" appended is sent to the server (if no action is
 taken by the server, the current document is reloaded with the modified search string).
 
-### Example #6: Using bookmarks without changing the `hash` property
+### Example 6: Using bookmarks without changing the `hash` property
 
 ```html
 <!DOCTYPE html>

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -24,7 +24,7 @@ The {{domxref("navigator")}} object.
 
 ## Examples
 
-### Example #1: Browser detect and return a string
+### Example 1: Browser detect and return a string
 
 ```js
 function getBrowserName(userAgent) {

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -321,7 +321,7 @@ All these methods are covered in preceding sections.
 
 If you're unable to remove `!important` flags from an authors style sheet, the only solution to overriding the important styles is by using `!important`. Creating a [cascade layer](/en-US/docs/Web/CSS/@layer) of important declaration overrides is an excellent solution. Two ways of doing this include:
 
-#### Method #1
+#### Method 1
 
 1. Create a separate, short style sheet containing only important declarations specifically overriding any important declarations you were unable to remove.
 2. Import this stylesheet as the first import in your CSS using `layer()`, including the `@import` statement, before linking to other stylesheets. This is to ensure that the important overrides is imported as the first layer.
@@ -332,7 +332,7 @@ If you're unable to remove `!important` flags from an authors style sheet, the o
 </style>
 ```
 
-#### Method #2
+#### Method 2
 
 1. At the beginning of your stylesheet declarations, create a named cascade layer, like so:
 

--- a/files/en-us/web/guide/mobile/mobile-friendliness/index.md
+++ b/files/en-us/web/guide/mobile/mobile-friendliness/index.md
@@ -10,20 +10,20 @@ tags:
 
 Mobile friendliness can mean a multitude of things, depending on who you're talking to. It can be helpful to think of it in terms of three goals for improving your site's user experience: Presentation, Content, and Performance.
 
-### Goal #1 (Presentation)
+### Goal 1 (Presentation)
 
 **Make websites that work well on a variety of screen sizes.**
 
 These days, users can access the web on devices in a wide range of form factors, including phones, tablets, and eReaders. Needless to say, a fixed-width, three-column layout filled with complex JavaScript animations and mouse-over effects is not going to look or feel quite right on a phone with a 2-inch-wide screen and a diminutive processor. A slimmed-down, linearized page layout with elements [sized for a touchscreen](https://www.lukew.com/ff/entry.asp?1085) would be much more appropriate. That's why this first goal is all about presenting your content in a way that makes life easy for users on mobile device.
 
-### Goal #2 (Content)
+### Goal 2 (Content)
 
 **Adjust your content for mobile users.**
 ![Screen shot of the Alaska Air desktop site on the left, and an iPhone showing the mobile version of the same page](alaska_air_mobile_and_desktop-300x225.png)
 
 Think about what your users want to do at your site if they are on a phone. A great example of this is [Alaska Air's website](https://www.alaskaair.com/). Their desktop site focuses on getting visitors to book trips. Mobile users, however, are probably more interested in checking-in for a flight or seeing if their flight is delayed. They've adjusted their site's content to reflect this, and it meets the needs of mobile users.
 
-### Goal #3 (Performance)
+### Goal 3 (Performance)
 
 **Give your users a smooth experience, even on a slow connection.**
 


### PR DESCRIPTION
Hashes in headings are more of an issue if they are trailing, since then they can be intepreted as the other heading style. Just noticed these in the translations side, and they didn't seem to match the convention in the rest of the files. Left the ones were the literal character was intended (ex: `PSCK #8`)