### PR TITLE
Change "??" to "||"

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -49,7 +49,7 @@ const x = {
   },
 };
 
-x.value ??= 2;
+x.value ||= 2;
 ```
 
 In fact, if `x` is truthy, `y` is not evaluated at all.


### PR DESCRIPTION
Wrong operator is used in getter/setter example of Logical OR Assignment #22504

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed "??" to "||" on the last line of the description example. Line 52

### Motivation

I resolving issue #22504.

### Additional details


### Related issues and pull requests

Fixes #22504 
