### PR TITLE
Update setAppBadge's contents parameter detail

### DIFF
--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -27,7 +27,7 @@ setAppBadge(contents)
 ### Parameters
 
 - `contents` {{optional_inline}}
-  - : A {{jsxref("number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
+  - : A {{jsxref("number")}} which will be used as the value of the badge. If `contents` is `0` then a badge not containing a count will be displayed.
 
 ### Return value
 


### PR DESCRIPTION
### Description

PWAs installed through Chrome on the desktop will show an empty badge when 0 is specified as the contents instead of clearing the badge. Tested on Mac and ChromeOS.

### Motivation

Prevent others from shipping bugs to prod based on this documentation.
