### PR TITLE
Total `this` reference overhaul

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
@@ -14,18 +14,21 @@ browser-compat: javascript.builtins.globalThis
 
 {{jsSidebar("Objects")}}
 
-The global **`globalThis`** property contains the global `this` value, which is akin to the [global object](/en-US/docs/Glossary/Global_object).
+The global **`globalThis`** property contains the [global `this`](/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context) value, which is usually akin to the [global object](/en-US/docs/Glossary/Global_object).
 
 {{EmbedInteractiveExample("pages/js/globalprops-globalthis.html","shorter")}}
 
 {{JS_Property_Attributes(1, 0, 1)}}
 
+> **Note:** The `globalThis` property is configurable and writable so that code authors can hide it when executing untrusted code and prevent exposing the global object.
+
 ## Description
 
-Historically, accessing the global object has required different syntax in different JavaScript environments. On the web you can use {{domxref("Window/window", "window")}}, {{domxref("Window/self", "self")}}, or {{domxref("Window/frames", "frames")}} - but in [Web Workers](/en-US/docs/Web/API/Worker) only `self` will work. In Node.js none of these work, and you must instead use `global`.
-The `this` keyword could be used inside functions running in non–strict mode, but `this` will be `undefined` in Modules and inside functions running in strict mode. You can also use `Function('return this')()`, but environments that disable {{jsxref("Global_Objects/eval", "eval()")}}, like {{Glossary("CSP")}} in browsers, prevent use of {{jsxref("Function")}} in this way.
+Historically, accessing the global object has required different syntax in different JavaScript environments. On the web you can use {{domxref("Window/window", "window")}}, {{domxref("Window/self", "self")}}, or {{domxref("Window/frames", "frames")}} - but in [Web Workers](/en-US/docs/Web/API/Worker) only `self` will work. In Node.js none of these work, and you must instead use `global`. The `this` keyword could be used inside functions running in non–strict mode, but `this` will be `undefined` in modules and inside functions running in strict mode. You can also use `Function('return this')()`, but environments that disable {{jsxref("Global_Objects/eval", "eval()")}}, like {{Glossary("CSP")}} in browsers, prevent use of {{jsxref("Function")}} in this way.
 
 The `globalThis` property provides a standard way of accessing the global `this` value (and hence the global object itself) across environments. Unlike similar properties such as `window` and `self`, it's guaranteed to work in window and non-window contexts. In this way, you can access the global object in a consistent manner without having to know which environment the code is being run in. To help you remember the name, just remember that in global scope the `this` value is `globalThis`.
+
+> **Note:** `globalThis` is generally the same concept as the global object (i.e. adding properties to `globalThis` makes them global variables) — this is the case for browsers and Node — but hosts are allowed to provide a different value for `globalThis` that's unrelated to the global object.
 
 ### HTML and the WindowProxy
 
