### PR TITLE
Several buttons behave as submit buttons in form

### DIFF
--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -141,7 +141,7 @@ This attribute is also available on [`<input type="image">`](/en-US/docs/Web/HTM
 
 `<input type="submit">` buttons are used to submit forms. If you want to create a custom button and then customize the behavior using JavaScript, you need to use [`<input type="button">`](/en-US/docs/Web/HTML/Element/input/button), or better still, a {{htmlelement("button")}} element.
 
-If you choose to use `<button>` elements to create the buttons in your form, keep this in mind: if there's only one `<button>` inside the {{HTMLElement("form")}}, that button will be treated as the "submit" button. So you should be in the habit of expressly specifying which button is the submit button.
+If you choose to use `<button>` elements to create the buttons in your form, keep this in mind: If the `<button>` is inside a {{HTMLElement("form")}}, that button will be treated as the "submit" button. So you should be in the habit of expressly specifying which button is the submit button.
 
 ### A simple submit button
 


### PR DESCRIPTION
The text claims that just a single button in a form will behave as a submit-button, but the truth is that several buttons in a form behaves as submit buttons when `type` is not defined. I have checked this both in Firefox and Chrome:

https://jsfiddle.net/lebbe/x93wyarh/

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

A minor error in the description of how buttons inside a form-tag behaves.

### Motivation

I was explicitly looking up this article when working with buttons in form tags.

### Additional details

See the test-link for verification. Bear in mind that I have not actually read the specification, and it might be that both Chrome and Firefox doesn't behave according to the specification. Also bear in mind that English is not my primary language, but I have tried to make the edit as clear and grammatical as possible within my language competence.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
