### PR TITLE
Use DefaultAPISidebar for service worker API

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -13,7 +13,7 @@ tags:
 spec-urls: https://w3c.github.io/ServiceWorker/
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar("Service Workers API")}}
 
 Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -10,7 +10,7 @@ tags:
   - basics
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar("Service Workers API")}}
 
 This article provides information on getting started with service workers, including basic architecture, registering a service worker, the install and activation process for a new service worker, updating your service worker, cache control and custom responses, all in the context of a simple app with offline functionality.
 


### PR DESCRIPTION
The Service Worker API overview and guide page have [their own special sidebar](https://github.com/mdn/yari/blob/main/kumascript/macros/ServiceWorkerSidebar.ejs) which is only used in those two pages.

https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers

This PR replaces it with the normal DefaultAPISidebar.

The only significant different is that the list of "related APIs" is gone, but I don't think it is worth having a whole separate sidebar for this.

If this is merged and we can do the same for translated content, we can delete that sidebar.
