### PR TITLE
Update examples for document.caret[Range/Position]FromPoint to clarify which is used

### DIFF
--- a/files/en-us/web/api/document/caretpositionfrompoint/index.md
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.md
@@ -42,7 +42,7 @@ Click anywhere in the **Demo** paragraph below to insert a line break at the poi
 
 {{EmbedLiveSample('Examples')}}
 
-The code below first checks for {{domxref("Document.caretRangeFromPoint", "document.caretRangeFromPoint")}} support, but if the browser doesn't support that, the code then checks for `document.caretPositionFromPoint`, and uses that instead.
+The code below first checks for `document.caretPositionFromPoint` support, but if the browser doesn't support that, the code then checks for {{domxref("Document.caretRangeFromPoint", "document.caretRangeFromPoint")}}, and uses that instead.
 
 ### JavaScript
 
@@ -52,35 +52,54 @@ function insertBreakAtPoint(e) {
   let textNode;
   let offset;
 
-  if (document.caretRangeFromPoint) {
-    range = document.caretRangeFromPoint(e.clientX, e.clientY);
-    textNode = range.startContainer;
-    offset = range.startOffset;
-  } else if (document.caretPositionFromPoint) {
+  if (document.caretPositionFromPoint) {
     range = document.caretPositionFromPoint(e.clientX, e.clientY);
     textNode = range.offsetNode;
     offset = range.offset;
+  } else if (document.caretRangeFromPoint) {
+    // Use WebKit-proprietary fallback method
+    range = document.caretRangeFromPoint(e.clientX, e.clientY);
+    textNode = range.startContainer;
+    offset = range.startOffset;
   } else {
-    document.body.textContent = "[This browser supports neither"
-      + " document.caretRangeFromPoint"
-      + " nor document.caretPositionFromPoint.]";
+    // Neither method is supported, do nothing
     return;
   }
   // Only split TEXT_NODEs
   if (textNode?.nodeType === 3) {
     let replacement = textNode.splitText(offset);
-    let br = document.createElement('br');
+    let br = document.createElement("br");
     textNode.parentNode.insertBefore(br, replacement);
   }
 }
 
 let paragraphs = document.getElementsByTagName("p");
 for (const paragraph of paragraphs) {
-  paragraph.addEventListener('click', insertBreakAtPoint, false);
+  paragraph.addEventListener("click", insertBreakAtPoint, false);
+}
+```
+
+```js hidden
+let message = document.getElementById("message");
+if (document.caretPositionFromPoint) {
+  message.textContent =
+    "This browser supports the standard document.caretPositionFromPoint";
+  message.classList.add("supported");
+} else if (document.caretRangeFromPoint) {
+  message.textContent =
+    "This browser supports the non-standard document.caretRangeFromPoint";
+  message.classList.add("supported");
 }
 ```
 
 ### HTML
+
+```html hidden
+<div id="message">
+  This browser supports neither document.caretRangeFromPoint nor
+  document.caretPositionFromPoint
+</div>
+```
 
 ```html
 <p>
@@ -89,6 +108,21 @@ for (const paragraph of paragraphs) {
   voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
   kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 </p>
+```
+
+```css hidden
+#message {
+  color: red;
+  font-weight: bold;
+}
+
+#message.fallback {
+  color: darkorange;
+}
+
+#message.supported {
+  color: green;
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/document/caretrangefrompoint/index.md
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.md
@@ -20,6 +20,8 @@ The **`caretRangeFromPoint()`** method of the
 {{domxref("Document")}} interface returns a {{domxref("Range")}} object for the document
 fragment under the specified coordinates.
 
+This method is the WebKit-proprietary implementation of the {{domxref("Document.caretPositionFromPoint")}} method.
+
 ## Syntax
 
 ```js-nolint
@@ -43,60 +45,7 @@ One of the following:
 
 ## Examples
 
-Click anywhere in the **Demo** paragraph below to insert a line break at the point where you click. The code for it is below the demo.
-
-### Demo
-
-{{EmbedLiveSample('Examples')}}
-
-The code below first checks for `document.caretRangeFromPoint` support, but if the browser doesn't support that, the code then checks for {{domxref("Document.caretPositionFromPoint", "document.caretPositionFromPoint")}}, and uses that instead.
-
-### JavaScript
-
-```js
-function insertBreakAtPoint(e) {
-  let range;
-  let textNode;
-  let offset;
-
-  if (document.caretRangeFromPoint) {
-    range = document.caretRangeFromPoint(e.clientX, e.clientY);
-    textNode = range.startContainer;
-    offset = range.startOffset;
-  } else if (document.caretPositionFromPoint) {
-    range = document.caretPositionFromPoint(e.clientX, e.clientY);
-    textNode = range.offsetNode;
-    offset = range.offset;
-  } else {
-    document.body.textContent = "[This browser supports neither"
-      + " document.caretRangeFromPoint"
-      + " nor document.caretPositionFromPoint.]";
-    return;
-  }
-  // Only split TEXT_NODEs
-  if (textNode?.nodeType === 3) {
-    let replacement = textNode.splitText(offset);
-    let br = document.createElement('br');
-    textNode.parentNode.insertBefore(br, replacement);
-  }
-}
-
-let paragraphs = document.getElementsByTagName("p");
-for (const paragraph of paragraphs) {
-  paragraph.addEventListener('click', insertBreakAtPoint, false);
-}
-```
-
-### HTML
-
-```html
-<p>
-  Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
-  eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-  voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
-  kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
-</p>
-```
+Visit the {{domxref("Document.caretPositionFromPoint#Examples", "Document.caretPositionFromPoint")}} page to view a live sample of this method.
 
 ## Browser compatibility
 


### PR DESCRIPTION
A couple of users have opened BCD issues that incorrectly claim that `caretRangeFromPoint` or `caretPositionFromPoint` is supported on their browser because of the example code, but the example code is designed to try one method and use the other as a fallback, so the demo will always work.  This PR attempts to resolve this by adding a message at the top of the demo to state which method is being used.  This also performs a few small tweaks, such as swapping which method is tried first (since `caretPositionFromPoint` is the standard method), adding language to the `caretRangeFromPoint` explaining that it's a proprietary implementation of `caretPositionFromPoint`, and simply linking to the example on `caretPositionFromPoint` rather than duplicating the example.
