### PR TITLE
expanded link

### DIFF
--- a/files/en-us/web/html/element/source/index.md
+++ b/files/en-us/web/html/element/source/index.md
@@ -78,7 +78,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("type")}}
 
-  - : The [MIME media type of the resource](/en-US/docs/Web/Media/Formats/Image_types), optionally with a [`codecs` parameter](/en-US/docs/Web/Media/Formats/codecs_parameter).
+  - : The [MIME media type of the image](/en-US/docs/Web/Media/Formats/Image_types) or [other media type](/en-US/docs/Web/Media/Formats/Containers), optionally with a [`codecs` parameter](/en-US/docs/Web/Media/Formats/codecs_parameter).
 
 - {{htmlattrdef("src")}}
 


### PR DESCRIPTION
The link appeared to be for all mime types, but only linked to image. separated it into two links, keeping images while adding a link to [media format](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
