### PR TITLE
Fix an element name which is printed the result

### DIFF
--- a/files/en-us/web/api/performance_api/using_the_performance_api/index.md
+++ b/files/en-us/web/api/performance_api/using_the_performance_api/index.md
@@ -35,7 +35,7 @@ function calculate_time() {
 
 ## Serializing the `Performance` object
 
-JSON serialization of the {{domxref("Performance")}} object is done via the {{domxref("Performance.toJSON","toJSON()")}} method. In the following example, JSON serialization for the {{domxref("Performance")}}, {{domxref("Performance.timing")}} and {{domxref("Performance.navigation")}} objects is printed in the `object` element.
+JSON serialization of the {{domxref("Performance")}} object is done via the {{domxref("Performance.toJSON","toJSON()")}} method. In the following example, JSON serialization for the {{domxref("Performance")}}, {{domxref("Performance.timing")}} and {{domxref("Performance.navigation")}} objects is printed in the `output` element.
 
 ```js
 function print_json() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix an element name which is printed the result.
The result should be printed in the `output` element, not the `object` element.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
