### PR TITLE
security: remove references to https://serviceworke.rs/

### DIFF
--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -209,7 +209,7 @@ if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
 }
 
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  'https://mdn.github.io/serviceworker-cookbook',
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );

--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -209,7 +209,7 @@ if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
 }
 
 webPush.setVapidDetails(
-  'https://mdn.github.io/serviceworker-cookbook',
+  'https://example.com',
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );


### PR DESCRIPTION
The domain https://serviceworke.rs/ (do not open) has been overtaken and are used to steal clicks.
This removes the domain and points people to the GitHub repo.
