### PR TITLE
Rework WebGL tutorial instructions

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -11,7 +11,7 @@ tags:
 
 ## Making the square rotate
 
-In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. The first thing we'll need is are variables in which to track the current rotation of the camera.
+In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. First we'll need some variables in which to track the current rotation of the camera.
 
 > **Note:** Add this code at the start of your "webgl-demo.js" script:
 
@@ -62,9 +62,9 @@ function render(now) {
 requestAnimationFrame(render);
 ```
 
-This code uses `requestAnimationFrame` to ask the browser to call the function "`render`" on each frame. `requestAnimationFrame` passes us the time in milliseconds since the page loaded. We convert that to seconds and then subtract from it the last time to compute `deltaTime` which is the number of second since the last frame was rendered.
+This code uses `requestAnimationFrame` to ask the browser to call the function "`render`" on each frame. `requestAnimationFrame` passes us the time in milliseconds since the page loaded. We convert that to seconds and then subtract from it the last time to compute `deltaTime`, which is the number of second since the last frame was rendered.
 
-Finally we update `squareRotation`.
+Finally, we update `squareRotation`.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510) }}
 

--- a/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -9,24 +9,28 @@ tags:
 
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL", "Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL") }}
 
-> **Note:** This example uses the glMatrix library to perform its matrix and vertex math. You'll need to include it if you create your own project based on this code. Our sample loads a copy from a CDN in our HTML's {{HTMLElement("head")}}.
-
 ## Making the square rotate
 
-In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. The first thing we'll need is a variable in which to track the current rotation of the camera:
+In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. The first thing we'll need is are variables in which to track the current rotation of the camera.
+
+> **Note:** Add this code at the start of your "webgl-demo.js" script:
 
 ```js
 let squareRotation = 0.0;
+let deltaTime = 0;
 ```
 
-Now we need to update the `drawScene()` function to apply the current rotation to the camera when drawing it. After translating the camera to the initial drawing position for the square, we apply the rotation like this:
+Now we need to update the `drawScene()` function to apply the current rotation to the camera when drawing it. After translating the camera to the initial drawing position for the square, we apply the rotation.
+
+> **Note:** In your "draw-scene.js" module, update the declaration of your `drawScene()` function so it can be passed the rotation to use:
+
+```js-nolint
+function drawScene(gl, programInfo, buffers, squareRotation) {
+```
+
+> **Note:** In your `drawScene()` function, right after the line `mat4.translate()` call, add this code:
 
 ```js
-mat4.translate(
-  modelViewMatrix, // destination matrix
-  modelViewMatrix, // matrix to translate
-  [-0.0, 0.0, -6.0]
-); // amount to translate
 mat4.rotate(
   modelViewMatrix, // destination matrix
   modelViewMatrix, // matrix to rotate
@@ -37,7 +41,9 @@ mat4.rotate(
 
 This rotates the modelViewMatrix by the current value of `squareRotation`, around the Z axis.
 
-To actually animate, we need to add code that changes the value of `squareRotation` over time. We can do that by creating a new variable to track the time at which we last animated (let's call it `then`), then adding the following code to the end of the main function
+To actually animate, we need to add code that changes the value of `squareRotation` over time.
+
+> **Note:** Add this code at the end of your `main()` function, replacing the existing `drawScene()` call:
 
 ```js
 let then = 0;
@@ -45,23 +51,20 @@ let then = 0;
 // Draw the scene repeatedly
 function render(now) {
   now *= 0.001; // convert to seconds
-  const deltaTime = now - then;
+  deltaTime = now - then;
   then = now;
 
-  drawScene(gl, programInfo, buffers, deltaTime);
+  drawScene(gl, programInfo, buffers, squareRotation);
+  squareRotation += deltaTime;
 
   requestAnimationFrame(render);
 }
 requestAnimationFrame(render);
 ```
 
-This code uses `requestAnimationFrame` to ask the browser to call the function "`render`" on each frame. `requestAnimationFrame` passes us the time in milliseconds since the page loaded. We convert that to seconds and then subtract from it the last time to compute `deltaTime` which is the number of second since the last frame was rendered. At the end of drawscene we add the code to update `squareRotation`.
+This code uses `requestAnimationFrame` to ask the browser to call the function "`render`" on each frame. `requestAnimationFrame` passes us the time in milliseconds since the page loaded. We convert that to seconds and then subtract from it the last time to compute `deltaTime` which is the number of second since the last frame was rendered.
 
-```js
-squareRotation += deltaTime;
-```
-
-This code uses the amount of time that's passed since the last time we updated the value of `squareRotation` to determine how far to rotate the square.
+Finally we update `squareRotation`.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510) }}
 

--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -144,7 +144,7 @@ function updateTexture(gl, texture, video) {
 
 You've seen this code before. It's nearly identical to the image onload function in the previous example — except when we call `texImage2D()`, instead of passing an `Image` object, we pass in the {{ HTMLElement("video") }} element. WebGL knows how to pull the current frame out and use it as a texture.
 
-Next, we need to call these new functions from out `main()` function.
+Next, we need to call these new functions from our `main()` function.
 
 > **Note:** In your `main()` function, replace the call to `loadTexture()` with this code:
 

--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -13,16 +13,20 @@ tags:
 
 In this demonstration, we build upon the previous example by replacing our static textures with the frames of an mp4 video file that's playing. This is actually pretty easy to do and fun to watch, so let's get started. You can use similar code to use any sort of data (such as a {{ HTMLElement("canvas") }}) as the source for your textures.
 
-> **Note:** This example uses the [glMatrix](https://glmatrix.net/) library to perform its matrix and vertex math. You'll need to include it if you create your own project based on this code. Our sample loads a copy from a CDN in our HTML's {{HTMLElement("head")}}.
-
 ## Getting access to the video
 
-The first step is to create the {{ HTMLElement("video") }} element that we'll use to retrieve the video frames:
+The first step is to create the {{ HTMLElement("video") }} element that we'll use to retrieve the video frames.
+
+> **Note:** Add this declaration to that start of your "webgl-demo.js" script:
 
 ```js
 // will set to true when video can be copied to texture
 let copyVideo = false;
+```
 
+> **Note:** Add this function your "webgl-demo.js" script:
+
+```js
 function setupVideo(url) {
   const video = document.createElement("video");
 
@@ -75,7 +79,9 @@ The video must be loaded from a secure source in order to be used to provide tex
 
 ## Using the video frames as a texture
 
-The next change is to `initTexture()`, which becomes much simpler, since it no longer needs to load an image file. Instead, all it does is create an empty texture object, put a single pixel in it, and set its filtering for later use:
+The next change is to initialize the texture, which becomes much simpler, since we no longer need to load an image file. Instead, we create an empty texture object, put a single pixel in it, and set its filtering for later use.
+
+> **Note:** Replace the `loadTexture()` function in "webgl-demo.js" with the following code:
 
 ```js
 function initTexture(gl) {
@@ -116,7 +122,7 @@ function initTexture(gl) {
 }
 ```
 
-Here's what the `updateTexture()` function looks like; this is where the real work is done:
+> **Note:** Add the following function to "webgl-demo.js":
 
 ```js
 function updateTexture(gl, texture, video) {
@@ -138,33 +144,38 @@ function updateTexture(gl, texture, video) {
 
 You've seen this code before. It's nearly identical to the image onload function in the previous example — except when we call `texImage2D()`, instead of passing an `Image` object, we pass in the {{ HTMLElement("video") }} element. WebGL knows how to pull the current frame out and use it as a texture.
 
-Then in `main()` in place of the call to `loadTexture()` in the previous example, we call `initTexture()` followed by `setupVideo()` .
+Next, we need to call these new functions from out `main()` function.
 
-In the definition of `render()` if `copyVideo` is true, then we call `updateTexture()` each time just before we call the `drawScene()` function.
+> **Note:** In your `main()` function, replace the call to `loadTexture()` with this code:
 
 ```js
 const texture = initTexture(gl);
-
 const video = setupVideo("Firefox.mp4");
+```
 
-let then = 0;
+> **Note:** You'll also need to download the [Firefox.mp4](https://github.com/mdn/dom-examples/blob/main/webgl-examples/tutorial/sample8/Firefox.mp4) file to the same local directory as your JavaScript files.
 
+> **Note:** In your `main()` function, replace the `render()` function with this:
+
+```js
 // Draw the scene repeatedly
 function render(now) {
   now *= 0.001; // convert to seconds
-  const deltaTime = now - then;
+  deltaTime = now - then;
   then = now;
 
   if (copyVideo) {
     updateTexture(gl, texture, video);
   }
 
-  drawScene(gl, programInfo, buffers, texture, deltaTime);
+  drawScene(gl, programInfo, buffers, texture, cubeRotation);
+  cubeRotation += deltaTime;
 
   requestAnimationFrame(render);
 }
-requestAnimationFrame(render);
 ```
+
+If `copyVideo` is true, we call `updateTexture()` just before we call the `drawScene()` function.
 
 That's all there is to it!
 

--- a/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -18,11 +18,11 @@ Let's take our square plane into three dimensions by adding five more faces to c
 
 Consider: each face requires four vertices to define it, but each vertex is shared by three faces. We can pass a lot fewer data around by building an array of all 24 vertices, then referring to each vertex by its index into that array instead of moving entire sets of coordinates around. If you wonder why we need 24 vertices, and not just 8, it is because each corner belongs to three faces of different colors, and a single vertex needs to have a single specific color; therefore we will create three copies of each vertex in three different colors, one for each face.
 
-> **Note:** This example uses the glMatrix library to perform its matrix and vertex math. You'll need to include it if you create your own project based on this code. Our sample loads a copy from a CDN in our HTML's {{HTMLElement("head")}}.
-
 ## Define the positions of the cube's vertices
 
-First, let's build the cube's vertex position buffer by updating the code in `initBuffers()`. This is pretty much the same as it was for the square plane, but somewhat longer since there are 24 vertices (4 per side):
+First, let's build the cube's vertex position buffer by updating the code in `initBuffers()`. This is pretty much the same as it was for the square plane, but somewhat longer since there are 24 vertices (4 per side).
+
+> **Note:** In the `initPositionBuffer()` function of your "init-buffers.js" module, replace the `positions` declaration with this code:
 
 ```js
 const positions = [
@@ -48,27 +48,17 @@ const positions = [
 
 Since we've added a z-component to our vertices, we need to update the `numComponents` of our `vertexPosition` attribute to 3.
 
+> **Note:** In the `setPositionAttribute()` function of your "draw-scene.js" module, change the `numComponents` constant from `2` to `3`:
+
 ```js
-// Tell WebGL how to pull out the positions from the position
-// buffer into the vertexPosition attribute
-{
-  const numComponents = 3;
-  // …
-  gl.vertexAttribPointer(
-    programInfo.attribLocations.vertexPosition,
-    numComponents,
-    type,
-    normalize,
-    stride,
-    offset
-  );
-  gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
-}
+const numComponents = 3;
 ```
 
 ## Define the vertices' colors
 
 We also need to build an array of colors for each of the 24 vertices. This code starts by defining a color for each face, then uses a loop to assemble an array of all the colors for each of the vertices.
+
+> **Note:** In the `initColorBuffer()` function of your "init-buffers.js" module, replace the `colors` declaration with this code:
 
 ```js
 const faceColors = [
@@ -89,17 +79,16 @@ for (var j = 0; j < faceColors.length; ++j) {
   // Repeat each color four times for the four vertices of the face
   colors = colors.concat(c, c, c, c);
 }
-
-const colorBuffer = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
 ```
 
 ## Define the element array
 
 Once the vertex arrays are generated, we need to build the element array.
 
+> **Note:** In your "init-buffer.js" module, add the following function:
+
 ```js
+function initIndexBuffer(gl) {
   const indexBuffer = gl.createBuffer();
   gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 
@@ -108,39 +97,86 @@ Once the vertex arrays are generated, we need to build the element array.
   // position.
 
   const indices = [
-    0,  1,  2,      0,  2,  3,    // front
-    4,  5,  6,      4,  6,  7,    // back
-    8,  9,  10,     8,  10, 11,   // top
-    12, 13, 14,     12, 14, 15,   // bottom
-    16, 17, 18,     16, 18, 19,   // right
-    20, 21, 22,     20, 22, 23,   // left
+    0,
+    1,
+    2,
+    0,
+    2,
+    3, // front
+    4,
+    5,
+    6,
+    4,
+    6,
+    7, // back
+    8,
+    9,
+    10,
+    8,
+    10,
+    11, // top
+    12,
+    13,
+    14,
+    12,
+    14,
+    15, // bottom
+    16,
+    17,
+    18,
+    16,
+    18,
+    19, // right
+    20,
+    21,
+    22,
+    20,
+    22,
+    23, // left
   ];
 
   // Now send the element array to GL
 
-  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER,
-      new Uint16Array(indices), gl.STATIC_DRAW);
+  gl.bufferData(
+    gl.ELEMENT_ARRAY_BUFFER,
+    new Uint16Array(indices),
+    gl.STATIC_DRAW
+  );
 
-  return {
-    position: positionBuffer,
-    color: colorBuffer,
-    indices: indexBuffer,
-  };
+  return indexBuffer;
 }
 ```
 
 The `indices` array defines each face like a pair of triangles, specifying each triangle's vertices as an index into the cube's vertex arrays. Thus the cube is described as a collection of 12 triangles.
 
+Next, you need to call this new function from `initBuffers()`, and return the buffer it creates.
+
+> **Note:** At the end of the `initBuffers()` function of your "init-buffers.js" module, add the following code, replacing the existing `return` statement:
+
+```js
+const indexBuffer = initIndexBuffer(gl);
+
+return {
+  position: positionBuffer,
+  color: colorBuffer,
+  indices: indexBuffer,
+};
+```
+
 ## Drawing the cube
 
-Next we need to add code to our `drawScene()` function to draw using the cube's index buffer, adding new {{domxref("WebGLRenderingContext.bindBuffer()", "gl.bindBuffer()")}} and {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} calls:
+Next we need to add code to our `drawScene()` function to draw using the cube's index buffer, adding new {{domxref("WebGLRenderingContext.bindBuffer()", "gl.bindBuffer()")}} and {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} calls.
+
+> **Note:** In your `drawScene()` function, add the following code just before the `gl.useProgram` line:
 
 ```js
 // Tell WebGL which indices to use to index the vertices
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers.indices);
+```
 
-// …
+> **Note:** In the `drawScene()` function of your "draw-scene.js" module, replace the block just after the two `gl.uniformMatrix4fv` calls, that contains the `gl.drawArrays()` line, with the following block:
 
+```js
 {
   const vertexCount = 36;
   const type = gl.UNSIGNED_SHORT;
@@ -151,10 +187,48 @@ gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers.indices);
 
 Since each face of our cube is comprised of two triangles, there are 6 vertices per side, or 36 total vertices in the cube, even though many of them are duplicates.
 
-Finally, let's replace our variable `squareRotation` by `cubeRotation` and add a second rotation around the x axis:
+Finally, let's replace our variable `squareRotation` by `cubeRotation` and add a second rotation around the x axis.
+
+> **Note:** At the start of your "webgl-demo.js" file, replace the `squareRotation` declaration with this line:
 
 ```js
-mat4.rotate(modelViewMatrix, modelViewMatrix, cubeRotation * 0.7, [0, 1, 0]);
+let cubeRotation = 0.0;
+```
+
+> **Note:** In your `drawScene()` function declaration, replace the `squareRotation` with `cubeRotation`:
+
+```js-nolint
+function drawScene(gl, programInfo, buffers, cubeRotation) {
+```
+
+> **Note:** In your `drawScene()` function, replace the `mat4.rotate` call with the following code:
+
+```js
+mat4.rotate(
+  modelViewMatrix, // destination matrix
+  modelViewMatrix, // matrix to rotate
+  cubeRotation, // amount to rotate in radians
+  [0, 0, 1]
+); // axis to rotate around (Z)
+mat4.rotate(
+  modelViewMatrix, // destination matrix
+  modelViewMatrix, // matrix to rotate
+  cubeRotation * 0.7, // amount to rotate in radians
+  [0, 1, 0]
+); // axis to rotate around (Y)
+mat4.rotate(
+  modelViewMatrix, // destination matrix
+  modelViewMatrix, // matrix to rotate
+  cubeRotation * 0.3, // amount to rotate in radians
+  [1, 0, 0]
+); // axis to rotate around (X)
+```
+
+> **Note:** In your `main()` function, replace the code that calls `drawScene()` and updates `squareRotation` to pass in and update `cubeRotation` instead:
+
+```js
+drawScene(gl, programInfo, buffers, cubeRotation);
+cubeRotation += deltaTime;
 ```
 
 At this point, we now have an animated cube rotating, its six faces rather vividly colored.

--- a/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -21,24 +21,42 @@ It's worth noting here that this series of articles introduces WebGL itself; how
 
 ## Preparing to render in 3D
 
-The first thing you need in order to use WebGL for rendering is a canvas. The HTML fragment below declares a canvas that our sample will draw into.
+First, create two new files:
+
+- "index.html"
+- "webgl-demo.js"
+
+The "index.html" file should contain the following:
 
 ```html
-<body>
-  <canvas id="glCanvas" width="640" height="480"></canvas>
-</body>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>WebGL Demo</title>
+    <script src="webgl-demo.js" type="module" defer></script>
+  </head>
+
+  <body>
+    <canvas id="glcanvas" width="640" height="480"></canvas>
+  </body>
+</html>
 ```
+
+Note that this declares a canvas that our sample will draw into.
 
 ### Preparing the WebGL context
 
-The `main()` function in our JavaScript code, is called when our script is loaded. Its purpose is to set up the WebGL context and start rendering content.
+Add the following code to the "webgl-demo.js" file:
 
 ```js
+main();
+
 //
 // start here
 //
 function main() {
-  const canvas = document.querySelector("#glCanvas");
+  const canvas = document.querySelector("#glcanvas");
   // Initialize the GL context
   const gl = canvas.getContext("webgl");
 
@@ -55,9 +73,9 @@ function main() {
   // Clear the color buffer with specified clear color
   gl.clear(gl.COLOR_BUFFER_BIT);
 }
-
-window.onload = main;
 ```
+
+The `main()` function is called when our script is loaded. Its purpose is to set up the WebGL context and start rendering content.
 
 The first thing we do here is obtain a reference to the canvas, assigning it to a variable named `canvas`.
 

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -21,8 +21,6 @@ tags:
 
 As should be clear by now, WebGL doesn't have much built-in knowledge. It just runs two functions you supply — a vertex shader and a fragment shader — and expects you to write creative functions to get the results you want. In other words, if you want lighting you have to calculate it yourself. Fortunately, it's not all that hard to do, and this article will cover some of the basics.
 
-> **Note:** This example uses the [glMatrix](https://glmatrix.net/) library to perform its matrix and vertex math. You'll need to include it if you create your own project based on this code. Our sample loads a copy from a CDN in our HTML's {{HTMLElement("head")}}.
-
 ## Simulating lighting and shading in 3D
 
 Although going into detail about the theory behind simulated lighting in 3D graphics is far beyond the scope of this article, it's helpful to know a bit about how it works. Instead of discussing it in depth here, take a look at the article on [Phong shading](https://en.wikipedia.org/wiki/Phong_shading) at Wikipedia, which provides a good overview of the most commonly used lighting model or if you'd like to see a WebGL based explanation [see this article](https://webglfundamentals.org/webgl/lessons/webgl-3d-lighting-point.html).
@@ -48,33 +46,51 @@ Then we update the vertex shader to adjust the color of each vertex, taking into
 
 The first thing we need to do is generate the array of normals for all the vertices that comprise our cube. Since a cube is a very simple object, this is easy to do; obviously for more complex objects, calculating the normals will be more involved.
 
+> **Note:** Add this function to your "init-buffer.js" module:
+
 ```js
-const normalBuffer = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+function initNormalBuffer(gl) {
+  const normalBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
 
-const vertexNormals = [
-  // Front
-  0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+  const vertexNormals = [
+    // Front
+    0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
 
-  // Back
-  0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0,
+    // Back
+    0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0,
 
-  // Top
-  0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+    // Top
+    0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0,
 
-  // Bottom
-  0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0,
+    // Bottom
+    0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0,
 
-  // Right
-  1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+    // Right
+    1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
 
-  // Left
-  -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0,
-];
+    // Left
+    -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0,
+  ];
 
-gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertexNormals), gl.STATIC_DRAW);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array(vertexNormals),
+    gl.STATIC_DRAW
+  );
 
-// …
+  return normalBuffer;
+}
+```
+
+This should look pretty familiar by now; we create a new buffer, bind it to be the buffer we're working with, then send along our array of vertex normals into the buffer by calling `bufferData()`.
+
+As before, we have update `initBuffers()` to call our new function, and to return the buffer it created.
+
+> **Note:** At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
+
+```js
+const normalBuffer = initNormalBuffer(gl);
 
 return {
   position: positionBuffer,
@@ -84,14 +100,14 @@ return {
 };
 ```
 
-This should look pretty familiar by now; we create a new buffer, bind it to be the buffer we're working with, then send along our array of vertex normals into the buffer by calling `bufferData()`.
+Then we add the code to the "draw-scene.js" module to bind the normals array to a shader attribute so the shader code can get access to it.
 
-Then we add the code to `drawScene()` to bind the normals array to a shader attribute so the shader code can get access to it:
+> **Note:** Add this function to your "draw-scene.js" module:
 
 ```js
 // Tell WebGL how to pull out the normals from
 // the normal buffer into the vertexNormal attribute.
-{
+function setNormalAttribute(gl, buffers, programInfo) {
   const numComponents = 3;
   const type = gl.FLOAT;
   const normalize = false;
@@ -110,15 +126,25 @@ Then we add the code to `drawScene()` to bind the normals array to a shader attr
 }
 ```
 
-Finally, we need to update the code that builds the uniform matrices to generate and deliver to the shader a **normal matrix**, which is used to transform the normals when dealing with the current orientation of the cube in relation to the light source:
+> **Note:** Add this line to the `drawScene()` function of your "draw-scene.js" module, just before the `gl.useProgram()` line:
+
+```js
+setNormalAttribute(gl, buffers, programInfo);
+```
+
+Finally, we need to update the code that builds the uniform matrices to generate and deliver to the shader a **normal matrix**, which is used to transform the normals when dealing with the current orientation of the cube in relation to the light source.
+
+> **Note:** Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the three `mat4.rotate()` calls:
 
 ```js
 const normalMatrix = mat4.create();
 mat4.invert(normalMatrix, modelViewMatrix);
 mat4.transpose(normalMatrix, normalMatrix);
+```
 
-// …
+> **Note:** Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the two previous `gl.uniformMatrix4fv()` calls:
 
+```js
 gl.uniformMatrix4fv(
   programInfo.uniformLocations.normalMatrix,
   false,
@@ -132,7 +158,9 @@ Now that all the data the shaders need is available to them, we need to update t
 
 ### The vertex shader
 
-The first thing to do is update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting. Let's take a look at the code:
+The first thing to do is update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
+
+> **Note:** Update the `vsSource` declaration in your `main()` function like this:
 
 ```js
 const vsSource = `
@@ -173,7 +201,9 @@ Once the amount of directional lighting is computed, we can generate the lightin
 
 ### The fragment shader
 
-The fragment shader now needs to be updated to take into account the lighting value computed by the vertex shader:
+The fragment shader now needs to be updated to take into account the lighting value computed by the vertex shader.
+
+> **Note:** Update the `fsSource` declaration in your `main()` function like this:
 
 ```js
 const fsSource = `
@@ -193,6 +223,8 @@ const fsSource = `
 Here we fetch the color of the texel, just like we did in the previous example, but before setting the color of the fragment, we multiply the texel's color by the lighting value to adjust the texel's color to take into account the effect of our light sources.
 
 The only thing left is to look up the location of the `aVertexNormal` attribute and the `uNormalMatrix` uniform.
+
+> **Note:** Update the `programInfo` declaration in your `main()` function like this:
 
 ```js
 const programInfo = {

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -85,7 +85,7 @@ function initNormalBuffer(gl) {
 
 This should look pretty familiar by now; we create a new buffer, bind it to be the buffer we're working with, then send along our array of vertex normals into the buffer by calling `bufferData()`.
 
-As before, we have update `initBuffers()` to call our new function, and to return the buffer it created.
+As before, we have updated `initBuffers()` to call our new function, and to return the buffer it created.
 
 > **Note:** At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
 
@@ -158,7 +158,7 @@ Now that all the data the shaders need is available to them, we need to update t
 
 ### The vertex shader
 
-The first thing to do is update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
+The first thing to do i,s update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
 
 > **Note:** Update the `vsSource` declaration in your `main()` function like this:
 

--- a/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -111,7 +111,7 @@ Each fragment receives the interpolated color based on its position relative to 
 
 ## Drawing using the colors
 
-Next, you need to add code to look up the attribute location for the colors and setup that attribute for the shader program.
+Next, you need to add code to look up the attribute location for the colors and set up that attribute for the shader program.
 
 > **Note:** Update the `programInfo` declaration in your `main()` function like this:
 

--- a/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -12,16 +12,16 @@ tags:
 
 Having created a square plane in the [previous demonstration](/en-US/docs/Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context), the next obvious step is to add a splash of color to it. We can do this by revising the shaders.
 
-> **Note:** This example uses the glMatrix library to perform its matrix and vertex math. You'll need to include it if you create your own project based on this code. Our sample loads a copy from a CDN in our HTML's {{HTMLElement("head")}}.
-
 ## Applying color to the vertices
 
 In WebGL objects are built using sets of vertices, each of which has a position and a color. By default, all other pixels' colors (and all its other attributes, including position) are computed using interpolation, automatically creating smooth gradients. Previously, our vertex shader didn't apply any specific colors to the vertices. Between this and the fragment shader assigning the fixed color of white to each pixel, the entire square was rendered as solid white.
 
-Let's say we want to render a gradient in which each corner of the square is a different color: red, blue, green, and white. The first thing to do is to establish these colors for the four vertices. To do this, we first need to create an array of vertex colors, then store it into a WebGL buffer. We'll do that by adding the following code to our `initBuffers()` function:
+Let's say we want to render a gradient in which each corner of the square is a different color: red, blue, green, and white. The first thing to do is to establish these colors for the four vertices. To do this, we first need to create an array of vertex colors, then store it into a WebGL buffer.
+
+> **Note:** Add the following function to your `init-buffers.js` module:
 
 ```js
-function initBuffers() {
+function initColorBuffer(gl) {
   const colors = [
     1.0,
     1.0,
@@ -45,18 +45,32 @@ function initBuffers() {
   gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
 
-  return {
-    position: positionBuffer,
-    color: colorBuffer,
-  };
+  return colorBuffer;
 }
 ```
 
 This code starts by creating a JavaScript array containing four 4-value vectors, one for each vertex color. Then a new WebGL buffer is allocated to store these colors, and the array is converted into floats and stored into the buffer.
 
-To use these colors, the vertex shader needs to be updated to pull the appropriate color from the color buffer:
+Of course, we also need to call this new function from `initBuffers()`, and return the new buffer it creates.
+
+> **Note:** At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
 
 ```js
+const colorBuffer = initColorBuffer(gl);
+
+return {
+  position: positionBuffer,
+  color: colorBuffer,
+};
+```
+
+To use these colors, the vertex shader needs to be updated to pull the appropriate color from the color buffer.
+
+> **Note:** Update the `vsSource` declaration in your `main()` function like this:
+
+```js
+// Vertex shader program
+
 const vsSource = `
     attribute vec4 aVertexPosition;
     attribute vec4 aVertexColor;
@@ -77,19 +91,13 @@ The key difference here is that for each vertex, we pass its color using a `vary
 
 ## Coloring the fragments
 
-As a refresher, here's what our fragment shader looked like previously:
+In order to pick up the interpolated color for each pixel, we need to change the fragment shader to fetch the value from the `vColor` varying.
+
+> **Note:** Update the `fsSource` declaration in your `main()` function like this:
 
 ```js
-const fsSource = `
-    void main() {
-      gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
-    }
-  `;
-```
+// Fragment shader program
 
-In order to pick up the interpolated color for each pixel, we need to change this to fetch the value from the `vColor` varying:
-
-```js
 const fsSource = `
     varying lowp vec4 vColor;
 
@@ -103,25 +111,36 @@ Each fragment receives the interpolated color based on its position relative to 
 
 ## Drawing using the colors
 
-Next, it's necessary to add code to look up the attribute location for the colors and setup that attribute for the shader program:
+Next, you need to add code to look up the attribute location for the colors and setup that attribute for the shader program.
+
+> **Note:** Update the `programInfo` declaration in your `main()` function like this:
 
 ```js
+// Collect all the info needed to use the shader program.
+// Look up which attributes our shader program is using
+// for aVertexPosition, aVertexColor and also
+// look up uniform locations.
 const programInfo = {
   program: shaderProgram,
   attribLocations: {
     vertexPosition: gl.getAttribLocation(shaderProgram, "aVertexPosition"),
     vertexColor: gl.getAttribLocation(shaderProgram, "aVertexColor"),
   },
-  // …
+  uniformLocations: {
+    projectionMatrix: gl.getUniformLocation(shaderProgram, "uProjectionMatrix"),
+    modelViewMatrix: gl.getUniformLocation(shaderProgram, "uModelViewMatrix"),
+  },
 };
 ```
 
-Then, `drawScene()` can have the following added to it so it actually uses these colors when drawing the square:
+Next, `drawScene()` needs to use these colors when drawing the square.
+
+> **Note:** Add the following function to your `draw-scene.js` module:
 
 ```js
 // Tell WebGL how to pull out the colors from the color buffer
 // into the vertexColor attribute.
-{
+function setColorAttribute(gl, buffers, programInfo) {
   const numComponents = 4;
   const type = gl.FLOAT;
   const normalize = false;
@@ -139,6 +158,14 @@ Then, `drawScene()` can have the following added to it so it actually uses these
   gl.enableVertexAttribArray(programInfo.attribLocations.vertexColor);
 }
 ```
+
+> **Note:** Call the `setColorAttribute()` function from `drawScene()`, right before the `gl.useProgram()` call:
+
+```js
+setColorAttribute(gl, buffers, programInfo);
+```
+
+The result should now look like this:
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 


### PR DESCRIPTION
This is a fix for https://github.com/mdn/content/issues/22399 that got a bit out of hand.

The [WebGL tutorial](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL) walks the reader through writing a WebGL program, adding a bit more complexity each time but having a complete working program at each stage.

Docs like this are really fiddly to maintain and can be frustrating to follow especially when the code backing them diverges from the code in the page, and when the instructions for what to update where are not very clear.

In this PR I've tried to make clearer, more precise, and more consistent signposts to the readers about what to update and where to update it. In the course of this I also decided to break the example up into separate JS modules: this makes it easier to refer to the bits of the program (and for me at least, helped to understand its organization).

I've run through this tutorial fairly mindlessly following the instructions and it seems to work: I'd appreciate a second pair of hands to do the same.

I haven't updated the prose in this PR and don't intend to, it's big enough as it is. But there are lots of instances of "this is simple" that I don't like and which we could fix in a follow-up.

There's a parallel PR in dom-examples: https://github.com/mdn/dom-examples/pull/187 which is the result of running through these instructions, and which produces code that seems to work.

