### PR TITLE
Update Transfer-Encoding to hex numbers

### DIFF
--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -13,32 +13,22 @@ browser-compat: http.headers.Transfer-Encoding
 
 {{HTTPSidebar}}
 
-The **`Transfer-Encoding`** header specifies the form of
-encoding used to safely transfer the {{Glossary("Payload body","payload body")}} to the
-user.
+The **`Transfer-Encoding`** header specifies the form of encoding used to safely transfer the {{Glossary("Payload body","payload body")}} to the user.
 
-> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) doesn't support
-> HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient,
-> mechanisms for data streaming.
+> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) doesn't support HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient, mechanisms for data streaming.
 
-`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a
-message between two nodes, not to a resource itself. Each segment of a multi-node
-connection can use different `Transfer-Encoding` values. If you want to
-compress data over the whole connection, use the end-to-end
-{{HTTPHeader("Content-Encoding")}} header instead.
+`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a message between two nodes, not to a resource itself.
+Each segment of a multi-node connection can use different `Transfer-Encoding` values.
+If you want to compress data over the whole connection, use the end-to-end {{HTTPHeader("Content-Encoding")}} header instead.
 
-When present on a response to a {{HTTPMethod("HEAD")}} request that has no body, it
-indicates the value that would have applied to the corresponding {{HTTPMethod("GET")}}
-message.
+When present on a response to a {{HTTPMethod("HEAD")}} request that has no body, it indicates the value that would have applied to the corresponding {{HTTPMethod("GET")}} message.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">Header type</th>
       <td>
-        {{Glossary("Request header")}},
-        {{Glossary("Response header")}},
-        {{Glossary("Payload header")}}
+        {{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Payload header")}}
       </td>
     </tr>
     <tr>
@@ -63,38 +53,27 @@ Transfer-Encoding: gzip, chunked
 ## Directives
 
 - `chunked`
-  - : Data is sent in a series of chunks. The {{HTTPHeader("Content-Length")}} header is
-    omitted in this case and at the beginning of each chunk you need to add the length of
-    the current chunk in hexadecimal format, followed by '`\r\n`' and then the
-    chunk itself, followed by another '`\r\n`'. The terminating chunk is a
-    regular chunk, with the exception that its length is zero. It is followed by the
-    trailer, which consists of a (possibly empty) sequence of header fields.
+  - : Data is sent in a series of chunks. The {{HTTPHeader("Content-Length")}} header is omitted in this case and at the beginning of each chunk you need to add the length of the current chunk in hexadecimal format, followed by '`\r\n`' and then the chunk itself, followed by another '`\r\n`'.
+    The terminating chunk is a regular chunk, with the exception that its length is zero.
+    It is followed by the trailer, which consists of a (possibly empty) sequence of header fields.
 - `compress`
-  - : A format using the [Lempel-Ziv-Welch](https://en.wikipedia.org/wiki/LZW) (LZW) algorithm. The
-    value name was taken from the UNIX _compress_ program, which implemented this
-    algorithm.
-    Like the compress program, which has disappeared from most UNIX distributions, this
-    content-encoding is used by almost no browsers today, partly because of a patent issue
-    (which expired in 2003).
+  - : A format using the [Lempel-Ziv-Welch](https://en.wikipedia.org/wiki/LZW) (LZW) algorithm.
+    The value name was taken from the UNIX _compress_ program, which implemented this algorithm.
+    Like the compress program, which has disappeared from most UNIX distributions, this content-encoding is used by almost no browsers today, partly because of a patent issue (which expired in 2003).
 - `deflate`
-  - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib)
-    structure (defined in [RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)), with the [_deflate_](https://en.wikipedia.org/wiki/DEFLATE)
-    compression algorithm (defined in [RFC 1951](https://datatracker.ietf.org/doc/html/rfc1952)).
+  - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib) structure (defined in [RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)), with the [_deflate_](https://en.wikipedia.org/wiki/DEFLATE) compression algorithm (defined in [RFC 1951](https://datatracker.ietf.org/doc/html/rfc1952)).
 - `gzip`
-  - : A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77)
-    (LZ77), with a 32-bit CRC. This is originally the format of the UNIX _gzip_
-    program. The HTTP/1.1 standard also recommends that the servers supporting this
-    content-encoding should recognize `x-gzip` as an alias, for compatibility
-    purposes.
+  - : A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) (LZ77), with a 32-bit CRC.
+    This is originally the format of the UNIX _gzip_ program.
+    The HTTP/1.1 standard also recommends that the servers supporting this content-encoding should recognize `x-gzip` as an alias, for compatibility purposes.
 
 ## Examples
 
 ### Chunked encoding
 
-Chunked encoding is useful when larger amounts of data are sent to the client and the
-total size of the response may not be known until the request has been fully processed.
-For example, when generating a large HTML table resulting from a database query or when
-transmitting large images. A chunked response looks like this:
+Chunked encoding is useful when larger amounts of data are sent to the client and the total size of the response may not be known until the request has been fully processed.
+For example, when generating a large HTML table resulting from a database query or when transmitting large images. \
+A chunked response looks like this:
 
 ```http
 HTTP/1.1 200 OK
@@ -122,6 +101,5 @@ Developer Network\r\n
 - {{HTTPHeader("Accept-Encoding")}}
 - {{HTTPHeader("Content-Encoding")}}
 - {{HTTPHeader("Content-Length")}}
-- Header fields that regulate the use of trailers: {{HTTPHeader("TE")}} (requests) and
-  {{HTTPHeader("Trailer")}} (responses).
+- Header fields that regulate the use of trailers: {{HTTPHeader("TE")}} (requests) and {{HTTPHeader("Trailer")}} (responses).
 - [Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -103,10 +103,8 @@ Transfer-Encoding: chunked
 
 7\r\n
 Mozilla\r\n
-9\r\n
-Developer\r\n
-7\r\n
-Network\r\n
+11\r\n
+Developer Network\r\n
 0\r\n
 \r\n
 ```


### PR DESCRIPTION
### Description

The current chunked encoded example is streaming strings that their length is lower than 10 (Mozilla, Developer, Network), therefore, it is easy to miss that the chunked length should be in hexadecimal form.

By merging the 2nd and 3rd line into `Developer Network`, we reach length of 17 which is 11. This marks it much clearer that it is hex.

### Motivation

Making the usage of hex numbers stand out.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
