### PR TITLE
docs: improve frame-ancestors syntax description

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -51,7 +51,7 @@ One or more sources can be set for the `frame-ancestors` policy:
 
 ```http
 Content-Security-Policy: frame-ancestors <source>;
-Content-Security-Policy: frame-ancestors <source> <source>;
+Content-Security-Policy: frame-ancestors <space separated list of sources>;
 ```
 
 ### Sources
@@ -91,6 +91,8 @@ Content-Security-Policy: frame-ancestors <source> <source>;
 Content-Security-Policy: frame-ancestors 'none';
 
 Content-Security-Policy: frame-ancestors 'self' https://www.example.org;
+
+Content-Security-Policy: frame-ancestors 'self' https://example.org https://example.com https://store.example.com;
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Improve CSP's `frame-ancestors` syntax description

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current syntax description is misleading & doesn't quite correspond to the spec.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

[The spec](https://w3c.github.io/webappsec-csp/#directive-frame-ancestors) clearly defines a possibly infinite number of ancestor sources:

```abnf
directive-name  = "frame-ancestors"
directive-value = ancestor-source-list

ancestor-source-list = ( ancestor-source *( required-ascii-whitespace ancestor-source) ) / "'none'"
ancestor-source      = scheme-source / host-source / "'self'"
```

### Related issues and pull requests

Fixes #22135

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
