### PR TITLE
Added 4 new system colors

### DIFF
--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -123,7 +123,7 @@ HWB colors are expressed through the functional `hwb()` notation.
 
 In _forced colors mode_ (detectable with the [forced-colors](/en-US/docs/Web/CSS/@media/forced-colors) media query), most colors are restricted into a user- and browser-defined palette. These system colors are exposed by the following keywords, which can be used to ensure that the rest of the page integrates well with the restricted palette. These values may also be used in other contexts, but are not widely supported by browsers.
 
-The keywords in the following list are defined by the CSS Color Module Level 4 specification: `ActiveText`, `ButtonBorder`, `ButtonFace`, `ButtonText`, `Canvas`, `CanvasText`, `Field`, `FieldText`, `GrayText`, `Highlight`, `HighlightText`, `LinkText`, `Mark`, `MarkText`, `VisitedText`.
+The keywords in the following list are defined by the CSS Color Module Level 4 specification: `AccentColor`, `AccentColorText`, `ActiveText`, `ButtonBorder`, `ButtonFace`, `ButtonText`, `Canvas`, `CanvasText`, `Field`, `FieldText`, `GrayText`, `Highlight`, `HighlightText`, `LinkText`, `Mark`, `MarkText`, `SelectedItem`, `SelectedItemText`, `VisitedText`.
 
 > **Note:** Note that these keywords are _case-insensitive_, but are listed here with mixed case for readability.
 


### PR DESCRIPTION
### Description

Added `AccentColor`, `AccentColorText`, `SelectedItem`, and `SelectedItemText`.

`AccentColor` and `AccentColorText` were introduced in the [28 June 2022 Working Draft](https://www.w3.org/TR/2022/WD-css-color-4-20220628/) and `SelectedItem` and `SelectedItemText` were introduced in the [15 December 2021 Working Draft](https://www.w3.org/TR/2021/WD-css-color-4-20211215/).

### Motivation

The list was incomplete.