### PR TITLE
relnote(108) CSS trig functions enabled by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -640,48 +640,6 @@ The [`animation-composition`](/en-US/docs/Web/CSS/animation-composition) propert
   </tbody>
 </table>
 
-### Trigonometric functions
-
-CSS [trigonometric functions](/en-US/docs/Web/CSS/CSS_Functions#trigonometric_functions) allow for making calculations relating to geometry.
-The functions available are `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()`.
-See {{bug(1774589)}} for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>105</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>105</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>105</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>105</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.trig.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### @font-face src feature checking
 
 The `@font-face` [`src` descriptor](/en-US/docs/Web/CSS/@font-face/src) now supports the `tech()` function, allowing fallback of whether a font resource is downloaded based on whether the user-agent supports a particular font feature or technology.

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -22,6 +22,10 @@ This article provides information about the changes in Firefox 108 that will aff
 
 ### CSS
 
+- Trigonometric functions are enabled with the `layout.css.trig.enabled` preference set to `true` by default.
+  This allows the use of `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()` functions within the CSS [`calc()`](/en-US/docs/Web/CSS/calc) function.
+  Additionally, a CSS [`<calc-constant>`](/en-US/docs/Web/CSS/calc-constant) type is implemented to allow for well-known constants such as `pi` and `e` within the `calc()` function ({{bug(1774589)}}, {{bug(1682444)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
CSS trig support for functions (`cos()`, `tan()`, etc.) are enabled by default in Fx 108.

Additionally, constants (`e`, `pi` etc.) can be used inside CSS `calc()` function

### Related issues

- [ ] Parent issue: https://github.com/mdn/content/issues/22115