### PR TITLE
CSP [style|style]-src-[attr|elem] example fixes

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -17,11 +17,11 @@ browser-compat: http.headers.Content-Security-Policy.script-src-attr
 
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`script-src-attr`** directive specifies valid sources for
-JavaScript inline event handlers. This includes only inline script event handlers like
-`onclick`, but not URLs loaded directly into {{HTMLElement("script")}}
-elements.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-attr`** directive specifies valid sources for JavaScript inline event handlers.
+
+This directive only specifies valid sources for inline script event handlers like `onclick`.
+It does not apply to other JavaScript sources that can trigger script execution, such as URLs loaded directly into {{HTMLElement("script")}} elements and [XSLT stylesheets](/en-US/docs/Web/XSLT).
+(Valid sources can be specified for all JavaScript script sources using {{CSP("script-src")}}, or just for `<script>` elements using {{CSP("script-src-elem")}}.)
 
 <table class="properties">
   <tbody>
@@ -52,7 +52,7 @@ Content-Security-Policy: script-src-attr <source>;
 Content-Security-Policy: script-src-attr <source> <source>;
 ```
 
-`script-src-attr` can be used in conjunction with {{CSP("script-src")}}:
+`script-src-attr` can be used in conjunction with {{CSP("script-src")}}, and will override that directive for checks on inline handlers:
 
 ```http
 Content-Security-Policy: script-src <source>;
@@ -67,11 +67,25 @@ Note that this same set of values can be used in all {{Glossary("fetch directive
 
 ## Examples
 
-### Fallback to script-src
+### Violation case
 
-If `script-src-attr` is absent, User Agent falls back to
-the {{CSP("script-src")}} directive, and if that is absent as well, to
-{{CSP("default-src")}}.
+Given this CSP header:
+
+```http
+Content-Security-Policy: script-src-attr 'none'
+```
+
+the following inline event handler is blocked and won't be loaded or executed:
+
+```html
+<button id="btn" onclick="doSomething()"></button>
+```
+
+Note that generally you should replace inline event handlers with {{domxref("EventTarget.addEventListener", "addEventListener")}} calls:
+
+```js
+document.getElementById("btn").addEventListener("click", doSomething);
+```
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -75,7 +75,7 @@ Given this CSP header:
 Content-Security-Policy: script-src-attr 'none'
 ```
 
-the following inline event handler is blocked and won't be loaded or executed:
+…the following inline event handler is blocked and won't be loaded or executed:
 
 ```html
 <button id="btn" onclick="doSomething()"></button>

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -37,7 +37,7 @@ It does not apply to other JavaScript sources that can trigger script execution,
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
         Yes.
-        If this directive is absent, the user agent will look for the {{CSP("script-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
+        If this directive is absent, the user agent will look for the {{CSP("script-src")}} directive, and if both of them are absent, fall back to <code>default-src</code> directive.
       </td>
     </tr>
   </tbody>
@@ -75,7 +75,7 @@ Given this CSP header:
 Content-Security-Policy: script-src-elem https://example.com/
 ```
 
