### PR TITLE
Clipboard.write: document file type limitations

### DIFF
--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -32,7 +32,7 @@ automatically to pages when they are in the active tab.
 > {{SectionOnPage("/en-US/docs/Web/API/Clipboard", "Clipboard availability")}} for more
 > information.
 
-> **Note:** For parity with Google Chrome, Firefox only allows this function to work with text, HTML, and PNG data. 
+> **Note:** For parity with Google Chrome, Firefox only allows this function to work with text, HTML, and PNG data.
 
 ## Syntax
 

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -32,6 +32,8 @@ automatically to pages when they are in the active tab.
 > {{SectionOnPage("/en-US/docs/Web/API/Clipboard", "Clipboard availability")}} for more
 > information.
 
+> **Note:** For parity with Google Chrome, Firefox only allows this function to work with text, HTML, and PNG data. 
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description

Listed the file types that can be written to the clipboard, based on Firefox source code.

### Motivation

No official documentation exists listing which file types are allowed. The API throws a JavaScript error if you pass in a bad type, but doesn't tell you which types are valid. Moreover, JavaScript errors cannot be relied upon, as JavaScript error reporting for WebExtensions has been broken for the last five years (see Bugzilla bug 1410932).

I personally ended up wasting several hours, a long while back, trying to get Clipboard.write working on arbitrary images due to the WebExtensions issue, before eventually having to dig through Firefox's own source code to identify the problem.

### Additional details

File type limits are enforced by [`mozilla::dom::IsValidType`](https://searchfox.org/mozilla-central/source/dom/events/Clipboard.cpp#523). This is [checked](https://searchfox.org/mozilla-central/source/dom/events/Clipboard.cpp#536) by `mozilla::dom::GetClipboardNativeItem`, which in turn [is used](https://searchfox.org/mozilla-central/source/dom/events/Clipboard.cpp#629) by `mozilla::dom::Clipboard::Write`, the underlying implementation for the JavaScript `Clipboard.write` API.

Comments on the former function indicate that these limits exist to maintain parity with Google Chrome.