### PR TITLE
Add MSE in workers content

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.md
@@ -106,6 +106,27 @@ if ('srcObject' in video) {
 }
 ```
 
+### Constructuring a `MediaSource` in a worker and passing it to the main thread to play
+
+The {{domxref("MediaSource.handle")}} property can be accessed inside a dedicated worker and the resulting {{domxref("MediaSourceHandle")}} object is then transferred over to the main thread via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
+
+```js
+let mediaSource = new MediaSource();
+let handle = mediaSource.handle;
+postMessage({arg: handle}, [handle]);
+
+// Fetch the media, buffer it, and pass it into the MediaSource
+```
+
+Over in the main thread, we receive the handle via a {{domxref("Worker.message_event", "message")}} event handler, attach it to a {{htmlelement("video")}} via its {{domxref("HTMLMediaElement.srcObject")}} property, and {{domxref("HTMLMediaElement.play()", "play")}} the video:
+
+```js
+worker.addEventListener('message', (msg) => {
+  video.srcObject = msg.data.arg;
+  video.play();
+})
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -43,6 +43,12 @@ Live profile content can introduce latency due to its transcoding and broadcasti
 
 There are numerous available free and open source tools for transcoding content and preparing it for use with DASH, DASH file servers, and DASH client libraries written in JavaScript.
 
+### Availability in workers
+
+Starting with Chrome 108, MSE features are available in dedicated {{domxref("Web Workers API", "web workers", "", "nocode")}}, which allows for improved performance when manipulating {{domxref("MediaSource")}}s and {{domxref("SourceBuffer")}}s. To play back the media, the {{domxref("MediaSource.handle")}} property is used to get a reference to a {{domxref("MediaSourceHandle")}} object, a proxy for the `MediaSource` that can be transferred back to the main thread and attached to a media element via its {{domxref("HTMLMediaElement.srcObject")}} property.
+
+See [MSE-in-Workers Demo by Matt Wolenetz](https://wolenetz.github.io/mse-in-workers-demo/mse-in-workers-demo.html) for a live example.
+
 ## Interfaces
 
 - {{domxref("MediaSource")}}

--- a/files/en-us/web/api/mediasource/canconstructindedicatedworker/index.md
+++ b/files/en-us/web/api/mediasource/canconstructindedicatedworker/index.md
@@ -1,0 +1,48 @@
+---
+title: MediaSource.canConstructInDedicatedWorker
+slug: Web/API/MediaSource/canConstructInDedicatedWorker
+page-type: web-api-static-property
+tags:
+  - API
+  - canConstructInDedicatedWorker
+  - Experimental
+  - Media Source Extensions
+  - MediaSource
+  - Property
+  - Static Property
+  - Reference
+browser-compat: api.MediaSource.canConstructInDedicatedWorker
+---
+
+{{APIRef("Media Source Extensions")}}{{seecompattable}}
+
+The **`canConstructInDedicatedWorker`** static property of the {{domxref("MediaSource")}} interface returns `true` if `MediaSource` worker support is implemented, providing a low-latency feature detection mechanism.
+
+If this were not available, the alternative would be a much higher latency approach such as attempting the creation of a `MediaSource` object from a dedicated worker and transferring the result back to the main thread.
+
+## Value
+
+A boolean. Returns `true` if `MediaSource` worker support is implemented, or `false` otherwise.
+
+## Examples
+
+```js
+if(MediaSource.canConstructInDedicatedWorker) {
+  // MSE is available in workers; let's do this
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [MSE-in-Workers Demo by Matt Wolenetz](https://wolenetz.github.io/mse-in-workers-demo/mse-in-workers-demo.html)
+- {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}}
+- {{domxref("MediaSource")}}
+- {{domxref("SourceBuffer")}}

--- a/files/en-us/web/api/mediasource/handle/index.md
+++ b/files/en-us/web/api/mediasource/handle/index.md
@@ -1,0 +1,61 @@
+---
+title: MediaSource.handle
+slug: Web/API/MediaSource/handle
+page-type: web-api-instance-property
+tags:
+  - API
+  - Experimental
+  - handle
+  - MSE
+  - Media Source Extensions
+  - MediaSource
+  - Property
+  - Reference
+browser-compat: api.MediaSource.handle
+---
+
+{{APIRef("Media Source Extensions")}}{{seecompattable}}
+
+The **`handle`** read-only property of the {{domxref("MediaSource")}} interface returns a {{domxref("MediaSourceHandle")}} object, a proxy for the `MediaSource` that can be transferred from a dedicated worker back to the main thread and attached to a media element via its {{domxref("HTMLMediaElement.srcObject")}} property.
+
+{{AvailableInWorkers}}
+
+## Value
+
+A {{domxref("MediaSourceHandle")}} object instance.
+
+## Examples
+
+The `handle` property can be accessed inside a dedicated worker and the resulting `MediaSourceHandle` object is then transferred over to the main thread via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
+
+```js
+let mediaSource = new MediaSource();
+let handle = mediaSource.handle;
+postMessage({arg: handle}, [handle]);
+
+// Fetch the media, buffer it, and pass it into the MediaSource
+```
+
+Over in the main thread, we receive the handle via a {{domxref("Worker.message_event", "message")}} event handler, attach it to a {{htmlelement("video")}} via its {{domxref("HTMLMediaElement.srcObject")}} property, and {{domxref("HTMLMediaElement.play()", "play")}} the video:
+
+```js
+worker.addEventListener('message', (msg) => {
+  video.srcObject = msg.data.arg;
+  video.play();
+})
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [MSE-in-Workers Demo by Matt Wolenetz](https://wolenetz.github.io/mse-in-workers-demo/mse-in-workers-demo.html)
+- {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}}
+- {{domxref("MediaSource")}}
+- {{domxref("SourceBuffer")}}

--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -18,7 +18,7 @@ browser-compat: api.MediaSource
 
 {{APIRef("Media Source Extensions")}}
 
-The **`MediaSource`** interface of the [Media Source Extensions API](/en-US/docs/Web/API/Media_Source_Extensions_API) represents a source of media data for an {{domxref("HTMLMediaElement")}} object. A `MediaSource` object can be attached to a {{domxref("HTMLMediaElement")}} to be played in the user agent.
+The **`MediaSource`** interface of the {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}} represents a source of media data for an {{domxref("HTMLMediaElement")}} object. A `MediaSource` object can be attached to a {{domxref("HTMLMediaElement")}} to be played in the user agent.
 
 {{InheritanceDiagram}}
 
