### PR TITLE
Cleanup PerformanceObserver pages

### DIFF
--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -16,10 +16,7 @@ browser-compat: api.PerformanceObserver.disconnect
 
 {{APIRef("Performance API")}}
 
-The **`disconnect()`** method of the
-{{domxref('PerformanceObserver')}} interface is used to stop the performance observer
-from receiving any {{domxref("PerformanceEntry","performance entry", '', 'true')}}
-events.
+The **`disconnect()`** method of the {{domxref('PerformanceObserver')}} interface is used to stop the performance observer from receiving any {{domxref("PerformanceEntry","performance entry", '', 'true')}} events.
 
 ## Syntax
 
@@ -37,23 +34,21 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Stopping a performance observer
+
+The following example disconnects the performance observer to disable receiving any more performance entry events.
+
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
     .forEach((entry) => {
-      // Process "mark" and "frame" events
+      // Process "measure" events
+      // …
+      // Disable additional performance events
+      observer.disconnect();
     });
 });
-observer.observe({ entryTypes: ["mark", "frame"] });
-
-function perfObserver(list, observer) {
-  // Process the "measure" event
-  // …
-  // Disable additional performance events
-  observer.disconnect();
-}
-const observer2 = new PerformanceObserver(perfObserver);
-observer2.observe({ entryTypes: ["measure"] });
+observer.observe({ entryTypes: ["mark", "measure"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/index.md
@@ -13,11 +13,9 @@ tags:
 browser-compat: api.PerformanceObserver
 ---
 
-{{APIRef("Performance API")}}
+{{APIRef("Performance API")}} {{AvailableInWorkers}}
 
-The **`PerformanceObserver`** interface is used to _observe_ performance measurement events and be notified of new {{domxref("PerformanceEntry","performance entries", '', 'true')}} as they are recorded in the browser's _performance timeline_.
-
-{{AvailableInWorkers}}
+The **`PerformanceObserver`** interface is used to observe performance measurement events and be notified of new {{domxref("PerformanceEntry","performance entries", '', 'true')}} as they are recorded in the browser's _performance timeline_.
 
 ## Constructor
 
@@ -32,20 +30,32 @@ The **`PerformanceObserver`** interface is used to _observe_ performance measure
 ## Instance methods
 
 - {{domxref("PerformanceObserver.observe","PerformanceObserver.observe()")}}
-  - : Specifies the set of {{domxref("PerformanceEntry.entryType","entry types")}} to observe. The performance observer's callback function will be invoked when a {{domxref("PerformanceEntry","performance entry")}} is recorded for one of the specified `entryTypes`
+  - : Specifies the set of entry types to observe. The performance observer's callback function will be invoked when performance entry is recorded for one of the specified `entryTypes`.
 - {{domxref("PerformanceObserver.disconnect","PerformanceObserver.disconnect()")}}
-  - : Stops the performance observer callback from receiving {{domxref("PerformanceEntry","performance entries")}}.
+  - : Stops the performance observer callback from receiving performance entries.
 - {{domxref("PerformanceObserver.takeRecords","PerformanceObserver.takeRecords()")}}
-  - : Returns the current list of {{domxref("PerformanceEntry","performance entries")}} stored in the performance observer, emptying it out.
+  - : Returns the current list of performance entries stored in the performance observer, emptying it out.
 
-## Example
+## Examples
+
+### Creating a PerformanceObserver
+
+The following example creates a `PerformanceObserver` watching for "mark" ({{domxref("PerformanceMark")}}) and "measure" ({{domxref("PerformanceMeasure")}}) events.
+The `perfObserver` callback provides a `list` ({{domxref("PerformanceObserverEntryList")}}) which allows you get observed performance entries.
 
 ```js
-function observer_callback(list, observer) {
-   // Process the "measure" event
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) =>  {
+    if (entry.entryType === "mark") {
+      console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+    };
+    if (entry.entryType === "measure") {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
+    };
+  });
 }
-let observer = new PerformanceObserver(observer_callback);
-observer.observe({entryTypes: ["measure"]});
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/index.md
@@ -41,7 +41,7 @@ The **`PerformanceObserver`** interface is used to observe performance measureme
 ### Creating a PerformanceObserver
 
 The following example creates a `PerformanceObserver` watching for "mark" ({{domxref("PerformanceMark")}}) and "measure" ({{domxref("PerformanceMeasure")}}) events.
-The `perfObserver` callback provides a `list` ({{domxref("PerformanceObserverEntryList")}}) which allows you get observed performance entries.
+The `perfObserver` callback provides a `list` ({{domxref("PerformanceObserverEntryList")}}) which allows you to get observed performance entries.
 
 ```js
 function perfObserver(list, observer) {

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -14,18 +14,11 @@ browser-compat: api.PerformanceObserver.observe
 
 {{APIRef("Performance API")}}
 
-The **`observe()`** method of the
-**{{domxref("PerformanceObserver")}}** interface is used to specify the
-set of performance entry types to observe.
+The **`observe()`** method of the **{{domxref("PerformanceObserver")}}** interface is used to specify the set of performance entry types to observe.
 
-The performance entry types are
-specified as an array of string objects, each naming one entry type;
-the type names are documented in
-{{SectionOnPage("/en-US/docs/Web/API/PerformanceEntry/entryType", "Performance entry
-  type names")}}.
+See {{domxref("PerformanceEntry.entryType")}} for a list of entry types and {{domxref("PerformanceObserver.supportedEntryTypes")}} for a list of entry types the user agent supports.
 
-When a matching performance entry is recorded, the performance observer's callback
-function—set when creating the {{domxref("PerformanceObserver")}}—is invoked.
+When a matching performance entry is recorded, the performance observer's callback function—set when creating the {{domxref("PerformanceObserver")}}—is invoked.
 
 ## Syntax
 
@@ -40,24 +33,16 @@ observe(options)
   - : An object with the following possible members:
 
     - `buffered`
-      - : A boolean flag to indicate whether buffered
-        entries should be queued into the observer's buffer. Must be used only with the
-        "`type`" option.
+      - : A boolean flag to indicate whether buffered entries should be queued into the observer's buffer. Must be used only with the "`type`" option.
     - `durationThreshold`
-      - : A {{domxref("DOMHighResTimeStamp")}} defining the threshold for {{domxref("PerformanceEventTiming")}} entries. Defaults to 104ms and is rounded to the nearest of 8ms. Lowest possible threshold is 16ms.
+      - : A {{domxref("DOMHighResTimeStamp")}} defining the threshold for {{domxref("PerformanceEventTiming")}} entries. Defaults to 104ms and is rounded to the nearest of 8ms. Lowest possible threshold is 16ms. May not be used together with the `entryTypes` option.
     - `entryTypes`
-      - : An array of string objects, each
-        specifying one performance entry type to observe. May not be used together with
-        the "`type`" or "`buffered`" options.
-    - `type`
-      - : A single string specifying exactly one
-        performance entry type to observe. May not be used together with the
-        `entryTypes` option.
+      - : An array of string objects, each specifying one performance entry type to observe. May not be used together with
+        the "`type`", "`buffered`", or "`durationThreshold`" options.
 
-    See {{domxref("PerformanceEntry.entryType")}} for a list of valid performance entry
-    type names. Unrecognized types are ignored, though the browser may output a warning
-    message to the console to help developers debug their code. If no valid types are
-    found, `observe()` has no effect.
+        See {{domxref("PerformanceEntry.entryType")}} for a list of valid performance entry type names. Unrecognized types are ignored, though the browser may output a warning message to the console to help developers debug their code. If no valid types are found, `observe()` has no effect.
+    - `type`
+      - : A single string specifying exactly one performance entry type to observe. May not be used together with the `entryTypes` option.
 
 ### Return value
 
@@ -65,24 +50,32 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-This example creates and configures two `PerformanceObservers`; one watches
-for `"mark"` and `"frame"` events, and the other watches for
-`"measure"` events.
+### Watching multiple performance entry types
+
+This example creates a `PerformanceObserver` and watches for `"mark"` and `"measure"` entry types as specified by the `entryTypes` option given in the `observe()` method.
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
     .forEach((entry) => {
-      // Process "mark" and "frame" events
+      // Process "mark" and "measure" events
     });
 });
-observer.observe({ entryTypes: ["mark", "frame"] });
+observer.observe({ entryTypes: ["mark", "measure"] });
+```
 
-function perfObserver(list, observer) {
-  // Process the "measure" event
-}
-const observer2 = new PerformanceObserver(perfObserver);
-observer2.observe({ entryTypes: ["measure"] });
+### Watching a single performance entry type
+
+The following example retrieves buffered events and subscribes to newer events for resource timing events ({{domxref("PerformanceResourceTiming")}}) using the `buffered` and `type` configuration options. Whenever you need to configure the observer to use the `buffered` or `durationTheshold` option, use `type` instead of `entryType`. Collecting multiple types of performance entry types will not work otherwise.
+
+```js
+const observer = new PerformanceObserver((list, obj) => {
+  list.getEntries()
+    .forEach((entry) => {
+      // Process "resource" events
+    });
+});
+observer.observe({ type: "resource", buffered: true });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -13,12 +13,7 @@ browser-compat: api.PerformanceObserver.PerformanceObserver
 
 {{APIRef("Performance API")}}
 
-The **`PerformanceObserver()`** constructor creates a new
-{{domxref("PerformanceObserver")}} object with the given observer `callback`.
-The observer callback is invoked when {{domxref("PerformanceEntry","performance entry
-  events", '', 'true')}} are recorded for the
-{{domxref("PerformanceEntry.entryType","entry types",'','true')}} that have been
-registered, via the {{domxref("PerformanceObserver.observe","observe()")}} method.
+The **`PerformanceObserver()`** constructor creates a new {{domxref("PerformanceObserver")}} object with the given observer `callback`. The observer callback is invoked when {{domxref("PerformanceEntry","performance entry events", '', 'true')}} are recorded for the {{domxref("PerformanceEntry.entryType","entry types",'','true')}} that have been registered, via the {{domxref("PerformanceObserver.observe","observe()")}} method.
 
 ## Syntax
 
@@ -29,33 +24,32 @@ new PerformanceObserver(callback)
 ### Parameters
 
 - `callback`
-  - : A `PerformanceObserverCallback` callback that will be invoked when
-    _observed_ performance events are recorded. When the callback is invoked, its
-    first parameter is a {{domxref("PerformanceObserverEntryList","list of performance
-    observer entries", '', 'true')}} and the second parameter is the
-    {{domxref("PerformanceObserver","observer")}} object.
+  - : A `PerformanceObserverCallback` callback that will be invoked when observed performance events are recorded. When the callback is invoked, its first parameter is a {{domxref("PerformanceObserverEntryList","list of performance observer entries", '', 'true')}} and the second parameter is the {{domxref("PerformanceObserver","observer")}} object.
 
 ### Return value
 
-A new {{domxref("PerformanceObserver")}} object which will call the specified
-`callback` when observed performance events occur.
+A new {{domxref("PerformanceObserver")}} object which will call the specified `callback` when observed performance events occur.
 
 ## Examples
 
-```js
-const observer = new PerformanceObserver((list, obj) => {
-  list.getEntries()
-    .forEach((entry) => {
-      // Process "mark" and "frame" events
-    });
-});
-observer.observe({ entryTypes: ["mark", "frame"] });
+### Creating a PerformanceObserver
 
+The following example creates a `PerformanceObserver` watching for "mark" ({{domxref("PerformanceMark")}}) and "measure" ({{domxref("PerformanceMeasure")}}) events.
+The `perfObserver` callback provides a `list` ({{domxref("PerformanceObserverEntryList")}}) which allows you get observed performance entries.
+
+```js
 function perfObserver(list, observer) {
-  // Process the "measure" event
+  list.getEntries().forEach((entry) =>  {
+    if (entry.entryType === "mark") {
+      console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+    };
+    if (entry.entryType === "measure") {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
+    };
+  });
 }
-const observer2 = new PerformanceObserver(perfObserver);
-observer2.observe({ entryTypes: ["measure"] });
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
@@ -14,8 +14,7 @@ browser-compat: api.PerformanceObserver.supportedEntryTypes
 
 {{APIRef("Performance API")}}
 
-The static **`supportedEntryTypes`** read-only property of the
-{{domxref("PerformanceObserver")}} interface returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.
+The static **`supportedEntryTypes`** read-only property of the {{domxref("PerformanceObserver")}} interface returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.
 
 As the list of supported entries varies per browser and is evolving, this property allows web developers to check which are available.
 
@@ -27,7 +26,7 @@ An array of {{domxref("PerformanceEntry.entryType")}} values.
 
 ### Using the console to check supported types
 
-To find out which {{domxref("PerformanceEntry.entryType","entryType")}} values a browser supports enter <kbd>PerformanceObserver.supportedEntryTypes</kbd> into the console. This will return an array of `EntryType` values.
+To find out which {{domxref("PerformanceEntry.entryType","entryType")}} values a browser supports, enter <kbd>PerformanceObserver.supportedEntryTypes</kbd> into the console. This will return an array of supported values.
 
 ```js
 PerformanceObserver.supportedEntryTypes
@@ -48,7 +47,7 @@ function detectSupport(entryTypes) {
   }
 }
 
-detectSupport(["resource", "mark", "frame"]);
+detectSupport(["resource", "mark", "first-input", "largest-contentful-paint"]);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -15,10 +15,7 @@ browser-compat: api.PerformanceObserver.takeRecords
 
 {{APIRef("Performance API")}}
 
-The **`takeRecords()`** method of the
-{{domxref('PerformanceObserver')}} interface returns the current list of
-{{domxref("PerformanceEntry","performance entries")}} stored in the performance
-observer, emptying it out.
+The **`takeRecords()`** method of the {{domxref('PerformanceObserver')}} interface returns the current list of {{domxref("PerformanceEntry","performance entries")}} stored in the performance observer, emptying it out.
 
 ## Syntax
 
@@ -36,14 +33,18 @@ A list of {{domxref("PerformanceEntry")}} objects.
 
 ## Examples
 
+### Taking records
+
+The following example stores the current list of performance entries into `records` and empties the performance observer.
+
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
     .forEach((entry) => {
-      // Process "mark" and "frame" events
+      // Process "mark" and "measure" events
     });
 });
-observer.observe({ entryTypes: ["mark", "frame"] });
+observer.observe({ entryTypes: ["mark", "measure"] });
 const records = observer.takeRecords();
 console.log(records[0].name);
 console.log(records[0].startTime);


### PR DESCRIPTION
### Description

This PR does some cleaning to the https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver pages.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

- "frame" is no more a thing. Removed it from examples.
- Examples sections are always in the form of: h2-"Examples" -> h3-myExample followed by a description and the code.
- minor formatting and line wrapping fixes
- The observe method now has two examples, one for watching multiple event types, one for observing just one.

### Related issues and pull requests

None.
