### PR TITLE
docs(API): Add note that scrollend is experimental

### DIFF
--- a/files/en-us/web/api/document/scrollend_event/index.md
+++ b/files/en-us/web/api/document/scrollend_event/index.md
@@ -6,6 +6,7 @@ browser-compat: api.Document.scrollend_event
 ---
 
 {{APIRef}}
+{{SeeCompatTable}}
 
 The **`scrollend`** event fires when the document view has completed scrolling.
 Scrolling is considered completed when the scroll position has no more pending updates and the user has completed their gesture.

--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -12,6 +12,7 @@ browser-compat: api.Element.scroll_event
 ---
 
 {{APIRef}}
+{{SeeCompatTable}}
 
 The **`scroll`** event fires when an element has been scrolled.
 To detect when scrolling has completed, see the {{domxref("Element/scrollend_event", "Element: scrollend event")}}.


### PR DESCRIPTION
See https://github.com/mdn/content/issues/22814

This feature is only behind preferences in both Chrome and Fx

__Related issues and pull requests:__
- [ ] https://github.com/mdn/browser-compat-data/pull/18407


__Support details:__
- Fx:
    - __108__ behind pref `apz.scrollend-event.content.enabled`
    - __109__ pref `apz.scrollend-event.content.enabled` set to `true` by default
- Chrome:
    - __110__ behind [CL flag](https://bugs.chromium.org/p/chromium/issues/detail?id=907601) `use --enable-blink-features=OverscrollCustomization` (see [platform status page](https://chromestatus.com/feature/5186382643855360))
