### PR TITLE
add alt texts

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -26,7 +26,7 @@ The manifest can also contain pointers to several other types of files:
 - [Web-accessible resources](#web_accessible_resources)
   - : Make packaged content accessible to web pages and content scripts.
 
-![](webextension-anatomy.png)
+![The components of a web extension. The manifest.JSON must be present in all extensions. It provides pointers to background pages, content scripts, browser actions, page actions, options pages, and web accessible resources. Background pages consist of HTML and JS. Content scripts consist of JS and CSS. The user clicks on an icon to trigger browser actions and page actions and the resulting pop-up consists of HTML, CSS, and JS. Options pages consist of HTML, CSS, and JS.](webextension-anatomy.png)
 
 See the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) reference page for all the details.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.md
@@ -43,7 +43,7 @@ The default code included with the example allows you to load a `userScript` whi
 
 In the following image, the extension will "eat" the content of pages whose domain name ends in .org. This is the default behavior for this extension.
 
-![](userscriptexample.png)
+![User script example](userscriptexample.png)
 
 Nothing will happen until you click the **Register script** button. The button implements the user script according to the settings on this dialog. That means that you can experiment with the behavior of the script without having to implement an extensions yourself.
 
@@ -104,7 +104,7 @@ This code first initializes the params object to pass values to the [userScripts
 
 Once the script has been registered, navigate to a page whose domain name ends in .org, and you will see something like this:
 
-![](user_script_in_action.png)
+![Status message indicating that websites ending in .org have been eaten: "This page has been eaten. {"OldStoredValue:" "website address", "NewStoredValue:" "website address"}"](user_script_in_action.png)
 
 ## See also
 

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -121,7 +121,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 If you need to exchange messages between the content scripts running in the target window and a devtools document, it's a good idea to use the {{WebExtAPIRef("runtime.connect()")}} and {{WebExtAPIRef("runtime.onConnect")}} to set up a connection between the background page and the devtools document. The background page can then maintain a mapping between tab IDs and {{WebExtAPIRef("runtime.Port")}} objects, and use this to route messages between the two scopes.
 
-![](devtools-content-scripts.png)
+![The background page tab ID is connected to the content script on the content page by a runtime.sendmessage() object. The Port of the background page is connected to the port of the Devtools document by a port.postMessage() object.](devtools-content-scripts.png)
 
 ## Limitations of the devtools APIs
 

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -38,7 +38,7 @@ Second, have a look at our [multimessaging demo](https://github.com/mdn/dom-exam
 
 We'll be focusing on the latter example in this article, which looks like:
 
-![](channel-messaging-demo.png)
+![Demo with "Hello this is my demo" sent as five separate messages. The messages are displayed as a bulleted list.](channel-messaging-demo.png)
 
 ## Creating the channel
 

--- a/files/en-us/web/api/element/clientwidth/index.md
+++ b/files/en-us/web/api/element/clientwidth/index.md
@@ -31,7 +31,7 @@ A number.
 
 ## Examples
 
-![](dimensions-client.png)
+![An example element with large padding, border and margin. clientWidth is the inner width of the element including its padding, and excluding its margin, border, and vertical scrollbar.](dimensions-client.png)
 
 ## Specifications
 


### PR DESCRIPTION
Add alt texts to webextension-anatomy.png, userscriptexample.png, user_script_in_action.png, devtools-content-scripts.png, channel-messaging-demo.png, dimensions-client.png

Relates to mdn/content#21616
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
