### PR TITLE
Add the error event to the <video> element

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -183,7 +183,7 @@ Like all other HTML elements, this element supports the [global attributes](/en-
         {{domxref("HTMLMediaElement.error_event", 'error')}}
       </td>
       <td>
-        An error occurred while fetching the media data or the type of the 
+        An error occurred while fetching the media data, or the type of the 
         resource is not a supported media format.
       </td>
     </tr>

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -180,6 +180,15 @@ Like all other HTML elements, this element supports the [global attributes](/en-
     </tr>
     <tr>
       <td>
+        {{domxref("HTMLMediaElement.error_event", 'error')}}
+      </td>
+      <td>
+        An error occurs while fetching the media data or the type of the 
+        resource is not a supported media format.
+      </td>
+    </tr>
+    <tr>
+      <td>
         {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}}
       </td>
       <td>The first frame of the media has finished loading.</td>

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -183,7 +183,7 @@ Like all other HTML elements, this element supports the [global attributes](/en-
         {{domxref("HTMLMediaElement.error_event", 'error')}}
       </td>
       <td>
-        An error occurs while fetching the media data or the type of the 
+        An error occurred while fetching the media data or the type of the 
         resource is not a supported media format.
       </td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I added the error event which is triggered when a media type is not supported
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I found it in the html standard docs https://html.spec.whatwg.org/multipage/media.html#mediaevents and found it useful when I wanted to trigger an event in case of not supported media
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
