### PR TITLE
TLS not SSL

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceResourceTiming.connectEnd
 
 {{APIRef("Performance API")}}
 
-The **`connectEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as SSL handshake and [SOCKS](https://en.wikipedia.org/wiki/SOCKS) authentication.
+The **`connectEnd`** read-only property returns the {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and [SOCKS](https://en.wikipedia.org/wiki/SOCKS) authentication.
 
 ## Value
 

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -28,7 +28,7 @@ The properties of this interface allow you to calculate certain resource timing 
 - Measuring DNS lookup time (`domainLookupEnd` - `domainLookupStart`)
 - Measuring redirection time (`redirectEnd` - `redirectStart`)
 - Measuring request time (`responseStart` - `requestStart`)
-- Measuring SSL negotiation time (`requestStart` - `secureConnectionStart`)
+- Measuring TLS negotiation time (`requestStart` - `secureConnectionStart`)
 - Measuring time to fetch (without redirects) (`responseEnd` - `fetchStart`)
 - Measuring ServiceWorker processing time (`fetchStart` - `workerStart`)
 - Checking if content was compressed (`decodedBodySize` should not be `encodedBodySize`)

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -25,12 +25,12 @@ The `secureConnectionStart` property can have the following values:
 
 ## Examples
 
-### Measuring SSL negotiation time
+### Measuring TLS negotiation time
 
-The `secureConnectionStart` and {{domxref("PerformanceResourceTiming.requestStart", "requestStart")}} properties can be used to measure how long it takes for the SSL negotiation to happen.
+The `secureConnectionStart` and {{domxref("PerformanceResourceTiming.requestStart", "requestStart")}} properties can be used to measure how long it takes for the TLS negotiation to happen.
 
 ```js
-const ssl = entry.requestStart - entry.secureConnectionStart;
+const tls = entry.requestStart - entry.secureConnectionStart;
 ```
 
 Using a {{domxref("PerformanceObserver")}}:
@@ -38,9 +38,9 @@ Using a {{domxref("PerformanceObserver")}}:
 ```js
 const observer = new PerformanceObserver((list) => {
   list.getEntries().forEach((entry) => {
-    const ssl = entry.requestStart - entry.secureConnectionStart;
-    if (ssl > 0) {
-      console.log(`${entry.name}: SSL negotiation duration: ${ssl}ms`);
+    const tls = entry.requestStart - entry.secureConnectionStart;
+    if (tls > 0) {
+      console.log(`${entry.name}: TLS negotiation duration: ${tls}ms`);
     }
   });
 });
@@ -53,9 +53,9 @@ Or using {{domxref("Performance.getEntriesByType()")}}, which only shows `resour
 ```js
 const resources = performance.getEntriesByType("resource");
 resources.forEach((entry) => {
-  const ssl = entry.requestStart - entry.secureConnectionStart;
-  if (ssl > 0) {
-    console.log(`${entry.name}: SSL negotiation duration: ${ssl}ms`);
+  const tls = entry.requestStart - entry.secureConnectionStart;
+  if (tls > 0) {
+    console.log(`${entry.name}: TLS negotiation duration: ${tls}ms`);
   }
 });
 ```


### PR DESCRIPTION
It's been TLS not SSL for a long time: https://developer.mozilla.org/en-US/docs/Glossary/TLS .