### PR TITLE
example: complement Web API Response redirected.

### DIFF
--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -33,11 +33,15 @@ Checking to see if the response comes from a redirected request is as simple as 
 In the code below, a textual message is inserted into an element when a redirect occurred during the fetch operation.
 Note, however, that this isn't as safe as outright rejecting redirects if they're unexpected, as described under [Disallowing redirects](#disallowing_redirects) below.
 
+When being redirected, [Response.url](/en-US/docs/Web/API/Response/url) can be used for the final URL obtained after redirects.
+
 ```js
 fetch("awesome-picture.jpg")
   .then((response) => {
     const elem = document.getElementById("warning-message-box");
     elem.textContent = response.redirected ? "Unexpected redirect" : "";
+    // final url obtained after redirects
+    console.log(response.url);
     return response.blob();
   })
   .then((imageBlob) => {
@@ -45,6 +49,8 @@ fetch("awesome-picture.jpg")
     document.getElementById("img-element-id").src = imgObjectURL;
   });
 ```
+
+
 
 ### Disallowing redirects
 

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -33,7 +33,7 @@ Checking to see if the response comes from a redirected request is as simple as 
 In the code below, a textual message is inserted into an element when a redirect occurred during the fetch operation.
 Note, however, that this isn't as safe as outright rejecting redirects if they're unexpected, as described under [Disallowing redirects](#disallowing_redirects) below.
 
-The {{domxref("Response.url", "url") property returns the final URL after redirects.
+The {{domxref("Response.url", "url")}} property returns the final URL after redirects.
 
 ```js
 fetch("awesome-picture.jpg")

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -33,7 +33,7 @@ Checking to see if the response comes from a redirected request is as simple as 
 In the code below, a textual message is inserted into an element when a redirect occurred during the fetch operation.
 Note, however, that this isn't as safe as outright rejecting redirects if they're unexpected, as described under [Disallowing redirects](#disallowing_redirects) below.
 
-When being redirected, [Response.url](/en-US/docs/Web/API/Response/url) can be used for the final URL obtained after redirects.
+The {{domxref("Response.url", "url") property returns the final URL after redirects.
 
 ```js
 fetch("awesome-picture.jpg")

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -50,8 +50,6 @@ fetch("awesome-picture.jpg")
   });
 ```
 
-
-
 ### Disallowing redirects
 
 Because using redirected to manually filter out redirects can allow forgery of redirects, you should instead set the redirect mode to `"error"` in the `init` parameter when calling {{domxref("fetch()")}}, like this:


### PR DESCRIPTION
Flag the url change as well as associate with another property `Response.rul` in redirected examples/scenarios.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Also flag the change reflected in another property `Response.url` in redirected scenarios to better associate the properties in `Response` API/object.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Adding the change took place in `Response.redirected` example will help developer understand `Response` API better and be aware of the corresponding change in `Response.url` that they may want to leverage.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Same as described above, adding `Response.url` in `Response.redirected` example will better help readers to associate the knowledge/information.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
