### PR TITLE
await description: Fix native promise test code

### DIFF
--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -41,7 +41,7 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
-- Native `Promise` (tested with `IsNativePromise(expression) && expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
+- Native `Promise` (which means `expression` belongs to `Promise` or a subclass, and `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
 - [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A new promise is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method and passing in a handler that calls the `resolve` callback.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -41,7 +41,7 @@ If the promise is rejected, the `await` expression throws the rejected value. Th
 
 The `expression` is resolved in the same way as {{jsxref("Promise.resolve()")}}: it's always converted to a native `Promise` and then awaited. If the `expression` is a:
 
-- Native `Promise` (tested with `expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
+- Native `Promise` (tested with `IsNativePromise(expression) && expression.constructor === Promise`): The promise is directly used and awaited natively, without calling `then()`.
 - [Thenable object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) (including non-native promises, polyfill, proxy, child class, etc.): A new promise is constructed with the native [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor by calling the object's `then()` method and passing in a handler that calls the `resolve` callback.
 - Non-thenable value: An already-fulfilled `Promise` is constructed and used.
 


### PR DESCRIPTION
### Description

Fix native promise test code

### Motivation

`constructor===Promise` does test if the object is a native Promise.
It's just not strict. It does test.
`a native Promise (tested with constructor===Promise)` sounds like "only constructor is tested" to me.

### Additional details

[PromiseResolve](https://tc39.es/ecma262/#sec-promise-resolve)
[IsPromise](https://tc39.es/ecma262/#sec-ispromise)

### Related issues and pull requests

https://github.com/mdn/content/pull/22229