### PR TITLE
Document limitations of performance.getEntries* methods

### DIFF
--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -18,16 +18,16 @@ If you are only interested in performance entries of certain types or that have 
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
->
-> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
->
-> - `"element"` ({{domxref("PerformanceElementTiming")}})
-> - `"event"` ({{domxref("PerformanceEventTiming")}})
-> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
-> - `"layout-shift"` ({{domxref("LayoutShift")}})
-> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
->
-> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
+
+The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+
+- `"element"` ({{domxref("PerformanceElementTiming")}})
+- `"event"` ({{domxref("PerformanceEventTiming")}})
+- `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+- `"layout-shift"` ({{domxref("LayoutShift")}})
+- `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+
+To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -18,6 +18,16 @@ If you are only interested in performance entries of certain types or that have 
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
+>
+> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+>
+> - `"element"` ({{domxref("PerformanceElementTiming")}})
+> - `"event"` ({{domxref("PerformanceEventTiming")}})
+> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+> - `"layout-shift"` ({{domxref("LayoutShift")}})
+> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+>
+> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 
@@ -45,21 +55,17 @@ performance.mark("login-started");
 performance.mark("login-finished");
 performance.mark("form-sent");
 performance.mark("video-loaded");
-performance.measure(
-   "login-duration",
-   "login-started",
-   "login-finished"
- );
+performance.measure("login-duration", "login-started", "login-finished");
 
 const entries = performance.getEntries();
 
 entries.forEach((entry) => {
   if (entry.entryType === "mark") {
     console.log(`${entry.name}'s startTime: ${entry.startTime}`);
-  };
+  }
   if (entry.entryType === "measure") {
     console.log(`${entry.name}'s duration: ${entry.duration}`);
-  };
+  }
 });
 ```
 

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -18,16 +18,16 @@ If you are interested in performance entries of certain types, see {{domxref("Pe
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
->
-> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
->
-> - `"element"` ({{domxref("PerformanceElementTiming")}})
-> - `"event"` ({{domxref("PerformanceEventTiming")}})
-> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
-> - `"layout-shift"` ({{domxref("LayoutShift")}})
-> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
->
-> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
+
+The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+
+- `"element"` ({{domxref("PerformanceElementTiming")}})
+- `"event"` ({{domxref("PerformanceEventTiming")}})
+- `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+- `"layout-shift"` ({{domxref("LayoutShift")}})
+- `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+
+To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -18,6 +18,16 @@ If you are interested in performance entries of certain types, see {{domxref("Pe
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
+>
+> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+>
+> - `"element"` ({{domxref("PerformanceElementTiming")}})
+> - `"event"` ({{domxref("PerformanceEventTiming")}})
+> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+> - `"layout-shift"` ({{domxref("LayoutShift")}})
+> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+>
+> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -18,16 +18,16 @@ If you are interested in performance entries of certain name, see {{domxref("Per
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
->
-> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
->
-> - `"element"` ({{domxref("PerformanceElementTiming")}})
-> - `"event"` ({{domxref("PerformanceEventTiming")}})
-> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
-> - `"layout-shift"` ({{domxref("LayoutShift")}})
-> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
->
-> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
+
+The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+
+- `"element"` ({{domxref("PerformanceElementTiming")}})
+- `"event"` ({{domxref("PerformanceEventTiming")}})
+- `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+- `"layout-shift"` ({{domxref("LayoutShift")}})
+- `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+
+To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -18,6 +18,16 @@ If you are interested in performance entries of certain name, see {{domxref("Per
 
 > **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
+>
+> The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:
+>
+> - `"element"` ({{domxref("PerformanceElementTiming")}})
+> - `"event"` ({{domxref("PerformanceEventTiming")}})
+> - `"largest-contentful-paint"` ({{domxref("LargestContentfulPaint")}})
+> - `"layout-shift"` ({{domxref("LayoutShift")}})
+> - `"longtask"` ({{domxref("PerformanceLongTaskTiming")}})
+>
+> To access entries of these types, you must use a {{domxref("PerformanceObserver")}} instead.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Fix https://github.com/mdn/content/issues/22619. I've expanded the notebox to mention this limitation. Hopefully this will lead to even more encouragement to prefer PerformanceObserver objects.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

None.

### Related issues and pull requests

None.