### PR TITLE
Add an attribute 'type="button"' in the example

### DIFF
--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -150,7 +150,7 @@ Consider this HTML:
   multiple
   accept="image/*"
   style="display:none" />
-<button id="fileSelect">Select some files</button>
+<button id="fileSelect" type="button">Select some files</button>
 ```
 
 The code that handles the `click` event can look like this:


### PR DESCRIPTION
Add the attribute In order to avoid immediate 'submit'.

Note that a default value of a 'type' attribute in a 'button' element is 'submit' (cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example might cause an immediate 'submit'.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Improve the example and make it work.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
