### PR TITLE
Missing Input 'date_of_death'

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_author_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_author_form/index.md
@@ -153,6 +153,7 @@ block content
     div.form-group
       label(for='date_of_birth') Date of birth:
       input#date_of_birth.form-control(type='date' name='date_of_birth' value=(undefined===author ? '' : author.date_of_birth) )
+      input#date_of_death.form-control(type='date' name='date_of_death' value=(undefined===author ? '' : author.date_of_death) )
     button.btn.btn-primary(type='submit') Submit
   if errors
     ul


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The `form` element was missing an `input` for the **date_of_death**

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The `form` element should have an `input` for the **date_of_death** (As can be seen in the image [here](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Create_author_form#what_does_it_look_like))
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
