### PR TITLE
explicitly provide 'filename' label for 'download' attribute

### DIFF
--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -30,7 +30,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 - {{HTMLAttrDef("download")}}
 
-  - : Causes the browser to treat the linked URL as a download. Can be used with or without a value:
+  - : Causes the browser to treat the linked URL as a download. Can be used with or without a `filename` value:
 
     - Without a value, the browser will suggest a filename/extension, generated from various sources:
 
@@ -38,7 +38,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
       - The final segment in the URL [path](/en-US/docs/Web/API/URL/pathname)
       - The {{Glossary("MIME_type", "media type")}} (from the {{HTTPHeader("Content-Type")}} header, the start of a [`data:` URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs), or {{domxref("Blob.type")}} for a [`blob:` URL](/en-US/docs/Web/API/URL/createObjectURL))
 
-    - Defining a value suggests it as the filename. `/` and `\` characters are converted to underscores (`_`). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.
+    - `filename`: defining a value suggests it as the filename. `/` and `\` characters are converted to underscores (`_`). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.
 
     > **Note:**
     >


### PR DESCRIPTION
### Description

clarify the exact label to be used when specifying a filename

### Motivation

without this change, the `filename` label is only implied, not confirmed

### Additional details

N/A

### Related issues and pull requests

N/A