-the following script is blocked and won't be loaded or executed:
+…the following script is blocked and won't be loaded or executed:
 
 ```html
 <script src="https://not-example.com/js/library.js"></script>

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -19,8 +19,9 @@ browser-compat: http.headers.Content-Security-Policy.script-src-elem
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** directive specifies valid sources for JavaScript {{HTMLElement("script")}} elements.
 
-Other JavaScript sources that can trigger script execution, such as inline script event handlers (`onclick`) and [XSLT stylesheets](/en-US/docs/Web/XSLT), are not blocked.
-(These can be blocked using {{CSP("script-src")}}.)
+This directive only specifies valid sources in `<script>` elements (both script requests and blocks).
+It does not apply to other JavaScript sources that can trigger script execution, such as inline script event handlers (`onclick`) and [XSLT stylesheets](/en-US/docs/Web/XSLT).
+(Valid sources can be specified for all JavaScript script sources using {{CSP("script-src")}}, or just for inline script handlers using {{CSP("script-src-attr")}}.)
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -17,7 +17,10 @@ browser-compat: http.headers.Content-Security-Policy.script-src-elem
 
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** directive specifies valid sources for JavaScript {{HTMLElement("script")}} elements, but not inline script event handlers like `onclick`.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** directive specifies valid sources for JavaScript {{HTMLElement("script")}} elements.
+
+Other JavaScript sources that can trigger script execution, such as inline script event handlers (`onclick`) and [XSLT stylesheets](/en-US/docs/Web/XSLT), are not blocked.
+(These can be blocked using {{CSP("script-src")}}.)
 
 <table class="properties">
   <tbody>
@@ -32,9 +35,8 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** d
     <tr>
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
-        Yes. If this directive is absent, the user agent will look for the
-        {{CSP("script-src")}} directive, and if both of them are absent,
-        fallback to <code>default-src</code> directive.
+        Yes.
+        If this directive is absent, the user agent will look for the {{CSP("script-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
       </td>
     </tr>
   </tbody>
@@ -64,9 +66,19 @@ Note that this same set of values can be used in all {{Glossary("fetch directive
 
 ## Examples
 
-### Fallback to script-src
+### Violation case
 
-If `script-src-elem` is absent, User Agent falls back to the {{CSP("script-src")}} directive, and if that is absent as well, to {{CSP("default-src")}}.
+Given this CSP header:
+
+```http
+Content-Security-Policy: script-src-elem https://example.com/
+```
+
+the following script is blocked and won't be loaded or executed:
+
+```html
+<script src="https://not-example.com/js/library.js"></script>
+```
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -20,7 +20,7 @@ browser-compat: http.headers.Content-Security-Policy.script-src-elem
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src-elem`** directive specifies valid sources for JavaScript {{HTMLElement("script")}} elements.
 
 This directive only specifies valid sources in `<script>` elements (both script requests and blocks).
-It does not apply to other JavaScript sources that can trigger script execution, such as inline script event handlers (`onclick`) and [XSLT stylesheets](/en-US/docs/Web/XSLT).
+It does not apply to other JavaScript sources that can trigger script execution, such as inline script event handlers (`onclick`), script execution methods [gated on the "unsafe-eval" check](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions), and [XSLT stylesheets](/en-US/docs/Web/XSLT).
 (Valid sources can be specified for all JavaScript script sources using {{CSP("script-src")}}, or just for inline script handlers using {{CSP("script-src-attr")}}.)
 
 <table class="properties">

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -77,7 +77,7 @@ Given this CSP header:
 Content-Security-Policy: script-src-attr 'none'
 ```
 
-The inline style applied to the element below not be applied:
+…the inline style applied to the element below not be applied:
 
 ```html
 <div style="display:none">Foo</div>

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -18,9 +18,10 @@ browser-compat: http.headers.Content-Security-Policy.style-src-attr
 
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`style-src-attr`** directive
-specifies valid sources for inline styles applied to individual DOM elements.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`style-src-attr`** directive specifies valid sources for inline styles applied to individual DOM elements.
+
+The directive does not set valid sources for {{HTMLElement("style")}} elements and {{HTMLElement("link")}} elements with `rel="stylesheet"`.
+These are set using {{CSP("style-src-elem")}} (and valid sources for all styles may be set with {{CSP("style-src")}}).
 
 <table class="properties">
   <tbody>
@@ -36,8 +37,8 @@ specifies valid sources for inline styles applied to individual DOM elements.
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
         <p>
-          Yes. If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are
-          absent, fallback to <code>default-src</code> directive.
+          Yes.
+          If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
         </p>
       </td>
     </tr>
