### PR TITLE
Regex global flag test() add examples for multiple matches

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
@@ -115,6 +115,15 @@ regex.test("barfoo"); // true
 regex.test("foobar"); //false
 
 // regex.lastIndex is at 0
+regex.test("foobarfoo"); // true
+
+// regex.lastIndex is at 3
+regex.test("foobarfoo"); // true
+
+// regex.lastIndex is at 9
+regex.test("foobarfoo"); // false
+
+// regex.lastIndex is at 0
 // (...and so on)
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
@@ -112,7 +112,7 @@ regex.test("foo"); // false
 regex.test("barfoo"); // true
 
 // regex.lastIndex is at 6
-regex.test("foobar"); //false
+regex.test("foobar"); // false
 
 // regex.lastIndex is at 0
 regex.test("foobarfoo"); // true


### PR DESCRIPTION
### Description

Added examples to show Regex's test() behavior when there are multiple matches in a string

### Motivation

There are no examples currently that show the behavior of test() when multiple matches are found in a string
