### PR TITLE
Made sentence easy to understand

### DIFF
--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -14,7 +14,7 @@ browser-compat: css.selectors.paused
 
 The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "paused".
 
-A resource is paused if the user explicitly paused it, or if it in a non-activated state.
+A resource is paused if the user explicitly paused it, or if it is in a non-activated state.
 
 ```css
 :paused {

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -14,7 +14,7 @@ browser-compat: css.selectors.paused
 
 The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "paused".
 
-A resource is paused either due to being in an non-activated state, or due to the user explicitly paused it.
+A resource is paused if the user explicitly paused it, or if it in a non-activated state.
 
 ```css
 :paused {


### PR DESCRIPTION
### Description

Originally, the sentence was hard to read and had minor grammar mistakes, such as using the article *an* instead of *a* for *non-activated*, and there was slight contradiction in sentence tense on each side of the conjunction.