### PR TITLE
Window load event should state that iframes are dependent resources

### DIFF
--- a/files/en-us/web/api/document/readystate/index.md
+++ b/files/en-us/web/api/document/readystate/index.md
@@ -12,11 +12,8 @@ browser-compat: api.Document.readyState
 
 {{APIRef("DOM")}}
 
-The **`Document.readyState`** property describes the loading
-state of the {{domxref("document")}}.
-
-When the value of this property changes, a {{domxref("Document/readystatechange_event", "readystatechange")}} event fires on
-the {{domxref("document")}} object.
+The **`Document.readyState`** property describes the loading state of the {{domxref("document")}}.
+When the value of this property changes, a {{domxref("Document/readystatechange_event", "readystatechange")}} event fires on the {{domxref("document")}} object.
 
 ## Value
 
@@ -38,11 +35,11 @@ The `readyState` of a document can be one of following:
 ```js
 switch (document.readyState) {
   case "loading":
-    // The document is still loading.
+    // The document is loading.
     break;
   case "interactive": {
-    // The document has finished loading. We can now access the DOM elements.
-    // But sub-resources such as scripts, images, stylesheets and frames are still loading.
+    // The document has finished loading and we can access DOM elements.
+    // Sub-resources such as scripts, images, stylesheets and frames are still loading.
     const span = document.createElement("span");
     span.textContent = "A <span> element.";
     document.body.appendChild(span);
@@ -62,10 +59,10 @@ switch (document.readyState) {
 ```js
 // Alternative to DOMContentLoaded event
 document.onreadystatechange = () => {
-  if (document.readyState === 'interactive') {
+  if (document.readyState === "interactive") {
     initApplication();
   }
-}
+};
 ```
 
 ### readystatechange as an alternative to load event
@@ -73,19 +70,19 @@ document.onreadystatechange = () => {
 ```js
 // Alternative to load event
 document.onreadystatechange = () => {
-  if (document.readyState === 'complete') {
+  if (document.readyState === "complete") {
     initApplication();
   }
-}
+};
 ```
 
 ### readystatechange as event listener to insert or modify the DOM before DOMContentLoaded
 
 ```js
-document.addEventListener('readystatechange', (event) => {
-  if (event.target.readyState === 'interactive') {
+document.addEventListener("readystatechange", (event) => {
+  if (event.target.readyState === "interactive") {
     initLoader();
-  } else if (event.target.readyState === 'complete') {
+  } else if (event.target.readyState === "complete") {
     initApp();
   }
 });
@@ -101,6 +98,7 @@ document.addEventListener('readystatechange', (event) => {
 
 ## See also
 
-- {{domxref("Document/readystatechange_event", "readystatechange")}} event
-- {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event
-- {{domxref("Window/load_event", "load")}} event
+- Related events:
+  - {{domxref("Document/readystatechange_event", "readystatechange")}}
+  - {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}
+  - {{domxref("Window/load_event", "load")}}

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.load_event
 
 {{APIRef}}
 
-The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets and images. This is in contrast to {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}, which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.
+The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts, iframes, and images.
+This is in contrast to {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}, which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.
 
 This event is not cancelable and does not bubble.
 
@@ -26,9 +27,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('load', (event) => {});
+addEventListener("load", (event) => {});
 
-onload = (event) => { };
+onload = (event) => {};
 ```
 
 ## Event type
@@ -40,8 +41,8 @@ A generic {{domxref("Event")}}.
 Log a message when the page is fully loaded:
 
 ```js
-window.addEventListener('load', (event) => {
-  console.log('page is fully loaded');
+window.addEventListener("load", (event) => {
+  console.log("page is fully loaded");
 });
 ```
 
@@ -49,7 +50,7 @@ The same, but using the `onload` event handler property:
 
 ```js
 window.onload = (event) => {
-  console.log('page is fully loaded');
+  console.log("page is fully loaded");
 };
 ```
 
@@ -107,25 +108,25 @@ button {
 #### JavaScript
 
 ```js
-const log = document.querySelector('.event-log-contents');
-const reload = document.querySelector('#reload');
+const log = document.querySelector(".event-log-contents");
+const reload = document.querySelector("#reload");
 
-reload.addEventListener('click', () => {
-  log.textContent ='';
+reload.addEventListener("click", () => {
+  log.textContent = "";
   setTimeout(() => {
-      window.location.reload(true);
+    window.location.reload(true);
   }, 200);
 });
 
-window.addEventListener('load', (event) => {
-  log.textContent += 'load\n';
+window.addEventListener("load", (event) => {
+  log.textContent += "load\n";
 });
 
-document.addEventListener('readystatechange', (event) => {
+document.addEventListener("readystatechange", (event) => {
   log.textContent += `readystate: ${document.readyState}\n`;
 });
 
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener("DOMContentLoaded", (event) => {
   log.textContent += `DOMContentLoaded\n`;
 });
 ```
@@ -144,4 +145,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 ## See also
 
-- Related events: {{domxref("Window/DOMContentLoaded_event", "DOMContentLoaded")}}, {{domxref("Document/readystatechange_event", "readystatechange")}}, {{domxref("Window/beforeunload_event", "beforeunload")}}, {{domxref("Window/unload_event", "unload")}}
+- Document [readyState](/en-US/docs/Web/API/Document/readyState) API
+- Related events:
+  - {{domxref("Window/DOMContentLoaded_event", "DOMContentLoaded")}}
+  - {{domxref("Document/readystatechange_event", "readystatechange")}}
+  - {{domxref("Window/beforeunload_event", "beforeunload")}}
+  - {{domxref("Window/unload_event", "unload")}}


### PR DESCRIPTION
__Updates:__

* clarification that iframes are dependent resources for window `load` events
* run Prettier


Fixes #22152