### PR TITLE
Remove `VideoStreamTrack` refrences

### DIFF
--- a/files/en-us/web/api/media_capture_and_streams_api/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/index.md
@@ -51,8 +51,6 @@ In these reference articles, you'll find the fundamental information you'll need
 - {{domxref("OverconstrainedError")}}
 - {{domxref("URL")}}
 
-Early versions of the Media Capture and Streams API specification included separate `AudioStreamTrack` and `VideoStreamTrack` interfaces—each based upon {{domxref("MediaStreamTrack")}}—which represented streams of those types. These no longer exist, and you should update any existing code to instead use `MediaStreamTrack` directly.
-
 ## Events
 
 - {{domxref("MediaStream/addtrack_event", "addtrack")}}

--- a/files/en-us/web/api/mediastream/getvideotracks/index.md
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.md
@@ -43,10 +43,6 @@ is empty if the stream contains no video tracks.
 > **Note:** The order of the tracks is not defined by the specification,
 > and may not be the same from one call to `getVideoTracks()` to another.
 
-Early versions of this API included a special `VideoStreamTrack` interface
-which was used as the type for each entry in the list of video streams; however, this
-has since been merged into the main {{domxref("MediaStreamTrack")}} interface.
-
 ## Examples
 
 The following example, extracted from [Chrome's

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -789,7 +789,6 @@
         "MediaTrackConstraints",
         "MediaTrackSettings",
         "MediaTrackSupportedConstraints",
-        "VideoStreamTrack"
       ],
       "methods": [
         "HTMLCanvasElement.captureStream()",

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -788,7 +788,7 @@
         "MediaTrackCapabilities",
         "MediaTrackConstraints",
         "MediaTrackSettings",
-        "MediaTrackSupportedConstraints",
+        "MediaTrackSupportedConstraints"
       ],
       "methods": [
         "HTMLCanvasElement.captureStream()",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Remove `VideoStreamTrack` references. It was removed in Firefox 64 and its now hard to find references of it. 
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Its gone.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
