### PR TITLE
typo remove method

### DIFF
--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -181,7 +181,7 @@ In `presentation.html`:
       connection !== newConnection &&
       connection.state !== "closed"
     ) {
-      connection.onclosed = undefined;
+      connection.onclose = undefined;
       connection.close();
     }
 


### PR DESCRIPTION
typo

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This logic is remove method when reconnect.

Target method name is `onclose` .

```js
    connection.onclose = () => {
      connection = null;
      showDisconnectedUI();
    };
```

But, this logic remove `onclosed` method.

```js
    // Disconnect from existing presentation, if not attempting to reconnect
    if (
      connection &&
      connection !== newConnection &&
      connection.state !== "closed"
    ) {
      connection.onclosed = undefined;
      connection.close();
    }
```

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

I posted PR same issue for W3C.
https://github.com/w3c/presentation-api/pull/508

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
