### PR TITLE
Experimental Features: FF109 enables 'scrollend' by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1648,6 +1648,49 @@ See these bugs for details: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556365)}}
   </tbody>
 </table>
 
+#### Document and element scrollend events
+
+The `scrollend` event indicates that the user has completed scrolling in {{domxref("Element")}} and {{domxref("Document")}} objects.
+For more information, see the [Element scrollend event](/en-US/docs/Web/API/Element/scrollend_event) and [Document scrollend event](/en-US/docs/Web/API/Document/scrollend_event) documentation ({{bug(1797013)}}, {{bug(1803435)}}).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>109</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>108</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td>
+        <code>apz.scrollend-event.content.enabled</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### Payment Request API
 
 #### Primary payment handling

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1648,10 +1648,10 @@ See these bugs for details: {{bug(1556362)}}, {{bug(1556373)}}, {{bug(1556365)}}
   </tbody>
 </table>
 
-#### Document and element scrollend events
+#### Document and Element scrollend events
 
 The `scrollend` event indicates that the user has completed scrolling in {{domxref("Element")}} and {{domxref("Document")}} objects.
-For more information, see the [Element scrollend event](/en-US/docs/Web/API/Element/scrollend_event) and [Document scrollend event](/en-US/docs/Web/API/Document/scrollend_event) documentation ({{bug(1797013)}}, {{bug(1803435)}}).
+For more information, see [Element: `scrollend` event](/en-US/docs/Web/API/Element/scrollend_event) and [Document: `scrollend` event](/en-US/docs/Web/API/Document/scrollend_event) ({{bug(1797013)}}, {{bug(1803435)}}).
 
 <table>
   <thead>


### PR DESCRIPTION
This PR adds experimental note for the `onscrollend` event which is fired when scrolling is complete inside scrollable elements or a Document.

This was added in 108 behind the pref which is enabled by default in 109.

__Related issues and pull requests:__
- [x] BCD https://github.com/mdn/browser-compat-data/pull/18407
- [x] Content https://github.com/mdn/content/pull/22894
- [ ] parent issue https://github.com/mdn/content/issues/22814
