### PR TITLE
[page types] Add SVG page types

### DIFF
--- a/files/en-us/web/svg/applying_svg_effects_to_html_content/index.md
+++ b/files/en-us/web/svg/applying_svg_effects_to_html_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Applying SVG effects to HTML content
 slug: Web/SVG/Applying_SVG_effects_to_HTML_content
+page-type: guide
 tags:
   - CSS
   - Guide

--- a/files/en-us/web/svg/attribute/accent-height/index.md
+++ b/files/en-us/web/svg/attribute/accent-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: accent-height
 slug: Web/SVG/Attribute/accent-height
+page-type: svg-attribute
 tags:
   - Deprecated
   - NeedsExample

--- a/files/en-us/web/svg/attribute/accumulate/index.md
+++ b/files/en-us/web/svg/attribute/accumulate/index.md
@@ -1,6 +1,7 @@
 ---
 title: accumulate
 slug: Web/SVG/Attribute/accumulate
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/additive/index.md
+++ b/files/en-us/web/svg/attribute/additive/index.md
@@ -1,6 +1,7 @@
 ---
 title: additive
 slug: Web/SVG/Attribute/additive
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/alignment-baseline/index.md
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.md
@@ -1,6 +1,7 @@
 ---
 title: alignment-baseline
 slug: Web/SVG/Attribute/alignment-baseline
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/alphabetic/index.md
+++ b/files/en-us/web/svg/attribute/alphabetic/index.md
@@ -1,6 +1,7 @@
 ---
 title: alphabetic
 slug: Web/SVG/Attribute/alphabetic
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/amplitude/index.md
+++ b/files/en-us/web/svg/attribute/amplitude/index.md
@@ -1,6 +1,7 @@
 ---
 title: amplitude
 slug: Web/SVG/Attribute/amplitude
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/arabic-form/index.md
+++ b/files/en-us/web/svg/attribute/arabic-form/index.md
@@ -1,6 +1,7 @@
 ---
 title: arabic-form
 slug: Web/SVG/Attribute/arabic-form
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/ascent/index.md
+++ b/files/en-us/web/svg/attribute/ascent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ascent
 slug: Web/SVG/Attribute/ascent
+page-type: svg-attribute
 tags:
   - Deprecated
   - NeedsExample

--- a/files/en-us/web/svg/attribute/attributename/index.md
+++ b/files/en-us/web/svg/attribute/attributename/index.md
@@ -1,6 +1,7 @@
 ---
 title: attributeName
 slug: Web/SVG/Attribute/attributeName
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/attribute/attributetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: attributeType
 slug: Web/SVG/Attribute/attributeType
+page-type: svg-attribute
 tags:
   - Deprecated
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/azimuth/index.md
+++ b/files/en-us/web/svg/attribute/azimuth/index.md
@@ -1,6 +1,7 @@
 ---
 title: azimuth
 slug: Web/SVG/Attribute/azimuth
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/basefrequency/index.md
+++ b/files/en-us/web/svg/attribute/basefrequency/index.md
@@ -1,6 +1,7 @@
 ---
 title: baseFrequency
 slug: Web/SVG/Attribute/baseFrequency
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/baseline-shift/index.md
+++ b/files/en-us/web/svg/attribute/baseline-shift/index.md
@@ -1,6 +1,7 @@
 ---
 title: baseline-shift
 slug: Web/SVG/Attribute/baseline-shift
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/baseprofile/index.md
+++ b/files/en-us/web/svg/attribute/baseprofile/index.md
@@ -1,6 +1,7 @@
 ---
 title: baseProfile
 slug: Web/SVG/Attribute/baseProfile
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/bbox/index.md
+++ b/files/en-us/web/svg/attribute/bbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: bbox
 slug: Web/SVG/Attribute/bbox
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/begin/index.md
+++ b/files/en-us/web/svg/attribute/begin/index.md
@@ -1,6 +1,7 @@
 ---
 title: begin
 slug: Web/SVG/Attribute/begin
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/bias/index.md
+++ b/files/en-us/web/svg/attribute/bias/index.md
@@ -1,6 +1,7 @@
 ---
 title: bias
 slug: Web/SVG/Attribute/bias
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsExample

--- a/files/en-us/web/svg/attribute/by/index.md
+++ b/files/en-us/web/svg/attribute/by/index.md
@@ -1,6 +1,7 @@
 ---
 title: by
 slug: Web/SVG/Attribute/by
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/calcmode/index.md
+++ b/files/en-us/web/svg/attribute/calcmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: calcMode
 slug: Web/SVG/Attribute/calcMode
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/cap-height/index.md
+++ b/files/en-us/web/svg/attribute/cap-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: cap-height
 slug: Web/SVG/Attribute/cap-height
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/class/index.md
+++ b/files/en-us/web/svg/attribute/class/index.md
@@ -1,6 +1,7 @@
 ---
 title: class
 slug: Web/SVG/Attribute/class
+page-type: svg-attribute
 tags:
   - Reference
   - SVG

--- a/files/en-us/web/svg/attribute/clip-path/index.md
+++ b/files/en-us/web/svg/attribute/clip-path/index.md
@@ -1,6 +1,7 @@
 ---
 title: clip-path
 slug: Web/SVG/Attribute/clip-path
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/clip-rule/index.md
+++ b/files/en-us/web/svg/attribute/clip-rule/index.md
@@ -1,6 +1,7 @@
 ---
 title: clip-rule
 slug: Web/SVG/Attribute/clip-rule
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/clip/index.md
+++ b/files/en-us/web/svg/attribute/clip/index.md
@@ -1,6 +1,7 @@
 ---
 title: clip
 slug: Web/SVG/Attribute/clip
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/clippathunits/index.md
+++ b/files/en-us/web/svg/attribute/clippathunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: clipPathUnits
 slug: Web/SVG/Attribute/clipPathUnits
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/color-interpolation-filters/index.md
+++ b/files/en-us/web/svg/attribute/color-interpolation-filters/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-interpolation-filters
 slug: Web/SVG/Attribute/color-interpolation-filters
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/color-interpolation/index.md
+++ b/files/en-us/web/svg/attribute/color-interpolation/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-interpolation
 slug: Web/SVG/Attribute/color-interpolation
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/color-profile/index.md
+++ b/files/en-us/web/svg/attribute/color-profile/index.md
@@ -1,6 +1,7 @@
 ---
 title: color-profile
 slug: Web/SVG/Attribute/color-profile
+page-type: svg-attribute
 tags:
   - Deprecated
   - NeedsExample

--- a/files/en-us/web/svg/attribute/color/index.md
+++ b/files/en-us/web/svg/attribute/color/index.md
@@ -1,6 +1,7 @@
 ---
 title: color
 slug: Web/SVG/Attribute/color
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/conditional_processing/index.md
+++ b/files/en-us/web/svg/attribute/conditional_processing/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Conditional Processing Attributes
 slug: Web/SVG/Attribute/Conditional_Processing
+page-type: svg-attribute
 tags:
   - Intermediate
   - NeedsExample

--- a/files/en-us/web/svg/attribute/contentscripttype/index.md
+++ b/files/en-us/web/svg/attribute/contentscripttype/index.md
@@ -1,6 +1,7 @@
 ---
 title: contentScriptType
 slug: Web/SVG/Attribute/contentScriptType
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/contentstyletype/index.md
+++ b/files/en-us/web/svg/attribute/contentstyletype/index.md
@@ -1,6 +1,7 @@
 ---
 title: contentStyleType
 slug: Web/SVG/Attribute/contentStyleType
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/core/index.md
+++ b/files/en-us/web/svg/attribute/core/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Core Attributes
 slug: Web/SVG/Attribute/Core
+page-type: svg-attribute
 tags:
   - Attribute
   - Intermediate

--- a/files/en-us/web/svg/attribute/crossorigin/index.md
+++ b/files/en-us/web/svg/attribute/crossorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'SVG attribute: crossorigin'
 slug: Web/SVG/Attribute/crossorigin
+page-type: svg-attribute
 tags:
   - Advanced
   - Attribute

--- a/files/en-us/web/svg/attribute/cursor/index.md
+++ b/files/en-us/web/svg/attribute/cursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: cursor
 slug: Web/SVG/Attribute/cursor
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -1,6 +1,7 @@
 ---
 title: cx
 slug: Web/SVG/Attribute/cx
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -1,6 +1,7 @@
 ---
 title: cy
 slug: Web/SVG/Attribute/cy
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/d/index.md
+++ b/files/en-us/web/svg/attribute/d/index.md
@@ -1,6 +1,7 @@
 ---
 title: d
 slug: Web/SVG/Attribute/d
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/data-_star_/index.md
+++ b/files/en-us/web/svg/attribute/data-_star_/index.md
@@ -1,6 +1,7 @@
 ---
 title: data-*
 slug: Web/SVG/Attribute/data-*
+page-type: svg-attribute
 tags:
   - Attribute
   - SVG

