### PR TITLE
Add word-spacing link to letter-spacing page

### DIFF
--- a/files/en-us/web/css/letter-spacing/index.md
+++ b/files/en-us/web/css/letter-spacing/index.md
@@ -116,3 +116,4 @@ Some written languages should not have any letter spacing applied. For instance,
 ## See also
 
 - {{cssxref("font-kerning")}}
+- {{cssxref("word-spacing")}}


### PR DESCRIPTION
The word-spacing page already has a link to letter-spacing. letter-spacing should likewise link to word-spacing.