### PR TITLE
Remove Media Recorder API from groupdata, and fix up some APIRef calls

### DIFF
--- a/files/en-us/web/api/blobevent/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/blobevent/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: api.BlobEvent.BlobEvent
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`BlobEvent()`** constructor returns a newly created
 {{domxref("BlobEvent")}} object with an associated {{domxref("Blob")}}.

--- a/files/en-us/web/api/blobevent/data/index.md
+++ b/files/en-us/web/api/blobevent/data/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: api.BlobEvent.data
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`BlobEvent.data`** read-only property represents a {{domxref("Blob")}} associated with the event.
 

--- a/files/en-us/web/api/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/index.md
@@ -17,7 +17,7 @@ tags:
 browser-compat: api.BlobEvent
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`BlobEvent`** interface represents events associated with a {{domxref("Blob")}}. These blobs are typically, but not necessarily, associated with media content.
 

--- a/files/en-us/web/api/blobevent/timecode/index.md
+++ b/files/en-us/web/api/blobevent/timecode/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: api.BlobEvent.timecode
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`timecode`** read only property of the {{domxref("BlobEvent")}} interface indicates the difference between the timestamp of the first chunk of data, and the timestamp of the first chunk in the first `BlobEvent` produced by this recorder.
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Media Recorder API
   - MediaRecorder
   - Property
   - Reference

--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - MediaStream Recording API
   - Event
