### PR TITLE
Remove documentation for the MathML <none/> element

### DIFF
--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -47,7 +47,6 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 ### N
 
 - {{MathMLElement("mn")}} (Number)
-- {{MathMLElement("none")}} (empty scripts)
 
 ### O
 
@@ -126,7 +125,6 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 - {{MathMLElement("msup")}}
 - {{MathMLElement("munder")}}
 - {{MathMLElement("munderover")}}
-- {{MathMLElement("none")}}
 
 ### Tabular math
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -13,7 +13,7 @@ browser-compat: mathml.elements.mmultiscripts
 
 The **`<mmultiscripts>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an arbitrary number of subscripts and superscripts to an expression at once, generalizing the {{ MathMLElement("msubsup") }} element. Scripts can be either prescripts (placed before the expression) or postscripts (placed after it).
 
-MathML uses the syntax below, that is a base expression, followed by an arbitrary number of postsubscript-postsuperscript pairs (attached in the given order) optionally followed by an `<mprescripts>` and an arbitrary number of presubscript-presuperscript pairs (attached in the given order). In addition you are able to use `<none/>` as a placeholder for empty scripts.
+MathML uses the syntax below, that is a base expression, followed by an arbitrary number of postsubscript-postsuperscript pairs (attached in the given order) optionally followed by an `<mprescripts>` and an arbitrary number of presubscript-presuperscript pairs (attached in the given order). In addition, empty `<mrow>` elements can be used to represent absent scripts.
 
 ```html
 <mmultiscripts>
@@ -64,19 +64,19 @@ Children after the `<mprescripts/>` element are placed as pre-scripts (before th
 
 {{ EmbedLiveSample('mprescripts_example', 700, 200, "", "") }}
 
-### Using `<none/>`
+### Empty scripts
 
-`<none/>` children don't render anything and represent empty scripts:
+Empty `<mrow>` elements can be used to represent absent scripts:
 
 ```html
 <math display="block">
   <mmultiscripts>
     <mi>X</mi>      <!-- base expression -->
-    <none />        <!-- postsubscript -->
+    <mrow></mrow>   <!-- postsubscript -->
     <mi>c</mi>      <!-- postsuperscript -->
     <mprescripts />
     <mi>b</mi>      <!-- presubscript -->
-    <none />        <!-- presuperscript -->
+    <mrow></mrow>   <!-- presuperscript -->
   </mmultiscripts>
 </math>
 ```


### PR DESCRIPTION
### Description

This removes documentation for the `<none/>` element and suggests using an `<mrow>` instead.

### Motivation

Same change was done in MathML Core [1].

### Additional details


Note that:
- In legacy spec/implementations `<none>` is an empty element and renders as an empty box.
- In modern spec/implementations `<none>` is an "unkown element" so is treated as an `<mrow>`

So replacing with `<none>` elements with empty `<mrow>` elements lead to no changes.

### Related issues and pull requests

[1] https://github.com/w3c/mathml-core/issues/173
