### PR TITLE
Provide an await alternative example to fetch

### DIFF
--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -70,7 +70,7 @@ fetch('png-logo.png')
 .then((rs) => rs.pipeTo(new FinalDestinationStream()))
 ```
 
-Same but using await:
+The same example, but using {{jsxref("Operators/await", "await")}}:
 
 ```js
 (async () => {

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -73,12 +73,14 @@ fetch('png-logo.png')
 Same but using await:
 
 ```js
-// Fetch the original image
-let response = await fetch('png-logo.png')
-// Retrieve its body as ReadableStream
-let body = await response.body
-let rs = await body.pipeThrough(new PNGTransformStream())
-await rs.pipeTo(new FinalDestinationStream())
+(async () => {
+  // Fetch the original image
+  const response = await fetch("png-logo.png");
+  // Retrieve its body as ReadableStream
+  response.body
+    .pipeThrough(new PNGTransformStream())
+    .pipeTo(new FinalDestinationStream());
+})();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -70,6 +70,16 @@ fetch('png-logo.png')
 .then((rs) => rs.pipeTo(new FinalDestinationStream()))
 ```
 
+Same but using await:
+```js
+// Fetch the original image
+let response = await fetch('png-logo.png')
+// Retrieve its body as ReadableStream
+let body = await response.body
+let rs = await body.pipeThrough(new PNGTransformStream())
+await rs.pipeTo(new FinalDestinationStream())
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -71,6 +71,7 @@ fetch('png-logo.png')
 ```
 
 Same but using await:
+
 ```js
 // Fetch the original image
 let response = await fetch('png-logo.png')


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Provide an await alternative example use to fetch().

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
In my opinion, using async/await is easier to read and use than using the promise's `then`. That is corroborated by the reason why async/await was made in the first place.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
