### PR TITLE
Document measureUserAgentSpecificMemory; deprecate performance.memory

### DIFF
--- a/files/en-us/web/api/performance/index.md
+++ b/files/en-us/web/api/performance/index.md
@@ -27,6 +27,7 @@ An object of this type can be obtained by calling the {{domxref("window.performa
 _The `Performance` interface doesn't inherit any properties._
 
 - {{domxref("Performance.eventCounts")}} {{ReadOnlyInline}}
+
   - : An {{domxref("EventCounts")}} map containing the number of events which have been dispatched per event type.
 
 - {{domxref("Performance.navigation")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
@@ -66,6 +67,8 @@ _The `Performance` interface doesn't inherit any methods._
   - : Creates a {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's _performance entry buffer_ with the given name.
 - {{domxref("Performance.measure()")}}
   - : Creates a named {{domxref("DOMHighResTimeStamp","timestamp")}} in the browser's performance entry buffer between two specified marks (known as the _start mark_ and _end mark_, respectively).
+- {{domxref("Performance.measureUserAgentSpecificMemory()")}}
+  - : Estimates the memory usage of a web application including all its iframes and workers.
 - {{domxref("Performance.now()")}}
   - : Returns a {{domxref("DOMHighResTimeStamp")}} representing the number of milliseconds elapsed since a reference instant.
 - {{domxref("Performance.setResourceTimingBufferSize()")}}

--- a/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
+++ b/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
@@ -13,13 +13,13 @@ browser-compat: api.Performance.measureUserAgentSpecificMemory
 
 {{APIRef("Performance API")}} {{SeeCompatTable}}
 
-The **`measureUserAgentSpecificMemory()`** method is used to estimate memory usage of web applications including all its iframes and workers.
+The **`measureUserAgentSpecificMemory()`** method is used to estimate the memory usage of a web application including all its iframes and workers.
 
 ## Description
 
-The browser automatically allocates memory when objects are created and frees it when they are not reachable anymore (garbage collection). This garbage collection (GC) is an approximation since the general problem of determining whether or not a specific piece of memory is still needed is impossible (see also [JavaScript Memory Management](/en-US/docs/Web/JavaScript/Memory_Management)). Developers need to make sure that objects are garbage collected, memory isn't leaked, and memory usage doesn't grow unnecessarily over time leading to slow and unresponsive web applications. Memory leaks are typically introduced by forgetting to unregister an event listener, not closing a worker, or accumulating objects in arrays, and more.
+The browser automatically allocates memory when objects are created and frees it when they are not reachable anymore (garbage collection). This garbage collection (GC) is an approximation since the general problem of determining whether or not a specific piece of memory is still needed is impossible (see also [JavaScript Memory Management](/en-US/docs/Web/JavaScript/Memory_Management)). Developers need to make sure that objects are garbage collected, memory isn't leaked, and memory usage doesn't grow unnecessarily over time leading to slow and unresponsive web applications. Memory leaks are typically introduced by forgetting to unregister an event listener, not closing a worker, accumulating objects in arrays, and more.
 
-The `measureUserAgentSpecificMemory()` API aggregates memory usage data to help you find memory leaks. It can be used for memory regression detection or for A/B testing features to evaluate their memory impact. Single calls of this method are less useful; the aggregation and periodical monitoring of aggregated memory usage data makes this API powerful.
+The `measureUserAgentSpecificMemory()` API aggregates memory usage data to help you find memory leaks. It can be used for memory regression detection or for A/B testing features to evaluate their memory impact. Rather than make single calls to this method, it's better to make periodic calls to track how memory usage changes over the duration of a session.
 
 The `byte` values this API returns aren't comparable across browsers or between different versions of the same browser as these are highly implementation dependent. Also, how `breakdown` and `attribution` arrays are provided is up to the browser as well. It is best to not hardcode any assumptions about this data. This API is rather meant to be called periodically (with a randomized interval) to aggregate data and analyze the difference between the samples.
 
@@ -46,13 +46,13 @@ A {{jsxref("Promise")}} that resolves to an object containing the following prop
     - `attribution`
       - : An {{jsxref("Array")}} of container elements of the JavaScript realms that use the memory. This object has the following properties:
         - `url`
-          - : If this attribution corresponds to a same-origin JavaScript realm, then this property contains realm's URL. Otherwise it is the string "cross-origin-url".
+          - : If this attribution corresponds to a same-origin JavaScript realm, then this property contains the realm's URL. Otherwise it is the string "cross-origin-url".
         - `container`
           - : An object describing the DOM element that contains this JavaScript realm. This object has the following properties:
             - `id`
               - : The `id` attribute of the container element.
             - `src`
-              - : The `src` attribute of the container element. If the container element is an {{HTMLLElement("object")}} element, then this field contains the value of the `data` attribute.
+              - : The `src` attribute of the container element. If the container element is an {{HTMLElement("object")}} element, then this field contains the value of the `data` attribute.
         - `scope`
           - : A string describing the type of the same-origin JavaScript realm. Either `"Window"`, `"DedicatedWorkerGlobalScope"`, `"SharedWorkerGlobalScope"`, `"ServiceWorkerGlobalScope"` or `"cross-origin-aggregated"` for the cross-origin case.
     - `types`
@@ -99,7 +99,7 @@ An example return value looks like this:
 
 ### Exceptions
 
-- {{domxref("SecurityError")}}
+- `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the security requirements for preventing cross-origin information leaks aren't fulfilled.
 
 ## Security requirements
@@ -138,7 +138,7 @@ function runMemoryMeasurements() {
 }
 
 async function measureMemory() {
-  let memorySample = await performance.measureUserAgentSpecificMemory();
+  const memorySample = await performance.measureUserAgentSpecificMemory();
   console.log(memorySample);
   runMemoryMeasurements();
 }

--- a/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
+++ b/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
@@ -1,0 +1,162 @@
+---
+title: performance.measureUserAgentSpecificMemory()
+slug: Web/API/Performance/measureUserAgentSpecificMemory
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+  - Experimental
+browser-compat: api.Performance.measureUserAgentSpecificMemory
+---
+
+{{APIRef("Performance API")}} {{SeeCompatTable}}
+
+The **`measureUserAgentSpecificMemory()`** method is used to estimate memory usage of web applications including all its iframes and workers.
+
+## Description
+
+The browser automatically allocates memory when objects are created and frees it when they are not reachable anymore (garbage collection). This garbage collection (GC) is an approximation since the general problem of determining whether or not a specific piece of memory is still needed is impossible (see also [JavaScript Memory Management](/en-US/docs/Web/JavaScript/Memory_Management)). Developers need to make sure that objects are garbage collected, memory isn't leaked, and memory usage doesn't grow unnecessarily over time leading to slow and unresponsive web applications. Memory leaks are typically introduced by forgetting to unregister an event listener, not closing a worker, or accumulating objects in arrays, and more.
+
+The `measureUserAgentSpecificMemory()` API aggregates memory usage data to help you find memory leaks. It can be used for memory regression detection or for A/B testing features to evaluate their memory impact. Single calls of this method are less useful; the aggregation and periodical monitoring of aggregated memory usage data makes this API powerful.
+
+The `byte` values this API returns aren't comparable across browsers or between different versions of the same browser as these are highly implementation dependent. Also, how `breakdown` and `attribution` arrays are provided is up to the browser as well. It is best to not hardcode any assumptions about this data. This API is rather meant to be called periodically (with a randomized interval) to aggregate data and analyze the difference between the samples.
+
+## Syntax
+
+```js-nolint
+measureUserAgentSpecificMemory()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to an object containing the following properties:
+
+- `bytes`
+  - : A number representing the total memory usage.
+- `breakdown`
+  - : An {{jsxref("Array")}} of objects partitioning the total `bytes` and providing attribution and type information. The object contains the following properties:
+    - `bytes`
+      - : The size of the memory that this entry describes.
+    - `attribution`
+      - : An {{jsxref("Array")}} of container elements of the JavaScript realms that use the memory. This object has the following properties:
+        - `url`
+          - : If this attribution corresponds to a same-origin JavaScript realm, then this property contains realm's URL. Otherwise it is the string "cross-origin-url".
+        - `container`
+          - : An object describing the DOM element that contains this JavaScript realm. This object has the following properties:
+            - `id`
+              - : The `id` attribute of the container element.
+            - `src`
+              - : The `src` attribute of the container element. If the container element is an {{HTMLLElement("object")}} element, then this field contains the value of the `data` attribute.
+        - `scope`
+          - : A string describing the type of the same-origin JavaScript realm. Either `"Window"`, `"DedicatedWorkerGlobalScope"`, `"SharedWorkerGlobalScope"`, `"ServiceWorkerGlobalScope"` or `"cross-origin-aggregated"` for the cross-origin case.
+    - `types`
+      - : An array of implementation-defined memory types associated with the memory.
+
+An example return value looks like this:
+
+```js
+{
+  bytes: 1500000,
+  breakdown: [
+    {
+      bytes: 1000000,
+      attribution: [
+        {
+          url: "https://example.com",
+          scope: "Window",
+        },
+      ],
+      types: ["DOM", "JS"],
+    },
+    {
+      bytes: 0,
+      attribution: [],
+      types: [],
+    },
+    {
+      bytes: 500000,
+      attribution: [
+        {
+          url: "https://example.com/iframe.html"
+          container: {
+            id: "example-id",
+            src: "redirect.html?target=iframe.html",
+          },
+          scope: "Window",
+        }
+      ],
+      types: ["JS", "DOM"],
+    },
+  ],
+}
+```
+
+### Exceptions
+
+- {{domxref("SecurityError")}}
+  - : Thrown if the security requirements for preventing cross-origin information leaks aren't fulfilled.
+
+## Security requirements
+
+Your site needs to be in a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
+
+Two headers need to be set to cross-origin isolate your site:
+
+- [`Cross-Origin-Opener-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) with `same-origin` as value (protects your origin from attackers)
+- [`Cross-Origin-Embedder-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) with `require-corp` as value (protects victims from your origin)
+
+```http
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:
+
+```js
+if (crossOriginIsolated) {
+  // Use measureUserAgentSpecificMemory
+}
+```
+
+## Examples
+
+### Monitoring memory usage
+
+The following code shows how to call the `measureUserAgentSpecificMemory()` method once every five minutes at a random interval using [Exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution#Random_variate_generation).
+
+```js
+function runMemoryMeasurements() {
+  const interval = -Math.log(Math.random()) * 5 * 60 * 1000;
+  console.log(`Next measurement in ${Math.round(interval / 1000)} seconds.`);
+  setTimeout(measureMemory, interval);
+}
+
+async function measureMemory() {
+  let memorySample = await performance.measureUserAgentSpecificMemory();
+  console.log(memorySample);
+  runMemoryMeasurements();
+}
+
+if (crossOriginIsolated) {
+  runMemoryMeasurements();
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("setTimeout")}}
+- [Monitor your web page's total memory usage with measureUserAgentSpecificMemory() - web.dev](https://web.dev/monitor-total-page-memory-usage/)

--- a/files/en-us/web/api/performance/memory/index.md
+++ b/files/en-us/web/api/performance/memory/index.md
@@ -3,24 +3,43 @@ title: Performance.memory
 slug: Web/API/Performance/memory
 page-type: web-api-instance-property
 browser-compat: api.Performance.memory
+tags:
+  - non-standard
+  - deprecated
 ---
 
-{{APIRef("Performance API")}}
+{{APIRef("Performance API")}} {{Deprecated_Header}}
 
-## Syntax
+The non-standard and legacy `performance.memory` property returns the size of the JavaScript heap which can be helpful to measure and reduce the memory footprint of websites.
 
-```js-nolint
-memoryInfo = performance.memory
-```
+Note that the information this API provides is unreliable as it might overestimate actual memory usage if web pages share the same heap, or might underestimate actual memory usage if web pages use workers and/or cross-site iframes that are allocated in separate heaps. It is not standardized what "heap" means exactly. The API is only available in Chromium-based browsers.
 
-## Attributes
+A new API aiming to replace `performance.memory` is {{domxref("Performance.measureUserAgentSpecificMemory()")}}. It tries to estimate the memory used by a web page.
+
+## Value
+
+The read-only `performance.memory` property is an object with the following properties:
 
 - `jsHeapSizeLimit`
   - : The maximum size of the heap, in bytes, that is available to the context.
 - `totalJSHeapSize`
   - : The total allocated heap size, in bytes.
-- usedJSHeapSize
+- `usedJSHeapSize`
   - : The currently active segment of JS heap, in bytes.
+
+## Examples
+
+### Getting JavaScript heap sizes
+
+Calling `performance.memory` returns an object like this:
+
+```js
+{
+  totalJSHeapSize: 39973671,
+  usedJSHeapSize: 39127515,
+  jsHeapSizeLimit: 4294705152
+}
+```
 
 ## Specifications
 
@@ -32,4 +51,4 @@ None.
 
 ## See also
 
-- The {{domxref("Performance")}} interface it belongs to.
+- {{domxref("Performance.measureUserAgentSpecificMemory()")}}


### PR DESCRIPTION
### Description

This PR deprecates the `performance.memory` API and documents its successor `performance.measureUserAgentSpecificMemory()`

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

This article has been helpful: https://web.dev/monitor-total-page-memory-usage/
Specification: https://wicg.github.io/performance-measure-memory/

I'm really not an expert here. Let me know if this is garbage and collect it :)

### Related issues and pull requests

Will submit a BCD PR for the mdn_url.