### PR TITLE
Cleanup PerformanceObserverEntryList pages

### DIFF
--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
@@ -13,87 +13,49 @@ browser-compat: api.PerformanceObserverEntryList.getEntries
 
 {{APIRef("Performance API")}}
 
-The **`getEntries()`** method of the
-{{domxref("PerformanceObserverEntryList")}} interface returns a list of explicitly
-_observed_ {{domxref("PerformanceEntry","performance entry", '', 'true')}}
-objects for a given filter. The list's members are determined by the set of
-{{domxref("PerformanceEntry.entryType","entry types", '', 'true')}} specified in the
-call to the {{domxref("PerformanceObserver.observe","observe()")}} method. The list is
-available in the observer's callback function (as the first parameter in the callback).
-
-This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
-interfaces.
+The **`getEntries()`** method of the {{domxref("PerformanceObserverEntryList")}} interface returns a list of explicitly observed {{domxref("PerformanceEntry","performance entry", '', 'true')}} objects. The list's members are determined by the set of {{domxref("PerformanceEntry.entryType","entry types", '', 'true')}} specified in the call to the {{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in the observer's callback function (as the first parameter in the callback).
 
 ## Syntax
 
 ```js-nolint
 getEntries()
-getEntries(performanceEntryFilterOptions)
 ```
-
-### Parameters
-
-- `performanceEntryFilterOptions` {{optional_inline}}
-
-  - : A `PerformanceEntryFilterOptions` object, having the following
-    fields:
-
-    - `"name"`, the name of a performance entry.
-    - `"entryType"`, the entry type. The valid entry types are listed in
-      the {{domxref("PerformanceEntry.entryType")}} method.
-    - `"initiatorType"`, the type of the initiating resource (for example
-      an HTML element). The values are defined by the
-      {{domxref("PerformanceResourceTiming.initiatorType")}} interface.
-
-    This parameter is currently not supported on Chrome or Opera.
 
 ### Return value
 
-A list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects that
-meets the criteria of the filter. The items will be in chronological order based on the
-entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects that meet
-the filter are found, an empty list is returned. If no argument is given, all entries
-are returned.
+A list of explicitly observed {{domxref("PerformanceEntry")}} objects. The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects are found, an empty list is returned.
 
 ## Examples
 
+### Working with getEntries, getEntriesByName and getEntriesByType
+
+The following example shows the difference between the `getEntries()`, {{domxref("PerformanceObserverEntryList.getEntriesByName", "getEntriesByName()")}}, and {{domxref("PerformanceObserverEntryList.getEntriesByType", "getEntriesByType()")}} methods.
+
 ```js
-function print_perf_entry(pe) {
-  console.log(`name: ${pe.name}`);
-  console.log(`entryType: ${pe.entryType}`);
-  console.log(`startTime: ${pe.startTime}`);
-  console.log(`duration: ${pe.duration}`);
-}
-
-// Create observer for all performance event types
-const observe_all = new PerformanceObserver((list, obs) => {
-  // Print all entries
+const observer = new PerformanceObserver((list, obs) => {
+  // Log all entries
   let perfEntries = list.getEntries();
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries named "Begin" with type "mark"
-  perfEntries = list.getEntriesByName("Begin", "mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  // Log entries named "debugging" with type "measure"
+  perfEntries = list.getEntriesByName("debugging", "measure");
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries with type "mark"
+  // Log entries with type "mark"
   perfEntries = list.getEntriesByType("mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s startTime: ${entry.startTime}`)
+  });
 });
 
