### PR TITLE
Performance API: toJSON methods

### DIFF
--- a/files/en-us/web/api/largestcontentfulpaint/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/index.md
@@ -42,7 +42,7 @@ _This interface also inherits properties from {{domxref("PerformanceEntry")}}._
 _This interface also inherits methods from {{domxref("PerformanceEntry")}}._
 
 - {{domxref("LargestContentfulPaint.toJSON()")}} {{Experimental_Inline}}
-  - : Returns the above properties as JSON.
+  - : Returns a JSON representation of the `LargestContentfulPaint` object.
 
 ## Examples
 

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -64,6 +64,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -14,7 +14,7 @@ browser-compat: api.LargestContentfulPaint.toJSON
 
 {{APIRef("Performance API")}}{{SeeCompatTable}}
 
-The **`toJSON()`** method of the {{domxref("LargestContentfulPaint")}} interface is a _serializer_, and returns a JSON representation of the `LargestContentfulPaint` object.
+The **`toJSON()`** method of the {{domxref("LargestContentfulPaint")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("LargestContentfulPaint")}} object.
 
 ## Syntax
 
@@ -28,26 +28,39 @@ None.
 
 ### Return value
 
-A JSON object that is the serialization of the {{domxref("LargestContentfulPaint")}} object.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("LargestContentfulPaint")}} object.
+
+The JSON doesn't contain the {{domxref("LargestContentfulPaint.element", "element")}} property, given it is of type {{domxref("Element")}} (which doesn't provide a `toJSON()` operation).
 
 ## Examples
 
-The following example gets the `LargestContentfulPaint` object and prints it as JSON to the console.
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `LargestContentfulPaint` object.
 
 ```js
-try {
-  let lcp;
-
-  const po = new PerformanceObserver((entryList) => {
-    const entries = entryList.getEntries();
-    const lastEntry = entries[entries.length - 1];
-    console.log(lastEntry.toJSON());
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
   });
+});
 
-  po.observe({type: 'largest-contentful-paint', buffered: true});
+observer.observe({type: 'largest-contentful-paint', buffered: true});
+```
 
-} catch (e) {
-  // Do nothing if the browser doesn't support this API.
+This would log a JSON object like so:
+
+```json
+{
+  "name": "",
+  "entryType": "largest-contentful-paint",
+  "startTime": 468.2,
+  "duration": 0,
+  "size": 19824,
+  "renderTime": 468.2,
+  "loadTime": 0,
+  "id": "",
+  "url": ""
 }
 ```
 
@@ -58,3 +71,7 @@ try {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -30,7 +30,7 @@ None.
 
 A {{jsxref("JSON")}} object that is the serialization of the {{domxref("LargestContentfulPaint")}} object.
 
-The JSON doesn't contain the {{domxref("LargestContentfulPaint.element", "element")}} property, given it is of type {{domxref("Element")}} (which doesn't provide a `toJSON()` operation).
+The JSON doesn't contain the {{domxref("LargestContentfulPaint.element", "element")}} property because it is of type {{domxref("Element")}}, which doesn't provide a `toJSON()` operation.
 
 ## Examples
 

--- a/files/en-us/web/api/performance/index.md
+++ b/files/en-us/web/api/performance/index.md
@@ -71,7 +71,7 @@ _The `Performance` interface doesn't inherit any methods._
 - {{domxref("Performance.setResourceTimingBufferSize()")}}
   - : Sets the browser's resource timing buffer size to the specified number of "`resource`" {{domxref("PerformanceEntry.entryType","type")}} {{domxref("PerformanceEntry","performance entry")}} objects.
 - {{domxref("Performance.toJSON()")}}
-  - : A jsonizer returning a JSON object representing the `Performance` object.
+  - : Returns a JSON representation of the `Performance` object.
 
 ## Events
 

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -28,7 +28,7 @@ None.
 
 A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Performance")}} object.
 
-The returned JSON doesn't contain the {{domxref("Performance.eventCounts", "eventCounts")}} property, given it is of type {{domxref("EventCounts")}} (which doesn't provide a `toJSON()` operation).
+The returned JSON doesn't contain the {{domxref("Performance.eventCounts", "eventCounts")}} property because it is of type {{domxref("EventCounts")}}, which doesn't provide a `toJSON()` operation.
 
 > **Note:** The JSON object contains the serialization of the deprecated {{domxref("performance.timing")}} and {{domxref("performance.navigation")}} properties. To get a JSON representation of the newer {{domxref("PerformanceNavigationTiming")}} interface, call {{domxref("PerformanceNavigationTiming.toJSON()")}} instead.
 

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -12,11 +12,7 @@ browser-compat: api.Performance.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method of the {{domxref("Performance")}}
-interface is a standard serializer: it returns a JSON representation of the performance
-object's properties.
-
-{{availableinworkers}}
+The **`toJSON()`** method of the {{domxref("Performance")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("Performance")}} object.
 
 ## Syntax
 
