### PR TITLE
Remove broken srt2vtt link in Captions and Subtitles article

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -39,7 +39,7 @@ HTML allows us to specify subtitles for a video using the {{ htmlelement("track"
 
 The files that contain the actual subtitle data are simple text files that follow a specified format, in this case the [Web Video Text Tracks](/en-US/docs/Web/API/WebVTT_API) (WebVTT) format. The [WebVTT specification](https://w3c.github.io/webvtt/) is still being worked on, but major parts of it are stable so we can use it today.
 
-Video providers (such as the [Blender Foundation](https://www.blender.org/about/foundation/)) provide captions and subtitles in a text format with their videos, but they're usually in the SubRip Text (SRT) format. These can be easily converted to WebVTT using an online converter such as [srt2vtt](https://atelier.u-sub.net/srt2vtt/).
+Video providers (such as the [Blender Foundation](https://www.blender.org/about/foundation/)) provide captions and subtitles in a text format with their videos, but they're usually in the SubRip Text (SRT) format. These can be easily converted to WebVTT using an online converter.
 
 ## Modifications to the HTML and CSS
 


### PR DESCRIPTION
### Description

This PR removes a broken link in the article "Adding captions and subtitles to HTML video" ([link](https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video#webvtt)) that directs readers to an online converter that converts SRT files to VTT files. I considered replacing this link with a better link, but I think it's more maintainable to remove the link completely and let readers search for a tool themselves.

However, here's another [one](https://www.webvtt.org/) that I found that seems reputable. If preferred, I can update this PR to add the link to this website instead.

### Motivation

A reader clicking the broken link will result in an "ERR_CONNECTION_REFUSED" error.

