### PR TITLE
Improve PerformanceEntry pages, part 2

### DIFF
--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -12,91 +12,53 @@ browser-compat: api.PerformanceEntry.duration
 
 {{APIRef("Performance API")}}
 
-The **`duration`** property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the
-{{domxref("PerformanceEntry","performance entry")}}.
-
-{{AvailableInWorkers}}
-
-The value returned by this property depends on the performance entry's
-{{domxref("PerformanceEntry.entryType","type")}}:
-
-- `"event"` - returns a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
-- `"first-input"` - returns a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
-- "`frame`" - returns a {{domxref("DOMHighResTimeStamp","timestamp")}}
-  indicating the difference between the `startTime`s of two successive
-  frames.
-- "`mark`" - returns "`0`" (a mark has no duration).
-- "`measure`" - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
-  that is the duration of the measure.
-- "`navigation`" - returns the
-  {{domxref("DOMHighResTimeStamp","timestamp")}} that is the difference between the
-  {{domxref("PerformanceNavigationTiming.loadEventEnd")}} and
-  {{domxref("PerformanceEntry.startTime")}} properties, respectively.
-- "`resource`" - returns the difference between the resource's
-  {{domxref("PerformanceResourceTiming/responseEnd","responseEnd")}}
-  {{domxref("DOMHighResTimeStamp","timestamp")}} and its
-  {{domxref("PerformanceEntry.startTime","startTime")}}
-  {{domxref("DOMHighResTimeStamp","timestamp")}}.
-
-This property is {{ReadOnlyInline}}.
+The read-only **`duration`** property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the {{domxref("PerformanceEntry","performance entry")}}. The semantics of this property depend on the subclass.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} representing the duration of the
-{{domxref("PerformanceEntry","performance entry")}}. If the duration concept doesn't
-apply for a particular performance metric, the browser may choose to return a duration
-of 0.
+A {{domxref("DOMHighResTimeStamp")}} representing the duration of the {{domxref("PerformanceEntry","performance entry")}}. If the duration concept doesn't apply for a particular performance metric, a duration of `0` is returned.
 
-Note: if the performance entry has an
-{{domxref("PerformanceEntry.entryType","entryType")}} of "`resource`" (i.e.
-the entry is a {{domxref("PerformanceResourceTiming")}} object), this property returns
-the difference between the {{domxref("PerformanceResourceTiming.responseEnd")}} and
-{{domxref("PerformanceEntry.startTime")}}
-{{domxref("DOMHighResTimeStamp","timestamps")}}.
+The value returned by this property depends on the performance entry's {{domxref("PerformanceEntry.entryType","type")}}:
+
+- `element`
+  - : The `duration` is always `0`.
+- `event`
+  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
+- `first-input`
+  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
+- `largest-contentful-paint`
+  - : The `duration` is always `0`.
+- `longtask`
+  - : The `duration` is the {{domxref("DOMHighResTimeStamp","timestamp")}} that is the elapsed time between the start and end of task, with a 1ms granularity.
+- `mark`
+  - : The `duration` is always `0`.
+- `measure`
+  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the measure.
+- `navigation`
+  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the difference between the {{domxref("PerformanceNavigationTiming.loadEventEnd")}} and {{domxref("PerformanceEntry.startTime")}} properties, respectively.
+- `paint`
+  - : The `duration` is always `0`.
+- `resource`
+  - : The `duration` is the difference between the resource's {{domxref("PerformanceResourceTiming/responseEnd", "responseEnd")}} {{domxref("DOMHighResTimeStamp","timestamp")}} and its {{domxref("PerformanceEntry.startTime","startTime")}} {{domxref("DOMHighResTimeStamp","timestamp")}}.
+- `taskattribution`
+  - : The `duration` is always `0`.
 
 ## Examples
 
