### PR TITLE
Clarify wording on cookie domain setting

### DIFF
--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -114,7 +114,7 @@ The `Domain` and `Path` attributes define the _scope_ of a cookie: what URLs the
 
 #### Domain attribute
 
-The `Domain` attribute specifies which hosts can receive a cookie. If unspecified, the attribute defaults to the same {{Glossary("host")}} that set the cookie, _excluding subdomains_. If `Domain` _is_ specified, then subdomains are always included. Therefore, specifying `Domain` is less restrictive than omitting it. However, it can be helpful when subdomains need to share information about a user.
+The `Domain` attribute specifies which hosts can receive a cookie. If the server does not specify a `Domain`, the browser defaults the domain to the same {{Glossary("host")}} that set the cookie, _excluding subdomains_. If `Domain` _is_ specified, then subdomains are always included. Therefore, specifying `Domain` is less restrictive than omitting it. However, it can be helpful when subdomains need to share information about a user.
 
 For example, if you set `Domain=mozilla.org`, cookies are available on subdomains like `developer.mozilla.org`.
 


### PR DESCRIPTION
### Description

Remove some ambiguity in the cookie `Domain` description.

### Motivation

The previous wording used the passive voice, which made it a little ambiguous, especially to readers who are not already familiar with the responsibilities of the server vs. browser.