### PR TITLE
Fix IDBRequest

### DIFF
--- a/files/en-us/web/api/idbrequest/index.md
+++ b/files/en-us/web/api/idbrequest/index.md
@@ -21,7 +21,7 @@ The request object does not initially contain any information about the result o
 
 All asynchronous operations immediately return an {{domxref("IDBRequest")}} instance. Each request has a `readyState` that is set to the `'pending'` state; this changes to `'done'` when the request is completed or fails. When the state is set to `done`, every request returns a `result` and an `error`, and an event is fired on the request. When the state is still `pending`, any attempt to access the `result` or `error` raises an `InvalidStateError` exception.
 
-In plain words, all asynchronous methods return a request object. If the request has been completed successfully, the result is made available through the `result` property and an event indicating success is fired at the request ({{domxref("IDBRequest.success_event", "success")}}). If an error occurs while performing the operation, the exception is made available through the `result` property and an error event is fired ({{domxref("IDBRequest.error_event", "error")}}).
+In plain words, all asynchronous methods return a request object. If the request has been completed successfully, the result is made available through the `result` property and an event indicating success is fired at the request ({{domxref("IDBRequest.success_event", "success")}}). If an error occurs while performing the operation, the exception is made available through the `error` property and an error event is fired ({{domxref("IDBRequest.error_event", "error")}}).
 
 The interface {{domxref("IDBOpenDBRequest")}} is derived from `IDBRequest`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fix the name of property for retrieving the exception from failed requests.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[Indexed Database API 3.0 / 4.1. The IDBRequest interface](https://w3c.github.io/IndexedDB/#request-api) says:

> request . result
> 
> When a request is completed, returns the result, or undefined if the request failed. Throws a "InvalidStateError" DOMException if the request is still pending.
> request . error
> 
> When a request is completed, returns the error (a DOMException), or null if the request succeeded. Throws a "InvalidStateError" DOMException if the request is still pending.

and

>  The result getter steps are:
> 
> 1. If this's done flag is false, then throw an "InvalidStateError" DOMException.
> 
> 2. Otherwise, return this's result, or undefined if the request resulted in an error.
> 
> The error getter steps are:
> 
> 1. If this's done flag is false, then throw an "InvalidStateError" DOMException.
> 
> 2. Otherwise, return this's error, or null if no error occurred.

From these parts, exceptions doesn't look available through the `result` property of `IDBRequest` objects correspond to failed requests because it is defined to `undefined`.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
