### PR TITLE
Feature is fully supported

### DIFF
--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -19,8 +19,6 @@ browser-compat: html.elements.input.type_email
 
 The input value is automatically validated to ensure that it's either empty or a properly-formatted e-mail address (or list of addresses) before the form can be submitted. The {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS pseudo-classes are automatically applied as appropriate to visually denote whether the current value of the field is a valid e-mail address or not.
 
-On browsers that don't support inputs of type `email`, a `email` input falls back to being a standard {{HTMLElement("input/text", "text")}} input.
-
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -261,7 +261,7 @@ There are two levels of content validation available for `email` inputs. First, 
 
 ### Basic validation
 
-Browsers that support the `email` input type automatically provide validation to ensure that only text that matches the standard format for Internet e-mail addresses is entered into the input box. Browsers that implement the specification should be using an algorithm equivalent to the following regular expression:
+Browsers automatically provide validation to ensure that only text that matches the standard format for Internet e-mail addresses is entered into the input box. Browsers use an algorithm equivalent to the following regular expression:
 
 ```js
 /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/


### PR DESCRIPTION
This made it seem like some browsers don't support email. Email is just a regular input with a very permissive regex requirement (so tld is needed). The main feature is the dynamic keyboard, which all mobile browsers I tested support.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
