### PR TITLE
relnote(108) Add details about container query length units

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -639,6 +639,47 @@ See {{bug(1715546)}} for more details.
   </tbody>
 </table>
 
+### Container query length units
+
+The CSS length units `cqw`, `cqh`, `cqi`, `cqb`, `cqmin`, `cqmax` are units of length relative to the size of a query container.
+For more information on these units, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1744231)}}).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.container-queries.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -27,8 +27,8 @@ This article provides information about the changes in Firefox 108 that will aff
   This allows the use of `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()` functions within the CSS [`calc()`](/en-US/docs/Web/CSS/calc) function.
   Additionally, a CSS [`<calc-constant>`](/en-US/docs/Web/CSS/calc-constant) type is implemented to allow for well-known constants such as `pi` and `e` within the `calc()` function ({{bug(1774589)}}, {{bug(1682444)}}).
 
-- Container query length units are now supported via the the `layout.css.container-queries.enabled` preference which is set to `false` by default.
-  Setting this preference to `true` allows the use of `cqw`, `cqh`, `cqi`, `cqb`, `cqmin`, `cqmax` units of length which are relative to the size of a query container.
+- Container query length units are now supported via the the `layout.css.container-queries.enabled` preference, which is set to `false` by default.
+  Setting this preference to `true` allows the use of `cqw`, `cqh`, `cqi`, `cqb`, `cqmin`, and `cqmax` units of length which are relative to the size of a query container.
   For more information on these units, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1744231)}}).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -27,6 +27,10 @@ This article provides information about the changes in Firefox 108 that will aff
   This allows the use of `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()` functions within the CSS [`calc()`](/en-US/docs/Web/CSS/calc) function.
   Additionally, a CSS [`<calc-constant>`](/en-US/docs/Web/CSS/calc-constant) type is implemented to allow for well-known constants such as `pi` and `e` within the `calc()` function ({{bug(1774589)}}, {{bug(1682444)}}).
 
+- Container query length units are now supported via the the `layout.css.container-queries.enabled` preference which is set to `false` by default.
+  Setting this preference to `true` allows the use of `cqw`, `cqh`, `cqi`, `cqb`, `cqmin`, `cqmax` units of length which are relative to the size of a query container.
+  For more information on these units, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1744231)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
This PR adds details about container query length units which are behind a pref `layout.css.container-queries.enabled`.


- [x] Parent issue https://github.com/mdn/content/issues/22119