### PR TITLE
Removed .effect since id is property of Animation

### DIFF
--- a/files/en-us/web/api/animation/id/index.md
+++ b/files/en-us/web/api/animation/id/index.md
@@ -25,7 +25,7 @@ A string which can be used to identify the animation, or `null` if the animation
 In the [Follow the White Rabbit example](https://codepen.io/rachelnabors/pen/eJyWzm?editors=0010), you can assign the `rabbitDownAnimation` an `id` like so:
 
 ```js
-rabbitDownAnimation.effect.id = "rabbitGo";
+rabbitDownAnimation.id = "rabbitGo";
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed example of setting `Animation.id`.

### Motivation

Example was wrong, showed setting of `Animation.effect.id` instead, but there's no such property on `KeyframeEffect`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
