### PR TITLE
Add/correct MathML sidebars

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -6,7 +6,9 @@ tags:
   - MathML Reference
 ---
 
-{{MathMLRef}}
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
 
 This is an alphabetical list of MathML attributes. More details for each attribute are available on relevant [MathML element pages](/en-US/docs/Web/MathML/Element) and on the [global attributes page](/en-US/docs/Web/MathML/Global_attributes). The [values](/en-US/docs/Web/MathML/Attribute/Values) page also describes some notes on common values used by MathML attributes.
 

--- a/files/en-us/web/mathml/attribute/values/index.md
+++ b/files/en-us/web/mathml/attribute/values/index.md
@@ -8,7 +8,9 @@ tags:
 browser-compat: mathml.attribute_values
 ---
 
-{{MathMLRef}}
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
 
 ## MathML-specific types
 

--- a/files/en-us/web/mathml/authoring/index.md
+++ b/files/en-us/web/mathml/authoring/index.md
@@ -7,7 +7,9 @@ tags:
   - MathML Project
 ---
 
-{{MathMLRef}}
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
 
 This page explains how to write mathematics using the MathML language, which is described with tags and attributes in text format. Just like for HTML or SVG, this text can become very verbose for complex content and so requires [proper authoring tools](https://www.w3.org/wiki/Math_Tools#Authoring_tools) such as converters from a [lightweight markup language](https://en.wikipedia.org/wiki/Lightweight_markup_language) or [WYSIWYG](https://en.wikipedia.org/wiki/WYSIWYG) equation editors. Many such tools are available and it is impossible to provide an exhaustive list. Instead, this article focuses on common approaches and examples.
 
@@ -227,7 +229,7 @@ After running that command, a file `output.html` containing the following HTML o
 </html>
 ```
 
-There are more sophisticated tools that aim at converting an arbitrary LaTeX document into a document with MathML content. For example, using [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) the following commands will convert `foo.tex` into a HTML or EPUB document:
+There are more sophisticated tools that aim at converting an arbitrary LaTeX document into a document with MathML content. For example, using [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) the following commands will convert `foo.tex` into an HTML or EPUB document:
 
 ```bash
 latexmlc --dest foo.html foo.tex # Generate a HTML document foo.html

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -6,7 +6,9 @@ tags:
   - MathML Reference
 ---
 
-{{MathMLRef}}
+<section id="Quick_links">
+  {{MathMLRef}}
+</section>
 
 This is an alphabetical list of MathML elements. All of them implement the {{domxref("MathMLElement")}} class.
 

--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -11,6 +11,8 @@ tags:
   - NeedsBeginnerUpdate
 ---
 
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Examples")}}
+
 This page outlines the derivation of the [Quadratic Formula](https://en.wikipedia.org/wiki/Quadratic_formula).
 
 We take a quadratic equation in its general form, and solve for x:

--- a/files/en-us/web/mathml/examples/index.md
+++ b/files/en-us/web/mathml/examples/index.md
@@ -8,6 +8,10 @@ tags:
   - MathML
 ---
 
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
+
 Below you'll find some examples you can look at to help you to understand how to use MathML.
 
 ## MathML formulas

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -11,6 +11,8 @@ tags:
   - NeedsBeginnerUpdate
 ---
 
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Examples")}}
+
 We will now prove the [Pythagorean theorem](https://en.wikipedia.org/wiki/Pythagorean_theorem):
 
 **Statement**: In a right triangle, the square of the hypotenuse is equal to

--- a/files/en-us/web/mathml/fonts/index.md
+++ b/files/en-us/web/mathml/fonts/index.md
@@ -7,6 +7,10 @@ tags:
   - Project
 ---
 
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
+
 Fonts with appropriate Unicode coverage and Open Font Format features are required for good math rendering.
 This page describes how users can install such math fonts to properly display MathML in browsers.
 
@@ -35,7 +39,7 @@ Install the _Latin Modern Math_ font as follows:
 2. Extract the ZIP archive, move inside the `latinmodern-math-1959` directory and then inside the `otf` directory. You will find a `latinmodern-math` font file.
 3. Double-click the `latinmodern-math` font file click the **Install font** button from the window that opens.
 
-> **Note:** If you are using macOS Ventura (version 13) or higher then _STIX Two Math_ is already pre-installed and you can skip the steps below.
+> **Note:** If you are using macOS Ventura (version 13) or higher, then _STIX Two Math_ is already pre-installed and you can skip the steps below.
 
 Install the _STIX Two Math_ font as follows:
 

--- a/files/en-us/web/mathml/global_attributes/dir/index.md
+++ b/files/en-us/web/mathml/global_attributes/dir/index.md
@@ -8,7 +8,7 @@ tags:
 browser-compat: mathml.global_attributes.dir
 ---
 
-{{MathMLRef("Global_attributes")}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
 
 The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that indicates the directionality of the MathML element.
 
@@ -49,7 +49,7 @@ The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an
 >
 > - This attribute can be overridden by the CSS property {{ cssxref("direction") }}, if a CSS page is active and the element supports these properties.
 > - As the directionality of mathematics is semantically related to its content and not to its presentation, it is recommended that web developers use this attribute instead of the related CSS properties when possible. That way, the formulas will display correctly even on a browser that doesn't support CSS or has the CSS deactivated.
-> - The `dir` attribute is used to set the directionality of math formulas, which is often from right to left in Arabic speaking world. However, languages written from right to left often embed mathematical content written from left to right. Consequently, the `auto` keyword from the HTML `dir` attribute is not recognized and by default the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) resets the direction property on the [`math`](/en-US/docs/Web/MathML/Element/math) element.
+> - The `dir` attribute is used to set the directionality of math formulas, which is often from right to left in Arabic-speaking world. However, languages written from right to left often embed mathematical content written from left to right. Consequently, the `auto` keyword from the HTML `dir` attribute is not recognized and by default the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) resets the direction property on the [`math`](/en-US/docs/Web/MathML/Element/math) element.
 
 ## Specifications
 

--- a/files/en-us/web/mathml/global_attributes/displaystyle/index.md
+++ b/files/en-us/web/mathml/global_attributes/displaystyle/index.md
@@ -8,7 +8,7 @@ tags:
 browser-compat: mathml.global_attributes.displaystyle
 ---
 
-{{MathMLRef("Global_attributes")}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
 
 The **`displaystyle`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is a boolean setting the [math-style](/en-US/docs/Web/CSS/math-style) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/href/index.md
+++ b/files/en-us/web/mathml/global_attributes/href/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: mathml.global_attributes.href
 ---
 
-{{MathMLRef("Global_attributes")}}{{Non-standard_header}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Non-standard_header}}
 
 The **`href`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) creates a hyperlink on the MathML element pointing to the specified URL.
 

--- a/files/en-us/web/mathml/global_attributes/index.md
+++ b/files/en-us/web/mathml/global_attributes/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: mathml.global_attributes
 ---
 
-{{MathMLRef}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
 
 **Global attributes** are attributes common to all MathML elements; they can be used on all elements, though they may have no effect on some elements.
 
@@ -23,7 +23,7 @@ In addition to the basic MathML global attributes, the following global attribut
 ## List of global attributes
 
 - [`class`](/en-US/docs/Web/HTML/Global_attributes/class)
-  - : A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the method {{DOMxRef("Document.getElementsByClassName()")}}.
+  - : A space-separated list of the classes of the element. Classes allow CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the method {{DOMxRef("Document.getElementsByClassName()")}}.
 - [`data-*`](/en-US/docs/Web/HTML/Global_attributes/data-*)
   - : Forms a class of attributes, called custom data attributes, that allow proprietary information to be exchanged between the [MathML](/en-US/docs/Web/MathML) and its {{glossary("DOM")}} representation that may be used by scripts. All such custom data are available via the {{DOMxRef("MathMLElement")}} interface of the element the attribute is set on. The {{DOMxRef("HTMLElement.dataset")}} property gives access to them.
 - [`dir`](/en-US/docs/Web/MathML/Global_attributes/dir)
@@ -61,7 +61,7 @@ In addition to the basic MathML global attributes, the following global attribut
 
 - [`nonce`](/en-US/docs/Web/HTML/Global_attributes/nonce)
 
-  - : A cryptographic nonce ("number used once") which can be used by [Content Security Policy](/en-US/docs/Web/HTTP/CSP) to determine whether or not a given fetch will be allowed to proceed.
+  - : A cryptographic nonce ("number used once") which can be used by [Content Security Policy](/en-US/docs/Web/HTTP/CSP) to determine whether a given fetch will be allowed to proceed.
 
 - [`scriptlevel`](/en-US/docs/Web/MathML/Global_attributes/scriptlevel)
 

--- a/files/en-us/web/mathml/global_attributes/mathbackground/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathbackground/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: mathml.global_attributes.mathbackground
 ---
 
-{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathbackground`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [background-color](/en-US/docs/Web/CSS/background-color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathcolor/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathcolor/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: mathml.global_attributes.mathcolor
 ---
 
-{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathcolor`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [color](/en-US/docs/Web/CSS/color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -9,7 +9,7 @@ tags:
 browser-compat: mathml.global_attributes.mathsize
 ---
 
-{{MathMLRef("Global_attributes")}}{{Deprecated_Header}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
 
 The **`mathsize`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [font-size](/en-US/docs/Web/CSS/font-size) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathvariant/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathvariant/index.md
@@ -8,11 +8,11 @@ tags:
 browser-compat: mathml.global_attributes.mathvariant
 ---
 
-{{MathMLRef("Global_attributes")}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
 
-The **`mathvariant`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) attribute sets a logical class for textual elements, which is visually
+The **`mathvariant`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets a logical class for textual elements, which is visually
 distinguished by using special [Mathematical Alphanumeric Symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols).
-With the exception of [`mi`](/en-US/docs/Web/MathML/Element/mi) elements with a single character,
+Except for [`mi`](/en-US/docs/Web/MathML/Element/mi) elements with a single character,
 which are by convention italic, no special classes are used by default.
 
 > **Note:** When possible, directly use [Mathematical Alphanumeric Symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols) instead of an explicit `mathvariant` attribute.
@@ -28,7 +28,7 @@ which are by convention italic, no special classes are used by default.
 <mtext mathvariant="italic">A</mtext>
 
 <!-- an italic "A" i.e. "𝐴"
-     (automatic italicization for mi elements with one character) -->
+     (automatic italicization for 'mi' elements with one character) -->
 <mi>A</mi>
 
 <!-- a normal "A" -->

--- a/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
+++ b/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
@@ -8,7 +8,7 @@ tags:
 browser-compat: mathml.global_attributes.scriptlevel
 ---
 
-{{MathMLRef("Global_attributes")}}
+{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
 
 The **`scriptlevel`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [math-depth](/en-US/docs/Web/CSS/math-depth) of a MathML element. It allows overriding rules from the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) that define automatic calculation of [font-size](/en-US/docs/Web/CSS/font-size) within MathML formulas.
 

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -10,7 +10,9 @@ tags:
 browser-compat: mathml.elements.math
 ---
 
-{{MathMLRef}}
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
+</section>
 
 **Mathematical Markup Language (MathML)** is an [XML](/en-US/docs/Web/XML)-based language for describing mathematical notation.
 


### PR DESCRIPTION
Some pages are missing sidebar.
Also, the `{{MathMLRef}}` macro use for root level documents is not appropriate. It's good for only element pages.