### PR TITLE
Fix "void tags" with "void elements"

### DIFF
--- a/files/en-us/glossary/html/index.md
+++ b/files/en-us/glossary/html/index.md
@@ -17,7 +17,7 @@ At that time, the W3C nearly abandoned HTML in favor of {{Glossary("XHTML")}}, p
 
 ## Concept and syntax
 
-An HTML document is a plaintext document structured with {{Glossary("element","elements")}}. Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty or _void_ tags that cannot enclose any text, for instance {{htmlelement("img")}}.
+An HTML document is a plaintext document structured with {{Glossary("element","elements")}}. Elements are surrounded by matching opening and closing {{Glossary("tag","tags")}}. Each tag begins and ends with angle brackets (`<>`). There are a few empty or _void_ elements that cannot enclose any text, for instance {{htmlelement("img")}}.
 
 You can extend HTML tags with {{Glossary("attribute","attributes")}}, which provide additional information affecting how the browser interprets the element:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix "void tags" with "void elements"

### Motivation

It should be corrected because `<img>` (which is mentioned in the article) is not a void tag but a void element.

### Additional details

A term definition of "void element": <https://developer.mozilla.org/en-US/docs/Glossary/Void_element>

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
