### PR TITLE
chore(contrib): fix markdown guide wording

### DIFF
--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -124,6 +124,7 @@ As a rule, do:
 Don't:
 
 - Try to cram multiple fixes into a single pull request. It makes it a lot harder to review, and raises suspicions (some people might think you are trying to hide some malicious code in between the valid changes).
+- Unnecessarily add or remove line breaks on pages that follow a certain formatting style.
 
 ## Deployment timeline
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -312,13 +312,11 @@ This issue was resolved in <https://github.com/mdn/content/issues/3483>.
 
 ## Definition lists
 
-To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}).
-In this form:
+To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}). In this form:
 
 - The GFM `<ul>` contains any number of top-level GFM `<li>` elements.
 - Each of these top-level GFM `<li>` elements must contain, as its final element, one GFM `<ul>` element.
-- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space).
-  This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
+- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space). This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
 
 Each of these top-level GFM `<li>` elements will be transformed into a `<dt>`/`<dd>` pair, as follows:
 
@@ -404,8 +402,7 @@ This issue was resolved in <https://github.com/mdn/content/issues/4367>.
 
 ## Tables
 
-In GFM (but not CommonMark) there is a syntax for tables: <https://github.github.com/gfm/#tables-extension->.
-We will make use of this but:
+In GFM (but not CommonMark) there is a syntax for tables: <https://github.github.com/gfm/#tables-extension->. We will make use of this but:
 
 - The GFM syntax only supports a subset of the features available in HTML. If you need to use table features that are not supported in GFM, use HTML for the table.
 - If the GFM representation of the table would be more than 150 characters wide, use HTML for the table.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -8,11 +8,14 @@ tags:
 
 {{MDNSidebar}}
 
-This page describes how we use Markdown to write documentation on MDN Web Docs. We have chosen GitHub-Flavored Markdown (GFM) as a baseline, and added some extensions to support some of the things we need to do on MDN that aren't readily supported in GFM.
+This page describes how we use Markdown to write documentation on MDN Web Docs.
+We have chosen GitHub-Flavored Markdown (GFM) as a baseline, and added some extensions to support some of the things we need to do on MDN that aren't readily supported in GFM.
 
 ## Baseline: GitHub-Flavored Markdown
 
