### PR TITLE
Slider controls use value instead of textContent #21318

### DIFF
--- a/files/en-us/learn/forms/html5_input_types/index.md
+++ b/files/en-us/learn/forms/html5_input_types/index.md
@@ -190,10 +190,10 @@ To actually display the current value, and update it as it changed, you must use
 const price = document.querySelector("#price");
 const output = document.querySelector(".price-output");
 
-output.textContent = price.value;
+output.value = price.value;
 
 price.addEventListener("input", () => {
-  output.textContent = price.value;
+  output.value = price.value;
 });
 ```
 

--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Presentation
 
 The Presentation API lets a {{Glossary("user agent")}} (such as a Web browser) effectively display web content through large presentation devices such as projectors and network-connected televisions. Supported types of multimedia devices include both displays which are wired using HDMI, DVI, or the like, or wireless, using [DLNA](https://www.dlna.org/), [Chromecast](https://developers.google.com/cast/), [AirPlay](https://developer.apple.com/airplay/), or [Miracast](https://www.wi-fi.org/discover-wi-fi/miracast).
 
-![](presentation_mode_illustration.png)
+![1-UA mode loaded the Controlling and Presenting pages together before outputting to displays. 2-UA mode loaded them separately using the Presentation Control Protocol.](presentation_mode_illustration.png)
 
 In general, a web page uses the Presentation Controller API to specify the web content to be rendered on presentation device and initiate the presentation session. With Presentation Receiver API, the presenting web content obtains the session status. With providing both the controller page and the receiver one with a messaged-based channel, a Web developer can implement the interaction between these two pages.
 

--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Presentation
 
 The Presentation API lets a {{Glossary("user agent")}} (such as a Web browser) effectively display web content through large presentation devices such as projectors and network-connected televisions. Supported types of multimedia devices include both displays which are wired using HDMI, DVI, or the like, or wireless, using [DLNA](https://www.dlna.org/), [Chromecast](https://developers.google.com/cast/), [AirPlay](https://developer.apple.com/airplay/), or [Miracast](https://www.wi-fi.org/discover-wi-fi/miracast).
 
-![1-UA mode loaded the Controlling and Presenting pages together before outputting to displays. 2-UA mode loaded them separately using the Presentation Control Protocol.](presentation_mode_illustration.png)
+![](presentation_mode_illustration.png)
 
 In general, a web page uses the Presentation Controller API to specify the web content to be rendered on presentation device and initiate the presentation session. With Presentation Receiver API, the presenting web content obtains the session status. With providing both the controller page and the receiver one with a messaged-based channel, a Web developer can implement the interaction between these two pages.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The Javascript example for HTML5 form slider `input` had the `textContent` prop on `output` changed to `value`.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Possible accessibility issues listed in ticket where the aria-live region may not properly announce changes in the output.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
[Fixes #21318](https://github.com/mdn/content/issues/21318)
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
