### PR TITLE
Clean up User Timing methods

### DIFF
--- a/files/en-us/web/api/performance/clearmarks/index.md
+++ b/files/en-us/web/api/performance/clearmarks/index.md
@@ -12,13 +12,7 @@ browser-compat: api.Performance.clearMarks
 
 {{APIRef("Performance API")}}
 
-The **`clearMarks()`** method removes the _named mark_
-from the browser's performance entry buffer. If the method is called with no arguments,
-all {{domxref("PerformanceEntry","performance entries")}} with an
-{{domxref("PerformanceEntry.entryType","entry type")}} of "`mark`" will be
-removed from the performance entry buffer.
-
-{{AvailableInWorkers}}
+The **`clearMarks()`** method removes all or specific markers from the browser's performance timeline.
 
 ## Syntax
 
@@ -30,10 +24,7 @@ clearMarks(name)
 ### Parameters
 
 - `name` {{optional_inline}}
-  - : A string representing the name of the timestamp. If this argument
-    is omitted, all {{domxref("PerformanceEntry","performance entries")}} with an
-    {{domxref("PerformanceEntry.entryType","entry type")}} of "`mark`" will be
-    removed.
+  - : A string representing the name of the {{domxref("PerformanceMark")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`mark`" will be removed.
 
 ### Return value
 
@@ -41,33 +32,28 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The following example shows both uses of the `clearMarks()` method.
+### Removing markers
+
+To clean up all performance marks, or just specific entries, use the `clearMarks()` method like this:
 
 ```js
-// Create a small helper to show how many PerformanceMark entries there are.
-function logMarkCount() {
-  console.log(
-    `Found this many entries: ${performance.getEntriesByType("mark").length}`
-  );
-}
+// Create a bunch of marks
+performance.mark("login-started");
+performance.mark("login-started");
+performance.mark("login-finished");
+performance.mark("form-sent");
+performance.mark("video-loaded");
+performance.mark("video-loaded");
 
-// Create a bunch of marks.
-performance.mark("squirrel");
-performance.mark("squirrel");
-performance.mark("monkey");
-performance.mark("monkey");
-performance.mark("dog");
-performance.mark("dog");
+performance.getEntriesByType("mark").length // 6
 
-logMarkCount() // "Found this many entries: 6"
+// Delete just the "login-started" mark entries
+performance.clearMarks("login-started");
+performance.getEntriesByType("mark").length // 4
 
-// Delete just the "squirrel" PerformanceMark entries.
-performance.clearMarks('squirrel');
-logMarkCount() // "Found this many entries: 4"
-
-// Delete all of the PerformanceMark entries.
+// Delete all of the mark entries
 performance.clearMarks();
-logMarkCount() // "Found this many entries: 0"
+performance.getEntriesByType("mark").length // 0
 ```
 
 ## Specifications
@@ -77,3 +63,7 @@ logMarkCount() // "Found this many entries: 0"
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("PerformanceMark")}}

--- a/files/en-us/web/api/performance/clearmarks/index.md
+++ b/files/en-us/web/api/performance/clearmarks/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Performance.clearMarks
 
 {{APIRef("Performance API")}}
 
-The **`clearMarks()`** method removes all or specific markers from the browser's performance timeline.
+The **`clearMarks()`** method removes all or specific {{domxref("PerformanceMark")}} objects from the browser's performance timeline.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ clearMarks(name)
 ### Parameters
 
 - `name` {{optional_inline}}
