### PR TITLE
ci(markdown-lint-fix): use PAT to trigger workflow

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -39,6 +39,7 @@ jobs:
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             All issues auto-fixed
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
 
       - name: Create PR with notice on unfixed issues
         if: failure()
@@ -51,3 +52,4 @@ jobs:
           body: |
             Auto-fix was run, but additional issues found.
             Please review the run log: https://github.com/mdn/content/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

reflect of mdn/translated-content#10235. So we can trigger workflow runs for PRs that are created by this workflow.
