### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
@@ -99,7 +99,7 @@ The following code logs a line for each element in a `Set` object:
 
 ```js
 function logSetElements(value1, value2, set) {
-  console.log(`s[${value}] = ${value2}`);
+  console.log(`s[${value1}] = ${value2}`);
 }
 
 new Set(["foo", "bar", undefined]).forEach(logSetElements);


### PR DESCRIPTION
### Description

The variable `value` doesn’t exist; it should be `value1`, like in the interactive example.

### Motivation

The code throws an error as currently written.