@@ -68,17 +67,17 @@ const chunks = [];
 mediaRecorder.onstop = (e) => {
   console.log("data available after MediaRecorder.stop() called.");
 
-  const audio = document.createElement('audio');
+  const audio = document.createElement("audio");
   audio.controls = true;
-  const blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
+  const blob = new Blob(chunks, { type: "audio/ogg; codecs=opus" });
   const audioURL = window.URL.createObjectURL(blob);
   audio.src = audioURL;
   console.log("recorder stopped");
-}
+};
 
 mediaRecorder.ondataavailable = (e) => {
   chunks.push(e.data);
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/error_event/index.md
+++ b/files/en-us/web/api/mediarecorder/error_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'MediaRecorder: error event'
+title: "MediaRecorder: error event"
 slug: Web/API/MediaRecorder/error_event
 page-type: web-api-event
 tags:
@@ -7,7 +7,7 @@ tags:
 browser-compat: api.MediaRecorder.error_event
 ---
 
-{{APIRef}}
+{{APIRef("MediaStream Recording")}}
 
 The {{domxref("MediaRecorder")}} interface's **`error`** event is fired when an error occurs: for example because recording wasn't allowed or was attempted using an unsupported codec.
 
@@ -18,9 +18,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('event', (event) => { });
+addEventListener("event", (event) => {});
 
-onevent = (event) => { };
+onevent = (event) => {};
 ```
 
 ## Event type
@@ -76,12 +76,12 @@ Using [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) to 
 
 ```js
 async function record() {
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
-    const recorder = new MediaRecorder(stream);
-    recorder.addEventListener('error', (event) => {
-        console.error(`error recording stream: ${event.error.name}`)
-    });
-    recorder.start();
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const recorder = new MediaRecorder(stream);
+  recorder.addEventListener("error", (event) => {
+    console.error(`error recording stream: ${event.error.name}`);
+  });
+  recorder.start();
 }
 
 record();
@@ -91,12 +91,12 @@ The same, but using the onerror event handler property:
 
 ```js
 async function record() {
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
-    const recorder = new MediaRecorder(stream);
-    recorder.onerror = (event) => {
-        console.error(`error recording stream: ${event.error.name}`)
-    };
-    recorder.start();
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const recorder = new MediaRecorder(stream);
+  recorder.onerror = (event) => {
+    console.error(`error recording stream: ${event.error.name}`);
+  };
+  recorder.start();
 }
 
 record();

--- a/files/en-us/web/api/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/index.md
@@ -9,14 +9,13 @@ tags:
   - Media
   - Media Capture
   - Media Capture and Streams
-  - Media Recorder API
   - MediaRecorder
   - Reference
   - Video
 browser-compat: api.MediaRecorder
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`MediaRecorder`** interface of the [MediaStream Recording API](/en-US/docs/Web/API/MediaStream_Recording_API) provides functionality to easily record media. It is created using the {{domxref("MediaRecorder.MediaRecorder", "MediaRecorder()")}} constructor.
 

--- a/files/en-us/web/api/mediarecorder/istypesupported/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported/index.md
@@ -7,7 +7,6 @@ tags:
   - Audio
   - Media
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Method
   - Reference
@@ -56,7 +55,11 @@ const types = [
 ];
 
 for (const type of types) {
-  console.log(`Is ${type} supported? ${MediaRecorder.isTypeSupported(type) ? "Maybe!" : "Nope :("}`);
+  console.log(
+    `Is ${type} supported? ${
+      MediaRecorder.isTypeSupported(type) ? "Maybe!" : "Nope :("
+    }`
+  );
 }
 ```
 

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.md
@@ -8,7 +8,6 @@ tags:
   - Constructor
   - Media
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Reference
   - Video
@@ -90,15 +89,15 @@ if (navigator.mediaDevices.getUserMedia) {
 
   const onSuccess = (stream) => {
     const options = {
-      audioBitsPerSecond : 128000,
-      videoBitsPerSecond : 2500000,
-      mimeType : 'video/mp4'
-    }
+      audioBitsPerSecond: 128000,
+      videoBitsPerSecond: 2500000,
+      mimeType: "video/mp4",
+    };
     const mediaRecorder = new MediaRecorder(stream, options);
     m = mediaRecorder;
 
     // …
-  }
+  };
 }
 ```
 

--- a/files/en-us/web/api/mediarecorder/mimetype/index.md
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.md
@@ -7,7 +7,6 @@ tags:
   - Audio
   - Media
   - MediaRecorder
-  - MediaRecorder API
   - MediaStream Recording
   - Property
   - Reference
@@ -48,18 +47,19 @@ about media types and how they're used in web content and by web browsers.
 
 ```js
 if (navigator.mediaDevices) {
-  console.log('getUserMedia supported.');
+  console.log("getUserMedia supported.");
 
   const constraints = { audio: true, video: true };
   const chunks = [];
 
-  navigator.mediaDevices.getUserMedia(constraints)
+  navigator.mediaDevices
+    .getUserMedia(constraints)
     .then((stream) => {
       const options = {
         audioBitsPerSecond: 128000,
         videoBitsPerSecond: 2500000,
-        mimeType: 'video/mp4'
-      }
+        mimeType: "video/mp4",
+      };
       const mediaRecorder = new MediaRecorder(stream, options);
       m = mediaRecorder;
 

--- a/files/en-us/web/api/mediarecorder/pause/index.md
+++ b/files/en-us/web/api/mediarecorder/pause/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Method
   - Reference
@@ -55,9 +54,9 @@ None ({{jsxref("undefined")}}).
 
 ```js
 pause.onclick = () => {
-    mediaRecorder.pause();
-    console.log("recording paused");
-}
+  mediaRecorder.pause();
+  console.log("recording paused");
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/pause_event/index.md
+++ b/files/en-us/web/api/mediarecorder/pause_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Event
   - Reference
@@ -15,7 +14,7 @@ tags:
 browser-compat: api.MediaRecorder.pause_event
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The `pause` event is thrown as a result of the
 {{domxref("MediaRecorder.pause()")}} method being invoked.
@@ -45,17 +44,17 @@ pause.onclick = () => {
     mediaRecorder.resume();
     // resume recording
   }
-}
+};
 
 mediaRecorder.onpause = () => {
   // do something in response to
   // recording being paused
-}
+};
 
 mediaRecorder.onresume = () => {
   // do something in response to
   // recording being resumed
-}
+};
 ```
 
 ## Instance properties

--- a/files/en-us/web/api/mediarecorder/requestdata/index.md
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.md
@@ -7,7 +7,6 @@ tags:
   - Audio
   - Media
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - MediaStream Recording
   - Method
@@ -64,7 +63,7 @@ captureMedia.onclick = () => {
   // makes snapshot available of data so far
   // ondataavailable fires, then capturing continues
   // in new Blob
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/resume/index.md
+++ b/files/en-us/web/api/mediarecorder/resume/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Method
   - Reference
@@ -62,7 +61,7 @@ pause.onclick = () => {
     mediaRecorder.resume();
     // resume recording
   }
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/resume_event/index.md
+++ b/files/en-us/web/api/mediarecorder/resume_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Event
   - Reference
@@ -15,7 +14,7 @@ tags:
 browser-compat: api.MediaRecorder.resume_event
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The `resume` event is thrown when
 {{domxref("MediaRecorder.resume()")}} is called.
@@ -45,17 +44,17 @@ pause.onclick = () => {
     mediaRecorder.resume();
     // resume recording
   }
-}
+};
 
 mediaRecorder.onpause = () => {
   // do something in response to
   // recording being paused
-}
+};
 
 mediaRecorder.onresume = () => {
   // do something in response to
   // recording being resumed
-}
+};
 ```
 
 ## Instance properties

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -8,8 +8,6 @@ tags:
   - Media
   - Media Capture
   - MediaRecorder
-  - MediaStream Recording
-  - MediaStream Recording API
   - Method
   - NeedsExample
   - Recording Media
@@ -103,7 +101,7 @@ handler to respond to these errors.
 record.onclick = () => {
   mediaRecorder.start();
   console.log("recorder started");
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/start_event/index.md
+++ b/files/en-us/web/api/mediarecorder/start_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Event
   - Reference
@@ -15,7 +14,7 @@ tags:
 browser-compat: api.MediaRecorder.start_event
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The `start` event is fired when
 {{domxref("MediaRecorder.start()")}} is called. At this point, the data
@@ -41,12 +40,12 @@ A generic {{domxref("Event")}}.
 record.onclick = () => {
   mediaRecorder.start();
   console.log("recorder started");
-}
+};
 
 mediaRecorder.onstart = () => {
   // do something in response to
   // recording being started
-}
+};
 ```
 
 ## Instance properties

