### PR TITLE
Rename render modes to use the new spec-defined names

### DIFF
--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -1,6 +1,6 @@
 ---
-title: Quirks Mode and Standards Mode
-slug: Web/HTML/Quirks_Mode_and_Standards_Mode
+title: Quirks Mode
+slug: Web/HTML/Quirks_Mode
 tags:
   - Gecko
   - Guide
@@ -15,7 +15,9 @@ tags:
 
 In the old days of the web, pages were typically written in two versions: One for Netscape Navigator, and one for Microsoft Internet Explorer. When the web standards were made at W3C, browsers could not just start using them, as doing so would break most existing sites on the web. Browsers therefore introduced two modes to treat new standards compliant sites differently from old legacy sites.
 
-There are now three modes used by the layout engines in web browsers: quirks mode, almost standards mode, and full standards mode. In **quirks mode**, layout emulates nonstandard behavior in Navigator 4 and Internet Explorer 5. This is essential in order to support websites that were built before the widespread adoption of web standards. In **full standards mode**, the behavior is (hopefully) the behavior described by the HTML and CSS specifications. In **almost standards mode**, there are only a very small number of quirks implemented.
+There are now three modes used by the layout engines in web browsers: quirks mode, linited-quirks mode, and no-quirks mode. In **quirks mode**, layout emulates behavior in Navigator 4 and Internet Explorer 5. This is essential in order to support websites that were built before the widespread adoption of web standards. In **no-quirks mode**, the behavior is (hopefully) the desired behavior described by the modern HTML and CSS specifications. In **limited-quirks mode**, there are only a very small number of quirks implemented.
+
+limited-quirks and no-quirks mode used to be called "almost-standards" mode and "full standards" mode respectively. These names were changed as the behavior is now actually standardized.
 
 ## How do browsers determine which mode to use?
 
@@ -36,7 +38,7 @@ The DOCTYPE shown in the example, `<!DOCTYPE html>`, is the simplest possible, a
 
 Make sure you put the DOCTYPE right at the beginning of your HTML document. Anything before the DOCTYPE, like a comment or an XML declaration will trigger quirks mode in Internet Explorer 9 and older.
 
-The only purpose of `<!DOCTYPE html>` is to activate full standards mode. Older versions of HTML standard DOCTYPEs provided additional meaning, but no browser ever used the DOCTYPE for anything other than switching between quirks mode and standards mode.
+The only purpose of `<!DOCTYPE html>` is to activate no-quirks mode. Older versions of HTML standard DOCTYPEs provided additional meaning, but no browser ever used the DOCTYPE for anything other than switching between render modes.
 
 See also a detailed description of [when different browsers choose various modes](https://hsivonen.fi/doctype/).
 
@@ -48,6 +50,4 @@ If you serve XHTML-like content using the `text/html` MIME type, browsers will r
 
 ## How do I see which mode is used?
 
-In Firefox, select _Page Info_ from the _Tools_ menu bar, and look for _Render Mode_. ([Learn more about the Firefox Page Info window](https://support.mozilla.org/en-US/kb/firefox-page-info-window))
-
-In Internet Explorer, press _F12_, and look for _Document Mode_.
+If the page is rendered in quirks or limited-quirks mode, Firefox will log a warning to the console tab in the developer tools. If this warning is not shown, Firefox is using no-quirks mode.

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -17,7 +17,7 @@ In the old days of the web, pages were typically written in two versions: One fo
 
 There are now three modes used by the layout engines in web browsers: quirks mode, linited-quirks mode, and no-quirks mode. In **quirks mode**, layout emulates behavior in Navigator 4 and Internet Explorer 5. This is essential in order to support websites that were built before the widespread adoption of web standards. In **no-quirks mode**, the behavior is (hopefully) the desired behavior described by the modern HTML and CSS specifications. In **limited-quirks mode**, there are only a very small number of quirks implemented.
 
-limited-quirks and no-quirks mode used to be called "almost-standards" mode and "full standards" mode respectively. These names were changed as the behavior is now actually standardized.
+The limited-quirks and no-quirks modes used to be called "almost-standards" mode and "full standards" mode, respectively. These names have been changed as the behavior is now standardized.
 
 ## How do browsers determine which mode to use?
 

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -51,3 +51,5 @@ If you serve XHTML-like content using the `text/html` MIME type, browsers will r
 ## How do I see which mode is used?
 
 If the page is rendered in quirks or limited-quirks mode, Firefox will log a warning to the console tab in the developer tools. If this warning is not shown, Firefox is using no-quirks mode.
+
+The value of `document.compatMode` in JavaScript will show whether or not the document is in quirks mode. If its value us `"quirks"`, the document is in quirks mode. If it isn't, it will have value `"CSS1Compat"`.

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -1,6 +1,6 @@
 ---
 title: Quirks Mode
-slug: Web/HTML/Quirks_Mode
+slug: Web/HTML/Quirks_Mode_and_Standards_Mode
 tags:
   - Gecko
   - Guide


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Renames almost standards mode and full standards mode to limited-quirks and no-quirks mode, in line with newer versions of the spec. Also removes mentions that quirks mode is nonstandard as it isn't.

### Motivation

Using the old names (and implying that the behavior is not standardized) is misleading information since it's no longer the case. Updating the information would be more useful for future readers to understand what these modes are.

### Additional details

See the note below this line on the [DOM spec](https://dom.spec.whatwg.org/#concept-document-no-quirks).
