### PR TITLE
Error handling for scripting.executeScript()

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -65,7 +65,7 @@ Each `InjectionResult` object has these properties:
 - `result` {{optional_inline}}
   - : `any`. The result of the script execution.
 - `error` {{optional_inline}}
-  - : `any`. If an error occured, contains the value the script threw or rejected with. Typically this is an error object with a message property, but could be any value (including primitives and undefined).
+  - : `any`. If an error occurs, contains the value the script threw or rejected with. Typically this is an error object with a message property but it could be any value (including primitives and undefined).
 
 The result of the script is the last evaluated statement, which is similar to the results seen if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) (not any `console.log()` output). For example, consider a script like this:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -65,9 +65,7 @@ Each `InjectionResult` object has these properties:
 - `result` {{optional_inline}}
   - : `any`. The result of the script execution.
 - `error` {{optional_inline}}
-  - : `object`. When the injection fails, details of the failure errors.
-    - `message`
-      - : `string`. A message explaining why the injection failed.
+  - : `any`. If an error occured, contains the value the script threw or rejected with. Typically this is an error object with a message property, but could be any value (including primitives and undefined).
 
 The result of the script is the last evaluated statement, which is similar to the results seen if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) (not any `console.log()` output). For example, consider a script like this:
 

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -66,7 +66,7 @@ This article provides information about the changes in Firefox 107 that will aff
 
 ### Other
 
-- The `error` property returned when an error occurs in {{WebExtAPIRef("scripting.executeScript")}} now represents any value the script throws or rejects with, such as an error object, primitive, or undefined {{bug(1740608)}}.
+- The `error` property returned when an error occurs in {{WebExtAPIRef("scripting.executeScript")}} now represents any value the script throws or rejects with, instead of being just an object with a message property {{bug(1740608)}}.
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -66,6 +66,8 @@ This article provides information about the changes in Firefox 107 that will aff
 
 ### Other
 
+- The `error` property returned when an error occurs in {{WebExtAPIRef("scripting.executeScript")}} now represents any value the script throws or rejects with, such as an error object, primitive, or undefined {{bug(1740608)}}.
+
 ## Older versions
 
 {{Firefox_for_developers(106)}}


### PR DESCRIPTION
### Description

[Bug 1740608](https://bugzilla.mozilla.org/show_bug.cgi?id=1740608) has amended the way in which error information is reported from `scripting.executeScript()` – the `error` property returned now represents the value the script throws or rejects with.