--- a/files/en-us/web/svg/attribute/descent/index.md
+++ b/files/en-us/web/svg/attribute/descent/index.md
@@ -1,6 +1,7 @@
 ---
 title: descent
 slug: Web/SVG/Attribute/descent
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/diffuseconstant/index.md
+++ b/files/en-us/web/svg/attribute/diffuseconstant/index.md
@@ -1,6 +1,7 @@
 ---
 title: diffuseConstant
 slug: Web/SVG/Attribute/diffuseConstant
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/direction/index.md
+++ b/files/en-us/web/svg/attribute/direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: direction
 slug: Web/SVG/Attribute/direction
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/display/index.md
+++ b/files/en-us/web/svg/attribute/display/index.md
@@ -1,6 +1,7 @@
 ---
 title: display
 slug: Web/SVG/Attribute/display
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/divisor/index.md
+++ b/files/en-us/web/svg/attribute/divisor/index.md
@@ -1,6 +1,7 @@
 ---
 title: divisor
 slug: Web/SVG/Attribute/divisor
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.md
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.md
@@ -1,6 +1,7 @@
 ---
 title: dominant-baseline
 slug: Web/SVG/Attribute/dominant-baseline
+page-type: svg-attribute
 tags:
   - Reference
   - SVG

--- a/files/en-us/web/svg/attribute/dur/index.md
+++ b/files/en-us/web/svg/attribute/dur/index.md
@@ -1,6 +1,7 @@
 ---
 title: dur
 slug: Web/SVG/Attribute/dur
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/dx/index.md
+++ b/files/en-us/web/svg/attribute/dx/index.md
@@ -1,6 +1,7 @@
 ---
 title: dx
 slug: Web/SVG/Attribute/dx
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/dy/index.md
+++ b/files/en-us/web/svg/attribute/dy/index.md
@@ -1,6 +1,7 @@
 ---
 title: dy
 slug: Web/SVG/Attribute/dy
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/edgemode/index.md
+++ b/files/en-us/web/svg/attribute/edgemode/index.md
@@ -1,6 +1,7 @@
 ---
 title: edgeMode
 slug: Web/SVG/Attribute/edgeMode
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/elevation/index.md
+++ b/files/en-us/web/svg/attribute/elevation/index.md
@@ -1,6 +1,7 @@
 ---
 title: elevation
 slug: Web/SVG/Attribute/elevation
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/enable-background/index.md
+++ b/files/en-us/web/svg/attribute/enable-background/index.md
@@ -1,6 +1,7 @@
 ---
 title: enable-background
 slug: Web/SVG/Attribute/enable-background
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/end/index.md
+++ b/files/en-us/web/svg/attribute/end/index.md
@@ -1,6 +1,7 @@
 ---
 title: end
 slug: Web/SVG/Attribute/end
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/events/index.md
+++ b/files/en-us/web/svg/attribute/events/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Event Attributes
 slug: Web/SVG/Attribute/Events
+page-type: svg-attribute
 tags:
   - Advanced
   - Attribute

--- a/files/en-us/web/svg/attribute/exponent/index.md
+++ b/files/en-us/web/svg/attribute/exponent/index.md
@@ -1,6 +1,7 @@
 ---
 title: exponent
 slug: Web/SVG/Attribute/exponent
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/fill-opacity/index.md
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: fill-opacity
 slug: Web/SVG/Attribute/fill-opacity
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/fill-rule/index.md
+++ b/files/en-us/web/svg/attribute/fill-rule/index.md
@@ -1,6 +1,7 @@
 ---
 title: fill-rule
 slug: Web/SVG/Attribute/fill-rule
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/fill/index.md
+++ b/files/en-us/web/svg/attribute/fill/index.md
@@ -1,6 +1,7 @@
 ---
 title: fill
 slug: Web/SVG/Attribute/fill
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/filter/index.md
+++ b/files/en-us/web/svg/attribute/filter/index.md
@@ -1,6 +1,7 @@
 ---
 title: filter
 slug: Web/SVG/Attribute/filter
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/filterres/index.md
+++ b/files/en-us/web/svg/attribute/filterres/index.md
@@ -1,6 +1,7 @@
 ---
 title: filterRes
 slug: Web/SVG/Attribute/filterRes
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/filterunits/index.md
+++ b/files/en-us/web/svg/attribute/filterunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: filterUnits
 slug: Web/SVG/Attribute/filterUnits
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/flood-color/index.md
+++ b/files/en-us/web/svg/attribute/flood-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: flood-color
 slug: Web/SVG/Attribute/flood-color
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/flood-opacity/index.md
+++ b/files/en-us/web/svg/attribute/flood-opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: flood-opacity
 slug: Web/SVG/Attribute/flood-opacity
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/font-family/index.md
+++ b/files/en-us/web/svg/attribute/font-family/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-family
 slug: Web/SVG/Attribute/font-family
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.md
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-size-adjust
 slug: Web/SVG/Attribute/font-size-adjust
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/font-size/index.md
+++ b/files/en-us/web/svg/attribute/font-size/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-size
 slug: Web/SVG/Attribute/font-size
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/font-stretch/index.md
+++ b/files/en-us/web/svg/attribute/font-stretch/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-stretch
 slug: Web/SVG/Attribute/font-stretch
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/font-style/index.md
+++ b/files/en-us/web/svg/attribute/font-style/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-style
 slug: Web/SVG/Attribute/font-style
+page-type: svg-attribute
 tags:
   - CSS
   - Font Style

--- a/files/en-us/web/svg/attribute/font-variant/index.md
+++ b/files/en-us/web/svg/attribute/font-variant/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-variant
 slug: Web/SVG/Attribute/font-variant
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/font-weight/index.md
+++ b/files/en-us/web/svg/attribute/font-weight/index.md
@@ -1,6 +1,7 @@
 ---
 title: font-weight
 slug: Web/SVG/Attribute/font-weight
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/format/index.md
+++ b/files/en-us/web/svg/attribute/format/index.md
@@ -1,6 +1,7 @@
 ---
 title: format
 slug: Web/SVG/Attribute/format
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -1,6 +1,7 @@
 ---
 title: fr
 slug: Web/SVG/Attribute/fr
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/from/index.md
+++ b/files/en-us/web/svg/attribute/from/index.md
@@ -1,6 +1,7 @@
 ---
 title: from
 slug: Web/SVG/Attribute/From
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/fx/index.md
+++ b/files/en-us/web/svg/attribute/fx/index.md
@@ -1,6 +1,7 @@
 ---
 title: fx
 slug: Web/SVG/Attribute/fx
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/fy/index.md
+++ b/files/en-us/web/svg/attribute/fy/index.md
@@ -1,6 +1,7 @@
 ---
 title: fy
 slug: Web/SVG/Attribute/fy
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/g1/index.md
+++ b/files/en-us/web/svg/attribute/g1/index.md
@@ -1,6 +1,7 @@
 ---
 title: g1
 slug: Web/SVG/Attribute/g1
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/g2/index.md
+++ b/files/en-us/web/svg/attribute/g2/index.md
@@ -1,6 +1,7 @@
 ---
 title: g2
 slug: Web/SVG/Attribute/g2
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/glyph-name/index.md
+++ b/files/en-us/web/svg/attribute/glyph-name/index.md
@@ -1,6 +1,7 @@
 ---
 title: glyph-name
 slug: Web/SVG/Attribute/glyph-name
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/glyph-orientation-horizontal/index.md
+++ b/files/en-us/web/svg/attribute/glyph-orientation-horizontal/index.md
@@ -1,6 +1,7 @@
 ---
 title: glyph-orientation-horizontal
 slug: Web/SVG/Attribute/glyph-orientation-horizontal
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/glyph-orientation-vertical/index.md
+++ b/files/en-us/web/svg/attribute/glyph-orientation-vertical/index.md
@@ -1,6 +1,7 @@
 ---
 title: glyph-orientation-vertical
 slug: Web/SVG/Attribute/glyph-orientation-vertical
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/glyphref/index.md
+++ b/files/en-us/web/svg/attribute/glyphref/index.md
@@ -1,6 +1,7 @@
 ---
 title: glyphRef
 slug: Web/SVG/Attribute/glyphRef
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/gradienttransform/index.md
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: gradientTransform
 slug: Web/SVG/Attribute/gradientTransform
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/gradientunits/index.md
+++ b/files/en-us/web/svg/attribute/gradientunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: gradientUnits
 slug: Web/SVG/Attribute/gradientUnits
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/hanging/index.md
+++ b/files/en-us/web/svg/attribute/hanging/index.md
@@ -1,6 +1,7 @@
 ---
 title: hanging
 slug: Web/SVG/Attribute/hanging
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/height/index.md
+++ b/files/en-us/web/svg/attribute/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: height
 slug: Web/SVG/Attribute/height
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/horiz-adv-x/index.md
+++ b/files/en-us/web/svg/attribute/horiz-adv-x/index.md
@@ -1,6 +1,7 @@
 ---
 title: horiz-adv-x
 slug: Web/SVG/Attribute/horiz-adv-x
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/horiz-origin-x/index.md
+++ b/files/en-us/web/svg/attribute/horiz-origin-x/index.md
@@ -1,6 +1,7 @@
 ---
 title: horiz-origin-x
 slug: Web/SVG/Attribute/horiz-origin-x
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/horiz-origin-y/index.md
+++ b/files/en-us/web/svg/attribute/horiz-origin-y/index.md
@@ -1,6 +1,7 @@
 ---
 title: horiz-origin-y
 slug: Web/SVG/Attribute/horiz-origin-y
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -1,6 +1,7 @@
 ---
 title: href
 slug: Web/SVG/Attribute/href
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/id/index.md
+++ b/files/en-us/web/svg/attribute/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: id
 slug: Web/SVG/Attribute/id
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/ideographic/index.md
+++ b/files/en-us/web/svg/attribute/ideographic/index.md
@@ -1,6 +1,7 @@
 ---
 title: ideographic
 slug: Web/SVG/Attribute/ideographic
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/image-rendering/index.md
+++ b/files/en-us/web/svg/attribute/image-rendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: image-rendering
 slug: Web/SVG/Attribute/image-rendering
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/in/index.md
+++ b/files/en-us/web/svg/attribute/in/index.md
@@ -1,6 +1,7 @@
 ---
 title: in
 slug: Web/SVG/Attribute/in
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/in2/index.md
+++ b/files/en-us/web/svg/attribute/in2/index.md
@@ -1,6 +1,7 @@
 ---
 title: in2
 slug: Web/SVG/Attribute/in2
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/index.md
+++ b/files/en-us/web/svg/attribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Attribute reference
 slug: Web/SVG/Attribute