-The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <https://github.github.com/gfm/>. This means that for anything not otherwise specified in this page, you can refer to the GFM specification. GFM in turn is a superset of CommonMark ([https://spec.commonmark.org/](https://spec.commonmark.org/)).
+The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <https://github.github.com/gfm/>.
+This means that you can refer to the GFM specification for anything not explicitly specified in this page.
+GFM in turn is a superset of CommonMark ([https://spec.commonmark.org/](https://spec.commonmark.org/)).
 
 ## Links
 
@@ -39,7 +42,9 @@ This is an incorrect way to write links on MDN:
 
 ## Example code blocks
 
-In GFM and CommonMark, authors can use "code fences" to demarcate `<pre>` blocks. The opening code fence may be followed by some text that is called the "info string". From the spec:
+In GFM and CommonMark, authors can use "code fences" to demarcate `<pre>` blocks.
+The opening code fence may be followed by some text that is called the "info string".
+The specification states the following:
 
 > The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag.
 
@@ -51,7 +56,9 @@ It's permissible for the info string to contain multiple words, like:
 ```
 ````
 
-In MDN, writers will use code fences for example code blocks. They must specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words are supported:
+On MDN, writers will use code fences for example code blocks.
+They must specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block.
+The following words are supported:
 
 - Programming Languages
   - JavaScript
@@ -108,7 +115,7 @@ const greeting = "I will get JavaScript syntax highlighting";
 ````
 
 If the highlighting that you wish to use is not listed above you should markup the code block as `plain`.
-Additional languages may be requested by following the [this process](https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366).
+Additional languages may be requested in the process [discussed on GitHub](https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366).
 
 ### Suppressing linting
 
@@ -122,7 +129,8 @@ I will not be linted.
 ```
 ````
 
-Code blocks like this will get appropriate syntax highlighting and will be recognized by the live sample system, but will be ignored by linters or automatic formatters like Prettier. This suffix is useful for demonstrating alternative formatting choices or intentionally invalid code that formatters or linters may complain about or autofix.
+Code blocks like this will get appropriate syntax highlighting and will be recognized by the live sample system, but will be ignored by linters or automatic formatters like Prettier.
+Authors should use this suffix for showing invalid code or alternative formatting that linters or formatters should not fix.
 
 ### Additional words
 
@@ -163,21 +171,27 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts.
+Sometimes writers want to call special attention to a piece of content.
+To do this, they will use a GFM blockquote with a special first paragraph.
+There are three types of these: notes, warnings, and callouts.
 
 - To add a note, create a GFM blockquote whose first paragraph starts with `**Note:**`.
 - To add a warning, create a GFM blockquote whose first paragraph starts with `**Warning:**`.
 - To add a callout, create a GFM blockquote whose first paragraph starts with `**Callout:**`.
 
-Notes and warnings will render the **Note:** or **Warning:** text in the output, while callouts will not. This makes callouts a good choice when an author wants to provide a custom title.
+Notes and warnings will render the **Note:** or **Warning:** text in the output, while callouts will not.
+This makes callouts a good choice when an author wants to provide a custom title.
 
-Processing of the markup works on the AST it produces, not on the exact characters provided. This means that providing `<strong>Note:</strong>` will also generate a note. However, the Markdown syntax is required as a matter of style.
+Processing of the markup works on the AST it produces, not on the exact characters provided.
+This means that providing `<strong>Note:</strong>` will also generate a note. However, the Markdown syntax is required as a matter of style.
 
-Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
+Multiple lines are produced by an empty block quote line in the same way as normal paragraphs.
+Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
 
 The blockquote can contain code blocks or other block elements.
 
-Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.
+Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations.
+In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.
 
 ### Examples
 
@@ -198,7 +212,7 @@ This will produce the following HTML:
 </div>
 ```
 
-This HTML will be rendered as a highlighted box, like:
+This HTML will be rendered as a highlighted box:
 
 > **Note:** This is how you write a note.
 >
@@ -221,7 +235,7 @@ This will produce the following HTML:
 </div>
 ```
 
-This HTML will be rendered as a highlighted box, like:
+This HTML will be rendered as a highlighted box:
 
 > **Warning:** This is how you write a warning.
 >
@@ -244,7 +258,7 @@ This will produce the following HTML:
 </div>
 ```
 
-This HTML will be rendered as a highlighted box, like:
+This HTML will be rendered as a highlighted box:
 
 > **Callout:**
 >
@@ -294,7 +308,7 @@ This will produce the following HTML:
 </div>
 ```
 
-This HTML will be rendered as with a code block, like:
+This HTML will be rendered as with a code block:
 
 > **Note:** This is how you write a note.
 >
@@ -312,17 +326,18 @@ This issue was resolved in <https://github.com/mdn/content/issues/3483>.
 
 ## Definition lists
 
-To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}). In this form:
+To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}).
+In this form:
 
 - The GFM `<ul>` contains any number of top-level GFM `<li>` elements.
 - Each of these top-level GFM `<li>` elements must contain, as its final element, one GFM `<ul>` element.
-- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space). This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
+- This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space).
+  This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
 
 Each of these top-level GFM `<li>` elements will be transformed into a
 `<dt>`/`<dd>` pair, as follows:
 
-- The top-level GFM `<li>` element will be parsed as a GFM `<li>` element
-  and its internal contents will comprise the contents of the `<dt>`, except for the final nested `<ul>`, which will not be included in the `<dt>`.
+- The top-level GFM `<li>` element will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dt>`, except for the final nested `<ul>`, which will not be included in the `<dt>`.
 - The `<li>` element in the final nested `<ul>` will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dd>`, except for the leading ": ", which will be discarded.
 
 For example, this is a `<dl>`:
