### PR TITLE
Correct WCAG 2.1 contrast value

### DIFF
--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -404,7 +404,7 @@ function sRGBtoLin(colorChannel) {
 }
 ```
 
-> **Note:** Those familiar with the WCAG 2.x contrast math may notice that the above code uses the threshold value of 0.04045. This is the official IEC standard. The WCAG 2.0 guidelines were drafted citing an obsolete value. In May 2021, this was corrected to 0.04045 in the WCAG 2.1 document. For the record, the WCAG 2.0 value is 0.03928.
+> **Note:** Those familiar with the WCAG 2.x contrast math may notice that the above code uses the threshold value of 0.04045. This is the official IEC standard. The WCAG 2.0 guidelines were drafted citing an obsolete value. In May 2021, this was corrected to 0.03928 in the WCAG 2.1 document. For the record, the WCAG 2.0 value is 0.03928.
 
 #### Step three: Spectrally Weighted Luminance
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In this PR I updated the WACG 2.1 value with the correct one as mentioned in the Web Content Accessibility Guidelines 2.1
[Reference](https://www.w3.org/TR/2018/REC-WCAG21-20180605/)
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Fixes #17864
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->