### PR TITLE
relnote(107) lquote/rquote attributes are disabled by default 

### DIFF
--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -20,6 +20,11 @@ This article provides information about the changes in Firefox 107 that will aff
 
 #### Removals
 
+### MathML
+
+- Deprecated `lquote` and `rquote` attributes of the [`<ms>`](/en-US/docs/Web/MathML/Element/ms) MathML element for custom opening and closing quotes are now disabled.
+  This behavior is configured via the `mathml.ms_lquote_rquote_attributes.disabled` preference which is set to `true` by default ({{bug(1793387)}}).
+
 ### CSS
 
 - The [`contain-intrinsic-size`](/en-US/docs/Web/CSS/contain-intrinsic-size) shorthand CSS property can now be applied to specify the size of a UI element that is subject to [size containment](/en-US/docs/Web/CSS/CSS_Containment#size_containment).


### PR DESCRIPTION
The `lquote` and `rquote` attributes are deprecated and the changes in 107 disable them by default. They can be enabled using 

```
mathml.ms_lquote_rquote_attributes.disabled = false
```

## Open question

Do we want to document the ["legacy" (deprecated) behavior](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/ms#examples) or just remove this example and keep the default case?


## Parent task

- [x] https://github.com/mdn/content/issues/21635

