### PR TITLE
stroke-dasharray: add "gap at start" example

### DIFF
--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.md
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.md
@@ -39,27 +39,29 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 30 12" xmlns="http://www.w3.org/2000/svg">
   <!-- No dashes nor gaps -->
   <line x1="0" y1="1" x2="30" y2="1" stroke="black" />
 
   <!-- Dashes and gaps of the same size -->
-  <line x1="0" y1="3" x2="30" y2="3" stroke="black" stroke-dasharray="4" />
+  <line x1="0" y1="3" x2="30" y2="3" stroke="black"
+    stroke-dasharray="4" />
 
   <!-- Dashes and gaps of different sizes -->
-  <line x1="0" y1="5" x2="30" y2="5" stroke="black" stroke-dasharray="4 1" />
+  <line x1="0" y1="5" x2="30" y2="5" stroke="black"
+    stroke-dasharray="4 1" />
 
   <!-- Dashes and gaps of various sizes with an odd number of values -->
-  <line x1="0" y1="7" x2="30" y2="7" stroke="black" stroke-dasharray="4 1 2" />
+  <line x1="0" y1="7" x2="30" y2="7" stroke="black"
+    stroke-dasharray="4 1 2" />
 
   <!-- Dashes and gaps of various sizes with an even number of values -->
-  <line
-    x1="0"
-    y1="9"
-    x2="30"
-    y2="9"
-    stroke="black"
+  <line x1="0" y1="9" x2="30" y2="9" stroke="black"
     stroke-dasharray="4 1 2 3" />
+
+  <!-- Dashes starting with a gap -->
+  <line x1="0" y1="11" x2="30" y2="11" stroke="black"
+    stroke-dasharray="0 4 0" />
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add "space at start" example for `stroke-dasharray`.

Notice: the fr translation is available at https://github.com/mdn/translated-content/pull/9945

### Motivation

It is not clear that we can start our "pattern" using a space. Doing that clarify that this is possible and show a simple way to achieve our result.

### Additional details

N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

I did not open an issue for this.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

@cw118 
