### PR TITLE
Minor: add links for `inert`

### DIFF
--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLElement.inert
 
 {{ APIRef("HTML DOM") }}
 
-The {{domxref("HTMLElement")}} property [**`inert`**](/en-US/docs/Web/HTML/Global_attributes/inert) is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
+The {{domxref("HTMLElement")}} property **`inert`** reflects the value of the element's [`inert`](/en-US/docs/Web/HTML/Global_attributes/inert) attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
 
 ## Value
 

--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLElement.inert
 
 {{ APIRef("HTML DOM") }}
 
-The {{domxref("HTMLElement")}} property **`inert`** is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
+The {{domxref("HTMLElement")}} property [**`inert`**](/en-US/docs/Web/HTML/Global_attributes/inert) is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
 
 ## Value
 
@@ -54,4 +54,7 @@ A Boolean which is `true` if the element is inert; otherwise, the value is `fals
 
 ## See also
 
+- [Global attribute: `inert`](/en-US/docs/Web/HTML/Global_attributes/inert)
+- {{HTMLElement('dialog')}}
 - [Inert Polyfill](https://github.com/WICG/inert)
+- {{domxref("HTMLInputElement.disabled", "disabled")}}


### PR DESCRIPTION
THe `inert` global attribute page was just recently added. 
added link.
added to "see also" 