### PR TITLE
font-palette: Add the missing closing code fence

### DIFF
--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -24,6 +24,7 @@ font-palette: normal;
 
 /* Using a user-defined palette */
 font-palette: --one;
+```
 
 ### Values
 

--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -49,7 +49,7 @@ font-palette: --one;
 
 ### Specifying a dark palette
 
-This example allows you to use the first palette marked as *dark* (works best on a near black background) by the font-maker.
+This example allows you to use the first palette marked as _dark_ (works best on a near black background) by the font-maker.
 
 ```css
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The Syntax section is missing the closing code fence for the `css` block. This PR fixes that.