### PR TITLE
Glossary: grammatical fix for non-normative entry

### DIFF
--- a/files/en-us/glossary/non-normative/index.md
+++ b/files/en-us/glossary/non-normative/index.md
@@ -7,7 +7,7 @@ tags:
   - Standardization
 ---
 
-Software {{Glossary("specification", "specifications")}} often contains information marked as **non-normative** or _informative_, which means that those are provided there to help the readers to understand the specification better or to show an example or a best practice and not need to be followed as a rule. Sections that contain the official part of the specification that must be followed are often marked as {{Glossary("normative")}}.
+Software {{Glossary("specification", "specifications")}} often contain information marked as **non-normative** or _informative_, which means that those are provided there to help the readers to understand the specification better or to show an example or a best practice and not need to be followed as a rule. Sections that contain the official part of the specification that must be followed are often marked as {{Glossary("normative")}}.
 
 ## See also
 

--- a/files/en-us/glossary/non-normative/index.md
+++ b/files/en-us/glossary/non-normative/index.md
@@ -7,7 +7,7 @@ tags:
   - Standardization
 ---
 
-Software {{Glossary("specification", "specifications")}} often contain information marked as **non-normative** or _informative_, which means that those are provided there to help the readers to understand the specification better or to show an example or a best practice and not need to be followed as a rule. Sections that contain the official part of the specification that must be followed are often marked as {{Glossary("normative")}}.
+Software {{Glossary("specification", "specifications")}} often contain information marked as **non-normative** or _informative_, which is provided to help readers understand the specification better or to show an example or best practice. This part of the specification does not need to be followed as a rule. Sections that contain the official part of the specification that must be followed are often marked as {{Glossary("normative")}}.
 
 ## See also
 

--- a/files/en-us/glossary/non-normative/index.md
+++ b/files/en-us/glossary/non-normative/index.md
@@ -7,7 +7,7 @@ tags:
   - Standardization
 ---
 
-Software {{Glossary("specification", "specifications")}} often contain information marked as **non-normative** or _informative_, which is provided to help readers understand the specification better or to show an example or best practice. This part of the specification does not need to be followed as a rule. Sections that contain the official part of the specification that must be followed are often marked as {{Glossary("normative")}}.
+Software {{Glossary("specification", "specifications")}} often contain information marked as **non-normative** or _informative_, which is provided to help readers understand the specification better, or to show an example or best practice. Non-normative parts of the specification are provided as guidelines, and are not considered part of the formal specification. Sections that contain the official part of the specification are often marked as {{Glossary("normative")}}.
 
 ## See also
 


### PR DESCRIPTION
### Description

Contains should be conjugated in the plural form to match 'software specifications' being plural as the subject.  Included a second minor tweak to improve clarity, but I can drop that commit if a more concise fix is desired.

### Motivation

Improving the glossary.