### PR TITLE
reset function in code example

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -276,7 +276,7 @@ function listenForClicks() {
      * Get the active tab,
      * then call "beastify()" or "reset()" as appropriate.
      */
-    if (e.target.type = "reset") {
+    if (e.target.type === "reset") {
       browser.tabs
         .query({ active: true, currentWindow: true })
         .then(reset)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fixed choose_beast.js in example

### Motivation

The reset function in the choose_beast.js file on the MDN site does not work. After making these changes the extension works as intended.