### PR TITLE
Fixed spelling mistake "two" -> "to"

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -152,7 +152,7 @@ moz-extension://<extension-UUID>/images/my-image.png"
 
 `<extension-UUID>` is **not** your extension's ID. This ID is randomly generated for every browser instance. This prevents websites from fingerprinting a browser by examining the extensions it has installed.
 
-> **Note:** In Chrome in Manifest V2, an extension's ID is fixed. When a resource is listed in `web_accessible_resources`, it is accessible as `chrome-extension://<your-extension-id>/<path/to/resource>`. In Manifest V3, Chrome can use a dynamic URL by setting `use_dynamic_url` two `true`.
+> **Note:** In Chrome in Manifest V2, an extension's ID is fixed. When a resource is listed in `web_accessible_resources`, it is accessible as `chrome-extension://<your-extension-id>/<path/to/resource>`. In Manifest V3, Chrome can use a dynamic URL by setting `use_dynamic_url` to `true`.
 
 The recommended approach to obtaining the URL of the resource is to use [`runtime.getURL`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL) passing the path relative to manifest.json, for example:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In [manifest.json/web_accessible_resources](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) there was a spelling mistake (two instead of to) in the following sentence:

> Chrome can use a dynamic URL by setting use_dynamic_url <ins>**two**</ins> true.

### Motivation

I just saw the spelling mistake and thought it would be nice to fix it :)

### Additional details

Nothing more :)