### PR TITLE
Add AccentColor and AccentColorText

### DIFF
--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -35,21 +35,21 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
 - `ButtonFace`
   - : Background color of controls
 - `ButtonText`
-  - : Foreground color of controls
+  - : Text color of controls
 - `Canvas`
   - : Background of application content or documents
 - `CanvasText`
-  - : Foreground color in application content or documents
+  - : Text color in application content or documents
 - `Field`
   - : Background of input fields
 - `FieldText`
   - : Text in input fields
 - `GrayText`
-  - : Foreground color for disabled items (e.g. a disabled control)
+  - : Text color for disabled items (e.g. a disabled control)
 - `Highlight`
   - : Background of selected items
 - `HighlightText`
-  - : Foreground color of selected items
+  - : Text color of selected items
 - `LinkText`
   - : Text of non-active, non-visited links
 - `Mark`

--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -27,7 +27,7 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
 - `AccentColor`
   - : Background of accented user interface controls
 - `AccentColorText`
-  - : Foreground of accented user interface controls
+  - : Text of accented user interface controls
 - `ActiveText`
   - : Text of active links
 - `ButtonBorder`

--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -27,7 +27,7 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
 - `AccentColor`
   - : Background of accented user interface controls
 - `AccentColorText`
-  - : Foreground of accented user interface controls 
+  - : Foreground of accented user interface controls
 - `ActiveText`
   - : Text of active links
 - `ButtonBorder`

--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -24,6 +24,10 @@ A `<system-color>` value can be used anywhere a [`<color>`](/en-US/docs/Web/CSS/
 
 Note that these keywords are _case insensitive_, but are listed here with mixed case for readability.
 
+- `AccentColor`
+  - : Background of accented user interface controls
+- `AccentColorText`
+  - : Foreground of accented user interface controls 
 - `ActiveText`
   - : Text of active links
 - `ButtonBorder`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds the `AccentColor` and `AccentColorText` system color keywords. They're present in [the spec](https://www.w3.org/TR/css-color-4/#valdef-system-color-accentcolor) but aren't on this page.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Keeping the content accurate and up to date. These keywords [were added](https://www.w3.org/TR/css-color-4/#changes-from-20220428) to the spec back at the end of April, but this content wasn't updated.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
