### PR TITLE
Grammar error in HTML img reference 

### DIFF
--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -254,7 +254,7 @@ The following example embeds an image into the page and includes alternative tex
 
 ### Image link
 
-This example builds upon the previous one, showing how to turn the image into a link. To do so, nest the `<img>` tag inside the {{HTMLElement("a")}}. You should made the alternative text describe the resource the link is pointing to, as if you were using a text link instead.
+This example builds upon the previous one, showing how to turn the image into a link. To do so, nest the `<img>` tag inside the {{HTMLElement("a")}}. You should make the alternative text describe the resource the link is pointing to, as if you were using a text link instead.
 
 ```html
 <a href="https://developer.mozilla.org">


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fix a grammar typo in HTML *img* tag reference.
Modify this line ==> *You should made the alternative text describe the resource the link is pointing to, as if you were using a text link instead.* 
into this ==> *You should* ***make*** *the alternative text describe the resource the link is pointing to, as if you were using a text link instead.*

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To help other users better understand it.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