+page-type: landing-page
 tags:
   - Drawing
   - Landing

--- a/files/en-us/web/svg/attribute/intercept/index.md
+++ b/files/en-us/web/svg/attribute/intercept/index.md
@@ -1,6 +1,7 @@
 ---
 title: intercept
 slug: Web/SVG/Attribute/intercept
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/k/index.md
+++ b/files/en-us/web/svg/attribute/k/index.md
@@ -1,6 +1,7 @@
 ---
 title: k
 slug: Web/SVG/Attribute/k
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/k1/index.md
+++ b/files/en-us/web/svg/attribute/k1/index.md
@@ -1,6 +1,7 @@
 ---
 title: k1
 slug: Web/SVG/Attribute/k1
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/k2/index.md
+++ b/files/en-us/web/svg/attribute/k2/index.md
@@ -1,6 +1,7 @@
 ---
 title: k2
 slug: Web/SVG/Attribute/k2
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/k3/index.md
+++ b/files/en-us/web/svg/attribute/k3/index.md
@@ -1,6 +1,7 @@
 ---
 title: k3
 slug: Web/SVG/Attribute/k3
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/k4/index.md
+++ b/files/en-us/web/svg/attribute/k4/index.md
@@ -1,6 +1,7 @@
 ---
 title: k4
 slug: Web/SVG/Attribute/k4
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/kernelmatrix/index.md
+++ b/files/en-us/web/svg/attribute/kernelmatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: kernelMatrix
 slug: Web/SVG/Attribute/kernelMatrix
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/kernelunitlength/index.md
+++ b/files/en-us/web/svg/attribute/kernelunitlength/index.md
@@ -1,6 +1,7 @@
 ---
 title: kernelUnitLength
 slug: Web/SVG/Attribute/kernelUnitLength
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/kerning/index.md
+++ b/files/en-us/web/svg/attribute/kerning/index.md
@@ -1,6 +1,7 @@
 ---
 title: kerning
 slug: Web/SVG/Attribute/kerning
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/keypoints/index.md
+++ b/files/en-us/web/svg/attribute/keypoints/index.md
@@ -1,6 +1,7 @@
 ---
 title: keyPoints
 slug: Web/SVG/Attribute/keyPoints
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/keysplines/index.md
+++ b/files/en-us/web/svg/attribute/keysplines/index.md
@@ -1,6 +1,7 @@
 ---
 title: keySplines
 slug: Web/SVG/Attribute/keySplines
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/keytimes/index.md
+++ b/files/en-us/web/svg/attribute/keytimes/index.md
@@ -1,6 +1,7 @@
 ---
 title: keyTimes
 slug: Web/SVG/Attribute/keyTimes
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/lang/index.md
+++ b/files/en-us/web/svg/attribute/lang/index.md
@@ -1,6 +1,7 @@
 ---
 title: lang
 slug: Web/SVG/Attribute/lang
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/lengthadjust/index.md
+++ b/files/en-us/web/svg/attribute/lengthadjust/index.md
@@ -1,6 +1,7 @@
 ---
 title: lengthAdjust
 slug: Web/SVG/Attribute/lengthAdjust
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/letter-spacing/index.md
+++ b/files/en-us/web/svg/attribute/letter-spacing/index.md
@@ -1,6 +1,7 @@
 ---
 title: letter-spacing
 slug: Web/SVG/Attribute/letter-spacing
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/lighting-color/index.md
+++ b/files/en-us/web/svg/attribute/lighting-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: lighting-color
 slug: Web/SVG/Attribute/lighting-color
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/limitingconeangle/index.md
+++ b/files/en-us/web/svg/attribute/limitingconeangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: limitingConeAngle
 slug: Web/SVG/Attribute/limitingConeAngle
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/marker-end/index.md
+++ b/files/en-us/web/svg/attribute/marker-end/index.md
@@ -1,6 +1,7 @@
 ---
 title: marker-end
 slug: Web/SVG/Attribute/marker-end
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/marker-mid/index.md
+++ b/files/en-us/web/svg/attribute/marker-mid/index.md
@@ -1,6 +1,7 @@
 ---
 title: marker-mid
 slug: Web/SVG/Attribute/marker-mid
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/marker-start/index.md
+++ b/files/en-us/web/svg/attribute/marker-start/index.md
@@ -1,6 +1,7 @@
 ---
 title: marker-start
 slug: Web/SVG/Attribute/marker-start
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/markerheight/index.md
+++ b/files/en-us/web/svg/attribute/markerheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: markerHeight
 slug: Web/SVG/Attribute/markerHeight
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/markerunits/index.md
+++ b/files/en-us/web/svg/attribute/markerunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: markerUnits
 slug: Web/SVG/Attribute/markerUnits
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/markerwidth/index.md
+++ b/files/en-us/web/svg/attribute/markerwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: markerWidth
 slug: Web/SVG/Attribute/markerWidth
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/mask/index.md
+++ b/files/en-us/web/svg/attribute/mask/index.md
@@ -1,6 +1,7 @@
 ---
 title: mask
 slug: Web/SVG/Attribute/mask
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/maskcontentunits/index.md
+++ b/files/en-us/web/svg/attribute/maskcontentunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: maskContentUnits
 slug: Web/SVG/Attribute/maskContentUnits
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/maskunits/index.md
+++ b/files/en-us/web/svg/attribute/maskunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: maskUnits
 slug: Web/SVG/Attribute/maskUnits
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/mathematical/index.md
+++ b/files/en-us/web/svg/attribute/mathematical/index.md
@@ -1,6 +1,7 @@
 ---
 title: mathematical
 slug: Web/SVG/Attribute/mathematical
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/max/index.md
+++ b/files/en-us/web/svg/attribute/max/index.md
@@ -1,6 +1,7 @@
 ---
 title: max
 slug: Web/SVG/Attribute/max
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/media/index.md
+++ b/files/en-us/web/svg/attribute/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: media
 slug: Web/SVG/Attribute/media
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/method/index.md
+++ b/files/en-us/web/svg/attribute/method/index.md
@@ -1,6 +1,7 @@
 ---
 title: method
 slug: Web/SVG/Attribute/method
+page-type: svg-attribute
 tags:
   - Experimental
   - NeedsExample

--- a/files/en-us/web/svg/attribute/min/index.md
+++ b/files/en-us/web/svg/attribute/min/index.md
@@ -1,6 +1,7 @@
 ---
 title: min
 slug: Web/SVG/Attribute/min
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/mode/index.md
+++ b/files/en-us/web/svg/attribute/mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: mode
 slug: Web/SVG/Attribute/mode
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/name/index.md
+++ b/files/en-us/web/svg/attribute/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: name
 slug: Web/SVG/Attribute/name
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/numoctaves/index.md
+++ b/files/en-us/web/svg/attribute/numoctaves/index.md
@@ -1,6 +1,7 @@
 ---
 title: numOctaves
 slug: Web/SVG/Attribute/numOctaves
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/onclick/index.md
+++ b/files/en-us/web/svg/attribute/onclick/index.md
@@ -1,6 +1,7 @@
 ---
 title: onclick
 slug: Web/SVG/Attribute/onclick
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/opacity/index.md
+++ b/files/en-us/web/svg/attribute/opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: opacity
 slug: Web/SVG/Attribute/opacity
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/operator/index.md
+++ b/files/en-us/web/svg/attribute/operator/index.md
@@ -1,6 +1,7 @@
 ---
 title: operator
 slug: Web/SVG/Attribute/operator
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/order/index.md
+++ b/files/en-us/web/svg/attribute/order/index.md
@@ -1,6 +1,7 @@
 ---
 title: order
 slug: Web/SVG/Attribute/order
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/orient/index.md
+++ b/files/en-us/web/svg/attribute/orient/index.md
@@ -1,6 +1,7 @@
 ---
 title: orient
 slug: Web/SVG/Attribute/orient
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attr

