### PR TITLE
Update Resource Timing Performance pages

### DIFF
--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -12,14 +12,12 @@ browser-compat: api.Performance.clearResourceTimings
 
 {{APIRef("Performance API")}}
 
-The **`clearResourceTimings()`** method removes all
-{{domxref("PerformanceEntry","performance entries")}} with an
-{{domxref("PerformanceEntry.entryType","entryType")}} of "`resource`" from
-the browser's performance data buffer and sets the size of the performance data buffer
-to zero. To set the size of the browser's performance data buffer, use the
+The **`clearResourceTimings()`** method removes all performance entries with an {{domxref("PerformanceEntry.entryType","entryType")}} of "`resource`" from the browser's performance timeline and sets the size of the performance resource data buffer to zero.
+
+To set the size of the browser's performance resource data buffer, use the
 {{domxref("Performance.setResourceTimingBufferSize()")}} method.
 
-{{AvailableInWorkers}}
+To get notified when the browser's resource timing buffer is full, listen for the {{domxref("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}} event.
 
 ## Syntax
 
@@ -33,39 +31,34 @@ None.
 
 ### Return value
 
-none
+None ({{jsxref("undefined")}}).
 
 ## Examples
 
-```js
-function load_resource() {
-  const image = new Image();
-  image.src = "https://developer.mozilla.org/static/img/opengraph-logo.png";
-}
-function clear_performance_timings() {
-  if (performance === undefined) {
-    log("Browser does not support Web Performance");
-    return;
-  }
-  // Create a resource timing performance entry by loading an image
-  load_resource();
+### Clearing the performance resource data buffer
 
-  const supported = typeof performance.clearResourceTimings === "function";
-  if (supported) {
-    console.log("Run: performance.clearResourceTimings()");
-    performance.clearResourceTimings();
-  } else {
-    console.log("performance.clearResourceTimings() NOT supported");
-    return;
-  }
-  // getEntries should now return zero
-  const p = performance.getEntriesByType("resource");
-  if (p.length === 0) {
-    console.log("… Performance data buffer cleared");
-  } else {
-    console.log("… Performance data buffer NOT cleared!");
-  }
+To remove all resource performance entries from the buffer, call the `clearResourceTimings()` at an appropriate point in your code or paste it into the console.
+
+```js
+performance.clearResourceTimings();
+performance.getEntriesByType("resource").length; // 0
+```
+
+### Taking records and emptying performance observers
+
+When using {{domxref("PerformanceObserver")}} objects (especially with the `buffered` flag set to `true`), the performance resource buffer might get full quickly. However, instead of clearing the buffer, you can also store the current list of performance entries and empty the performance observer using the {{domxref("PerformanceObserver.takeRecords()")}} method. This works with all kinds of performance entry types, not just "`resource`" entries.
+
+```js
+function perfObserver(list, observer) {
+  list.getEntries().forEach((entry) => {
+    // do something with the entries
+  });
 }
+const observer = new PerformanceObserver(perfObserver);
+observer.observe({ type: "resource", buffered: true });
+
+// Store entries and empty performance observer
+const records = observer.takeRecords();
 ```
 
 ## Specifications
@@ -75,3 +68,8 @@ function clear_performance_timings() {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.setResourceTimingBufferSize()")}}
+- {{domxref("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}}

--- a/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.md
+++ b/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.md
@@ -22,9 +22,9 @@ The `resourcetimingbufferfull` event is fired when the browser's [resource timin
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('resourcetimingbufferfull', (event) => { });
+addEventListener("resourcetimingbufferfull", (event) => {});
 
-onresourcetimingbufferfull = (event) => { };
+onresourcetimingbufferfull = (event) => {};
 ```
 
 ## Event type
@@ -33,27 +33,22 @@ A generic {{domxref("Event")}}.
 
 ## Examples
 
-The following example sets a callback function on the `onresourcetimingbufferfull` property.
+### Increasing size when buffer is full
+
+The following example listens for the `resourcetimingbufferfull` event and increases the buffer size using the {{domxref("Performance.setResourceTimingBufferSize", "setResourceTimingBufferSize()")}} method.
 
 ```js
-function buffer_full(event) {
-  console.log("WARNING: Resource Timing Buffer is FULL!");
-  performance.setResourceTimingBufferSize(200);
+function increaseFilledBufferSize(event) {
+  console.log(
+    "WARNING: Resource Timing Buffer is FULL! Increasing buffer size to 500."
+  );
+  performance.setResourceTimingBufferSize(500);
 }
-function init() {
-  // Set a callback if the resource buffer becomes filled
-  performance.onresourcetimingbufferfull = buffer_full;
-}
-```
 
