### PR TITLE
relnote(108) height & width attrs of source element enabled by defalt

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -143,48 +143,6 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
   </tbody>
 </table>
 
-### Height & Width attributes for `<source>`
-
-HTML attributes for [height](/en-US/docs/Web/HTML/Element/source#attr-height) & [width](/en-US/docs/Web/HTML/Element/source#attr-width) ({{bug(1694741)}}).
-
-These attributes can be used in {{HTMLElement("source")}} elements when they are children of {{HTMLElement("picture")}} elements and help to eliminate layout shift.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>106</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>106</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>106</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>106</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.picture_source_dimension_attributes.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -18,6 +18,9 @@ This article provides information about the changes in Firefox 108 that will aff
 
 ### HTML
 
+- The {{HTMLElement("source")}} element supports [`height`](/en-US/docs/Web/HTML/Element/source#attr-height) & [`width`](/en-US/docs/Web/HTML/Element/source#attr-width) attributes when it is a child of a {{HTMLElement("picture")}} element.
+  This functionality can be configured via the `dom.picture_source_dimension_attributes.enabled` preference which is now set to `true` by default ({{bug(1795953)}}).
+
 #### Removals
 
 ### CSS


### PR DESCRIPTION
The `<source>` element supports `height` & `width` attrs by default in 108. The pref `dom.picture_source_dimension_attributes.enabled` is set to `true`.

Also removed the experimental note.

### Related issues

- [ ] Parent issue: https://github.com/mdn/content/issues/22116