### PR TITLE
Update Performance.get* method pages

### DIFF
--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -12,16 +12,12 @@ browser-compat: api.Performance.getEntries
 
 {{APIRef("Performance API")}}
 
-The **`getEntries()`** method returns a list of all
-{{domxref("PerformanceEntry")}} objects for the page. The list's members
-(_entries_) can be created by making performance _marks_ or
-_measures_ (for example by calling the {{domxref("Performance.mark","mark()")}}
-method) at explicit points in time. If you are only interested in performance entries of
-certain types or that have certain names, see {{domxref("Performance.getEntriesByType",
-  "getEntriesByType()")}} and {{domxref("Performance.getEntriesByName",
-  "getEntriesByName()")}}.
+The **`getEntries()`** method returns an array of all {{domxref("PerformanceEntry")}} objects currently present in the performance timeline.
 
-{{AvailableInWorkers}}
+If you are only interested in performance entries of certain types or that have certain names, see {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} and {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.
+
+> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 ## Syntax
 
@@ -35,70 +31,36 @@ None.
 
 ### Return value
 
-- entries
-  - : An array of {{domxref("PerformanceEntry")}} objects. The items will be in
-    chronological order based on the entries'
-    {{domxref("PerformanceEntry.startTime","startTime")}}.
+An {{jsxref("Array")}} of {{domxref("PerformanceEntry")}} objects. The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}.
 
 ## Examples
 
+### Logging all performance markers and measures
+
+Assuming you created your own {{domxref("PerformanceMark")}} and {{domxref("PerformanceMeasure")}} objects at appropriate places in your code, you might want to log all them to the console like this:
+
 ```js
-function usePerformanceEntryMethods() {
-  console.log("PerformanceEntry tests…");
+// Example markers/measures
+performance.mark("login-started");
+performance.mark("login-finished");
+performance.mark("form-sent");
+performance.mark("video-loaded");
+performance.measure(
+   "login-duration",
+   "login-started",
+   "login-finished"
+ );
 
-  if (performance.mark === undefined) {
-    console.error("The property performance.mark is not supported");
-    return;
-  }
+const entries = performance.getEntries();
 
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  do_work(50000);
-  performance.mark("End");
-  performance.mark("Begin");
-  do_work(100000);
-  performance.mark("End");
-  do_work(200000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByType() to get all "mark" entries
-  performance.getEntriesByType("mark")
-    .forEach((entry, i) => {
-      console.log(`Mark only entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByName() to get all "mark" entries named "Begin"
-  performance.getEntriesByName("Begin", "mark")
-    .forEach((entry, i) => {
-      console.log(`Mark and Begin entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
-  });
-
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
-  });
-}
+entries.forEach((entry) => {
+  if (entry.entryType === "mark") {
+    console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+  };
+  if (entry.entryType === "measure") {
+    console.log(`${entry.name}'s duration: ${entry.duration}`);
+  };
+});
 ```
 
 ## Specifications
@@ -108,3 +70,8 @@ function checkPerformanceEntry(obj) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.getEntriesByType()")}}
+- {{domxref("Performance.getEntriesByName()")}}

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -12,13 +12,12 @@ browser-compat: api.Performance.getEntriesByName
 
 {{APIRef("Performance API")}}
 
-The **`getEntriesByName()`** method returns a list of
-{{domxref("PerformanceEntry")}} objects for the given _name_ and _type_.
-The list's members (_entries_) can be created by making performance
-_marks_ or _measures_ (for example by calling the
-{{domxref("Performance.mark","mark()")}} method) at explicit points in time.
+The **`getEntriesByName()`** method returns an array of {{domxref("PerformanceEntry")}} objects currently present in the performance timeline with the given _name_ and _type_.
 
-{{AvailableInWorkers}}
+If you are interested in performance entries of certain types, see {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}. For all performance entries, see {{domxref("Performance.getEntries", "getEntries()")}}.
+
+> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 ## Syntax
 
@@ -30,86 +29,28 @@ getEntriesByName(name, type)
 ### Parameters
 
 - `name`
-  - : The name of the entry to retrieve.
+  - : The name of the entries to retrieve.
 - `type` {{optional_inline}}
-  - : The type of entry to retrieve such as "`mark`". The valid entry types are
+  - : The type of entries to retrieve such as "`mark`". The valid entry types are
     listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 
-A list of {{domxref("PerformanceEntry")}} objects that have the specified
-`name` and `type`. If the `type` argument is not
-specified, only the `name` will be used to determine the entries to return.
-The items will be in chronological order based on the entries'
-{{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the
-specified criteria, an empty list is returned.
+An {{jsxref("Array")}} of {{domxref("PerformanceEntry")}} objects that have the specified `name` and `type`.
+The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the
+specified criteria, an empty array is returned.
 
 ## Examples
 
+### Logging performance markers
+
+The following example logs all {{domxref("PerformanceMark")}} objects named "`debug-mark`".
+
 ```js
