### PR TITLE
Use CSSSyntax for at-rules and at-rule descriptors

### DIFF
--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -61,6 +61,8 @@ The `src` descriptor specifies the URL to retrieve the color-profile information
 
 ## Formal syntax
 
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/@counter-style/additive-symbols/index.md
+++ b/files/en-us/web/css/@counter-style/additive-symbols/index.md
@@ -32,11 +32,7 @@ When the `system` descriptor is `cyclic`, `numeric`, `alphabetic`, `symbolic`, o
 
 ## Formal syntax
 
-```
-[ <integer [0,∞]> && <symbol> ]#
-
-<symbol> = <string> | <image> | <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/fallback/index.md
+++ b/files/en-us/web/css/@counter-style/fallback/index.md
@@ -39,11 +39,7 @@ A couple of scenarios where a fallback style will be used are:
 
 ## Formal syntax
 
-```
-<counter-style-name>
-
-<counter-style-name> = <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/index.md
+++ b/files/en-us/web/css/@counter-style/index.md
@@ -70,9 +70,7 @@ Each `@counter-style` is identified by a name and has a set of descriptors.
 
 ## Formal syntax
 
-```
-@counter-style <counter-style-name> { <declaration-list> }
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/negative/index.md
+++ b/files/en-us/web/css/@counter-style/negative/index.md
@@ -40,14 +40,7 @@ If the counter value is negative, the symbol provided as value for the descripto
 
 ## Formal syntax
 
-```
-<symbol> <symbol>?
-
-<symbol> =
-  <string>       |
-  <image>        |
-  <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/pad/index.md
+++ b/files/en-us/web/css/@counter-style/pad/index.md
@@ -37,14 +37,7 @@ If a marker representation is smaller than the specified pad length, then the ma
 
 ## Formal syntax
 
-```
-<integer> && <symbol>
-
-<symbol> =
-  <string>       |
-  <image>        |
-  <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/prefix/index.md
+++ b/files/en-us/web/css/@counter-style/prefix/index.md
@@ -36,14 +36,7 @@ prefix: url(bullet.png);
 
 ## Formal syntax
 
-```
-<symbol>
-
-<symbol> =
-  <string>       |
-  <image>        |
-  <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/range/index.md
+++ b/files/en-us/web/css/@counter-style/range/index.md
@@ -62,10 +62,7 @@ When range is specified as integers, the value `infinite` can be used to denote 
 
 ## Formal syntax
 
-```
-[ [ <integer> | infinite ]{2} ]# |
-auto
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -63,16 +63,7 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ## Formal syntax
 
-```
-auto                 |
-bullets              |
-numbers              |
-words                |
-spell-out            |
-<counter-style-name>
-
-<counter-style-name> = <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/suffix/index.md
+++ b/files/en-us/web/css/@counter-style/suffix/index.md
@@ -36,14 +36,7 @@ suffix: url(bullet.png);
 
 ## Formal syntax
 
-```
-<symbol>
-
-<symbol> =
-  <string>       |
-  <image>        |
-  <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/symbols/index.md
+++ b/files/en-us/web/css/@counter-style/symbols/index.md
@@ -3,7 +3,7 @@ title: symbols
 slug: Web/CSS/@counter-style/symbols
 page-type: css-at-rule-descriptor
 tags:
-  - '@counter-style'
+  - "@counter-style"
   - At-rule descriptor
   - CSS
   - CSS Counter Styles
@@ -36,9 +36,9 @@ A symbol can be a string, image, or identifier. It is used within the {{cssxref(
 
 ```css
 symbols: A B C D E;
-symbols: "\24B6" "\24B7" "\24B8" D E;
+symbols: "\24B6""\24B7""\24B8"D E;
 symbols: "0" "1" "2" "4" "5" "6" "7" "8" "9";
