### PR TITLE
WebMidi: Remove sitepermission addon instructions

### DIFF
--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -16,9 +16,8 @@ browser-compat: api.Navigator.requestMIDIAccess
 
 The Web MIDI API connects to and interacts with Musical Instrument Digital Interface (MIDI) Devices.
 
-The interfaces deal with the practical aspects of sending and receiving MIDI messages. Therefore, the API can be used for musical and non-musical uses, with any MIDI device connected to your computer.
-
-> **Note:** In Firefox the Web MIDI API is an _add-on-gated feature_. This means your website or app needs a site permission add-on for users to download, install and be able to access this API's functionality. [Instructions on how to set up a site permission add-on can be found here](https://extensionworkshop.com/documentation/publish/site-permission-add-on/).
+The interfaces deal with the practical aspects of sending and receiving MIDI messages.
+Therefore, the API can be used for musical and non-musical uses, with any MIDI device connected to your computer.
 
 ## Interfaces
 


### PR DESCRIPTION
This is a partial fix for #21951 - simply removing the information about the defunct method for requesting site permission.

I say partial because this same information is linked from the BCD, and I can't update the BCD yet because I don't understand how this "fix" works and in what versions. That's to follow.

This should be OK to merge though, because whatever Firefox is doing with this it is orthogonal to the WebMidi spec