### PR TITLE
requestFullScreen - make transient user activation obvious

### DIFF
--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -21,9 +21,7 @@ browser-compat: api.Element.requestFullscreen
 
 {{APIRef("Fullscreen API")}}
 
-The **`Element.requestFullscreen()`**
-method issues an asynchronous request to make the element be displayed in fullscreen
-mode.
+The **`Element.requestFullscreen()`** method issues an asynchronous request to make the element be displayed in fullscreen mode.
 
 It's not guaranteed that the element will be put into full screen mode. If permission
 to enter full screen mode is granted, the returned {{JSxRef("Promise")}} will resolve
@@ -31,6 +29,8 @@ and the element will receive a {{domxref("Element/fullscreenchange_event", "full
 it's now in full screen mode. If permission is denied, the promise is rejected and the
 element receives a {{domxref("Element/fullscreenerror_event", "fullscreenerror")}} event instead. If the element has been
 detached from the original document, then the document receives these events instead.
+
+[Transient user activation](/en-US/docs/Web/Security/User_activation) is required. The user has to interact with the page or a UI element in order for this feature to work.
 
 ## Syntax
 
@@ -79,10 +79,6 @@ returned. The rejection handler receives one of the following exception values:_
     - The element is not permitted to use the `"fullscreen"` feature,
       either because of Feature Policy configuration or other access control features.
     - The element and its document are the same node.
-
-## Security
-
-[Transient user activation](/en-US/docs/Web/Security/User_activation) is required. The user has to interact with the page or a UI element in order for this feature to work.
 
 ## Usage notes
 


### PR DESCRIPTION
Issue #22303 states that transient user activation is not mentioned. That is incorrect - but it clearly isn't visible enough or the issue wouldn't have been posted.

I have moved it to the description. @foolip - work for you?

Fixes #22303