@@ -29,14 +29,21 @@ The **`MediaSource`** interface of the [Media Source Extensions API](/en-US/docs
 
 ## Instance properties
 
-- {{domxref("MediaSource.sourceBuffers")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("SourceBufferList")}} object containing the list of {{domxref("SourceBuffer")}} objects associated with this `MediaSource`.
 - {{domxref("MediaSource.activeSourceBuffers")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("SourceBufferList")}} object containing a subset of the {{domxref("SourceBuffer")}} objects contained within {{domxref("MediaSource.sourceBuffers")}} — the list of objects providing the selected video track, enabled audio tracks, and shown/hidden text tracks.
-- {{domxref("MediaSource.readyState")}} {{ReadOnlyInline}}
-  - : Returns an enum representing the state of the current `MediaSource`, whether it is not currently attached to a media element (`closed`), attached and ready to receive {{domxref("SourceBuffer")}} objects (`open`), or attached but the stream has been ended via {{domxref("MediaSource.endOfStream()")}} (`ended`.)
 - {{domxref("MediaSource.duration")}}
   - : Gets and sets the duration of the current media being presented.
+- {{domxref("MediaSource.handle")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("MediaSourceHandle")}} object, a proxy for the `MediaSource` that can be transferred from a dedicated worker back to the main thread and attached to a media element via its {{domxref("HTMLMediaElement.srcObject")}} property.
+- {{domxref("MediaSource.readyState")}} {{ReadOnlyInline}}
+  - : Returns an enum representing the state of the current `MediaSource`, whether it is not currently attached to a media element (`closed`), attached and ready to receive {{domxref("SourceBuffer")}} objects (`open`), or attached but the stream has been ended via {{domxref("MediaSource.endOfStream()")}} (`ended`.)
+- {{domxref("MediaSource.sourceBuffers")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("SourceBufferList")}} object containing the list of {{domxref("SourceBuffer")}} objects associated with this `MediaSource`.
+
+## Static properties
+
+- {{domxref("MediaSource.canConstructInDedicatedWorker")}} {{ReadOnlyInline}}
+  - : A boolean; returns `true` if `MediaSource` worker support is implemented, providing a low-latency feature detection mechanism.
 
 ## Instance methods
 
@@ -68,6 +75,8 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
   - : Fired when the `MediaSource` instance has been opened by a media element and is ready for data to be appended to the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}}.
 
 ## Examples
+
+### Complete basic example
 
 The following simple example loads a video with {{domxref("XMLHttpRequest")}}, playing it as soon as it can. This example was written by Nick Desaulniers and can be [viewed live here](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html) (you can also [download the source](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html) for further investigation). The function `getMediaSource()`, which is not defined here, returns a `MediaSource`.
 
@@ -112,6 +121,27 @@ function fetchAB (url, cb) {
   };
   xhr.send();
 };