-symbols: url('first.svg') url('second.svg') url('third.svg');
+symbols: url("first.svg") url("second.svg") url("third.svg");
 symbols: indic-numbers;
 ```
 
@@ -50,14 +50,7 @@ The `symbols` descriptor must be specified when the value of the {{cssxref('@cou
 
 ## Formal syntax
 
-```
-<symbol>+
-
-<symbol> =
-  <string>       |
-  <image>        |
-  <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 
@@ -80,7 +73,7 @@ The `symbols` descriptor must be specified when the value of the {{cssxref('@cou
 ```css
 @counter-style symbols-example {
   system: fixed;
-  symbols: A "1" "\24B7" D E;
+  symbols: A "1" "\24B7"D E;
 }
 
 .list {

--- a/files/en-us/web/css/@counter-style/system/index.md
+++ b/files/en-us/web/css/@counter-style/system/index.md
@@ -78,17 +78,7 @@ This may take one of three forms:
 
 ## Formal syntax
 
-```
-cyclic                             |
-numeric                            |
-alphabetic                         |
-symbolic                           |
-additive                           |
-[ fixed <integer>? ]               |
-[ extends <counter-style-name> ]
-
-<counter-style-name> = <custom-ident>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/ascent-override/index.md
+++ b/files/en-us/web/css/@font-face/ascent-override/index.md
@@ -36,9 +36,7 @@ ascent-override: 90%;
 
 ## Formal syntax
 
-```
-normal | <percentage>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/descent-override/index.md
+++ b/files/en-us/web/css/@font-face/descent-override/index.md
@@ -36,9 +36,7 @@ descent-override: 90%;
 
 ## Formal syntax
 
-```
-normal | <percentage>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-display/index.md
+++ b/files/en-us/web/css/@font-face/font-display/index.md
@@ -67,9 +67,7 @@ The font display timeline is based on a timer that begins the moment the user ag
 
 ## Formal syntax
 
-```
-[ auto | block | swap | fallback | optional ]
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-family/index.md
+++ b/files/en-us/web/css/@font-face/font-family/index.md
@@ -41,13 +41,7 @@ font-family: examplefont;
 
 ## Formal syntax
 
-```
-<family-name>
-
-<family-name> =
-  <string>        |
-  <custom-ident>+
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-stretch/index.md
+++ b/files/en-us/web/css/@font-face/font-stretch/index.md
@@ -127,21 +127,7 @@ People with dyslexia and other cognitive conditions may have difficulty reading 
 
 ## Formal syntax
 
-```
-<font-stretch-absolute>{1,2}
-
-<font-stretch-absolute> =
-  normal          |
-  ultra-condensed |
-  extra-condensed |
-  condensed       |
-  semi-condensed  |
-  semi-expanded   |
-  expanded        |
-  extra-expanded  |
-  ultra-expanded  |
-  <percentage>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-style/index.md
+++ b/files/en-us/web/css/@font-face/font-style/index.md
@@ -47,11 +47,7 @@ font-style: oblique 30deg 50deg;
 
 ## Formal syntax
 
-```
-normal               |
-italic               |
-oblique <angle>{0,2}
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-variation-settings/index.md
+++ b/files/en-us/web/css/@font-face/font-variation-settings/index.md
@@ -39,10 +39,7 @@ font-variation-settings: "xhgt" 0.7;
 
 ## Formal syntax
 
-```
-normal                 |
-[ <string> <number> ]#
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -83,11 +83,7 @@ People experiencing low vision conditions may have difficulty reading text set w
 
 ## Formal syntax
 
-```
-<font-weight-absolute>{1,2}
-
-<font-weight-absolute> = normal | bold | <number [1,1000]>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -24,9 +24,8 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
 @font-face {
   font-family: "Trickster";
   src: local("Trickster"),
-       url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1),
-       url("trickster-outline.otf") format("opentype"),
-       url("trickster-outline.woff") format("woff");
+    url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf")
+      format("opentype"), url("trickster-outline.woff") format("woff");
 }
 ```
 
@@ -45,6 +44,7 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
 - {{cssxref("@font-face/font-style", "font-style")}}
   - : A {{cssxref("font-style")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-style: oblique 20deg 50deg;`
 - {{cssxref("@font-face/font-weight", "font-weight")}}
+
   - : A {{cssxref("font-weight")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-weight: 100 400;`
 
     > **Note:** The font-variant descriptor was removed from the specification in 2018. The {{cssxref("font-variant")}} value property is supported, but there is no descriptor equivalent.
@@ -58,20 +58,20 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
 - {{cssxref("@font-face/size-adjust", "size-adjust")}}
   - : Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.
 - {{cssxref("@font-face/src", "src")}}
+
   - : Specifies font resources. A comma-separated list representing the resource fallback order, each resource specified by a `url()` or `local()`. If the previous resource is loaded successfully, the latter resources will not be used. The `url()` can be followed by `format()` and `tech()`, like this:
 
     ```css
     src: local("Trickster"),
-         url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1),
-         url("trickster-outline.otf") format("opentype"),
-         url("trickster-outline.woff") format("woff");
+      url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf")
+        format("opentype"), url("trickster-outline.woff") format("woff");
     ```
 
     `url()`: Specifies the URL of a font file, like any other `url()` in CSS. If the font file is a container for multiple fonts, a fragment identifier is included to indicate which sub-font should be used, as follows:
 
     ```css
     src: url(collection.otc#WhichFont); /* WhichFont is the PostScript name of a font in the font file */
-    src: url(fonts.svg#WhichFont);      /* WhichFont is the element id of a font in the SVG Font file */
+    src: url(fonts.svg#WhichFont); /* WhichFont is the element id of a font in the SVG Font file */
     ```
 
     `local()`: Specifies the font name should the font be available on the user's device. Quoting the font name is optional.
@@ -147,11 +147,7 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 
 ## Formal syntax
 
-```
-@font-face {
-  <declaration-list>
-}
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/line-gap-override/index.md
+++ b/files/en-us/web/css/@font-face/line-gap-override/index.md
@@ -36,9 +36,7 @@ line-gap-override: 90%;
 
 ## Formal syntax
 
-```
-normal | <percentage>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/size-adjust/index.md
+++ b/files/en-us/web/css/@font-face/size-adjust/index.md
@@ -37,9 +37,7 @@ All metrics associated with this font are scaled by the given percentage. This i
 
 ## Formal syntax
 
-```
-<percentage [0,∞]>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/unicode-range/index.md
+++ b/files/en-us/web/css/@font-face/unicode-range/index.md
@@ -47,9 +47,7 @@ The purpose of this descriptor is to allow the font resources to be segmented so
 
 ## Formal syntax
 
-```
-<unicode-range>#
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-feature-values/index.md
+++ b/files/en-us/web/css/@font-feature-values/index.md
@@ -35,9 +35,7 @@ The `@font-feature-values` at-rule may be used either at the top level of your C
 
 ## Formal syntax
 
-```
-@font-feature-values <family-name># { <declaration-list> }
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -20,12 +20,12 @@ The **`@import`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-ru
 ```css
 @import url;
 @import url list-of-media-queries;
-@import url supports( supports-query );
-@import url supports( supports-query ) list-of-media-queries;
+@import url supports(supports-query);
+@import url supports(supports-query) list-of-media-queries;
 @import url layer;
-@import url layer( layer-name );
-@import url layer( layer-name ) list-of-media-queries;
-@import url layer( layer-name ) supports( supports-query ) list-of-media-queries;
+@import url layer(layer-name);
+@import url layer(layer-name) list-of-media-queries;
+@import url layer(layer-name) supports(supports-query) list-of-media-queries;
 ```
 
 where:
@@ -49,11 +49,7 @@ The `@import` rule can also be used to create a [cascade layer](/en-US/docs/Web/
 
 ## Formal syntax
 
-```
-@import [ <url> | <string> ]
-        [ supports( [ <supports-condition> | <declaration> ] ) ]?
-        <media-query-list>? ;
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -142,9 +142,7 @@ Declarations in a keyframe qualified with `!important` are ignored.
 
 ## Formal syntax
 
-```
-@keyframes <keyframes-name> { <rule-list> }
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -111,11 +111,7 @@ To append rules to the `layout` layer inside `framework`, join the two names wit
 
 ## Formal syntax
 
-```
-@layer [ <layer-name># | <layer-name>?  {
-  <stylesheet>
-} ]
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -181,11 +181,7 @@ Because of this potential, a browser may opt to fudge the returned values in som
 
 ## Formal syntax
 
-```
-@media <media-query-list> {
-  <stylesheet>
-}
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@namespace/index.md
+++ b/files/en-us/web/css/@namespace/index.md
@@ -46,9 +46,7 @@ In [HTML5](/en-US/docs/Glossary/HTML5), known [foreign elements](https://html.sp
 
 ## Formal syntax
 
-```
-@namespace <namespace-prefix>? [ <string> | <url> ] ;
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -54,11 +54,7 @@ The `@page` at-rule can be accessed via the CSS object model interface {{domxref
 
 ## Formal syntax
 
-```
-@page <pseudo-selector> {
-  <page-body>
-}
-```
+{{csssyntax}}
 
 Where the `<page-body>` includes:
 

--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -85,24 +85,7 @@ size: A4 portrait;
 
 ## Formal syntax
 
-```
-<length>{1,2}                               |
-auto                                        |
-[ <page-size> || [ portrait | landscape ] ]
-
-where
-<page-size> =
-  A5     |
-  A4     |
-  A3     |
-  B5     |
-  B4     |
-  JIS-B5 |
-  JIS-B4 |
-  letter |
-  legal  |
-  ledger
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -71,11 +71,7 @@ window.CSS.registerProperty({
 
 ## Formal syntax
 
-```
-@property <custom-property-name> {
-  <declaration-list>
-}
-```
+{{csssyntax}}
 
 ## Specifications
 

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -45,9 +45,7 @@ The **`inherits`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using 
 
 ## Formal syntax
 
-```
-true | false
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -44,9 +44,7 @@ A string with a value which is a correct value for the chosen `syntax`.
 
 ## Formal syntax
 
-```
-<string>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -69,9 +69,7 @@ A string with a supported syntax as defined by the specification. Supported synt
 
 ## Formal syntax
 
-```
-<string>
-```
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -182,11 +182,7 @@ Multiple disjunctions can be juxtaposed without the need of more parentheses. Th
 
 ## Formal syntax
 
-```
-@supports <supports-condition> {
-  <stylesheet>
-}
-```
+{{csssyntax}}
 
 ## Examples
 


### PR DESCRIPTION
When we replaced mdn/data with webref for the formal syntax, we had to remove `{{csssyntax}}` calls for at-rules and at-rule descriptors, because webref didn't make it easy to get values for them.

[Now it does!](https://github.com/mdn/yari/pull/4656#issuecomment-1217979274) So I filed https://github.com/mdn/yari/pull/7322 to make `{{csssyntax}}` understand how to get values for these things. That PR got merged yesterday, so here's the content part.

There are two exceptional cases:

- https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src, where the spec lists the value as "See prose" (https://w3c.github.io/csswg-drafts/css-fonts/#src-desc)
- https://developer.mozilla.org/en-US/docs/Web/CSS/@charset, which does not get an entry in webref

For the time being I'm just hardcoding these values and not using `{{csssyntax}}`, but it might be possible to fix one or both of them upstream.


