### PR TITLE
FF108 RelNote: Import maps are supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -52,7 +52,7 @@ This article provides information about the changes in Firefox 108 that will aff
 ### APIs
 
 - [Import maps](/en-US/docs/Web/HTML/Element/script/type/importmap) are now supported.
-  These allow more flexible and ergonomic module specifiers when importing [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules).
+  Import maps provide flexibility and additional control over how browsers resolve module specifiers when importing [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules).
   ({{bug(1795647)}}).
 
 #### DOM

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -51,6 +51,10 @@ This article provides information about the changes in Firefox 108 that will aff
 
 ### APIs
 
+- [Import maps](/en-US/docs/Web/HTML/Element/script/type/importmap) are now supported.
+  These allow more flexible and ergonomic module specifiers when importing [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules).
+  ({{bug(1795647)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF108 adds support for import maps - this adds the release note.

This depends on #22300 because that adds the docs this links to. 

Other docs work for this can be tracked in #16150

