### PR TITLE
Add info for buffered flag; be consistent in examples

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -32,7 +32,7 @@ The `connectEnd` and {{domxref("PerformanceResourceTiming.connectStart", "connec
 const tcp = entry.connectEnd - entry.connectStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -32,7 +32,7 @@ The `connectStart` and {{domxref("PerformanceResourceTiming.connectEnd", "connec
 const tcp = entry.connectEnd - entry.connectStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -27,7 +27,7 @@ The `decodedBodySize` property can have the following values:
 
 If the `decodedBodySize` and {{domxref("PerformanceResourceTiming.encodedBodySize", "encodedBodySize")}} properties are non-null and differ, the content was compressed (for example, gzip or Brotli).
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -43,7 +43,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Here's an example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -34,7 +34,7 @@ The `domainLookupEnd` and {{domxref("PerformanceResourceTiming.domainLookupStart
 const dns = entry.domainLookupEnd - entry.domainLookupStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -49,7 +49,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -32,7 +32,7 @@ The `domainLookupStart` and {{domxref("PerformanceResourceTiming.domainLookupEnd
 const dns = entry.domainLookupEnd - entry.domainLookupStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -28,7 +28,7 @@ The `encodedBodySize` property can have the following values:
 
 If the `encodedBodySize` and {{domxref("PerformanceResourceTiming.decodedBodySize", "decodedBodySize")}} properties are non-null and differ, the content was compressed (for example, gzip or Brotli).
 
-Here's an example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -33,7 +33,7 @@ The `fetchStart` and {{domxref("PerformanceResourceTiming.responseEnd", "respons
 const timeToFetch = entry.responseEnd - entry.fetchStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -48,7 +48,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -112,7 +112,7 @@ Additionally, this interface exposes the following properties containing more in
 
 ### Logging resource timing information
 
-Here's an example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -124,7 +124,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Here's an example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -71,7 +71,7 @@ The `initiatorType` property can have the following values, or `other` if none o
 
 The `initiatorType` property can be used to get specific resource timing entries only. For example, only those that were initiated by {{HTMLElement("script")}} elements.
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -84,7 +84,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const scripts = performance.getEntriesByType("resource").filter((entry) => {

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -36,7 +36,7 @@ The `nextHopProtocol` property can have the following values:
 
 The `nextHopProtocol` property can be used to see resources that don't use the HTTP/2 or HTTP/3 protocols.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -36,7 +36,7 @@ The `redirectEnd` and {{domxref("PerformanceResourceTiming.redirectStart", "redi
 const redirect = entry.redirectEnd - entry.redirectStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -36,7 +36,7 @@ The `redirectStart` and {{domxref("PerformanceResourceTiming.redirectEnd", "redi
 const redirect = entry.redirectEnd - entry.redirectStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
@@ -44,7 +44,7 @@ The `renderBlockingStatus` property can have the following values:
 
 The `renderBlockingStatus` property can be used to see resources that block rendering.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -34,7 +34,7 @@ The `requestStart` and {{domxref("PerformanceResourceTiming.responseStart", "res
 const request = entry.responseStart - entry.requestStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -49,7 +49,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -32,7 +32,7 @@ The `responseEnd` and {{domxref("PerformanceResourceTiming.fetchStart", "fetchSt
 const timeToFetch = entry.responseEnd - entry.fetchStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -32,7 +32,7 @@ The `responseStart` and {{domxref("PerformanceResourceTiming.requestStart", "req
 const request = entry.responseStart - entry.requestStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -47,7 +47,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/responsestatus/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestatus/index.md
@@ -31,7 +31,7 @@ The `responseStatus` property can have the following values:
 
 The `responseStatus` property can be used to check for cached resources with a {{HTTPStatus("304")}} `Not Modified` response status code.
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -45,7 +45,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -33,7 +33,7 @@ The `secureConnectionStart` and {{domxref("PerformanceResourceTiming.requestStar
 const ssl = entry.requestStart - entry.secureConnectionStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -48,7 +48,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
@@ -22,6 +22,8 @@ Server timing metrics require the server to send the {{HTTPHeader("Server-Timing
 Server-Timing: cache;desc="Cache Read";dur=23.2
 ```
 
+The `serverTiming` entries can live on `navigation` and `resource` entries.
+
 ## Value
 
 An array of {{domxref("PerformanceServerTiming")}} entries.
@@ -32,6 +34,8 @@ An array of {{domxref("PerformanceServerTiming")}} entries.
 
 You can use a {{domxref("PerformanceObserver")}} to watch for {{domxref("PerformanceServerTiming")}} entries. Each server entry's duration is logged to the console.
 
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
+
 ```js
 const observer = new PerformanceObserver((list) => {
   list.getEntries().forEach((entry) => {
@@ -41,10 +45,12 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource", "navigation"] });
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
 ```
 
-Alternatively, you can use {{domxref("Performance.getEntriesByType()")}} to get performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.md
@@ -41,7 +41,7 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource"] });
+observer.observe({ type: "resource", buffered: true });
 ```
 
 This would log a JSON object like so:

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -30,7 +30,7 @@ The `transferSize` property can have the following values:
 
 For environments not supporting the {{domxref("PerformanceResourceTiming.responseStatus", "responseStatus")}} property, the `transferSize` property can be used to determine cache hits. If `transferSize` is zero and the resource has a non-zero decoded body size (meaning the resource is same-origin or has {{HTTPHeader("Timing-Allow-Origin")}}), the resource was fetched from a local cache.
 
-Here's an example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -44,7 +44,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Here's an example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -35,7 +35,7 @@ The `workerStart` and {{domxref("PerformanceResourceTiming.fetchStart", "fetchSt
 const workerProcessingTime = entry.fetchStart - entry.workerStart;
 ```
 
-Using a {{domxref("PerformanceObserver")}}:
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -52,7 +52,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: "resource", buffered: true });
 ```
 
-Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 const resources = performance.getEntriesByType("resource");

--- a/files/en-us/web/api/performanceservertiming/description/index.md
+++ b/files/en-us/web/api/performanceservertiming/description/index.md
@@ -30,7 +30,9 @@ Server timing metrics require the server to send the {{HTTPHeader("Server-Timing
 Server-Timing: cache;desc="Cache Read";dur=23.2
 ```
 
-Then use a {{domxref("PerformanceObserver")}} to watch for {{domxref("PerformanceServerTiming")}} entries as they are recorded.
+The `serverTiming` entries can live on `navigation` and `resource` entries.
+
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -44,10 +46,12 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource", "navigation"] });
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
 ```
 
-Alternatively, you can use {{domxref("Performance.getEntriesByType()")}} to get performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/description/index.md
+++ b/files/en-us/web/api/performanceservertiming/description/index.md
@@ -32,7 +32,7 @@ Server-Timing: cache;desc="Cache Read";dur=23.2
 
 The `serverTiming` entries can live on `navigation` and `resource` entries.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `navigation` and `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -51,7 +51,7 @@ const observer = new PerformanceObserver((list) => {
 );
 ```
 
-Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `navigation` and `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/duration/index.md
+++ b/files/en-us/web/api/performanceservertiming/duration/index.md
@@ -28,7 +28,9 @@ Server timing metrics require the server to send the {{HTTPHeader("Server-Timing
 Server-Timing: cache;desc="Cache Read";dur=23.2
 ```
 
-Then use a {{domxref("PerformanceObserver")}} to watch for {{domxref("PerformanceServerTiming")}} entries as they are recorded.
+The `serverTiming` entries can live on `navigation` and `resource` entries.
+
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -42,10 +44,12 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource", "navigation"] });
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
 ```
 
-Alternatively, you can use {{domxref("Performance.getEntriesByType()")}} to get performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/duration/index.md
+++ b/files/en-us/web/api/performanceservertiming/duration/index.md
@@ -30,7 +30,7 @@ Server-Timing: cache;desc="Cache Read";dur=23.2
 
 The `serverTiming` entries can live on `navigation` and `resource` entries.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `navigation` and `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -49,7 +49,7 @@ const observer = new PerformanceObserver((list) => {
 );
 ```
 
-Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `navigation` and `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/index.md
+++ b/files/en-us/web/api/performanceservertiming/index.md
@@ -35,34 +35,66 @@ This interface is restricted to the same origin, but you can use the {{HTTPHeade
 Given a server that sends the {{HTTPHeader("Server-Timing")}} header, for example a Node.js server like this:
 
 ```js
-const http = require('http');
+const http = require("http");
 
 function requestHandler(request, response) {
   const headers = {
-    'Server-Timing': `
+    "Server-Timing": `
       cache;desc="Cache Read";dur=23.2,
       db;dur=53,
       app;dur=47.2
-    `.replace(/\n/g, '')
+    `.replace(/\n/g, ""),
   };
   response.writeHead(200, headers);
-  response.write('');
+  response.write("");
   return setTimeout(() => {
-   response.end();
- }, 1000)
-};
+    response.end();
+  }, 1000);
+}
 
-http.createServer(requestHandler).listen(3000).on('error', console.error);
+http.createServer(requestHandler).listen(3000).on("error", console.error);
 ```
 
-The `PerformanceServerTiming` entries are now observable from JavaScript via the {{domxref("PerformanceResourceTiming.serverTiming")}} property:
+The `PerformanceServerTiming` entries are now observable from JavaScript via the {{domxref("PerformanceResourceTiming.serverTiming")}} property and live on `navigation` and `resource` entries.
+
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `navigation` and `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
-let entries = performance.getEntriesByType('resource');
-console.log(entries[0].serverTiming);
-// 0: PerformanceServerTiming {name: "cache", duration: 23.2, description: "Cache Read"}
-// 1: PerformanceServerTiming {name: "db", duration: 53, description: ""}
-// 2: PerformanceServerTiming {name: "app", duration: 47.2, description: ""}
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    entry.serverTiming.forEach((serverEntry) => {
+      console.log(
+        `${serverEntry.name} (${serverEntry.description}) duration: ${serverEntry.duration}`
+      );
+      // Logs "cache (Cache Read) duration: 23.2"
+      // Logs "db () duration: 53"
+      // Logs "app () duration: 47.2"
+    });
+  });
+});
+
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
+```
+
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `navigation` and `resource` performance entries present in the browser's performance timeline at the time you call this method:
+
+```js
+for (const entryType of ["navigation", "resource"]) {
+  for (const { name: url, serverTiming } of performance.getEntriesByType(
+    entryType
+  )) {
+    if (serverTiming) {
+      for (const { name, description, duration } of serverTiming) {
+        console.log(`${name} (${description}) duration: ${duration}`);
+        // Logs "cache (Cache Read) duration: 23.2"
+        // Logs "db () duration: 53"
+        // Logs "app () duration: 47.2"
+      }
+    }
+  }
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceservertiming/name/index.md
+++ b/files/en-us/web/api/performanceservertiming/name/index.md
@@ -29,7 +29,9 @@ Server timing metrics require the server to send the {{HTTPHeader("Server-Timing
 Server-Timing: cache;desc="Cache Read";dur=23.2
 ```
 
-Then use a {{domxref("PerformanceObserver")}} to watch for {{domxref("PerformanceServerTiming")}} entries as they are recorded.
+The `serverTiming` entries can live on `navigation` and `resource` entries.
+
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -43,10 +45,12 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource", "navigation"] });
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
 ```
 
-Alternatively, you can use {{domxref("Performance.getEntriesByType()")}} to get performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/name/index.md
+++ b/files/en-us/web/api/performanceservertiming/name/index.md
@@ -31,7 +31,7 @@ Server-Timing: cache;desc="Cache Read";dur=23.2
 
 The `serverTiming` entries can live on `navigation` and `resource` entries.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `navigation` and `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -50,7 +50,7 @@ const observer = new PerformanceObserver((list) => {
 );
 ```
 
-Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
+Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `navigation` and `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
 for (const entryType of ["navigation", "resource"]) {

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -42,7 +42,7 @@ Server-Timing: cache;desc="Cache Read";dur=23.2
 
 The `serverTiming` entries can live on `navigation` and `resource` entries.
 
-Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `navigation` and `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -40,7 +40,9 @@ Server timing metrics require the server to send the {{HTTPHeader("Server-Timing
 Server-Timing: cache;desc="Cache Read";dur=23.2
 ```
 
-Then use a {{domxref("PerformanceObserver")}} to watch for {{domxref("PerformanceServerTiming")}} entries as they are recorded.
+The `serverTiming` entries can live on `navigation` and `resource` entries.
+
+Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resource` performance entries as they are recorded in the browser's performance timeline. Use the `buffered` option to access entries from before the observer creation.
 
 ```js
 const observer = new PerformanceObserver((list) => {
@@ -51,7 +53,9 @@ const observer = new PerformanceObserver((list) => {
   });
 });
 
-observer.observe({ entryTypes: ["resource", "navigation"] });
+["navigation", "resource"].forEach((type) =>
+  observer.observe({ type, buffered: true })
+);
 ```
 
 This would log a JSON object like so:


### PR DESCRIPTION
### Description

This PR makes updates to the `PerformanceResourceTiming` and `PerformanceServerTiming` examples to explain why it is a good idea to use the `buffered` flag. It also makes the language consistent and avoids fragment sentences.

This is in response to feedback from previous PRs. Thank you, Joe and Will.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

The `PerformanceServerTiming` examples are interesting as they want multiple types and `buffered`. I wrapped the `observe` call in a `forEach`.

### Related issues and pull requests

Previous PRs where this came up, e.g. https://github.com/mdn/content/pull/22683#discussion_r1039483338.