### PR TITLE
Fix SerialPort.getSignals()

### DIFF
--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -44,7 +44,7 @@ Returns a {{jsxref("Promise")}} that resolves with an object containing the foll
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Returned if the signals on the device could not be set.
+  - : Returned if the signals on the device could not be read.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fix the condition of when `NetworkError` is thrown from `SerialPort.getSignals()`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This method is for retrieving the status of signals and doesn't look setting signals, so "Returned if the signals on the device could not be **set**." looked weird.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Specification: [Web Serial API / 4.8 getSignals() method](https://wicg.github.io/serial/#dom-serialport-getsignals)

> If the operating system fails to determine the status of these signals for any reason, [queue a global task](https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task) on the [relevant global object](https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global) of [this](https://webidl.spec.whatwg.org/#this) using the [serial port task source](https://wicg.github.io/serial/#dfn-serial-port-task-source) to reject promise with a "[NetworkError](https://webidl.spec.whatwg.org/#networkerror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException) and abort these steps.

This looks like about reading the signals, not setting ones.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
