### PR TITLE
Remove needless indentation on "good" example

### DIFF
--- a/files/en-us/web/css/time/index.md
+++ b/files/en-us/web/css/time/index.md
@@ -36,12 +36,12 @@ The `<time>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by o
 ### Valid times
 
 ```plain example-good
-    12s         Positive integer
-    -456ms      Negative integer
-    4.3ms       Non-integer
-    14mS        The unit is case-insensitive, although capital letters are not recommended.
-    +0s         Zero with a leading + and a unit
-    -0ms        Zero with a leading - and a unit
+12s         Positive integer
+-456ms      Negative integer
+4.3ms       Non-integer
+14mS        The unit is case-insensitive, although capital letters are not recommended.
++0s         Zero with a leading + and a unit
+-0ms        Zero with a leading - and a unit
 ```
 
 ### Invalid times


### PR DESCRIPTION
Remove needless indentation on the "good" example for `<time>`.