### PR TITLE
Removed redundant phrase

### DIFF
--- a/files/en-us/web/css/selector_list/index.md
+++ b/files/en-us/web/css/selector_list/index.md
@@ -101,7 +101,7 @@ They are not equivalent. In the first rule set, styles will be applied on the `h
 
 ### Forgiving selector list
 
-A way to remedy the [invalid selector list](#invalid_selector_list) problem is to use the {{CSSxRef(":is", ":is()")}} or the {{CSSxRef(":where", ":where()")}} pseudo-class, which accept a forgiving selector list. Each selector in a forgiving selector list is parsed individually. So any invalid selectors in the list are ignored and the valid ones that are valid are used.
+A way to remedy the [invalid selector list](#invalid_selector_list) problem is to use the {{CSSxRef(":is", ":is()")}} or the {{CSSxRef(":where", ":where()")}} pseudo-class, which accept a forgiving selector list. Each selector in a forgiving selector list is parsed individually. So any invalid selectors in the list are ignored and the valid ones are used.
 
 Carrying on from the previous example, the following two CSS rule sets are now equivalent:
 


### PR DESCRIPTION
### Description

Removed redundancy in a sentence.

> valid ones ~~that are valid~~ are used.