### PR TITLE
Corrected formatting mistake

### DIFF
--- a/files/en-us/web/css/shorthand_properties/index.md
+++ b/files/en-us/web/css/shorthand_properties/index.md
@@ -56,7 +56,7 @@ Shorthands handling properties related to edges of a box, like {{cssxref("border
 
 - **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top edge, the second, the horizontal, that is left and right, ones, and the third value the bottom edge: ![Box edges with three-value syntax](border3.png)
 
-- **4-value syntax:** border-width: 1em 2em 3em 4em — The four values represent the top, right, bottom and left edges respectively, always in that order, that is clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
+- **4-value syntax:** `border-width: 1em 2em 3em 4em` — The four values represent the top, right, bottom and left edges respectively, always in that order, that is clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
 
 #### Corners of a box
 


### PR DESCRIPTION
### Description

Added backticks around a code fragment that was formatted as plain text rather than code, whereas all corresponding instances were correctly formatted as code.

### Before

> - 1-value syntax: `border-width: 1em`
> - 2-value syntax: `border-width: 1em 2em`
> - 3-value syntax: `border-width: 1em 2em 3em`
> - ***4-value syntax: border-width: 1em 2em 3em 4em***

### After

> - 1-value syntax: `border-width: 1em`
> - 2-value syntax: `border-width: 1em 2em`
> - 3-value syntax: `border-width: 1em 2em 3em`
> - ***4-value syntax: `border-width: 1em 2em 3em 4em`***