@@ -30,13 +26,55 @@ None.
 
 ### Return value
 
-A JSON object that is the serialization of the {{domxref("Performance")}} object.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Performance")}} object.
+
+The returned JSON doesn't contain the {{domxref("Performance.eventCounts", "eventCounts")}} property, given it is of type {{domxref("EventCounts")}} (which doesn't provide a `toJSON()` operation).
+
+> **Note:** The JSON object contains the serialization of the deprecated {{domxref("performance.timing")}} and {{domxref("performance.navigation")}} properties. To get a JSON representation of the newer {{domxref("PerformanceNavigationTiming")}} interface, call {{domxref("PerformanceNavigationTiming.toJSON()")}} instead.
 
 ## Examples
 
+### Using the toJSON method
+
+In this example, calling `performance.toJSON()` returns a JSON representation of the `Performance` object.
+
 ```js
-const js = window.performance.toJSON();
-console.log(`json = ${JSON.stringify(js)}`);
+performance.toJSON();
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "timeOrigin": 1668077531367.4,
+  "timing": {
+    "connectStart": 1668077531372,
+    "navigationStart": 1668077531367,
+    "secureConnectionStart": 0,
+    "fetchStart": 1668077531372,
+    "domContentLoadedEventStart": 1668077531580,
+    "responseStart": 1668077531372,
+    "domInteractive": 1668077531524,
+    "domainLookupEnd": 1668077531372,
+    "responseEnd": 1668077531500,
+    "redirectStart": 0,
+    "requestStart": 1668077531372,
+    "unloadEventEnd": 0,
+    "unloadEventStart": 0,
+    "domLoading": 1668077531512,
+    "domComplete": 1668077531585,
+    "domainLookupStart": 1668077531372,
+    "loadEventStart": 1668077531585,
+    "domContentLoadedEventEnd": 1668077531580,
+    "loadEventEnd": 1668077531585,
+    "redirectEnd": 0,
+    "connectEnd": 1668077531372
+  },
+  "navigation": {
+    "type": 0,
+    "redirectCount": 0
+  }
+}
 ```
 
 ## Specifications