--- a/files/en-us/web/svg/attribute/orientation/index.md
+++ b/files/en-us/web/svg/attribute/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: orientation
 slug: Web/SVG/Attribute/orientation
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/origin/index.md
+++ b/files/en-us/web/svg/attribute/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: origin
 slug: Web/SVG/Attribute/origin
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/overflow/index.md
+++ b/files/en-us/web/svg/attribute/overflow/index.md
@@ -1,6 +1,7 @@
 ---
 title: overflow
 slug: Web/SVG/Attribute/overflow
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/overline-position/index.md
+++ b/files/en-us/web/svg/attribute/overline-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: overline-position
 slug: Web/SVG/Attribute/overline-position
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/overline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/overline-thickness/index.md
@@ -1,6 +1,7 @@
 ---
 title: overline-thickness
 slug: Web/SVG/Attribute/overline-thickness
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/paint-order/index.md
+++ b/files/en-us/web/svg/attribute/paint-order/index.md
@@ -1,6 +1,7 @@
 ---
 title: paint-order
 slug: Web/SVG/Attribute/paint-order
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/panose-1/index.md
+++ b/files/en-us/web/svg/attribute/panose-1/index.md
@@ -1,6 +1,7 @@
 ---
 title: panose-1
 slug: Web/SVG/Attribute/panose-1
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/path/index.md
+++ b/files/en-us/web/svg/attribute/path/index.md
@@ -1,6 +1,7 @@
 ---
 title: path
 slug: Web/SVG/Attribute/path
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/pathlength/index.md
+++ b/files/en-us/web/svg/attribute/pathlength/index.md
@@ -1,6 +1,7 @@
 ---
 title: pathLength
 slug: Web/SVG/Attribute/pathLength
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/patterncontentunits/index.md
+++ b/files/en-us/web/svg/attribute/patterncontentunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: patternContentUnits
 slug: Web/SVG/Attribute/patternContentUnits
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/patterntransform/index.md
+++ b/files/en-us/web/svg/attribute/patterntransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: patternTransform
 slug: Web/SVG/Attribute/patternTransform
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/patternunits/index.md
+++ b/files/en-us/web/svg/attribute/patternunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: patternUnits
 slug: Web/SVG/Attribute/patternUnits
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/pointer-events/index.md
+++ b/files/en-us/web/svg/attribute/pointer-events/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointer-events
 slug: Web/SVG/Attribute/pointer-events
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/points/index.md
+++ b/files/en-us/web/svg/attribute/points/index.md
@@ -1,6 +1,7 @@
 ---
 title: points
 slug: Web/SVG/Attribute/points
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/pointsatx/index.md
+++ b/files/en-us/web/svg/attribute/pointsatx/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointsAtX
 slug: Web/SVG/Attribute/pointsAtX
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/pointsaty/index.md
+++ b/files/en-us/web/svg/attribute/pointsaty/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointsAtY
 slug: Web/SVG/Attribute/pointsAtY
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/pointsatz/index.md
+++ b/files/en-us/web/svg/attribute/pointsatz/index.md
@@ -1,6 +1,7 @@
 ---
 title: pointsAtZ
 slug: Web/SVG/Attribute/pointsAtZ
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/presentation/index.md
+++ b/files/en-us/web/svg/attribute/presentation/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Presentation Attributes
 slug: Web/SVG/Attribute/Presentation
+page-type: svg-attribute
 tags:
   - Attribute
   - Beginner

--- a/files/en-us/web/svg/attribute/preservealpha/index.md
+++ b/files/en-us/web/svg/attribute/preservealpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: preserveAlpha
 slug: Web/SVG/Attribute/preserveAlpha
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/preserveaspectratio/index.md
+++ b/files/en-us/web/svg/attribute/preserveaspectratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: preserveAspectRatio
 slug: Web/SVG/Attribute/preserveAspectRatio
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/primitiveunits/index.md
+++ b/files/en-us/web/svg/attribute/primitiveunits/index.md
@@ -1,6 +1,7 @@
 ---
 title: primitiveUnits
 slug: Web/SVG/Attribute/primitiveUnits
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -1,6 +1,7 @@
 ---
 title: r
 slug: Web/SVG/Attribute/r
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/radius/index.md
+++ b/files/en-us/web/svg/attribute/radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: radius
 slug: Web/SVG/Attribute/radius
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsExample

--- a/files/en-us/web/svg/attribute/refx/index.md
+++ b/files/en-us/web/svg/attribute/refx/index.md
@@ -1,6 +1,7 @@
 ---
 title: refX
 slug: Web/SVG/Attribute/refX
+page-type: svg-attribute
 tags:
   - NeedsBrowserCompatibility
   - NeedsExample

--- a/files/en-us/web/svg/attribute/refy/index.md
+++ b/files/en-us/web/svg/attribute/refy/index.md
@@ -1,6 +1,7 @@
 ---
 title: refY
 slug: Web/SVG/Attribute/refY
+page-type: svg-attribute
 tags:
   - NeedsBrowserCompatibility
   - NeedsExample

--- a/files/en-us/web/svg/attribute/repeatcount/index.md
+++ b/files/en-us/web/svg/attribute/repeatcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: repeatCount
 slug: Web/SVG/Attribute/repeatCount
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/repeatdur/index.md
+++ b/files/en-us/web/svg/attribute/repeatdur/index.md
@@ -1,6 +1,7 @@
 ---
 title: repeatDur
 slug: Web/SVG/Attribute/repeatDur
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/requiredfeatures/index.md
+++ b/files/en-us/web/svg/attribute/requiredfeatures/index.md
@@ -1,6 +1,7 @@
 ---
 title: requiredFeatures
 slug: Web/SVG/Attribute/requiredFeatures
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/restart/index.md
+++ b/files/en-us/web/svg/attribute/restart/index.md
@@ -1,6 +1,7 @@
 ---
 title: restart
 slug: Web/SVG/Attribute/restart
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/result/index.md
+++ b/files/en-us/web/svg/attribute/result/index.md
@@ -1,6 +1,7 @@
 ---
 title: result
 slug: Web/SVG/Attribute/result
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/rotate/index.md
+++ b/files/en-us/web/svg/attribute/rotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: rotate
 slug: Web/SVG/Attribute/rotate
+page-type: svg-attribute
 tags:
   - Animation
   - Experimental

--- a/files/en-us/web/svg/attribute/rx/index.md
+++ b/files/en-us/web/svg/attribute/rx/index.md
@@ -1,6 +1,7 @@
 ---
 title: rx
 slug: Web/SVG/Attribute/rx
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/ry/index.md
+++ b/files/en-us/web/svg/attribute/ry/index.md
@@ -1,6 +1,7 @@
 ---
 title: ry
 slug: Web/SVG/Attribute/ry
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/scale/index.md
+++ b/files/en-us/web/svg/attribute/scale/index.md
@@ -1,6 +1,7 @@
 ---
 title: scale
 slug: Web/SVG/Attribute/scale
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/seed/index.md
+++ b/files/en-us/web/svg/attribute/seed/index.md
@@ -1,6 +1,7 @@
 ---
 title: seed
 slug: Web/SVG/Attribute/seed
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/shape-rendering/index.md
+++ b/files/en-us/web/svg/attribute/shape-rendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: shape-rendering
 slug: Web/SVG/Attribute/shape-rendering
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/side/index.md
+++ b/files/en-us/web/svg/attribute/side/index.md
@@ -1,6 +1,7 @@
 ---
 title: side
 slug: Web/SVG/Attribute/side
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/slope/index.md
+++ b/files/en-us/web/svg/attribute/slope/index.md
@@ -1,6 +1,7 @@
 ---
 title: slope
 slug: Web/SVG/Attribute/slope
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/spacing/index.md
+++ b/files/en-us/web/svg/attribute/spacing/index.md
@@ -1,6 +1,7 @@
 ---
 title: spacing
 slug: Web/SVG/Attribute/spacing
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/specularconstant/index.md
+++ b/files/en-us/web/svg/attribute/specularconstant/index.md
@@ -1,6 +1,7 @@
 ---
 title: specularConstant
 slug: Web/SVG/Attribute/specularConstant
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/specularexponent/index.md
+++ b/files/en-us/web/svg/attribute/specularexponent/index.md
@@ -1,6 +1,7 @@
 ---
 title: specularExponent
 slug: Web/SVG/Attribute/specularExponent
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/spreadmethod/index.md
+++ b/files/en-us/web/svg/attribute/spreadmethod/index.md
@@ -1,6 +1,7 @@
 ---
 title: spreadMethod
 slug: Web/SVG/Attribute/spreadMethod
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/startoffset/index.md
+++ b/files/en-us/web/svg/attribute/startoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: startOffset
 slug: Web/SVG/Attribute/startOffset
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stddeviation/index.md
+++ b/files/en-us/web/svg/attribute/stddeviation/index.md
@@ -1,6 +1,7 @@
 ---
 title: stdDeviation
 slug: Web/SVG/Attribute/stdDeviation
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/stemh/index.md
+++ b/files/en-us/web/svg/attribute/stemh/index.md
@@ -1,6 +1,7 @@
 ---
 title: stemh
 slug: Web/SVG/Attribute/stemh
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/stemv/index.md
+++ b/files/en-us/web/svg/attribute/stemv/index.md
@@ -1,6 +1,7 @@
 ---
 title: stemv
 slug: Web/SVG/Attribute/stemv
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/stitchtiles/index.md
+++ b/files/en-us/web/svg/attribute/stitchtiles/index.md
@@ -1,6 +1,7 @@
 ---
 title: stitchTiles
 slug: Web/SVG/Attribute/stitchTiles
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/stop-color/index.md
+++ b/files/en-us/web/svg/attribute/stop-color/index.md
@@ -1,6 +1,7 @@
 ---
 title: stop-color
 slug: Web/SVG/Attribute/stop-color
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/stop-opacity/index.md
+++ b/files/en-us/web/svg/attribute/stop-opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: stop-opacity
 slug: Web/SVG/Attribute/stop-opacity
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/strikethrough-position/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: strikethrough-position
 slug: Web/SVG/Attribute/strikethrough-position
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
@@ -1,6 +1,7 @@
 ---
 title: strikethrough-thickness
 slug: Web/SVG/Attribute/strikethrough-thickness
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/string/index.md
+++ b/files/en-us/web/svg/attribute/string/index.md
@@ -1,6 +1,7 @@
 ---
 title: string
 slug: Web/SVG/Attribute/string
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.md
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-dasharray
 slug: Web/SVG/Attribute/stroke-dasharray
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke-dashoffset/index.md
+++ b/files/en-us/web/svg/attribute/stroke-dashoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-dashoffset
 slug: Web/SVG/Attribute/stroke-dashoffset
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.md
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-linecap
 slug: Web/SVG/Attribute/stroke-linecap
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.md
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-linejoin
 slug: Web/SVG/Attribute/stroke-linejoin
