### PR TITLE
Document AudioDecoder/AudioEncoder.isConfigSupported()

### DIFF
--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -36,6 +36,11 @@ _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 - {{domxref("AudioDecoder.dequeue_event", "dequeue")}} {{Experimental_Inline}}
   - : Fires to signal a decrease in {{domxref("AudioDecoder.decodeQueueSize")}}.
 
+## Static methods
+
+- {{domxref("AudioDecoder.isConfigSupported()")}} {{Experimental_Inline}}
+  - : Returns a promise indicating whether the provided `AudioDecoderConfig` is supported.
+
 ## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("EventTarget")}}._

--- a/files/en-us/web/api/audiodecoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/audiodecoder/isconfigsupported/index.md
@@ -1,0 +1,71 @@
+---
+title: AudioDecoder.isConfigSupported()
+slug: Web/API/AudioDecoder/isConfigSupported
+page-type: web-api-static-method
+tags:
+  - API
+  - Method
+  - Reference
+  - isConfigSupported
+  - AudioDecoder
+  - Experimental
+browser-compat: api.AudioDecoder.isConfigSupported
+---
+
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
+
+The **`isConfigSupported()`** static method of the {{domxref("AudioDecoder")}} interface checks if the given config is supported (that is, if {{domxref("AudioDecoder")}} objects can be successfully configured with the given config).
+
+## Syntax
+
+```js-nolint
+isConfigSupported(config)
+```
+
+### Parameters
+
+- `config`
+  - : The dictionary object accepted by {{domxref("AudioDecoder.configure")}}
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an object containing the following members:
+
+- `supported`
+  - : A boolean value which is `true` if the given config is supported by the decoder.
+- `config`
+  - : A copy of the given config with all the fields recognized by the decoder.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the provided `config` is invalid; that is, if doesn't have required values (such as an empty `codec` field) or has invalid values (such as a negative `sampleRate`).
+
+## Examples
+
+The following example tests if the browser supports several audio codecs.
+
+```js
+const codecs = ['mp4a.40.2', 'mp3', 'alaw', 'ulaw'];
+const configs = [];
+for (const codec of codecs) {
+  configs.push({
+      codec,
+      sampleRate: 48000,
+      numberOfChannels: 1,
+      not_supported_field: 123
+  });
+}
+for (const config of configs) {
+  const support = await AudioDecoder.isConfigSupported(config);
+  console.log(`AudioDecoder's config ${JSON.stringify(support.config)} support: ${support.supported}`);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -28,9 +28,9 @@ configure(config)
   - : A dictionary object containing the following members:
     - `codec`
       - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
-    - `sampleRate` {{optional_inline}}
+    - `sampleRate`
       - : An integer representing the number of frame samples per second.
-    - `numberOfChannels` {{optional_inline}}
+    - `numberOfChannels`
       - : An integer representing the number of audio channels.
     - `bitrate` {{optional_inline}}
       - : An integer representing the bitrate.
@@ -61,8 +61,10 @@ const init = {
 };
 
 let config = {
-  codec: "vp8",
-  bitrate: 2_000_000, // 2 Mbps
+  codec: "opus",
+  sampleRate: 44100,
+  numberOfCannels: 2,
+  bitrate: 128_000, // 128 kbps
 };
 
 let encoder = new AudioEncoder(init);

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -35,6 +35,11 @@ _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 - {{domxref("AudioEncoder.dequeue_event", "dequeue")}} {{Experimental_Inline}}
   - : Fires to signal a decrease in {{domxref("AudioEncoder.encodeQueueSize")}}.
 
+## Static methods
+
+- {{domxref("AudioEncoder.isConfigSupported()")}} {{Experimental_Inline}}
+  - : Returns a promise indicating whether the provided `AudioEncoderConfig` is supported.
+
 ## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("EventTarget")}}._

--- a/files/en-us/web/api/audioencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/audioencoder/isconfigsupported/index.md
@@ -1,0 +1,71 @@
+---
+title: AudioEncoder.isConfigSupported()
+slug: Web/API/AudioEncoder/isConfigSupported
+page-type: web-api-static-method
+tags:
+  - API
+  - Method
+  - Reference
+  - isConfigSupported
+  - AudioEncoder
+  - Experimental
+browser-compat: api.AudioEncoder.isConfigSupported
+---
+
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
+
+The **`isConfigSupported()`** static method of the {{domxref("AudioEncoder")}} interface checks if the given config is supported (that is, if {{domxref("AudioEncoder")}} objects can be successfully configured with the given config).
+
+## Syntax
+
+```js-nolint
+isConfigSupported(config)
+```
+
+### Parameters
+
+- `config`
+  - : The dictionary object accepted by {{domxref("AudioEncoder.configure")}}
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an object containing the following members:
+
+- `supported`
+  - : A boolean value which is `true` if the given config is supported by the encoder.
+- `config`
+  - : A copy of the given config with all the fields recognized by the encoder.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the provided `config` is invalid; that is, if doesn't have required values (such as an empty `codec` field) or has invalid values (such as a negative `sampleRate`).
+
+## Examples
+
+The following example tests if the browser supports several audio codecs.
+
+```js
+const codecs = ['mp4a.40.2', 'mp3', 'alaw', 'ulaw'];
+const configs = [];
+for (const codec of codecs) {
+  configs.push({
+      codec,
+      sampleRate: 48000,
+      numberOfChannels: 1,
+      not_supported_field: 123
+  });
+}
+for (const config of configs) {
+  const support = await AudioEncoder.isConfigSupported(config);
+  console.log(`AudioEncoder's config ${JSON.stringify(support.config)} support: ${support.supported}`);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Document `AudioDecoder.isConfigSupported()` and `AudioEncoder.isConfigSupported()`.

### Motivation

These are core APIs for `AudioDecoder` and `AudioEncoder`.

### Additional details

https://www.w3.org/TR/webcodecs/#dom-audiodecoder-isconfigsupported
https://www.w3.org/TR/webcodecs/#dom-audioencoder-isconfigsupported

### Related issues and pull requests

Relates to #22375