### PR TITLE
Improve PerformanceResourceTiming pages, part 1

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -12,48 +12,61 @@ browser-compat: api.PerformanceResourceTiming.connectEnd
 
 {{APIRef("Performance API")}}
 
-The **`connectEnd`** read-only property returns the
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes
-establishing the connection to the server to retrieve the resource. The timestamp value
-includes the time interval to establish the transport connection, as well as other time
-intervals such as SSL handshake and SOCKS authentication.
-
-{{AvailableInWorkers}}
+The **`connectEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as SSL handshake and [SOCKS](https://en.wikipedia.org/wiki/SOCKS) authentication.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} representing the time after a connection is
-established.
+The `connectEnd` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} representing the time after a connection is established.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring TCP handshake time
+
+The `connectEnd` and {{domxref("PerformanceResourceTiming.connectStart", "connectStart")}} properties can be used to measure how long it takes for the TCP handshake to happen.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const tcp = entry.connectEnd - entry.connectStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+Using a {{domxref("PerformanceObserver")}}:
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const tcp = entry.connectEnd - entry.connectStart;
+    if (tcp > 0) {
+      console.log(`${entry.name}: TCP handshake duration: ${tcp}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const tcp = entry.connectEnd - entry.connectStart;
+  if (tcp > 0) {
+    console.log(`${entry.name}: TCP handshake duration: ${tcp}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `connectEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -63,3 +76,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -19,7 +19,7 @@ The **`connectEnd`** read-only property returns the {{domxref("DOMHighResTimeSta
 The `connectEnd` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} representing the time after a connection is established.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -63,7 +63,7 @@ resources.forEach((entry) => {
 
 If the value of the `connectEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -19,7 +19,7 @@ The **`connectStart`** read-only property returns the {{domxref("DOMHighResTimeS
 The `connectStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to establish the connection to the server to retrieve the resource.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -63,7 +63,7 @@ resources.forEach((entry) => {
 
 If the value of the `connectStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -12,47 +12,61 @@ browser-compat: api.PerformanceResourceTiming.connectStart
 
 {{APIRef("Performance API")}}
 
-The **`connectStart`** read-only property returns the
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the user agent starts
-establishing the connection to the server to retrieve the resource.
-
-{{AvailableInWorkers}}
+The **`connectStart`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the user agent starts establishing the connection to the server to retrieve the resource.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to establish
-the connection to the server to retrieve the resource.
+The `connectStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to establish the connection to the server to retrieve the resource.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring TCP handshake time
+
+The `connectStart` and {{domxref("PerformanceResourceTiming.connectEnd", "connectEnd")}} properties can be used to measure how long it takes for the TCP handshake to happen.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const tcp = entry.connectEnd - entry.connectStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const tcp = entry.connectEnd - entry.connectStart;
+    if (tcp > 0) {
+      console.log(`${entry.name}: TCP handshake duration: ${tcp}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const tcp = entry.connectEnd - entry.connectStart;
+  if (tcp > 0) {
+    console.log(`${entry.name}: TCP handshake duration: ${tcp}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `connectStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -62,3 +76,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceResourceTiming.domainLookupEnd
 
 {{APIRef("Performance API")}}
 
-The **`domainLookupEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes the domain name lookup for the resource.
+The **`domainLookupEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes the domain-name lookup for the resource.
 
 If the user agent has the domain information in cache, {{domxref("PerformanceResourceTiming.domainLookupStart","domainLookupStart")}} and {{domxref("PerformanceResourceTiming.domainLookupEnd","domainLookupEnd")}} represent the times when the user agent starts and ends the domain data retrieval from the cache.
 
@@ -21,7 +21,7 @@ If the user agent has the domain information in cache, {{domxref("PerformanceRes
 The `domainLookupEnd` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the browser finishes the domain name lookup for the resource.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -49,7 +49,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -65,7 +65,7 @@ resources.forEach((entry) => {
 
 If the value of the `domainLookupEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -12,52 +12,63 @@ browser-compat: api.PerformanceResourceTiming.domainLookupEnd
 
 {{APIRef("Performance API")}}
 
-The **`domainLookupEnd`** read-only property returns the
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes
-the domain name lookup for the resource.
+The **`domainLookupEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes the domain name lookup for the resource.
 
-If the user agent has the domain information in cache,
-{{domxref("PerformanceResourceTiming.domainLookupStart","domainLookupStart")}} and
-{{domxref("PerformanceResourceTiming.domainLookupEnd","domainLookupEnd")}} represent the
-times when the user agent starts and ends the domain data retrieval from the cache.
-
-{{AvailableInWorkers}}
+If the user agent has the domain information in cache, {{domxref("PerformanceResourceTiming.domainLookupStart","domainLookupStart")}} and {{domxref("PerformanceResourceTiming.domainLookupEnd","domainLookupEnd")}} represent the times when the user agent starts and ends the domain data retrieval from the cache.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the
-browser finishes the domain name lookup for the resource.
+The `domainLookupEnd` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the browser finishes the domain name lookup for the resource.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring DNS lookup time
+
+The `domainLookupEnd` and {{domxref("PerformanceResourceTiming.domainLookupStart", "domainLookupStart")}} properties can be used to measure how long it takes for the DNS lookup to happen.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const dns = entry.domainLookupEnd - entry.domainLookupStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const dns = entry.domainLookupEnd - entry.domainLookupStart;
+    if (dns > 0) {
+      console.log(`${entry.name}: DNS lookup duration: ${dns}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const dns = entry.domainLookupEnd - entry.domainLookupStart;
+  if (dns > 0) {
+    console.log(`${entry.name}: DNS lookup duration: ${dns}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `domainLookupEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -67,3 +78,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -12,47 +12,61 @@ browser-compat: api.PerformanceResourceTiming.domainLookupStart
 
 {{APIRef("Performance API")}}
 
-The **`domainLookupStart`** read-only property returns the
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts the
-domain name lookup for the resource.
-
-{{AvailableInWorkers}}
+The **`domainLookupStart`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts the domain name lookup for the resource.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the domain
-name lookup for the resource.
+The `domainLookupStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the domain name lookup for the resource.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring DNS lookup time
+
+The `domainLookupStart` and {{domxref("PerformanceResourceTiming.domainLookupEnd", "domainLookupEnd")}} properties can be used to measure how long it takes for the DNS lookup to happen.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const dns = entry.domainLookupEnd - entry.domainLookupStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const dns = entry.domainLookupEnd - entry.domainLookupStart;
+    if (dns > 0) {
+      console.log(`${entry.name}: DNS lookup duration: ${dns}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const dns = entry.domainLookupEnd - entry.domainLookupStart;
+  if (dns > 0) {
+    console.log(`${entry.name}: DNS lookup duration: ${dns}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `domainLookupStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -62,3 +76,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -19,7 +19,7 @@ The **`domainLookupStart`** read-only property returns the {{domxref("DOMHighRes
 The `domainLookupStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the domain name lookup for the resource.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -63,7 +63,7 @@ resources.forEach((entry) => {
 
 If the value of the `domainLookupStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PerformanceResourceTiming.fetchStart
 
 The **`fetchStart`** read-only property represents a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts to fetch the resource.
 
-If there are HTTP redirects the property returns the time immediately before the user agent starts to fetch the final resource in the redirection.
+If there are HTTP redirects, the property returns the time immediately before the user agent starts to fetch the final resource in the redirection.
 
 Unlike many other `PerformanceResourceTiming` properties, the `fetchStart` property is available for cross-origin requests without the need of the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header.
 
@@ -48,7 +48,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -12,14 +12,11 @@ browser-compat: api.PerformanceResourceTiming.fetchStart
 
 {{APIRef("Performance API")}}
 
-The **`fetchStart`** read-only property represents a
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts to
-fetch the resource.
+The **`fetchStart`** read-only property represents a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts to fetch the resource.
 
-If there are HTTP redirects the property returns the time immediately before the user
-agent starts to fetch the final resource in the redirection.
+If there are HTTP redirects the property returns the time immediately before the user agent starts to fetch the final resource in the redirection.
 
-{{AvailableInWorkers}}
+Unlike many other `PerformanceResourceTiming` properties, the `fetchStart` property is available for cross-origin requests without the need of the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header.
 
 ## Value
 
@@ -28,34 +25,39 @@ resource.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring time to fetch (without redirects)
+
+The `fetchStart` and {{domxref("PerformanceResourceTiming.responseEnd", "responseEnd")}} properties can be used to measure the overall time it took to fetch the final resource (without redirects). If you want to include redirects, the overall time to fetch is provided in the {{domxref("PerformanceEntry.duration", "duration")}} property.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const timeToFetch = entry.responseEnd - entry.fetchStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const timeToFetch = entry.responseEnd - entry.fetchStart;
+    if (timeToFetch > 0) {
+      console.log(`${entry.name}: Time to fetch: ${timeToFetch}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const timeToFetch = entry.responseEnd - entry.fetchStart;
+  if (timeToFetch > 0) {
+    console.log(`${entry.name}: Time to fetch: ${timeToFetch}ms`);
   }
-}
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -67,7 +67,7 @@ resources.forEach((entry) => {
 
 If the value of the `redirectEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -12,53 +12,65 @@ browser-compat: api.PerformanceResourceTiming.redirectEnd
 
 {{APIRef("Performance API")}}
 
-The **`redirectEnd`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately after receiving the last byte
-of the response of the last redirect.
+The **`redirectEnd`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after receiving the last byte of the response of the last redirect.
 
-When fetching a resource, if there are multiple HTTP redirects, and any of the
-redirects have an origin that is different from the current document, and the timing
-allow check algorithm passes for each redirected resource, this property returns the
-time immediately after receiving the last byte of the response of the last redirect;
-otherwise, zero is returned.
+When fetching a resource, if there are multiple HTTP redirects, and any of the redirects have an origin that is different from the current document, and the timing allow check algorithm passes for each redirected resource, this property returns the time immediately after receiving the last byte of the response of the last redirect; otherwise, zero is returned.
 
-{{AvailableInWorkers}}
+To get the amount of redirects, see also {{domxref("PerformanceNavigationTiming.redirectCount")}}.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after receiving the last
-byte of the response of the last redirect.
+The `redirectEnd` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after receiving the last byte of the response of the last redirect.
+- `0` if there is no redirect.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring redirection time
+
+The `redirectEnd` and {{domxref("PerformanceResourceTiming.redirectStart", "redirectStart")}} properties can be used to measure how long the redirection takes.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const redirect = entry.redirectEnd - entry.redirectStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const redirect = entry.redirectEnd - entry.redirectStart;
+    if (redirect > 0) {
+      console.log(`${entry.name}: Redirect time: ${redirect}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const redirect = entry.redirectEnd - entry.redirectStart;
+  if (redirect > 0) {
+    console.log(`${entry.name}: Redirect time: ${redirect}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `redirectEnd` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -68,3 +80,8 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("PerformanceNavigationTiming.redirectCount")}}
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -12,52 +12,65 @@ browser-compat: api.PerformanceResourceTiming.redirectStart
 
 {{APIRef("Performance API")}}
 
-The **`redirectStart`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} representing the start time of the fetch
-which that initiates the redirect.
+The **`redirectStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} representing the start time of the fetch which that initiates the redirect.
 
-If there are HTTP redirects when fetching the resource and if any of the redirects are
-not from the same origin as the current document, but the timing allow check algorithm
-passes for each redirected resource, this property returns the starting time of the
-fetch that initiates the redirect; otherwise, zero is returned.
+If there are HTTP redirects when fetching the resource and if any of the redirects are not from the same origin as the current document, but the timing allow check algorithm passes for each redirected resource, this property returns the starting time of the fetch that initiates the redirect; otherwise, zero is returned.
 
-{{AvailableInWorkers}}
+To get the amount of redirects, see also {{domxref("PerformanceNavigationTiming.redirectCount")}}.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the start time of the
-fetch which initiates the redirect.
+The `redirectStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the start time of the fetch which initiates the redirect.
+- `0` if there is no redirect.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring redirection time
+
+The `redirectStart` and {{domxref("PerformanceResourceTiming.redirectEnd", "redirectEnd")}} properties can be used to measure how long the redirection takes.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const redirect = entry.redirectEnd - entry.redirectStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const redirect = entry.redirectEnd - entry.redirectStart;
+    if (redirect > 0) {
+      console.log(`${entry.name}: Redirect time: ${redirect}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const redirect = entry.redirectEnd - entry.redirectStart;
+  if (redirect > 0) {
+    console.log(`${entry.name}: Redirect time: ${redirect}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `redirectStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -67,3 +80,8 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("PerformanceNavigationTiming.redirectCount")}}
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -67,7 +67,7 @@ resources.forEach((entry) => {
 
 If the value of the `redirectStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -21,7 +21,7 @@ There is no _end_ property for `requestStart`. To measure the request time, calc
 The `requestStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the browser starts requesting the resource from the server.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -49,7 +49,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -12,51 +12,63 @@ browser-compat: api.PerformanceResourceTiming.requestStart
 
 {{APIRef("Performance API")}}
 
-The **`requestStart`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} of the time immediately before the
-browser starts requesting the resource from the server, cache, or local resource. If the
-transport connection fails and the browser retires the request, the value returned will
-be the start of the retry request.
+The **`requestStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} of the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.
 
-There is no _end_ property for `requestStart`.
-
-{{AvailableInWorkers}}
+There is no _end_ property for `requestStart`. To measure the request time, calculate {{domxref("PerformanceResourceTiming.responseStart", "responseStart")}} - `requestStart` (see the example below).
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the
-browser starts requesting the resource from the server
+The `requestStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the browser starts requesting the resource from the server.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring request time
+
+The `requestStart` and {{domxref("PerformanceResourceTiming.responseStart", "responseStart")}} properties can be used to measure how long the request takes.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const request = entry.responseStart - entry.requestStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const request = entry.responseStart - entry.requestStart;
+    if (request > 0) {
+      console.log(`${entry.name}: Request time: ${request}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const request = entry.responseStart - entry.requestStart;
+  if (request > 0) {
+    console.log(`${entry.name}: Request time: ${request}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `requestStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -66,3 +78,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -65,7 +65,7 @@ resources.forEach((entry) => {
 
 If the value of the `requestStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -12,12 +12,9 @@ browser-compat: api.PerformanceResourceTiming.responseEnd
 
 {{APIRef("Performance API")}}
 
-The **`responseEnd`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives
-the last byte of the resource or immediately before the transport connection is closed,
-whichever comes first.
+The **`responseEnd`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first.
 
-{{AvailableInWorkers}}
+Unlike many other `PerformanceResourceTiming` properties, the `responseEnd` property is available for cross-origin requests without the need of the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header.
 
 ## Value
 
@@ -27,34 +24,39 @@ comes first.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring time to fetch (without redirects)
+
+The `responseEnd` and {{domxref("PerformanceResourceTiming.fetchStart", "fetchStart")}} properties can be used to measure the overall time it took to fetch the final resource (without redirects). If you want to include redirects, the overall time to fetch is provided in the {{domxref("PerformanceEntry.duration", "duration")}} property.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const timeToFetch = entry.responseEnd - entry.fetchStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
- for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const timeToFetch = entry.responseEnd - entry.fetchStart;
+    if (timeToFetch > 0) {
+      console.log(`${entry.name}: Time to fetch: ${timeToFetch}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const timeToFetch = entry.responseEnd - entry.fetchStart;
+  if (timeToFetch > 0) {
+    console.log(`${entry.name}: Time to fetch: ${timeToFetch}ms`);
   }
-}
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -12,47 +12,61 @@ browser-compat: api.PerformanceResourceTiming.responseStart
 
 {{APIRef("Performance API")}}
 
-The **`responseStart`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives
-the first byte of the response from the server, cache, or local resource.
-
-{{AvailableInWorkers}}
+The **`responseStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the first byte of the response from the server, cache, or local resource.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first
-byte of the response from the server.
+The `responseStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first byte of the response from the server.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring request time
+
+The `responseStart` and {{domxref("PerformanceResourceTiming.requestStart", "requestStart")}} properties can be used to measure how long the request takes.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const request = entry.responseStart - entry.requestStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const request = entry.responseStart - entry.requestStart;
+    if (request > 0) {
+      console.log(`${entry.name}: Request time: ${request}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const request = entry.responseStart - entry.requestStart;
+  if (request > 0) {
+    console.log(`${entry.name}: Request time: ${request}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `responseStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -62,3 +76,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -63,7 +63,7 @@ resources.forEach((entry) => {
 
 If the value of the `responseStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -19,7 +19,7 @@ The **`responseStart`** read-only property returns a {{domxref("DOMHighResTimeSt
 The `responseStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first byte of the response from the server.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -12,50 +12,62 @@ browser-compat: api.PerformanceResourceTiming.secureConnectionStart
 
 {{APIRef("Performance API")}}
 
-The **`secureConnectionStart`** read-only property returns a
-{{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts the
-handshake process to secure the current connection. If a secure connection is not used,
-the property returns zero.
-
-{{AvailableInWorkers}}
+The **`secureConnectionStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts the handshake process to secure the current connection. If a secure connection is not used, the property returns zero.
 
 ## Value
 
-If the resource is fetched over a secure connection, a
-{{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the handshake
-process to secure the current connection. If a secure connection is not used, this
-property returns zero.
+The `secureConnectionStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}} indicating the time immediately before the browser starts the handshake process to secure the current connection if the resource is fetched over a secure connection.
+- `0` if no secure connection is used.
+- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring SSL negotiation time
+
+The `secureConnectionStart` and {{domxref("PerformanceResourceTiming.requestStart", "requestStart")}} properties can be used to measure how long it takes for the SSL negotiation to happen.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const ssl = entry.requestStart - entry.secureConnectionStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const ssl = entry.requestStart - entry.secureConnectionStart;
+    if (ssl > 0) {
+      console.log(`${entry.name}: SSL negotiation duration: ${ssl}ms`);
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const ssl = entry.requestStart - entry.secureConnectionStart;
+  if (ssl > 0) {
+    console.log(`${entry.name}: SSL negotiation duration: ${ssl}ms`);
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `secureConnectionStart` property is `0`, the resource is either not using a secure connection or it is a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -65,3 +77,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -20,7 +20,7 @@ The `secureConnectionStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} indicating the time immediately before the browser starts the handshake process to secure the current connection if the resource is fetched over a secure connection.
 - `0` if no secure connection is used.
-- `0` if the resource instantaneously retrieved from a cache.
+- `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
@@ -48,7 +48,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");
@@ -64,7 +64,7 @@ resources.forEach((entry) => {
 
 If the value of the `secureConnectionStart` property is `0`, the resource is either not using a secure connection or it is a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -52,7 +52,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -14,50 +14,66 @@ browser-compat: api.PerformanceResourceTiming.workerStart
 
 {{APIRef("Performance API")}}
 
-The **`workerStart`** read-only property of the
-{{domxref("PerformanceResourceTiming")}} interface returns a
-{{domxref("DOMHighResTimeStamp")}} immediately before dispatching the
-{{domxref("FetchEvent")}} if a Service Worker thread is already running, or immediately
-before starting the Service Worker thread if it is not already running. If the resource
-is not intercepted by a Service Worker the property will always return 0.
-
-{{AvailableInWorkers}}
+The **`workerStart`** read-only property of the {{domxref("PerformanceResourceTiming")}} interface returns a
+{{domxref("DOMHighResTimeStamp")}} immediately before dispatching the {{domxref("FetchEvent")}} if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running. If the resource is not intercepted by a Service Worker the property will always return 0.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}}.
+The `workerStart` property can have the following values:
+
+- A {{domxref("DOMHighResTimeStamp")}}.
+- `0` if no service worker is used.
+- `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
 
 ## Examples
 
-In the following example, the value of the `*Start` and `*End`
-properties of all "`resource`"
-{{domxref("PerformanceEntry.entryType","type")}} events are logged.
+### Measuring ServiceWorker processing time
+
+The `workerStart` and {{domxref("PerformanceResourceTiming.fetchStart", "fetchStart")}} properties can be used to measure the processing time of a {{domxref("ServiceWorker")}}.
 
 ```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printStartAndEndProperties(entry);
-    });
-}
+const workerProcessingTime = entry.fetchStart - entry.workerStart;
+```
 
-function printStartAndEndProperties(perfEntry) {
-  // Print timestamps of the *start and *end properties
-  properties = ["connectStart", "connectEnd",
-                "domainLookupStart", "domainLookupEnd",
-                "fetchStart",
-                "redirectStart", "redirectEnd",
-                "requestStart",
-                "responseStart", "responseEnd",
-                "secureConnectionStart",
-                "workerStart"];
+Using a {{domxref("PerformanceObserver")}}:
 
-  for (const property of properties) {
-    // Log the property
-    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    const workerProcessingTime = entry.fetchStart - entry.workerStart;
+    if (workerProcessingTime > 0) {
+      console.log(
+        `${entry.name}: Worker processing time: ${workerProcessingTime}ms`
+      );
+    }
+  });
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const resources = performance.getEntriesByType("resource");
+resources.forEach((entry) => {
+  const workerProcessingTime = entry.fetchStart - entry.workerStart;
+  if (workerProcessingTime > 0) {
+    console.log(
+      `${entry.name}: Worker processing time: ${workerProcessingTime}ms`
+    );
   }
-}
+});
+```
+
+### Cross-origin timing information
+
+If the value of the `workerStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+
+```http
+Timing-Allow-Origin: https://developer.mozilla.org
 ```
 
 ## Specifications
@@ -67,3 +83,7 @@ function printStartAndEndProperties(perfEntry) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{HTTPHeader("Timing-Allow-Origin")}}

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -70,7 +70,7 @@ resources.forEach((entry) => {
 
 If the value of the `workerStart` property is `0`, the resource might be a cross-origin request. To allow seeing cross-origin timing information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should sent:
+For example, to allow `https://developer.mozilla.org` to see timing resources, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org


### PR DESCRIPTION
### Description

This PR improves property pages of the `PerformanceResourceTiming` interface.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I tried to make the examples more practical by calculating things instead of just logging out the properties. I'm also showing how to use `PerformanceObservers` and the older `getEntriesByType()` method because I think both are practical. Additionally, I've provided info about cross-origin resources. I think this is a common pitfall. C.f. https://stackoverflow.com/questions/71129039/javascript-performance-api-performanceresourcetiming-returns-0-for-most-of-prope (doesn't apply to `fetchStart` and `responseEnd`)

The examples do the following:

- `connectEnd`: Measuring TCP handshake time (`entry.connectEnd - entry.connectStart`)
- `connectStart`: Measuring TCP handshake time (`entry.connectEnd - entry.connectStart`)
- `domainLookupEnd`: Measuring DNS lookup time (`entry.domainLookupEnd - entry.domainLookupStart`)
- `domainLookupStart`: Measuring DNS lookup time (`entry.domainLookupEnd - entry.domainLookupStart`)
- `redirectEnd`: Measuring redirection time (`entry.redirectEnd - entry.redirectStart`)
- `redirectStart`: Measuring redirection time (`entry.redirectEnd - entry.redirectStart`)
- `requestStart`: Measuring request time (`entry.responseStart - entry.requestStart`)
- `responseStart`: Measuring request time (`entry.responseStart - entry.requestStart`)
- `secureConnectionStart`: Measuring SSL negotiation time (`entry.requestStart - entry.secureConnectionStart`)
- `responseEnd`: Measuring time to fetch (without redirects) (`entry.responseEnd - entry.fetchStart`)
- `fetchStart`: Measuring time to fetch (without redirects) (`entry.responseEnd - entry.fetchStart`)
-  `workerStart`: Measuring ServiceWorker processing time (`entry.fetchStart - entry.workerStart`) 

Let me know if any of this doesn't make any sense or if there are other interesting things to measure with these timestamps.

### Related issues and pull requests

None.
