### PR TITLE
Disclaimer: explain why new feature might not show

### DIFF
--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -44,8 +44,6 @@ In this example we have:
 
 We also have some JavaScript that listens for the `beforematch` event firing on the hidden until found element. The event handler changes the text content of the box.
 
-If your browser does not support the `"until-found"` enumerated value of the `hidden` attribute, the second `<div>` will be hidden as `hidden` was boolean prior to the addition of the `until-found` value.
-
 #### HTML
 
 ```html
@@ -102,6 +100,8 @@ Clicking the "Go to hidden content" button navigates to the hidden-until-found e
 To run the example again, click "Reload".
 
 {{EmbedLiveSample("Using beforematch", "", 300)}}
+
+If your browser does not support the `"until-found"` enumerated value of the `hidden` attribute, the second `<div>` will be hidden as `hidden` was boolean prior to the addition of the `until-found` value.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -44,6 +44,8 @@ In this example we have:
 
 We also have some JavaScript that listens for the `beforematch` event firing on the hidden until found element. The event handler changes the text content of the box.
 
+If your browser does not support the `"until-found"` enumerated value of the `hidden` attribute, the second `<div>` will be hidden as `hidden` was boolean prior to the addition of the `until-found` value.
+
 #### HTML
 
 ```html

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -101,7 +101,7 @@ To run the example again, click "Reload".
 
 {{EmbedLiveSample("Using beforematch", "", 300)}}
 
-If your browser does not support the `"until-found"` enumerated value of the `hidden` attribute, the second `<div>` will be hidden as `hidden` was boolean prior to the addition of the `until-found` value.
+If your browser does not support the `"until-found"` enumerated value of the `hidden` attribute, the second `<div>` will be hidden (as `hidden` was boolean prior to the addition of the `until-found` value).
 
 ## Specifications
 


### PR DESCRIPTION
The example doesn't work in FF or Safari yet. Added a sentence explaining our visitors may not see what is being shown.