@@ -387,7 +402,9 @@ On MDN, this would produce the following HTML:
 </dl>
 ```
 
-Definition lists written using this syntax must consist of pairs of `<dt>`/`<dd>` elements. Using this syntax, it's not possible to write a list with more than one consecutive `<dt>` element or more than one consecutive `<dd>` element: the parser will treat this as an error. We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.
+Definition lists written using this syntax must consist of pairs of `<dt>`/`<dd>` elements.
+Using this syntax, it's not possible to write a list with more than one consecutive `<dt>` element or more than one consecutive `<dd>` element: the parser will treat this as an error.
+We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.
 
 As a workaround for cases where an author needs to associate multiple `<dt>` items with a single `<dd>`, consider providing them as a single `<dt>` that holds multiple terms, separated by commas, like this:
 
@@ -404,13 +421,15 @@ This issue was resolved in <https://github.com/mdn/content/issues/4367>.
 
 ## Tables
 
-In GFM (but not CommonMark) there is a syntax for tables: <https://github.github.com/gfm/#tables-extension->. We will make use of this but:
+In GFM (but not CommonMark) there is a syntax for tables: <https://github.github.com/gfm/#tables-extension->.
+We will make use of this but:
 
 - The GFM syntax only supports a subset of the features available in HTML. If you need to use table features that are not supported in GFM, use HTML for the table.
 - If the GFM representation of the table would be more than 150 characters wide, use HTML for the table.
 - We support a special kind of table called a "properties table", which has its own CSS class and is therefore always HTML.
 
-So the general principle here is: authors should use the GFM Markdown syntax when they can, and fall back to raw HTML when they have to or when HTML is more readable. See "When to use HTML tables" below.
+So the general principle is that authors should use the GFM Markdown syntax when they can, and fall back to raw HTML when they have to or when HTML is more readable.
+For more information, see [When to use HTML tables](#when_to_use_html_tables).
 
 ### GFM table syntax style
 
@@ -436,7 +455,11 @@ cell 4    | cell 5    | cell 6
 
 ### When to use HTML tables
 
-There are three main circumstances in which authors should use HTML tables rather than GFM syntax: when the table uses features that are not supported in GFM, when the GFM table would be too wide to be readable, and when the writer wants a special type of table called a "properties table".
+There are three main circumstances in which authors should use HTML tables rather than GFM syntax:
+
+1. The table uses features that are not supported in GFM.
+2. The GFM table would be too wide to be readable.
+3. The writer wants a special type of table called a "properties table".
 
 #### Table features that are not supported in GFM
 
@@ -454,7 +477,8 @@ Note that we don't recommend the general use of `<caption>` elements on tables, 
 
 #### GFM table maximum width
 
-Even when a table could be written in GFM it is sometimes better to use HTML, because GFM uses an "ASCII art" approach to tables that is not readable when table rows get long. For example, consider this table:
+Even when a table could be written in GFM it is sometimes better to use HTML, because GFM uses an "ASCII art" approach to tables that is not readable when table rows get long.
+Consider the following table:
 
 ```html
 <table>
@@ -499,7 +523,9 @@ This leads us to the following guideline: _if the Markdown representation of the
 
 #### Properties tables
 
-Properties tables are a specific type of table used for displaying structured property-value content across a set of pages of a particular type. These tables have two columns: the first column is the header column and lists the properties, and the second column lists their values for this particular item. For example, here's the properties table for the {{domxref("PannerNode")}} interface:
+Properties tables are a specific type of table used for displaying structured property-value content across a set of pages of a particular type.
+These tables have two columns: the first column is the header column and lists the properties, and the second column lists their values for this particular item.
+For example, here's the properties table for the {{domxref("PannerNode")}} interface:
 
 <table class="properties">
   <tbody>
@@ -526,7 +552,8 @@ Properties tables are a specific type of table used for displaying structured pr
   </tbody>
 </table>
 