+```
+
+### Constructuring a `MediaSource` in a worker and passing it to the main thread
+
+The `handle` property can be accessed inside a dedicated worker and the resulting `MediaSourceHandle` object is then transferred over to the main thread via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
+
+```js
+let mediaSource = new MediaSource();
+let handle = mediaSource.handle;
+postMessage({arg: handle}, [handle]);
+
+// Fetch the media, buffer it, and pass it into the MediaSource
+```
+
+Over in the main thread, we receive the handle via a {{domxref("Worker.message_event", "message")}} event handler, attach it to a {{htmlelement("video")}} via its {{domxref("HTMLMediaElement.srcObject")}} property, and {{domxref("HTMLMediaElement.play()", "play")}} the video:
+
+```js
+worker.addEventListener('message', (msg) => {
+  video.srcObject = msg.data.arg;
+  video.play();
+})
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediasourcehandle/index.md
+++ b/files/en-us/web/api/mediasourcehandle/index.md
@@ -1,0 +1,66 @@
+---
+title: MediaSourceHandle
+slug: Web/API/MediaSourceHandle
+page-type: web-api-interface
+tags:
+  - API
+  - Experimental
+  - Interface
+  - MSE
+  - MediaSource
+  - MediaSource Extensions
+  - Reference
+browser-compat: api.MediaSourceHandle
+---
+
+{{APIRef("Media Source Extensions")}}{{seecompattable}}
+
+The **`MediaSourceHandle`** interface of the {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}} is a proxy for a {{domxref("MediaSource")}} that can be transferre from a dedicated worker back to the main thread and attached to a media element via its {{domxref("HTMLMediaElement.srcObject")}} property. `MediaSource` objects are not transferable because they are event targets, hence the need for `MediaSourceHandle`s. Each `MediaSource` object has its own distinct `MediaSourceHandle`.
+
+It can be accessed via the {{domxref("MediaSource.handle")}} property.
+
+{{AvailableInWorkers}}
+
+## Instance properties
+
+None.
+
+## Instance methods
+
+None.
+
+## Examples
+
+The `handle` property can be accessed inside a dedicated worker and the resulting `MediaSourceHandle` object is then transferred over to the main thread via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
+
+```js
+let mediaSource = new MediaSource();
+let handle = mediaSource.handle;
+postMessage({arg: handle}, [handle]);
+
+// Fetch the media, buffer it, and pass it into the MediaSource
+```
+
+Over in the main thread, we receive the handle via a {{domxref("Worker.message_event", "message")}} event handler, attach it to a {{htmlelement("video")}} via its {{domxref("HTMLMediaElement.srcObject")}} property, and {{domxref("HTMLMediaElement.play()", "play")}} the video:
+
+```js
+worker.addEventListener('message', (msg) => {
+  video.srcObject = msg.data.arg;
+  video.play();
+})
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [MSE-in-Workers Demo by Matt Wolenetz](https://wolenetz.github.io/mse-in-workers-demo/mse-in-workers-demo.html)
+- {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}}
+- {{domxref("MediaSource")}}
+- {{domxref("SourceBuffer")}}

--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -44,6 +44,7 @@ The following Web APIs are available to workers:
 - {{domxref("FormData")}}
 - {{domxref("ImageData")}}
 - {{domxref("IndexedDB_API", "IndexedDB")}}
+- {{domxref("Media Source Extensions API", "Media Source Extensions API", "", "nocode")}} (dedicated workers only)
 - [Network Information API](/en-US/docs/Web/API/Network_Information_API)
 - {{domxref("Notifications_API", "Notifications")}}
 - {{domxref("Performance")}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -822,6 +822,7 @@
       "overview": ["Media Source Extensions API"],
       "interfaces": [
         "MediaSource",
+        "MediaSourceHandle",
         "SourceBuffer",
         "SourceBufferList",
         "VideoPlaybackQuality"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds content for the new MSE support in workers available in Chrome 108+. You can see details of what's been added in my research document: https://docs.google.com/document/d/1_zwIr7c9_O3_PEoAnaS5M7yExx9VtjMSUJ6U5yiEias/edit#

One thing that I wanted to mention — on the [`srcObject`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject) reference page, there is a note up top mentioning the lack of support for attaching `MediaSource`s via `srcObject`:

> As of March 2020, only Safari supports setting objects other than MediaStream. Until other browsers catch up, for MediaSource, Blob and File, consider falling back to creating a URL with [URL.createObjectURL()](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) and assign it to [HTMLMediaElement.src](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/src).

I thought that since this is how `MediaSourceHandle`s are attached to media elements, this must now be working, at least in Chrome, but it appears that I am wrong. I tried taking Nick's example at https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html and modifying it to use `srcObject` instead of `src` and `URL.createObjectURL`, but it didn't work!

So what's the deal here, and what do you think I should say on the `srcObject` page?

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

People will want to know about these new web platform features.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
