### PR TITLE
HTMLRef -> HTMLSidebar , part 1

### DIFF
--- a/files/en-us/web/html/element/abbr/index.md
+++ b/files/en-us/web/html/element/abbr/index.md
@@ -18,7 +18,7 @@ tags:
 browser-compat: html.elements.abbr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<abbr>`** [HTML](/en-US/docs/Web/HTML) element represents an abbreviation or acronym.
 
@@ -89,7 +89,7 @@ The optional {{htmlattrxref("title")}} attribute can provide an expansion for th
 
 This element only supports the [global attributes](/en-US/docs/Web/HTML/Global_attributes). The {{htmlattrxref("title")}} attribute has a specific semantic meaning when used with the `<abbr>` element; it _must_ contain a full human-readable description or expansion of the abbreviation. This text is often presented by browsers as a tooltip when the mouse cursor is hovered over the element.
 
-Each `<abbr>` element you use is independent from all others; providing a `title` for one does not automatically attach the same expansion text to others with the same content text.
+Each `<abbr>` element you use is independent of all others; providing a `title` for one does not automatically attach the same expansion text to others with the same content text.
 
 ## Usage notes
 

--- a/files/en-us/web/html/element/applet/index.md
+++ b/files/en-us/web/html/element/applet/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.applet
 ---
 
-{{HTMLRef}}{{Deprecated_Header}}
+{{HTMLSidebar}}{{Deprecated_Header}}
 
 The obsolete **HTML Applet Element** (**`<applet>`**) embeds a Java applet into the document; this element has been deprecated in favor of {{HTMLElement("object")}}.
 

--- a/files/en-us/web/html/element/area/index.md
+++ b/files/en-us/web/html/element/area/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.area
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<area>`** [HTML](/en-US/docs/Web/HTML) element defines an area inside an image map that has predefined clickable areas. An _image map_ allows geometric areas on an image to be associated with {{Glossary("Hyperlink", "hypertext link")}}.
 

--- a/files/en-us/web/html/element/aside/index.md
+++ b/files/en-us/web/html/element/aside/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.aside
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<aside>`** [HTML](/en-US/docs/Web/HTML) element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes.
 

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -17,7 +17,7 @@ tags:
 browser-compat: html.elements.audio
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<audio>`** [HTML](/en-US/docs/Web/HTML) element is used to embed sound content in documents. It may contain one or more audio sources, represented using the `src` attribute or the {{HTMLElement("source")}} element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a {{domxref("MediaStream")}}.
 

--- a/files/en-us/web/html/element/b/index.md
+++ b/files/en-us/web/html/element/b/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.b
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<b>`** [HTML](/en-US/docs/Web/HTML) element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use `<b>` for styling text; instead, you should use the CSS {{cssxref("font-weight")}} property to create boldface text, or the {{HTMLElement("strong")}} element to indicate that text is of special importance.
 

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.base
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<base>`** [HTML](/en-US/docs/Web/HTML) element specifies the base URL to use for all _relative_ URLs in a document. There can be only one `<base>` element in a document.
 

--- a/files/en-us/web/html/element/bdi/index.md
+++ b/files/en-us/web/html/element/bdi/index.md
@@ -24,7 +24,7 @@ tags:
 browser-compat: html.elements.bdi
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<bdi>`** [HTML](/en-US/docs/Web/HTML) element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted.
 

--- a/files/en-us/web/html/element/bdo/index.md
+++ b/files/en-us/web/html/element/bdo/index.md
@@ -22,7 +22,7 @@ tags:
 browser-compat: html.elements.bdo
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<bdo>`** [HTML](/en-US/docs/Web/HTML) element overrides the current directionality of text, so that the text within is rendered in a different direction.
 

--- a/files/en-us/web/html/element/big/index.md
+++ b/files/en-us/web/html/element/big/index.md
@@ -10,11 +10,11 @@ tags:
 browser-compat: html.elements.big
 ---
 
-{{deprecated_header}}
+{{HTMLSidebar}}{{deprecated_header}}
 
 The **`<big>`** [HTML](/en-US/docs/Web/HTML) deprecated element renders the enclosed text at a font size one level larger than the surrounding text (`medium` becomes `large`, for example). The size is capped at the browser's maximum permitted font size.
 
