### PR TITLE
minor tip on createPattern usage

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -84,7 +84,7 @@ const ctx = canvas.getContext("2d");
 
 const img = new Image();
 img.src = "canvas_createpattern.png";
-img.onload = () => {
+img.onload = () => { // Only use the image after it's loaded
   const pattern = ctx.createPattern(img, "repeat");
   ctx.fillStyle = pattern;
   ctx.fillRect(0, 0, 300, 300);


### PR DESCRIPTION
### Description

Enrich the code example of `CanvasRenderingContext2D.createPattern` to explain the use of `img.onload` in order to get a value instead of `null`. 

### Motivation

This comment justifies the use of the `img.onload` pattern to avoid getting `null` instead of the expected `CanvasPattern`. Beginner readers will better understand that this pattern is necessary.

### Related issues and pull requests

Relates to #22288
Relates to Issue #8684
