### PR TITLE
fix: replace method name with a generic one

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -177,7 +177,7 @@ Where `callbackFn` takes three arguments:
 - `index`
   - : The index of the current element being processed in the array.
 - `array`
-  - : The array `method()` was called upon.
+  - : The array that the method was called upon.
 
 What `callbackFn` is expected to return depends on the array method that was called.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -177,7 +177,7 @@ Where `callbackFn` takes three arguments:
 - `index`
   - : The index of the current element being processed in the array.
 - `array`
-  - : The array `groupToMap()` was called upon.
+  - : The array `method()` was called upon.
 
 What `callbackFn` is expected to return depends on the array method that was called.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The section describes generic method interface, the use of `groupToMap` doesn't make any sense here.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
