### PR TITLE
Fix instances of code formatting with backticks

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.md
@@ -167,7 +167,7 @@ return <li className="todo">{isEditing ? editingTemplate : viewTemplate}</li>;
 
 Your browser should render all your tasks just like before. To see the editing template, you will have to change the default `isEditing` state from `false` to `true` in your code for now; we will look at making the edit button toggle this in the next section!
 
-## Toggling the <Todo /> templates
+## Toggling the `<Todo />` templates
 
 At long last, we are ready to make our final core feature interactive. To start with, we want to call `setEditing()` with a value of `true` when a user presses the "Edit" button in our `viewTemplate`, so that we can switch templates.
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_interactivity_filtering_conditional_rendering/index.md
@@ -48,7 +48,7 @@ As we near the end of our React journey (for now at least), we'll add the finish
 
 We don't have a user interface for editing the name of a task yet. We'll get to that in a moment. To start with, we can at least implement an `editTask()` function in `App.js`. It'll be similar to `deleteTask()` because it'll take an `id` to find its target object, but it'll also take a `newName` property containing the name to update the task to. We'll use [`Array.prototype.map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) instead of [`Array.prototype.filter()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) because we want to return a new array with some changes, instead of deleting something from the array.
 
-Add the `editTask()` function inside your App component, in the same place as the other functions:
+Add the `editTask()` function inside your `App` component, in the same place as the other functions:
 
 ```jsx
 function editTask(id, newName) {
@@ -167,7 +167,7 @@ return <li className="todo">{isEditing ? editingTemplate : viewTemplate}</li>;
 
 Your browser should render all your tasks just like before. To see the editing template, you will have to change the default `isEditing` state from `false` to `true` in your code for now; we will look at making the edit button toggle this in the next section!
 
-## Toggling the `<Todo />` templates
+## Toggling the <Todo /> templates
 
 At long last, we are ready to make our final core feature interactive. To start with, we want to call `setEditing()` with a value of `true` when a user presses the "Edit" button in our `viewTemplate`, so that we can switch templates.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Added missing backticks around `App` component name
- Removed backticks around `<Todo />` component name since it's in the heading


