### PR TITLE
Dialog element minutia.

### DIFF
--- a/files/en-us/web/api/htmldialogelement/cancel_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/cancel_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLDialogElement.cancel_event
 
 {{APIRef}}
 
-The **`cancel`** event fires on a {{HTMLElement("dialog")}} when the user instructs the browser that they wish to dismiss the current open dialog. For example, the browser might fire this event when the user presses the <kbd>Esc</kbd> key or clicks a "Close dialog" button which is part of the browser's UI.
+The **`cancel`** event fires on a {{HTMLElement("dialog")}} when the user instructs the browser that they wish to dismiss the current open dialog. The browser fires this event when the user presses the <kbd>Esc</kbd> key.
 
 This event does not bubble.
 

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -44,6 +44,7 @@ A generic {{domxref("Event")}}.
      <button>Close via method="dialog"</button>
   </form>
   <button class="close">Close via .close() method</button>
+  <p>Or hit the <kbd>Esc</kbd> key</p>
 </dialog>
 
 <button class="open-dialog">Open dialog</button>
@@ -70,12 +71,8 @@ dialog.addEventListener('close', (event) => {
 
 const openDialog = document.querySelector('.open-dialog');
 openDialog.addEventListener('click', () => {
-  if (typeof dialog.showModal === 'function') {
       dialog.showModal();
       result.textContent = '';
-  } else {
-      result.textContent = 'The dialog API is not supported by this browser';
-  }
 });
 
 const closeButton = document.querySelector('.close');
@@ -86,7 +83,7 @@ closeButton.addEventListener('click', () => {
 
 #### Result
 
-{{ EmbedLiveSample('Live_example', '100%', '100px') }}
+{{ EmbedLiveSample('Live_example', '100%', '200px') }}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLDialogElement.close_event
 
 {{ APIRef() }}
 
-The `close` event is fired on an `HTMLDialogElement` object when the dialog it represents has been closed.
+The `close` event is fired on an `HTMLDialogElement` object when the dialog it represents has been closed whether via the <kbd>escape</kbd> key, the [`HTMLDialogElement.close()` method](/en-US/docs/Web/API/HTMLDialogElement/close), or by submitting a form via the [`dialog`](/en-US/docs/Web/HTML/Element/form#attr-method) method.
 
 This event is not cancelable and does not bubble.
 
@@ -40,7 +40,10 @@ A generic {{domxref("Event")}}.
 
 ```html
 <dialog class="example-dialog">
-  <button class="close" type="reset">Close</button>
+  <form method="dialog">
+     <button>Close via method="dialog"</button>
+  </form>
+  <button class="close">Close via .close() method</button>
 </dialog>
 
 <button class="open-dialog">Open dialog</button>

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -71,8 +71,8 @@ dialog.addEventListener('close', (event) => {
 
 const openDialog = document.querySelector('.open-dialog');
 openDialog.addEventListener('click', () => {
-      dialog.showModal();
-      result.textContent = '';
+  dialog.showModal();
+  result.textContent = "";
 });
 
 const closeButton = document.querySelector('.close');

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -42,7 +42,7 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLDialogElement/cancel_event", "cancel")}}
   - : Fired when the user dismisses the current open dialog with the escape key.
 - {{domxref("HTMLDialogElement/close_event", "close")}}
-  - : Fired when the dialog is closed.
+  - : Fired when the dialog is closed, whether with the escape key, the `HTMLDialogElement.close()` method, or via submitting a form within the dialog with [`method="dialog"`](/en-US/docs/Web/HTML/Element/form#attr-method).
 
 ## Examples
 

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -35,18 +35,18 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLDialogElement.show()")}}
   - : Displays the dialog modelessly, i.e. still allowing interaction with content outside of the dialog.
 - {{domxref("HTMLDialogElement.showModal()")}}
-  - : Displays the dialog as a modal, over the top of any other dialogs that might be present. Interaction outside the dialog is blocked.
+  - : Displays the dialog as a modal, over the top of any other dialogs that might be present. Everything outside the dialog are [inert](/en-US/docs/Web/API/HTMLElement/inert) with interactions outside the dialog being blocked.
 
 ## Events
 
 - {{domxref("HTMLDialogElement/cancel_event", "cancel")}}
-  - : Fired when the user instructs the browser that they wish to dismiss the current open dialog.
+  - : Fired when the user dismisses the current open dialog with the escape key.
 - {{domxref("HTMLDialogElement/close_event", "close")}}
   - : Fired when the dialog is closed.
 
 ## Examples
 
-The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form via the {{domxref("HTMLDialogElement.showModal()")}} function. From there you can click the _Cancel_ button to close the dialog (via the {{domxref("HTMLDialogElement.close()")}} function), or submit the form via the submit button.
+The following example shows a simple button that, when clicked, opens a modal {{htmlelement("dialog")}} containing a form via the {{domxref("HTMLDialogElement.showModal()")}} function. While open, everything other than the dialog contents is inert. From there you can click the _Cancel_ button to close the dialog (via the {{domxref("HTMLDialogElement.close()")}} function), or submit the form via the submit button.
 
 ```html
 <!-- Simple pop-up dialog box, containing a form -->
@@ -64,7 +64,7 @@ The following example shows a simple button that, when clicked, opens a {{htmlel
       </p>
     </section>
     <menu>
-      <button id="cancel" type="reset">Cancel</button>
+      <button id="cancel" type="button">Cancel</button>
       <button type="submit">Confirm</button>
     </menu>
   </form>


### PR DESCRIPTION
Dialog is well supported across all evergreen browsers, so I removed fallback script. 
Cancel only happens when esc is clicked, not when a button is clicked.
close happens any time it's closed, no matter how that happen.
removed the 'reset' because people might think that has special powers, but it doesn't. don't want to add confusion.