### PR TITLE
Fix red links to `WindowProxy`

### DIFF
--- a/files/en-us/mozilla/firefox/releases/55/index.md
+++ b/files/en-us/mozilla/firefox/releases/55/index.md
@@ -71,7 +71,7 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 #### DOM events
 
 - The event types supported by the {{domxref("Document.createEvent()")}} method have been updated as per the latest DOM spec ({{bug(1251198)}}).
-- The {{domxref("MessageEvent.origin")}} property value is now of type `USVString`, not `DOMString`, and the {{domxref("MessageEvent.source")}} property now takes a `MessageEventSource` value (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) ({{bug(1311324)}}).
+- The {{domxref("MessageEvent.origin")}} property value is now of type `USVString`, not `DOMString`, and the {{domxref("MessageEvent.source")}} property now takes a `MessageEventSource` value (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) ({{bug(1311324)}}).
 - The pinch-to-zoom gesture has now been mapped to the {{domxref("Element/wheel_event","wheel")}} event plus the + `Ctrl` key. This mapping was implemented to allow developers to implement simple zooming functionality using the pinch-to-zoom gesture on mobile screens/trackpads (mousewheel + `Ctrl` commonly zooms) ({{bug(1052253)}}).
 
 #### Selection API

--- a/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/eventsource/message_event/index.md
+++ b/files/en-us/web/api/eventsource/message_event/index.md
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -31,7 +31,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 - {{domxref("HTMLIFrameElement.contentDocument")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Document")}}, the active document in the inline frame's nested browsing context.
 - {{domxref("HTMLIFrameElement.contentWindow")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("WindowProxy")}}, the window proxy for the nested browsing context.
+  - : Returns a {{glossary("WindowProxy")}}, the window proxy for the nested browsing context.
 - {{domxref("HTMLIFrameElement.csp")}} {{Experimental_Inline}}
   - : Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.
 - {{domxref("HTMLIFrameElement.fetchPriority")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
@@ -16,7 +16,7 @@ browser-compat: api.HTMLObjectElement.contentWindow
 {{APIRef("HTML DOM")}}
 
 The **`contentWindow`** read-only property of
-the {{domxref("HTMLObjectElement")}} interface returns a {{domxref("WindowProxy")}}
+the {{domxref("HTMLObjectElement")}} interface returns a {{glossary("WindowProxy")}}
 representing the window proxy of the object element's nested browsing context, if any;
 otherwise null.
 

--- a/files/en-us/web/api/htmlobjectelement/index.md
+++ b/files/en-us/web/api/htmlobjectelement/index.md
@@ -35,7 +35,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLObjectElement.contentDocument")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Document")}} representing the active document of the object element's nested browsing context, if any; otherwise `null`.
 - {{domxref("HTMLObjectElement.contentWindow")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("WindowProxy")}} representing the window proxy of the object element's nested browsing context, if any; otherwise `null`.
+  - : Returns a {{glossary("WindowProxy")}} representing the window proxy of the object element's nested browsing context, if any; otherwise `null`.
 - {{domxref("HTMLObjectElement.data")}}
   - : Returns a string that reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address of a resource's data.
 - {{domxref("HTMLObjectElement.declare")}} {{deprecated_inline}}

--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
@@ -37,7 +37,7 @@ initKeyboardEvent(type, canBubble, cancelable,
 - `cancelable` {{optional_inline}}
   - : Indicates whether or not the event can be canceled. Defaults to `false`.
 - `view` {{optional_inline}}
-  - : The {{domxref("WindowProxy")}} it is associated to. Defaults to `null`.
+  - : The {{glossary("WindowProxy")}} it is associated to. Defaults to `null`.
 - `key` {{optional_inline}}
   - : The value of the key attribute. Defaults to `""`.
 - `location` {{optional_inline}}

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -49,7 +49,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/messageevent/source/index.md
+++ b/files/en-us/web/api/messageevent/source/index.md
@@ -17,12 +17,12 @@ browser-compat: api.MessageEvent.source
 
 The **`source`** read-only property of the
 {{domxref("MessageEvent")}} interface is a `MessageEventSource` (which can be
-a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or
+a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or
 {{domxref("ServiceWorker")}} object) representing the message emitter.
 
 ## Value
 
-a `MessageEventSource` (which can be a {{domxref("WindowProxy")}},
+a `MessageEventSource` (which can be a {{glossary("WindowProxy")}},
 {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the
 message emitter.
 

--- a/files/en-us/web/api/messageport/message_event/index.md
+++ b/files/en-us/web/api/messageport/message_event/index.md
@@ -40,7 +40,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/messageport/messageerror_event/index.md
+++ b/files/en-us/web/api/messageport/messageerror_event/index.md
@@ -40,7 +40,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/rtcdatachannel/message_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/message_event/index.md
@@ -55,7 +55,7 @@ _Also inherits properties from its parent interface, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A reference to the message emitter, one of {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}}.
+  - : A reference to the message emitter, one of {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}}.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/serviceworkercontainer/message_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/message_event/index.md
@@ -43,7 +43,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.md
@@ -45,7 +45,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/svganimationelement/beginevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/beginevent_event/index.md
@@ -41,7 +41,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 - {{domxref("TimeEvent.detail")}} {{ReadOnlyInline}}
   - : A `long` that specifies some detail information about the Event, depending on the type of the event. For this event type, indicates the repeat number for the animation.
 - {{domxref("TimeEvent.view")}} {{ReadOnlyInline}}
-  - : A {{domxref("WindowProxy")}} that identifies the Window from which the event was generated.
+  - : A {{glossary("WindowProxy")}} that identifies the Window from which the event was generated.
 
 ## Examples
 

--- a/files/en-us/web/api/svganimationelement/endevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/endevent_event/index.md
@@ -41,7 +41,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 - {{domxref("TimeEvent.detail")}} {{ReadOnlyInline}}
   - : A `long` that specifies some detail information about the Event, depending on the type of the event. For this event type, indicates the repeat number for the animation.
 - {{domxref("TimeEvent.view")}} {{ReadOnlyInline}}
-  - : A {{domxref("WindowProxy")}} that identifies the Window from which the event was generated.
+  - : A {{glossary("WindowProxy")}} that identifies the Window from which the event was generated.
 
 ## Examples
 

--- a/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
@@ -41,7 +41,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 - {{domxref("TimeEvent.detail")}} {{ReadOnlyInline}}
   - : A `long` that specifies some detail information about the Event, depending on the type of the event. For this event type, indicates the repeat number for the animation.
 - {{domxref("TimeEvent.view")}} {{ReadOnlyInline}}
-  - : A {{domxref("WindowProxy")}} that identifies the Window from which the event was generated.
+  - : A {{glossary("WindowProxy")}} that identifies the Window from which the event was generated.
 
 ## Examples
 

--- a/files/en-us/web/api/timeevent/index.md
+++ b/files/en-us/web/api/timeevent/index.md
@@ -20,7 +20,7 @@ The **`TimeEvent`** interface, a part of [SVG SMIL](/en-US/docs/Web/SVG/SVG_anim
 - {{domxref("TimeEvent.detail")}} {{ReadOnlyInline}}
   - : A `long` that specifies some detail information about the Event, depending on the type of the event. For this event type, indicates the repeat number for the animation.
 - {{domxref("TimeEvent.view")}} {{ReadOnlyInline}}
-  - : A {{domxref("WindowProxy")}} that identifies the Window from which the event was generated.
+  - : A {{glossary("WindowProxy")}} that identifies the Window from which the event was generated.
 
 ## Instance methods
 

--- a/files/en-us/web/api/uievent/index.md
+++ b/files/en-us/web/api/uievent/index.md
@@ -37,7 +37,7 @@ _This interface also inherits properties of its parent, {{domxref("Event")}}._
 - {{domxref("UIEvent.sourceCapabilities")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : Returns an instance of the `InputDeviceCapabilities` interface, which provides information about the physical device responsible for generating a touch event.
 - {{domxref("UIEvent.view")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("WindowProxy")}} that contains the view that generated the event.
+  - : Returns a {{glossary("WindowProxy")}} that contains the view that generated the event.
 - {{domxref("UIEvent.which")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
   - : Returns the numeric `keyCode` of the key pressed, or the character code (`charCode`) for an alphanumeric key pressed.
 

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -44,7 +44,7 @@ initUIEvent(type, canBubble, cancelable, view, detail)
   - : A boolean value defining whether the event can be canceled. Once set, the
     read-only property {{ domxref("Event.cancelable") }} will give its value.
 - `view`
-  - : Is the {{domxref("WindowProxy")}} associated with the event.
+  - : Is the {{glossary("WindowProxy")}} associated with the event.
 - `detail`
   - : An `unsigned long` specifying some detail information about the
     event, depending on the type of event. For mouse events, it indicates how many times

--- a/files/en-us/web/api/uievent/view/index.md
+++ b/files/en-us/web/api/uievent/view/index.md
@@ -16,7 +16,7 @@ browser-compat: api.UIEvent.view
 {{APIRef("UI Events")}}
 
 The **`UIEvent.view`** read-only property returns the
-{{domxref("WindowProxy")}} object from which the event was generated. In browsers, this
+{{glossary("WindowProxy")}} object from which the event was generated. In browsers, this
 is the {{ domxref("Window") }} object the event happened in.
 
 ## Value

--- a/files/en-us/web/api/window/message_event/index.md
+++ b/files/en-us/web/api/window/message_event/index.md
@@ -40,7 +40,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/window/messageerror_event/index.md
+++ b/files/en-us/web/api/window/messageerror_event/index.md
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -49,7 +49,7 @@ _This interface also inherits properties of its parent, {{domxref("Event")}}._
 - {{domxref("UIEvent.sourceCapabilities")}} {{experimental_inline}} {{ReadOnlyInline}}
   - : Returns an instance of the `InputDeviceCapabilities` interface, which provides information about the physical device responsible for generating a touch event.
 - {{domxref("UIEvent.view")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("WindowProxy")}} that contains the view that generated the event.
+  - : Returns a {{glossary("WindowProxy")}} that contains the view that generated the event.
 - {{domxref("UIEvent.which")}} {{deprecated_inline}} {{Non-standard_inline}} {{ReadOnlyInline}}
   - : Returns the numeric `keyCode` of the key pressed, or the character code (`charCode`) for an alphanumeric key pressed.
 

--- a/files/en-us/web/api/window/self/index.md
+++ b/files/en-us/web/api/window/self/index.md
@@ -14,11 +14,11 @@ browser-compat: api.Window.self
 
 {{APIRef}}
 
-The **`Window.self`** read-only property returns the window itself, as a {{domxref("WindowProxy")}}. It can be used with dot notation on a `window` object (that is, `window.self`) or standalone (`self`). The advantage of the standalone notation is that a similar notation exists for non-window contexts, such as in {{domxref("Worker", "Web Workers", "", 1)}}. By using `self`, you can refer to the global scope in a way that will work not only in a window context (`self` will resolve to `window.self`) but also in a worker context (`self` will then resolve to {{domxref("WorkerGlobalScope.self")}}).
+The **`Window.self`** read-only property returns the window itself, as a {{glossary("WindowProxy")}}. It can be used with dot notation on a `window` object (that is, `window.self`) or standalone (`self`). The advantage of the standalone notation is that a similar notation exists for non-window contexts, such as in {{domxref("Worker", "Web Workers", "", 1)}}. By using `self`, you can refer to the global scope in a way that will work not only in a window context (`self` will resolve to `window.self`) but also in a worker context (`self` will then resolve to {{domxref("WorkerGlobalScope.self")}}).
 
 ## Value
 
-A {{domxref("WindowProxy")}} object.
+A {{glossary("WindowProxy")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/worker/message_event/index.md
+++ b/files/en-us/web/api/worker/message_event/index.md
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 

--- a/files/en-us/web/api/worker/messageerror_event/index.md
+++ b/files/en-us/web/api/worker/messageerror_event/index.md
@@ -44,7 +44,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.lastEventId")}} {{ReadOnlyInline}}
   - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
-  - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
+  - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
   - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix red links to `WindowProxy`. It should be replaced with a link to a glossary entry.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