-  - : A string representing the name of the {{domxref("PerformanceMark")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`mark`" will be removed.
+  - : A string representing the {{domxref("PerformanceEntry.name", "name")}} of the {{domxref("PerformanceMark")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`mark`" will be removed.
 
 ### Return value
 
@@ -45,15 +45,15 @@ performance.mark("form-sent");
 performance.mark("video-loaded");
 performance.mark("video-loaded");
 
-performance.getEntriesByType("mark").length // 6
+performance.getEntriesByType("mark").length; // 6
 
 // Delete just the "login-started" mark entries
 performance.clearMarks("login-started");
-performance.getEntriesByType("mark").length // 4
+performance.getEntriesByType("mark").length; // 4
 
 // Delete all of the mark entries
 performance.clearMarks();
-performance.getEntriesByType("mark").length // 0
+performance.getEntriesByType("mark").length; // 0
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performance/clearmeasures/index.md
+++ b/files/en-us/web/api/performance/clearmeasures/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Performance.clearMeasures
 
 {{APIRef("Performance API")}}
 
-The **`clearMeasures()`** method removes all or specific measures from the browser's performance timeline.
+The **`clearMeasures()`** method removes all or specific {{domxref("PerformanceMeasure")}} objects from the browser's performance timeline.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ clearMeasures(name)
 ### Parameters
 
 - `name` {{optional_inline}}
-  - : A string representing the name of the {{domxref("PerformanceMeasure")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`measure`" will be removed.
+  - : A string representing the {{domxref("PerformanceEntry.name", "name")}} of the {{domxref("PerformanceMeasure")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`measure`" will be removed.
 
 ### Return value
 
@@ -46,15 +46,15 @@ performance.measure("from mark a", "a");
 performance.mark("b");
 performance.measure("between a and b", "a", "b");
 
-performance.getEntriesByType("measure").length // 5
+performance.getEntriesByType("measure").length; // 5
 
 // Delete just the "from navigation" measure entries
 performance.clearMeasures("from navigation");
-performance.getEntriesByType("measure").length // 3
+performance.getEntriesByType("measure").length; // 3
 
 // Delete all of the measure entries
 performance.clearMeasures();
-performance.getEntriesByType("measure").length // 0
+performance.getEntriesByType("measure").length; // 0
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performance/clearmeasures/index.md
+++ b/files/en-us/web/api/performance/clearmeasures/index.md
@@ -12,13 +12,7 @@ browser-compat: api.Performance.clearMeasures
 
 {{APIRef("Performance API")}}
 
-The **`clearMeasures()`** method removes the _named
-measure_ from the browser's performance entry buffer. If the method is called with
-no arguments, all {{domxref("PerformanceEntry","performance entries")}} with an
-{{domxref("PerformanceEntry.entryType","entry type")}} of "`measure`" will be
-removed from the performance entry buffer.
-
-{{AvailableInWorkers}}
+The **`clearMeasures()`** method removes all or specific measures from the browser's performance timeline.
 
 ## Syntax
 
@@ -30,10 +24,7 @@ clearMeasures(name)
 ### Parameters
 
 - `name` {{optional_inline}}
-  - : A string representing the name of the timestamp. If this argument
-    is omitted, all {{domxref("PerformanceEntry","performance entries")}} with an
-    {{domxref("PerformanceEntry.entryType","entry type")}} of "`measure`" will
-    be removed.
+  - : A string representing the name of the {{domxref("PerformanceMeasure")}} object. If this argument is omitted, all entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`measure`" will be removed.
 
 ### Return value
 
@@ -41,17 +32,12 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The following example shows both uses of the `clearMeasures()` method.
+### Removing measures
+
+To clean up all performance measure, or just specific entries, use the `clearMeasures()` method like this:
 
 ```js
-// Create a small helper to show how many PerformanceMeasure entries there are.
-function logMeasureCount() {
-  console.log(
-    `Found this many entries: ${performance.getEntriesByType("measure").length}`
-  );
-}
-
-// Create a bunch of measures.
+// Create a bunch of measures
 performance.measure("from navigation");
 performance.mark("a");
 performance.measure("from mark a", "a");
@@ -60,15 +46,15 @@ performance.measure("from mark a", "a");
 performance.mark("b");
 performance.measure("between a and b", "a", "b");
 
-logMeasureCount() // "Found this many entries: 5"
+performance.getEntriesByType("measure").length // 5
 
-// Delete just the "from navigation" PerformanceMeasure entries.
+// Delete just the "from navigation" measure entries
 performance.clearMeasures("from navigation");
-logMeasureCount() // "Found this many entries: 3"
+performance.getEntriesByType("measure").length // 3
 
-// Delete all of the PerformanceMeasure entries.
+// Delete all of the measure entries
 performance.clearMeasures();
-logMeasureCount() // "Found this many entries: 0"
+performance.getEntriesByType("measure").length // 0
 ```
 
 ## Specifications
@@ -78,3 +64,7 @@ logMeasureCount() // "Found this many entries: 0"
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("PerformanceMeasure")}}

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -28,7 +28,7 @@ mark(name, markOptions)
 - `markOptions` {{optional_inline}}
   - : An object for specifying a timestamp and additional metadata for the mark.
     - `detail` {{optional_inline}}
-      - : Arbitrary metadata to include in the mark. Defaults to `null`.
+      - : Arbitrary metadata to include in the mark. Defaults to `null`. Must be [structured-clonable](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
     - `startTime` {{optional_inline}}
       - : {{domxref("DOMHighResTimeStamp")}} to use as the mark time. Defaults to {{domxref("performance.now()")}}.
 

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -58,7 +58,7 @@ const videoMarker = performance.mark("video-loaded");
 
 ### Creating markers with details
 
-If the `name` argument isn't enough, `mark()` is configurable using the `markOptions` object where you can put additional information in the `detail` property, which can be of any type.
+The performance mark is configurable using the `markOptions` object where you can put additional information in the `detail` property, which can be of any type.
 
 ```js
 performance.mark("login-started", {
@@ -86,7 +86,7 @@ performance.mark("login-button-pressed", {
 
 ### Reserved names
 
-Note that names that are part of the deprecated {{domxref("PerformanceTiming")}} interface can't be used to remain backwards compatible. The following example throws:
+Note in order to maintain backwards compatibility, names that are part of the deprecated {{domxref("PerformanceTiming")}} interface can't be used. The following example throws:
 
 ```js example-bad
 performance.mark("navigationStart"); 

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -24,7 +24,7 @@ mark(name, markOptions)
 ### Parameters
 
 - `name`
-  - : A string representing the name of the mark.
+  - : A string representing the name of the mark. Must not be the same name as one of the properties of the deprecated {{domxref("PerformanceTiming")}} interface.
 - `markOptions` {{optional_inline}}
   - : An object for specifying a timestamp and additional metadata for the mark.
     - `detail` {{optional_inline}}
@@ -38,7 +38,7 @@ The {{domxref("PerformanceMark")}} entry that was created.
 
 ### Exceptions
 
-- {{jsxref("SyntaxError")}}: Thrown if the `name` given to this method already exists in the {{domxref("PerformanceTiming")}} interface.
+- {{jsxref("SyntaxError")}}: Thrown if the `name` is one of the properties of the deprecated {{domxref("PerformanceTiming")}} interface. See the [example below](#reserved_names).
 - {{jsxref("TypeError")}}: Thrown if `startTime` is negative.
 
 ## Examples

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -12,20 +12,7 @@ browser-compat: api.Performance.mark
 
 {{APIRef("Performance API")}}
 
-The **`mark()`** method creates a
-{{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance entry
-buffer_ with the given name.
-
-The application defined timestamp can also be retrieved by one of the
-{{domxref("Performance")}} interface's `getEntries*()` methods
-({{domxref("Performance.getEntries","getEntries()")}},
-{{domxref("Performance.getEntriesByName","getEntriesByName()")}} or
-{{domxref("Performance.getEntriesByType","getEntriesByType()")}}).
-
-The `mark()'s` stores its data internally as
-{{domxref("PerformanceEntry")}}.
-
-{{AvailableInWorkers}}
+The **`mark()`** method creates a named {{domxref("PerformanceMark")}} object representing a high resolution timestamp marker in the browser's performance timeline.
 
 ## Syntax
 
@@ -56,30 +43,56 @@ The {{domxref("PerformanceMark")}} entry that was created.
 
 ## Examples
 
-The following example shows how to use `mark()` to create and retrieve
-{{domxref("PerformanceMark")}} entries.
+### Creating named markers
+
+The following example uses `mark()` to create named {{domxref("PerformanceMark")}} entries. You can create several marks with the same name. You can also assign them, to have a reference to the {{domxref("PerformanceMark")}} object that has been created.
 
 ```js
-// Create a bunch of marks.
-performance.mark("squirrel");
-performance.mark("squirrel");
-performance.mark("monkey");
-performance.mark("monkey");
-performance.mark("dog");
-performance.mark("dog");
+performance.mark("login-started");
+performance.mark("login-started");
+performance.mark("login-finished");
+performance.mark("form-sent");
 
-// Get all of the PerformanceMark entries.
-const allEntries = performance.getEntriesByType("mark");
-console.log(allEntries.length);
-// 6
+const videoMarker = performance.mark("video-loaded");
+```
 
-// Get all of the "monkey" PerformanceMark entries.
-const monkeyEntries = performance.getEntriesByName("monkey");
-console.log(monkeyEntries.length);
-// 2
+### Creating markers with details
 
-// Clear out all of the marks.
-performance.clearMarks();
+If the `name` argument isn't enough, `mark()` is configurable using the `markOptions` object where you can put additional information in the `detail` property, which can be of any type.
+
+```js
+performance.mark("login-started", {
+  detail: "Login started using the login button in the top menu."
+});
+
+performance.mark("login-started", {
+  detail: { htmlElement: myElement.id }
+});
+```
+
+### Creating markers with a different start time
+
+The default timestamp of the `mark()` method is {{domxref("performance.now()")}}. You can set it to a different time using the `startTime` option in `markOptions`.
+
+```js
+performance.mark("start-checkout", {
+  startTime: 20.0
+});
+
+performance.mark("login-button-pressed", {
+  startTime: myEvent.timeStamp
+});
+```
+
+### Reserved names
+
+Note that names that are part of the deprecated {{domxref("PerformanceTiming")}} interface can't be used to remain backwards compatible. The following example throws:
+
+```js example-bad
+performance.mark("navigationStart"); 
+// SyntaxError: "navigationStart" is part of 
+// the PerformanceTiming interface, 
+// and cannot be used as a mark name
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -13,17 +13,10 @@ browser-compat: api.Performance.measure
 
 {{APIRef("Performance API")}}
 
-The **`measure()`** method creates a named {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance entry buffer_ between marks, the navigation start time, or the current time.
+The **`measure()`** method creates a named {{domxref("PerformanceMeasure")}} object representing a time measurement between two marks in the browser's performance timeline.
 
 When measuring between two marks, there is a _start mark_ and _end mark_, respectively.
 The named timestamp is referred to as a _measure_.
-
-The `measure` can be retrieved using any of the {{domxref("Performance")}} interfaces:
-({{domxref("Performance.getEntries","getEntries()")}},
-{{domxref("Performance.getEntriesByName","getEntriesByName()")}} or
-{{domxref("Performance.getEntriesByType","getEntriesByType()")}}).
-
-{{AvailableInWorkers}}
 
 ## Syntax
 
@@ -49,24 +42,19 @@ If only `measureName` is specified, the start timestamp is set to zero, and the 
     - `detail`
       - : Arbitrary metadata to be included in the measure.
     - `start`
-      - : Timestamp {{domxref("DOMHighResTimeStamp")}} to be used as the start time, or string to be used as start mark.
-        If this represents the name of a start mark, then it is defined in the same way as `startMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the start time, or string to be used as start mark.
+        If this represents the name of a start mark, then it is defined in the same way as `startMark`.
     - `duration`
       - : Duration between the start and end mark times ({{domxref("DOMHighResTimeStamp")}}).
     - `end`
       - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or string to be used as end mark.
-        If this represents the name of an end mark, then it is defined in the same way as `endMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
+        If this represents the name of an end mark, then it is defined in the same way as `endMark`.
 
 - `startMark` {{optional_inline}}
-
   - : A string representing the name of the measure's starting mark.
-    May also be the name of a {{domxref("PerformanceTiming")}} property.
-    Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
 
 - `endMark` {{optional_inline}}
   - : A string representing the name of the measure's ending mark.
-    This may also be the name of a {{domxref("PerformanceTiming")}} property.
-    Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
 
 ### Return value
 
@@ -122,31 +110,40 @@ The returned _measure_ will have the following property values:
 
 ## Examples
 
-The following example shows how `measure()` is used to create a new _measure_ {{domxref("PerformanceEntry","performance entry")}} in the browser's performance entry buffer.
+### Measuring duration between named markers
+
+Given two of your own markers `"login-started"` and `"login-finished"`, you can create a measurement called `"login-duration"` as shown in the following example. The returned {{domxref("PerformanceMeasure")}} object will then provide a `duration` property to tell you the elapsed time between the two markers.
 
 ```js
-const markerNameA = "example-marker-a"
-const markerNameB = "example-marker-b"
+const loginMeasure = performance.measure(
+  "login-duration",
+  "login-started",
+  "login-finished"
+);
+console.log(loginMeasure.duration);
+```
 
-// Run some nested timeouts, and create a PerformanceMark for each.
-performance.mark(markerNameA);
-setTimeout(() => {
-  performance.mark(markerNameB);
-  setTimeout(() => {
-    // Create a variety of measurements.
-    performance.measure("measure a to b", markerNameA, markerNameB);
-    performance.measure("measure a to now", markerNameA);
-    performance.measure("measure from navigation start to b", undefined, markerNameB);
-    performance.measure("measure from navigation start to now");
+### Measuring duration with custom start and end times
 
-    // Pull out all of the measurements.
-    console.log(performance.getEntriesByType("measure"));
+To do more advanced measurements, you can configure an `MeasureOptions` object. For example, you can use the [`event.timestamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) as the start time.
 
-    // Finally, clean up the entries.
-    performance.clearMarks();
-    performance.clearMeasures();
-  }, 1000);
-}, 1000);
+```js
+performance.measure("login-click", {
+  start: myClickEvent.timeStamp,
+  end: myMarker.startTime
+});
+```
+
+### Proving additional measurement details
+
+You can use the `details` property to provide additional information of any type. Maybe you want to record which HTML element was clicked, for example.
+
+```js
+performance.measure("login-click", {
+  detail: { htmlElement: myElement.id },
+  start: myClickEvent.timeStamp,
+  end: myMarker.startTime
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -22,7 +22,7 @@ The named timestamp is referred to as a _measure_.
 
 ```js-nolint
 measure(measureName)
-measure(measureName, MeasureOptions)
+measure(measureName, measureOptions)
 measure(measureName, startMark)
 measure(measureName, startMark, endMark)
 ```
@@ -35,17 +35,17 @@ If only `measureName` is specified, the start timestamp is set to zero, and the 
 
   - : A string representing the name of the measure.
 
-- `MeasureOptions` {{optional_inline}}
+- `measureOptions` {{optional_inline}}
 
-  - : An object that may contain all measure options (the `startMark` and `endMark` may be specified in this object or as their own arguments):
+  - : An object that may contain measure options. If this object is given as a parameter, the `startMark` and `endMark` parameters must both be omitted.
 
     - `detail`
-      - : Arbitrary metadata to be included in the measure.
+      - : Arbitrary metadata to be included in the measure. Defaults to `null`. Must be [structured-clonable](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
     - `start`
       - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the start time, or string to be used as start mark.
         If this represents the name of a start mark, then it is defined in the same way as `startMark`.
     - `duration`
-      - : Duration between the start and end mark times ({{domxref("DOMHighResTimeStamp")}}).
+      - : Duration between the start and end mark times. If omitted, this defaults to {{domxref("performance.now()")}}; the time that has elapsed since the context was created. If provided, you must also specify either `start` or `end` but not both.
     - `end`
       - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or string to be used as end mark.
         If this represents the name of an end mark, then it is defined in the same way as `endMark`.
@@ -66,21 +66,21 @@ The returned _measure_ will have the following property values:
 - {{domxref("PerformanceEntry.name","name")}} - set to the "`name`" argument.
 - {{domxref("PerformanceEntry.startTime","startTime")}} - set to:
 
-  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `MeasureOptions.start`.
-  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark, if specified in `MeasureOptions.start` or `startMark`
-  - a timestamp calculated from the `MeasureOptions.end` and `MeasureOptions.duration` (if `MeasureOptions.start` was not specified)
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `measureOptions.start`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark, if specified in `measureOptions.start` or `startMark`
+  - a timestamp calculated from the `measureOptions.end` and `measureOptions.duration` (if `measureOptions.start` was not specified)
   - 0, if it isn't specified and can't be determined from other values.
 
 - {{domxref("PerformanceEntry.duration","duration")}} - set to a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure calculated by subtracting the `startTime` from the end timestamp.
 
   The end timestamp is one of:
 
-  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `MeasureOptions.end`.
-  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of an end mark, if one is specified in `MeasureOptions.end` or `endMark`
-  - a timestamp calculated from the `MeasureOptions.start` and `MeasureOptions.duration` (if `MeasureOptions.end` was not specified)
+  - a {{domxref("DOMHighResTimeStamp","timestamp")}}, if specified in `measureOptions.end`.
+  - the {{domxref("DOMHighResTimeStamp","timestamp")}} of an end mark, if one is specified in `measureOptions.end` or `endMark`
+  - a timestamp calculated from the `measureOptions.start` and `measureOptions.duration` (if `measureOptions.end` was not specified)
   - the value returned by {{domxref("Performance.now()")}}, if no end mark is specified or can be determined from other values.
 
-- {{domxref("PerformanceMeasure","detail")}} - set to the value passed in `MeasureOptions`.
+- {{domxref("PerformanceMeasure","detail")}} - set to the value passed in `measureOptions`.
 
 ### Exceptions
 
@@ -88,25 +88,25 @@ The returned _measure_ will have the following property values:
 
   - : This can be thrown in any case where the start, end or duration might be ambiguous:
 
-    - Both `endMark` and `MeasureOptions` are specified.
-    - `MeasureOptions` is specified without either `start` and `end` members.
-    - `MeasureOptions` is specified with all of `start`, `end`, and `duration` members (which might then be inconsistent).
+    - Both `endMark` and `measureOptions` are specified.
+    - `measureOptions` is specified with `duration` but without specifying either `start` or `end`.
+    - `measureOptions` is specified with all of `start`, `end`, and `duration`.
 
 - `SyntaxError` {{domxref("DOMException")}}
 
   - : The named mark does not exist.
 
-    - An end mark is specified using either `endMark` or `MeasureOptions.end`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
-    - An end mark is specified using either `endMark` or `MeasureOptions.end`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
-    - A start mark is specified using either `startMark` or `MeasureOptions.start`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
-    - A start mark is specified using either `startMark` or `MeasureOptions.start`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
+    - An end mark is specified using either `endMark` or `measureOptions.end`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
+    - An end mark is specified using either `endMark` or `measureOptions.end`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
+    - A start mark is specified using either `startMark` or `measureOptions.start`, but there is no {{domxref('PerformanceMark')}} in the performance buffer with the matching name.
+    - A start mark is specified using either `startMark` or `measureOptions.start`, but it cannot be converted to match that of a read only attribute in the {{domxref("PerformanceTiming")}} interface.
 
 - `DataCloneError` {{domxref("DOMException")}}
 
-  - : The `MeasureOptions.detail` value is non-`null` and cannot be serialized using the HTML "StructuredSerialize" algorithm.
+  - : The `measureOptions.detail` value is non-`null` and cannot be serialized using the HTML "StructuredSerialize" algorithm.
 
 - {{jsxref("RangeError")}}
-  - : The `MeasureOptions.detail` value is non-`null` and memory cannot be allocated during serialization using the HTML "StructuredSerialize" algorithm.
+  - : The `measureOptions.detail` value is non-`null` and memory cannot be allocated during serialization using the HTML "StructuredSerialize" algorithm.
 
 ## Examples
 

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -125,7 +125,7 @@ console.log(loginMeasure.duration);
 
 ### Measuring duration with custom start and end times
 
-To do more advanced measurements, you can configure an `MeasureOptions` object. For example, you can use the [`event.timestamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) as the start time.
+To do more advanced measurements, you can pass a `measureOptions` parameter. For example, you can use the [`event.timeStamp`](/en-US/docs/Web/API/Event/timeStamp) property from a [`click` event](/en-US/docs/Web/API/Element/click_event) as the start time.
 
 ```js
 performance.measure("login-click", {

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -22,12 +22,18 @@ The named timestamp is referred to as a _measure_.
 
 ```js-nolint
 measure(measureName)
-measure(measureName, measureOptions)
 measure(measureName, startMark)
 measure(measureName, startMark, endMark)
+measure(measureName, measureOptions)
+measure(measureName, measureOptions, endMark)
 ```
 
 If only `measureName` is specified, the start timestamp is set to zero, and the end timestamp (which is used to calculate the duration) is the value that would be returned by {{domxref("Performance.now()")}}.
+
+You can use strings to identify {{domxref("PerformanceMark")}} objects as start and end marks.
+
+To only provide an `endMark`, you need to provide an empty `measureOptions` object:
+`performance.measure("myMeasure", {}, "myEndMarker")`.
 
 ### Parameters
 
@@ -37,24 +43,28 @@ If only `measureName` is specified, the start timestamp is set to zero, and the 
 
 - `measureOptions` {{optional_inline}}
 
-  - : An object that may contain measure options. If this object is given as a parameter, the `startMark` and `endMark` parameters must both be omitted.
+  - : An object that may contain measure options.
 
-    - `detail`
+    - `detail` {{optional_inline}}
       - : Arbitrary metadata to be included in the measure. Defaults to `null`. Must be [structured-clonable](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
-    - `start`
-      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the start time, or string to be used as start mark.
-        If this represents the name of a start mark, then it is defined in the same way as `startMark`.
-    - `duration`
+    - `start` {{optional_inline}}
+
+      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the start time, or string that names a {{domxref("PerformanceMark")}} to use for the start time.
+
+        If this is a string naming a {{domxref("PerformanceMark")}}, then it is defined in the same way as `startMark`.
+
+    - `duration` {{optional_inline}}
       - : Duration between the start and end mark times. If omitted, this defaults to {{domxref("performance.now()")}}; the time that has elapsed since the context was created. If provided, you must also specify either `start` or `end` but not both.
-    - `end`
-      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or string to be used as end mark.
-        If this represents the name of an end mark, then it is defined in the same way as `endMark`.
+    - `end` {{optional_inline}}
+      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or string that names a {{domxref("PerformanceMark")}} to use for the end time.
+
+        If this is a string naming a {{domxref("PerformanceMark")}}, then it is defined in the same way as `endMark`.
 
 - `startMark` {{optional_inline}}
-  - : A string representing the name of the measure's starting mark.
-
+  - : A string naming a {{domxref("PerformanceMark")}} in the performance timeline. The {{domxref("PerformanceEntry.startTime")}} property of this mark will be used for calculating the measure.
 - `endMark` {{optional_inline}}
-  - : A string representing the name of the measure's ending mark.
+  - : A string naming a {{domxref("PerformanceMark")}} in the performance timeline. The {{domxref("PerformanceEntry.startTime")}} property of this mark will be used for calculating the measure.
+    If you want to pass this argument, you must also pass either `startMark` or an empty `measureOptions` object.
 
 ### Return value
 
@@ -130,7 +140,7 @@ To do more advanced measurements, you can pass a `measureOptions` parameter. For
 ```js
 performance.measure("login-click", {
   start: myClickEvent.timeStamp,
-  end: myMarker.startTime
+  end: myMarker.startTime,
 });
 ```
 
@@ -142,7 +152,7 @@ You can use the `details` property to provide additional information of any type
 performance.measure("login-click", {
   detail: { htmlElement: myElement.id },
   start: myClickEvent.timeStamp,
-  end: myMarker.startTime
+  end: myMarker.startTime,
 });
 ```
 


### PR DESCRIPTION
### Description

This PR does some cleaning on the user timing methods of the [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance) interface with the goal to provide better example code.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

- I'm not quite sure how I feel about the large return value section on https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#return_value. It's not wrong, but is it useful?

### Related issues and pull requests

https://github.com/mdn/browser-compat-data/pull/18216 is a BCD PR to change "returns undefined" on https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#browser_compatibility. I think it is backwards and that is confusing. It should be "Returns PerformanceMeasure" which is the new behavior which has new browser versions then.