+page-type: svg-attribute
 tags:
   - Reference
   - SVG

--- a/files/en-us/web/svg/attribute/stroke-miterlimit/index.md
+++ b/files/en-us/web/svg/attribute/stroke-miterlimit/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-miterlimit
 slug: Web/SVG/Attribute/stroke-miterlimit
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.md
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-opacity
 slug: Web/SVG/Attribute/stroke-opacity
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke-width/index.md
+++ b/files/en-us/web/svg/attribute/stroke-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke-width
 slug: Web/SVG/Attribute/stroke-width
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/stroke/index.md
+++ b/files/en-us/web/svg/attribute/stroke/index.md
@@ -1,6 +1,7 @@
 ---
 title: stroke
 slug: Web/SVG/Attribute/stroke
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/style/index.md
+++ b/files/en-us/web/svg/attribute/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: style
 slug: Web/SVG/Attribute/style
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/styling/index.md
+++ b/files/en-us/web/svg/attribute/styling/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Styling Attributes
 slug: Web/SVG/Attribute/Styling
+page-type: svg-attribute
 tags:
   - Attribute
   - Beginner

--- a/files/en-us/web/svg/attribute/surfacescale/index.md
+++ b/files/en-us/web/svg/attribute/surfacescale/index.md
@@ -1,6 +1,7 @@
 ---
 title: surfaceScale
 slug: Web/SVG/Attribute/surfaceScale
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsCompatTable

--- a/files/en-us/web/svg/attribute/systemlanguage/index.md
+++ b/files/en-us/web/svg/attribute/systemlanguage/index.md
@@ -1,6 +1,7 @@
 ---
 title: systemLanguage
 slug: Web/SVG/Attribute/systemLanguage
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/tabindex/index.md
+++ b/files/en-us/web/svg/attribute/tabindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: tabindex
 slug: Web/SVG/Attribute/tabindex
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/tablevalues/index.md
+++ b/files/en-us/web/svg/attribute/tablevalues/index.md
@@ -1,6 +1,7 @@
 ---
 title: tableValues
 slug: Web/SVG/Attribute/tableValues
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/target/index.md
+++ b/files/en-us/web/svg/attribute/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: target
 slug: Web/SVG/Attribute/target
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/targetx/index.md
+++ b/files/en-us/web/svg/attribute/targetx/index.md
@@ -1,6 +1,7 @@
 ---
 title: targetX
 slug: Web/SVG/Attribute/targetX
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsExample

--- a/files/en-us/web/svg/attribute/targety/index.md
+++ b/files/en-us/web/svg/attribute/targety/index.md
@@ -1,6 +1,7 @@
 ---
 title: targetY
 slug: Web/SVG/Attribute/targetY
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsExample

--- a/files/en-us/web/svg/attribute/text-anchor/index.md
+++ b/files/en-us/web/svg/attribute/text-anchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: text-anchor
 slug: Web/SVG/Attribute/text-anchor
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/text-decoration/index.md
+++ b/files/en-us/web/svg/attribute/text-decoration/index.md
@@ -1,6 +1,7 @@
 ---
 title: text-decoration
 slug: Web/SVG/Attribute/text-decoration
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/text-rendering/index.md
+++ b/files/en-us/web/svg/attribute/text-rendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: text-rendering
 slug: Web/SVG/Attribute/text-rendering
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/textlength/index.md
+++ b/files/en-us/web/svg/attribute/textlength/index.md
@@ -1,6 +1,7 @@
 ---
 title: textLength
 slug: Web/SVG/Attribute/textLength
+page-type: svg-attribute
 tags:
   - Attribute
   - CSS

--- a/files/en-us/web/svg/attribute/to/index.md
+++ b/files/en-us/web/svg/attribute/to/index.md
@@ -1,6 +1,7 @@
 ---
 title: to
 slug: Web/SVG/Attribute/To
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/transform-origin/index.md
+++ b/files/en-us/web/svg/attribute/transform-origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: transform-origin
 slug: Web/SVG/Attribute/transform-origin
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/transform/index.md
+++ b/files/en-us/web/svg/attribute/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: transform
 slug: Web/SVG/Attribute/transform
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/type/index.md
+++ b/files/en-us/web/svg/attribute/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: type
 slug: Web/SVG/Attribute/type
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/u1/index.md
+++ b/files/en-us/web/svg/attribute/u1/index.md
@@ -1,6 +1,7 @@
 ---
 title: u1
 slug: Web/SVG/Attribute/u1
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/u2/index.md
+++ b/files/en-us/web/svg/attribute/u2/index.md
@@ -1,6 +1,7 @@
 ---
 title: u2
 slug: Web/SVG/Attribute/u2
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/underline-position/index.md
+++ b/files/en-us/web/svg/attribute/underline-position/index.md
@@ -1,6 +1,7 @@
 ---
 title: underline-position
 slug: Web/SVG/Attribute/underline-position
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/underline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/underline-thickness/index.md
@@ -1,6 +1,7 @@
 ---
 title: underline-thickness
 slug: Web/SVG/Attribute/underline-thickness
+page-type: svg-attribute
 tags:
   - Attribute
   - Reference

--- a/files/en-us/web/svg/attribute/unicode-bidi/index.md
+++ b/files/en-us/web/svg/attribute/unicode-bidi/index.md
@@ -1,6 +1,7 @@
 ---
 title: unicode-bidi
 slug: Web/SVG/Attribute/unicode-bidi
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/unicode-range/index.md
+++ b/files/en-us/web/svg/attribute/unicode-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: unicode-range
 slug: Web/SVG/Attribute/unicode-range
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/unicode/index.md
+++ b/files/en-us/web/svg/attribute/unicode/index.md
@@ -1,6 +1,7 @@
 ---
 title: unicode
 slug: Web/SVG/Attribute/unicode
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/units-per-em/index.md
+++ b/files/en-us/web/svg/attribute/units-per-em/index.md
@@ -1,6 +1,7 @@
 ---
 title: units-per-em
 slug: Web/SVG/Attribute/units-per-em
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/v-alphabetic/index.md
+++ b/files/en-us/web/svg/attribute/v-alphabetic/index.md
@@ -1,6 +1,7 @@
 ---
 title: v-alphabetic
 slug: Web/SVG/Attribute/v-alphabetic
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/v-hanging/index.md
+++ b/files/en-us/web/svg/attribute/v-hanging/index.md
@@ -1,6 +1,7 @@
 ---
 title: v-hanging
 slug: Web/SVG/Attribute/v-hanging
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/v-ideographic/index.md
+++ b/files/en-us/web/svg/attribute/v-ideographic/index.md
@@ -1,6 +1,7 @@
 ---
 title: v-ideographic
 slug: Web/SVG/Attribute/v-ideographic
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/v-mathematical/index.md
+++ b/files/en-us/web/svg/attribute/v-mathematical/index.md
@@ -1,6 +1,7 @@
 ---
 title: v-mathematical
 slug: Web/SVG/Attribute/v-mathematical
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/values/index.md
+++ b/files/en-us/web/svg/attribute/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: values
 slug: Web/SVG/Attribute/values
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - NeedsExample

--- a/files/en-us/web/svg/attribute/vector-effect/index.md
+++ b/files/en-us/web/svg/attribute/vector-effect/index.md
@@ -1,6 +1,7 @@
 ---
 title: vector-effect
 slug: Web/SVG/Attribute/vector-effect
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/version/index.md
+++ b/files/en-us/web/svg/attribute/version/index.md
@@ -1,6 +1,7 @@
 ---
 title: version
 slug: Web/SVG/Attribute/version
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/vert-adv-y/index.md
+++ b/files/en-us/web/svg/attribute/vert-adv-y/index.md
@@ -1,6 +1,7 @@
 ---
 title: vert-adv-y
 slug: Web/SVG/Attribute/vert-adv-y
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/vert-origin-x/index.md
+++ b/files/en-us/web/svg/attribute/vert-origin-x/index.md
@@ -1,6 +1,7 @@
 ---
 title: vert-origin-x
 slug: Web/SVG/Attribute/vert-origin-x
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/vert-origin-y/index.md
+++ b/files/en-us/web/svg/attribute/vert-origin-y/index.md
@@ -1,6 +1,7 @@
 ---
 title: vert-origin-y
 slug: Web/SVG/Attribute/vert-origin-y
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: viewBox
 slug: Web/SVG/Attribute/viewBox
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/viewtarget/index.md
+++ b/files/en-us/web/svg/attribute/viewtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: viewTarget
 slug: Web/SVG/Attribute/viewTarget
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/visibility/index.md
+++ b/files/en-us/web/svg/attribute/visibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: visibility
 slug: Web/SVG/Attribute/visibility
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: width
 slug: Web/SVG/Attribute/width
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/widths/index.md
+++ b/files/en-us/web/svg/attribute/widths/index.md
@@ -1,6 +1,7 @@
 ---
 title: widths
 slug: Web/SVG/Attribute/widths
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -1,6 +1,7 @@
 ---
 title: word-spacing
 slug: Web/SVG/Attribute/word-spacing
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/writing-mode/index.md
+++ b/files/en-us/web/svg/attribute/writing-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: writing-mode
 slug: Web/SVG/Attribute/writing-mode