-The following example shows the use of the `duration` property.
+### Using the duration property
+
+The following example logs all observed performance entries with a `duration` larger than `0`.
 
 ```js
-function runPerformanceEntry() {
-  console.log("PerformanceEntry support…");
-
-  if (performance.mark === undefined) {
-    console.log("The property performance.mark is not supported");
-    return;
-  }
-
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  do_work(50000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
-  });
-
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) =>  {
+    if (entry.duration > 0) {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
+    };
   });
 }
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark", "resource"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -20,28 +20,26 @@ A {{domxref("DOMHighResTimeStamp")}} representing the duration of the {{domxref(
 
 The meaning of this property depends on the value of this performance entry's {{domxref("PerformanceEntry.entryType","entryType")}}:
 
-- `element`
-  - : The `duration` is always `0`.
 - `event`
-  - : Indicates the time from the event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
+  - : The time from the event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
 - `first-input`
-  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
-- `largest-contentful-paint`
-  - : The `duration` is always `0`.
+  - : The time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
 - `longtask`
-  - : The `duration` is the {{domxref("DOMHighResTimeStamp","timestamp")}} that is the elapsed time between the start and end of task, with a 1ms granularity.
-- `mark`
-  - : The `duration` is always `0`.
+  - : The elapsed time between the start and end of task, with a 1ms granularity.
 - `measure`
-  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the measure.
+  - : The duration of the measure.
 - `navigation`
   - : The difference between the entry's {{domxref("PerformanceNavigationTiming.loadEventEnd", "loadEventEnd")}} and {{domxref("PerformanceEntry.startTime", "startTime")}} properties.
-- `paint`
-  - : The `duration` is always `0`.
 - `resource`
   - : The entry's {{domxref("PerformanceResourceTiming/responseEnd", "responseEnd")}} value minus the entry's {{domxref("PerformanceEntry.startTime","startTime")}} value.
+
+For the following entry types, `duration` is not applicable, and in this case the value is always `0`:
+
+- `element`
+- `largest-contentful-paint`
+- `mark`
+- `paint`
 - `taskattribution`
-  - : The `duration` is always `0`.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -12,18 +12,18 @@ browser-compat: api.PerformanceEntry.duration
 
 {{APIRef("Performance API")}}
 
-The read-only **`duration`** property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the {{domxref("PerformanceEntry","performance entry")}}. The semantics of this property depend on the subclass.
+The read-only **`duration`** property returns a {{domxref("DOMHighResTimeStamp","timestamp", "", "no-code")}} that is the duration of the {{domxref("PerformanceEntry","performance entry", "", "no-code")}}. The meaning of this property depends on the value of this entry's {{domxref("PerformanceEntry.entryType", "entryType")}}.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} representing the duration of the {{domxref("PerformanceEntry","performance entry")}}. If the duration concept doesn't apply for a particular performance metric, a duration of `0` is returned.
+A {{domxref("DOMHighResTimeStamp")}} representing the duration of the {{domxref("PerformanceEntry","performance entry", "", "no-code")}}. If the duration concept doesn't apply for a particular performance metric, a duration of `0` is returned.
 
-The value returned by this property depends on the performance entry's {{domxref("PerformanceEntry.entryType","type")}}:
+The meaning of this property depends on the value of this performance entry's {{domxref("PerformanceEntry.entryType","entryType")}}:
 
 - `element`
   - : The `duration` is always `0`.
 - `event`
-  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
+  - : Indicates the time from the event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
 - `first-input`
   - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} indicating the time from the first input event's `startTime` to the next rendering paint (rounded to the nearest 8ms).
 - `largest-contentful-paint`
@@ -35,11 +35,11 @@ The value returned by this property depends on the performance entry's {{domxref
 - `measure`
   - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the duration of the measure.
 - `navigation`
-  - : The `duration` is a {{domxref("DOMHighResTimeStamp","timestamp")}} that is the difference between the {{domxref("PerformanceNavigationTiming.loadEventEnd")}} and {{domxref("PerformanceEntry.startTime")}} properties, respectively.
+  - : The difference between the entry's {{domxref("PerformanceNavigationTiming.loadEventEnd", "loadEventEnd")}} and {{domxref("PerformanceEntry.startTime", "startTime")}} properties.
 - `paint`
   - : The `duration` is always `0`.
 - `resource`
-  - : The `duration` is the difference between the resource's {{domxref("PerformanceResourceTiming/responseEnd", "responseEnd")}} {{domxref("DOMHighResTimeStamp","timestamp")}} and its {{domxref("PerformanceEntry.startTime","startTime")}} {{domxref("DOMHighResTimeStamp","timestamp")}}.
+  - : The entry's {{domxref("PerformanceResourceTiming/responseEnd", "responseEnd")}} value minus the entry's {{domxref("PerformanceEntry.startTime","startTime")}} value.
 - `taskattribution`
   - : The `duration` is always `0`.
 

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -12,86 +12,66 @@ browser-compat: api.PerformanceEntry.startTime
 
 {{APIRef("Performance API")}}
 
-The **`startTime`** property returns the first recorded
-{{domxref("DOMHighResTimeStamp","timestamp")}} of the
-{{domxref("PerformanceEntry","performance entry")}}.
-
-{{AvailableInWorkers}}
-
-The value returned by this property depends on the performance entry's
-{{domxref("PerformanceEntry.entryType","type")}}:
-
-- `"event"` - returns a {{domxref("DOMHighResTimeStamp")}} representing the associated event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property. This is the time the event was created.
-- `"first-input"` - returns a {{domxref("DOMHighResTimeStamp")}} representing the associated event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property. This is the time the first input event was created.
-- `"frame"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
-  when the frame was started.
-- `"mark"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
-  when the mark was created by a call to
-  {{domxref("Performance.mark","performance.mark()")}}.
-- `"measure"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
-  when the measure was created by a call to
-  {{domxref("Performance.measure","performance.measure()")}}.
-- `"navigation"` - returns the
-  {{domxref("DOMHighResTimeStamp","timestamp")}} with a value of "`0`".
-- `"resource"` - returns the {{domxref("DOMHighResTimeStamp","timestamp")}}
-  immediately before the browser {{domxref("PerformanceResourceTiming/fetchStart","starts
-    fetching the resource")}}.
-
-This property is {{ReadOnlyInline}}.
+The read-only **`startTime`** property returns the first recorded {{domxref("DOMHighResTimeStamp","timestamp")}} of the {{domxref("PerformanceEntry","performance entry")}}. The semantics of this property depend on the subclass.
 
 ## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the first timestamp when the
 {{domxref("PerformanceEntry","performance entry")}} was created.
 
-Note: if the performance entry has an
-{{domxref("PerformanceEntry.entryType","entryType")}} of "`resource`" (i.e.
-the entry is a {{domxref("PerformanceResourceTiming")}} object), this property returns
-the {{domxref("PerformanceResourceTiming.fetchStart")}}
-{{domxref("DOMHighResTimeStamp","timestamp")}}.
+The value returned by this property depends on the performance entry's {{domxref("PerformanceEntry.entryType","type")}}:
+
+- `element`
+  - : The `startTime` is either the value of {{domxref("PerformanceElementTiming.renderTime")}} if it is not `0`, otherwise it is the value of {{domxref("PerformanceElementTiming.loadTime")}}.
+- `event`
+  - : The `startTime` is the time the event was created, i.e. the event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property.
+- `first-input`
+  - : The `startTime` is the time the first input event was created, i.e. that event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp).
+- `largest-contentful-paint`
+  - : The `startTime` is either the value of {{domxref("LargestContentfulPaint.renderTime")}} if it is not `0`, otherwise it is the value of {{domxref("LargestContentfulPaint.loadTime")}}.
+- `longtask`
+  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the task started.
+- `mark`
+  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the mark was created by a call to {{domxref("Performance.mark","performance.mark()")}}.
+- `measure`
+  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the measure was created by a call to {{domxref("Performance.measure","performance.measure()")}}.
+- `navigation`
+  - : The `startTime` is always `0`.
+- `paint`
+  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the paint occurred.
+- `resource`
+  - : The `startTime` is the {{domxref("PerformanceResourceTiming.fetchStart")}} {{domxref("DOMHighResTimeStamp","timestamp")}}.
+- `taskattribution`
+  - : The `startTime` is always `0`.
 
 ## Examples
 
-The following example shows the use of the `startTime` property.
+### Using the startTime property
+
+The following example shows the use of the `startTime` property which you can log during performance observation.
+
+Note: The {{domxref("performance.mark()")}} method allows you to set your own `startTime`, as well as {{domxref("performance.measure()")}} which allows to set the `start` of the measure.
 
 ```js
-function runPerformanceEntry() {
-  console.log("PerformanceEntry support…");
+performance.mark("my-mark");
+performance.mark("my-other-mark", { startTime: 12.5 });
 
-  if (performance.mark === undefined) {
-    console.log("The property performance.mark is not supported");
-    return;
-  }
+loginButton.addEventListener('click', (clickEvent) => {
+  performance.measure("login-click", { start: clickEvent.timeStamp });
+});
 
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  do_work(50000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
-  });
-
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) =>  {
+    if (entry.entryType === "mark") {
+      console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+    };
+    if (entry.entryType === "measure") {
+      console.log(`${entry.name}'s duration: ${entry.duration}`);
+    };
   });
 }
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ entryTypes: ["measure", "mark"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -12,37 +12,37 @@ browser-compat: api.PerformanceEntry.startTime
 
 {{APIRef("Performance API")}}
 
-The read-only **`startTime`** property returns the first recorded {{domxref("DOMHighResTimeStamp","timestamp")}} of the {{domxref("PerformanceEntry","performance entry")}}. The semantics of this property depend on the subclass.
+The read-only **`startTime`** property returns the first {{domxref("DOMHighResTimeStamp","timestamp", "", "no-code")}} recorded for this {{domxref("PerformanceEntry","performance entry", "", "no-code")}}. The meaning of this property depends on the value of this entry's {{domxref("PerformanceEntry.entryType", "entryType")}}.
 
 ## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the first timestamp when the
 {{domxref("PerformanceEntry","performance entry")}} was created.
 
-The value returned by this property depends on the performance entry's {{domxref("PerformanceEntry.entryType","type")}}:
+The meaning of this property depends on the value of this performance entry's {{domxref("PerformanceEntry.entryType","entryType")}}:
 
 - `element`
-  - : The `startTime` is either the value of {{domxref("PerformanceElementTiming.renderTime")}} if it is not `0`, otherwise it is the value of {{domxref("PerformanceElementTiming.loadTime")}}.
+  - : Either the value of this entry's {{domxref("PerformanceElementTiming.renderTime", "renderTime")}} if it is not `0`, otherwise the value of this entry's {{domxref("PerformanceElementTiming.loadTime", "loadTime")}}.
 - `event`
-  - : The `startTime` is the time the event was created, i.e. the event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp) property.
+  - : The time the event was created, i.e. the event's [`timeStamp`](/en-US/docs/Web/API/Event/timeStamp) property.
 - `first-input`
