### PR TITLE
Rephrase single h1 as best practice

### DIFF
--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -77,20 +77,19 @@ The **`<h1>`** to **`<h6>`** [HTML](/en-US/docs/Web/HTML) elements represent six
 
 These elements only include the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-> **Note:** The `align` attribute is obsolete; don't use it.
-
 ## Usage notes
 
 - Heading information can be used by user agents to construct a table of contents for a document automatically.
-- Avoid using heading elements to resize text. Instead, use the {{glossary("CSS")}} {{cssxref("font-size")}} property.
-- Avoid skipping heading levels: always start from `<h1>`, followed by `<h2>` and so on.
-- Use only one `<h1>` per page or view. It should concisely describe the overall purpose of the content.
+- Do not use heading elements to resize text. Instead, use the {{glossary("CSS")}} {{cssxref("font-size")}} property.
+- Do not skip heading levels: always start from `<h1>`, followed by `<h2>` and so on.
 
-### Do not use multiple `<h1>` elements on one page
+### Avoid using multiple `<h1>` elements on one page
 
-Using more than one `<h1>` on one page was allowed in older versions of the HTML specification that included the concept of an _outline algorithm_. However, this was never considered a best practice. Read more in [There Is No Document Outline Algorithm](https://adrianroselli.com/2016/08/there-is-no-document-outline-algorithm.html).
+While using multiple `<h1>` elements on one page is allowed by the HTML standard (as long as they are not [nested](#nesting)), this is not considered a best practice. A page should generally have a single `<h1>` element that describes the content of the page (similar to the document's [`<title> element`](/en-US/docs/Web/HTML/Element/title)).
 
-Use only one `<h1>` per page and [nest headings](#nesting) without skipping levels.
+> **Note:** Nesting multiple `<h1>` elements in nested [sectioning elements](/en-US/docs/Web/HTML/Element#content_sectioning) was allowed in older versions of the HTML standard. However, this was never considered a best practice and is now non-conforming. Read more in [There Is No Document Outline Algorithm](https://adrianroselli.com/2016/08/there-is-no-document-outline-algorithm.html).
+
+Prefer using only one `<h1>` per page and [nest headings](#nesting) without skipping levels.
 
 ## Examples
 


### PR DESCRIPTION
### Description

See https://github.com/orgs/mdn/discussions/232 and specifically [this comment](https://github.com/orgs/mdn/discussions/232?sort=new#discussioncomment-3978795).

### Motivation

The docs for heading elements (h1–h6) is mixing up conforming to the HTML standard with following best practices. This can be misleading.

In a nutshell: while using multiple `h1` elements on a page is allowed by the standard, it is not considered a best practice.

### Additional details

Line comments with extra details below.

This PR is a quick rephrasing of the problematic paragraph (to hopefully make reviewing easier).

However, I believe that this page would need some major rework (mostly around structure):

- the "usage notes" bullet points lack context, are not commonly used on other pages, and duplicate information found later on the page (e.g. in the accessibility section)
- in the accessibility section, "navigation" and "nesting" could be grouped under a single heading—they essentially cover the same requirement but from different angles
- other concerns could be added to the accessibility section, such as (on top of my head):
  - don't use heading elements for non-heading content (e.g. for large text) (this is mentioned in "usage notes")
  - the counterpart of the above, don't use e.g. large text without a heading element for headings
  - headings essentially section content, and they should label sections accurately

### Related issues and pull requests

Relates to [discussion #232](https://github.com/orgs/mdn/discussions/232)

