### PR TITLE
Add TextDecoderOptions.ignoreBOM

### DIFF
--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -36,6 +36,10 @@ new TextDecoder(label, options)
       - : A boolean value indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a {{jsxref("TypeError")}} when decoding invalid data.
         It defaults to `false`, which means that the decoder will substitute malformed data with a replacement character.
 
+    - `ignoreBOM`
+      - : A boolean value indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) is ignored.
+        It defaults to `false`.
+
 ### Exceptions
 
 - {{jsxref("RangeError")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add TextDecoderOptions.ignoreBOM

### Motivation

It was missing

### Additional details

https://encoding.spec.whatwg.org/#dom-textdecoderoptions-ignorebom

### Related issues and pull requests

Fixes #22268


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
