### PR TITLE
Fix grammar

### DIFF
--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -103,7 +103,7 @@ CSS selectors can be grouped into the following categories based on the type of 
 
     **Syntax:** `A + B`
 
-    **Example:** `h2 + p` will match the first {{HTMLElement("p")}} element that _immediately_ follow an {{HTMLElement("h2")}} element.
+    **Example:** `h2 + p` will match the first {{HTMLElement("p")}} element that _immediately_ follows an {{HTMLElement("h2")}} element.
 
 - [Column combinator](/en-US/docs/Web/CSS/Column_combinator) {{Experimental_Inline}}
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Line 106 uses incorrect grammar where it says "...element that immediately follow..."

### Motivation

This is a minor grammar correction that improves readability.

### Additional details

The phrase has been adjusted to read "...element that immediately follows..."

### Related issues and pull requests

N/A


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
