### PR TITLE
Clarify flex shorthand one-value syntax cases

### DIFF
--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -63,26 +63,24 @@ The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax:** the value must be one of:
 
-  - a {{cssxref("&lt;number&gt;")}}: then it is interpreted as {{cssxref("flex-grow")}} and expands to `flex: <number> 1 0`.
-  - a {{cssxref("&lt;width&gt;")}} or the keyword `content`: then it is interpreted as {{cssxref("flex-basis")}} and expands to `flex: 1 1 (<width> | content)`.
+  - a valid value for {{cssxref("&lt;flex-grow&gt;")}}: then the shorthand expands to `flex: <flex-grow> 1 0`.
+  - a valid value for {{cssxref("&lt;flex-basis&gt;")}}: then the shorthand expands to `flex: 1 1 <flex-basis>`.
   - the keyword `none` or one of the global keywords.
 
 - **Two-value syntax:**
 
-  - The first value must be:
-
-    - a {{cssxref("&lt;number&gt;")}} and it is interpreted as `<flex-grow>`.
+  - The first value must be a valid value for {{cssxref("flex-grow")}}.
 
   - The second value must be one of:
 
-    - a {{cssxref("&lt;number&gt;")}}: then it is interpreted as `<flex-shrink>`.
-    - a {{cssxref("width")}} or the keyword `content`: then it is interpreted as `<flex-basis>`.
+    - a valid value for {{cssxref("flex-shrink")}}: then the shorthand expands to `flex: <flex-grow> <flex-shrink> 0`.
+    - a valid value for {{cssxref("flex-basis")}}: then the shorthand expands to `flex: <flex-grow> 1 <flex-basis>`.
 
 - **Three-value syntax:** the values must be in the following order:
 
-  1. a {{cssxref("&lt;number&gt;")}} for `<flex-grow>`.
-  2. a {{cssxref("&lt;number&gt;")}} for `<flex-shrink>`.
-  3. a {{cssxref("width")}} or the keyword `content` for `<flex-basis>`.
+  1. a valid value for {{cssxref("flex-grow")}}.
+  2. a valid value for {{cssxref("flex-shrink")}}.
+  3. a valid value for {{cssxref("flex-basis")}}.
 
 ### Values
 

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -63,8 +63,18 @@ The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax:** the value must be one of:
 
-  - a `<number>`: In this case it is interpreted as `flex: <number> 1 0`; the {{cssxref("flex-shrink")}} value is assumed to be `1` and the {{cssxref("flex-basis")}} value is assumed to be `0`.
-  - a `<width>`: In this case it is interpreted as `flex: 1 1 <width>`; the {{cssxref("flex-grow")}} value is assumed to be `1` and the {{cssxref("flex-shrink")}} value is assumed to be `1`.
+  - a unitless `<number>`: In this case it is interpreted as `flex: <number> 1 0` where:
+  
+    - the {{cssxref("flex-grow")}} value is `<number>`
+    - the {{cssxref("flex-shrink")}} value is assumed to be `1`
+    - the {{cssxref("flex-basis")}} value is assumed to be `0`
+    
+  - a valid value for {{cssxref("&lt;width&gt;")}}: In this case it is interpreted as `flex: 1 1 <width>` where:
+  
+    - the {{cssxref("flex-grow")}} value is assumed to be `1`
+    - the {{cssxref("flex-shrink")}} value is assumed to be `1`.
+    - the {{cssxref("flex-basis")}} value is `<width>`
+    
   - one of the keywords: `none`, `auto`, or `initial`.
 
 - **Two-value syntax:**

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -63,19 +63,9 @@ The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax:** the value must be one of:
 
-  - a unitless `<number>`: In this case it is interpreted as `flex: <number> 1 0` where:
-
-    - the {{cssxref("flex-grow")}} value is `<number>`
-    - the {{cssxref("flex-shrink")}} value is assumed to be `1`
-    - the {{cssxref("flex-basis")}} value is assumed to be `0`
-
-  - a valid value for {{cssxref("&lt;width&gt;")}}: In this case it is interpreted as `flex: 1 1 <width>` where:
-
-    - the {{cssxref("flex-grow")}} value is assumed to be `1`
-    - the {{cssxref("flex-shrink")}} value is assumed to be `1`.
-    - the {{cssxref("flex-basis")}} value is `<width>`
-
-  - one of the keywords: `none`, `auto`, or `initial`.
+  - a {{cssxref("&lt;number&gt;")}}: then it is interpreted as {{cssxref("flex-grow")}} and expands to `flex: <number> 1 0`.
+  - a {{cssxref("&lt;width&gt;")}} or the keyword `content`: then it is interpreted as {{cssxref("flex-basis")}} and expands to `flex: 1 1 (<width> | content)`.
+  - the keyword `none` or one of the global keywords.
 
 - **Two-value syntax:**
 
@@ -86,13 +76,13 @@ The `flex` property may be specified using one, two, or three values.
   - The second value must be one of:
 
     - a {{cssxref("&lt;number&gt;")}}: then it is interpreted as `<flex-shrink>`.
-    - a valid value for {{cssxref("width")}}: then it is interpreted as `<flex-basis>`.
+    - a {{cssxref("width")}} or the keyword `content`: then it is interpreted as `<flex-basis>`.
 
 - **Three-value syntax:** the values must be in the following order:
 
   1. a {{cssxref("&lt;number&gt;")}} for `<flex-grow>`.
   2. a {{cssxref("&lt;number&gt;")}} for `<flex-shrink>`.
-  3. a valid value for {{cssxref("width")}} for `<flex-basis>`.
+  3. a {{cssxref("width")}} or the keyword `content` for `<flex-basis>`.
 
 ### Values
 

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -64,17 +64,17 @@ The `flex` property may be specified using one, two, or three values.
 - **One-value syntax:** the value must be one of:
 
   - a unitless `<number>`: In this case it is interpreted as `flex: <number> 1 0` where:
-  
+
     - the {{cssxref("flex-grow")}} value is `<number>`
     - the {{cssxref("flex-shrink")}} value is assumed to be `1`
     - the {{cssxref("flex-basis")}} value is assumed to be `0`
-    
+
   - a valid value for {{cssxref("&lt;width&gt;")}}: In this case it is interpreted as `flex: 1 1 <width>` where:
-  
+
     - the {{cssxref("flex-grow")}} value is assumed to be `1`
     - the {{cssxref("flex-shrink")}} value is assumed to be `1`.
     - the {{cssxref("flex-basis")}} value is `<width>`
-    
+
   - one of the keywords: `none`, `auto`, or `initial`.
 
 - **Two-value syntax:**


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Updated the one-value syntax section for the `flex` property to clarify when values are interpreted as `<number>` vs. `<width>`, and which of `flex-grow` and `flex-basis` will be set based on the interpretation.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
When reading this section, I was confused about the differences between `<number>` and `<width>` before realizing that the latter needed to be a valid value for the CSS `width` property (e.g. `0` would be interpreted as a `<number>` whereas `0px` would be interpreted as a `<width>`). I've added "unitless" before the `<number>` and a link to the `width` page to clarify this.

It was also not apparent which of the three flex properties would be set based on whether `<number>` or `<width>` was provided, so I broke it down into three bullet points to clarify this.

These changes can help readers understand the one-value syntax for `flex` at first glance (improved skimmability).
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
