### PR TITLE
Remove error cause from Error's prototype

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -25,7 +25,7 @@ The **`AggregateError`** object represents an error when several errors need to 
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{JSxRef("Error.prototype.name", "AggregateError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "AggregateError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - `AggregateError.prototype.errors`
   - : An array that essentially reflects the iterable with which the `AggregateError` was instantiated; for example, if the `AggregateError` was created using the {{JSxRef("AggregateError/AggregateError", "AggregateError()")}} constructor, an array produced from whatever iterable was passed to the constructor as its first argument.

--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -14,7 +14,7 @@ The **`cause`** property indicates the specific original cause of an error.
 
 It is used when catching and re-throwing an error with a more-specific or useful error message in order to still have access to the original error.
 
-> **Note:** This property is created directly to instances by the engine using defineProperty, it is not a property of Error's prototype that all instances will inherit but it is created conditionally according to the way you called the Error constructor see:[omitting options argument](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#omitting_options_argument).
+> **Note:** This property is created directly to instances by the engine, it is not a property of Error's prototype that all instances will inherit but it is created conditionally according to the way you called the Error constructor see:[omitting options argument](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#omitting_options_argument).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -1,5 +1,5 @@
 ---
-title: Error.prototype.cause
+title: Error cause
 slug: Web/JavaScript/Reference/Global_Objects/Error/cause
 tags:
   - JavaScript
@@ -13,6 +13,8 @@ browser-compat: javascript.builtins.Error.cause
 The **`cause`** property indicates the specific original cause of an error.
 
 It is used when catching and re-throwing an error with a more-specific or useful error message in order to still have access to the original error.
+
+> **Note:** This property is created directly to instances by the engine using defineProperty, it is not a property of Error's prototype that all instances will inherit but it is created conditionally according to the way you called the Error constructor see:[omitting options argument](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#omitting_options_argument).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -65,7 +65,7 @@ Besides the generic `Error` constructor, there are other core error constructors
   - : Error message. For user-created `Error` objects, this is the string provided as the constructor's first argument.
 - {{jsxref("Error.prototype.name")}}
   - : Error name. This is determined by the constructor function.
-- {{jsxref("Error.prototype.cause")}}
+- {{jsxref("Error.prototype.cause","Cause")}}
   - : Error cause indicating the reason why the current error is thrown — usually another caught error. For user-created `Error` objects, this is the value provided as the `cause` property of the constructor's second argument.
 - {{jsxref("Error.prototype.fileName")}} {{non-standard_inline}}
   - : A non-standard Mozilla property for the path to the file that raised this error.

--- a/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
@@ -27,7 +27,7 @@ The **`EvalError`** object indicates an error regarding the global {{jsxref("Glo
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "EvalError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "EvalError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "EvalError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/internalerror/index.md
@@ -32,7 +32,7 @@ Example cases are mostly when something is too large, e.g.:
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "InternalError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "InternalError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "InternalError.prototype.fileName")}} {{Non-standard_Inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/rangeerror/index.md
@@ -36,7 +36,7 @@ This can be encountered when:
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "RangeError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "RangeError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "RangeError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
@@ -27,7 +27,7 @@ The **`ReferenceError`** object represents an error when a variable that doesn't
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "ReferenceError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "ReferenceError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "ReferenceError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -27,7 +27,7 @@ The **`SyntaxError`** object represents an error when trying to interpret syntac
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "SyntaxError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "SyntaxError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "SyntaxError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
@@ -33,7 +33,7 @@ A `TypeError` may be thrown when:
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "TypeError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "TypeError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "TypeError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.

--- a/files/en-us/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/index.md
@@ -27,7 +27,7 @@ The **`URIError`** object represents an error when a global URI handling functio
   - : Error message. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.name", "URIError.prototype.name")}}
   - : Error name. Inherited from {{jsxref("Error")}}.
-- {{jsxref("Error.prototype.cause", "URIError.prototype.cause")}}
+- {{jsxref("Error.prototype.cause", "Cause")}}
   - : Error cause. Inherited from {{jsxref("Error")}}.
 - {{jsxref("Error.prototype.fileName", "URIError.prototype.fileName")}} {{non-standard_inline}}
   - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

since the cause property is created directly to instances by the engine, and it is not a property of Error's prototype.