### PR TITLE
Remove Firefox-specific and outdated content in requestStorageAccess

### DIFF
--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -51,7 +51,7 @@ document.requestStorageAccess().then(
 
 Access to cross-site cookies is granted to iframes based on a number of prerequisites:
 
-1. The browser must be processing a user gesture (see {{Glossary("Transient activation")}}).
+1. The browser must be processing a user gesture ({{Glossary("transient activation")}}).
 2. The document or the top-level document must not have a null origin.
 3. The document's window must be a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 4. If the document is sandboxed, it must have the `allow-storage-access-by-user-activation` token.

--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -51,7 +51,7 @@ document.requestStorageAccess().then(
 
 Access to cross-site cookies is granted to iframes based on a number of prerequisites:
 
-1. The browser must be processing a user gesture, reject (see {{Glossary("Transient activation")}}).
+1. The browser must be processing a user gesture (see {{Glossary("Transient activation")}}).
 2. The document or the top-level document must not have a null origin.
 3. The document's window must be a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 4. If the document is sandboxed, it must have the `allow-storage-access-by-user-activation` token.

--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -49,67 +49,13 @@ document.requestStorageAccess().then(
 
 ## Security
 
-Storage access is granted based on a series of checks described here:
+Access to cross-site cookies is granted to iframes based on a number of prerequisites:
 
-1. If the browser is not processing a user gesture, reject (see {{Glossary("Transient activation")}}).
-2. If the document already has been granted access, resolve.
-3. If the document has a null origin, reject.
-4. If the document's frame is the main frame, resolve.
-5. If the sub frame's origin is equal to the main frame's, resolve.
-6. If the sub frame is not sandboxed, skip to step 7.
-7. If the sub frame doesn't have the token `allow-storage-access-by-user-activation`, reject.
-8. If the sub frame's parent frame is not the top frame, reject.
-9. Check any additional rules that the browser has. Examples: allow lists, block lists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
-   Reject if some rule is not fulfilled.
-10. Grant the document access to cookies and other site storage and store that fact for the purposes of future calls to {{domxref("Document.hasStorageAccess()")}} and `requestStorageAccess()`.
-
-Assuming all of the requirements above are satisfied, Firefox will automatically grant storage access to the requesting origin on up to a threshold number of first-party sites in the current session for the duration of user's session, up to a maximum of 24 hours.
-After the requesting origin has exceeded the maximum allowable number of storage access grants, any future call to `requestStorageAccess()` during the same browsing session will prompt the user.
-
-The maximum number of concurrent storage access grants an origin can obtain is a positive integer currently defined as one percent of the number of top-level sites visited in the current session or 5, whichever is higher.
-The threshold is enforced on the level of site, so for example two storage access grants for `foo.example.com` and `bar.example.com` will only count as a single exception against the limit.
-
-At the time of a `requestStorageAccess()` call, if the requesting origin has
-storage access to fewer sites than the maximum and has been interacted with as a first party in the last 30 days:
-
-- The user is not prompted.
-- The origin is given an ephemeral storage access grant for the current top-level site.
-- The number of sites the requesting origin has storage access to is incremented by one.
-
-  - Note that this number is also incremented when automatic access grants are given through [Firefox compatibility heuristics](/en-US/docs/Web/Privacy/Storage_Access_Policy#automatic_storage_access_upon_interaction).
-
-- The ephemeral storage access grant is:
-
-  - Invalidated at the end of the browser session.
-  - Not persisted to disk (e.g. will not persist if the browser crashes).
-  - Reset after 24 hours in the case of a long-running browser session.
-
-When equal or more sites than the maximum or has not been interacted with as a first party in the last 30 days:
-
-- The user is prompted
-- If the user clicks "Allow" or "Allow on any site" the request is resolved.
-- If the user clicks "Don't Allow", the storage access request is rejected and the requesting origin can re-request once it receives another user interaction.
-- If the user allows storage the requesting origin is given a persistent storage access grant on the current top-level site.
-- The number of sites the requesting origin has storage access to is incremented by one.
-- The persistent storage access permission is:
-
-  - Persisted to disk and will remain valid in future browser sessions.
-  - Reset after 30 days.
-
-When an ephemeral or persistent storage access grant expires, the number of sites the requesting origin has storage access to is decremented by one.
-
-> **Note:** If the requesting origin is not [classified as a tracking origin](/en-US/docs/Web/Privacy/Storage_Access_Policy#tracking_protection_explained), the access request is automatically given an ephemeral storage access grant, which will go away when the page is reloaded.
-> The user is never shown a prompt in this case, and calling `requestStorageAccess()` won't have any side effects besides changing the value returned by {{domxref("Document.hasStorageAccess()")}}.
-
-## Debugging
-
-The storage access grant threshold may make it more difficult to test your website under the condition where Firefox prompts the user for access.
-To make testing easier, we have added two preferences in `about:config` that control prompting upon `requestStorageAccess()` calls:
-
-- `dom.storage_access.auto_grants` can be set to `false` to disable the automatic granting of ephemeral storage access grants.
-  All calls to `requestStorageAccess()` by origins classified as trackers will trigger a prompt.
-- `dom.storage_access.max_concurrent_auto_grants` controls the threshold number of storage access grants at which users will begin to receive prompts.
-  For example, if you want to configure Firefox to automatically grant access on the first site where `requestStorageAccess()` is called and then prompt afterwards, you should adjust the value of the `dom.storage_access.max_concurrent_auto_grants` preference to 1.
+1. The browser must be processing a user gesture, reject (see {{Glossary("Transient activation")}}).
+2. The document or the top-level document must not have a null origin.
+3. The document's window must be a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
+4. If the document is sandboxed, it must have the `allow-storage-access-by-user-activation` token.
+5. The document must pass additional browser-specific checks. Examples: allow lists, block lists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
 
 ## Specifications
 


### PR DESCRIPTION
This section verbosely quoted outdated spec instructions and had some very Firefox-specific tips that should belong somewhere else. I replaced it with more condensed guidance on what requirements are needed to get a storage access grant.

I think we can still improve on this documentation :)

cc @annevk @bvandersloot-mozilla @lghall