### PR TITLE
Drop Plugins section from “Adding captions and subtitles to HTML video”

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -323,3 +323,8 @@ Safari 6.1+ has similar support to Internet Explorer 10+, displaying a menu with
 ### Chrome and Opera
 
 These browsers have similar implementations again: subtitles are enabled by default and the default control set contains a 'cc' button that turns subtitles on and off. Chrome and Opera ignore the `default` attribute on the `<track>` element and will instead try to match the browser's language to the subtitle's language.
+
+## Plugins
+
+There are also many open-source and commercial HTML video player plugins that offer caption and subtitle support that you can use instead of rolling out your own.
+You can search for these on the Internet using terms like "HTML Video Player Plugin".

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -326,5 +326,5 @@ These browsers have similar implementations again: subtitles are enabled by defa
 
 ## Plugins
 
-There are also many open-source and commercial HTML video player plugins that offer caption and subtitle support that you can use instead of rolling out your own.
-You can search for these on the Internet using terms like "HTML Video Player Plugin".
+There are also many open-source and commercial HTML video-player plugins that offer caption and subtitle support that you can use instead of rolling your own.
+You can search for those on the web using search terms like _"HTML video player plugin"_.

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -323,30 +323,3 @@ Safari 6.1+ has similar support to Internet Explorer 10+, displaying a menu with
 ### Chrome and Opera
 
 These browsers have similar implementations again: subtitles are enabled by default and the default control set contains a 'cc' button that turns subtitles on and off. Chrome and Opera ignore the `default` attribute on the `<track>` element and will instead try to match the browser's language to the subtitle's language.
-
-## Plugins
-
-If, after reading through this article you decide that you can't be bothered to do all of this and want someone else to do it for you, there are plenty of plugins out there that offer caption and subtitle support that you can use.
-
-- [plyr.io](https://plyr.io)
-  - : This modern video player implements subtitles in both SRT and WebVTT file formats.
-- [Playr](https://www.delphiki.com/html5/playr/)
-  - : This small plugin implements subtitles, captions, and chapters as well as both WebVTT and SRT file formats.
-- [Flowplayer](https://flowplayer.com/features/html5-player)
-  - : HTML player supporting WebVTT.
-- [jwplayer](https://www.jwplayer.com/)
-  - : This video player is very extensive and does a lot more than support video captions. It supports the WebVTT, SRT and DFXP formats.
-- [MediaElement.js](https://www.mediaelementjs.com/)
-  - : Another complete video player that also support video captions, albeit only in SRT format.
-- [LeanBack Player](https://www.leanbackplayer.com/)
-  - : Yet another video player that supports WebVTT captions as well as providing other standard player functionality.
-- [SublimeVideo](https://www.sublimevideo.net/)
-  - : This player also supports captions through WebVTT and SRT files.
-- [Video.js](https://videojs.com/)
-  - : Supports WebVTT video subtitles.
-- [Radiant Media Player](https://www.radiantmediaplayer.com)
-  - : Supports multi-languages WebVTT closed captions
-- [AblePlayer](https://ableplayer.github.io/ableplayer/)
-  - : Supports multi-languages WebVTT closed captions along with a clickable, interactive transcript for audio and video
-
-> **Note:** You can find an excellent list of HTML Video Players and their current "state" at [HTML Video Player Comparison](https://videosws.praegnanz.de/).


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/22176. This is a good example of why it’s problematic to include listings of 3rd-party tools in MDN articles: Nobody ever actively maintains them — and in most cases, the 3rd-party-tools lists were created in the wiki days, without ever getting review scrutiny.

So we really have no reason to be confident to begin with that these lists actually contain quality tools, nor any reason to be confident that the lists are at all up to date.

In this case, as noted in https://github.com/mdn/content/issues/22176, the Plugins list in this article contains multiple tools whose sites are now 404.

And on top of that, the tools in this Plugins list aren’t even tools that developers can use for help in developing their own implementations; instead, the list has a very different purpose:

> If, after reading through this article you decide that you can't be bothered to do all of this and want someone else to do it for you, there are plenty of plugins out there that offer caption and subtitle support that you can use.

In general, providing lists of tools in MDN for cases where developers “can’t be bothered” to do development using the features that MDN is documenting and instead “want someone else to do it for you” seems pretty at odds altogether with what MDN is supposed to be for.