### PR TITLE
Improve await description

### DIFF
--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -312,6 +312,7 @@ Only `lastAsyncTask` appears in the stack trace, because the promise is rejected
 
 ```js
 async function lastAsyncTask() {
+  await null;
   throw new Error("failed");
 }
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -42,6 +42,7 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}.
 As same as `Promise.resolve()`, the result is always a native `Promise` (that is constructed by engine's original constructor {{jsxref("Promise")}}), then this `Promise` is used internally to perform the awaition.
 If the `expression` is a:
+
 - native `Promise`: The promise is directly used. Method `then` doesn't get called, because the awaition is performed natively.
 - [thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, that is polyfill, proxy, child class, ...): A native `Promise` is constructed by calling object's method `then`. The native `Promise` is used.
 - non-thenable value: A `Promise` already fulfilled is constructed and used.

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -39,13 +39,11 @@ Throws the rejection reason if the promise or thenable object is rejected.
 
 If the promise is rejected, the `await` expression throws the rejected value. The function containing the `await` expression will [appear in the stack trace](#improving_stack_trace) of the error. Otherwise, if the rejected promise is not awaited or is immediately returned, the caller function will not appear in the stack trace.
 
-The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}.
-As same as `Promise.resolve()`, the result is always a native `Promise` (that is constructed by engine's original constructor {{jsxref("Promise")}}), then this `Promise` is used internally to perform the awaition.
-If the `expression` is a:
+The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
-- native `Promise`: The promise is directly used. Method `then` doesn't get called, because the awaition is performed natively.
-- [thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, that is polyfill, proxy, child class, ...): A native `Promise` is constructed by calling object's method `then`. The native `Promise` is used.
-- non-thenable value: A `Promise` already fulfilled is constructed and used.
+- Native `Promise` (tested by checking `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
+- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed by calling the `resolve` callback within the object's `then()` method.
+- Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 
 Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -149,6 +149,8 @@ const response = await promisedFunction().catch((err) => {
 // response will be "default response" if the promise is rejected
 ```
 
+Note that `catch()`'s behavior could be unexpected when the object returned by `promisedFunction()` is not a native {{jsxref("Promise")}}. To avoid unexpected behavior, use `Promise.resolve(promisedFunction())` instead of `promisedFunction()`.
+
 ### Top level await
 
 You can use the `await` keyword on its own (outside of an async function) at the top level of a [module](/en-US/docs/Web/JavaScript/Guide/Modules). This means that modules with child modules that use `await` will wait for the child modules to execute before they themselves run, all while not blocking other child modules from loading.

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -148,8 +148,6 @@ const response = await promisedFunction().catch((err) => {
 // response will be "default response" if the promise is rejected
 ```
 
-Note that `catch()`'s behavior could be unexpected when the object returned by `promisedFunction()` is not a native {{jsxref("Promise")}}. To avoid unexpected behavior, use `Promise.resolve(promisedFunction())` instead of `promisedFunction()`.
-
 ### Top level await
 
 You can use the `await` keyword on its own (outside of an async function) at the top level of a [module](/en-US/docs/Web/JavaScript/Guide/Modules). This means that modules with child modules that use `await` will wait for the child modules to execute before they themselves run, all while not blocking other child modules from loading.

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -45,7 +45,7 @@ The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}:
 - [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A new promise is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method and passing in a handler that calls the `resolve` callback.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 
-Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)
+Even when the used promise is already fulfilled, the async function's execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)
 
 Because `await` is only valid inside async functions and modules, which themselves are asynchronous and return promises, the `await` expression never blocks the main thread and only defers execution of code that actually depends on the result, i.e. anything after the `await` expression.
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -294,7 +294,7 @@ However, consider the case where `someAsyncTask` asynchronously throws an error.
 
 ```js
 async function lastAsyncTask() {
-  await setTimeout(() => {}, 100);
+  await null;
   throw new Error("failed");
 }
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -41,8 +41,8 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
-- Native `Promise` (tested by checking `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
-- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method with a handler that calls the `resolve` callback.
+- Native `Promise` (tested with `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
+- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A new promise is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method and passing in a handler that calls the `resolve` callback.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 
 Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -42,7 +42,7 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
 - Native `Promise` (tested by checking `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
-- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed by calling the `resolve` callback within the object's `then()` method.
+- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the `resolve` callback within the object's `then()` method.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 
 Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -39,7 +39,14 @@ Throws the rejection reason if the promise or thenable object is rejected.
 
 If the promise is rejected, the `await` expression throws the rejected value. The function containing the `await` expression will [appear in the stack trace](#improving_stack_trace) of the error. Otherwise, if the rejected promise is not awaited or is immediately returned, the caller function will not appear in the stack trace.
 
-The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}. This means [thenable objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) are supported, and if `expression` is not a promise, it's implicitly wrapped in a `Promise` and then resolved. Even when `expression` is not a promise, the async function execution still pauses until the next tick, due to the implicit promise wrapping and unwrapping. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)
+The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}.
+As same as `Promise.resolve()`, the result is always a native `Promise` (that is constructed by engine's original constructor {{jsxref("Promise")}}), then this `Promise` is used internally to perform the awaition.
+If the `expression` is a:
+- native `Promise`: The promise is directly used. Method `then` doesn't get called, because the awaition is performed natively.
+- [thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, that is polyfill, proxy, child class, ...): A native `Promise` is constructed by calling object's method `then`. The native `Promise` is used.
+- non-thenable value: A `Promise` already fulfilled is constructed and used.
+
+Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)
 
 Because `await` is only valid inside async functions and modules, which themselves are asynchronous and return promises, the `await` expression never blocks the main thread and only defers execution of code that actually depends on the result, i.e. anything after the `await` expression.
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -42,7 +42,7 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
 - Native `Promise` (tested by checking `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
-- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the `resolve` callback within the object's `then()` method.
+- [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A native `Promise` is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method with a handler that calls the `resolve` callback.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 
 Even when the used promise has been already fulfilled, the async function execution still pauses until the next tick. In the meantime, the caller of the async function resumes execution. [See example below.](#control_flow_effects_of_await)

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -302,7 +302,6 @@ Only `lastAsyncTask` appears in the stack trace, because the promise is rejected
 
 ```js
 async function lastAsyncTask() {
-  await setTimeout(() => {}, 100);
   throw new Error("failed");
 }
 


### PR DESCRIPTION
### Description

edited description
removed useless await setTimeout(()=>{},100);

### Motivation

### Additional details

[await](https://tc39.es/ecma262/#await)
[perform Promise.resolve()](https://tc39.es/ecma262/#sec-promise-resolve)
[perform awaition](https://tc39.es/ecma262/#sec-performpromisethen)