### PR TITLE
Add note warning about invoking every with an empty array

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -17,6 +17,8 @@ The **`every()`** method tests whether
 all elements in the array pass the test implemented by the provided function. It
 returns a Boolean value.
 
+> **Note:** **Warning**: Invoking this method with an empty array will return `true` regardless of the condition!
+
 {{EmbedInteractiveExample("pages/js/array-every.html","shorter")}}
 
 ## Syntax


### PR DESCRIPTION
### Description

Add a note warning about invoking this method with an empty array.

### Motivation

Some languages, for example, Spanish, have this note at the beginning of the documentation.

### Additional details

French, Spanish, Russian, and Chinese Simplified have this note. 

### Related issues and pull requests

I couldn't find any issues related to this.