### PR TITLE
Mention the white-space property in the "Wrapping and breaking text" page

### DIFF
--- a/files/en-us/web/css/css_text/wrapping_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_text/index.md
@@ -78,5 +78,6 @@ In the below example the text breaks in the location of the {{HTMLElement("wbr")
 - The HTML {{HTMLElement("wbr")}} element
 - The CSS {{cssxref("word-break")}} property
 - The CSS {{cssxref("overflow-wrap")}} property
+- The CSS {{cssxref("white-space")}} property
 - The CSS {{cssxref("hyphens")}} property
 - [Overflow and Data Loss in CSS](https://www.smashingmagazine.com/2019/09/overflow-data-loss-css/)


### PR DESCRIPTION
### Description

This change simply adds a link to the [white-space](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) property in the [Wrapping and breaking text](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Text/Wrapping_Text) page.

### Motivation

The `white-space` property is relevant for text wrapping, so it should be mentioned in this overview page.

### Additional details

N/A

### Related issues and pull requests

N/A
