### PR TITLE
Add the install_origins manifest key

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -44,6 +44,7 @@ These are the `manifest.json` keys and the manifest versions they are supported 
 - [host_permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) (Manifest V3 and above)
 - [icons](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) (Manifest V2 and above)
 - [incognito](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) (Manifest V2 and above)
+- [install_origins](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/install_origins) (Manifest V3 and above)
 - [manifest_version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version) (Manifest V2 and above)
 - [name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name) (Manifest V2 and above)
 - [offline_enabled](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/offline_enabled) (Manifest V2 and above)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
@@ -33,8 +33,6 @@ browser-compat: webextensions.manifest.install_origins
 
 Enables the distribution and update of Manifest V3 extensions from a third-party {{glossary("origin")}}, in addition to store distribution. If [`update_url`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties) is specified, its origin must be included here.
 
-Up to 5 origins can be specified.
-
 ## Example
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
@@ -1,5 +1,5 @@
 ---
-title: author
+title: install_origins
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/install_origins
 tags:
   - Add-ons
@@ -14,7 +14,7 @@ browser-compat: webextensions.manifest.install_origins
   <tbody>
     <tr>
       <th scope="row">Type</th>
-      <td><code>String</code></td>
+      <td><code>Array of string</code></td>
     </tr>
     <tr>
       <th scope="row">Mandatory</th>
@@ -26,7 +26,7 @@ browser-compat: webextensions.manifest.install_origins
     </tr>
     <tr>
       <th scope="row">Example</th>
-      <td><pre class="brush: json">"install_origins": "https://www.example.com"</pre></td>
+      <td><pre class="brush: json">"install_origins": ["https://www.example.com"]</pre></td>
     </tr>
   </tbody>
 </table>
@@ -38,7 +38,7 @@ Up to 5 origins can be specified.
 ## Example
 
 ```json
-"install_origins": "https://www.example.com"
+"install_origins": ["https://www.example.com"]
 ```
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
@@ -31,7 +31,7 @@ browser-compat: webextensions.manifest.install_origins
   </tbody>
 </table>
 
-Enables the distribution and update of Manifest V3 extensions from third-party origins, in addition to store distribution. If [`update_url`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties) is specified, its origin must be included here.
+Enables the distribution and update of Manifest V3 extensions from a third-party {{glossary("origin")}}, in addition to store distribution. If [`update_url`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties) is specified, its origin must be included here.
 
 Up to 5 origins can be specified.
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
@@ -33,9 +33,22 @@ browser-compat: webextensions.manifest.install_origins
 
 Enables the distribution and update of Manifest V3 extensions from a third-party {{glossary("origin")}}, in addition to store distribution. If [`update_url`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties) is specified, its origin must be included here.
 
-## Example
+## Examples
+
+In this example, the extension can also be installed from www.example.com.
 
 ```json
+"install_origins": ["https://www.example.com"]
+```
+
+In this example, in addition to being available to install from www.example.com an [extension update manifest](https://extensionworkshop.com/documentation/manage/updating-your-extension/) is also provided.
+
+```json
+"browser_specific_settings": {
+  "gecko": {
+    "update_url": "https://example.com/updates.json"
+  }
+},
 "install_origins": ["https://www.example.com"]
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/install_origins/index.md
@@ -1,0 +1,46 @@
+---
+title: author
+slug: Mozilla/Add-ons/WebExtensions/manifest.json/install_origins
+tags:
+  - Add-ons
+  - Extensions
+  - WebExtensions
+browser-compat: webextensions.manifest.install_origins
+---
+
+{{AddonSidebar}}
+
+<table class="fullwidth-table standard-table">
+  <tbody>
+    <tr>
+      <th scope="row">Type</th>
+      <td><code>String</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Mandatory</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Manifest version</th>
+      <td>3 or higher</td>
+    </tr>
+    <tr>
+      <th scope="row">Example</th>
+      <td><pre class="brush: json">"install_origins": "https://www.example.com"</pre></td>
+    </tr>
+  </tbody>
+</table>
+
+Enables the distribution and update of Manifest V3 extensions from third-party origins, in addition to store distribution. If [`update_url`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties) is specified, its origin must be included here.
+
+Up to 5 origins can be specified.
+
+## Example
+
+```json
+"install_origins": "https://www.example.com"
+```
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
### Description

Adds details about the `install_origins` manifest key that enables extensions to be distributed from a third-party website in addition to a store.