### PR TITLE
Move "Property attributes" window below Interactive Examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/infinity/index.md
@@ -12,9 +12,9 @@ browser-compat: javascript.builtins.Infinity
 
 The global property **`Infinity`** is a numeric value representing infinity.
 
-{{js_property_attributes(0,0,0)}}
-
 {{EmbedInteractiveExample("pages/js/globalprops-infinity.html")}}
+
+{{js_property_attributes(0,0,0)}}
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -12,9 +12,9 @@ browser-compat: javascript.builtins.NaN
 
 The global **`NaN`** property is a value representing Not-A-Number.
 
-{{js_property_attributes(0, 0, 0)}}
-
 {{EmbedInteractiveExample("pages/js/globalprops-nan.html")}}
+
+{{js_property_attributes(0, 0, 0)}}
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -15,9 +15,9 @@ browser-compat: javascript.builtins.String.length
 
 The **`length`** read-only property of a string contains the length of the string in UTF-16 code units.
 
-{{js_property_attributes(0, 0, 0)}}
-
 {{EmbedInteractiveExample("pages/js/string-length.html", "shorter")}}
+
+{{js_property_attributes(0, 0, 0)}}
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -14,9 +14,9 @@ The global **`undefined`** property represents the primitive
 value `{{Glossary("Undefined", "undefined")}}`. It is one of JavaScript's
 {{Glossary("Primitive", "primitive types")}}.
 
-{{js_property_attributes(0,0,0)}}
-
 {{EmbedInteractiveExample("pages/js/globalprops-undefined.html")}}
+
+{{js_property_attributes(0,0,0)}}
 
 ## Syntax
 


### PR DESCRIPTION
There are 35 pages in which "Property attributes" window is below Interactive Example and 4 pages in which "Property attributes" is above. For example [Infinity](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity) page has "Property attributes" placed first, while in [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) its the opposite. I have moved Property Attributes window in those 4 pages, so order is uniform.