### PR TITLE
Update PerformanceResourceTiming.initiatorType

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -84,7 +84,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const scripts = performance.getEntriesByType("resource").filter((entry) => {

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -12,43 +12,85 @@ browser-compat: api.PerformanceResourceTiming.initiatorType
 
 {{APIRef("Performance API")}}
 
-The **`initiatorType`** read-only property is a
-string that represents the _type_ of resource that
-initiated the performance event.
+The **`initiatorType`** read-only property is a string representing the way a resource was initiated to be fetched.
 
-The value of this string is as follows:
-
-- If the initiator is a {{domxref("Element")}}, the property returns the element's
-  {{domxref("Element.localName","localName")}}.
-- If the initiator is a {{domxref("CSS")}} resource, the property returns
-  "`css`".
-- If the initiator is a {{domxref("XMLHttpRequest")}} object, the property returns
-  "`xmlhttprequest`".
-- If the initiator is a {{domxref("PerformanceNavigationTiming")}} object, the
-  property returns an empty string (`""`).
-
-{{AvailableInWorkers}}
+> **Note:** This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file the `initiatorType` will be `css` and not `img`.
 
 ## Value
 
-A string representing the _type_ of resource that
-initiated the performance event, as specified above.
+The `initiatorType` property can have the following values or `other` if none of the conditions match.
+
+- `audio`
+  - : If the request was initiated by an {{HTMLElement("audio")}} element's `src` attribute.
+- `beacon`
+  - : If the request was initiated by a {{domxref("navigator.sendBeacon()")}} method.
+- `body`
+  - : If the request was initiated by a {{HTMLElement("body")}} element's `background` attribute.
+- `css`
+  - : If the request was initiated by a CSS `url()` function.
+- `early-hint`
+  - : If the request was initiated by an {{HTTPStatus("103")}} `Early Hint` response.
+- `embed`
+  - : If the request was initiated by an {{HTMLElement("embed")}} element's `src` attribute.
+- `fetch`
+  - : If the request was initiated by a {{domxref("fetch()")}} method.
+- `font`
+  - : If the request was initiated by a {{cssxref("@font-face")}} at rule.
+- `frame`
+  - : If the request was initiated by loading a {{HTMLElement("frame")}} element.
+- `iframe`
+  - : If the request was initiated by an {{HTMLElement("iframe")}} element's `src` attribute.
+- `icon` {{non-standard_inline}}
+  - : If the request was initiated by a favicon. Non-standard and only reported by Safari.
+- `image`
+  - : If the request was initiated by an {{SVGElement("image")}} element.
+- `img`
+  - : If the request was initiated by an {{HTMLElement("img")}} element's `src` or `srcset` attribute.
+- `input`
+  - : If the request was initiated by an {{HTMLElement("input")}} element of type `image`.
+- `link`
+  - : If the request was initiated by a {{HTMLElement("link")}} element.
+- `navigation`
+  - : If the request was initiated by a navigation request.
+- `object`
+  - : If the request was initiated by an {{HTMLElement("object")}} element.
+- `ping`
+  - : If the request was initiated by an {{HTMLElement("a")}} element's `ping`.
+- `script`
+  - : If the request was initiated by a {{HTMLElement("script")}} element.
+- `track`
+  - : If the request was initiated by a {{HTMLElement("track")}} element's `src`.
+- `video`
+  - : If the request was initiated by a {{HTMLElement("video")}} element's `poster` or `src`.
+- `xmlhttprequest`
+  - : If the request was initiated by a {{domxref("XMLHttpRequest")}}.
 
 ## Examples
 
-```js
-function printPerformanceEntries() {
-  // Use getEntriesByType() to just get the "resource" events
-  performance.getEntriesByType("resource")
-    .forEach((entry) => {
-      printInitiatorType(entry);
-    });
-}
+### Filtering resources
 
-function printInitiatorType(perfEntry) {
-  // Print this performance entry object's initiatorType value
-  console.log(`… initiatorType = ${perfEntry.initiatorType ?? "NOT supported"}`);
-}
+The `initiatorType` property can be used to get specific resource timing entries only. For example, only those that were initiated by {{HTMLElement("script")}} elements.
+
+Using a {{domxref("PerformanceObserver")}}:
+
+```js
+const observer = new PerformanceObserver((list) => {
+  const scripts = list.getEntries().filter((entry) => {
+    return entry.initiatorType === "script";
+  });
+  console.log(scripts);
+});
+
+observer.observe({ type: "resource", buffered: true });
+```
+
+Or using {{domxref("Performance.getEntriesByType()")}} which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+const scripts = performance.getEntriesByType("resource").filter((entry) => {
+  return entry.initiatorType === "script";
+});
+console.log(scripts);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -63,7 +63,7 @@ The `initiatorType` property can have the following values, or `other` if none o
 - `video`
   - : If the request was initiated by a {{HTMLElement("video")}} element's `poster` or `src`.
 - `xmlhttprequest`
-  - : If the request was initiated by a {{domxref("XMLHttpRequest")}}.
+  - : If the request was initiated by an {{domxref("XMLHttpRequest")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -18,7 +18,7 @@ The **`initiatorType`** read-only property is a string representing the way a re
 
 ## Value
 
-The `initiatorType` property can have the following values or `other` if none of the conditions match.
+The `initiatorType` property can have the following values, or `other` if none of the conditions match.
 
 - `audio`
   - : If the request was initiated by an {{HTMLElement("audio")}} element's `src` attribute.

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PerformanceResourceTiming.initiatorType
 
 The **`initiatorType`** read-only property is a string representing the way a resource was initiated to be fetched.
 
-> **Note:** This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file the `initiatorType` will be `css` and not `img`.
+> **Note:** This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file, the `initiatorType` will be `css` and not `img`.
 
 ## Value
 


### PR DESCRIPTION
### Description

This PR updates https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType with the goal to provide a better list of possible values and more practical example code.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

Finding out which values are actually possible (spec'ed and observed in the wild) was quite tricky and lead me into a bit of a rabbit hole today. I filed https://github.com/w3c/resource-timing/issues/364 with the specification. Depending on an answer there, this PR might need more tweaks.