### PR TITLE
Fix incorrect drop target example

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -203,14 +203,18 @@ A listener for the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {
 
 If you want to allow a drop, you must prevent the default behavior by cancelling both the `dragenter` and `dragover` events. You can do this by calling their {{domxref("Event.preventDefault","preventDefault()")}} methods:
 
-```js
-const draggableElement = document.querySelector('p[draggable="true"]');
+```html
+<div id="drop-target">You can drag and then drop a draggable item here</div>
+```
 
-draggableElement.addEventListener("dragenter", (event) => {
+```js
+const dropElement = document.getElementById("drop-target");
+
+dropElement.addEventListener("dragenter", (event) => {
   event.preventDefault();
 });
 
-draggableElement.addEventListener("dragover", (event) => {
+dropElement.addEventListener("dragover", (event) => {
   event.preventDefault();
 });
 ```


### PR DESCRIPTION
### Description

Example was applying the preventDefault() on the draggable item and not the drop target. This has been fixed.

### Motivation

The example was wrong, and could confuse readers. It has been fixed.

### Additional details

https://html.spec.whatwg.org/multipage/dnd.html#event-drag

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
