### PR TITLE
chore(repo) Remove .gitmodules leftovers from meta site

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "meta/themes/docsy"]
-	path = meta/themes/docsy
-	url = https://github.com/google/docsy.git


### PR DESCRIPTION
This seems to be left over after cleaning out the meta docs pages.

__Related issues and PRs:__

- [x] https://github.com/mdn/content/pull/20775