@@ -68,7 +69,34 @@ Note that this same set of values can be used in all {{Glossary("fetch directive
 
 ## Examples
 
-TBD
+### Violation cases
+
+Given this CSP header:
+
+```http
+Content-Security-Policy: script-src-attr 'none'
+```
+
+The inline style applied to the element below not be applied:
+
+```html
+<div style="display:none">Foo</div>
+```
+
+The policy would also block any styles applied in JavaScript by setting the `style` attribute directly, or by setting {{domxref("CSSStyleDeclaration.cssText", "cssText")}}:
+
+```js
+document.querySelector('div').setAttribute('style', 'display:none;');
+document.querySelector('div').style.cssText = 'display:none;';
+```
+
+Style properties that are set directly on the element's {{domxref("HTMLElement/style", "style")}} property will not be blocked, allowing users to safely manipulate styles via JavaScript:
+
+```js
+document.querySelector('div').style.display = 'none';
+```
+
+Note that using JavaScript might independently be blocked using the {{CSP("script-src")}} CSP directive.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -18,10 +18,9 @@ browser-compat: http.headers.Content-Security-Policy.style-src-elem
 
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`style-src-elem`** directive
-specifies valid sources for stylesheets {{HTMLElement("style")}} elements and
-{{HTMLElement("link")}} elements with `rel="stylesheet"`.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`style-src-elem`** directive specifies valid sources for stylesheet {{HTMLElement("style")}} elements and {{HTMLElement("link")}} elements with `rel="stylesheet"`.
+
+The directive does not set valid sources for inline style attributes; these are set using {{CSP("style-src-attr")}} (and valid sources for all styles may be set with {{CSP("style-src")}}).
 
 <table class="properties">
   <tbody>
@@ -37,9 +36,8 @@ specifies valid sources for stylesheets {{HTMLElement("style")}} elements and
       <th scope="row">{{CSP("default-src")}} fallback</th>
       <td>
         <p>
-          Yes. If this directive is absent, the user agent will look for
-          the {{CSP("style-src")}} directive, and if both of them are
-          absent, fallback to <code>default-src</code> directive.
+          Yes.
+          If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
         </p>
       </td>
     </tr>
@@ -70,7 +68,35 @@ Note that this same set of values can be used in all {{Glossary("fetch directive
 
 ## Examples
 
-TBD
+### Violation cases
+
+Given this CSP header:
+
+```http
+Content-Security-Policy: style-src-elem https://example.com/
+```
+
+the following stylesheets are blocked and won't load:
+
+```html
+<link href="https://not-example.com/styles/main.css" rel="stylesheet" />
+
+<style>
+  #inline-style {
+    background: red;
+  }
+</style>
+
+<style>
+  @import url("https://not-example.com/styles/print.css") print;
+</style>
+```
+
+as well as styles loaded using the {{HTTPHeader("Link")}} header:
+
+```http
+Link: <https://not-example.com/styles/stylesheet.css>;rel=stylesheet
+```
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -37,7 +37,7 @@ The directive does not set valid sources for inline style attributes; these are 
       <td>
         <p>
           Yes.
-          If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are absent, fallback to <code>default-src</code> directive.
+          If this directive is absent, the user agent will look for the {{CSP("style-src")}} directive, and if both of them are absent, fall back to <code>default-src</code> directive.
         </p>
       </td>
     </tr>
@@ -76,7 +76,7 @@ Given this CSP header:
 Content-Security-Policy: style-src-elem https://example.com/
 ```
 
-the following stylesheets are blocked and won't load:
+…the following stylesheets are blocked and won't load:
 
 ```html
 <link href="https://not-example.com/styles/main.css" rel="stylesheet" />
@@ -92,7 +92,7 @@ the following stylesheets are blocked and won't load:
 </style>
 ```
 
-as well as styles loaded using the {{HTTPHeader("Link")}} header:
+…as well as styles loaded using the {{HTTPHeader("Link")}} header:
 
 ```http
 Link: <https://not-example.com/styles/stylesheet.css>;rel=stylesheet


### PR DESCRIPTION
FF108 ships [style-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem), [style-src-attr](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr), [script-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem), [script-src-attr](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr) in https://bugzilla.mozilla.org/show_bug.cgi?id=1782513

This updates the four docs to add examples. These examples are either copied from, or derived heavily from, the corresponding `script-src` and `style-src` docs. It also now uses a consistent approach to indicating what the directives do not cover in each case.

Right now it is clear that you can use these to set inline or element script/sources rather than just applying a global settting for both. It would be good to explain _why_ you would do it this way instead of usign `script-src` and `style-src` and how you use them together. However I don't know the reason for that - so this stops with what I can infer from the existing docs and the spec. @teoli2003 If you have insight on what we might write that would be good - but perhaps as a separate update.

Other docs work can be tracked in #22113