### PR TITLE
Improve description of floating point inaccuracy

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -28,7 +28,7 @@ Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use i
 
 ### Testing equality
 
-Because floating point numbers are represented in binary, not decimal, they are not always exact. For example, `0.1 + 0.2` is not exactly equal to `0.3`:
+Any number encoding system occupying a finite number of bits, of whatever base you choose (eg. decimal or binary), will _necessarily_ be unable to represent all numbers exactly, because you are trying to represent an infinite number of points on a number line using a finite amount of memory. For example, a base-10 (decimal) numbering system cannot represent 1/3 exactly; and a base-2 (binary) numbering system cannot represent `0.1` exactly. Thus, for example, `0.1 + 0.2` is not exactly equal to `0.3`:
 
 ```js
 console.log(0.1 + 0.2); // 0.30000000000000004

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -28,7 +28,7 @@ Because `EPSILON` is a static property of {{jsxref("Number")}}, you always use i
 
 ### Testing equality
 
-Any number encoding system occupying a finite number of bits, of whatever base you choose (eg. decimal or binary), will _necessarily_ be unable to represent all numbers exactly, because you are trying to represent an infinite number of points on a number line using a finite amount of memory. For example, a base-10 (decimal) numbering system cannot represent 1/3 exactly; and a base-2 (binary) numbering system cannot represent `0.1` exactly. Thus, for example, `0.1 + 0.2` is not exactly equal to `0.3`:
+Any number encoding system occupying a finite number of bits, of whatever base you choose (e.g. decimal or binary), will _necessarily_ be unable to represent all numbers exactly, because you are trying to represent an infinite number of points on the number line using a finite amount of memory. For example, a base-10 (decimal) system cannot represent 1/3 exactly, and a base-2 (binary) system cannot represent `0.1` exactly. Thus, for example, `0.1 + 0.2` is not exactly equal to `0.3`:
 
 ```js
 console.log(0.1 + 0.2); // 0.30000000000000004


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Correction of sentence about loss of exactitude.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The assertion that, "Because floating point numbers are represented in binary, not decimal, they are not always exact. " is incorrect, and this change proposes a correction. For more, see the commentary under [this question](https://stackoverflow.com/a/618542/38522).


<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The update corrects an incorrect assertion.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
