### PR TITLE
Add Sprig as Canvas resource

### DIFF
--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -92,6 +92,7 @@ The Canvas API is extremely powerful, but not always simple to use. The librarie
 - [Rekapi](https://github.com/jeremyckahn/rekapi) is an animation key-framing API for Canvas.
 - [Scrawl-canvas](https://scrawl.rikweb.org.uk/) is an open-source JavaScript library for creating and manipulating 2D canvas elements.
 - The [ZIM](https://zimjs.com) framework provides conveniences, components, and controls for coding creativity on the canvas — includes accessibility and hundreds of colorful tutorials.
+- [Sprig](https://github.com/hackclub/sprig) is a beginner-friendly, open-source, tile-based game development library that uses Canvas.
 
 > **Note:** See the [WebGL API](/en-US/docs/Web/API/WebGL_API) for 2D and 3D libraries that use WebGL.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change adds [Sprig](https://github.com/hackclub/sprig) as a resource on the Canvas page. 

### Motivation

At [Hack Club](https://hackclub.com/), a nonprofit, we recently published an open source game engine (with companion open source hardware) for people getting started with game dev in JavaScript called [Sprig](https://sprig.hackclub.com/). A lot of the code for it is written by teenage hackers and the engine, editor, and hardware are entirely open source: https://github.com/hackclub/sprig 

100+ games have already been built in it by beginner coders. This is a [zombie game](https://editor.sprig.hackclub.com/?id=3a82dcd05d924d5e827d89c553d89b2d) and one teenager even built a [3D raycasted game](https://editor.sprig.hackclub.com/?id=8c7dd316dd8cc43cf028c16b6f104be5) in it.

It's a great way for new coders to get started with game dev, and I wanted to suggest adding it as a resource on MDN's Canvas page. I think it's a lot more beginner friendly than some of the other libraries linked, and a great starting off point for newer coders reading the page.

I completely understand if it's not a good resource for the page, or if there's a conflict because I work at Hack Club, which created this!