### PR TITLE
TE Expand warning for using header in HTTP/2

### DIFF
--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.Transfer-Encoding
 
 The **`Transfer-Encoding`** header specifies the form of encoding used to safely transfer the {{Glossary("Payload body","payload body")}} to the user.
 
-> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) disallows all uses of the Transfer-Encoding header other than the HTTP/2 specific: `"trailers"`. HTTP 2 provides its own, more efficient, mechanisms for data streaming than chunked, and [forbids](https://www.rfc-editor.org/rfc/rfc7540) the use of the header. Usage of the header in HTTP/2 may likely result in a specific `protocol error` as HTTP/2 Protocol prohibits the use.
+> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) disallows all uses of the Transfer-Encoding header other than the HTTP/2 specific: `"trailers"`. HTTP 2 provides its own more efficient mechanisms for data streaming than chunked transfer and forbids the use of the header. Usage of the header in HTTP/2 may likely result in a specific `protocol error` as HTTP/2 Protocol prohibits the use.
 
 `Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a message between two nodes, not to a resource itself.
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -15,7 +15,7 @@ browser-compat: http.headers.Transfer-Encoding
 
 The **`Transfer-Encoding`** header specifies the form of encoding used to safely transfer the {{Glossary("Payload body","payload body")}} to the user.
 
-> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) doesn't support HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient, mechanisms for data streaming.
+> **Note:** [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) disallows all uses of the Transfer-Encoding header other than the HTTP/2 specific: `"trailers"`. HTTP 2 provides its own, more efficient, mechanisms for data streaming than chunked, and [forbids](https://www.rfc-editor.org/rfc/rfc7540) the use of the header. Usage of the header in HTTP/2 may likely result in a specific `protocol error` as HTTP/2 Protocol prohibits the use.
 
 `Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a message between two nodes, not to a resource itself.
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.


### PR DESCRIPTION
I recently experienced a cryptic protocol error as a result of an upstream HTTP/2.0 interceptor (envoy mesh network/sidecar) reading a header for `Transfer-Encoding`. Due to the documentation here only warning about `chunked` I specified a different value than chunked in case there was a HTTP2 error. Turns out ALL usage of Transfer-Encoding is forbidden very explicitly in the HTTP/2.0 RFC now linked.



<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The documentation for the Transfer-Encoding header on MDN incorrectly advised that only `"chunked"` did not work with HTTP/2. In fact all of those headers listed should be indicated as "HTTP/1.1"-only. 

### Motivation

This misled me into hours of extra debugging as I did not use "chunked" value for Transfer-Encoding, but instead used `gzip` thinking that as long as I use a value other than chunked I'd be safe in case some upstream service used HTTP/2. In fact, I was unsafe in using any value for TransferEncoding and got a cryptic Protocol error which ended up resulting from passing any Transfer-Encoding header.

### Additional details

In the RFC I found for HTTP/2 Protocol:

It talks about how the Transfer-Encoding (and others) header MUST be removed before sending something with the HTTP/2 protocol:

> This means that an intermediary transforming an HTTP/1.x message to
   HTTP/2 will need to remove any header fields nominated by the
   Connection header field, along with the Connection header field
   itself.  Such intermediaries SHOULD also remove other connection-
   specific header fields, such as Keep-Alive, Proxy-Connection,
   Transfer-Encoding, and Upgrade, even if they are not nominated by the
   Connection header field.

It then explicitly talks about the Transfer-Encoding header as allowed only if used with the value of `trailers`. 
>    The only exception to this is the TE header field, which MAY be
   present in an HTTP/2 request; when it is, it MUST NOT contain any
   value other than "trailers".

Indeed, failure to do so with a service using HTTP/2 will result in a protocol error at least in my lived experience.
