### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -194,7 +194,7 @@ function in the legacy JavaScript.
 
 ### A possible solution
 
-All modern JavaScript runtimes (in browsers and elsewhere) support [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), with lexical `this` — allowing us to write `setInterval(() => this.myMethod)` if we're inside the `myArray` method.
+All modern JavaScript runtimes (in browsers and elsewhere) support [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), with lexical `this` — allowing us to write `setInterval(() => this.myMethod())` if we're inside the `myArray` method.
 
 If you need to support IE, use the [`Function.prototype.bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) method, which lets you specify the value that should be used as `this` for all calls to a given function. That lets you easily bypass problems where it's unclear what `this` will be, depending on the context from which your function was called.
 


### PR DESCRIPTION
Execution inside interval context needs to invoke myMethod, not return its definition

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Execution inside interval context needs to invoke myMethod, not return its definition, that is, this runs the wrapper function and returns what was assigned to `this.myMethod`, instead of calling it.

### Motivation

This typo will confuse new coders.
