### PR TITLE
Add mention of the return value

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -42,6 +42,7 @@ set(typedarray, targetOffset)
   - : The offset into the target array at which to begin writing values from the source
     array. If this value is omitted, 0 is assumed (that is, the source array will
     overwrite values in the target array starting at index 0).
+
 ### Return value
 
 {{jsxref("undefined")}}.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -42,7 +42,6 @@ set(typedarray, targetOffset)
   - : The offset into the target array at which to begin writing values from the source
     array. If this value is omitted, 0 is assumed (that is, the source array will
     overwrite values in the target array starting at index 0).
-    
 ### Return value
 
 {{jsxref("undefined")}}.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -42,6 +42,10 @@ set(typedarray, targetOffset)
   - : The offset into the target array at which to begin writing values from the source
     array. If this value is omitted, 0 is assumed (that is, the source array will
     overwrite values in the target array starting at index 0).
+    
+### Return value
+
+{{jsxref("undefined")}}.
 
 ### Exceptions
 


### PR DESCRIPTION
### Description
Add mention of the return value TypedArray.prototype.set() 

### Motivation
Help improve article content https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set

### Additional details
Fix #21860

### Related issues and pull requests