### PR TITLE
Add structuredClone mention on spread syntax page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -122,7 +122,7 @@ arr2.push(4);
 //  arr remains unaffected
 ```
 
-> **Note:** Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays. The same is true with {{jsxref("Object.assign()")}} — no native operation in JavaScript does a deep clone.
+> **Note:** Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays. The same is true with {{jsxref("Object.assign()")}} — no native operation in JavaScript does a deep clone, however the WebAPI method {{domxref("structuredClone()")}} could be used in certain cases to deep copy values of [supported types](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types).
 >
 > ```js example-bad
 > const a = [[1], [2], [3]];

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -122,7 +122,7 @@ arr2.push(4);
 //  arr remains unaffected
 ```
 
-> **Note:** Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays. The same is true with {{jsxref("Object.assign()")}} — no native operation in JavaScript does a deep clone, however the WebAPI method {{domxref("structuredClone()")}} could be used in certain cases to deep copy values of [supported types](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types).
+> **Note:** Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays. The same is true with {{jsxref("Object.assign()")}} — no native operation in JavaScript does a deep clone. The web API method {{domxref("structuredClone()")}} allows deep copying values of certain [supported types](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types).
 >
 > ```js example-bad
 > const a = [[1], [2], [3]];


### PR DESCRIPTION
### Description

As per https://github.com/mdn/content/issues/22371, a short mention of WebAPI's method `structuredClone` has been added to the note stating that there is no native JavaScript operation that does a deep clone. This change applies to the "Copy an array" section of the "Spread syntax" page.

### Motivation

Even though the `structuredClone` method is not Javascript-native, people reading "Spread syntax" page might be interested in knowing that there's a ready-to-use, browser-compatible, method that allows to deep clone objects (with certain limitations that have been indicated). 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #22371

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
