### PR TITLE
WeakSet: Improve recursive validation example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/index.md
@@ -45,6 +45,7 @@ function execRecursively(fn, subject, _refs = new WeakSet()) {
     for (const key in subject) {
       execRecursively(fn, subject[key], _refs);
     }
+    _refs.delete(subject);
   }
 }
 


### PR DESCRIPTION
### Description

If subject is used in unrelated parts of the object, the example would only recurse the first instance.

### Motivation

The example is wrong, and developers that blindly copy it are likely to cause unexpected bugs.

### Related issues and pull requests

https://github.com/Automattic/mongoose/pull/12774
