### PR TITLE
fx72 for devs: move `crossOriginIsolated` to APIs section

### DIFF
--- a/files/en-us/mozilla/firefox/releases/72/index.md
+++ b/files/en-us/mozilla/firefox/releases/72/index.md
@@ -69,6 +69,7 @@ _No changes._
 #### New APIs
 
 - {{domxref("FormDataEvent")}} and [event-based form participation](/en-US/docs/Web/API/FormData/Using_FormData_Objects#using_a_formdata_event) is now enabled by default ({{bug(1594708)}}).
+- The {{domxref("crossOriginIsolated")}} property is now supported ({{bug(1591892)}}).
 
 #### DOM
 
@@ -90,10 +91,6 @@ _No changes._
 #### DOM events
 
 - {{domxref("Notification.requestPermission()")}} and {{domxref("PushManager.subscribe()")}} can now only be called in response to a user gesture such as a [`click`](/en-US/docs/Web/API/Element/click_event) event ({{bug(1593644)}}).
-
-#### Service workers
-
-- The {{domxref("crossOriginIsolated")}} property is now supported ({{bug(1591892)}}).
 
 #### Media, Web Audio, and WebRTC
 


### PR DESCRIPTION
as it's not tied to Service Workers but defined in Window or Worker global scope

https://bugzilla.mozilla.org/show_bug.cgi?id=1591892 https://html.spec.whatwg.org/multipage/webappapis.html#dom-crossoriginisolated-dev

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
