### PR TITLE
Web Midi release note -clarification suggested by developer

### DIFF
--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -56,7 +56,7 @@ This article provides information about the changes in Firefox 108 that will aff
 #### Media, WebRTC, and Web Audio
 
 - The [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API) is now available in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
-  Users must grants permission by accepting a prompt to install a [Site Permission Add-On](https://support.mozilla.org/en-US/kb/site-permission-addons).
+  Calls to [`navigator.requestMIDIAccess()`](/en-US/docs/Web/API/Navigator/requestMIDIAccess) will prompt users with active MIDI devices to install a [Site Permission Add-On](https://support.mozilla.org/en-US/kb/site-permission-addons), which is required to enable the API.
   For more information see {{bug(1795025)}}.
 
 #### Removals


### PR DESCRIPTION
This updates the release note for Web Midi. It captures the nuance that you get the prompt to install the site permission add on if you have active devices - not just "attempt to use the API".

Related to #22111