+page-type: svg-attribute
 tags:
   - NeedsExample
   - SVG

--- a/files/en-us/web/svg/attribute/x-height/index.md
+++ b/files/en-us/web/svg/attribute/x-height/index.md
@@ -1,6 +1,7 @@
 ---
 title: x-height
 slug: Web/SVG/Attribute/x-height
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: x
 slug: Web/SVG/Attribute/x
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -1,6 +1,7 @@
 ---
 title: x1
 slug: Web/SVG/Attribute/x1
+page-type: svg-attribute
 tags:
   - Drawing Lines
   - Gradients

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -1,6 +1,7 @@
 ---
 title: x2
 slug: Web/SVG/Attribute/x2
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/xchannelselector/index.md
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.md
@@ -1,6 +1,7 @@
 ---
 title: xChannelSelector
 slug: Web/SVG/Attribute/xChannelSelector
+page-type: svg-attribute
 tags:
   - Filters
   - NeedsExample

--- a/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.md
@@ -1,6 +1,7 @@
 ---
 title: xlink:arcrole
 slug: Web/SVG/Attribute/xlink:arcrole
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/xlink_colon_href/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_href/index.md
@@ -1,6 +1,7 @@
 ---
 title: xlink:href
 slug: Web/SVG/Attribute/xlink:href
+page-type: svg-attribute
 tags:
   - NeedsCompatTable
   - SVG

--- a/files/en-us/web/svg/attribute/xlink_colon_show/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_show/index.md
@@ -1,6 +1,7 @@
 ---
 title: xlink:show
 slug: Web/SVG/Attribute/xlink:show
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.md
@@ -1,6 +1,7 @@
 ---
 title: xlink:title
 slug: Web/SVG/Attribute/xlink:title
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/xlink_colon_type/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_type/index.md
@@ -1,6 +1,7 @@
 ---
 title: xlink:type
 slug: Web/SVG/Attribute/xlink:type
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/xml_colon_base/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_base/index.md
@@ -1,6 +1,7 @@
 ---
 title: xml:base
 slug: Web/SVG/Attribute/xml:base
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.md
@@ -1,6 +1,7 @@
 ---
 title: xml:lang
 slug: Web/SVG/Attribute/xml:lang
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/xml_colon_space/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.md
@@ -1,6 +1,7 @@
 ---
 title: xml:space
 slug: Web/SVG/Attribute/xml:space
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'y'
 slug: Web/SVG/Attribute/y
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -1,6 +1,7 @@
 ---
 title: y1
 slug: Web/SVG/Attribute/y1
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -1,6 +1,7 @@
 ---
 title: y2
 slug: Web/SVG/Attribute/y2
+page-type: svg-attribute
 tags:
   - SVG
   - SVG Attribute

--- a/files/en-us/web/svg/attribute/ychannelselector/index.md
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.md
@@ -1,6 +1,7 @@
 ---
 title: yChannelSelector
 slug: Web/SVG/Attribute/yChannelSelector
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: z
 slug: Web/SVG/Attribute/z
+page-type: svg-attribute
 tags:
   - Filters
   - SVG

--- a/files/en-us/web/svg/attribute/zoomandpan/index.md
+++ b/files/en-us/web/svg/attribute/zoomandpan/index.md
@@ -1,6 +1,7 @@
 ---
 title: zoomAndPan
 slug: Web/SVG/Attribute/zoomAndPan
+page-type: svg-attribute
 tags:
   - Deprecated
   - SVG

--- a/files/en-us/web/svg/compatibility_sources/index.md
+++ b/files/en-us/web/svg/compatibility_sources/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compatibility sources
 slug: Web/SVG/Compatibility_sources
+page-type: guide
 tags:
   - SVG
 ---

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content type
 slug: Web/SVG/Content_type
+page-type: guide
 tags:
   - NeedsTechnicalReview
   - SVG

--- a/files/en-us/web/svg/element/a/index.md
+++ b/files/en-us/web/svg/element/a/index.md
@@ -1,6 +1,7 @@
 ---
 title: <a>
 slug: Web/SVG/Element/a
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/altglyph/index.md
+++ b/files/en-us/web/svg/element/altglyph/index.md
@@ -1,6 +1,7 @@
 ---
 title: <altGlyph>
 slug: Web/SVG/Element/altGlyph
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/altglyphdef/index.md
+++ b/files/en-us/web/svg/element/altglyphdef/index.md
@@ -1,6 +1,7 @@
 ---
 title: <altGlyphDef>
 slug: Web/SVG/Element/altGlyphDef
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/altglyphitem/index.md
+++ b/files/en-us/web/svg/element/altglyphitem/index.md
@@ -1,6 +1,7 @@
 ---
 title: <altGlyphItem>
 slug: Web/SVG/Element/altGlyphItem
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/animate/index.md
+++ b/files/en-us/web/svg/element/animate/index.md
@@ -1,6 +1,7 @@
 ---
 title: <animate>
 slug: Web/SVG/Element/animate
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/animatemotion/index.md
+++ b/files/en-us/web/svg/element/animatemotion/index.md
@@ -1,6 +1,7 @@
 ---
 title: <animateMotion>
 slug: Web/SVG/Element/animateMotion
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/animatetransform/index.md
+++ b/files/en-us/web/svg/element/animatetransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: <animateTransform>
 slug: Web/SVG/Element/animateTransform
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/circle/index.md
+++ b/files/en-us/web/svg/element/circle/index.md
@@ -1,6 +1,7 @@
 ---
 title: <circle>
 slug: Web/SVG/Element/circle
+page-type: svg-element
 tags:
   - Circle
   - Element

--- a/files/en-us/web/svg/element/clippath/index.md
+++ b/files/en-us/web/svg/element/clippath/index.md
@@ -1,6 +1,7 @@
 ---
 title: <clipPath>
 slug: Web/SVG/Element/clipPath
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/cursor/index.md
+++ b/files/en-us/web/svg/element/cursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: <cursor>
 slug: Web/SVG/Element/cursor
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/defs/index.md
+++ b/files/en-us/web/svg/element/defs/index.md
@@ -1,6 +1,7 @@
 ---
 title: <defs>
 slug: Web/SVG/Element/defs
+page-type: svg-element
 tags:
   - SVG
   - SVG Container

--- a/files/en-us/web/svg/element/desc/index.md
+++ b/files/en-us/web/svg/element/desc/index.md
@@ -1,6 +1,7 @@
 ---
 title: <desc>
 slug: Web/SVG/Element/desc
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/discard/index.md
+++ b/files/en-us/web/svg/element/discard/index.md
@@ -1,6 +1,7 @@
 ---
 title: <discard>
 slug: Web/SVG/Element/discard
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/ellipse/index.md
+++ b/files/en-us/web/svg/element/ellipse/index.md
@@ -1,6 +1,7 @@
 ---
 title: <ellipse>
 slug: Web/SVG/Element/ellipse
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/feblend/index.md
+++ b/files/en-us/web/svg/element/feblend/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feBlend>
 slug: Web/SVG/Element/feBlend
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fecolormatrix/index.md
+++ b/files/en-us/web/svg/element/fecolormatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feColorMatrix>
 slug: Web/SVG/Element/feColorMatrix
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fecomponenttransfer/index.md
+++ b/files/en-us/web/svg/element/fecomponenttransfer/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feComponentTransfer>
 slug: Web/SVG/Element/feComponentTransfer
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fecomposite/index.md
+++ b/files/en-us/web/svg/element/fecomposite/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feComposite>
 slug: Web/SVG/Element/feComposite
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/feconvolvematrix/index.md
+++ b/files/en-us/web/svg/element/feconvolvematrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feConvolveMatrix>
 slug: Web/SVG/Element/feConvolveMatrix
+page-type: svg-element
 tags:
   - Element
   - Filters

--- a/files/en-us/web/svg/element/fediffuselighting/index.md
+++ b/files/en-us/web/svg/element/fediffuselighting/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feDiffuseLighting>
 slug: Web/SVG/Element/feDiffuseLighting
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fedisplacementmap/index.md
+++ b/files/en-us/web/svg/element/fedisplacementmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feDisplacementMap>
 slug: Web/SVG/Element/feDisplacementMap
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fedistantlight/index.md
+++ b/files/en-us/web/svg/element/fedistantlight/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feDistantLight>
 slug: Web/SVG/Element/feDistantLight
+page-type: svg-element
 tags:
   - Element
   - Filters

--- a/files/en-us/web/svg/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/element/fedropshadow/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feDropShadow>
 slug: Web/SVG/Element/feDropShadow
+page-type: svg-element
 tags:
   - Element
   - Filters

