### PR TITLE
Amend no-code-in-heading rule as there is no clear consensus

### DIFF
--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -433,9 +433,7 @@ Keep the following dos and don'ts in mind while creating headings for subsection
 
 - **Don't create single subsections.** Don't subdivide a topic into a single subtopic.
   It's either two subheadings or more or none at all.
-- **Don't use styles, classes, or macros within headings.** This includes the {{HTMLElement("code")}} element for code terms.
-  So don't format the heading as "Using the `SuperAmazingThing` interface".
-  It should instead just be "Using the SuperAmazingThing interface".
+- **Don't use inline styles, classes, or macros within headings.** However, you can use backticks to indicate code terms (e.g. "Using `FooBar` interface").
 - **Don't create "bumping heads".** These are headings followed immediately by a subheading, with no content text in between them.
   This doesn't look good and leaves readers without any explanatory text at the beginning of the outer section.
 


### PR DESCRIPTION
### Description

This update the style rule regarding `code` terms forbidden in headings to allow them "back".

### Motivation

After starting https://github.com/orgs/mdn/discussions/271, I found there was no clear consensus regarding this rule and decided to go a step further as I'm a proponent of having code terms marked as such in headings.

### Related issues and pull requests

https://github.com/orgs/mdn/discussions/271
I didn't find any git history from the yari epoch.

