### PR TITLE
More description of meta-property values

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -14,8 +14,7 @@ browser-compat: javascript.operators.import_meta
 
 {{JSSidebar("Operators")}}
 
-The **`import.meta`** object exposes context-specific metadata
-to a JavaScript module. It contains information about the module, like the module's URL.
+The **`import.meta`** meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, like the module's URL.
 
 ## Syntax
 
@@ -23,39 +22,24 @@ to a JavaScript module. It contains information about the module, like the modul
 import.meta
 ```
 
+### Value
+
+The `import.meta` object is created by the host environment, as an extensible [`null`-prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) object where all properties are writable, configurable, and enumerable. The spec doesn't specify any properties to be defined on it, but hosts usually implement the following property:
+
+- `url`
+  - : The full URL to the module, includes query parameters and/or hash (following the `?` or `#`). In browsers, this is either the URL from which the script was obtained (for external scripts), or the URL of the containing document (for inline scripts). In Node.js, this is the file path (including the `file://` protocol).
+
 ## Description
 
-The syntax consists of the keyword {{JSxRef("Statements/import","import")}}, a dot, and
-the identifier `meta`. Normally the left-hand side of the dot is the object
-on which property access is performed, but here `import` is not really an
-object.
+The `import.meta` syntax consists of the keyword `import`, a dot, and the identifier `meta`. Because `import` is a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words), not an identifier, this is not a [property accessor](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors), but a special expression syntax.
 
