### PR TITLE
Update WebGL1 texImage2D example

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -21,7 +21,6 @@ image.
 
 ```js-nolint
 // WebGL1
-texImage2D(target, level, internalformat, width, height, border, format, type)
 texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels can be a TypedArray or a DataView or null
 texImage2D(target, level, internalformat, format, type, pixels) // pixels cannot be a TypedArray or a DataView or null
 

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -22,9 +22,8 @@ image.
 ```js-nolint
 // WebGL1
 texImage2D(target, level, internalformat, width, height, border, format, type)
-texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels a TypedArray or a DataView
-texImage2D(target, level, internalformat, format, type)
-texImage2D(target, level, internalformat, format, type, pixels)
+texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels can be a TypedArray or a DataView or null
+texImage2D(target, level, internalformat, format, type, pixels) // pixels cannot be a TypedArray or a DataView or null
 
 
 // WebGL2


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Hi, I was using this documentation for reference and found out that the overload  `texImage2D(target, level, internalformat, format, type)` and `texImage2D(target, level, internalformat, width, height, border, format, type, pixels) ` are actually not supported by either Firefox or Chrome. They is not even part of the WebGL1 specification: https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8.

Also, `texImage2D(target, level, internalformat, format, type, pixels)` does not work with TypedArray or a DataView or null  so just for clarity I propose also updating the comment in the example.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
- Remove the example which is not implemented in the browser and does not conform to WebGL1 specifications.
- Make the code comment more descriptive
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
You can verify the issue using this [jsfiddle](https://jsfiddle.net/f405whr8/10/) and [jsfiddle2](https://jsfiddle.net/cm9etons/3/)
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
