### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/css/env/index.md
+++ b/files/en-us/web/css/env/index.md
@@ -163,7 +163,7 @@ p {
 padding: env(safe-area-inset-bottom, 50px);
 
 /* 50px because UA properties are case sensitive */
-padding: env(Safe-area-inset-bottom, 50px);
+padding: env(safe-area-inset-bottom, 50px);
 
 /* as if padding: '50px 20px' were set because x is not a valid environment variable */
 padding: env(x, 50px 20px);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fix a typo. `safe-area-*` should be started with a lowercase letter.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The example won't work because of a typo.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The typo should be fixed like this.
```diff
-- padding: env(Safe-area-inset-bottom, 50px);
++ padding: env(safe-area-inset-bottom, 50px);
```
