### PR TITLE
Remove duplicate warning about -webkit-box-reflect

### DIFF
--- a/files/en-us/web/css/-webkit-box-reflect/index.md
+++ b/files/en-us/web/css/-webkit-box-reflect/index.md
@@ -36,8 +36,6 @@ The **`-webkit-box-reflect`** [CSS](/en-US/docs/Web/CSS) property lets you refle
 -webkit-box-reflect: unset;
 ```
 
-> **Warning:** This feature is **not intended to be used by Web sites**. To achieve reflection on the Web, the standard way is to use the CSS {{CSSxRef("element", "element()")}} function.
-
 ## Syntax
 
 ### Values


### PR DESCRIPTION
### Description

This PR removes the following warning:

<img width="754" alt="CleanShot 2022-11-01 at 11 29 44@2x" src="https://user-images.githubusercontent.com/6692932/199272181-8d28f67f-eb3b-4092-ab0f-c0b30aeff895.png">


### Motivation

There are two reasons for this:

1. There is already the common “non-standard” warning at the top of the page, as well as a section under “Specifications” that mentions `element()`. The information is redundant.
2. The warning is potentially misleading

To elaborate on that second point, I wanna dig into the phrasing a bit:

> This feature is **not intended to be used by Web sites**

According to who? This is a very subjective opinion, phrased as an objective statement.

> To achieve reflection on the Web, the standard way is to use the CSS element() function.

I suppose this is true, if we're defining “standard” as “in the CSS specification”. But, right now, `element()` is only supported by Firefox ([~3.5% of global traffic](https://caniuse.com/css-element-function)), while `-webkit-box-reflect` is supported by every other major browser ([94.5% of global traffic](https://caniuse.com/?search=-webkit-box-reflect)). And so, the standard way that developers are _actually implementing_ reflections is with `-webkit-box-reflect`, and it's pretty much the only option if you want _most_ people to see it, but you'd never know it from this warning box.

### Additional details

I understand the desire to push people towards the standards-aligned way of doing things, but I think that only helps when the standards-aligned way is well-supported by browsers. As it stands, we're pushing people towards making changes that will detract from the user experience for most users.

If there are legitimate issues with the `-webkit-box-reflect` property (eg. bugs, inconsistent behaviour), I believe we should specify those issues explicitly, rather than warning developers against a property that, as far as I can tell, works fine across the browsers it's implemented in.

