### PR TITLE
font-palette: Terminate code block

### DIFF
--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -24,6 +24,7 @@ font-palette: normal;
 
 /* Using a user-defined palette */
 font-palette: --one;
+```
 
 ### Values
 


### PR DESCRIPTION
The page was missing the <code>```</code> to terminate a code block, so the remainder of the content got sucked into the block.