### PR TITLE
fix(ci): do not paginate for fetching file changes

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -23,7 +23,6 @@ jobs:
           # Use the GitHub API to get the list of changed files
           # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
-            --paginate \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
           # filter out files that are not markdown
           DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -39,7 +39,6 @@ jobs:
           # Use the GitHub API to get the list of changed files
           # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
-            --paginate \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 
           # filter out files that are not markdown files


### PR DESCRIPTION
### Description

ci: do not paginate for fetching file changes. For the paginated API call's response will not contain the files field (all in the first call).

### Motivation

See https://github.com/mdn/content/actions/runs/3673568856/jobs/6210798159

### Related issues and pull requests

#22439
