### PR TITLE
fix #8684

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -63,6 +63,8 @@ createPattern(image, repetition)
 
 - {{domxref("CanvasPattern")}}
   - : An opaque object describing a pattern.
+  
+  If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned. Follow the examples below to ensure that the image is loaded.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -63,7 +63,8 @@ createPattern(image, repetition)
 
 - {{domxref("CanvasPattern")}}
   - : An opaque object describing a pattern.
-  If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned. Follow the examples below to ensure that the image is loaded.
+
+If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -13,15 +13,11 @@ browser-compat: api.CanvasRenderingContext2D.createPattern
 
 {{APIRef}}
 
-The
-**`CanvasRenderingContext2D.createPattern()`**
-method of the Canvas 2D API creates a pattern using the specified image and repetition.
+The **`CanvasRenderingContext2D.createPattern()`** method of the Canvas 2D API creates a pattern using the specified image and repetition.
 This method returns a {{domxref("CanvasPattern")}}.
 
-This method doesn't draw anything to the canvas directly. The pattern it creates must
-be assigned to the {{domxref("CanvasRenderingContext2D.fillStyle")}} or
-{{domxref("CanvasRenderingContext2D.strokeStyle")}} properties, after which it is
-applied to any subsequent drawing.
+This method doesn't draw anything to the canvas directly.
+The pattern it creates must be assigned to the {{domxref("CanvasRenderingContext2D.fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle")}} properties, after which it is applied to any subsequent drawing.
 
 ## Syntax
 
@@ -33,13 +29,12 @@ createPattern(image, repetition)
 
 - `image`
 
-  - : An image to be used as the pattern's image. It can be any
-    of the following:
+  - : An image to be used as the pattern's image.
+    It can be any of the following:
 
     - {{domxref("HTMLImageElement")}} ({{HTMLElement("img")}})
     - {{domxref("SVGImageElement")}} ({{SVGElement("image")}})
-    - {{domxref("HTMLVideoElement")}} ({{HTMLElement("video")}}, by using the capture
-      of the video)
+    - {{domxref("HTMLVideoElement")}} ({{HTMLElement("video")}}, by using the capture of the video)
     - {{domxref("HTMLCanvasElement")}} ({{HTMLElement("canvas")}})
     - {{domxref("ImageBitmap")}}
     - {{domxref("OffscreenCanvas")}}
@@ -47,17 +42,15 @@ createPattern(image, repetition)
 
 - `repetition`
 
-  - : A string indicating how to repeat the pattern's image. Possible
-    values are:
+  - : A string indicating how to repeat the pattern's image.
+    Possible values are:
 
     - `"repeat"` (both directions)
     - `"repeat-x"` (horizontal only)
     - `"repeat-y"` (vertical only)
     - `"no-repeat"` (neither direction)
 
-    If `repetition` is specified as an empty string (`""`) or
-    [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) (but not {{jsxref("undefined")}}), a value of `"repeat"`
-    will be used.
+    If `repetition` is specified as an empty string (`""`) or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) (but not {{jsxref("undefined")}}), a value of `"repeat"` will be used.
 
 ### Return value
 
@@ -70,9 +63,8 @@ If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is 
 
 ### Creating a pattern from an image
 
-This example uses the `createPattern()` method to create a
-{{domxref("CanvasPattern")}} with a repeating source image. Once created, the pattern is
-assigned to the canvas context's fill style and applied to a rectangle.
+This example uses the `createPattern()` method to create a {{domxref("CanvasPattern")}} with a repeating source image.
+Once created, the pattern is assigned to the canvas context's fill style and applied to a rectangle.
 
 The original image looks like this:
 
@@ -103,8 +95,8 @@ img.onload = () => {
 
 ### Creating a pattern from a canvas
 
-In this example we create a pattern from the contents of an offscreen canvas. We then
-apply it to the fill style of our primary canvas, and fill that canvas with the pattern.
+In this example we create a pattern from the contents of an offscreen canvas.
+We then apply it to the fill style of our primary canvas, and fill that canvas with the pattern.
 
 #### JavaScript
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -63,7 +63,6 @@ createPattern(image, repetition)
 
 - {{domxref("CanvasPattern")}}
   - : An opaque object describing a pattern.
-  
   If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned. Follow the examples below to ensure that the image is loaded.
 
 ## Examples


### PR DESCRIPTION
As described in #8684, this method can return `null`.

I tried to follow guidelines but this is my very first contribution, so I hope the style fits.

I couldn't test my change since I only edited the file in GitHub.

### Description

Fix an undocumented case where the method returns `null`.

### Motivation

Now that this return value is documented, readers will be able to handle this case.

### Related issues and pull requests

Fixes #8684