-  - : The `startTime` is the time the first input event was created, i.e. that event's [`timestamp`](/en-US/docs/Web/API/Event/timestamp).
+  - : The time the first input event was created, i.e. that event's [`timeStamp`](/en-US/docs/Web/API/Event/timeStamp).
 - `largest-contentful-paint`
-  - : The `startTime` is either the value of {{domxref("LargestContentfulPaint.renderTime")}} if it is not `0`, otherwise it is the value of {{domxref("LargestContentfulPaint.loadTime")}}.
+  - : The value of this entry's {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} if it is not `0`, otherwise the value of this entry's {{domxref("LargestContentfulPaint.loadTime", "loadTime")}}.
 - `longtask`
-  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the task started.
+  - : The time when the task started.
 - `mark`
-  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the mark was created by a call to {{domxref("Performance.mark","performance.mark()")}}.
+  - : The time at which the mark was created by a call to {{domxref("Performance.mark","performance.mark()")}}.
 - `measure`
-  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the measure was created by a call to {{domxref("Performance.measure","performance.measure()")}}.
+  - : The time at which the measure was created by a call to {{domxref("Performance.measure","performance.measure()")}}.
 - `navigation`
-  - : The `startTime` is always `0`.
+  - : Always `0`.
 - `paint`
-  - : The `startTime` is the {{domxref("DOMHighResTimeStamp","timestamp")}} when the paint occurred.
+  - : The time when the paint occurred.
 - `resource`
