### PR TITLE
Add example for retrieving current select option

### DIFF
--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.md
@@ -55,6 +55,16 @@ selectElem.addEventListener('change', () => {
 
 {{EmbedLiveSample("Examples", "200px", "120px")}}
 
+### Retrieving the Currently Selected Option
+
+```js
+const selectElem = document.getElementById('select')
+selectElem.addEventListener('change', () => {
+  const index = selectElem.selectedIndex;
+  const selectedOption = selectElem.options[selectedIndex];
+})
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added some sample code on how to get the currently selected slement for an HTMLSelectElement using the `selectedIndex` and `options` properties.

### Motivation

I think it would be helpful to have a section that explains the most common usage (I would think) of this property.

