### PR TITLE
Fix #10078 Add missing translation string in files/jsondata/L10n-Common.json for es

### DIFF
--- a/files/jsondata/L10n-Common.json
+++ b/files/jsondata/L10n-Common.json
@@ -174,6 +174,7 @@
   },
   "section": {
     "en-US": "section",
+    "es": "sección",
     "fr": "section",
     "ja": "セクション",
     "pt-BR": "sessão",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add missing translation string in files/jsondata/L10n-Common.json for es

### Motivation

the chore of translations strings

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fix https://github.com/mdn/translated-content/issues/10078
Relates to https://github.com/mdn/translated-content/issues/8749
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