-> **Warning:** This element has been removed from the specification and shouldn't be used any more. Use the CSS {{cssxref("font-size")}} property to adjust the font size.
+> **Warning:** This element has been removed from the specification and shouldn't be used anymore. Use the CSS {{cssxref("font-size")}} property to adjust the font size.
 
 ## Attributes
 
@@ -83,5 +83,3 @@ This element implements the {{domxref('HTMLElement')}} interface.
 - CSS: {{cssxref("font-size")}}, {{cssxref("font")}}
 - HTML: {{htmlelement("small")}}, {{htmlelement("font")}}, {{htmlelement("style")}}
 - HTML 4.01 Specification: [Font Styles](https://www.w3.org/TR/html4/present/graphics.html#h-15.2)
-
-{{HTMLRef}}

--- a/files/en-us/web/html/element/blink/index.md
+++ b/files/en-us/web/html/element/blink/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.blink
 ---
 
-{{HTMLRef}}{{Deprecated_header}}
+{{HTMLSidebar}}{{Deprecated_header}}
 
 The **`<blink>`** [HTML](/en-US/docs/Web/HTML) element is a non-standard element which causes the enclosed text to flash slowly.
 

--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.body
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<body>`** [HTML](/en-US/docs/Web/HTML) element represents the content of an HTML document. There can be only one `<body>` element in a document.
 
@@ -95,7 +95,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Color of text for hyperlinks when selected.
     **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead.**
 - {{htmlattrdef("background")}} {{deprecated_inline}}
-  - : URI of a image to use as a background.
+  - : URI of an image to use as a background.
     **Do not use this attribute! Use the CSS {{cssxref("background")}} property on the element instead.**
 - {{htmlattrdef("bgcolor")}} {{deprecated_inline}}
   - : Background color for the document.

--- a/files/en-us/web/html/element/br/index.md
+++ b/files/en-us/web/html/element/br/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.br
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<br>`** [HTML](/en-US/docs/Web/HTML) element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.
 

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.button
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<button>`** [HTML](/en-US/docs/Web/HTML) element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a [form](/en-US/docs/Learn/Forms) or opening a dialog.
 

--- a/files/en-us/web/html/element/canvas/index.md
+++ b/files/en-us/web/html/element/canvas/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.canvas
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Use the **HTML `<canvas>` element** with either the [canvas scripting API](/en-US/docs/Web/API/Canvas_API) or the [WebGL API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
 
@@ -89,7 +89,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 - {{htmlattrdef("height")}}
   - : The height of the coordinate space in CSS pixels. Defaults to 150.
 - {{htmlattrdef("moz-opaque")}} {{non-standard_inline}} {{deprecated_inline}}
-  - : Lets the canvas know whether or not translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized {{domxref("HTMLCanvasElement.getContext()", "canvas.getContext('2d', { alpha: false })")}} instead.
+  - : Lets the canvas know whether translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized {{domxref("HTMLCanvasElement.getContext()", "canvas.getContext('2d', { alpha: false })")}} instead.
 - {{htmlattrdef("width")}}
   - : The width of the coordinate space in CSS pixels. Defaults to 300.
 
@@ -126,7 +126,7 @@ The maximum size of a `<canvas>` element is very large, but the exact size depen
 
 ### HTML
 
-This code snippet adds a canvas element to your HTML document. A fallback text is provided if a browser is unable to render the canvas, or if can't read a canvas.
+This code snippet adds a canvas element to your HTML document. A fallback text is provided if a browser is unable to read or render the canvas.
 
 ```html
 <canvas width="300" height="300">

--- a/files/en-us/web/html/element/center/index.md
+++ b/files/en-us/web/html/element/center/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.center
 ---
 
-{{deprecated_header}}
+{{HTMLSidebar}}{{deprecated_header}}
 
 The **`<center>`** [HTML](/en-US/docs/Web/HTML) element is a [block-level element](/en-US/docs/Web/HTML/Block-level_elements) that displays its block-level or inline contents centered horizontally within its containing element. The container is usually, but isn't required to be, {{HTMLElement("body")}}.
 
@@ -67,5 +67,3 @@ Applying {{Cssxref("text-align")}}`:center` to a {{HTMLElement("div")}} or {{HTM
 
 - {{Cssxref("text-align")}}
 - {{Cssxref("display")}}
-
-{{HTMLRef}}

--- a/files/en-us/web/html/element/cite/index.md
+++ b/files/en-us/web/html/element/cite/index.md
@@ -15,7 +15,7 @@ tags:
 browser-compat: html.elements.cite
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<cite>`** [HTML](/en-US/docs/Web/HTML) element is used to describe a reference to a cited creative work, and must include the title of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata.
 

--- a/files/en-us/web/html/element/code/index.md
+++ b/files/en-us/web/html/element/code/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.code
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<code>`** [HTML](/en-US/docs/Web/HTML) element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the {{Glossary("user agent", "user agent's")}} default monospace font.
 

--- a/files/en-us/web/html/element/col/index.md
+++ b/files/en-us/web/html/element/col/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.col
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<col>`** [HTML](/en-US/docs/Web/HTML) element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a {{HTMLElement("colgroup")}} element.
 

--- a/files/en-us/web/html/element/data/index.md
+++ b/files/en-us/web/html/element/data/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.data
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<data>`** [HTML](/en-US/docs/Web/HTML) element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the {{HTMLElement("time")}} element must be used.
 

--- a/files/en-us/web/html/element/dd/index.md
+++ b/files/en-us/web/html/element/dd/index.md
@@ -15,7 +15,7 @@ tags:
 browser-compat: html.elements.dd
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<dd>`** [HTML](/en-US/docs/Web/HTML) element provides the description, definition, or value for the preceding term ({{HTMLElement("dt")}}) in a description list ({{HTMLElement("dl")}}).
 

--- a/files/en-us/web/html/element/del/index.md
+++ b/files/en-us/web/html/element/del/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.del
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<del>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The {{HTMLElement("ins")}} element can be used for the opposite purpose: to indicate text that has been added to the document.
 

--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.dfn
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element is used to indicate the term being defined within the context of a definition phrase or sentence. The {{HTMLElement("p")}} element, the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the {{HTMLElement("section")}} element which is the nearest ancestor of the `<dfn>` is considered to be the definition of the term.
 

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.dialog
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<dialog>`** [HTML](/en-US/docs/Web/HTML) element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.
 
@@ -91,7 +91,7 @@ When implementing a dialog, it is important to consider the most appropriate pla
 
 Ensure a mechanism is provided to allow users to close a dialog. The most robust way to ensure all users can close a dialog is to include an explicit button to do so. For instance, a confirmation, cancel or close button as appropriate. Additionally, for those using a device with a keyboard, the <kbd>Escape</kbd> key is commonly expected to close modal dialogs as well. By default, a `<dialog>` invoked by the `showModal()` method will allow for its dismissal by the <kbd>Escape</kbd>. A non-modal dialog does not dismiss via the <kbd>Escape</kbd> key by default, and depending on what the non-modal dialog represents, it may not be desired for this behavior. If multiple modal dialogs are open, <kbd>Escape</kbd> should only close the last shown dialog.
 
-The `<dialog>` element is exposed by browsers similarly to custom dialogs using the ARIA [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) attribute. `<dialog>` elements invoked by the `showModal()` method will have an implicit [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal), where as `<dialog>` elements invoked by the `show()` method, or rendered by use of the `open` attribute or changing the default `display` of a `<dialog>` will be exposed as `[aria-modal="false"]`. It is recommended to use the appropriate `showModal()` or `show()` method to render dialogs.
+The `<dialog>` element is exposed by browsers similarly to custom dialogs using the ARIA [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) attribute. `<dialog>` elements invoked by the `showModal()` method will have an implicit [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal), whereas `<dialog>` elements invoked by the `show()` method, or rendered by use of the `open` attribute or changing the default `display` of a `<dialog>` will be exposed as `[aria-modal="false"]`. It is recommended to use the appropriate `showModal()` or `show()` method to render dialogs.
 
 Ensure your dialog implementation doesn't break expected default behaviors and follows proper labeling recommendations.
 

--- a/files/en-us/web/html/element/dir/index.md
+++ b/files/en-us/web/html/element/dir/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.dir
 ---
 
-{{HTMLRef}}{{Deprecated_Header}}
+{{HTMLSidebar}}{{Deprecated_Header}}
 
 The **`<dir>`** [HTML](/en-US/docs/Web/HTML) element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the {{Glossary("user agent")}}. Do not use this obsolete element; instead, you should use the {{HTMLElement("ul")}} element for lists, including lists of files.
 

--- a/files/en-us/web/html/element/div/index.md
+++ b/files/en-us/web/html/element/div/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.div
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<div>`** [HTML](/en-US/docs/Web/HTML) element is the generic container for flow content. It has no effect on the content or layout until styled in some way using {{glossary("CSS")}} (e.g. styling is directly applied to it, or some kind of layout model like [Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout) is applied to its parent element).
 

--- a/files/en-us/web/html/element/dl/index.md
+++ b/files/en-us/web/html/element/dl/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.dl
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<dl>`** [HTML](/en-US/docs/Web/HTML) element represents a description list. The element encloses a list of groups of terms (specified using the {{HTMLElement("dt")}} element) and descriptions (provided by {{HTMLElement("dd")}} elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).
 

--- a/files/en-us/web/html/element/dt/index.md
+++ b/files/en-us/web/html/element/dt/index.md
@@ -16,7 +16,7 @@ tags:
 browser-compat: html.elements.dt
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<dt>`** [HTML](/en-US/docs/Web/HTML) element specifies a term in a description or definition list, and as such must be used inside a {{HTMLElement("dl")}} element. It is usually followed by a {{HTMLElement("dd")}} element; however, multiple `<dt>` elements in a row indicate several terms that are all defined by the immediate next {{HTMLElement("dd")}} element.
 

--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.em
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<em>`** [HTML](/en-US/docs/Web/HTML) element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis.
 

--- a/files/en-us/web/html/element/embed/index.md
+++ b/files/en-us/web/html/element/embed/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.embed
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.
 

--- a/files/en-us/web/html/element/figure/index.md
+++ b/files/en-us/web/html/element/figure/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.figure
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<figure>`** [HTML](/en-US/docs/Web/HTML) element represents self-contained content, potentially with an optional caption, which is specified using the {{HTMLElement("figcaption")}} element. The figure, its caption, and its contents are referenced as a single unit.
 

--- a/files/en-us/web/html/element/footer/index.md
+++ b/files/en-us/web/html/element/footer/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: html.elements.footer
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for its nearest ancestor [sectioning content](/en-US/docs/Web/Guide/HTML/Content_categories#sectioning_content) or [sectioning root](/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_root) element. A `<footer>` typically contains information about the author of the section, copyright data or links to related documents.
 

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -13,13 +13,13 @@ tags:
 browser-compat: html.elements.form
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<form>`** [HTML](/en-US/docs/Web/HTML) element represents a document section containing interactive controls for submitting information.
 
 {{EmbedInteractiveExample("pages/tabbed/form.html", "tabbed-standard")}}
 
-It is possible to use the {{cssxref(':valid')}} and {{cssxref(':invalid')}} CSS [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) to style a `<form>` element based on whether or not the {{domxref("HTMLFormElement.elements", "elements")}} inside the form are valid.
+It is possible to use the {{cssxref(':valid')}} and {{cssxref(':invalid')}} CSS [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) to style a `<form>` element based on whether the {{domxref("HTMLFormElement.elements", "elements")}} inside the form are valid.
 
 <table class="properties">
   <tbody>
@@ -148,7 +148,7 @@ The following attributes control behavior during form submission.
     The only allowed methods/values are (case insensitive):
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
-    - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).
+    - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side effects](/en-US/docs/Glossary/Idempotent).
     - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog and throws a submit event on submission without submitting data or clearing the form.
 
     This value is overridden by {{htmlattrxref("formmethod", "button")}} attributes on {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image">`](/en-US/docs/Web/HTML/Element/input/image) elements.

--- a/files/en-us/web/html/element/frame/index.md
+++ b/files/en-us/web/html/element/frame/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.frame
 ---
 
-{{HTMLRef}}{{Deprecated_Header}}
+{{HTMLSidebar}}{{Deprecated_Header}}
 
 The **`<frame>`** [HTML](/en-US/docs/Web/HTML) element defines a particular area in which another HTML document can be displayed. A frame should be used within a {{HTMLElement("frameset")}}.
 

--- a/files/en-us/web/html/element/head/index.md
+++ b/files/en-us/web/html/element/head/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.head
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<head>`** [HTML](/en-US/docs/Web/HTML) element contains machine-readable information ({{glossary("metadata")}}) about the document, like its [title](/en-US/docs/Web/HTML/Element/title), [scripts](/en-US/docs/Web/HTML/Element/script), and [style sheets](/en-US/docs/Web/HTML/Element/style).
 

--- a/files/en-us/web/html/element/hr/index.md
+++ b/files/en-us/web/html/element/hr/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: html.elements.hr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<hr>`** [HTML](/en-US/docs/Web/HTML) element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
 

--- a/files/en-us/web/html/element/html/index.md
+++ b/files/en-us/web/html/element/html/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.html
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<html>`** [HTML](/en-US/docs/Web/HTML) element represents the root (top-level element) of an HTML document, so it is also referred to as the _root element_. All other elements must be descendants of this element.
 

--- a/files/en-us/web/html/element/i/index.md
+++ b/files/en-us/web/html/element/i/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.i
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<i>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the `<i>` naming of this element.
 

--- a/files/en-us/web/html/element/image/index.md
+++ b/files/en-us/web/html/element/image/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.image
 ---
 
-{{HTMLRef}}{{deprecated_header}}{{Non-standard_header}}
+{{HTMLSidebar}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`<image>`** [HTML](/en-US/docs/Web/HTML) element is an ancient and poorly supported precursor to the {{HTMLElement("img")}} element.
 **It should not be used**.

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -22,7 +22,7 @@ tags:
 browser-compat: html.elements.img
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<img>`** [HTML](/en-US/docs/Web/HTML) element embeds an image into the document.
 

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.input.type_checkbox
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{htmlelement("input")}} elements of type **`checkbox`** are rendered by default as boxes that are checked (ticked) when activated, like you might see in an official government paper form. The exact appearance depends upon the operating system configuration under which the browser is running. Generally this is a square but it may have rounded corners. A checkbox allows you to select single values for submission in a form (or not).
 
@@ -91,7 +91,7 @@ In addition to the common attributes shared by all {{HTMLElement("input")}} elem
 
 - {{htmlattrdef("checked")}}
 
-  - : A Boolean attribute indicating whether or not this checkbox is checked by default (when the page loads). It does _not_ indicate whether this checkbox is currently checked: if the checkbox's state is changed, this content attribute does not reflect the change. (Only the {{domxref("HTMLInputElement")}}'s `checked` IDL attribute is updated.)
+  - : A Boolean attribute indicating whether this checkbox is checked by default (when the page loads). It does _not_ indicate whether this checkbox is currently checked: if the checkbox's state is changed, this content attribute does not reflect the change. (Only the {{domxref("HTMLInputElement")}}'s `checked` IDL attribute is updated.)
     > **Note:** Unlike other input controls, a checkbox's value is only included in the submitted data if the checkbox is currently `checked`. If it is, then the value of the checkbox's `value` attribute is reported as the input's value.
     > Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the {{htmlattrxref("autocomplete","input")}} attribute to control this feature.
 

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -15,7 +15,7 @@ tags:
 browser-compat: html.elements.input.type_color
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of type **`color`** provide a user interface element that lets a user specify a color, either by using a visual color picker interface or by entering the color into a text field in `#rrggbb` hexadecimal format.
 

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -15,7 +15,7 @@ tags:
 browser-compat: html.elements.input.type_date
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of **`type="date"`** create input fields that let the user enter a date, either with a textbox that validates the input or a special date picker interface.
 
