### PR TITLE
fix(WebExtensions/API/commands): move WebExtExamples before Compat section

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -35,9 +35,9 @@ Listen for the user executing commands that you have registered using the [`comm
 - {{WebExtAPIRef("commands.onCommand")}}
   - : Fired when a command is executed using its associated keyboard shortcut.
 
-## Browser compatibility
-
 {{WebExtExamples("h2")}}
+
+## Browser compatibility
 
 {{Compat}}
 


### PR DESCRIPTION
### Description

Fixes that the `WebExtExamples` macro is called inside the "Browser compatibility" section:

<img width="793" alt="image" src="https://user-images.githubusercontent.com/495429/204789923-7efcb5f2-2290-4e49-a621-e440567d208b.png">


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/mdn/yari/issues/7703.
Part of https://github.com/mdn/content/issues/22631.