### PR TITLE
Dialog: links to page

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -33,7 +33,7 @@ When a modal element is displayed, authors **should** mark all other contents as
 
 The [`inert`](/en-US/docs/Web/HTML/Global_attributes/inert) attribute is a boolean attribute that indicates, by its presence, that the element and all its shadow-including descendants are to be made inert. Until [`HTMLElement.inert`](/en-US/docs/Web/API/HTMLElement/inert) is fully supported, content can be [made inert with JavaScript](https://whistlr.info/2021/inert/).
 
-Including `aria-modal="true"` on a [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role), removes the requirement of putting [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) on background content, as the `aria-modal` informs assistive technologies that content outside a dialog is inert. Note that while support for the `<dialog>` element is good, thoroughly testing your implementation is vitally important.
+Including `aria-modal="true"` on a [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role), removes the requirement of putting [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) on background content, as the `aria-modal` informs assistive technologies that content outside a dialog is inert. Note that while support for the {{HTMLElement('dialog')}} element is good, thoroughly testing your implementation is vitally important.
 
 If a dialog is not modal — there is no inert background and focus isn't confined to the dialog — either include `aria-modal="false"` or omit the attribute altogether.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -33,7 +33,7 @@ When a modal element is displayed, authors **should** mark all other contents as
 
 The [`inert`](/en-US/docs/Web/HTML/Global_attributes/inert) attribute is a boolean attribute that indicates, by its presence, that the element and all its shadow-including descendants are to be made inert. Until [`HTMLElement.inert`](/en-US/docs/Web/API/HTMLElement/inert) is fully supported, content can be [made inert with JavaScript](https://whistlr.info/2021/inert/).
 
-Including `aria-modal="true"` on a [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role), removes the requirement of putting [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) on background content, as the `aria-modal` informs assistive technologies that content outside a dialog is inert. Note that while support for the {{HTMLElement('dialog')}} element is good, thoroughly testing your implementation is vitally important.
+Including `aria-modal="true"` on a [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role), removes the requirement of putting [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) on background content, as the `aria-modal` informs assistive technologies that content outside a dialog is inert. Note that while support for the {{HTMLElement("dialog")}} element is good, thoroughly testing your implementation is vitally important.
 
 If a dialog is not modal — there is no inert background and focus isn't confined to the dialog — either include `aria-modal="false"` or omit the attribute altogether.
 
@@ -99,7 +99,7 @@ Inherits into roles:
 
 ## See Also
 
-- HTML {{HTMLElement('dialog')}} element
+- HTML {{HTMLElement("dialog")}} element
 - [`alertdialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role)
 - [`dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
 - HTML [`inert` global attribute](/en-US/docs/Web/HTML/Global_attributes/inert)

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -93,7 +93,7 @@ The code snippet above shows how to mark up an alert dialog that only provides a
 
 ## See Also
 
-- HTML {{HTMLElement('dialog')}} element
+- HTML {{HTMLElement("dialog")}} element
 - [The `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
 - [The `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [`aria-modal` attribute](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -15,7 +15,7 @@ browser-compat: api.HTMLDialogElement.close
 {{ APIRef("HTML DOM") }}
 
 The **`close()`** method of the {{domxref("HTMLDialogElement")}}
-interface closes the dialog. An optional string may be passed as an
+interface closes the {{htmlelement("dialog")}}. An optional string may be passed as an
 argument, updating the `returnValue` of the dialog.
 
 ## Syntax

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLDialogElement.close_event
 
 {{ APIRef() }}
 
-The `close` event is fired on an `HTMLDialogElement` object when the dialog it represents has been closed.
+The `close` event is fired on an `HTMLDialogElement` object when the {{htmlelement("dialog")}} it represents has been closed.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/htmldialogelement/open/index.md
+++ b/files/en-us/web/api/htmldialogelement/open/index.md
@@ -16,7 +16,7 @@ browser-compat: api.HTMLDialogElement.open
 
 The **`open`** property of the
 {{domxref("HTMLDialogElement")}} interface is a boolean value reflecting the
-{{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is
+{{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the {{htmlelement("dialog")}} is
 available for interaction.
 
 ## Value

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -16,7 +16,7 @@ browser-compat: api.HTMLDialogElement.returnValue
 
 The **`returnValue`** property of the
 {{domxref("HTMLDialogElement")}} interface gets or sets the return value for the
-`<dialog>`, usually to indicate which button the user pressed to
+{{htmlelement("dialog")}}, usually to indicate which button the user pressed to
 close it.
 
 ## Value

--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -55,6 +55,6 @@ A Boolean which is `true` if the element is inert; otherwise, the value is `fals
 ## See also
 
 - [Global attribute: `inert`](/en-US/docs/Web/HTML/Global_attributes/inert)
-- {{HTMLElement('dialog')}}
+- {{HTMLElement("dialog")}}
 - [Inert Polyfill](https://github.com/WICG/inert)
 - {{domxref("HTMLInputElement.disabled", "disabled")}}

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -32,7 +32,7 @@ Examples of elements that will prevent user interaction with the rest of the pag
 
 ### Styling a modal dialog
 
-This example styles a modal dialog that opens when the "Update details" button is activated. This example has been built on top of the {{HTMLElement('dialog')}} element [example](/en-US/docs/Web/HTML/Element/dialog#advanced_example).
+This example styles a modal dialog that opens when the "Update details" button is activated. This example has been built on top of the {{HTMLElement("dialog")}} element [example](/en-US/docs/Web/HTML/Element/dialog#advanced_example).
 
 ```html hidden
 <!-- Simple modal dialog containing a form -->

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -32,7 +32,7 @@ Examples of elements that will prevent user interaction with the rest of the pag
 
 ### Styling a modal dialog
 
-This example styles a modal dialog that opens when the "Update details" button is activated. This example has been built on top of the dialog element [example](/en-US/docs/Web/HTML/Element/dialog#advanced_example).
+This example styles a modal dialog that opens when the "Update details" button is activated. This example has been built on top of the {{HTMLElement('dialog')}} element [example](/en-US/docs/Web/HTML/Element/dialog#advanced_example).
 
 ```html hidden
 <!-- Simple modal dialog containing a form -->
@@ -81,10 +81,7 @@ const confirmBtn = favDialog.querySelector("#confirmBtn");
 // dialog contents by default.
 if (typeof favDialog.showModal !== "function") {
   favDialog.hidden = true;
-  /* a fallback script to allow this dialog/form to function
-     for legacy browsers that do not support <dialog>
-     could be provided here.
-  */
+  /* a fallback script */
 }
 // "Update details" button opens the <dialog> modally
 updateButton.addEventListener("click", () => {
@@ -92,7 +89,7 @@ updateButton.addEventListener("click", () => {
     favDialog.showModal();
   } else {
     outputBox.value =
-      "Sorry, the <dialog> API is not supported by this browser.";
+      "Sorry, the dialog API is not supported by this browser.";
   }
 });
 // "Favorite animal" input sets the value of the submit button

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -81,7 +81,7 @@ const confirmBtn = favDialog.querySelector("#confirmBtn");
 // dialog contents by default.
 if (typeof favDialog.showModal !== "function") {
   favDialog.hidden = true;
-  /* a fallback script */
+  // Your fallback script
 }
 // "Update details" button opens the <dialog> modally
 updateButton.addEventListener("click", () => {

--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -16,7 +16,7 @@ browser-compat: html.global_attributes.inert
 
 {{HTMLSidebar("Global_attributes")}}
 
-The **`inert`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a Boolean attribute indicating that the browser will ignore the element. With the `inert` attribute, all of the element's flat tree descendants (such as modal {{htmlelement('dialog')}}s) that don't otherwise escape inertness are ignored. The `inert` attribute also makes the browser ignore input events sent by the user, including focus-related events and events from assistive technologies.
+The **`inert`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a Boolean attribute indicating that the browser will ignore the element. With the `inert` attribute, all of the element's flat tree descendants (such as modal {{htmlelement("dialog")}}s) that don't otherwise escape inertness are ignored. The `inert` attribute also makes the browser ignore input events sent by the user, including focus-related events and events from assistive technologies.
 
 Specifically, `inert` does the following:
 
@@ -52,6 +52,6 @@ While providing visual and non-visual cues about content inertness, also remembe
 
 ## See also
 
-- HTML {{HTMLElement('dialog')}} element
+- HTML {{HTMLElement("dialog")}} element
 - [Introducing inert](https://developer.chrome.com/articles/inert/)
 - [The "inert" attribute is finally coming to the web](https://www.stefanjudis.com/blog/the-inert-attribute-is-finally-coming-to-the-web/)

--- a/files/en-us/web/html/global_attributes/tabindex/index.md
+++ b/files/en-us/web/html/global_attributes/tabindex/index.md
@@ -25,7 +25,7 @@ It accepts an integer as a value, with different results depending on the intege
 
   > **Warning:** Avoid using `tabindex` values greater than 0. Doing so makes it difficult for people who rely on assistive technology to navigate and operate page content. Instead, write the document with the elements in a logical sequence.
 
-The `tabindex` attribute must not be specified on {{htmlelement('dialog')}} elements and should not be used on non-interactive content. If you set the `tabindex` attribute on a {{htmlelement("div")}}, then its child content cannot be scrolled with the arrow keys unless you set `tabindex` on the content, too. [Check out this fiddle to understand the scrolling effects of `tabindex`](https://jsfiddle.net/jainakshay/0b2q4Lgv/).
+The `tabindex` attribute must not be specified on {{htmlelement("dialog")}} elements and should not be used on non-interactive content. If you set the `tabindex` attribute on a {{htmlelement("div")}}, then its child content cannot be scrolled with the arrow keys unless you set `tabindex` on the content, too. [Check out this fiddle to understand the scrolling effects of `tabindex`](https://jsfiddle.net/jainakshay/0b2q4Lgv/).
 
 ## Accessibility concerns
 


### PR DESCRIPTION
* added a few links to the dialog page.
* changed one instance of element syntax to non-element, as it's talking about the API, not the element.
* removed test that made it seem common for this fully supported element to not have support
* made single quotes double quotes