### PR TITLE
Fix examples in Control flow effects of await

### DIFF
--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -176,15 +176,15 @@ foo("Second");
 // Second end
 ```
 
-In this case, the two async functions are synchronous in effect, because they don't contain any `await` expression. The three statements happen in the same tick. In promise terms, the function corresponds to:
+In this case, the two async functions are synchronous in effect, because they don't contain any `await` expression. The three statements happen synchronously before `foo()` returns.
+In promise terms, the function corresponds to:
 
 ```js
 function foo(name) {
-  return Promise.resolve().then(() => {
-    console.log(name, "start");
-    console.log(name, "middle");
-    console.log(name, "end");
-  });
+  console.log(name, "start");
+  console.log(name, "middle");
+  console.log(name, "end");
+  return Promise.resolve();
 }
 ```
 
@@ -212,10 +212,46 @@ This corresponds to:
 
 ```js
 function foo(name) {
-  return Promise.resolve()
+  console.log(name, "start");
+  return Promise.resolve(console.log(name, "middle"))
     .then(() => {
-      console.log(name, "start");
+      console.log(name, "end");
+    });
+}
+```
+
+The first executed `await` ends the synchronous execution of async function.
+
+After the first one, `await` ends the current microtask.
+
+```js
+async function foo(name) {
+  console.log(name, "start");
+  await null;
+  console.log(name, "middle");
+  await null;
+  console.log(name, "end");
+}
+foo("First");
+foo("Second");
+
+// First start
+// Second start
+// First middle
+// Second middle
+// First end
+// Second end
+```
+
+This corresponds to:
+
+```js
+function foo(name) {
+  console.log(name, "start");
+  return Promise.resolve(null)
+    .then(() => {
       console.log(name, "middle");
+      return null;
     })
     .then(() => {
       console.log(name, "end");
@@ -223,7 +259,47 @@ function foo(name) {
 }
 ```
 
-While the extra `then()` handler is not necessary and can be merged with the previous one, its existence means the code will take one extra tick to complete. The same happens for `await`. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
+While the extra `then()` handler is not necessary and can be merged with the previous one, its existence means the code will take one extra tick to complete. The same happens for `await`.
+
+Therefore, make sure to use `await` only when necessary (to unwrap promises into their values). Other microtasks can execute before async function resumes:
+
+```js
+let i = 0;
+queueMicrotask(function test() {
+  i++;
+  console.log("microtask", i);
+  if (i < 4) {
+    queueMicrotask(test);
+  }
+});
+(async () => {
+  console.log("start");
+  await null;
+  console.log("resume", 1);
+  for (let i = 2; i < 4; i++) {
+    await null;
+    console.log("resume", i);
+  }
+  await null;
+  console.log("end");
+})();
+queueMicrotask(() => {
+  console.log("queueMicrotask() after calling async function");
+})
+console.log("sync");
+
+// start
+// sync
+// microtask 1
+// resume 1
+// queueMicrotask() after calling async function
+// microtask 2
+// resume 2
+// microtask 3
+// resume 3
+// microtask 4
+// end
+```
 
 ### Improving stack trace
 


### PR DESCRIPTION
1. Fixes examples in Control flow effects of await.
2. Squashes commit https://github.com/Worldwidebrine/content/commit/9a771cdf71361a2d7528fa729e1512461a97db28 and commit https://github.com/Worldwidebrine/content/commit/12089e4fd80bebc58c30a3c70a5945d49cf3d205, and fixes typo in the commit message.

check not passed. okay