### PR TITLE
Add caveat about memory usage

### DIFF
--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -18,7 +18,8 @@ When the read operation is complete, the {{domxref("FileReader.readyState","read
 the {{domxref("FileReader/loadend_event", "loadend")}} event is triggered, and the {{domxref("FileReader.result","result")}} property contains the contents of the file as a text string.
 
 > **Note:** The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as text.
-> **Note:** This method loads the entire contents of the file in memory and is not suitable for large files. Prefer readAsArrayBuffer for large files
+
+> **Note:** This method loads the entire file's content into memory and is not suitable for large files. Prefer [`readAsArrayBuffer()`](/en-US/docs/Web/API/FileReader/readAsArrayBuffer) for large files.
 
 ## Syntax
 

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -18,6 +18,7 @@ When the read operation is complete, the {{domxref("FileReader.readyState","read
 the {{domxref("FileReader/loadend_event", "loadend")}} event is triggered, and the {{domxref("FileReader.result","result")}} property contains the contents of the file as a text string.
 
 > **Note:** The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as text.
+> **Note:** This method loads the entire contents of the file in memory and is not suitable for large files. Prefer readAsArrayBuffer for large files
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Add note about readAsText() loading the complete blob into memory and to prefer readAsArrayBuffer for large files

### Motivation

Im working on a project that potentially reads files over 3 GBs in size and these behaviors were not immediately clear to me

### Additional details

(https://joji.me/en-us/blog/processing-huge-files-using-filereader-readasarraybuffer-in-web-browser/)

### Related issues and pull requests
