### PR TITLE
chore(meta): Move changelog from 'MDN/Contribute/Changelog' to 'MDN/Changelog'

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5396,6 +5396,7 @@
 /en-US/docs/MDC:How_to_Help	/en-US/docs/MDN/Contribute
 /en-US/docs/MDN/About	/en-US/docs/MDN/Writing_guidelines
 /en-US/docs/MDN/At_ten/Contributing_to_MDN	/en-US/docs/MDN/Contribute
+/en-US/docs/MDN/Contribute/Changelog	/en-US/docs/MDN/Changelog
 /en-US/docs/MDN/Contribute/Code_sample_guidelines	/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
 /en-US/docs/MDN/Contribute/Content	/en-US/docs/MDN/Writing_guidelines
 /en-US/docs/MDN/Contribute/Content/Content_blocks	/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN

--- a/files/en-us/mdn/changelog/index.md
+++ b/files/en-us/mdn/changelog/index.md
@@ -11,6 +11,15 @@ tags:
 
 This document provides a record of MDN content processes, constructs, and best practices that have changed, and when they changed. It is useful to allow regular contributors to check in and see what has changed about the process of creating content for MDN.
 
+## October 2022
+
+The [MDN project documentation](/en-US/docs/MDN) is refreshed and organized under two main categories:
+
+- **Writing:** Documentation about how to write for MDN, what we document, definitions of experimental, style guidelines and so on are found under the [Writing guidelines](/en-US/docs/MDN/Writing_guidelines) pages.
+- **Community:** Information about open source etiquette, discussions, processes for pull requests and issues, users and teams, and general hints for contributors are found under the [Community](/en-US/docs/MDN/Community) pages.
+
+For more details on what has changed, see the [Revamp of MDN Web Docs Contribution Docs](https://hacks.mozilla.org/2022/10/revamp-of-mdn-web-docs-contribution-docs/) blog post published to Mozilla Hacks.
+
 ## November 2021
 
 Conversion to Markdown is done, so remove the old CSS style guide and redirect to the Markdown in MDN page.

--- a/files/en-us/mdn/changelog/index.md
+++ b/files/en-us/mdn/changelog/index.md
@@ -1,6 +1,6 @@
 ---
-title: MDN contribution changelog
-slug: MDN/Contribute/Changelog
+title: MDN Web Docs changelog
+slug: MDN/Changelog
 tags:
   - Changelog
   - Contribute


### PR DESCRIPTION
This PR has the following changes:

* Move changelog from mdn/contribute/changelog to mdn/changelog
* Add details about Oct 22 changes and link to Hacks post