-These pages can't be represented in GFM anyway, because they have a header column. Writers should therefore use HTML. To get the special styling, writers should apply the `"properties"` class to the table:
+These pages can't be represented in GFM because they have a header column, so writers should use HTML in this case.
+To get the special styling, writers should apply the `"properties"` class to the table:
 
 ```html-nolint
 <table class="properties">
@@ -541,13 +568,8 @@ This issue was resolved in <https://github.com/mdn/content/issues/4325>, <https:
 Writers will be able to use the HTML {{HTMLElement("sup")}} and {{HTMLElement("sub")}} elements if necessary, but should use alternatives if possible. In particular:
 
 - For exponentiation, use the caret: `2^53`.
-- For ordinal expressions like 1
-
-  <sup>st</sup>
-
-  , prefer words like "first".
-
-- For footnotes, don't mark up the footnote references with, e.g., `<sup>[1]</sup>`; it's unnecessary.
+- For ordinal expressions like 1<sup>st</sup>, prefer words like "first".
+- For footnotes, don't mark up the footnote references, e.g., `<sup>[1]</sup>`.
 
 ### Discussion reference
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -8,14 +8,11 @@ tags:
 
 {{MDNSidebar}}
 
-This page describes how we use Markdown to write documentation on MDN Web Docs.
-We have chosen GitHub-Flavored Markdown (GFM) as a baseline, and added some extensions to support some of the things we need to do on MDN that aren't readily supported in GFM.
+This page describes how we use Markdown to write documentation on MDN Web Docs. We have chosen GitHub-Flavored Markdown (GFM) as a baseline, and added some extensions to support some of the things we need to do on MDN that aren't readily supported in GFM.
 
 ## Baseline: GitHub-Flavored Markdown
 
-The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <https://github.github.com/gfm/>.
-This means that you can refer to the GFM specification for anything not explicitly specified in this page.
-GFM in turn is a superset of CommonMark ([https://spec.commonmark.org/](https://spec.commonmark.org/)).
+The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <https://github.github.com/gfm/>. This means that you can refer to the GFM specification for anything not explicitly specified in this page. GFM in turn is a superset of CommonMark ([https://spec.commonmark.org/](https://spec.commonmark.org/)).
 
 ## Links
 
@@ -42,9 +39,7 @@ This is an incorrect way to write links on MDN:
 
 ## Example code blocks
 
-In GFM and CommonMark, authors can use "code fences" to demarcate `<pre>` blocks.
-The opening code fence may be followed by some text that is called the "info string".
-The specification states the following:
+In GFM and CommonMark, authors can use "code fences" to demarcate `<pre>` blocks. The opening code fence may be followed by some text that is called the "info string". The specification states the following:
 
 > The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag.
 
@@ -56,9 +51,7 @@ It's permissible for the info string to contain multiple words, like:
 ```
 ````
 
-On MDN, writers will use code fences for example code blocks.
-They must specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block.
-The following words are supported:
+On MDN, writers will use code fences for example code blocks. They must specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words are supported:
 
 - Programming Languages
   - JavaScript
@@ -129,8 +122,7 @@ I will not be linted.
 ```
 ````
 
-Code blocks like this will get appropriate syntax highlighting and will be recognized by the live sample system, but will be ignored by linters or automatic formatters like Prettier.
-Authors should use this suffix for showing invalid code or alternative formatting that linters or formatters should not fix.
+Code blocks like this will get appropriate syntax highlighting and will be recognized by the live sample system, but will be ignored by linters or automatic formatters like Prettier. Authors should use this suffix for showing invalid code or alternative formatting that linters or formatters should not fix.
 
 ### Additional words
 
@@ -171,27 +163,21 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Sometimes writers want to call special attention to a piece of content.
-To do this, they will use a GFM blockquote with a special first paragraph.
-There are three types of these: notes, warnings, and callouts.
+Sometimes writers want to call special attention to a piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts.
 
 - To add a note, create a GFM blockquote whose first paragraph starts with `**Note:**`.
 - To add a warning, create a GFM blockquote whose first paragraph starts with `**Warning:**`.
 - To add a callout, create a GFM blockquote whose first paragraph starts with `**Callout:**`.
 
-Notes and warnings will render the **Note:** or **Warning:** text in the output, while callouts will not.
-This makes callouts a good choice when an author wants to provide a custom title.
+Notes and warnings will render the **Note:** or **Warning:** text in the output, while callouts will not. This makes callouts a good choice when an author wants to provide a custom title.
 
-Processing of the markup works on the AST it produces, not on the exact characters provided.
-This means that providing `<strong>Note:</strong>` will also generate a note. However, the Markdown syntax is required as a matter of style.
+Processing of the markup works on the AST it produces, not on the exact characters provided. This means that providing `<strong>Note:</strong>` will also generate a note. However, the Markdown syntax is required as a matter of style.
 
-Multiple lines are produced by an empty block quote line in the same way as normal paragraphs.
-Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
+Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
 
 The blockquote can contain code blocks or other block elements.
 
-Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations.
-In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.
+Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.
 
 ### Examples
 
@@ -334,8 +320,7 @@ In this form:
 - This final nested `<ul>` must contain a single GFM `<li>` element, whose text content must start with ": " (a colon followed by a space).
   This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.
 
-Each of these top-level GFM `<li>` elements will be transformed into a
-`<dt>`/`<dd>` pair, as follows:
+Each of these top-level GFM `<li>` elements will be transformed into a `<dt>`/`<dd>` pair, as follows:
 
 - The top-level GFM `<li>` element will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dt>`, except for the final nested `<ul>`, which will not be included in the `<dt>`.
 - The `<li>` element in the final nested `<ul>` will be parsed as a GFM `<li>` element and its internal contents will comprise the contents of the `<dd>`, except for the leading ": ", which will be discarded.