--- a/files/en-us/web/api/mediarecorder/state/index.md
+++ b/files/en-us/web/api/mediarecorder/state/index.md
@@ -4,7 +4,6 @@ slug: Web/API/MediaRecorder/state
 page-type: web-api-instance-property
 tags:
   - API
-  - Media Recorder API
   - MediaRecording
   - Property
   - Reference
@@ -37,7 +36,7 @@ record.onclick = () => {
   console.log(mediaRecorder.state);
   // Will return "recording"
   console.log("recorder started");
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/stop/index.md
+++ b/files/en-us/web/api/mediarecorder/stop/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Method
   - Reference
@@ -56,7 +55,7 @@ is "inactive" — it makes no sense to stop media capture if it is already stopp
 stop.onclick = () => {
   mediaRecorder.stop();
   console.log("recorder stopped, data available");
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/stop_event/index.md
+++ b/files/en-us/web/api/mediarecorder/stop_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Event
   - Reference
@@ -15,7 +14,7 @@ tags:
 browser-compat: api.MediaRecorder.stop_event
 ---
 
-{{APIRef("Media Recorder API")}}
+{{APIRef("MediaStream Recording")}}
 
 The `stop` event is fired when
 {{domxref("MediaRecorder.stop()")}} is called, or when the media stream being
@@ -43,17 +42,17 @@ A generic {{domxref("Event")}}.
 mediaRecorder.onstop = (e) => {
   console.log("data available after MediaRecorder.stop() called.");
 
-  const audio = document.createElement('audio');
+  const audio = document.createElement("audio");
   audio.controls = true;
-  const blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
+  const blob = new Blob(chunks, { type: "audio/ogg; codecs=opus" });
   const audioURL = window.URL.createObjectURL(blob);
   audio.src = audioURL;
   console.log("recorder stopped");
-}
+};
 
 mediaRecorder.ondataavailable = (e) => {
   chunks.push(e.data);
-}
+};
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/stream/index.md
+++ b/files/en-us/web/api/mediarecorder/stream/index.md
@@ -4,7 +4,6 @@ slug: Web/API/MediaRecorder/stream
 page-type: web-api-instance-property
 tags:
   - API
-  - Media Recorder API
   - MediaRecorder
   - Property
   - Reference
@@ -27,7 +26,7 @@ The MediaStream passed into the `MediaRecorder()` constructor when the
 
 ```js
 if (navigator.getUserMedia) {
-  console.log('getUserMedia supported.');
+  console.log("getUserMedia supported.");
   navigator.getUserMedia(
     // constraints - only audio needed for this app
     {

--- a/files/en-us/web/api/mediarecorder/warning_event/index.md
+++ b/files/en-us/web/api/mediarecorder/warning_event/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Media Capture
-  - Media Recorder API
   - MediaRecorder
   - Property
   - Reference
@@ -17,7 +16,8 @@ tags:
 browser-compat: api.MediaRecorder.warning_event
 ---
 
-{{APIRef("Media Recorder API")}}{{Deprecated_Header}}
+{{APIRef("MediaStream Recording")}}
+{{Deprecated_Header}}
 
 The `warning` event fires on non-fatal errors during media recording via a `MediaRecorder`. Non-fatal errors are one's that don't halt recording.
 
@@ -30,7 +30,7 @@ A function reference.
 ```js
 mediaRecorder.onwarning = (e) => {
   console.warn(`A warning has been raised: ${e.message}`);
-}
+};
 ```
 
 ## Browser compatibility

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -797,16 +797,6 @@
       "properties": ["Navigator.mediaDevices"],
       "events": ["HTMLMediaElement: ended", "HTMLMediaElement: ratechange"]
     },
-    "Media Recorder API": {
-      "overview": ["Media Recorder API"],
-      "interfaces": ["MediaRecorder", "BlobEvent"],
-      "methods": [],
-      "properties": ["window.MediaRecorder"],
-      "events": [],
-      "dictionaries": ["MediaRecorderOptions", "BlobEventInit"],
-      "types": ["BitrateMode", "RecordingState"],
-      "callbacks": []
-    },
     "Media Session API": {
       "overview": ["Media Session API"],
       "interfaces": ["MediaMetadata", "MediaSession"],


### PR DESCRIPTION
Follow up to https://github.com/mdn/content/pull/22583.

- remove the "Media Recorder API" entry from GroupData, which was giving us a broken link in https://developer.mozilla.org/en-US/docs/Web/API
- update some APIRef calls to use the right group