### PR TITLE
Include TransformStream in Streams API group

### DIFF
--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: api.TransformStreamDefaultController
 ---
 
-{{DefaultAPISidebar("Streams API")}}
+{{APIRef("Streams")}}
 
 The **`TransformStreamDefaultController`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides methods to manipulate the associated {{domxref("ReadableStream")}} and {{domxref("WritableStream")}}.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1206,6 +1206,8 @@
         "ReadableStreamBYOBRequest",
         "ReadableStreamDefaultController",
         "ReadableStreamDefaultReader",
+        "TransformStream",
+        "TransformStreamDefaultController",
         "WritableStream",
         "WritableStreamDefaultController",
         "WritableStreamDefaultWriter"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Adds `TransformStream` and `TransformStreamDefaultController` to the Stream API group. Fixes `TransformStreamDefaultController` sidebar to reference this group.


### Motivation

Makes it easier to navigate to/from `TransformStream` pages.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