@@ -402,9 +387,7 @@ On MDN, this would produce the following HTML:
 </dl>
 ```
 
-Definition lists written using this syntax must consist of pairs of `<dt>`/`<dd>` elements.
-Using this syntax, it's not possible to write a list with more than one consecutive `<dt>` element or more than one consecutive `<dd>` element: the parser will treat this as an error.
-We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.
+Definition lists written using this syntax must consist of pairs of `<dt>`/`<dd>` elements. Using this syntax, it's not possible to write a list with more than one consecutive `<dt>` element or more than one consecutive `<dd>` element: the parser will treat this as an error. We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.
 
 As a workaround for cases where an author needs to associate multiple `<dt>` items with a single `<dd>`, consider providing them as a single `<dt>` that holds multiple terms, separated by commas, like this:
 
@@ -428,8 +411,7 @@ We will make use of this but:
 - If the GFM representation of the table would be more than 150 characters wide, use HTML for the table.
 - We support a special kind of table called a "properties table", which has its own CSS class and is therefore always HTML.
 
-So the general principle is that authors should use the GFM Markdown syntax when they can, and fall back to raw HTML when they have to or when HTML is more readable.
-For more information, see [When to use HTML tables](#when_to_use_html_tables).
+So the general principle is that authors should use the GFM Markdown syntax when they can, and fall back to raw HTML when they have to or when HTML is more readable. For more information, see [When to use HTML tables](#when_to_use_html_tables).
 
 ### GFM table syntax style
 
@@ -477,8 +459,7 @@ Note that we don't recommend the general use of `<caption>` elements on tables, 
 
 #### GFM table maximum width
 
-Even when a table could be written in GFM it is sometimes better to use HTML, because GFM uses an "ASCII art" approach to tables that is not readable when table rows get long.
-Consider the following table:
+Even when a table could be written in GFM it is sometimes better to use HTML, because GFM uses an "ASCII art" approach to tables that is not readable when table rows get long. Consider the following table:
 
 ```html
 <table>
@@ -523,9 +504,7 @@ This leads us to the following guideline: _if the Markdown representation of the
 
 #### Properties tables
 
-Properties tables are a specific type of table used for displaying structured property-value content across a set of pages of a particular type.
-These tables have two columns: the first column is the header column and lists the properties, and the second column lists their values for this particular item.
-For example, here's the properties table for the {{domxref("PannerNode")}} interface:
+Properties tables are a specific type of table used for displaying structured property-value content across a set of pages of a particular type. These tables have two columns: the first column is the header column and lists the properties, and the second column lists their values for this particular item. For example, here's the properties table for the {{domxref("PannerNode")}} interface:
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
This is a follow-up after some rewording in #22299