### PR TITLE
Glossary reference fix

### DIFF
--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.-webkit-line-clamp
 
 {{CSSRef}}
 
-The **`-webkit-line-clamp`** CSS property allows limiting of the contents of a {{Glossary("block container")}} to the specified number of lines.
+The **`-webkit-line-clamp`** CSS property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
 
 It only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("-webkit-box-orient")}} property set to `vertical`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
'block container' does not exist. Fixed reference to point towards 'block' instead.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Additional details
MDN web docs are incredible. Thanks for all the work you all do maintaining and developing this project. 
