### PR TITLE
Correct PerformanceEntry.name for ElementTiming

### DIFF
--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -32,7 +32,12 @@ A string. The value depends on the subclass of the `PerformanceEntry` object as 
     </tr>
     <tr>
       <td>{{domxref('PerformanceElementTiming')}}</td>
-      <td>The string the <code>elementtiming</code> HTML content attribute was set to (reflected as {{domxref("Element.elementTiming")}}).</td>
+      <td>One of the following strings:
+        <ul>
+          <li><code>"image-paint"</code></li>
+          <li><code>"text-paint"</code></li>
+        </ul>
+      </td>
     </tr>
     <tr>
       <td>{{domxref('PerformanceEventTiming')}}</td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I made a mistake. The `name` property is either "image-paint" or "text-paint". 

(The <code>elementtiming</code> HTML content attribute is available as the `identifier` property.)

### Motivation

Fixing wrong docs.

### Additional details

Relevant spec links:
- https://wicg.github.io/element-timing/#sec-report-image-element
- https://wicg.github.io/element-timing/#sec-report-text

### Related issues and pull requests

Error introduced in https://github.com/mdn/content/pull/22064.