### PR TITLE
DOM whitespace: show 0th step of example processing

### DIFF
--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -103,7 +103,14 @@ Because of this, it establishes what is called an [inline formatting context](/e
 
 Inside this context, whitespace character processing can be summarized as follows:
 
-1. First, all spaces and tabs immediately before and after a line break are ignored so, if we take our example markup from before and apply this first rule, we get:
+1. First, all spaces and tabs immediately before and after a line break are ignored so, if we take our example markup from before:
+
+   ```html
+   <h1>◦◦◦Hello◦⏎
+   ⇥⇥⇥⇥<span>◦World!</span>⇥◦◦</h1>
+   ```
+
+   ...and apply this first rule, we get:
 
    ```html
    <h1>◦◦◦Hello⏎
@@ -173,9 +180,19 @@ This renders like so:
 
 #### Explanation
 
-We can summarize how the whitespace here is handled as follows (the may be some slight differences in exact behavior between browsers, but this basically works):
+We can summarize how the whitespace here is handled as follows (there may be some slight differences in exact behavior between browsers, but this basically works):
 
-1. Because we're inside a block formatting context, everything must be a block, so our 3 text nodes also become blocks, just like the 2 `<div>`s. Blocks occupy the full width available and are stacked on top of each other, which means that we end up with a layout composed of this list of blocks:
+1. Because we're inside a block formatting context, everything must be a block, so our 3 text nodes also become blocks, just like the 2 `<div>`s. Blocks occupy the full width available and are stacked on top of each other, which means that, starting from the example above:
+
+   ```html
+   <body>⏎
+   ⇥<div>◦◦Hello◦◦</div>⏎
+   ⏎
+   ◦◦◦<div>◦◦World!◦◦</div>◦◦⏎
+   </body>
+   ```
+
+   ...we end up with a layout composed of this list of blocks:
 
    ```html
    <block>⏎⇥</block>


### PR DESCRIPTION
### Description

In the [How whitespace is handled by HTML, CSS, and in the DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace) page, the source code for the whitespace processing examples is shown a bit earlier in the document than the corresponding processing steps, sufficiently so that they can be above the fold when one gets to the sequence of steps.

Furthermore, the sequences of steps include the visual whitespace indicators directly in the HTML code, unlike what's done in the initial example code blocks.

This change introduces the starting code in the processing steps (as a "zeroth step"), including the whitespace characters.

### Motivation

For pedagogical purposes, it's helpful to allow readers to see the source text be gradually transformed, rather than scroll up and down to see the effect of the first transformation step. 

### Additional details

A small typo is also fixed: "the may be" → "there may be".

### Related issues and pull requests

N/A