-function usePerformanceEntryMethods() {
-  console.log("PerformanceEntry tests…");
-
-  if (performance.mark === undefined) {
-    console.error("The property performance.mark is not supported");
-    return;
-  }
-
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  do_work(50000);
-  performance.mark("End");
-  performance.mark("Begin");
-  do_work(100000);
-  performance.mark("End");
-  do_work(200000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntries(name, entryType) to get specific entries
-  performance.getEntries({ name: "Begin", entryType: "mark" })
-    .forEach((entry, i) => {
-      console.log(`Begin[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByType() to get all "mark" entries
-  performance.getEntriesByType("mark")
-    .forEach((entry, i) => {
-      console.log(`Mark only entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByName() to get all "mark" entries named "Begin"
-  performance.getEntriesByName("Begin", "mark")
-    .forEach((entry, i) => {
-      console.log(`Mark and Begin entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
-  });
-
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
-  });
-}
+const debugMarks = performance.getEntriesByName("debug-mark", "mark");
+debugMarks.forEach((entry) => {
+  console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+});
 ```
 
 ## Specifications
@@ -119,3 +60,8 @@ function checkPerformanceEntry(obj) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.getEntries()")}}
+- {{domxref("Performance.getEntriesByType()")}}

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -12,13 +12,12 @@ browser-compat: api.Performance.getEntriesByType
 
 {{APIRef("Performance API")}}
 
-The **`getEntriesByType()`** method returns a list of
-{{domxref("PerformanceEntry")}} objects for a given _type_. The list's members
-(_entries_) can be created by making performance _marks_ or
-_measures_ (for example by calling the {{domxref("Performance.mark","mark()")}}
-method) at explicit points in time.
+The **`getEntriesByType()`** method returns an array of {{domxref("PerformanceEntry")}} objects currently present in the performance timeline for a given _type_.
 
-{{AvailableInWorkers}}
+If you are interested in performance entries of certain name, see {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}. For all performance entries, see {{domxref("Performance.getEntries", "getEntries()")}}.
+
+> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 ## Syntax
 
@@ -29,82 +28,23 @@ getEntriesByType(type)
 ### Parameters
 
 - `type`
-  - : The type of entry to retrieve such as "`mark`". The valid entry types are
-    listed in {{domxref("PerformanceEntry.entryType")}}.
+  - : The type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
 
 ### Return value
 
-A list of {{domxref("PerformanceEntry")}} objects that have the specified
-`type`. The items will be in chronological order based on the entries'
-{{domxref("PerformanceEntry.startTime","startTime")}}. If no objects have the
-specified `type`, or no argument is provided, an empty list is returned.
+An {{jsxref("Array")}} of {{domxref("PerformanceEntry")}} objects that have the specified `type`. The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects have the specified `type`, or no argument is provided, an empty array is returned.
 
 ## Examples
 
+### Logging resource entries
+
+The following example logs all entries with the type "`resource`".
+
 ```js
-function usePerformanceEntryMethods() {
-  console.log("PerformanceEntry tests…");
-
-  if (performance.mark === undefined) {
-    console.error("The property performance.mark is not supported");
-    return;
-  }
-
-  // Create some performance entries via the mark() method
-  performance.mark("Begin");
-  doWork(50000);
-  performance.mark("End");
-  performance.mark("Begin");
-  doWork(100000);
-  performance.mark("End");
-  doWork(200000);
-  performance.mark("End");
-
-  // Use getEntries() to iterate through the each entry
-  performance.getEntries()
-    .forEach((entry, i) => {
-      console.log(`Entry[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntries(name, entryType) to get specific entries
-  performance.getEntries({ name: "Begin", entryType: "mark" })
-    .forEach((entry, i) => {
-      console.log(`Begin[${i}]`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByType() to get all "mark" entries
-  performance.getEntriesByType("mark")
-    .forEach((entry, i) => {
-      console.log(`Mark only entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-
-  // Use getEntriesByName() to get all "mark" entries named "Begin"
-  performance.getEntriesByName("Begin", "mark")
-    .forEach((entry, i) => {
-      console.log(`Mark and Begin entry[${i}]:`);
-      checkPerformanceEntry(entry);
-    });
-}
-
-function checkPerformanceEntry(obj) {
-  const properties = ["name", "entryType", "startTime", "duration"];
-  const methods = ["toJSON"];
-
-  // Check each property
-  properties.forEach((property) => {
-    const supported = property in obj;
-    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
-  });
-
-  // Check each method
-  methods.forEach((method) => {
-    const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
-  });
-}
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  console.log(`${entry.name}'s startTime: ${entry.startTime}`);
+});
 ```
 
 ## Specifications
@@ -114,3 +54,8 @@ function checkPerformanceEntry(obj) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.getEntries()")}}
+- {{domxref("Performance.getEntriesByName()")}}

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -28,7 +28,7 @@ getEntriesByType(type)
 ### Parameters
 
 - `type`
-  - : The type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}.
+  - : The type of entry to retrieve such as "`mark`". The valid entry types are listed in {{domxref("PerformanceEntry.entryType")}}. The supported `entryTypes` can be retrieved using the static property {{domxref("PerformanceObserver.supportedEntryTypes")}}.
 
 ### Return value
 
@@ -59,3 +59,4 @@ resources.forEach((entry) => {
 
 - {{domxref("Performance.getEntries()")}}
 - {{domxref("Performance.getEntriesByName()")}}
+- {{domxref("PerformanceObserver.supportedEntryTypes")}}


### PR DESCRIPTION
### Description

This PR updates the `get*` method pages on the main `Performance` interface.
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntries
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByName
- https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I've provided a notebox to say that PerformanceObservers are the better way to retrieve performance entries.
I've simplified again the code examples a lot to not check for the method's support etc.

### Related issues and pull requests

None.