### PR TITLE
postMessage correct targetOrigin option

### DIFF
--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -201,7 +201,7 @@ window.addEventListener("message", (event) => {
   // event.origin as the targetOrigin.
   event.source.postMessage("hi there yourself!  the secret response " +
                            "is: rheeeeet!",
-                           event.origin);
+                           { targetOrigin: event.origin });
 });
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Incorrect way of passing `targetOrigin` on `event.source.postMessage`, at least according to TypeScript.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To fix incorrect example, and avoid confusion.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
