### PR TITLE
GB -> GiB

### DIFF
--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -13,9 +13,9 @@ tags:
 The JavaScript exception "Invalid array length" occurs when specifying an array length that is either negative, a floating number or exceeds the maximum supported by the platform (i.e. when creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}}, or when setting the {{jsxref("Array/length", "length")}} property).
 
 The maximum allowed array length depends on the platform, browser and browser version.
-For {{jsxref("Array")}} the maximum length is 4GiB-1 (2^32-1).
-For {{jsxref("ArrayBuffer")}} the maximum is 2GiB-1 on 32-bit systems (2^31-1).
-From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 8GiB on 64-bit systems (2^33).
+For {{jsxref("Array")}} the maximum length is 2<sup>32</sup>-1.
+For {{jsxref("ArrayBuffer")}} the maximum is 2<sup>31</sup>-1 (2GiB-1) on 32-bit systems.
+From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 2<sup>33</sup> (8GiB) on 64-bit systems.
 
 > **Note:** `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
 
@@ -36,10 +36,10 @@ RangeError: Array size is not a small enough positive integer. (Safari)
 An invalid array length might appear in these situations:
 
 - Creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with a negative length, or setting a negative value for the {{jsxref("Array/length", "length")}} property.
-- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2GiB-1 (2^32-1).
-- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GiB-1 (2^32-1) on a 32-bit system, or 8GiB (2^33) on a 64-bit system.
+- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2<sup>32</sup>-1.
+- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>32</sup>-1 (2GiB-1) on a 32-bit system, or 2<sup>33</sup> (8GiB) on a 64-bit system.
 - Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property to a floating-point number.
-- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GiB-1 (2^32-1).
+- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>32</sup>-1 (2GiB-1).
 
 If you are creating an `Array`, using the constructor, you probably want to
 use the literal notation instead, as the first argument is interpreted as the length of

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -13,9 +13,9 @@ tags:
 The JavaScript exception "Invalid array length" occurs when specifying an array length that is either negative, a floating number or exceeds the maximum supported by the platform (i.e. when creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}}, or when setting the {{jsxref("Array/length", "length")}} property).
 
 The maximum allowed array length depends on the platform, browser and browser version.
-For {{jsxref("Array")}} the maximum length is 4GB-1 (2^32-1).
-For {{jsxref("ArrayBuffer")}} the maximum is 2GB-1 on 32-bit systems (2^31-1).
-From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 8GB on 64-bit systems (2^33).
+For {{jsxref("Array")}} the maximum length is 4GiB-1 (2^32-1).
+For {{jsxref("ArrayBuffer")}} the maximum is 2GiB-1 on 32-bit systems (2^31-1).
+From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 8GiB on 64-bit systems (2^33).
 
 > **Note:** `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
 
@@ -36,10 +36,10 @@ RangeError: Array size is not a small enough positive integer. (Safari)
 An invalid array length might appear in these situations:
 
 - Creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with a negative length, or setting a negative value for the {{jsxref("Array/length", "length")}} property.
-- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2GB-1 (2^32-1).
-- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GB-1 (2^32-1) on a 32-bit system or 8GB (2^33) on a 64-bit system.
+- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2GiB-1 (2^32-1).
+- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GiB-1 (2^32-1) on a 32-bit system, or 8GiB (2^33) on a 64-bit system.
 - Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property to a floating-point number.
-- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GB-1 (2^32-1).
+- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GiB-1 (2^32-1).
 
 If you are creating an `Array`, using the constructor, you probably want to
 use the literal notation instead, as the first argument is interpreted as the length of

--- a/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -37,7 +37,7 @@ number. The range of allowed values can be described like this: \[0, +∞).
 
 The resulting string can also not be larger than the maximum string size, which can
 differ in JavaScript engines. In Firefox (SpiderMonkey) the maximum string size is
-2<sup>30</sup> - 2 (\~1GB).
+2<sup>30</sup> - 2 (\~2GiB).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -23,11 +23,11 @@ The **`length`** read-only property of a string contains the length of the strin
 
 This property returns the number of code units in the string. JavaScript uses [UTF-16](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_codepoints_and_grapheme_clusters) encoding, where each Unicode character may be encoded as one or two code units, so it's possible for the value returned by `length` to not match the actual number of Unicode characters in the string. For common scripts like Latin, Cyrillic, wellknown CJK characters, etc., this should not be an issue, but if you are working with certain scripts, such as emojis, [mathematical symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols), or obscure Chinese characters, you may need to account for the difference between code units and characters.
 
-The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
+The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MB).
-- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MB).
-- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
+- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
+- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 
 For an empty string, `length` is 0.
 


### PR DESCRIPTION
### Description

Use GibiByte units instead of GigaByte units, in /files/en-us/web/javascript/reference/errors/invalid_array_length/index.md

### Motivation

"BiBytes" are more accurate. Using "traditional" decimal units is misleading

### Additional details

[Wikipedia](https://en.wikipedia.org/wiki/Byte#Units_based_on_powers_of_2)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
- I haven't found issues about this
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
- I haven't found related PRs


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
