### PR TITLE
Add/update XPath sidebars

### DIFF
--- a/files/en-us/web/xpath/axes/index.md
+++ b/files/en-us/web/xpath/axes/index.md
@@ -9,7 +9,11 @@ tags:
   - XSLT_Reference
 ---
 
-{{ XsltRef() }} There are thirteen different axes in the [XPath](/en-US/docs/Web/XPath) specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree.
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/XPath")}}
+</section>
+
+There are thirteen different axes in the [XPath](/en-US/docs/Web/XPath) specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree.
 
 For further information on using XPath expressions, please see the [For Further Reading](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT#for_further_reading) section at the end of [Transforming XML with XSLT](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT) document. Also see the ['axes' section in the xpath spec](https://www.w3.org/TR/xpath-30/#axes).
 
@@ -22,7 +26,7 @@ For further information on using XPath expressions, please see the [For Further 
 - [child](/en-US/docs/Web/XPath/Axes/child)
   - : Indicates the children of the context node. If an XPath expression does not specify an axis, this is understood by default. Since only the root node or element nodes have children, any other use will select nothing.
 - [descendant](/en-US/docs/Web/XPath/Axes/descendant)
-  - : Indicates all of the children of the context node, and all of their children, and so forth. Attribute and namespace nodes are **not** included - the `parent` of an `attribute` node is an element node, but `attribute` nodes are not the children of their parents.
+  - : Indicates all the children of the context node, and all of their children, and so forth. Attribute and namespace nodes are **not** included - the `parent` of an `attribute` node is an element node, but `attribute` nodes are not the children of their parents.
 - [descendant-or-self](/en-US/docs/Web/XPath/Axes/descendant-or-self)
   - : Indicates the context node and all of its descendants. Attribute and namespace nodes are **not** included - the `parent` of an `attribute` node is an element node, but `attribute` nodes are not the children of their parents.
 - [following](/en-US/docs/Web/XPath/Axes/following)

--- a/files/en-us/web/xpath/comparison_with_css_selectors/index.md
+++ b/files/en-us/web/xpath/comparison_with_css_selectors/index.md
@@ -10,7 +10,9 @@ tags:
   - XPath
 ---
 
-{{XSLTRef}}
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/XPath")}}
+</section>
 
 This article seeks to document the difference between CSS Selectors and XPath for web developers to be able to better choose the right tool for the right job.
 

--- a/files/en-us/web/xpath/functions/index.md
+++ b/files/en-us/web/xpath/functions/index.md
@@ -9,7 +9,11 @@ tags:
   - XSLT_Reference
 ---
 
-{{ XsltRef() }} The following is an annotated list of core [XPath](/en-US/docs/Web/XPath) functions and [XSLT](/en-US/docs/Web/XSLT)-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation. For further information on using XPath/XSLT functions, please see the [For Further Reading](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT) page.
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/XPath")}}
+</section>
+
+The following is an annotated list of core [XPath](/en-US/docs/Web/XPath) functions and [XSLT](/en-US/docs/Web/XSLT)-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation. For further information on using XPath/XSLT functions, please see the [For Further Reading](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT) page.
 
 - [boolean()](/en-US/docs/Web/XPath/Functions/boolean)
 - [ceiling()](/en-US/docs/Web/XPath/Functions/ceiling)

--- a/files/en-us/web/xpath/index.md
+++ b/files/en-us/web/xpath/index.md
@@ -12,7 +12,21 @@ tags:
   - XSLT
 ---
 
-{{XSLTRef}}
+<section id="Quick_links">
+  <ol>
+    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+    <li class="toggle"><details open><summary>Guides</summary>
+      <ol>
+        <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
+        <li><a href="/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript">Introduction to using XPath in JavaScript</a></li>
+        <li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li>
+      </ol></details>
+    </li>
+    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details></li>
+    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details></li>
+  </ol>
+</section>
 
 XPath stands for XML Path Language. It uses a non-XML syntax to provide a flexible way of addressing (pointing to) different parts of an [XML](/en-US/docs/Web/XML/XML_introduction) document. It can also be used to test addressed nodes within a document to determine whether they match a pattern or not.
 
@@ -46,18 +60,3 @@ XPath uses a path notation (as in URLs) for navigating through the hierarchical 
 
 - [XSLT](/en-US/docs/Web/XSLT), [XML](/en-US/docs/Web/XML), [DOM](/en-US/docs/Web/API/Document_Object_Model)
 - [Comparison of CSS Selectors and XPath](/en-US/docs/Web/XPath/Comparison_with_CSS_selectors)
-
-<section id="Quick_links">
-  <ol>
-    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
-    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
-    <li class="toggle"><details open><summary>Guides</summary>
-      <ol>
-        <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
-        <li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li>
-      </ol></details>
-    </li>
-    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details></li>
-    <li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details></li>
-  </ol>
-</section>

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -13,6 +13,10 @@ tags:
   - XSLT
 ---
 
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/XPath")}}
+</section>
+
 This document describes the interface for using [XPath](/en-US/docs/Web/XPath) in JavaScript internally, in extensions, and from websites. Mozilla implements a fair amount of the [DOM 3 XPath](https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/), which means that XPath expressions can be run against both HTML and XML documents.
 
 The main interface to using XPath is the [evaluate](/en-US/docs/Web/API/Document/evaluate) function of the [document](/en-US/docs/Web/API/Document) object.
@@ -33,7 +37,7 @@ The [`evaluate()`](/en-US/docs/Web/API/Document/evaluate) method takes a total o
 - `contextNode`: A node in the document against which the `xpathExpression` should be evaluated, including any and all of its child nodes. The [document](/en-US/docs/Web/API/Document) node is the most commonly used.
 - `namespaceResolver`: A function that will be passed any namespace prefixes contained within `xpathExpression` which returns a string representing the namespace URI associated with that prefix. This enables conversion between the prefixes used in the XPath expressions and the possibly different prefixes used in the document. The function can be either:
 
-  - [Created](#implementing_a_default_namespace_resolver) by using the [`createNSResolver`](/en-US/docs/Web/API/Document/createNSResolver) method of a [`XPathEvaluator`](/en-US/docs/Web/API/XPathEvaluator) object. You should use this virtually all of the time.
+  - [Created](#implementing_a_default_namespace_resolver) by using the [`createNSResolver`](/en-US/docs/Web/API/Document/createNSResolver) method of a [`XPathEvaluator`](/en-US/docs/Web/API/XPathEvaluator) object. You should use this virtually all the time.
   - `null`, which can be used for HTML documents or when no namespace prefixes are used. Note that, if the `xpathExpression` contains a namespace prefix, this will result in a `DOMException` being thrown with the code `NAMESPACE_ERR`.
   - A custom user-defined function. See the [Using a User Defined Namespace Resolver](#implementing_a_user_defined_namespace_resolver) section in the appendix for details.
 
@@ -279,7 +283,7 @@ function nsResolver(prefix) {
 }
 ```
 
-Our call to `document.evaluate` would then looks like:
+Our call to `document.evaluate` would then look like:
 
 ```js
 document.evaluate('//xhtml:td/mathml:math', document, nsResolver, XPathResult.ANY_TYPE, null);

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -9,6 +9,10 @@ tags:
   - XSLT
 ---
 
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/XPath")}}
+</section>
+
 This article provides some XPath code snippets — simple examples of how to a few simple **utility functions** based on standard interfaces from the [DOM Level 3 XPath specification](https://www.w3.org/TR/DOM-Level-3-XPath/) that expose XPath functionality to JavaScript code. The snippets are functions you can use in the real world in your own code.
 
 ### Node-specific evaluator function
@@ -146,5 +150,3 @@ function getXPathForElement(el, xml) {
 ## See also
 
 - [Introduction to using XPath in JavaScript](/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript)
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}


### PR DESCRIPTION
One page was missing sidebar. One had double sidebar declaration.
Here using `{{QuickLinksWithSubpages}}` macro creates [very ugly sidebars](https://developer.mozilla.org/en-US/docs/Web/XPath/snippets). So used `{{ListSubpagesForSidebar}}` macro.