### PR TITLE
Update hotlink glossary page

### DIFF
--- a/files/en-us/glossary/hotlink/index.md
+++ b/files/en-us/glossary/hotlink/index.md
@@ -7,7 +7,7 @@ tags:
 
 A **hotlink** (also known as an **inline link**) is an object (typically an image) directly linked to from another site. For example, an image hosted on site1.com is shown directly on site2.com.
 
-The practice is frowned upon as it can cause unwanted bandwidth usage on the website hosting the linked-to object. From an ethical standpoint, it could be considered stealing when done without permission.
+The practice is frowned upon, as it can cause unwanted bandwidth usage on the website hosting the linked-to object. From an ethical standpoint, it could be considered stealing when done without permission.
 
 ## See also
 

--- a/files/en-us/glossary/hotlink/index.md
+++ b/files/en-us/glossary/hotlink/index.md
@@ -7,7 +7,7 @@ tags:
 
 A **hotlink** (also known as an **inline link**) is an object (typically an image) directly linked to from another site. For example, an image hosted on site1.com is shown directly on site2.com.
 
-The practice is often frowned upon as it can cause unwanted bandwidth usage on the website hosting the linked-to object, and copyright concerns — it is considered stealing when it is done without permission.
+The practice is frowned upon as it can cause unwanted bandwidth usage on the website hosting the linked-to object. From an ethical standpoint, it could be considered stealing when done without permission.
 
 ## See also
 


### PR DESCRIPTION
### Description

This page stated that hotlinking causes copyright concerns.  However, in a weird way, hotlinking actually might avoid copyright concerns by linking to it instead of hosting copyrighted content directly.  Better just to say hotlinking is frowned upon because of the bandwidth usage without permission.

### Motivation

Hotlinking probably should be considered unethical, but we should have correct statements about why (bandwidth usage) rather than iffy/incorrect ones (copyright).

### Related issues and pull requests
Relates to #22039
