### PR TITLE
MathML: directly refer to W3C's math tools.

### DIFF
--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -46,10 +46,7 @@ Below you will find links to documentation, examples, and tools to work with Mat
 ## Tools
 
 - [W3C Validator](https://validator.w3.org)
-- [Mathzilla Firefox add-on collection](https://addons.mozilla.org/en-US/firefox/collections/5509895/mathzilla/)
-- [TeXZilla](https://github.com/fred-wang/TeXZilla) — JavaScript LaTeX to MathML converter ([live demo](https://fred-wang.github.io/TeXZilla/), [Firefox add-on](https://addons.mozilla.org/en-US/firefox/addon/texzilla/), [using in a Web Page, JS program, etc.](https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla))
-- [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) - Convert LaTeX documents into HTML+MathML Web pages
-- [MathJax](https://www.mathjax.org/) - Cross-browser JavaScript display engine for mathematics. To force MathJax to use native MathML, try [this Mozilla add-on](https://addons.mozilla.org/en-US/firefox/addon/native-mathml/), this [Safari extension](https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz) or this [GreaseMonkey script](https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/).
+- [W3C's wiki page](https://www.w3.org/wiki/Math_Tools)
 
 ## Related topics
 


### PR DESCRIPTION
### Description

This removes the math tools and link to https://www.w3.org/wiki/Math_Tools instead. Tools currently listed on MDN are on the W3C list too.

### Motivation

This will defer the maintenance of the list to W3C's Math WG instead and avoid having people requesting to add tools (e.g. https://github.com/mdn/content/pull/22640).

### Additional details

N/A

### Related issues and pull requests

N/A