### PR TITLE
Add security and privacy concerns for `spellcheck` attribute

### DIFF
--- a/files/en-us/web/html/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.md
@@ -23,16 +23,16 @@ If this attribute is not set, its default value is element-type and browser-defi
 
 This attribute is merely a hint for the browser: browsers are not required to check for spelling errors. Typically non-editable elements are not checked for spelling errors, even if the `spellcheck` attribute is set to `true` and the browser supports spellchecking.
 
-## Specifications
-
-{{Specifications}}
-
 ## Security and privacy concerns
 
 Using spellchecking can can have consequences for users' security and privacy.
 The specification does not regulate _how_ spellchecking is done and the content of the element may be sent to a third party for spellchecking results (see [enhanced spellchecking and "spell-jacking"](https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords)).
 
 You should consider setting `spellcheck` to `false` for elements that can contain sensitive information.
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/html/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.md
@@ -27,6 +27,13 @@ This attribute is merely a hint for the browser: browsers are not required to ch
 
 {{Specifications}}
 
+## Security and privacy concerns
+
+Using spellchecking can can have consequences for users' security and privacy.
+The specification does not regulate _how_ spellchecking is done and the content of the element may be sent to a third party for spellchecking results (see [enhanced spellchecking and "spell-jacking"](https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords)).
+
+You should consider setting `spellcheck` to `false` for elements that can contain sensitive information.
+
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change adds a short section about privacy and security concerns to the `spellcheck` attribute page.

### Motivation

Recently the security firm "otto-js" released an article about "spell-jacking", which showcases how some enhanced spellchecking features in Chrome and Windows send the content of your text fields to Google and Microsoft, respectively (https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords). This raises some privacy concerns, especially for fields that contain sensitive information and/or PII.

### Additional details

This is my first contribution to this repository, so I took inspiration from similar sections of the `<a>` and `<img>` element pages.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