@@ -46,3 +84,7 @@ console.log(`json = ${JSON.stringify(js)}`);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -77,6 +77,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(performance)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -41,7 +41,7 @@ The **`PerformanceElementTiming`** interface of the {{domxref('Element Timing AP
 ## Instance methods
 
 - {{domxref("PerformanceElementTiming.toJSON()")}} {{Experimental_Inline}}
-  - : Generates a JSON description of the object.
+  - : Returns a JSON representation of the `PerformanceElementTiming` object.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -30,7 +30,7 @@ None.
 
 A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceElementTiming")}} object.
 
-The JSON doesn't contain the {{domxref("PerformanceElementTiming.element", "element")}} property, given it is of type {{domxref("Element")}} (which doesn't provide a `toJSON()` operation). The {{domxref("PerformanceElementTiming.id", "id")}} of the element is provided, though.
+The JSON doesn't contain the {{domxref("PerformanceElementTiming.element", "element")}} property because it is of type {{domxref("Element")}}, which doesn't provide a `toJSON()` operation. The {{domxref("PerformanceElementTiming.id", "id")}} of the element is provided, though.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PerformanceElementTiming.toJSON
 
 {{APIRef("Performance API")}}{{SeeCompatTable}}
 
-The **`toJSON()`** method of the {{domxref("PerformanceElementTiming")}} interface is a standard serializer. It returns a JSON representation of the object's properties.
+The **`toJSON()`** method of the {{domxref("PerformanceElementTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceElementTiming")}} object.
 
 ## Syntax
 
@@ -28,12 +28,15 @@ None.
 
 ### Return value
 
-- json
-  - : A JSON object that is the serialization of the `PerformanceElementTiming` object.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceElementTiming")}} object.
+
+The JSON doesn't contain the {{domxref("PerformanceElementTiming.element", "element")}} property, given it is of type {{domxref("Element")}} (which doesn't provide a `toJSON()` operation). The {{domxref("PerformanceElementTiming.id", "id")}} of the element is provided, though.
 
 ## Examples
 
-In this example calling `entry.toJSON()` returns a JSON representation of the `PerformanceElementTiming` object, with the information about the image element.
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceElementTiming` object, with the information about the image element.
 
 ```html
 <img
@@ -54,7 +57,33 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note:** This example uses the {{domxref("PerformanceObserver")}} interface to create a list of performance measurement events. In our case we observe the {{domxref("PerformanceEntry.entrytype")}} `element` in order to use the `PerformanceElementTiming` interface.
+This would log a JSON object like so:
+
+```json
+{
+  "name": "image-paint",
+  "entryType": "element",
+  "startTime": 670894.1000000238,
+  "duration": 0,
+  "renderTime": 0,
+  "loadTime": 670894.1000000238,
+  "intersectionRect": {
+    "x": 299,
+    "y": 76,
+     "width": 135,
+     "height": 155,
+     "top": 76,
+     "right": 434,
+     "bottom": 231,
+      "left": 299
+  },
+  "identifier": "big-image",
+  "naturalWidth": 135,
+  "naturalHeight": 155,
+  "id": "myImage",
+  "url": "https://en.wikipedia.org/static/images/project-logos/enwiki.png"
+}
+```
 
 ## Specifications
 
@@ -63,3 +92,7 @@ observer.observe({ entryTypes: ["element"] });
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -85,6 +85,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -61,6 +61,8 @@ This would log a JSON object like so:
 
 Note that it doesn't contain `PerformanceMark`'s {{domxref("PerformanceMark.detail", "detail")}} property.
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceEntry.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceEntry","performance entry", "", "no-code")}} object.
+The **`toJSON()`** method is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceEntry")}} object.
 
 ## Syntax
 
@@ -26,38 +26,40 @@ None.
 
 ### Return value
 
-A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} object.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceEntry")}} object.
 
 ## Examples
 
 ### Using the toJSON method
 
-The following example shows the use of the `toJSON()` method.
+In this example, calling `entry.toJSON()` returns a JSON representation of the {{domxref("PerformanceMark")}} object.
 
 ```js
+performance.mark("debug-marker", { 
+  detail: "debugging-marker-123" 
+});
+
 const observer = new PerformanceObserver((list) => {
   list.getEntries().forEach((entry) => {
     console.log(entry.toJSON());
   });
 });
 
-// Register the observer for events
-observer.observe({type: "event", buffered: true});
+observer.observe({ entryTypes: ["mark"] });
 ```
 
 This would log a JSON object like so:
 
 ```json
 {
-  "name": "dragover",
-  "entryType": "event",
-  "startTime": 67090751.599999905,
-  "duration": 128,
-  "processingStart": 67090751.70000005,
-  "processingEnd": 67090751.900000095,
-  "cancelable": true
+  "name": "debug-marker", 
+  "entryType": "mark", 
+  "startTime": 158361, 
+  "duration": 0
 }
 ```
