### PR TITLE
Improve substring description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substring/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.String.substring
 
 {{JSRef}}
 
-The **`substring()`** method returns the part of the `string` between the start and end indexes, or to the end of the string.
+The **`substring()`** method returns the part of the `string` from the start index up to and excluding the end index, or to the end of the string if no end index is supplied.
 
 {{EmbedInteractiveExample("pages/js/string-substring.html")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarify the description of how `String.prototype.substring()` works.

### Motivation

The previous version of the text made it reasonable to assume that if the text would be "Mozilla" and the indexes were `(1, 3)`, the end result would be the character `z`, i.e. the string "between the start and end indexes".

Since that would be very unusual, some users might instead assume that it would result in `ozi`.

This change makes it clear that the function includes the first index and excludes the second.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
