### PR TITLE
Fix a typo

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.md
@@ -50,7 +50,7 @@ import Form from "./Form";
 import "./Form.css";
 ```
 
-This approach makes it easy to identify and manage the CSS that belongs to a specific component. However, it also fragments your stylesheet across your codebase, and this fragmentation might not be worthwhile. For larger applications with hundreds of unique views and lots of moving parts, it makes sense to limit the amount of irrelevant code that's sent to your user. You'll likely have app-wide styles and specific component styles that built on top of those.
+This approach makes it easy to identify and manage the CSS that belongs to a specific component. However, it also fragments your stylesheet across your codebase, and this fragmentation might not be worthwhile. For larger applications with hundreds of unique views and lots of moving parts, it makes sense to limit the amount of irrelevant code that's sent to your user. You'll likely have app-wide styles and specific component styles that build on top of those.
 
 You can [read more about component stylesheets in the create-react-app docs](https://create-react-app.dev/docs/adding-a-stylesheet/).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The word "built" is used grammatically wrong in the specified context. Changed it to "build".