### PR TITLE
CSSRef should be the only sidebar in the CSS docs

### DIFF
--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.at-rules.media.prefers-color-scheme
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/@media/")}}
+{{CSSRef}}
 
 The **`prefers-color-scheme`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#targeting_media_features) is used to detect if a user has requested light or dark color themes.
 A user indicates their preference through an operating system setting (e.g. light or dark mode) or a user agent setting.

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: css.at-rules.media.prefers-reduced-motion
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/@media/")}}
+{{CSSRef}}
 
 > **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
 

--- a/files/en-us/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -7,6 +7,8 @@ tags:
   - Tools
 ---
 
+{{CSSRef}}
+
 This tool can be used to generate CSS {{cssxref("border-image")}} values.
 
 {{EmbedGHLiveSample("css-examples/tools/border-image-generator/", '100%', 1200)}}

--- a/files/en-us/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -8,6 +8,8 @@ tags:
   - Tools
 ---
 
+{{CSSRef}}
+
 This tool can be used to generate CSS {{cssxref("border-radius")}} effects.
 
 {{EmbedGHLiveSample("css-examples/tools/border-radius-generator/", '100%', 900)}}

--- a/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
@@ -8,6 +8,8 @@ tags:
   - box-shadow
 ---
 
+{{CSSRef}}
+
 This tool lets you construct CSS {{cssxref("box-shadow")}} effects, to add box shadow effects to your CSS objects.
 
 {{EmbedGHLiveSample("css-examples/tools/box-shadow-generator/", '100%', 900)}}

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
@@ -13,6 +13,8 @@ tags:
   - text-overflow
 ---
 
+{{CSSRef}}
+
 When there is more content than can fit into a container, an overflow situation occurs. Understanding how overflow behaves is important in dealing with any element with a constrained size in CSS. This guide explains how overflow works when working with normal flow.
 
 ## What is overflow?
@@ -70,5 +72,3 @@ This is useful in the situation where you have a listing of articles, for exampl
 ## Summary
 
 Whether you are in continuous media on the web or in a Paged Media format such as print or EPUB, understanding how content overflows is useful when dealing with any layout method. By understanding how overflow works in normal flow, you should find it easier to understand the implications of overflow content in layout methods such as grid and flexbox.
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/CSS_Flow_Layout/")}}

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -10,6 +10,8 @@ tags:
   - Writing-mode
 ---
 
+{{CSSRef}}
+
 The CSS 2.1 specification, which details how normal flow behaves, assumes a horizontal writing mode. [Layout](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow) properties should work in the same way in vertical writing modes. In this guide, we look at how flow layout behaves when used with different document writing modes.
 
 This is not a comprehensive guide to the use of writing modes in CSS, the aim here is to document the areas where flow layout interacts with writing modes in possibly unanticipated ways. The [external resources](#external_resources) and [see also](#see_also) sections of this document link to more writing modes resources.
@@ -81,5 +83,3 @@ In most cases, flow layout works as you would expect it to when changing the wri
 - [Writing Modes](/en-US/docs/Web/CSS/CSS_Writing_Modes)
 - [Writing Modes And CSS Layout](https://www.smashingmagazine.com/2019/08/writing-modes-layout/)
 - [CSS Writing Modes](https://24ways.org/2016/css-writing-modes/)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/CSS_Flow_Layout/")}}


### PR DESCRIPTION
All CSS pages should use the CSSRef sidebar.

(This should not even be a choice that can be made in content! Sidebars should be assigned automatically based on page type/IA.)