### PR TITLE
Document VideoDecoder.isConfigSupported()

### DIFF
--- a/files/en-us/web/api/videodecoder/index.md
+++ b/files/en-us/web/api/videodecoder/index.md
@@ -36,6 +36,11 @@ _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 - {{domxref("VideoDecoder.dequeue_event", "dequeue")}} {{Experimental_Inline}}
   - : Fires to signal a decrease in {{domxref("VideoDecoder.decodeQueueSize")}}.
 
+## Static methods
+
+- {{domxref("VideoDecoder.isConfigSupported()")}} {{Experimental_Inline}}
+  - : Returns a promise indicating whether the provided `VideoDecoderConfig` is supported.
+
 ## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("EventTarget")}}._

--- a/files/en-us/web/api/videodecoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported/index.md
@@ -1,0 +1,78 @@
+---
+title: VideoDecoder.isConfigSupported()
+slug: Web/API/VideoDecoder/isConfigSupported
+page-type: web-api-static-method
+tags:
+  - API
+  - Method
+  - Reference
+  - isConfigSupported
+  - VideoDecoder
+  - Experimental
+browser-compat: api.VideoDecoder.isConfigSupported
+---
+
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
+
+The **`isConfigSupported()`** static method of the {{domxref("VideoDecoder")}} interface checks if the given config is supported (that is, if {{domxref("VideoDecoder")}} objects can be successfully configured with the given config).
+
+## Syntax
+
+```js-nolint
+isConfigSupported(config)
+```
+
+### Parameters
+
+- `config`
+  - : The dictionary object accepted by {{domxref("VideoDecoder.configure")}}
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an object containing the following members:
+
+- `supported` {{optional_inline}}
+  - : A boolean value which is `true` if the given config is supported by the decoder.
+- `config` {{optional_inline}}
+  - : A copy of the given config with all the fields recognized by the decoder.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the provided `config` is invalid; that is, if doesn't have required values (such as an empty `codec` field) or has invalid values (such as a negative `codedWidth`)
+
+## Examples
+
+The following example tests if the browser supports accelerated and un-accelerated
+versions of several video codecs.
+
+```js
+const codecs = ['avc1.42001E', 'vp8', 'vp09.00.10.08', 'av01.0.04M.08'];
+const accelerations = ['prefer-hardware', 'prefer-software']
+
+const configs = [];
+for (const codec of codecs) {
+  for (const acceleration of accelerations) {
+    configs.push({
+      codec,
+      hardwareAcceleration: acceleration,
+      codedWidth: 1280,
+      codedHeight: 720,
+      not_supported_field: 123
+    });
+  }
+}
+
+for (const config of configs) {
+  const support = await VideoDecoder.isConfigSupported(config);
+  console.log(`VideoDecoder's config ${JSON.stringify(support.config)} support: ${support.supported}`);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videodecoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported/index.md
@@ -31,9 +31,9 @@ isConfigSupported(config)
 
 A {{jsxref("Promise")}} that resolves with an object containing the following members:
 
-- `supported` {{optional_inline}}
+- `supported`
   - : A boolean value which is `true` if the given config is supported by the decoder.
-- `config` {{optional_inline}}
+- `config`
   - : A copy of the given config with all the fields recognized by the decoder.
 
 ### Exceptions

--- a/files/en-us/web/api/videodecoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported/index.md
@@ -39,7 +39,7 @@ A {{jsxref("Promise")}} that resolves with an object containing the following me
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the provided `config` is invalid; that is, if doesn't have required values (such as an empty `codec` field) or has invalid values (such as a negative `codedWidth`)
+  - : Thrown if the provided `config` is invalid; that is, if doesn't have required values (such as an empty `codec` field) or has invalid values (such as a negative `codedWidth`).
 
 ## Examples
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -31,9 +31,9 @@ isConfigSupported(config)
 
 A {{jsxref("Promise")}} that resolves with an object containing the following members:
 
-- `supported` {{optional_inline}}
+- `supported`
   - : A boolean value which is `true` if the given config is supported by the encoder.
-- `config` {{optional_inline}}
+- `config`
   - : A copy of the given config with all the fields recognized by the encoder.
 
 ### Exceptions


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Document `VideoDecoder.isConfigSupported()`, similar to `VideoEncoder.isConfigSupported()`.

### Motivation

This is a core method of the `VideoDecoder` interface.

### Additional details

https://www.w3.org/TR/webcodecs/#dom-videodecoder-isconfigsupported

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
