### PR TITLE
Add `combobox` role to `button` and `input[type="button"]`

### DIFF
--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -93,8 +93,8 @@ By default, HTML buttons are presented in a style resembling the platform the {{
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("checkbox")}}, {{ARIARole("link")}},
-        {{ARIARole("menuitem")}},
+        {{ARIARole("checkbox")}}, {{ARIARole("combobox")}},
+        {{ARIARole("link")}}, {{ARIARole("menuitem")}},
         {{ARIARole("menuitemcheckbox")}},
         {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
         {{ARIARole("radio")}}, {{ARIARole("switch")}},

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -1323,7 +1323,9 @@ Firefox uses the following heuristics to determine the locale to validate the us
       <td>
         <ul>
           <li>
-            <code>type=button</code>: {{ARIARole("link")}},
+            <code>type=button</code>: {{ARIARole("checkbox")}},
+            {{ARIARole("combobox")}},
+            {{ARIARole("link")}},
             {{ARIARole("menuitem")}},
             {{ARIARole("menuitemcheckbox")}},
             {{ARIARole("menuitemradio")}},


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add `combobox` role to `button` element and `input[type="button"]`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
`combobox` role for `button` element and `input[type="button"]` was [added](https://github.com/w3c/html-aria/pull/396) to ARIA in HTML on January 15, 2022. Aligning MDN documentation to spec.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Related docs for [`button`](https://w3c.github.io/html-aria/#el-button) and for [`input[type="button"]`](https://w3c.github.io/html-aria/#el-input-button).


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
