### PR TITLE
Fix letter case, spelling and naming issues

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
@@ -288,7 +288,7 @@ To fix this, we need to return a `<Todo />` component from our `map()` function 
   const taskList = props.tasks.map((task) => <Todo />);
 ```
 
-Look again at your app; now our tasks look more like they used to, but they're missing the names of the tasks themselves. Remember that each task we map over has the `id`, `name`, and `checked` properties we want to pass into our `<Todo />` component. If we put that knowledge together, we get code like this:
+Look again at your app; now our tasks look more like they used to, but they're missing the names of the tasks themselves. Remember that each task we map over has the `id`, `name`, and `completed` properties we want to pass into our `<Todo />` component. If we put that knowledge together, we get code like this:
 
 ```jsx
 const taskList = props.tasks.map((task) => (

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -86,7 +86,7 @@ Notes:
 
 ## Project starter code
 
-As a starting point for this project, we're going to provide two things: An `App()` function to replace the one you have now, and some CSS to style your app.
+As a starting point for this project, we're going to provide two things: an `App()` function to replace the one you have now, and some CSS to style your app.
 
 ### The JSX
 
@@ -208,7 +208,7 @@ It's ugly, and doesn't function yet, but that's okay — we'll style it in a mom
 - We have a [`<form>`](/en-US/docs/Web/HTML/Element/form) element, with an [`<input type="text">`](/en-US/docs/Web/HTML/Element/input/text) for writing out a new task, and a button to submit the form.
 - We have an array of buttons that will be used to filter our tasks.
 - We have a heading that tells us how many tasks remain.
-- We have our 3 tasks, arranged in an un-ordered list. Each task is a list item ([`<li>`](/en-US/docs/Web/HTML/Element/li)), and has buttons to edit and delete it and a checkbox to check it off as done.
+- We have our 3 tasks, arranged in an unordered list. Each task is a list item ([`<li>`](/en-US/docs/Web/HTML/Element/li)), and has buttons to edit and delete it and a checkbox to check it off as done.
 
 The form will allow us to _make_ tasks; the buttons will let us _filter_ them; the heading and list are our way to _read_ them. The UI for _editing_ a task is conspicuously absent for now. That's okay – we'll write that later.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Changed `checked` to `completed` as the tasks object contains `completed` properties for each task, not `checked`. Made the article 'An' that appears in the middle of the sentence lowercase. Removed a hyphen from 'un-ordered' (this is the only instance on MDN where this word is spelled with a hyphen).
