### PR TITLE
Add roundRect method to Path2D

### DIFF
--- a/files/en-us/web/api/path2d/index.md
+++ b/files/en-us/web/api/path2d/index.md
@@ -42,6 +42,8 @@ The **`Path2D`** interface of the Canvas 2D API is used to declare a path that c
   - : Adds an elliptical arc to the path which is centered at (`x, y`) position with the radii `radiusX` and `radiusY` starting at `startAngle` and ending at `endAngle` going in the given direction by `counterclockwise` (defaulting to clockwise).
 - {{domxref("CanvasRenderingContext2D.rect()", "Path2D.rect()")}}
   - : Creates a path for a rectangle at position (`x, y`) with a size that is determined by `width` and `height`.
+- {{domxref("CanvasRenderingContext2D.roundRect()", "Path2D.roundRect()")}}
+  - : Creates a path for a rounded rectangle at position (`x, y`) with a size that is determined by `width` and `height` and the radii of the circular arc to be used for the corners of the rectangle is determined by `radii`.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Adds the `roundRect` method to the `Path2D` interface.

### Motivation
`roundRect` was added to the `CanvasRenderingContext2D` interface and `Path2D`.  
Sounds like this page somehow missed the update.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Specs PR: https://github.com/whatwg/html/pull/6765
There, the method is defined on the `CanvasPath` interface which is included by both `CanvasRenderingContext2D` and `Path2D`.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