--- a/files/en-us/web/svg/element/feflood/index.md
+++ b/files/en-us/web/svg/element/feflood/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feFlood>
 slug: Web/SVG/Element/feFlood
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fefunca/index.md
+++ b/files/en-us/web/svg/element/fefunca/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feFuncA>
 slug: Web/SVG/Element/feFuncA
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/fefuncb/index.md
+++ b/files/en-us/web/svg/element/fefuncb/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feFuncB>
 slug: Web/SVG/Element/feFuncB
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/fefuncg/index.md
+++ b/files/en-us/web/svg/element/fefuncg/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feFuncG>
 slug: Web/SVG/Element/feFuncG
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/fefuncr/index.md
+++ b/files/en-us/web/svg/element/fefuncr/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feFuncR>
 slug: Web/SVG/Element/feFuncR
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/fegaussianblur/index.md
+++ b/files/en-us/web/svg/element/fegaussianblur/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feGaussianBlur>
 slug: Web/SVG/Element/feGaussianBlur
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/feimage/index.md
+++ b/files/en-us/web/svg/element/feimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feImage>
 slug: Web/SVG/Element/feImage
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/femerge/index.md
+++ b/files/en-us/web/svg/element/femerge/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feMerge>
 slug: Web/SVG/Element/feMerge
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/femergenode/index.md
+++ b/files/en-us/web/svg/element/femergenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feMergeNode>
 slug: Web/SVG/Element/feMergeNode
+page-type: svg-element
 tags:
   - Element
   - NeedsContent

--- a/files/en-us/web/svg/element/femorphology/index.md
+++ b/files/en-us/web/svg/element/femorphology/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feMorphology>
 slug: Web/SVG/Element/feMorphology
+page-type: svg-element
 tags:
   - Element
   - NeedsBrowserCompatibility

--- a/files/en-us/web/svg/element/feoffset/index.md
+++ b/files/en-us/web/svg/element/feoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feOffset>
 slug: Web/SVG/Element/feOffset
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/fepointlight/index.md
+++ b/files/en-us/web/svg/element/fepointlight/index.md
@@ -1,6 +1,7 @@
 ---
 title: <fePointLight>
 slug: Web/SVG/Element/fePointLight
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/fespecularlighting/index.md
+++ b/files/en-us/web/svg/element/fespecularlighting/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feSpecularLighting>
 slug: Web/SVG/Element/feSpecularLighting
+page-type: svg-element
 tags:
   - Element
   - NeedsBrowserCompatibility

--- a/files/en-us/web/svg/element/fespotlight/index.md
+++ b/files/en-us/web/svg/element/fespotlight/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feSpotLight>
 slug: Web/SVG/Element/feSpotLight
+page-type: svg-element
 tags:
   - Element
   - NeedsBrowserCompatibility

--- a/files/en-us/web/svg/element/fetile/index.md
+++ b/files/en-us/web/svg/element/fetile/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feTile>
 slug: Web/SVG/Element/feTile
+page-type: svg-element
 tags:
   - Element
   - NeedsBrowserCompatibility

--- a/files/en-us/web/svg/element/feturbulence/index.md
+++ b/files/en-us/web/svg/element/feturbulence/index.md
@@ -1,6 +1,7 @@
 ---
 title: <feTurbulence>
 slug: Web/SVG/Element/feTurbulence
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -1,6 +1,7 @@
 ---
 title: <filter>
 slug: Web/SVG/Element/filter
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/font-face-format/index.md
+++ b/files/en-us/web/svg/element/font-face-format/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font-face-format>
 slug: Web/SVG/Element/font-face-format
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/font-face-name/index.md
+++ b/files/en-us/web/svg/element/font-face-name/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font-face-name>
 slug: Web/SVG/Element/font-face-name
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/font-face-src/index.md
+++ b/files/en-us/web/svg/element/font-face-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font-face-src>
 slug: Web/SVG/Element/font-face-src
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/font-face-uri/index.md
+++ b/files/en-us/web/svg/element/font-face-uri/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font-face-uri>
 slug: Web/SVG/Element/font-face-uri
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/font-face/index.md
+++ b/files/en-us/web/svg/element/font-face/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font-face>
 slug: Web/SVG/Element/font-face
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/font/index.md
+++ b/files/en-us/web/svg/element/font/index.md
@@ -1,6 +1,7 @@
 ---
 title: <font>
 slug: Web/SVG/Element/font
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/foreignobject/index.md
+++ b/files/en-us/web/svg/element/foreignobject/index.md
@@ -1,6 +1,7 @@
 ---
 title: <foreignObject>
 slug: Web/SVG/Element/foreignObject
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/g/index.md
+++ b/files/en-us/web/svg/element/g/index.md
@@ -1,6 +1,7 @@
 ---
 title: <g>
 slug: Web/SVG/Element/g
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/glyph/index.md
+++ b/files/en-us/web/svg/element/glyph/index.md
@@ -1,6 +1,7 @@
 ---
 title: <glyph>
 slug: Web/SVG/Element/glyph
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/glyphref/index.md
+++ b/files/en-us/web/svg/element/glyphref/index.md
@@ -1,6 +1,7 @@
 ---
 title: <glyphRef>
 slug: Web/SVG/Element/glyphRef
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/hkern/index.md
+++ b/files/en-us/web/svg/element/hkern/index.md
@@ -1,6 +1,7 @@
 ---
 title: <hkern>
 slug: Web/SVG/Element/hkern
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/image/index.md
+++ b/files/en-us/web/svg/element/image/index.md
@@ -1,6 +1,7 @@
 ---
 title: <image>
 slug: Web/SVG/Element/image
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG element reference
 slug: Web/SVG/Element
+page-type: landing-page
 tags:
   - Drawing
   - Elements

--- a/files/en-us/web/svg/element/line/index.md
+++ b/files/en-us/web/svg/element/line/index.md
@@ -1,6 +1,7 @@
 ---
 title: <line>
 slug: Web/SVG/Element/line
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/lineargradient/index.md
+++ b/files/en-us/web/svg/element/lineargradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: <linearGradient>
 slug: Web/SVG/Element/linearGradient
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/marker/index.md
+++ b/files/en-us/web/svg/element/marker/index.md
@@ -1,6 +1,7 @@
 ---
 title: <marker>
 slug: Web/SVG/Element/marker
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/mask/index.md
+++ b/files/en-us/web/svg/element/mask/index.md
@@ -1,6 +1,7 @@
 ---
 title: <mask>
 slug: Web/SVG/Element/mask
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/metadata/index.md
+++ b/files/en-us/web/svg/element/metadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: <metadata>
 slug: Web/SVG/Element/metadata
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/missing-glyph/index.md
+++ b/files/en-us/web/svg/element/missing-glyph/index.md
@@ -1,6 +1,7 @@
 ---
 title: <missing-glyph>
 slug: Web/SVG/Element/missing-glyph
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/element/mpath/index.md
+++ b/files/en-us/web/svg/element/mpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: <mpath>
 slug: Web/SVG/Element/mpath
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/path/index.md
+++ b/files/en-us/web/svg/element/path/index.md
@@ -1,6 +1,7 @@
 ---
 title: <path>
 slug: Web/SVG/Element/path
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/pattern/index.md
+++ b/files/en-us/web/svg/element/pattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: <pattern>
 slug: Web/SVG/Element/pattern
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/polygon/index.md
+++ b/files/en-us/web/svg/element/polygon/index.md
@@ -1,6 +1,7 @@
 ---
 title: <polygon>
 slug: Web/SVG/Element/polygon
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/polyline/index.md
+++ b/files/en-us/web/svg/element/polyline/index.md
@@ -1,6 +1,7 @@
 ---
 title: <polyline>
 slug: Web/SVG/Element/polyline
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/radialgradient/index.md
+++ b/files/en-us/web/svg/element/radialgradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: <radialGradient>
 slug: Web/SVG/Element/radialGradient
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/rect/index.md
+++ b/files/en-us/web/svg/element/rect/index.md
@@ -1,6 +1,7 @@
 ---
 title: <rect>
 slug: Web/SVG/Element/rect
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/script/index.md
+++ b/files/en-us/web/svg/element/script/index.md
@@ -1,6 +1,7 @@
 ---
 title: <script>
 slug: Web/SVG/Element/script
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/set/index.md
+++ b/files/en-us/web/svg/element/set/index.md
@@ -1,6 +1,7 @@
 ---
 title: <set>
 slug: Web/SVG/Element/set
+page-type: svg-element
 tags:
   - Element
   - SVG

--- a/files/en-us/web/svg/element/stop/index.md
+++ b/files/en-us/web/svg/element/stop/index.md
@@ -1,6 +1,7 @@
 ---
 title: <stop>
 slug: Web/SVG/Element/stop
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/style/index.md
+++ b/files/en-us/web/svg/element/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: <style>
 slug: Web/SVG/Element/style
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/svg/index.md
+++ b/files/en-us/web/svg/element/svg/index.md
@@ -1,6 +1,7 @@
 ---
 title: <svg>
 slug: Web/SVG/Element/svg
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/switch/index.md
+++ b/files/en-us/web/svg/element/switch/index.md
@@ -1,6 +1,7 @@
 ---
 title: <switch>
 slug: Web/SVG/Element/switch
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/symbol/index.md
+++ b/files/en-us/web/svg/element/symbol/index.md
@@ -1,6 +1,7 @@
 ---
 title: <symbol>
 slug: Web/SVG/Element/symbol
+page-type: svg-element
 tags:
   - SVG
   - SVG Container