@@ -34,6 +37,8 @@ In many engines `globalThis` will be a reference to the actual global object, bu
 ### Naming
 
 Several other popular name choices such as `self` and `global` were removed from consideration because of their potential to break compatibility with existing code. See the [language proposal's "naming" document](https://github.com/tc39/proposal-global/blob/master/NAMING.md) for more details.
+
+`globalThis` is, quite literally, the global `this` value. It's the same value as the `this` value in a non-strict function called without an object. It's also the value of `this` in the global scope of a script.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -37,7 +37,7 @@ The value of `this` depends on in which context it appears: function, class, or 
 
 Inside a function, the value of `this` depends on how the function is called. Think about `this` as a hidden parameter of a function — just like the parameters declared in the function definition, `this` is a binding that the language creates for you when the function body is evaluated.
 
-For a typical function, the value of `this` is the object that the function is accessed on. In other words, if the function call is the form `obj.f()`, then `this` refers to `obj`. For example:
+For a typical function, the value of `this` is the object that the function is accessed on. In other words, if the function call is in the form `obj.f()`, then `this` refers to `obj`. For example:
 
 ```js
 function getThis() {
@@ -92,8 +92,8 @@ function getThisStrict() {
 }
 
 // Only for demonstration — you should not mutate built-in prototypes
-Number.prototype.getThis = getThisStrict;
-console.log(typeof (1).f()); // "number"
+Number.prototype.getThisStrict = getThisStrict;
+console.log(typeof (1).getThisStrict()); // "number"
 ```
 
 If the function is called without being accessed on anything, `this` will be `undefined` — but only if the function is in strict mode.
@@ -118,7 +118,7 @@ console.log(typeof (1).getThis()); // "object"
 console.log(getThis() === globalThis); // true
 ```
 
-In typical function calls, `this` is implicitly passed like a parameter through the function's prefix (the part before the dot). You can also explicitly set the value of `this` using the {{jsxref("Function.prototype.call()")}}, {{jsxref("Function.prototype.apply()")}}, or {{jsxref("Reflect.apply()")}} methods. You can also use the {{jsxref("Function.prototype.bind()")}} method to create a new function with a specific value of `this` that doesn't change regardless of how the function is called. When using these methods, the `this` substitution rules above still apply if the function is non-strict.
+In typical function calls, `this` is implicitly passed like a parameter through the function's prefix (the part before the dot). You can also explicitly set the value of `this` using the {{jsxref("Function.prototype.call()")}}, {{jsxref("Function.prototype.apply()")}}, or {{jsxref("Reflect.apply()")}} methods. Using {{jsxref("Function.prototype.bind()")}}, you can create a new function with a specific value of `this` that doesn't change regardless of how the function is called. When using these methods, the `this` substitution rules above still apply if the function is non-strict.
 
 #### Callbacks
 
@@ -260,7 +260,7 @@ console.log(window.b); // "MDN"
 console.log(b); // "MDN"
 ```
 
-If the source is loaded as a [module](/en-US/docs/Web/JavaScript/Guide/Modules) (for HTML, this means adding `type="module"` to the `<script>` tag), `this` is always `undefined` at the top level — this behavior is specified by the language.
+If the source is loaded as a [module](/en-US/docs/Web/JavaScript/Guide/Modules) (for HTML, this means adding `type="module"` to the `<script>` tag), `this` is always `undefined` at the top level.
 
 If the source is executed with [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval), `this` is the same as the enclosing context for direct eval, or `globalThis` (as if it's run in a separate global script) for indirect eval.
 

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -141,7 +141,7 @@ Some APIs allow you to set a `this` value for invocations of the callback. For e
 // { name: 'obj' }, { name: 'obj' }, { name: 'obj' }
 ```
 
-Occasionally, a callback is called with `this` value other than `undefined`. For example, the `reviver` parameter of {{jsxref("JSON.parse()")}} and the `replacer` parameter of {{jsxref("JSON.stringify()")}} are both called with `this` set to the object that the property being parsed/serialized belongs to.
+Occasionally, a callback is called with a `this` value other than `undefined`. For example, the `reviver` parameter of {{jsxref("JSON.parse()")}} and the `replacer` parameter of {{jsxref("JSON.stringify()")}} are both called with `this` set to the object that the property being parsed/serialized belongs to.
 
 #### Arrow functions
 
@@ -383,7 +383,7 @@ const fn = obj.getThisGetter();
 console.log(fn() === obj); // true
 ```
 
-But caution if you unbind the method of `obj` without calling it, because `getThisGetter` is still a method that has varying `this` value. Calling `fn2()()` in the following example returns `globalThis`, because it follows the `this` from `fn2`, which is `globalThis` since it's called without being attached to any object.
+But be careful if you unbind the method of `obj` without calling it, because `getThisGetter` is still a method that has a varying `this` value. Calling `fn2()()` in the following example returns `globalThis`, because it follows the `this` from `fn2`, which is `globalThis` since it's called without being attached to any object.
 
 ```js
 const fn2 = obj.getThisGetter;
@@ -501,7 +501,7 @@ bird.sayBye = car.sayBye;
 bird.sayBye(); // Bye from Ferrari
 ```
 
-> **Note:** Classes are always strict mode code. Calling methods with an undefined `this` will throw an error if the method tries to access properties on `this`.
+> **Note:** Classes are always in strict mode. Calling methods with an undefined `this` will throw an error if the method tries to access properties on `this`.
 
 Note, however, that auto-bound methods suffer from the same problem as [using arrow functions for class properties](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cannot_be_used_as_methods): each instance of the class will have its own copy of the method, which increases memory usage. Only use it where absolutely necessary. You can also mimic the implementation of [`Intl.NumberFormat.prototype.format()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format#using_format_with_map): define the property as a getter that returns a bound function when accessed and saves it, so that the function is only created once and only created when necessary.
 

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -13,9 +13,7 @@ browser-compat: javascript.operators.this
 
 {{jsSidebar("Operators")}}
 
-A **function's `this` keyword** behaves a little differently in
-JavaScript compared to other languages. It also has some differences between [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) and non-strict
-mode.
+A function's **`this` keyword** behaves a little differently in JavaScript compared to other languages. It also has some differences between [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) and non-strict mode.
 
 In most cases, the value of `this` is determined by how a function is called (runtime binding). It can't be set by assignment during execution, and it may be different each time the function is called. The {{jsxref("Function.prototype.bind()", "bind()")}} method can [set the value of a function's `this` regardless of how it's called](#the_bind_method), and [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) don't provide their own `this` binding (it retains the `this` value of the enclosing lexical context).
 
@@ -29,239 +27,140 @@ this
 
 ### Value
 
-A property of an execution context (global, function or eval) that, in non–strict mode,
-is always a reference to an object and in strict mode can be any value.
+In non–strict mode, `this` is always a reference to an object. In strict mode, it can be any value. For more information on how the value is determined, see the description below.
 
 ## Description
 
-### Global context
-
-In the global execution context (outside of any function), `this` refers to
-the global object whether in strict mode or not.
-
-```js
-// In web browsers, the window object is also the global object:
-console.log(this === window); // true
-
-a = 37;
-console.log(window.a); // 37
-
-this.b = "MDN";
-console.log(window.b)  // "MDN"
-console.log(b)         // "MDN"
-```
-
-> **Note:** You can always easily get the global object using the global
-> {{jsxref("globalThis")}} property, regardless of the current context in which your
-> code is running.
+The value of `this` depends on in which context it appears: function, class, or global.
 
 ### Function context
 
-Inside a function, the value of `this` depends on how the function is
-called.
+Inside a function, the value of `this` depends on how the function is called. Think about `this` as a hidden parameter of a function — just like the parameters declared in the function definition, `this` is a binding that the language creates for you when the function body is evaluated.
 
-Since the following code is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), and because
-the value of `this` is not set by the call, `this` will default to
-the global object, which is {{domxref("Window", "window")}} in a browser.
+For a typical function, the value of `this` is the object that the function is accessed on. In other words, if the function call is the form `obj.f()`, then `this` refers to `obj`. For example:
 
 ```js
-function f1() {
+function getThis() {
   return this;
 }
 
-// In a browser:
-f1() === window; // true
+const obj1 = { name: "obj1" };
+const obj2 = { name: "obj2" };
 
-// In Node:
-f1() === globalThis; // true
+obj1.getThis = getThis;
+obj2.getThis = getThis;
+
+console.log(obj1.getThis()); // { name: 'obj1', getThis: [Function: getThis] }
+console.log(obj2.getThis()); // { name: 'obj2', getThis: [Function: getThis] }
 ```
 
-In strict mode, however, if the value of `this` is not set when entering an
-execution context, it remains as `undefined`, as shown in the following
-example:
+Note how the function is the same, but based on how it's invoked, the value of `this` is different. This is analogous to how function parameters work.
+
+The value of `this` is not the object that has the function as an own property, but the object that is used to call the function. You can prove this by calling a method of an object up in the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).
 
 ```js
-function f2() {
-  'use strict'; // see strict mode
+const obj3 = {
+  __proto__: obj1,
+  name: "obj3",
+};
+
+console.log(obj3.getThis()); // { name: 'obj3' }
+```
+
+The value of `this` always changes based on how a function is called, even when the function was defined on an object at creation:
+
+```js
+const obj4 = {
+  name: "obj4",
+  getThis() {
+    return this;
+  },
+};
+
+const obj5 = { name: "obj5" };
+
+obj5.getThis = obj4.getThis;
+console.log(obj5.getThis()); // { name: 'obj5', getThis: [Function: getThis] }
+```
+
+If the value that the method is accessed on is a primitive, `this` will be a primitive value as well — but only if the function is in strict mode.
+
+```js
+function getThisStrict() {
+  "use strict"; // Enter strict mode
   return this;
 }
 
-f2() === undefined; // true
+// Only for demonstration — you should not mutate built-in prototypes
+Number.prototype.getThis = getThisStrict;
+console.log(typeof (1).f()); // "number"
 ```
 
-> **Note:** In the second example, `this` should be
-> {{jsxref("undefined")}}, because `f2` was called directly and not as a method
-> or property of an object (e.g. `window.f2()`). This feature wasn't
-> implemented in some browsers when they first started to support [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode). As a result,
-> they incorrectly returned the `window` object.
-
-To set the value of `this` to a particular value when calling a function,
-use {{jsxref("Function.prototype.call()", "call()")}}, or
-{{jsxref("Function.prototype.apply()", "apply()")}} as in the examples below.
-
-### Class context
-
-The behavior of `this` in [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and functions is
-similar, since classes are functions under the hood. But there are some differences and
-caveats.
-
-Within a class constructor, `this` is a regular object. All non-static
-methods within the class are added to the prototype of `this`:
+If the function is called without being accessed on anything, `this` will be `undefined` — but only if the function is in strict mode.
 
 ```js
-class Example {
-  constructor() {
-    const proto = Object.getPrototypeOf(this);
-    console.log(Object.getOwnPropertyNames(proto));
-  }
-  first(){}
-  second(){}
-  static third(){}
-}
-
-new Example(); // ['constructor', 'first', 'second']
+console.log(typeof getThisStrict()); // "undefined"
 ```
 
-> **Note:** Static methods are not properties of `this`. They
-> are properties of the class itself.
+In non-strict mode, a special process called [`this` substitution](/en-US/docs/Web/JavaScript/Reference/Strict_mode#no_this_substitution) ensures that the value of `this` is always an object. This means:
 
-### Derived classes
-
-Unlike base class constructors, derived constructors have no initial `this`
-binding. Calling {{jsxref("Operators/super", "super()")}} creates a `this`
-binding within the constructor and essentially has the effect of evaluating the
-following line of code, where Base is the inherited class:
+- If a function is called with `this` set to `undefined` or `null`, `this` gets substituted with {{jsxref("globalThis")}}.
+- If the function is called with `this` set to a primitive value, `this` gets substituted with the primitive value's wrapper object.
 
 ```js
-this = new Base();
+function getThis() {
+  return this;
+}
+
+// Only for demonstration — you should not mutate built-in prototypes
+Number.prototype.getThis = getThis;
+console.log(typeof (1).getThis()); // "object"
+console.log(getThis() === globalThis); // true
 ```
 
-> **Warning:** Referring to `this` before calling
-> `super()` will throw an error.
+In typical function calls, `this` is implicitly passed like a parameter through the function's prefix (the part before the dot). You can also explicitly set the value of `this` using the {{jsxref("Function.prototype.call()")}}, {{jsxref("Function.prototype.apply()")}}, or {{jsxref("Reflect.apply()")}} methods. You can also use the {{jsxref("Function.prototype.bind()")}} method to create a new function with a specific value of `this` that doesn't change regardless of how the function is called. When using these methods, the `this` substitution rules above still apply if the function is non-strict.
 
-Derived classes must not return before calling `super()`, unless they return
-an `Object` or have no constructor at all.
+#### Callbacks
+
+When a function is passed as a callback, the value of `this` depends on how the callback is called, which is determined by the implementor of the API. Callbacks are _typically_ called with a `this` value of `undefined` (calling it directly without attaching it to any object), which means if the function is non–strict, the value of `this` is the global object ({{jsxref("globalThis")}}). This is the case for [iterative array methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods), the [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor, [`setTimeout()`](/en-US/docs/Web/API/setTimeout), etc.
 
 ```js
-class Base {}
-class Good extends Base {}
-class AlsoGood extends Base {
-  constructor() {
-    return {a: 5};
-  }
-}
-class Bad extends Base {
-  constructor() {}
+function logThis() {
+  "use strict";
+  console.log(this);
 }
 
-new Good();
-new AlsoGood();
-new Bad(); // ReferenceError
+[1, 2, 3].forEach(logThis); // undefined, undefined, undefined
+setTimeout(logThis, 1000); // undefined
 ```
 
-## Examples
-
-### this in function contexts
+Some APIs allow you to set a `this` value for invocations of the callback. For example, all iterative array methods and related ones like {{jsxref("Set.prototype.forEach()")}} accept an optional `thisArg` parameter.
 
 ```js
-// An object can be passed as the first argument to call
-// or apply and this will be bound to it.
-const obj = { a: 'Custom' };
-
-// Variables declared with var become properties of the global object.
-var a = 'Global';
-
-function whatsThis() {
-  return this.a;  // The value of this is dependent on how the function is called
-}
-
-whatsThis();          // 'Global' as this in the function isn't set, so it defaults to the global/window object in non–strict mode
-whatsThis.call(obj);  // 'Custom' as this in the function is set to obj
-whatsThis.apply(obj); // 'Custom' as this in the function is set to obj
+[1, 2, 3].forEach(logThis, { name: "obj" });
+// { name: 'obj' }, { name: 'obj' }, { name: 'obj' }
 ```
 
-### this and object conversion
+Occasionally, a callback is called with `this` value other than `undefined`. For example, the `reviver` parameter of {{jsxref("JSON.parse()")}} and the `replacer` parameter of {{jsxref("JSON.stringify()")}} are both called with `this` set to the object that the property being parsed/serialized belongs to.
 
-```js
-function add(c, d) {
-  return this.a + this.b + c + d;
-}
+#### Arrow functions
 
-const o = { a: 1, b: 3 };
+In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `this` retains the value of the enclosing lexical context's `this`. In other words, when evaluating an arrow function's body, the language does not create a new `this` binding.
 
-// The first parameter is the object to use as
-// 'this', subsequent parameters are passed as
-// arguments in the function call
-add.call(o, 5, 7); // 16
-
-// The first parameter is the object to use as
-// 'this', the second is an array whose
-// members are used as the arguments in the function call
-add.apply(o, [10, 20]); // 34
-```
-
-Note that in non–strict mode, with `call` and `apply`, if the
-value passed as `this` is not an object, an attempt will be made to convert
-it to an object. Values `null` and `undefined` become the global
-object. Primitives like `7` or `'foo'` will be converted to an
-Object using the related constructor, so the primitive number `7` is
-converted to an object as if by `new Number(7)` and the string
-`'foo'` to an object as if by `new String('foo')`, e.g.
-
-```js
-function bar() {
-  console.log(Object.prototype.toString.call(this));
-}
-
-bar.call(7);     // [object Number]
-bar.call('foo'); // [object String]
-bar.call(undefined); // [object global]
-```
-
-### The bind() method
-
-ECMAScript 5 introduced {{jsxref("Function.prototype.bind()")}}. Calling
-`f.bind(someObject)` creates a new function with the same body and scope as
-`f`, but where `this` occurs in the original function, in the new
-function it is permanently bound to the first argument of `bind`, regardless
-of how the function is being used.
-
-```js
-function f() {
-  return this.a;
-}
-
-const g = f.bind({ a: 'azerty' });
-console.log(g()); // azerty
-
-const h = g.bind({ a: 'yoo' }); // bind only works once!
-console.log(h()); // azerty
-
-const o = { a: 37, f, g, h };
-console.log(o.a, o.f(), o.g(), o.h()); // 37,37, azerty, azerty
-```
-
-### Arrow functions
-
-In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
-`this` retains the value of the enclosing lexical context's `this`.
-In global code, it will be set to the global object:
+For example, in global code, `this` is always `globalThis` regardless of strictness, because of the [global context](#global_context) binding:
 
 ```js
 const globalObject = this;
-const foo = (() => this);
+const foo = () => this;
 console.log(foo() === globalObject); // true
 ```
 
-> **Note:** If `this` arg is passed to `call`, `bind`, or
-> `apply` on invocation of an arrow function it will be ignored. You can
-> still prepend arguments to the call, but the first argument (`thisArg`)
-> should be set to `null`.
+Arrow functions create a [closure](/en-US/docs/Web/JavaScript/Closures) over the `this` value of its surrounding scope, which means arrow functions behave as if they are "auto-bound" — no matter how it's invoked, `this` is set to what it was when the function was created (in the example above, the global object). The same applies to arrow functions created inside other functions: their `this` remains that of the enclosing lexical context. [See example below](#this_in_arrow_functions).
+
+Furthermore, when invoking arrow functions using `call()`, `bind()`, or `apply()`, the `thisArg` parameter is ignored. You can still pass other arguments using these methods, though.
 
 ```js
-// Call as a method of an object
-const obj = { func: foo };
-console.log(obj.func() === globalObject); // true
+const obj = { name: "obj" };
 
 // Attempt to set this using call
 console.log(foo.call(obj) === globalObject); // true
@@ -271,191 +170,11 @@ const boundFoo = foo.bind(obj);
 console.log(boundFoo() === globalObject); // true
 ```
 
-No matter what, `foo`'s `this` is set to what it was when it was
-created (in the example above, the global object). The same applies to arrow functions
-created inside other functions: their `this` remains that of the enclosing
-lexical context.
+#### Constructors
+
+When a function is used as a constructor (with the {{jsxref("Operators/new", "new")}} keyword), its `this` is bound to the new object being constructed, no matter which object the constructor function is accessed on. The value of `this` becomes the value of the `new` expression unless the constructor returns another non–primitive value.
 
 ```js
-// Create obj with a method bar that returns a function that
-// returns its this. The returned function is created as
-// an arrow function, so its this is permanently bound to the
-// this of its enclosing function. The value of bar can be set
-// in the call, which in turn sets the value of the
-// returned function.
-// Note: the `bar()` syntax is equivalent to `bar: function ()`
-// in this context
-const obj = {
-  bar() {
-    const x = (() => this);
-    return x;
-  }
-};
-
-// Call bar as a method of obj, setting its this to obj
-// Assign a reference to the returned function to fn
-const fn = obj.bar();
-
-// Call fn without setting this, would normally default
-// to the global object or undefined in strict mode
-console.log(fn() === obj); // true
-
-// But caution if you reference the method of obj without calling it
-const fn2 = obj.bar;
-// Calling the arrow function's this from inside the bar method()
-// will now return window, because it follows the this from fn2.
-console.log(fn2()() === window); // true
-```
-
-In the above, the function (call it anonymous function A) assigned to
-`obj.bar` returns another function (call it anonymous function B) that is
-created as an arrow function. As a result, function B's `this` is permanently
-set to the `this` of `obj.bar` (function A) when called. When the
-returned function (function B) is called, its `this` will always be what it
-was set to initially. In the above code example, function B's `this` is set
-to function A's `this` which is `obj`, so it remains set to
-`obj` even when called in a manner that would normally set its
-`this` to `undefined` or the global object (or any other method as
-in the previous example in the global execution context).
-
-### As an object method
-
-When a function is called as a method of an object, its `this` is set to the
-object the method is called on.
-
-In the following example, when `o.f()` is invoked, inside the function
-`this` is bound to the `o` object.
-
-```js
-const o = {
-  prop: 37,
-  f() {
-    return this.prop;
-  }
-};
-
-console.log(o.f()); // 37
-```
-
-Note that this behavior is not at all affected by how or where the function was
-defined. In the previous example, we defined the function inline as the `f`
-member during the definition of `o`. However, we could have just as easily
-defined the function first and later attached it to `o.f`. Doing so results
-in the same behavior:
-
-```js
-const o = { prop: 37 };
-
-function independent() {
-  return this.prop;
-}
-
-o.f = independent;
-
-console.log(o.f()); // 37
-```
-
-This demonstrates that it matters only that the function was invoked from the
-`f` member of `o`.
-
-Similarly, the `this` binding is only affected by the most immediate member
-reference. In the following example, when we invoke the function, we call it as a method
-`g` of the object `o.b`. This time during execution,
-`this` inside the function will refer to `o.b`. The fact that the
-object is itself a member of `o` has no consequence; the most immediate
-reference is all that matters.
-
-```js
-o.b = { g: independent, prop: 42 };
-console.log(o.b.g()); // 42
-```
-
-#### this on the object's prototype chain
-
-The same notion holds true for methods defined somewhere on the object's prototype
-chain. If the method is on an object's prototype chain, `this` refers to the
-object the method was called on, as if the method were on the object.
-
-```js
-const o = {
-  f() {
-    return this.a + this.b;
-  },
-};
-const p = Object.create(o);
-p.a = 1;
-p.b = 4;
-
-console.log(p.f()); // 5
-```
-
-In this example, the object assigned to the variable `p` doesn't have its
-own `f` property, it inherits it from its prototype. But it doesn't matter
-that the lookup for `f` eventually finds a member with that name on
-`o`; the lookup began as a reference to `p.f`, so
-`this` inside the function takes the value of the object referred to as
-`p`. That is, since `f` is called as a method of `p`,
-its `this` refers to `p`. This is an interesting feature of
-JavaScript's prototype inheritance.
-
-#### this with a getter or setter
-
-Again, the same notion holds true when a function is invoked from a getter or a setter.
-A function used as getter or setter has its `this` bound to the object from
-which the property is being set or gotten.
-
-```js
-function sum() {
-  return this.a + this.b + this.c;
-}
-
-const o = {
-  a: 1,
-  b: 2,
-  c: 3,
-  get average() {
-    return (this.a + this.b + this.c) / 3;
-  }
-};
-
-Object.defineProperty(o, 'sum', {
-  get: sum,
-  enumerable: true,
-  configurable: true,
-});
-
-console.log(o.average, o.sum); // 2, 6
-```
-
-### As a constructor
-
-When a function is used as a constructor (with the {{jsxref("Operators/new", "new")}}
-keyword), its `this` is bound to the new object being constructed.
-
-> **Note:** While the default for a constructor is to return the object referenced by
-> `this`, it can instead return some other object (if the return value isn't
-> an object, then the `this` object is returned).
-
-```js
-/*
- * Constructors work like this:
- *
- * function MyConstructor() {
- *   // Actual function body code goes here.
- *   // Create properties on `this` as
- *   // desired by assigning to them, for example,
- *   this.fum = "nom";
- *   // et cetera...
- *
- *   // If the function has a return statement that
- *   // returns an object, that object will be the
- *   // result of the `new` expression. Otherwise,
- *   // the result of the expression is the object
- *   // currently bound to `this`
- *   // (i.e., the common case most usually seen).
- * }
- */
-
 function C() {
   this.a = 37;
 }
@@ -472,17 +191,237 @@ o = new C2();
 console.log(o.a); // 38
 ```
 
-In the last example (`C2`), because an object was returned during
-construction, the new object that `this` was bound to gets discarded. (This
-essentially makes the statement `this.a = 37;` dead code. It's not exactly
-dead because it gets executed, but it can be eliminated with no outside effects.)
+In the second example (`C2`), because an object was returned during construction, the new object that `this` was bound to gets discarded. (This essentially makes the statement `this.a = 37;` dead code. It's not exactly dead because it gets executed, but it can be eliminated with no outside effects.)
+
+### Class context
+
+A [class](/en-US/docs/Web/JavaScript/Reference/Classes) can be split into two contexts: static and instance. [Constructors](/en-US/docs/Web/JavaScript/Reference/Classes/constructor), methods, and instance field initializers ([public](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) or [private](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)) belong to the instance context. [Static](/en-US/docs/Web/JavaScript/Reference/Classes/static) methods, static field initializers, and [static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks) belong to the static context. The `this` value is different in each context.
+
+Class constructors are always called with `new`, so their behavior is the same as [function constructors](#constructors): the `this` value is the new instance being created. Class methods behave like methods in object literals — the `this` value is the object that the method was accessed on. If the method is not transferred to another object, `this` is generally an instance of the class.
+
+Static methods are not properties of `this`. They are properties of the class itself. Therefore, they are generally accessed on the class, and `this` is the value of the class (or a subclass). Static initialization blocks are also evaluated with `this` set to the current class.
+
+Field initializers are also evaluated in the context of the class. Instance fields are evaluated with `this` set to the instance being constructed. Static fields are evaluated with `this` set to the current class. This is why arrow functions in field initializers are [bound to the class](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cannot_be_used_as_methods).
+
+```js
+class C {
+  instanceField = this;
+  static staticField = this;
+}
+
+const c = new C();
+console.log(c.instanceField === c); // true
+console.log(C.staticField === C); // true
+```
+
+#### Derived class constructors
+
+Unlike base class constructors, derived constructors have no initial `this` binding. Calling {{jsxref("Operators/super", "super()")}} creates a `this` binding within the constructor and essentially has the effect of evaluating the following line of code, where `Base` is the base class:
+
+```js
+this = new Base();
+```
+
+> **Warning:** Referring to `this` before calling `super()` will throw an error.
+
+Derived classes must not return before calling `super()`, unless the constructor returns an object (so the `this` value is overridden) or the class has no constructor at all.
+
+```js
+class Base {}
+class Good extends Base {}
+class AlsoGood extends Base {
+  constructor() {
+    return { a: 5 };
+  }
+}
+class Bad extends Base {
+  constructor() {}
+}
+
+new Good();
+new AlsoGood();
+new Bad(); // ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor
+```
+
+### Global context
+
+In the global execution context (outside of any functions or classes; may be inside [blocks](/en-US/docs/Web/JavaScript/Reference/Statements/block) or [arrow functions](#arrow_functions) defined in the global scope), the `this` value depends on what execution context the script runs in. Like [callbacks](#callbacks), the `this` value is determined by the runtime environment (the caller).
+
+At the top level of a script, `this` refers to {{jsxref("globalThis")}} whether in strict mode or not. This is generally the same as the global object — for example, if the source is put inside an HTML [`<script>`](/en-US/docs/Web/HTML/Element/script) element and executed as a script, `this === window`.
+
+> **Note:** `globalThis` is generally the same concept as the global object (i.e. adding properties to `globalThis` makes them global variables) — this is the case for browsers and Node — but hosts are allowed to provide a different value for `globalThis` that's unrelated to the global object.
+
+```js
+// In web browsers, the window object is also the global object:
+console.log(this === window); // true
+
+this.b = "MDN";
+console.log(window.b); // "MDN"
+console.log(b); // "MDN"
+```
+
+If the source is loaded as a [module](/en-US/docs/Web/JavaScript/Guide/Modules) (for HTML, this means adding `type="module"` to the `<script>` tag), `this` is always `undefined` at the top level — this behavior is specified by the language.
+
+If the source is executed with [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval), `this` is the same as the enclosing context for direct eval, or `globalThis` (as if it's run in a separate global script) for indirect eval.
+
+```js
+function test() {
+  // Direct eval
+  console.log(eval("this") === this);
+  // Indirect eval, non-strict
+  console.log(eval?.("this") === globalThis);
+  // Indirect eval, strict
+  console.log(eval?.("'use strict'; this") === globalThis);
+}
+
+test.call({ name: "obj" }); // Logs 3 "true"
+```
+
+Note that some source code, while looking like the global scope, is actually wrapped in a function when executed. For example, Node.js CommonJS modules are wrapped in a function and executed with the `this` value set to `module.exports`. [Event handler attributes](#this_in_inline_event_handlers) are executed with `this` set to the element they are attached to.
+
+Object literals don't create a `this` scope — only functions (methods) defined within the object do. Using `this` in an object literal inherits the value from the surrounding scope.
+
+```js
+const obj = {
+  a: this,
+};
+
+console.log(obj.a === window); // true
+```
+
+## Examples
+
+### this in function contexts
+
+The value of `this` depends on how the function is called, not how it's defined.
+
+```js
+// An object can be passed as the first argument to call
+// or apply and this will be bound to it.
+const obj = { a: "Custom" };
+
+// Variables declared with var become properties of the global object.
+var a = "Global";
+
+function whatsThis() {
+  return this.a; // The value of this is dependent on how the function is called
+}
+
+whatsThis(); // 'Global'; this in the function isn't set, so it defaults to the global/window object in non–strict mode
+obj.whatsThis = whatsThis;
+obj.whatsThis(); // 'Custom'; this in the function is set to obj
+```
+
+Using `call()` and `apply()`, you can pass the value of `this` as if it's an actual parameter.
+
+```js
+function add(c, d) {
+  return this.a + this.b + c + d;
+}
+
+const o = { a: 1, b: 3 };
+
+// The first parameter is the object to use as 'this'; subsequent
+// parameters are used as arguments in the function call
+add.call(o, 5, 7); // 16
+
+// The first parameter is the object to use as 'this', the second is an
+// array whose members are used as arguments in the function call
+add.apply(o, [10, 20]); // 34
+```
+
+### this and object conversion
+
+In non–strict mode, if a function is called with a `this` value that's not an object, the `this` value is substituted with an object. `null` and `undefined` become `globalThis`. Primitives like `7` or `'foo'` are converted to an object using the related constructor, so the primitive number `7` is converted to a {{jsxref("Number")}} wrapper class and the string `'foo'` to a {{jsxref("String")}} wrapper class.
+
+```js
+function bar() {
+  console.log(Object.prototype.toString.call(this));
+}
+
+bar.call(7); // [object Number]
+bar.call("foo"); // [object String]
+bar.call(undefined); // [object Window]
+```
+
+### The bind() method
+
+Calling [`f.bind(someObject)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) creates a new function with the same body and scope as `f`, but the value of `this` is permanently bound to the first argument of `bind`, regardless of how the function is being called.
+
+```js
+function f() {
+  return this.a;
+}
+
+const g = f.bind({ a: "azerty" });
+console.log(g()); // azerty
+
+const h = g.bind({ a: "yoo" }); // bind only works once!
+console.log(h()); // azerty
+
+const o = { a: 37, f, g, h };
+console.log(o.a, o.f(), o.g(), o.h()); // 37,37, azerty, azerty
+```
+
+### this in arrow functions
+
+Arrow functions create closures over the `this` value of the enclosing execution context. In the following example, we create `obj` with a method `getThisGetter` that returns a function that returns the value of `this`. The returned function is created as an arrow function, so its `this` is permanently bound to the `this` of its enclosing function. The value of `this` inside `getThisGetter` can be set in the call, which in turn sets the return value of the returned function.
+
+```js
+const obj = {
+  getThisGetter() {
+    const getter = () => this;
+    return getter;
+  },
+};
+```
+
+We can call `getThisGetter` as a method of `obj`, which sets `this` inside the body to `obj`. The returned function is assigned to a variable `fn`. Now, when calling `fn`, the value of `this` returned is still the one set by the call to `getThisGetter`, which is `obj`. If the returned function is not an arrow function, such calls would cause the `this` value to be `globalThis` or `undefined` in strict mode.
+
+```js
+const fn = obj.getThisGetter();
+console.log(fn() === obj); // true
+```
+
+But caution if you unbind the method of `obj` without calling it, because `getThisGetter` is still a method that has varying `this` value. Calling `fn2()()` in the following example returns `globalThis`, because it follows the `this` from `fn2`, which is `globalThis` since it's called without being attached to any object.
+
+```js
+const fn2 = obj.getThisGetter;
+console.log(fn2()() === globalThis); // true
+```
+
+This behavior is very useful when defining callbacks. Usually, each function expression creates its own `this` binding, which shadows the `this` value of the upper scope. Now, you can define functions as arrow functions if you don't care about the `this` value, and only create `this` bindings where you do (e.g. in class methods). See [example with `setTimeout()`](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#using_call_bind_and_apply).
+
+### this with a getter or setter
+
+`this` in getters and setters is based on which object the property is accessed on, not which object the property is defined on. A function used as getter or setter has its `this` bound to the object from which the property is being set or gotten.
+
+```js
+function sum() {
+  return this.a + this.b + this.c;
+}
+
+const o = {
+  a: 1,
+  b: 2,
+  c: 3,
+  get average() {
+    return (this.a + this.b + this.c) / 3;
+  },
+};
+
+Object.defineProperty(o, "sum", {
+  get: sum,
+  enumerable: true,
+  configurable: true,
+});
+
+console.log(o.average, o.sum); // 2, 6
+```
 
 ### As a DOM event handler
 
-When a function is used as an event handler, its `this` is set to the
-element on which the listener is placed (some browsers do not follow this convention for
-listeners added dynamically with methods other than
-{{domxref("EventTarget/addEventListener", "addEventListener()")}}).
+When a function is used as an event handler, its `this` is set to the element on which the listener is placed (some browsers do not follow this convention for listeners added dynamically with methods other than {{domxref("EventTarget/addEventListener", "addEventListener()")}}).
 
 ```js
 // When called as a listener, turns the related element blue
@@ -491,32 +430,28 @@ function bluify(e) {
   console.log(this === e.currentTarget);
   // true when currentTarget and target are the same object
   console.log(this === e.target);
-  this.style.backgroundColor = '#A5D9F3';
+  this.style.backgroundColor = "#A5D9F3";
 }
 
 // Get a list of every element in the document
-const elements = document.getElementsByTagName('*');
+const elements = document.getElementsByTagName("*");
 
 // Add bluify as a click listener so when the
 // element is clicked on, it turns blue
 for (const element of elements) {
-  element.addEventListener('click', bluify, false);
+  element.addEventListener("click", bluify, false);
 }
 ```
 
-### In an inline event handler
+### this in inline event handlers
 
-When the code is called from an inline [on-event handler](/en-US/docs/Web/Events/Event_handlers),
-its `this` is set to the DOM element on which the listener is placed:
+When the code is called from an inline [event handler attribute](/en-US/docs/Web/HTML/Attributes#event_handler_attributes), its `this` is set to the DOM element on which the listener is placed:
 
 ```html
-<button onclick="alert(this.tagName.toLowerCase());">
-  Show this
-</button>
+<button onclick="alert(this.tagName.toLowerCase());">Show this</button>
 ```
 
-The above alert shows `button`. Note however that only the outer code has
-its `this` set this way:
+The above alert shows `button`. Note, however, that only the outer code has its `this` set this way:
 
 ```html
 <button onclick="alert((function () { return this; })());">
@@ -524,16 +459,11 @@ its `this` set this way:
 </button>
 ```
 
-In this case, the inner function's `this` isn't set so it returns the
-global/window object (i.e. the default object in non–strict mode where `this`
-isn't set by the call).
+In this case, the inner function's `this` isn't set, so it returns the global/window object (i.e. the default object in non–strict mode where `this` isn't set by the call).
 
-### this in classes
+### Bound methods in classes
 
-Just like with regular functions, the value of `this` within methods depends
-on how they are called. Sometimes it is useful to override this behavior so that
-`this` within classes always refers to the class instance. To achieve this,
-bind the class methods in the constructor:
+Just like with regular functions, the value of `this` within methods depends on how they are called. Sometimes it is useful to override this behavior so that `this` within classes always refers to the class instance. To achieve this, bind the class methods in the constructor:
 
 ```js
 class Car {
@@ -548,13 +478,13 @@ class Car {
     console.log(`Bye from ${this.name}`);
   }
   get name() {
-    return 'Ferrari';
+    return "Ferrari";
   }
 }
 
 class Bird {
   get name() {
-    return 'Tweety';
+    return "Tweety";
   }
 }
 
@@ -568,11 +498,28 @@ bird.sayHi(); // Hello from Tweety
 
 // For bound methods, 'this' doesn't depend on the caller
 bird.sayBye = car.sayBye;
-bird.sayBye();  // Bye from Ferrari
+bird.sayBye(); // Bye from Ferrari
 ```
 
-> **Note:** Classes are always strict mode code. Calling methods with an
-> undefined `this` will throw an error.
+> **Note:** Classes are always strict mode code. Calling methods with an undefined `this` will throw an error if the method tries to access properties on `this`.
+
+Note, however, that auto-bound methods suffer from the same problem as [using arrow functions for class properties](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cannot_be_used_as_methods): each instance of the class will have its own copy of the method, which increases memory usage. Only use it where absolutely necessary. You can also mimic the implementation of [`Intl.NumberFormat.prototype.format()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format#using_format_with_map): define the property as a getter that returns a bound function when accessed and saves it, so that the function is only created once and only created when necessary.
+
+### this in with statements
+
+Although [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) statements are deprecated and not available in strict mode, they still serve as an exception to the normal `this` binding rules. If a function is called within a `with` statement and that function is a property of the scope object, the `this` value is set to the scope object, as if the `obj1.` prefix exists.
+
+```js
+const obj1 = {
+  foo() {
+    return this;
+  },
+};
+
+with (obj1) {
+  console.log(foo() === obj1); // true
+}
+```
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As it appears, the `this` document is slightly confusing and underexplained in certain places (though not a lot). Decided to add more information about function scoping. May prepare us for https://github.com/mdn/content/issues/5006

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
