### PR TITLE
Fix missing `&&`

### DIFF
--- a/files/en-us/web/api/node/comparedocumentposition/index.md
+++ b/files/en-us/web/api/node/comparedocumentposition/index.md
@@ -55,7 +55,7 @@ called, then both the `DOCUMENT_POSITION_CONTAINS` and
 const head = document.head;
 const body = document.body;
 
-if (head.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING) {
+if (head.compareDocumentPosition(body) && Node.DOCUMENT_POSITION_FOLLOWING) {
   console.log('Well-formed document');
 } else {
   console.error('<head> is not before <body>');


### PR DESCRIPTION
-  There was a single `&` missing from the comparison of the head position and node constant

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I added the missing `&` to create a fully formed `&&` and functioning code.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
