### PR TITLE
docs(API): Correct note that scrollend is experimental, not element scroll

### DIFF
--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -12,7 +12,6 @@ browser-compat: api.Element.scroll_event
 ---
 
 {{APIRef}}
-{{SeeCompatTable}}
 
 The **`scroll`** event fires when an element has been scrolled.
 To detect when scrolling has completed, see the {{domxref("Element/scrollend_event", "Element: scrollend event")}}.

--- a/files/en-us/web/api/element/scrollend_event/index.md
+++ b/files/en-us/web/api/element/scrollend_event/index.md
@@ -6,6 +6,7 @@ browser-compat: api.Element.scrollend_event
 ---
 
 {{APIRef}}
+{{SeeCompatTable}}
 
 The **`scrollend`** event fires when element scrolling has completed.
 Scrolling is considered completed when the scroll position has no more pending updates and the user has completed their gesture.


### PR DESCRIPTION
Correct mistake introduced in https://github.com/mdn/content/pull/22945