### PR TITLE
Fix broken example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -78,29 +78,32 @@ Because both [strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Strin
 
 ```js
 function logIterable(it) {
-  if (!(Symbol.iterator in it)) {
-    console.log(it, " is not an iterable object.");
+  if (typeof it[Symbol.iterator] !== 'function') {
+    console.log(it, "is not an iterable object.");
     return;
   }
-
   for (const letter of it) {
     console.log(letter);
   }
 }
 
+const arr = ['a','b','c'];
+const str = "abc";
+const num = 123;
+
 // Array
-logIterable(["a", "b", "c"]);
+logIterable(arr);
 // a
 // b
 // c
 
 // string
-logIterable("abc");
+logIterable(str);
 // a
 // b
 // c
 
-logIterable(123);
+logIterable(num);
 // 123 is not an iterable object.
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -78,8 +78,8 @@ Because both [strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Strin
 
 ```js
 function logIterable(it) {
-  if (typeof it[Symbol.iterator] !== 'function') {
-    console.log(it, "is not an iterable object.");
+  if (typeof it[Symbol.iterator] !== "function") {
+    console.log(it, "is not iterable.");
     return;
   }
   for (const letter of it) {
@@ -92,11 +92,14 @@ logIterable(["a", "b", "c"]);
 // a
 // b
 // c
-// string
+
+// String
 logIterable("abc");
 // a
 // b
 // c
+
+// Number
 logIterable(123);
 // 123 is not an iterable object.
 ```

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -101,7 +101,7 @@ logIterable("abc");
 
 // Number
 logIterable(123);
-// 123 is not an iterable object.
+// 123 is not iterable.
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -87,23 +87,17 @@ function logIterable(it) {
   }
 }
 
-const arr = ['a','b','c'];
-const str = "abc";
-const num = 123;
-
 // Array
-logIterable(arr);
+logIterable(["a", "b", "c"]);
 // a
 // b
 // c
-
 // string
-logIterable(str);
+logIterable("abc");
 // a
 // b
 // c
-
-logIterable(num);
+logIterable(123);
 // 123 is not an iterable object.
 ```
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/22250

The subsection 'Handling strings and string arrays with the same function' contained a broken example that would throw a TypeError when ran. The if-condition wasn't working for primitives, so it has been replaced with a functioning if-condition.

Broken if-condition: 
if (!(Symbol.iterator in it)) {if body}

Functioning replacement:
if (typeof it[Symbol.iterator] !== 'function') { if body }

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I fixed a broken if-condition in the example under the subsection '[Handling strings and string arrays with the same function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator#handling_strings_and_string_arrays_with_the_same_function)' for the documentation regarding [Array.prototype[@@iterator]()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Documentation should be accurate and communities can help it to be that way. I participated in my community to help maintain that more-perfect accuracy.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Here is the link to the ticket I had made regarding this change: #22250 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