+
+Note that it doesn't contain `PerformanceMark`'s {{domxref("PerformanceMark.detail", "detail")}} property, in case you provided it when calling {{domxref("Performance.mark()")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -59,7 +59,7 @@ This would log a JSON object like so:
 }
 ```
 
-Note that it doesn't contain `PerformanceMark`'s {{domxref("PerformanceMark.detail", "detail")}} property, in case you provided it when calling {{domxref("Performance.mark()")}}.
+Note that it doesn't contain `PerformanceMark`'s {{domxref("PerformanceMark.detail", "detail")}} property.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -159,7 +159,7 @@ This interface also supports the following properties:
 ## Instance methods
 
 - {{domxref("PerformanceEventTiming.toJSON()")}}
-  - : Converts the PerformanceEventTiming object to JSON.
+  - : Returns a JSON representation of the `PerformanceEventTiming` object.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -60,6 +60,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -12,9 +12,7 @@ browser-compat: api.PerformanceEventTiming.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a _serializer_; it returns a JSON representation of the {{domxref("PerformanceEventTiming","performance event timing entry")}} object.
-
-Note that it doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property, given it is of type {{domxref("Node")}} (which doesn't provide a `toJSON()` operation).
+The **`toJSON()`** method of the {{domxref("PerformanceEventTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceEventTiming")}} object.
 
 ## Syntax
 
@@ -28,13 +26,15 @@ None.
 
 ### Return value
 
-A JSON object that is the serialization of the {{domxref("PerformanceEventTiming")}} object.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceEventTiming")}} object.
+
+The JSON doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property, given it is of type {{domxref("Node")}} (which doesn't provide a `toJSON()` operation).
 
 ## Examples
 
 ### Using the toJSON method
 
-The following example shows the use of the `toJSON()` method.
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceEventTiming` object.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -43,7 +43,6 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-// Register the observer for events
 observer.observe({type: "event", buffered: true});
 ```
 

--- a/files/en-us/web/api/performanceeventtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceeventtiming/tojson/index.md
@@ -28,7 +28,7 @@ None.
 
 A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceEventTiming")}} object.
 
-The JSON doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property, given it is of type {{domxref("Node")}} (which doesn't provide a `toJSON()` operation).
+The JSON doesn't contain the {{domxref("PerformanceEventTiming.target", "target")}} property because it is of type {{domxref("Node")}}, which doesn't provide a `toJSON()` operation.
 
 ## Examples
 

--- a/files/en-us/web/api/performancelongtasktiming/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/index.md
@@ -23,6 +23,11 @@ The **`PerformanceLongTaskTiming`** interface of the [Long Tasks API](/en-US/doc
 - {{domxref("PerformanceLongTaskTiming.attribution")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a sequence of {{domxref('TaskAttributionTiming')}} instances.
 
+## Instance methods
+
+- {{domxref("PerformanceLongTaskTiming.toJSON()")}} {{Experimental_Inline}}
+  - : Returns a JSON representation of the `PerformanceLongTaskTiming` object.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performancelongtasktiming/tojson/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/tojson/index.md
@@ -68,6 +68,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performancelongtasktiming/tojson/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/tojson/index.md
@@ -1,0 +1,81 @@
+---
+title: PerformanceLongTaskTiming.toJSON()
+slug: Web/API/PerformanceLongTaskTiming/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance,
+  - Experimental
+browser-compat: api.PerformanceLongTaskTiming.toJSON
+---
+
+{{APIRef("Performance API")}}
+
+The **`toJSON()`** method of the {{domxref("PerformanceLongTaskTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceLongTaskTiming")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceLongTaskTiming")}} object.
+
+## Examples
+
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceLongTaskTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+observer.observe({ type: "longtask", buffered: true });
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "self",
+  "entryType": "longtask",
+  "startTime": 183,
+  "duration": 60,
+  "attribution": [
+    {
+      "name": "unknown",
+      "entryType": "taskattribution",
+      "startTime": 0,
+      "duration": 0,
+      "containerType": "window",
+      "containerSrc": "",
+      "containerId": "",
+      "containerName": ""
+    }
+  ]
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performancenavigationtiming/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/index.md
@@ -70,7 +70,7 @@ The interface also supports the following properties:
 ## Instance methods
 
 - {{domxref("PerformanceNavigationTiming.toJSON()")}}
-  - : Returns a string that is the JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.
+  - : Returns a JSON representation of the `PerformanceNavigationTiming` object.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.md
@@ -96,6 +96,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.md
@@ -12,8 +12,7 @@ browser-compat: api.PerformanceNavigationTiming.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a _serializer_ - it returns
-a JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.
+The **`toJSON()`** method of the {{domxref("PerformanceNavigationTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.
 
 ## Syntax
 
@@ -27,20 +26,74 @@ None.
 
 ### Return value
 
-A JSON object that is the serialization of the
-{{domxref("PerformanceNavigationTiming")}} object as a map with entries from the
-closest inherited interface and with entries for each of the serializable attributes.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceNavigationTiming")}} object.
 
 ## Examples
 
-```js
-// Get a resource performance entry
-const [entry] = performance.getEntriesByType("navigation");
+### Using the toJSON method
 
-// Get the JSON and log it
-const json = entry.toJSON();
-const s = JSON.stringify(json);
-console.log(`PerformanceNavigationTiming.toJSON() = ${s}`);
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceNavigationTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+observer.observe({ entryTypes: ["navigation"] });
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "https://en.wikipedia.org/wiki/Main_Page",
+  "entryType": "navigation",
+  "startTime": 0,
+  "duration": 227.60000002384186,
+  "initiatorType": "navigation",
+  "nextHopProtocol": "h2",
+  "renderBlockingStatus": "blocking",
+  "workerStart": 0,
+  "redirectStart": 4,
+  "redirectEnd": 71.40000000596046,
+  "fetchStart": 71.40000000596046,
+  "domainLookupStart": 71.40000000596046,
+  "domainLookupEnd": 71.40000000596046,
+  "connectStart": 71.40000000596046,
+  "connectEnd": 71.40000000596046,
+  "secureConnectionStart": 71.40000000596046,
+  "requestStart": 73.7000000178814,
+  "responseStart": 102.90000000596046,
+  "responseEnd": 105.2000000178814,
+  "transferSize": 19464,
+  "encodedBodySize": 19164,
+  "decodedBodySize": 83352,
+  "serverTiming": [
+    {
+      "name": "cache",
+      "duration": 0,
+      "description": "hit-front"
+    },
+    {
+      "name": "host",
+      "duration": 0,
+      "description": "cp3062"
+    }
+  ],
+  "unloadEventStart": 0,
+  "unloadEventEnd": 0,
+  "domInteractive": 178.10000002384186,
+  "domContentLoadedEventStart": 178.2000000178814,
+  "domContentLoadedEventEnd": 178.2000000178814,
+  "domComplete": 227.60000002384186,
+  "loadEventStart": 227.60000002384186,
+  "loadEventEnd": 227.60000002384186,
+  "type": "navigate",
+  "redirectCount": 1,
+  "activationStart": 0
+}
 ```
 
 ## Specifications
@@ -50,3 +103,7 @@ console.log(`PerformanceNavigationTiming.toJSON() = ${s}`);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -77,7 +77,7 @@ The interface also supports the following properties which are listed in the ord
 ## Instance methods
 
 - {{domxref("PerformanceResourceTiming.toJSON()")}}
-  - : Returns a string that is the JSON representation of the {{domxref("PerformanceResourceTiming")}} object.
+  - : Returns a JSON representation of the `PerformanceResourceTiming` object.
 
 ## Example
 

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.md
@@ -12,8 +12,7 @@ browser-compat: api.PerformanceResourceTiming.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method is a _serializer_ that returns
-a JSON representation of the {{domxref("PerformanceResourceTiming")}} object.
+The **`toJSON()`** method of the {{domxref("PerformanceResourceTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceResourceTiming")}} object.
 
 ## Syntax
 
@@ -27,22 +26,63 @@ None.
 
 ### Return value
 
-- json
-  - : A JSON object that is the serialization of the
-    {{domxref("PerformanceResourceTiming")}} object as a map with entries from the closest
-    inherited interface and with entries for each of the serializable attributes.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceResourceTiming")}} object.
 
 ## Examples
 
-```js
-// Get a resource performance entry
-const perfEntries = performance.getEntriesByType("resource");
-const entry = perfEntries[0];
+### Using the toJSON method
 