-  - : The `startTime` is the {{domxref("PerformanceResourceTiming.fetchStart")}} {{domxref("DOMHighResTimeStamp","timestamp")}}.
+  - : The value of this entry's {{domxref("PerformanceResourceTiming.fetchStart", "fetchStart")}} property.
 - `taskattribution`
-  - : The `startTime` is always `0`.
+  - : Always `0`.
 
 ## Examples
 
@@ -50,7 +50,7 @@ The value returned by this property depends on the performance entry's {{domxref
 
 The following example shows the use of the `startTime` property which you can log during performance observation.
 
-Note: The {{domxref("performance.mark()")}} method allows you to set your own `startTime`, as well as {{domxref("performance.measure()")}} which allows to set the `start` of the measure.
+Note: The {{domxref("performance.mark()")}} method allows you to set your own `startTime`, and the {{domxref("performance.measure()")}} method allows to set the start of the measure.
 
 ```js
 performance.mark("my-mark");

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -12,10 +12,7 @@ browser-compat: api.PerformanceEntry.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a _serializer_; it returns
-a JSON representation of the {{domxref("PerformanceEntry","performance entry")}} object.
-
-{{AvailableInWorkers}}
+The **`toJSON()`** method is a _serializer_; it returns a JSON representation of the {{domxref("PerformanceEntry","performance entry")}} object.
 
 ## Syntax
 
@@ -33,45 +30,32 @@ A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} o
 
 ## Examples
 
+### Using the toJSON method
+
 The following example shows the use of the `toJSON()` method.
 
 ```js
-function runPerformanceEntry() {
-  console.log("PerformanceEntry support…");
-
-  if (performance.mark === undefined) {
-    console.log("The property performance.mark is not supported");
-    return;
-  }
-
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  doWork(50000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
   });
+});
 
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
-  });
+// Register the observer for events
+observer.observe({type: "event", buffered: true});
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "dragover",
+  "entryType": "event",
+  "startTime": 67090751.599999905,
+  "duration": 128,
+  "processingStart": 67090751.70000005,
+  "processingEnd": 67090751.900000095,
+  "cancelable": true
 }
 ```
 
@@ -82,3 +66,7 @@ function checkPerformanceEntry(obj) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceEntry.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a _serializer_; it returns a JSON representation of the {{domxref("PerformanceEntry","performance entry")}} object.
+The **`toJSON()`** method is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceEntry","performance entry", "", "no-code")}} object.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR improves the other 3 PerformanceEntry reference pages.
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/duration
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/startTime
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/toJSON

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I think definition lists work here? To compare, the `name` page uses a table. https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/name

### Related issues and pull requests

Part 1 was done in https://github.com/mdn/content/pull/22064
