### PR TITLE
[files/en-us/web/html/element/img/index.md] Reflect that `<img>` tags autoclose

### DIFF
--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -253,7 +253,7 @@ Depending on its type, an image may have an intrinsic width and height. For some
 The following example embeds an image into the page and includes alternative text for accessibility.
 
 ```html
-<img src="favicon144.png" alt="MDN logo" />
+<img src="favicon144.png" alt="MDN logo">
 ```
 
 {{ EmbedLiveSample('Alternative_text', '100%', '160') }}
@@ -264,7 +264,7 @@ This example builds upon the previous one, showing how to turn the image into a 
 
 ```html
 <a href="https://developer.mozilla.org">
-  <img src="favicon144.png" alt="Visit the MDN site" />
+  <img src="favicon144.png" alt="Visit the MDN site">
 </a>
 ```
 
@@ -275,7 +275,7 @@ This example builds upon the previous one, showing how to turn the image into a 
 In this example we include a `srcset` attribute with a reference to a high-resolution version of the logo; this will be loaded instead of the `src` image on high-resolution devices. The image referenced in the `src` attribute is counted as a `1x` candidate in {{glossary("User agent", "user agents")}} that support `srcset`.
 
 ```html
-<img src="favicon72.png" alt="MDN logo" srcset="favicon144.png 2x" />
+<img src="favicon72.png" alt="MDN logo" srcset="favicon144.png 2x">
 ```
 
 {{EmbedLiveSample("Using_the_srcset_attribute", "100%", "160")}}
@@ -289,7 +289,7 @@ The `src` attribute is ignored in {{glossary("User agent", "user agents")}} that
   src="clock-demo-200px.png"
   alt="Clock"
   srcset="clock-demo-200px.png 200w, clock-demo-400px.png 400w"
-  sizes="(max-width: 600px) 200px, 50vw" />
+  sizes="(max-width: 600px) 200px, 50vw">
 ```
 
 {{EmbedLiveSample("Using_the_srcset_and_sizes_attributes", "100%", 350)}}
@@ -309,13 +309,13 @@ An `alt` attribute's value should clearly and concisely describe the image's con
 #### Don't
 
 ```html example-bad
-<img alt="image" src="penguin.jpg" />
+<img alt="image" src="penguin.jpg">
 ```
 
 #### Do
 
 ```html example-good
-<img alt="A Rockhopper Penguin standing on a beach." src="penguin.jpg" />
+<img alt="A Rockhopper Penguin standing on a beach." src="penguin.jpg">
 ```
 
 When an `alt` attribute is not present on an image, some screen readers may announce the image's file name instead. This can be a confusing experience if the file name isn't representative of the image's contents.
@@ -331,7 +331,7 @@ When an `alt` attribute is not present on an image, some screen readers may anno
 Due to a [VoiceOver bug](https://bugs.webkit.org/show_bug.cgi?id=216364), VoiceOver does not correctly announce SVG images as images. Include [`role="img"`](/en-US/docs/Web/Accessibility/ARIA/Roles/img_role) to all `<img>` elements with SVG source files to ensure assistive technologies correctly announce the SVG as image content.
 
 ```html
-<img src="mdn.svg" alt="MDN logo" role="img" />
+<img src="mdn.svg" alt="MDN logo" role="img">
 ```
 
 ### The title attribute


### PR DESCRIPTION
### Description

See w3 Nu HTML Checker for verification, I get this _Info_ level issue when I explicitly autoclose my `img` tags:
https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing

### Motivation

MDN examples should pass the w3 validator without erring.

### Additional details

Test it out here https://validator.w3.org/nu

### Related issues and pull requests
