### PR TITLE
Missing type key in Clipboard.write() example

### DIFF
--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -58,7 +58,7 @@ string.
 ```js
 function setClipboard(text) {
     const type = "text/plain";
-    const blob = new Blob([text], { type });
+    const blob = new Blob([text], { type: type });
     const data = [new ClipboardItem({ [type]: blob })];
 
     navigator.clipboard.write(data).then(


### PR DESCRIPTION
Seems like there is a key missing when creating the blob in the `setClipboard` example 

https://developer.mozilla.org/en-US/docs/Web/API/Blob#creating_a_blob

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add omitted object property

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I was confusing enough for me to look up the Blob doc
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
