### PR TITLE
Add the Refresh header to the HTTP headers page

### DIFF
--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -240,6 +240,8 @@ _Learn more about CORS [here](/en-US/docs/Glossary/CORS)._
 
 - {{HTTPHeader("Location")}}
   - : Indicates the URL to redirect a page to.
+- {{HTTPHeader("Refresh")}}
+  - : Directs the browser to reload the page or redirect to another. Takes the same value as the `meta` element with [`http-equiv="refresh"`](/en-US/docs/Web/HTML/Element/meta#attr-http-equiv).
 
 ## Request context
 


### PR DESCRIPTION
### Description

This adds an entry for the [HTTP `Refresh` header](https://html.spec.whatwg.org/#the-refresh-header) to the MDN [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) list.

### Motivation

The header used to be non-standard (but still commonly used), which is probably why it isn't documented yet.

It was [specified in the HTML spec in 2017](https://github.com/whatwg/html/pull/2892).

### Additional details

This should be followed-up with a PR to add a full docs page for the header. In its current state, this will already help developers know that the header exists and how to use it, but more detailed usage examples would be helpful.

### Related issues and pull requests

Related to #15340
