### PR TITLE
Modify createImageBitmap arguments

### DIFF
--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -32,12 +32,15 @@ createImageBitmap(image, sx, sy, sw, sh, options)
 ### Parameters
 
 - `image`
-  - : An image source, which can be a 
-    {{domxref("HTMLImageElement")}}(or get from {{HTMLElement("img")}}), {{domxref("SVGImageElement")}}(or get from SVG
-    {{SVGElement("image")}}),
-    {{domxref("HTMLVideoElement")}}(or get from {{HTMLElement("video")}}),
-    {{domxref("HTMLCanvasElement")}}(or get from {{HTMLElement("canvas")}}), {{domxref("Blob")}}, {{domxref("ImageData")}},
-    {{domxref("ImageBitmap")}}, or {{domxref("OffscreenCanvas")}} object.
+  - : An image source, which can any one of the following:
+    - {{domxref("HTMLImageElement")}}
+    - {{domxref("SVGImageElement")}}
+    - {{domxref("HTMLVideoElement")}}
+    - {{domxref("HTMLCanvasElement")}}
+    - {{domxref("Blob")}}
+    - {{domxref("ImageData")}}
+    - {{domxref("ImageBitmap")}
+    - {{domxref("OffscreenCanvas")})
 - `sx`
   - : The x coordinate of the reference point of the rectangle from which the
     `ImageBitmap` will be extracted.

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -39,7 +39,7 @@ createImageBitmap(image, sx, sy, sw, sh, options)
     - {{domxref("HTMLCanvasElement")}}
     - {{domxref("Blob")}}
     - {{domxref("ImageData")}}
-    - {{domxref("ImageBitmap")}
+    - {{domxref("ImageBitmap")}}
     - {{domxref("OffscreenCanvas")})
 - `sx`
   - : The x coordinate of the reference point of the rectangle from which the

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -32,11 +32,11 @@ createImageBitmap(image, sx, sy, sw, sh, options)
 ### Parameters
 
 - `image`
-  - : An image source, which can be an {{HTMLElement("img")}}, SVG
-    {{SVGElement("image")}}, {{HTMLElement("video")}}, {{HTMLElement("canvas")}},
-    {{domxref("HTMLImageElement")}}, {{domxref("SVGImageElement")}},
-    {{domxref("HTMLVideoElement")}},
-    {{domxref("HTMLCanvasElement")}}, {{domxref("Blob")}}, {{domxref("ImageData")}},
+  - : An image source, which can be a 
+    {{domxref("HTMLImageElement")}}(or get from {{HTMLElement("img")}}), {{domxref("SVGImageElement")}}(or get from SVG
+    {{SVGElement("image")}}),
+    {{domxref("HTMLVideoElement")}}(or get from {{HTMLElement("video")}}),
+    {{domxref("HTMLCanvasElement")}}(or get from {{HTMLElement("canvas")}}), {{domxref("Blob")}}, {{domxref("ImageData")}},
     {{domxref("ImageBitmap")}}, or {{domxref("OffscreenCanvas")}} object.
 - `sx`
   - : The x coordinate of the reference point of the rectangle from which the

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -40,7 +40,7 @@ createImageBitmap(image, sx, sy, sw, sh, options)
     - {{domxref("Blob")}}
     - {{domxref("ImageData")}}
     - {{domxref("ImageBitmap")}}
-    - {{domxref("OffscreenCanvas")})
+    - {{domxref("OffscreenCanvas")}}
 - `sx`
   - : The x coordinate of the reference point of the rectangle from which the
     `ImageBitmap` will be extracted.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The `createImageBitmap` cannot be an Element such as `<img>`,`SVG <image>`,`<video>`,`<canvas>`,but it can get from these Elements.So i modyfied the doc to be less confused.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

createImageBitmap method lists elements as arguments[#22447](https://github.com/mdn/content/issues/22447)

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
