### PR TITLE
initiatorType does not have a font value

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -91,7 +91,7 @@ Additionally, this interface exposes the following properties containing more in
 - {{domxref('PerformanceResourceTiming.encodedBodySize')}} {{ReadOnlyInline}}
   - : A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload body, before removing any applied content encodings.
 - {{domxref('PerformanceResourceTiming.initiatorType')}} {{ReadOnlyInline}}
-  - : A string representing the type of resource that initiated the performance entry.
+  - : A string representing the web platform feature that initiated the performance entry.
 - {{domxref('PerformanceResourceTiming.nextHopProtocol')}} {{ReadOnlyInline}}
   - : A string representing the network protocol used to fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
 - {{domxref('PerformanceResourceTiming.renderBlockingStatus')}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceResourceTiming.initiatorType
 
 {{APIRef("Performance API")}}
 
-The **`initiatorType`** read-only property is a string representing the way a resource was initiated to be fetched.
+The **`initiatorType`** read-only property is a string representing web platform feature that initiated the resource load.
 
 > **Note:** This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file, the `initiatorType` will be `css` and not `img`.
 
@@ -34,8 +34,6 @@ The `initiatorType` property can have the following values, or `other` if none o
   - : If the request was initiated by an {{HTMLElement("embed")}} element's `src` attribute.
 - `fetch`
   - : If the request was initiated by a {{domxref("fetch()")}} method.
-- `font`
-  - : If the request was initiated by a {{cssxref("@font-face")}} at rule.
 - `frame`
   - : If the request was initiated by loading a {{HTMLElement("frame")}} element.
 - `iframe`


### PR DESCRIPTION
`"font"` is not listed as a value for `initiatorType` (https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-initiatortype) and in practice, a font loaded using `@font-face` gets a type of `"css"` (which we would expect, since it uses `url()` to load it.

Try https://mdn.github.io/learning-area/css/styling-text/web-fonts/web-font-finished.html with this code:

```js
const observer = new PerformanceObserver((list) => {
  list.getEntries().forEach((entry) => {
    console.log(`${entry.initiatorType} : ${entry.name}`);
  });
});

observer.observe({ type: "resource", buffered: true });
```

=>

```
link : https://mdn.github.io/learning-area/css/styling-text/web-fonts/web-font-finished.css
css : https://mdn.github.io/learning-area/css/styling-text/web-fonts/fonts/zantroke-webfont.woff2
css : https://mdn.github.io/learning-area/css/styling-text/web-fonts/fonts/cicle_fina-webfont.woff2
other : https://mdn.github.io/favicon.ico
```

Also corrected the entry in the parent interface, `initiatorType` is not the type of resource.