### PR TITLE
Add a note about unhandledrejection_event not firing from cross-origin scripts

### DIFF
--- a/files/en-us/web/api/window/unhandledrejection_event/index.md
+++ b/files/en-us/web/api/window/unhandledrejection_event/index.md
@@ -59,6 +59,8 @@ In addition to the `Window` interface, the event handler property `onunhandledre
 
 Allowing the `unhandledrejection` event to bubble will eventually result in an error message being output to the console. You can prevent this by calling {{domxref("Event.preventDefault", "preventDefault()")}} on the {{domxref("PromiseRejectionEvent")}}; see [Preventing default handling](#preventing_default_handling) below for an example.
 
+Because this event can leak data, {{jsxref("Promise")}} rejections that originate from a cross-origin script won't fire this event.
+
 ## Examples
 
 ### Basic error logging


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This event does not fire from cross-origin non-CORS scripts. This PR adds a note about that.

### Motivation
Some people at https://stackoverflow.com/a/74369913/3702797 got surprised by this behavior and its lack of documentation.

I'm not entirely sure this is the good place to add this note though, nor if the wording is perfect...

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Specs text is at https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation Tests are at https://wpt.fyi/results/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html?label=master&label=experimental&aligned&view=subtest&q=unhandled-promise-rejections

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
