### PR TITLE
Fix description of SerialPort.getInfo()

### DIFF
--- a/files/en-us/web/api/serialport/index.md
+++ b/files/en-us/web/api/serialport/index.md
@@ -33,7 +33,7 @@ Instances of this interface may be obtained by calling methods of the {{domxref(
 - {{domxref("SerialPort.forget()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves when the port closes and is forgotten.
 - {{domxref("SerialPort.getInfo()")}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with an object containing properties of the port.
+  - : Returns an object containing properties of the port.
 - {{domxref("SerialPort.open()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves when the port is opened. By default the port is opened with 8 data bits, 1 stop bit and no parity checking.
 - {{domxref("SerialPort.setSignals()")}} {{Experimental_Inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Correcct description of `SerialPort.getInfo()` on the `SerialPort` page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
`SerialPort.getInfo()` returns an information object directly, not `Promise`.

The [`SerialPort.getInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/SerialPort/getInfo) page looks correct.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Specification: [Web Serial API / 4.3 getInfo() method](https://wicg.github.io/serial/#getinfo-method)

I tested with Google Chrome 107.0.5304.107 (Official Build) x64 and confirmed that the information is returned directly, not via `Promise`.

```
> d = navigator.serial.requestPort();
< Promise {<pending>}
> d = await d;
< SerialPort {onconnect: null, ondisconnect: null, readable: null, writable: null}
> d.getInfo()
< {usbProductId: 46388, usbVendorId: 1241}
> await d.forget()
< undefined
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
