### PR TITLE
Add sidebars to Ajax guide pages

### DIFF
--- a/files/en-us/web/guide/ajax/community/index.md
+++ b/files/en-us/web/guide/ajax/community/index.md
@@ -5,6 +5,8 @@ tags:
   - AJAX
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}
+
 If you know of useful mailing lists, newsgroups, forums, or other communities related to AJAX, please link to them here.
 
 ## Ajax Resources
@@ -13,7 +15,6 @@ If you know of useful mailing lists, newsgroups, forums, or other communities re
 
 - [skillsmatter.com](https://skillsmatter.com/explore?q=ajax-ria): Courses and events on JavaScript, Ajax, and Reverse Ajax technologies
 - [telerik.com](https://www.telerik.com/forums/aspnet-ajax): An active community forum for Ajax
-- [community.tableau.com](https://community.tableau.com/search.jspa?q=ajax): Community support forum and courses available for Ajax
 - [codementor.io](https://www.codementor.io/community/search?q=ajax): Social platform with Ajax forums and tutorials
 - [LinkedIn Learning](https://www.linkedin.com/learning/search?keywords=ajax): Tutorials available for learning the fundamentals of Ajax
 - [Ajax Interview Questions and answer](https://www.onlineinterviewquestions.com/ajax-interview-questions/)

--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -10,7 +10,7 @@ tags:
   - XMLHttpRequest
 ---
 
-{{DefaultAPISidebar("XMLHttpRequest")}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}
 
 This article guides you through the AJAX basics and gives you some simple hands-on examples to get you started.
 

--- a/files/en-us/web/guide/ajax/index.md
+++ b/files/en-us/web/guide/ajax/index.md
@@ -10,6 +10,20 @@ tags:
   - XMLHttpRequest
 ---
 
+<section id="Quick_links">
+  {{ListSubpagesForSidebar("/en-US/docs/Web/Guide/AJAX")}}
+  <ol>
+    <li class="toggle">
+      <details>
+        <summary>Guides</summary>
+        <ol>
+          {{ListSubpagesForSidebar("/en-US/docs/Web/Guide")}}
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>
+
 ## Getting Started
 
 **Asynchronous JavaScript and XML**, or [**Ajax**](https://www.semanticscholar.org/paper/Ajax%3A-A-New-Approach-to-Web-Applications-Garrett/c440ae765ff19ddd3deda24a92ac39cef9570f1e?p2df), is not a technology in itself, but rather an approach to using a number of existing technologies together, including [HTML](/en-US/docs/Web/HTML) or [XHTML](/en-US/docs/Glossary/XHTML), [CSS](/en-US/docs/Web/CSS), [JavaScript](/en-US/docs/Web/JavaScript), [DOM](/en-US/docs/Web/API/Document_Object_Model), [XML](/en-US/docs/Web/XML), [XSLT](/en-US/docs/Web/XSLT), and most importantly the {{domxref("XMLHttpRequest")}} object.
@@ -34,7 +48,7 @@ Although X in Ajax stands for XML, {{glossary("JSON")}} is preferred because it 
 - [Sending and Receiving Binary Data](/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data)
   - : The `responseType` property of the `XMLHttpRequest` object can be set to change the expected response type from the server. Possible values are the empty string (default), `arraybuffer`, `blob`, `document`, `json`, and `text`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This article will show some Ajax I/O techniques.
 - [XML](/en-US/docs/Web/XML)
-  - : The **Extensible Markup Language (XML)** is a W3C-recommended general-purpose markup language for creating special-purpose markup languages. It is a simplified subset of SGML, capable of describing many different kinds of data. Its primary purpose is to facilitate the sharing of data across different systems, particularly systems connected via the Internet.
+  - : The **Extensible Markup Language (XML)** is a W3C-recommended general-purpose markup language for creating special-purpose markup languages. It is a simplified subset of SGML, capable of describing many kinds of data. Its primary purpose is to facilitate the sharing of data across different systems, particularly systems connected via the Internet.
 - [Parsing and serializing XML](/en-US/docs/Web/Guide/Parsing_and_serializing_XML)
   - : How to parse an XML document from a string, a file or via JavaScript and how to serialize XML documents to strings, JavaScript Object trees (JXON) or files.
 - [XPath](/en-US/docs/Web/XPath)

--- a/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
+++ b/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
@@ -6,6 +6,8 @@ tags:
   - Accessibility
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}
+
 > **Warning:** These notes are for developers of screen readers. Developers should use the [ARIA live regions developer documentation](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 
 Firefox 3 contains important improvements to the way the Mozilla engine exposes live changes in a document.


### PR DESCRIPTION
The PR adds missing sidebars to Ajax guide pages.

The link that now requires an account and login has been removed from the resources list.