-The `import.meta` object is created by the ECMAScript implementation, as an extensible [`null`-prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) object. The JavaScript spec doesn't specify any properties to be defined on it, but usually there's a `url` property, which is writable, configurable, and enumerable.
+The `import.meta` meta-property is available in JavaScript modules; using `import.meta` outside of a module (including [direct `eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval) within a module) is a syntax error.
 
 ## Examples
 
-### Using import.meta
+### Passing query parameters
 
-Given a module `my-module.js`:
-
-```html
-<script type="module" src="my-module.js"></script>
-```
-
-You can access meta information about the module using the `import.meta` object.
-
-```js
-console.log(import.meta); // { url: "file:///home/user/my-module.js" }
-```
-
-It returns an object with a `url` property indicating the base URL of the
-module. This will either be the URL from which the script was obtained, for external
-scripts, or the document base URL of the containing document, for inline scripts.
-
-Note that this will include query parameters and/or hash (i.e., following the
-`?` or `#`).
-
-For example, with the following HTML:
+Using query parameters in the `import` specifier allows module-specific argument passing, which may be complementary to reading parameters from the application-wide [`window.location`](/en-US/docs/Web/API/Window/location) (or on Node.js, through `process.argv`). For example, with the following HTML:
 
 ```html
 <script type="module">
@@ -63,14 +47,14 @@ For example, with the following HTML:
 </script>
 ```
 
-The following JavaScript logs the `someURLInfo` parameter:
+The `index.mjs` module is able to retrieve the `someURLInfo` parameter through `import.meta`:
 
 ```js
 // index.mjs
 new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
-The same applies when a file imports another:
+The same applies when a module imports another:
 
 ```js
 // index.mjs
@@ -80,14 +64,31 @@ import "./index2.mjs?someURLInfo=5";
 new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
-Note that while Node.js will pass on query parameters (or the hash) as in the latter
-example, as of Node 18.12.0, a URL with query parameters will err when loading in the
-form `node index.mjs?someURLInfo=5` (it is treated as
-a file rather than a URL in this context).
+The ES module implementation in Node.js supports resolving module specifiers containing query parameters (or the hash), as in the latter example. However, you cannot use queries or hashes when the module is specified through the CLI command (like `node index.mjs?someURLInfo=5`), because the CLI entrypoint uses a more CommonJS-like resolution mode, treating the path as a file path rather than a URL. To pass parameters to the entrypoint module, use CLI arguments and read them through `process.argv` instead (like `node index.mjs --someURLInfo=5`).
 
-Such file-specific argument passing may be complementary to that used in the
-application-wide `location.href` (with query strings or hash added after the
-HTML file path) (or on Node.js, through `process.argv`).
+### Getting current module's file path
+
+In Node.js CommonJS modules, there's a `__dirname` variable that contains the absolute path to the folder containing current module, which is useful for resolving relative paths. However, ES modules cannot have contextual variables except for `import.meta`. Therefore, to get the current module's file path, you can use `import.meta.url`.
+
+Before (CommonJS):
+
+```js
+const fs = require("fs/promises");
+const path = require("path");
+
+const filePath = path.join(__dirname, "someFile.txt");
+fs.readFile(filePath, "utf8").then(console.log);
+```
+
+After (ES modules):
+
+```js
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const filePath = fileURLToPath(new URL('./someFile.txt', import.meta.url));
+fs.readFile(filePath, "utf8").then(console.log);
+```
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.import_meta
 
 {{JSSidebar("Operators")}}
 
-The **`import.meta`** meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, like the module's URL.
+The **`import.meta`** meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, such as the module's URL.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/new.target/index.md
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.md
@@ -12,11 +12,7 @@ browser-compat: javascript.operators.new_target
 
 {{JSSidebar("Operators")}}
 
-The **`new.target`** pseudo-property lets you detect whether a
-function or constructor was called using the [new](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. In
-constructors and functions invoked using the [new](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator,
-`new.target` returns a reference to the constructor or function. In normal
-function calls, `new.target` is {{jsxref("undefined")}}.
+The **`new.target`** meta-property lets you detect whether a function or constructor was called using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. In constructors and functions invoked using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator, `new.target` returns a reference to the constructor or function that `new` was called upon. In normal function calls, `new.target` is {{jsxref("undefined")}}.
 
 {{EmbedInteractiveExample("pages/js/expressions-newtarget.html")}}
 
@@ -26,31 +22,27 @@ function calls, `new.target` is {{jsxref("undefined")}}.
 new.target
 ```
 
+### Value
+
+`new.target` is guaranteed to be a constructable function value or `undefined`.
+
+- In class constructors, it refers to the class that `new` was called upon, which may be a subclass of the current constructor, because subclasses transitively call the superclass's constructor through [`super()`](/en-US/docs/Web/JavaScript/Reference/Operators/super).
+- In ordinary functions, if the function is constructed directly with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new), `new.target` refers to the function itself. If the function is called without `new`, `new.target` is {{jsxref("undefined")}}. Functions can be used as the base class for [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends), in which case `new.target` may refer to the subclass.
+- If a constructor (class or function) is called via {{jsxref("Reflect.construct()")}}, then `new.target` refers to the value passed as `newTarget` (which defaults to `target`).
+- In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `new.target` is inherited from the surrounding scope. If the arrow function is not defined within another class or function which has a `new.target` binding, then a syntax error is thrown.
+- In [static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks), `new.target` is {{jsxref("undefined")}}.
+
 ## Description
 
-The `new.target` syntax consists of the keyword `new`, a dot, and
-the identifier `target`. Normally, the left-hand side of the dot is the
-object on which property access is performed, but here, `new` is not an
-object.
+The `new.target` syntax consists of the keyword `new`, a dot, and the identifier `target`. Because `new` is a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words), not an identifier, this is not a [property accessor](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors), but a special expression syntax.
 
-The `new.target` pseudo-property is available in all functions.
-
-In class constructors, it refers to the constructed class.
-
-In ordinary functions, it refers to the function itself, assuming it was invoked via
-the [new](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator;
-otherwise `new.target` is {{jsxref("undefined")}}.
-
-In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
-`new.target` is inherited from the surrounding scope.
+The `new.target` meta-property is available in all function/class bodies; using `new.target` outside of functions or classes is a syntax error.
 
 ## Examples
 
 ### new\.target in function calls
 
-In normal function calls (as opposed to constructor function calls),
-`new.target` is {{jsxref("undefined")}}. This lets you detect whether a
-function was called with [new](/en-US/docs/Web/JavaScript/Reference/Operators/new) as a constructor.
+In normal function calls (as opposed to constructor function calls), `new.target` is {{jsxref("undefined")}}. This lets you detect whether a function was called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) as a constructor.
 
 ```js
 function Foo() {
@@ -66,11 +58,7 @@ Foo(); // Throws "Foo() must be called with new"
 
 ### new\.target in constructors
 
-In class constructors, `new.target` refers to the constructor that was
-directly invoked by `new`. This is also the case if the constructor is in a
-parent class and was delegated from a child constructor. `new.target` points to the class definition of class which is initialized. For example, when `b` was initialized using
-`new B()`, the name of `B` was printed; and similarly,
-in case of `a`, the name of class `A` was printed.
+In class constructors, `new.target` refers to the constructor that was directly invoked by `new`. This is also the case if the constructor is in a parent class and was delegated from a child constructor. `new.target` points to the class that `new` was called upon. For example, when `b` was initialized using `new B()`, the name of `B` was printed; and similarly, in case of `a`, the name of class `A` was printed.
 
 ```js
 class A {
@@ -87,6 +75,83 @@ class B extends A {
 
 const a = new A(); // Logs "A"
 const b = new B(); // Logs "B"
+```
+
+### new\.target using Reflect.construct()
+
+Before {{jsxref("Reflect.construct()")}} or classes, it was common to implement inheritance by passing the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this), and letting the base constructor mutate it.
+
+```js example-bad
+function Base() {
+  this.name = "Base";
+}
+
+function Extended() {
+  // Only way to make the Base() constructor work on the existing
+  // `this` value instead of a new object that `new` creates.
+  Base.call(this);
+  this.otherProperty = "Extended";
+}
+
+Object.setPrototypeOf(Extended.prototype, Base.prototype);
+Object.setPrototypeOf(Extended, Base);
+
+console.log(new Extended()); // Extended { name: 'Base', otherProperty: 'Extended' }
+```
+
+However, {{jsxref("Function/call", "call()")}} and {{jsxref("Function/apply", "apply()")}} actually _call_ the function instead of _constructing_ it, so `new.target` has value `undefined`. This means that if `Base()` checks whether it's constructed with `new`, an error will be thrown, or it may behave in other unexpected ways. For example, you can't extend [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/Map) this way, because the `Map()` constructor cannot be called without `new`.
+
+All built-in constructors directly construct the entire prototype chain of the new instance by reading `new.target.prototype`. So to make sure that (1) `Base` is constructed with `new`, and (2) `new.target` points to the subclass instead of `Base` itself, we need to use {{jsxref("Reflect.construct()")}}.
+
+```js
+function BetterMap(entries) {
+  // Call the base class constructor, but setting `new.target` to the subclass,
+  // so that the instance created has the correct prototype chain.
+  return Reflect.construct(Map, [entries], ExtendedMap);
+}
+
+BetterMap.prototype.upsert = function (key, actions) {
+  if (this.has(key)) {
+    this.set(key, actions.update(this.get(key)));
+  } else {
+    this.set(key, actions.insert());
+  }
+};
+
+Object.setPrototypeOf(BetterMap.prototype, Map.prototype);
+Object.setPrototypeOf(BetterMap, Map);
+
+const map = new BetterMap([["a", 1]]);
+map.upsert("a", {
+  update: (value) => value + 1,
+  insert: () => 1,
+});
+console.log(map.get("a")); // 2
+```
+
+> **Note:** In fact, due to the lack of `Reflect.construct()`, it is not possible to properly subclass built-ins (like [`Error` subclassing](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types)) when transpiling to pre-ES6 code.
+
+However, if you are writing ES6 code, prefer using classes and `extends` instead, as it's more readable and less error-prone.
+
+```js
+class BetterMap extends Map {
+  // The constructor is omitted because it's just the default one
+
+  upsert(key, actions) {
+    if (this.has(key)) {
+      this.set(key, actions.update(this.get(key)));
+    } else {
+      this.set(key, actions.insert());
+    }
+  }
+}
+
+const map = new BetterMap([["a", 1]]);
+map.upsert("a", {
+  update: (value) => value + 1,
+  insert: () => 1,
+});
+console.log(map.get("a")); // 2
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

1. The proper name of `import.meta` and `new.target` is "meta-property", not "pseudo-property".
2. Split out a "value" subsection for the sake of page structure.
3. More information about the value of `new.target` in different contexts.
4. Make the `import.meta` examples make more sense.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
