### PR TITLE
added image alt attribute to canvas_grid_translate.png

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
@@ -27,7 +27,7 @@ The `translate()` method adds a translation transformation to the current
 matrix by moving the canvas and its origin `x` units horizontally and
 `y` units vertically on the grid.
 
-![Grid with cross illustrates how the canvas and origin move based off the values of x and y.](canvas_grid_translate.png)
+![A canvas's origin moved on the x and y axes based on the values of the translate method.](canvas_grid_translate.png)
 
 ### Parameters
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
@@ -27,7 +27,7 @@ The `translate()` method adds a translation transformation to the current
 matrix by moving the canvas and its origin `x` units horizontally and
 `y` units vertically on the grid.
 
-![](canvas_grid_translate.png)
+![Grid with cross illustrates how the canvas and origin move based off the values of x and y.](canvas_grid_translate.png)
 
 ### Parameters
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

An `alt` attribute description was added to canvas_grid_translate.png on [this page](https://developer.mozilla.org/en-US/docs/web/api/canvasrenderingcontext2d/translate).

### Motivation

I want to practice contributing to open source that I use frequently.

### Additional details

`alt` text content: Grid with cross illustrates how the canvas and origin move based off the values of x and y.

### Related issues and pull requests
Partially completes issue: "[Add alt attributes to images #21616](https://github.com/mdn/content/issues/21616#issue-1412437014)"
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
