### PR TITLE
Add a page for HTMLElement.inputMode

### DIFF
--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -43,13 +43,15 @@ _Inherits properties from its parent, {{DOMxRef("Element")}}._
 - {{DOMxRef("HTMLElement.enterkeyhint")}}
   - : A string defining what action label (or icon) to present for the enter key on virtual keyboards.
 - {{DOMxRef("HTMLElement.hidden")}}
-  - : A boolean value indicating if the element is hidden or not.
+  - : A string or boolean value reflecting the value of the element's [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute.
 - {{DOMxRef("HTMLElement.inert")}}
   - : A boolean value indicating whether the user agent must act as though the given node is absent for the purposes of user interaction events, in-page text searches ("find in page"), and text selection.
 - {{DOMxRef("HTMLElement.innerText")}}
   - : Represents the rendered text content of a node and its descendants.
     As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied it to the clipboard.
     As a setter, it replaces the content inside the selected element, converting any line breaks into {{HTMLElement("br")}} elements.
+- {{DOMxRef("HTMLElement.inputMode")}}
+  - : A string value reflecting the value of the element's [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) attribute.
 - {{DOMxRef("HTMLElement.lang")}}
   - : A string representing the language of an element's attributes, text, and element contents.
 - {{DOMxRef("HTMLElement.noModule")}}

--- a/files/en-us/web/api/htmlelement/inputmode/index.md
+++ b/files/en-us/web/api/htmlelement/inputmode/index.md
@@ -1,0 +1,64 @@
+---
+title: HTMLElement.inputMode
+slug: Web/API/HTMLElement/inputMode
+page-type: web-api-instance-property
+tags:
+  - API
+  - Attribute
+  - Element
+  - HTML
+  - HTML element
+  - Property
+  - Reference
+  - hidden
+browser-compat: api.HTMLElement.inputMode
+---
+
+{{ APIRef("HTML DOM") }}
+
+The {{domxref("HTMLElement")}} property **`inputMode`** reflects the value of the element's [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) attribute.
+
+It provides a hint about the type of data that might be entered by the user while editing the element or its contents. This allows the browser to display an appropriate virtual keyboard.
+
+It is used primarily on {{HTMLElement("input")}} elements, but is usable on any element in {{HTMLAttrxRef("contenteditable")}} mode.
+
+## Value
+
+This attribute may have one of the following values:
+
+- `decimal`
+  - : Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>).
+- `email`
+  - : A virtual keyboard optimized for entering email addresses.
+    Typically includes the <kbd>@</kbd>character as well as other optimizations.
+- `none`
+  - : No virtual keyboard, for when the page implements its own keyboard input control.
+- `numeric`
+  - : Numeric input keyboard, but only requires the digits 0–9.
+    Devices may or may not show a minus key.
+- `search`
+  - : A virtual keyboard optimized for search input.
+    For instance, the [return/submit key](https://html.spec.whatwg.org/dev/interaction.html#input-modalities:-the-enterkeyhint-attribute) may be labeled "Search".
+- `tel`
+  - : A telephone keypad input, including the digits 0–9, the asterisk (<kbd>\*</kbd>), and the pound (<kbd>#</kbd>) key.
+- `text`
+  - : Standard input keyboard for the user's current locale.
+- `url`
+  - : A keypad optimized for entering URLs.
+    This may have the <kbd>/</kbd> key more prominent, for example.
+
+For details on the usage of this attribute, see the page for the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) HTML attribute that this property reflects.
+
+## Examples
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{htmlattrxref("inputmode")}} attribute

--- a/files/en-us/web/api/htmlelement/inputmode/index.md
+++ b/files/en-us/web/api/htmlelement/inputmode/index.md
@@ -10,7 +10,6 @@ tags:
   - HTML element
   - Property
   - Reference
-  - hidden
 browser-compat: api.HTMLElement.inputMode
 ---
 

--- a/files/en-us/web/api/htmlelement/inputmode/index.md
+++ b/files/en-us/web/api/htmlelement/inputmode/index.md
@@ -26,20 +26,20 @@ It is used primarily on {{HTMLElement("input")}} elements, but is usable on any 
 This attribute may have one of the following values:
 
 - `decimal`
-  - : Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>).
+  - : Fractional numeric input keyboard that contains the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>).
 - `email`
   - : A virtual keyboard optimized for entering email addresses.
     Typically includes the <kbd>@</kbd>character as well as other optimizations.
 - `none`
-  - : No virtual keyboard, for when the page implements its own keyboard input control.
+  - : No virtual keyboard. This is used when the page implements its own keyboard input control.
 - `numeric`
-  - : Numeric input keyboard, but only requires the digits 0–9.
+  - : Numeric input keyboard that only requires the digits 0–9.
     Devices may or may not show a minus key.
 - `search`
   - : A virtual keyboard optimized for search input.
     For instance, the [return/submit key](https://html.spec.whatwg.org/dev/interaction.html#input-modalities:-the-enterkeyhint-attribute) may be labeled "Search".
 - `tel`
-  - : A telephone keypad input, including the digits 0–9, the asterisk (<kbd>\*</kbd>), and the pound (<kbd>#</kbd>) key.
+  - : A telephone keypad input that includes the digits 0–9, the asterisk (<kbd>\*</kbd>), and the pound (<kbd>#</kbd>) key.
 - `text`
   - : Standard input keyboard for the user's current locale.
 - `url`


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/22003.

This PR adds a page for `HTMLElement.inputMode`. Note that the spec table isn't showing because BCD is currently missing `spec_url`, so I filed https://github.com/mdn/browser-compat-data/pull/18137 for that.