@@ -206,7 +206,7 @@ If you try to submit the form with an incomplete date (or with a date outside th
 
 {{EmbedLiveSample('Validation', 600, 100)}}
 
-Here's the CSS used in the above example. We make use of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) to add an icon next to the input, based on whether or not the current value is valid. We had to put the icon on a {{htmlelement("span")}} next to the input, not on the input itself, because in Chrome at least the input's generated content is placed inside the form control, and can't be styled or shown effectively.
+Here's the CSS used in the above example. We make use of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) to add an icon next to the input, based on whether the current value is valid. We had to put the icon on a {{htmlelement("span")}} next to the input, not on the input itself, because in Chrome at least the input's generated content is placed inside the form control, and can't be styled or shown effectively.
 
 ```css
 label {
@@ -233,7 +233,7 @@ input:valid + span::after {
 
 Browsers that don't support this input type gracefully degrade to a text input, but this creates problems in consistency of user interface (the presented controls are different) and data handling.
 
-The second problem is the more serious one; with date input supported, the value is normalized to the format `yyyy-mm-dd`. But with a text input, the browser has no recognition of what format the date should be in, and there are many different formats in which people write dates. For example:
+The second problem is the more serious one; with date input supported, the value is normalized to the format `yyyy-mm-dd`. But with a text input, the browser has no recognition of what format the date should be in, and there are many formats in which people write dates. For example:
 
 - `ddmmyyyy`
 - `dd/mm/yyyy`
@@ -242,7 +242,7 @@ The second problem is the more serious one; with date input supported, the value
 - `mm-dd-yyyy`
 - `Month dd, yyyy`
 
-One way around this is the {{htmlattrxref("pattern", "input")}} attribute on your date input. Even though the date picker doesn't use it, the text input fallback will. For example, try viewing the following in a unsupporting browser:
+One way around this is the {{htmlattrxref("pattern", "input")}} attribute on your date input. Even though the date picker doesn't use it, the text input fallback will. For example, try viewing the following in an unsupporting browser:
 
 ```html
 <form>

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.input.type_email
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of type **`email`** are used to let the user enter and edit an e-mail address, or, if the [`multiple`](/en-US/docs/Web/HTML/Attributes/multiple) attribute is specified, a list of e-mail addresses.
 
@@ -96,7 +96,7 @@ The input will fail [constraint validation](/en-US/docs/Web/Guide/HTML/Constrain
 
 ### minlength
 
-The minimum number of characters (as UTF-16 code units) the user can enter into the `email` input. This must be an non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the `email` input has no minimum length.
+The minimum number of characters (as UTF-16 code units) the user can enter into the `email` input. This must be a non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the `email` input has no minimum length.
 
 The input will fail [constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation) if the length of the text entered into the field is fewer than `minlength` UTF-16 code units long. Constraint validation is only applied when the value is changed by the user.
 
@@ -138,7 +138,7 @@ This does _not_ set a limit on how many characters the user can enter into the f
 
 ## Using email inputs
 
-E-mail addresses are among the most frequently-inputted textual data forms on the web; they're used when logging into web sites, when requesting information, to allow order confirmation, for webmail, and so forth. As such, the `email` input type can make your job as a web developer much easier since it can help simplify your work when building the user interface and logic for e-mail addresses. When you create an email input with the proper `type` value, `email`, you get automatic validation that the entered text is at least in the correct form to potentially be a legitimate e-mail address. This can help avoid cases in which the user mistypes their address, or provides an invalid address.
+E-mail addresses are among the most frequently-inputted textual data forms on the web; they're used when logging into websites, when requesting information, to allow order confirmation, for webmail, and so forth. As such, the `email` input type can make your job as a web developer much easier since it can help simplify your work when building the user interface and logic for e-mail addresses. When you create an email input with the proper `type` value, `email`, you get automatic validation that the entered text is at least in the correct form to potentially be a legitimate e-mail address. This can help avoid cases in which the user mistypes their address, or provides an invalid address.
 
 It's important, however, to note that this is not enough to ensure that the specified text is an e-mail address which actually exists, corresponds to the user of the site, or is acceptable in any other way. It ensures that the value of the field is properly formatted to be an e-mail address.
 
@@ -269,7 +269,7 @@ Browsers that support the `email` input type automatically provide validation to
 /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 ```
 
-To learn more about how form validation works and how to take advantage of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS properties to style the input based on whether or not the current value is valid, see [Form data validation](/en-US/docs/Learn/Forms/Form_validation).
+To learn more about how form validation works and how to take advantage of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS properties to style the input based on whether the current value is valid, see [Form data validation](/en-US/docs/Learn/Forms/Form_validation).
 
 > **Note:** There are known specification issues related to international domain names and the validation of e-mail addresses in HTML. See [W3C bug 15489](https://www.w3.org/Bugs/Public/show_bug.cgi?id=15489) for details.
 

--- a/files/en-us/web/html/element/input/hidden/index.md
+++ b/files/en-us/web/html/element/input/hidden/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.input.type_hidden
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of type **`hidden`** let web developers include data that cannot be seen or modified by users when a form is submitted. For example, the ID of the content that is currently being ordered or edited, or a unique security token. Hidden inputs are completely invisible in the rendered page, and there is no way to make it visible in the page's content.
 
@@ -97,7 +97,7 @@ Hidden inputs don't participate in constraint validation; they have no real valu
 
 Let's look at how we might implement a simple version of the edit form we described earlier (see [Tracking edited content](#tracking_edited_content)), using a hidden input to remember the ID of the record being edited.
 
-The edit form's HTML might look a little bit like this:
+The edit form's HTML might look a bit like this:
 
 ```html
 <form>

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -17,7 +17,7 @@ tags:
 browser-compat: html.elements.input.type_image
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of type **`image`** are used to create graphical submit buttons, i.e. submit buttons that take the form of an image rather than text.
 
@@ -201,7 +201,7 @@ Let's look at a basic example that includes all the essential features you'd nee
   - : Specifies the HTTP method that the browser uses to submit the form. Possible values are:
 
     - `post`: The data from the form is included in the body of the form and is sent to the server.
-    - `get`: The data from the form is appended to the **`form`** attribute URI, with a '?' as a separator, and the resulting URI is sent to the server. Use this method when the form has no side-effects and contains only ASCII characters.
+    - `get`: The data from the form is appended to the **`form`** attribute URI, with a '?' as a separator, and the resulting URI is sent to the server. Use this method when the form has no side effects and contains only ASCII characters.
 
     If specified, this attribute overrides the {{htmlattrxref("method","form")}} attribute of the element's form owner.
 
@@ -331,7 +331,7 @@ label {
 }
 ```
 
-Here, `object-position` is configured to draw the image at the top-right corner of the element, while `object-fit` is set to `contain`, which indicates that the image should be drawn at the largest size that will fit within the element's box without altering its aspect ratio. Note the visible grey background of the element still visible in the area not covered by the image.
+Here, `object-position` is configured to draw the image in the top-right corner of the element, while `object-fit` is set to `contain`, which indicates that the image should be drawn at the largest size that will fit within the element's box without altering its aspect ratio. Note the visible grey background of the element still visible in the area not covered by the image.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/ins/index.md
+++ b/files/en-us/web/html/element/ins/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: html.elements.ins
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<ins>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text that has been added to a document. You can use the {{HTMLElement("del")}} element to similarly represent a range of text that has been deleted from the document.
 

--- a/files/en-us/web/html/element/kbd/index.md
+++ b/files/en-us/web/html/element/kbd/index.md
@@ -18,7 +18,7 @@ tags:
 browser-compat: html.elements.kbd
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<kbd>`** [HTML](/en-US/docs/Web/HTML) element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the {{Glossary("user agent")}} defaults to rendering the contents of a `<kbd>` element using its default monospace font, although this is not mandated by the HTML standard.
 

--- a/files/en-us/web/html/element/label/index.md
+++ b/files/en-us/web/html/element/label/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.label
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<label>`** [HTML](/en-US/docs/Web/HTML) element represents a caption for an item in a user interface.
 

--- a/files/en-us/web/html/element/li/index.md
+++ b/files/en-us/web/html/element/li/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: html.elements.li
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **`<li>`** [HTML](/en-US/docs/Web/HTML) element is used to represent an item in a list. It must be contained in a parent element: an ordered list ({{HTMLElement("ol")}}), an unordered list ({{HTMLElement("ul")}}), or a menu ({{HTMLElement("menu")}}). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.
 


### PR DESCRIPTION
The `{{HTMLSidebar}}` macro [has been buffed](https://github.com/mdn/yari/pull/7402) to include everything related to HTML.
Now the `{{HTMLRef}}` macro is redundant as it contains lesser entries.

The PR replaces macro HTMLRef with HTMLSidebar as per [the decision](https://github.com/mdn/content/pull/21617#issuecomment-1286240392).

/cc @teoli2003 , @wbamberg 