### PR TITLE
Clarify prefixed numeric literal descriptions

### DIFF
--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -354,7 +354,7 @@ The decimal exponential literal is specified by the following format: `beN`; whe
 
 #### Binary
 
-Binary number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "B" (`0b` or `0B`). If the digit after the `0b` is not 0 or 1, the following {{jsxref("SyntaxError")}} is thrown: "missing binary digits after '0b'". If a digit other than 0 or 1 is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "unexpected token: numeric literal".
+Binary number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "B" (`0b` or `0B`). Any character after the `0b` that is not 0 or 1 will terminate the literal sequence.
 
 ```js-nolint
 0b10000000000000000000000000000000 // 2147483648

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -354,7 +354,7 @@ The decimal exponential literal is specified by the following format: `beN`; whe
 
 #### Binary
 
-Binary number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "B" (`0b` or `0B`). If the digits after the `0b` are not 0 or 1, the following {{jsxref("SyntaxError")}} is thrown: "Missing binary digits after 0b".
+Binary number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "B" (`0b` or `0B`). If the digit after the `0b` is not 0 or 1, the following {{jsxref("SyntaxError")}} is thrown: "missing binary digits after '0b'". If a digit other than 0 or 1 is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "unexpected token: numeric literal".
 
 ```js-nolint
 0b10000000000000000000000000000000 // 2147483648
@@ -364,7 +364,7 @@ Binary number syntax uses a leading zero followed by a lowercase or uppercase La
 
 #### Octal
 
-Octal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "O" (`0o` or `0O)`. If the digits after the `0o` are outside the range (01234567), the following {{jsxref("SyntaxError")}} is thrown: "Missing octal digits after 0o".
+Octal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "O" (`0o` or `0O)`. If the digit after the `0o` is outside the range (01234567), the following {{jsxref("SyntaxError")}} is thrown: "missing octal digits after '0o'". If a digit outside the octal range (i.e. 8 or 9) is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "unexpected token: numeric literal".
 
 ```js-nolint
 0O755 // 493
@@ -373,7 +373,7 @@ Octal number syntax uses a leading zero followed by a lowercase or uppercase Lat
 
 #### Hexadecimal
 
-Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). If the digits after 0x are outside the range (0123456789ABCDEF), the following {{jsxref("SyntaxError")}} is thrown: "Identifier starts immediately after numeric literal".
+Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). If the digit after 0x is outside the range (0123456789ABCDEF), the following {{jsxref("SyntaxError")}} is thrown: "missing hexadecimal digits after '0x'". If an [`ID_Start`](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) character outside the hexadecimal range is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "identifier starts immediately after numeric literal".
 
 ```js-nolint
 0xFFFFFFFFFFFFFFFFF // 295147905179352830000

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -364,7 +364,7 @@ Binary number syntax uses a leading zero followed by a lowercase or uppercase La
 
 #### Octal
 
-Octal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "O" (`0o` or `0O)`. If the digit after the `0o` is outside the range (01234567), the following {{jsxref("SyntaxError")}} is thrown: "missing octal digits after '0o'". If a digit outside the octal range (i.e. 8 or 9) is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "unexpected token: numeric literal".
+Octal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "O" (`0o` or `0O)`. Any character after the `0o` that is outside the range (01234567) will terminate the literal sequence.
 
 ```js-nolint
 0O755 // 493

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -373,7 +373,7 @@ Octal number syntax uses a leading zero followed by a lowercase or uppercase Lat
 
 #### Hexadecimal
 
-Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). If the digit after 0x is outside the range (0123456789ABCDEF), the following {{jsxref("SyntaxError")}} is thrown: "missing hexadecimal digits after '0x'". If an [`ID_Start`](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) character outside the hexadecimal range is used further along in the numeric literal, then the following {{jsxref("SyntaxError")}} is thrown: "identifier starts immediately after numeric literal".
+Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). Any character after the `0x` that is outside the range (0123456789ABCDEF) will terminate the literal sequence.
 
 ```js-nolint
 0xFFFFFFFFFFFFFFFFF // 295147905179352830000


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Clarify prefixed numeric literal descriptions in the javascript lexical grammar section.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I'm making the changes so that the documentation accurately reflects reality. How it will help other readers is I hope it will help to confuse people less, whereas before they might have been confused when they observed different behavior in the browser than what is stated in the documentation, and might have to waste time testing and understanding the nuance of numeric literals instead of being able to glean that information from the documentation.
