### PR TITLE
CSP trusted types docs: Fix capitalization of `trustedTypes.createPolicy`

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Content-Security-Policy.trusted-types
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`trusted-types`** {{experimental_inline}} directive instructs user agents to restrict the creation of Trusted Types policies - functions that build non-spoofable, typed values intended to be passed to DOM XSS sinks in place of strings.
 
-Together with **[`require-trusted-types-for`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)** directive, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review. This directive declares an allow-list of trusted type policy names created with `TrustedTypes.createPolicy` from Trusted Types API.
+Together with **[`require-trusted-types-for`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)** directive, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review. This directive declares an allow-list of trusted type policy names created with `trustedTypes.createPolicy` from Trusted Types API.
 
 ## Syntax
 


### PR DESCRIPTION
`TrustedTypes.createPolicy` does not exist, so `trustedTypes.createPolicy` was almost certainly meant.

### Description

Fix a typo.

### Motivation

Avoid confusing people about what the function is called.

### Additional details

Docs lower in the same page.

### Related issues and pull requests

N/A