-```html
-<body onload="init()"></body>
-```
-
-Note that you could also set up the handler using the addEventListener() function:
-
-```js
-performance.addEventListener('resourcetimingbufferfull', buffer_full);
+performance.addEventListener(
+  "resourcetimingbufferfull",
+  increaseFilledBufferSize
+);
 ```
 
 ## Specifications
@@ -66,5 +61,5 @@ performance.addEventListener('resourcetimingbufferfull', buffer_full);
 
 ## See also
 
-- {{domxref("Performance.clearResourceTimings","Performance.clearResourceTimings()")}}
-- {{domxref("Performance.setResourceTimingBufferSize","Performance.setResourceTimingBufferSize()")}}
+- {{domxref("Performance.clearResourceTimings()")}}
+- {{domxref("Performance.setResourceTimingBufferSize()")}}

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
@@ -12,15 +12,14 @@ browser-compat: api.Performance.setResourceTimingBufferSize
 
 {{APIRef("Performance API")}}
 
-The **`setResourceTimingBufferSize()`** method sets the
-browser's _resource timing buffer_ size to the specified number of
-"`resource`" {{domxref("PerformanceEntry.entryType","performance entry
-  type")}} objects.
+The **`setResourceTimingBufferSize()`** method sets the desired size of the browser's resource timing buffer which stores the "`resource`" performance entries.
 
-A browser's recommended resource timing buffer size is at least 150
-{{domxref("PerformanceEntry","performance entry")}} objects.
+The specification requires the resource timing buffer initially to be 250 or greater.
 
-{{AvailableInWorkers}}
+To clear the browser's performance resource data buffer, use the
+{{domxref("Performance.clearResourceTimings()")}} method.
+
+To get notified when the browser's resource timing buffer is full, listen for the {{domxref("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}} event.
 
 ## Syntax
 
@@ -31,30 +30,31 @@ setResourceTimingBufferSize(maxSize)
 ### Parameters
 
 - `maxSize`
-  - : A `number` representing the maximum number of
-    {{domxref("PerformanceEntry","performance entry")}} objects the browser should hold in
-    its performance entry buffer.
+  - : A `number` representing the maximum number of {{domxref("PerformanceEntry","performance entry")}} objects the browser should hold in its performance entry buffer.
 
 ### Return value
 
-This method has no return value.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Setting a resource timing buffer size
+
+The following call allows 500 "`resource`" performance entries in the browser's performance timeline.
+
 ```js
-function setResourceTimingBufferSize(maxSize) {
-  if (performance === undefined) {
-    log("Browser does not support Web Performance");
-    return;
-  }
-  const supported = typeof performance.setResourceTimingBufferSize === "function";
-  if (supported) {
-    console.log("… Performance.setResourceTimingBufferSize() = Yes");
-    performance.setResourceTimingBufferSize(maxSize);
-  } else {
-    console.error("The method Performance.setResourceTimingBufferSize() is not supported.");
-  }
-}
+performance.setResourceTimingBufferSize(500);
+```
+
+If you set the buffer size to a number lower than the amount of current entries in the buffer, no entries will be removed. Instead, to clear the buffer, call {{domxref("Performance.clearResourceTimings()")}}.
+
+```js
+performance.getEntriesByType("resource").length; // 20
+performance.setResourceTimingBufferSize(10);
+performance.getEntriesByType("resource").length; // 20
+
+performance.clearResourceTimings();
+performance.getEntriesByType("resource").length; // 0
 ```
 
 ## Specifications
@@ -64,3 +64,8 @@ function setResourceTimingBufferSize(maxSize) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.clearResourceTimings()")}}
+- {{domxref("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}}


### PR DESCRIPTION
### Description

This PR updates the Resource Timing related methods and events on the main `Performance` interface.
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearResourceTimings
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/setResourceTimingBufferSize
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/resourcetimingbufferfull_event

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I think very often code examples that check for support aren't very useful. It is a very meta thing to do that outdates quickly as the feature becomes available broadly. Imho it also distracts from showing how the feature in question behaves.

### Related issues and pull requests

None.
