### PR TITLE
PerformanceEventTiming pages should use buffered option

### DIFF
--- a/files/en-us/web/api/performanceeventtiming/cancelable/index.md
+++ b/files/en-us/web/api/performanceeventtiming/cancelable/index.md
@@ -35,7 +35,7 @@ const observer = new PerformanceObserver((list) => {
 });
 
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe({type: "event", buffered: true});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -23,7 +23,7 @@ This API enables visibility into slow events by providing event timestamps and d
 
 This API is particularly useful for measuring the {{Glossary("first input delay")}} (FID): the time from the point when a user first interacts with your app to the point when the browser is actually able to respond to that interaction.
 
-You typically work with `PerformanceEventTiming` objects by creating a {{domxref("PerformanceObserver")}} instance and then calling its [`observe()`](/en-US/docs/Web/API/PerformanceObserver/observe) method, passing in `"event"` or `"first-input"` as the value of the [`entryType`](/en-US/docs/Web/API/PerformanceEntry/entryType) option. The `PerformanceObserver` object's callback will then be called with a list of `PerformanceEventTiming` objects which you can analyze. See the [example below](#getting_event_timing_information) for more.
+You typically work with `PerformanceEventTiming` objects by creating a {{domxref("PerformanceObserver")}} instance and then calling its [`observe()`](/en-US/docs/Web/API/PerformanceObserver/observe) method, passing in `"event"` or `"first-input"` as the value of the [`type`](/en-US/docs/Web/API/PerformanceEntry/entryType) option. The `PerformanceObserver` object's callback will then be called with a list of `PerformanceEventTiming` objects which you can analyze. See the [example below](#getting_event_timing_information) for more.
 
 By default, `PerformanceEventTiming` entries are exposed when their `duration` is 104ms or greater. Research suggests that user input that is not handled within 100ms is considered slow and 104ms is the first multiple of 8 greater than 100ms (for security reasons, this API is rounded to the nearest multiple of 8ms).
 However, you can set the {{domxref("PerformanceObserver")}} to a different threshold using the `durationThreshold` option in the [`observe()`](/en-US/docs/Web/API/PerformanceObserver/observe) method.
@@ -165,7 +165,7 @@ This interface also supports the following properties:
 
 ### Getting event timing information
 
-To get event timing information, create a {{domxref("PerformanceObserver")}} instance and then call its [`observe()`](/en-US/docs/Web/API/PerformanceObserver/observe) method, passing in `"event"` or `"first-input"` as the value of the [`entryType`](/en-US/docs/Web/API/PerformanceEntry/entryType) option. The `PerformanceObserver` object's callback will then be called with a list of `PerformanceEventTiming` objects which you can analyze.
+To get event timing information, create a {{domxref("PerformanceObserver")}} instance and then call its [`observe()`](/en-US/docs/Web/API/PerformanceObserver/observe) method, passing in `"event"` or `"first-input"` as the value of the [`type`](/en-US/docs/Web/API/PerformanceEntry/entryType) option. You also need to set `buffered` to `true` to get access to events the user agent buffered while constructing the document. The `PerformanceObserver` object's callback will then be called with a list of `PerformanceEventTiming` objects which you can analyze.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -186,13 +186,13 @@ const observer = new PerformanceObserver((list) => {
 });
 
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe({type: "event", buffered: true});
 ```
 
 You can also set a different [`durationThreshold`](/en-US/docs/Web/API/PerformanceObserver/observe#durationthreshold). The default is 104ms and the minimum possible duration threshold is 16ms.
 
 ```js
-observer.observe({entryTypes: ["event"], durationThreshold: 16});
+observer.observe({type: "event", durationThreshold: 16, buffered: true});
 ```
 
 ### Reporting the First Input Delay (FID)

--- a/files/en-us/web/api/performanceeventtiming/interactionid/index.md
+++ b/files/en-us/web/api/performanceeventtiming/interactionid/index.md
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({entryTypes: ["event"]}); 
+observer.observe({type: "event", buffered: true}); 
 
 // Log events with maximum event duration for a user interaction
 Object.entries(eventLatencies).forEach(([k, v]) => {

--- a/files/en-us/web/api/performanceeventtiming/processingend/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingend/index.md
@@ -39,7 +39,7 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe(type: "event", buffered: true});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceeventtiming/processingend/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingend/index.md
@@ -39,7 +39,7 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 // Register the observer for events
-observer.observe(type: "event", buffered: true});
+observer.observe({type: "event", buffered: true});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceeventtiming/processingstart/index.md
+++ b/files/en-us/web/api/performanceeventtiming/processingstart/index.md
@@ -37,7 +37,7 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe({type: "event", buffered: true});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceeventtiming/target/index.md
+++ b/files/en-us/web/api/performanceeventtiming/target/index.md
@@ -37,7 +37,7 @@ const observer = new PerformanceObserver((list) => {
 });
 
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe({type: "event", buffered: true});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -44,7 +44,7 @@ const observer = new PerformanceObserver((list) => {
 });
 
 // Register the observer for events
-observer.observe({entryTypes: ["event"]});
+observer.observe({type: "event", buffered: true});
 ```
 
 This would log a JSON object like so:


### PR DESCRIPTION
### Description

I think it makes more sense for these code examples to use the `buffered` option.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

None.

### Related issues and pull requests

None.