-// Subscribe to all performance event types
-observe_all.observe({
-  entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server'],
+// Subscribe to various performance event types
+observer.observe({
+  entryTypes: ['mark', 'measure', 'navigation', 'resource']
 });
-
-const observe_frame = new PerformanceObserver((list, obs) => {
-  const perfEntries = list.getEntries();
-
-  // Should only have 'frame' entries
-  perfEntries.forEach((entry) => print_perf_entry(entry));
-});
-
-// Subscribe to frame event only
-observe_frame.observe({entryTypes: ['frame']});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
@@ -13,18 +13,7 @@ browser-compat: api.PerformanceObserverEntryList.getEntriesByName
 
 {{APIRef("Performance API")}}
 
-The **`getEntriesByName()`** method of the
-{{domxref("PerformanceObserverEntryList")}} interface returns a list of explicitly
-_observed_ {{domxref("PerformanceEntry","performance entry", '', 'true')}}
-objects for a given _{{domxref("PerformanceEntry.name","name")}}_ and
-_{{domxref("PerformanceEntry.entryType","entry type")}}_. The list's members are
-determined by the set of {{domxref("PerformanceEntry.entryType","entry types", '',
-  'entry')}} specified in the call to the
-{{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in
-the observer's callback function (as the first parameter in the callback).
-
-This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}}
-interfaces.
+The **`getEntriesByName()`** method of the {{domxref("PerformanceObserverEntryList")}} interface returns a list of explicitly observed {{domxref("PerformanceEntry","performance entry", '', 'true')}} objects for a given {{domxref("PerformanceEntry.name","name")}} and {{domxref("PerformanceEntry.entryType","entry type")}}. The list's members are determined by the set of {{domxref("PerformanceEntry.entryType","entry types", '', 'entry')}} specified in the call to the {{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in the observer's callback function (as the first parameter in the callback).
 
 ## Syntax
 
@@ -38,58 +27,43 @@ getEntriesByName(name, type)
 - `name`
   - : A string representing the name of the entry to retrieve.
 - `type` {{optional_inline}}
-  - : A string representing the type of entry to retrieve such as
-    "`mark`". The valid entry types are listed in
-    {{domxref("PerformanceEntry.entryType")}}.
+  - : A string representing the type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 
-A list of explicitly _observed_ {{domxref("PerformanceEntry","performance
-  entry", '', 'true')}} objects that have the specified `name` and
-`type`. If the `type` argument is not specified, only the
-`name` will be used to determine the entries to return. The items will be in
-chronological order based on the entries'
-{{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the specified
-criteria, an empty list is returned.
+A list of explicitly _observed_ {{domxref("PerformanceEntry","performance entry", '', 'true')}} objects that have the specified `name` and `type`. If the `type` argument is not specified, only the `name` will be used to determine the entries to return. The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the specified criteria, an empty list is returned.
 
 ## Examples
 
+### Working with getEntries, getEntriesByName and getEntriesByType
+
+The following example shows the difference between the {{domxref("PerformanceObserverEntryList.getEntries", "getEntries()")}}, `getEntriesByName()`, and {{domxref("PerformanceObserverEntryList.getEntriesByType", "getEntriesByType()")}} methods.
+
 ```js
-function print_perf_entry(pe) {
-  console.log(`name: ${pe.name}`);
-  console.log(`entryType: ${pe.entryType}`);
-  console.log(`startTime: ${pe.startTime}`);
-  console.log(`duration: ${pe.duration}`);
-}
-
-// Create observer for all performance event types
-const observe_all = new PerformanceObserver((list, obs) => {
-  // Print all entries
+const observer = new PerformanceObserver((list, obs) => {
+  // Log all entries
   let perfEntries = list.getEntries();
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries named "Begin" with type "mark"
-  perfEntries = list.getEntriesByName("Begin", "mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  // Log entries named "debugging" with type "measure"
+  perfEntries = list.getEntriesByName("debugging", "measure");
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries with type "mark"
+  // Log entries with type "mark"
   perfEntries = list.getEntriesByType("mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s startTime: ${entry.startTime}`)
+  });
 });
 
-// Subscribe to all performance event types
-observe_all.observe({
-  entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server'],
+// Subscribe to various performance event types
+observer.observe({
+  entryTypes: ['mark', 'measure', 'navigation', 'resource']
 });
-
-const observe_frame = new PerformanceObserver((list, obs) => {
-  const perfEntries = list.getEntries();
-  // Should only have 'frame' entries
-  perfEntries.forEach((entry) => print_perf_entry(entry));
-});
-
-// Subscribe to only the 'frame' event
-observe_frame.observe({ entryTypes: ['frame'] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
@@ -27,7 +27,7 @@ getEntriesByName(name, type)
 - `name`
   - : A string representing the name of the entry to retrieve.
 - `type` {{optional_inline}}
-  - : A string representing the type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
+  - : A string representing the type of entry to retrieve such as `"mark"`. The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
@@ -15,8 +15,6 @@ browser-compat: api.PerformanceObserverEntryList.getEntriesByType
 
 The **`getEntriesByType()`** method of the {{domxref("PerformanceObserverEntryList")}} returns a list of explicitly _observed_ {{domxref("PerformanceEntry","performance entry", '', 'true')}} objects for a given {{domxref("PerformanceEntry.entryType","performance entry type", '', 'true')}}. The list's members are determined by the set of {{domxref("PerformanceEntry.entryType","entry types", '', 'true')}} specified in the call to the {{domxref("PerformanceObserver.observe","observe()")}} method. The list is available in the observer's callback function (as the first parameter in the callback).
 
-This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}} interfaces.
-
 ## Syntax
 
 ```js-nolint
@@ -26,7 +24,7 @@ getEntriesByType(type)
 ### Parameters
 
 - `type`
-  - : The type of entry to retrieve such as "`frame`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
+  - : The type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 
@@ -34,40 +32,35 @@ A list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects that hav
 
 ## Examples
 
+### Working with getEntries, getEntriesByName and getEntriesByType
+
+The following example shows the difference between the {{domxref("PerformanceObserverEntryList.getEntries", "getEntries()")}}, {{domxref("PerformanceObserverEntryList.getEntriesByName", "getEntriesByName()")}}, and `getEntriesByType()` methods.
+
 ```js
-function print_perf_entry(pe) {
-  console.log(`name: ${pe.name}`);
-  console.log(`entryType: ${pe.entryType}`);
-  console.log(`startTime: ${pe.startTime}`);
-  console.log(`duration: ${pe.duration}`);
-}
-
-// Create observer for all performance event types
-const observe_all = new PerformanceObserver((list, obs) => {
-  // Print all entries
+const observer = new PerformanceObserver((list, obs) => {
+  // Log all entries
   let perfEntries = list.getEntries();
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries named "Begin" with type "mark"
-  perfEntries = list.getEntriesByName("Begin", "mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  // Log entries named "debugging" with type "measure"
+  perfEntries = list.getEntriesByName("debugging", "measure");
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s duration: ${entry.duration}`)
+  });
 
-  // Print entries with type "mark"
+  // Log entries with type "mark"
   perfEntries = list.getEntriesByType("mark");
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+  perfEntries.forEach((entry) => {
+    console.log(`${entry.name}'s startTime: ${entry.startTime}`)
+  });
 });
 
-// Subscribe to all performance event types
-observe_all.observe({ entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server'] });
-
-const observe_frame = new PerformanceObserver((list, obs) => {
-  const perfEntries = list.getEntries();
-  // Should only have 'frame' entries
-  perfEntries.forEach((entry) => print_perf_entry(entry));
+// Subscribe to various performance event types
+observer.observe({
+  entryTypes: ['mark', 'measure', 'navigation', 'resource']
 });
-
-// Subscribe to only the 'frame' event
-observe_frame.observe({entryTypes: ['frame']});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
@@ -24,7 +24,7 @@ getEntriesByType(type)
 ### Parameters
 
 - `type`
-  - : The type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
+  - : The type of entry to retrieve such as `"mark"`. The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/performanceobserverentrylist/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/index.md
@@ -12,28 +12,36 @@ browser-compat: api.PerformanceObserverEntryList
 
 {{APIRef("Performance API")}}
 
-The **`PerformanceObserverEntryList`** interface is a list of {{domxref("PerformanceEntry","performance events", '', 'true')}} that were explicitly _observed_ via the {{domxref("PerformanceObserver.observe","observe()")}} method.
-
-Note: this interface is exposed to {{domxref("Window")}} and {{domxref("Worker")}}.
+The **`PerformanceObserverEntryList`** interface is a list of {{domxref("PerformanceEntry","performance events", '', 'true')}} that were explicitly observed via the {{domxref("PerformanceObserver.observe","observe()")}} method.
 
 ## Instance methods
 
 - {{domxref("PerformanceObserverEntryList.getEntries","PerformanceObserverEntryList.getEntries()")}}
-  - : Returns a list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects based on the given _filter_.
+  - : Returns a list of all explicitly observed {{domxref("PerformanceEntry")}} objects.
 - {{domxref("PerformanceObserverEntryList.getEntriesByType","PerformanceObserverEntryList.getEntriesByType()")}}
-  - : Returns a list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects of the given _entry type_.
+  - : Returns a list of all explicitly observed {{domxref("PerformanceEntry")}} objects of the given entry type.
 - {{domxref("PerformanceObserverEntryList.getEntriesByName","PerformanceObserverEntryList.getEntriesByName()")}}
-  - : Returns a list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects based on the given _name_ and _entry type_.
+  - : Returns a list of all explicitly observed {{domxref("PerformanceEntry")}} objects based on the given name and entry type.
 
 ## Example
 
+### Using PerformanceObserverEntryList
+
+In the following example, `list` is the `PerformanceObserverEntryList` object. The {{domxref("PerformanceObserverEntryList.getEntries","getEntries()")}} method is called to get all explicitly observed {{domxref("PerformanceEntry")}} objects which are "measure" and "mark" in this case.
+
 ```js
-// Create observer for all performance event types
-// list is of type PerformanceObserveEntryList
-const observe_all = new PerformanceObserver((list, obs) => {
-  const perfEntries = list.getEntries();
-  perfEntries.forEach((entry) => print_perf_entry(entry));
-})
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) =>  {
+    if (entry.entryType === "mark") {
+      console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+    };
+    if (entry.entryType === "measure") {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
+    };
+  });
+}
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR cleans up the https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserverEntryList pages.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

- Formatting tweaks
- "frame" is no more
- Code example now without any indirections and added an h3 plus description to it. Reused on all 3 get* pages.
- PerformanceEntryFilterOptions is gone since 2016 and was never implemented!!! (https://github.com/w3c/performance-timeline/pull/61)

### Related issues and pull requests

None.