### PR TITLE
AudioNode.channelCountMode - table as definition list in value

### DIFF
--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -23,12 +23,11 @@ The possible values of the `channelCountMode` enumerated value, and their meanin
 - `max`
   - : The number of channels is equal to the maximum number of channels of all connections.
     In this case, `channelCount` is ignored and only up-mixing happens.
-    
+
     The following AudioNode children default to this value: {{domxref("GainNode")}}, {{domxref("DelayNode")}}, {{domxref("ScriptProcessorNode")}}, {{domxref("BiquadFilterNode")}}, {{domxref("WaveShaperNode")}}.
-    
 - `clamped-max`
   - : The number of channels is equal to the maximum number of channels of all connections, clamped to the value of `channelCount`.
-  
+
     The following AudioNode children default to this value: {{domxref("PannerNode")}}, {{domxref("ConvolverNode")}}, {{domxref("DynamicsCompressorNode")}}
 - `explicit`
   - :	The number of channels is defined by the value of `channelCount`.

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -16,65 +16,26 @@ browser-compat: api.AudioNode.channelCountMode
 
 The `channelCountMode` property of the {{ domxref("AudioNode") }} interface represents an enumerated value describing the way channels must be matched between the node's inputs and outputs.
 
-The possible values of `channelCountMode` and their meanings are:
-
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Value</th>
-      <th scope="col">Description</th>
-      <th scope="col">
-        The following <code>AudioNode</code> children default to this value
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>max</code></td>
-      <td>
-        The number of channels is equal to the maximum number of channels of all
-        connections. In this case, <code>channelCount</code> is ignored and only
-        up-mixing happens.
-      </td>
-      <td>
-        {{domxref("GainNode")}}, {{domxref("DelayNode")}},
-        {{domxref("ScriptProcessorNode")}},
-        {{domxref("BiquadFilterNode")}},
-        {{domxref("WaveShaperNode")}}
-      </td>
-    </tr>
-    <tr>
-      <td><code>clamped-max</code></td>
-      <td>
-        The number of channels is equal to the maximum number of channels of all
-        connections, <em>clamped</em> to the value of <code>channelCount</code>.
-      </td>
-      <td>
-        {{domxref("PannerNode")}}, {{domxref("ConvolverNode")}},
-        {{domxref("DynamicsCompressorNode")}}
-      </td>
-    </tr>
-    <tr>
-      <td><code>explicit</code></td>
-      <td>
-        The number of channels is defined by the value of
-        <code>channelCount</code>.
-      </td>
-      <td>
-        {{domxref("AudioDestinationNode")}},
-        {{domxref("AnalyserNode")}},
-        {{domxref("ChannelSplitterNode")}},
-        {{domxref("ChannelMergerNode")}}
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-> **Note:** In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was max.
-
 ## Value
 
-An enumerated value representing a [channelCountMode](https://webaudio.github.io/web-audio-api/#idl-def-ChannelCountMode).
+The possible values of the `channelCountMode` enumerated value, and their meanings are:
+
+- `max`
+  - : The number of channels is equal to the maximum number of channels of all connections.
+    In this case, `channelCount` is ignored and only up-mixing happens.
+    
+    The following AudioNode children default to this value: {{domxref("GainNode")}}, {{domxref("DelayNode")}}, {{domxref("ScriptProcessorNode")}}, {{domxref("BiquadFilterNode")}}, {{domxref("WaveShaperNode")}}.
+    
+- `clamped-max`
+  - : The number of channels is equal to the maximum number of channels of all connections, clamped to the value of `channelCount`.
+  
+    The following AudioNode children default to this value: {{domxref("PannerNode")}}, {{domxref("ConvolverNode")}}, {{domxref("DynamicsCompressorNode")}}
+- `explicit`
+  - :	The number of channels is defined by the value of `channelCount`.
+
+    The following AudioNode children default to this value: {{domxref("AudioDestinationNode")}}, {{domxref("AnalyserNode")}}, {{domxref("ChannelSplitterNode")}}, {{domxref("ChannelMergerNode")}}
+
+> **Note:** In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was `max`.
 
 ## Examples
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -30,7 +30,7 @@ The possible values of the `channelCountMode` enumerated value, and their meanin
 
     The following AudioNode children default to this value: {{domxref("PannerNode")}}, {{domxref("ConvolverNode")}}, {{domxref("DynamicsCompressorNode")}}
 - `explicit`
-  - :	The number of channels is defined by the value of `channelCount`.
+  - : The number of channels is defined by the value of `channelCount`.
 
     The following AudioNode children default to this value: {{domxref("AudioDestinationNode")}}, {{domxref("AnalyserNode")}}, {{domxref("ChannelSplitterNode")}}, {{domxref("ChannelMergerNode")}}
 


### PR DESCRIPTION
This moves a table that was a description for `AudioNode.channelCountMode` into the value section - which is IMO where it belongs.