-// Get the JSON and log it
-const json = entry.toJSON();
-const s = JSON.stringify(json);
-console.log(`PerformanceEntry.toJSON = ${s}`);
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceResourceTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+observer.observe({ entryTypes: ["resource"] });
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/31px-Commons-logo.svg.png",
+  "entryType": "resource",
+  "startTime": 110.80000001192093,
+  "duration": 11.599999994039536,
+  "initiatorType": "img",
+  "nextHopProtocol": "h2",
+  "renderBlockingStatus": "non-blocking",
+  "workerStart": 0,
+  "redirectStart": 0,
+  "redirectEnd": 0,
+  "fetchStart": 110.80000001192093,
+  "domainLookupStart": 110.80000001192093,
+  "domainLookupEnd": 110.80000001192093,
+  "connectStart": 110.80000001192093,
+  "connectEnd": 110.80000001192093,
+  "secureConnectionStart": 110.80000001192093,
+  "requestStart": 117.30000001192093,
+  "responseStart": 120.40000000596046,
+  "responseEnd": 122.40000000596046,
+  "transferSize": 0,
+  "encodedBodySize": 880,
+  "decodedBodySize": 880,
+  "serverTiming": [
+    {
+      "name": "cache",
+      "duration": 0,
+      "description": "hit-front"
+    },
+    {
+      "name": "host",
+      "duration": 0,
+      "description": "cp3061"
+    }
+  ]
+}
 ```
 
 ## Specifications
@@ -52,3 +92,7 @@ console.log(`PerformanceEntry.toJSON = ${s}`);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.md
@@ -85,6 +85,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceservertiming/index.md
+++ b/files/en-us/web/api/performanceservertiming/index.md
@@ -28,7 +28,7 @@ This interface is restricted to the same origin, but you can use the {{HTTPHeade
 ## Instance methods
 
 - {{domxref('PerformanceServerTiming.toJSON()')}}
-  - : Returns a string that is the JSON representation of the `PerformanceServerTiming` object.
+  - : Returns a JSON representation of the `PerformanceServerTiming` object.
 
 ## Example
 

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -58,6 +58,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(serverEntry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -14,9 +14,7 @@ browser-compat: api.PerformanceServerTiming.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method of the
-{{domxref("PerformanceServerTiming")}} interface returns a string that
-is the JSON representation of the {{domxref('PerformanceServerTiming')}} object.
+The **`toJSON()`** method of the {{domxref("PerformanceServerTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceServerTiming")}} object.
 
 ## Syntax
 
@@ -30,11 +28,35 @@ None.
 
 ### Return value
 
-A {{domxref('DomString')}} containing JSON.
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceServerTiming")}} object.
 
-### Exceptions
+## Examples
 
-None.
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceResourceTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+      entry.serverTiming.forEach((serverEntry) => {
+        console.log(serverEntry.toJSON());
+      });
+  });
+});
+
+observer.observe({ entryTypes: ["resource"] });
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "cache",
+  "duration": 0,
+  "description": "hit-front"
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -34,7 +34,7 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Performa
 
 ### Using the toJSON method
 
-In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceResourceTiming` object.
+In this example, calling `serverEntry.toJSON()` returns a JSON representation of the `PerformanceServerTiming` object.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/taskattributiontiming/index.md
+++ b/files/en-us/web/api/taskattributiontiming/index.md
@@ -29,6 +29,11 @@ The **`TaskAttributionTiming`** interface of the [Long Tasks API](/en-US/docs/We
 - {{domxref('TaskAttributionTiming.containerName')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the container's `name` attribute.
 
+## Instance methods
+
+- {{domxref("TaskAttributionTiming.toJSON()")}} {{Experimental_Inline}}
+  - : Returns a JSON representation of the `TaskAttributionTiming` object.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/taskattributiontiming/tojson/index.md
+++ b/files/en-us/web/api/taskattributiontiming/tojson/index.md
@@ -60,6 +60,8 @@ This would log a JSON object like so:
 }
 ```
 
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/taskattributiontiming/tojson/index.md
+++ b/files/en-us/web/api/taskattributiontiming/tojson/index.md
@@ -1,0 +1,73 @@
+---
+title: TaskAttributionTiming.toJSON()
+slug: Web/API/TaskAttributionTiming/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+  - Experimental
+browser-compat: api.TaskAttributionTiming.toJSON
+---
+
+{{APIRef("Performance API")}}
+
+The **`toJSON()`** method of the {{domxref("TaskAttributionTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("TaskAttributionTiming")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("TaskAttributionTiming")}} object.
+
+## Examples
+
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `TaskAttributionTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+observer.observe({ type: "taskattribution", buffered: true });
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "unknown",
+  "entryType": "taskattribution",
+  "startTime": 0,
+  "duration": 0,
+  "containerType": "window",
+  "containerSrc": "",
+  "containerId": "",
+  "containerName": ""
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}


### PR DESCRIPTION
### Description

This PR improves (or creates) docs for the 10 `toJSON` method pages in the Performance API docs. I tried to make them consistent.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

It is not easy to be consistent.

### Related issues and pull requests

I will create a BCD PR to add mdn_urls for the two new pages.