### PR TITLE
docs(events): remove broken link to deleted document

### DIFF
--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -332,11 +332,6 @@ This topic provides an index to the main _sorts_ of events you might be interest
               ><code>MSGestureTap</code></a
             >.
           </li>
-          <li>
-            <a href="/en-US/docs/Web/Events/Mouse_gesture_events"
-              >Mouse gesture events for Firefox Addons</a
-            >
-          </li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
Removing a link to a deleted document on XUL add-ons.

Fixes #22025 