--- a/files/en-us/web/svg/element/text/index.md
+++ b/files/en-us/web/svg/element/text/index.md
@@ -1,6 +1,7 @@
 ---
 title: <text>
 slug: Web/SVG/Element/text
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/textpath/index.md
+++ b/files/en-us/web/svg/element/textpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: <textPath>
 slug: Web/SVG/Element/textPath
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/title/index.md
+++ b/files/en-us/web/svg/element/title/index.md
@@ -1,6 +1,7 @@
 ---
 title: <title> — the SVG accessible name element
 slug: Web/SVG/Element/title
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/tref/index.md
+++ b/files/en-us/web/svg/element/tref/index.md
@@ -1,6 +1,7 @@
 ---
 title: <tref>
 slug: Web/SVG/Element/tref
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/tspan/index.md
+++ b/files/en-us/web/svg/element/tspan/index.md
@@ -1,6 +1,7 @@
 ---
 title: <tspan>
 slug: Web/SVG/Element/tspan
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -1,6 +1,7 @@
 ---
 title: <use>
 slug: Web/SVG/Element/use
+page-type: svg-element
 tags:
   - Element
   - Reference

--- a/files/en-us/web/svg/element/view/index.md
+++ b/files/en-us/web/svg/element/view/index.md
@@ -1,6 +1,7 @@
 ---
 title: <view>
 slug: Web/SVG/Element/view
+page-type: svg-element
 tags:
   - Element
   - NeedsExample

--- a/files/en-us/web/svg/element/vkern/index.md
+++ b/files/en-us/web/svg/element/vkern/index.md
@@ -1,6 +1,7 @@
 ---
 title: <vkern>
 slug: Web/SVG/Element/vkern
+page-type: svg-element
 tags:
   - Deprecated
   - Element

--- a/files/en-us/web/svg/index.md
+++ b/files/en-us/web/svg/index.md
@@ -1,6 +1,7 @@
 ---
-title: 'SVG: Scalable Vector Graphics'
+title: "SVG: Scalable Vector Graphics"
 slug: Web/SVG
+page-type: landing-page
 tags:
   - 2D Graphics
   - Graphics

--- a/files/en-us/web/svg/linking/index.md
+++ b/files/en-us/web/svg/linking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Linking
 slug: Web/SVG/Linking
+page-type: guide
 tags:
   - Guide
   - SVG

--- a/files/en-us/web/svg/namespaces_crash_course/example/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/example/index.md
@@ -1,6 +1,7 @@
 ---
 title: Example
 slug: Web/SVG/Namespaces_Crash_Course/Example
+page-type: guide
 tags:
   - SVG
   - XML

--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -1,6 +1,7 @@
 ---
 title: Namespaces crash course
 slug: Web/SVG/Namespaces_Crash_Course
+page-type: guide
 tags:
   - SVG
   - XML

--- a/files/en-us/web/svg/scripting/index.md
+++ b/files/en-us/web/svg/scripting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Scripting
 slug: Web/SVG/Scripting
+page-type: guide
 tags:
   - Graphics
   - SVG

--- a/files/en-us/web/svg/server-configuration/index.md
+++ b/files/en-us/web/svg/server-configuration/index.md
@@ -1,6 +1,7 @@
 ---
 title: Server configuration
 slug: Web/SVG/Server-configuration
+page-type: guide
 tags:
   - SVG
 ---

--- a/files/en-us/web/svg/specification_deviations/index.md
+++ b/files/en-us/web/svg/specification_deviations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Specification deviations
 slug: Web/SVG/Specification_Deviations
+page-type: guide
 tags:
   - SVG
 ---

--- a/files/en-us/web/svg/svg_animation_with_smil/index.md
+++ b/files/en-us/web/svg/svg_animation_with_smil/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG animation with SMIL
 slug: Web/SVG/SVG_animation_with_SMIL
+page-type: guide
 tags:
   - Animation
   - Firefox 4

--- a/files/en-us/web/svg/svg_as_an_image/index.md
+++ b/files/en-us/web/svg/svg_as_an_image/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG as an Image
 slug: Web/SVG/SVG_as_an_Image
+page-type: guide
 tags:
   - Images
   - NeedsContent

--- a/files/en-us/web/svg/tutorial/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorial/basic_shapes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic shapes
 slug: Web/SVG/Tutorial/Basic_Shapes
+page-type: guide
 tags:
   - Beginner
   - SVG

--- a/files/en-us/web/svg/tutorial/basic_transformations/index.md
+++ b/files/en-us/web/svg/tutorial/basic_transformations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic transformations
 slug: Web/SVG/Tutorial/Basic_Transformations
+page-type: guide
 tags:
   - Intermediate
   - SVG

--- a/files/en-us/web/svg/tutorial/clipping_and_masking/index.md
+++ b/files/en-us/web/svg/tutorial/clipping_and_masking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipping and masking
 slug: Web/SVG/Tutorial/Clipping_and_masking
+page-type: guide
 tags:
   - Advanced
   - SVG

--- a/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
+++ b/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fills and Strokes
 slug: Web/SVG/Tutorial/Fills_and_Strokes
+page-type: guide
 tags:
   - Beginner
   - NeedLiveSamples

--- a/files/en-us/web/svg/tutorial/filter_effects/index.md
+++ b/files/en-us/web/svg/tutorial/filter_effects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Filter effects
 slug: Web/SVG/Tutorial/Filter_effects
+page-type: guide
 tags:
   - Advanced
   - NeedsContent

--- a/files/en-us/web/svg/tutorial/getting_started/index.md
+++ b/files/en-us/web/svg/tutorial/getting_started/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started
 slug: Web/SVG/Tutorial/Getting_Started
+page-type: guide
 tags:
   - Beginner
   - NeedsBeginnerUpdate

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gradients in SVG
 slug: Web/SVG/Tutorial/Gradients
+page-type: guide
 tags:
   - Intermediate
   - SVG

--- a/files/en-us/web/svg/tutorial/index.md
+++ b/files/en-us/web/svg/tutorial/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Tutorial
 slug: Web/SVG/Tutorial
+page-type: guide
 tags:
   - Intermediate
   - NeedsContent

--- a/files/en-us/web/svg/tutorial/introduction/index.md
+++ b/files/en-us/web/svg/tutorial/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 slug: Web/SVG/Tutorial/Introduction
+page-type: guide
 tags:
   - Beginner
   - Guide

--- a/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
+++ b/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
@@ -1,6 +1,7 @@
 ---
 title: Other content in SVG
 slug: Web/SVG/Tutorial/Other_content_in_SVG
+page-type: guide
 tags:
   - Intermediate
   - SVG

--- a/files/en-us/web/svg/tutorial/paths/index.md
+++ b/files/en-us/web/svg/tutorial/paths/index.md
@@ -1,6 +1,7 @@
 ---
 title: Paths
 slug: Web/SVG/Tutorial/Paths
+page-type: guide
 tags:
   - Intermediate
   - SVG

--- a/files/en-us/web/svg/tutorial/patterns/index.md
+++ b/files/en-us/web/svg/tutorial/patterns/index.md
@@ -1,6 +1,7 @@
 ---
 title: Patterns
 slug: Web/SVG/Tutorial/Patterns
+page-type: guide
 tags:
   - Advanced
   - SVG

--- a/files/en-us/web/svg/tutorial/positions/index.md
+++ b/files/en-us/web/svg/tutorial/positions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Positions
 slug: Web/SVG/Tutorial/Positions
+page-type: guide
 tags:
   - Beginner
   - Coordinate systems

--- a/files/en-us/web/svg/tutorial/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorial/svg_and_css/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG and CSS
 slug: Web/SVG/Tutorial/SVG_and_CSS
+page-type: guide
 tags:
   - CSS
   - CSS:Getting_Started

--- a/files/en-us/web/svg/tutorial/svg_filters_tutorial/index.md
+++ b/files/en-us/web/svg/tutorial/svg_filters_tutorial/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG Filters Tutorial
 slug: Web/SVG/Tutorial/SVG_Filters_Tutorial
+page-type: guide
 tags:
   - SVG filters primitives
 ---

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG fonts
 slug: Web/SVG/Tutorial/SVG_fonts
+page-type: guide
 tags:
   - Advanced
   - NeedsUpdate

--- a/files/en-us/web/svg/tutorial/svg_image_tag/index.md
+++ b/files/en-us/web/svg/tutorial/svg_image_tag/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG image element
 slug: Web/SVG/Tutorial/SVG_Image_Tag
+page-type: guide
 tags:
   - Beginner
   - NeedsBeginnerUpdate

--- a/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
+++ b/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG In HTML Introduction
 slug: Web/SVG/Tutorial/SVG_In_HTML_Introduction
+page-type: guide
 tags:
   - Beginner
   - SVG

--- a/files/en-us/web/svg/tutorial/texts/index.md
+++ b/files/en-us/web/svg/tutorial/texts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Texts
 slug: Web/SVG/Tutorial/Texts
+page-type: guide
 tags:
   - Intermediate
   - SVG

--- a/files/en-us/web/svg/tutorial/tools_for_svg/index.md
+++ b/files/en-us/web/svg/tutorial/tools_for_svg/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tools for SVG
 slug: Web/SVG/Tutorial/Tools_for_SVG
+page-type: guide
 tags:
   - Intermediate
   - NeedsUpdate


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15539.

This PR updates the SVG pages to add the page types as described in https://github.com/mdn/content/issues/22762.

The reason I've chosen SVG next is that it will enable us to remove tag references from [CSSInfo.ejs](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSInfo.ejs), which will help out with the [tag removal project](https://github.com/mdn/mdn/issues/262).