### PR TITLE
Move "use strict" directive

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -45,9 +45,10 @@ A bound function can be further bound by calling `boundFn.bind(thisArg, /* more 
 
 ```js
 "use strict"; // prevent `this` from being boxed into the wrapper object
+
 function log(...args) {
   console.log(this, ...args);
-};
+}
 const boundLog = log.bind("this value", 1, 2);
 const boundLog2 = boundLog.bind("new this value", 3, 4);
 boundLog2(5, 6); // "this value", 1, 2, 3, 4, 5, 6

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -44,8 +44,8 @@ The `bind()` function creates a new _bound function_. Calling the bound function
 A bound function can be further bound by calling `boundFn.bind(thisArg, /* more args */)`, which creates another bound function `boundFn2`. The newly bound `thisArg` value is ignored, because the target function of `boundFn2`, which is `boundFn`, already has a bound `this`. When `boundFn2` is called, it would call `boundFn`, which in turn calls `fn`. The arguments that `fn` ultimately receives are, in order: the arguments bound by `boundFn`, arguments bound by `boundFn2`, and the arguments received by `boundFn2`.
 
 ```js
+"use strict"; // prevent `this` from being boxed into the wrapper object
 function log(...args) {
-  "use strict"; // prevent `this` from being boxed into the wrapper object
   console.log(this, ...args);
 };
 const boundLog = log.bind("this value", 1, 2);


### PR DESCRIPTION
Function.prototype.bind()/Description: example contains "[Illegal 'use strict' in function](https://mzl.la/3Oai8Vt)"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The code below returns `SyntaxError: Illegal 'use strict' directive in function with non-simple parameter list` when running it, while it is expected to return something like `[String: 'this value'] 1 2 3 4 5 6`

```
function log(...args) {
  "use strict"; // prevent `this` from being boxed into the wrapper object
  console.log(this, ...args);
};
const boundLog = log.bind("this value", 1, 2);
const boundLog2 = boundLog.bind("new this value", 3, 4);
boundLog2(5, 6); // "this value", 1, 2, 3, 4, 5, 6
```

![image](https://user-images.githubusercontent.com/61774862/202009752-8b20f272-173f-4ea8-b38a-b1ccbd5ba7d9.png)


### Motivation

Participating in the community while diving deeper into JavaScript.

### Additional details

The problem is noted here in the MDN documentation here: [SyntaxError: "use strict" not allowed in function with non-simple parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
