### PR TITLE
Clean up the functions reference page

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -74,10 +74,10 @@ The [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) keyword refers
 
 Broadly speaking, JavaScript has four kinds of functions:
 
-- Regular functions: can return anything; always runs to completion after invocation
-- Generator functions: returns a [`Generator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object; can be paused and resumed with the [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) operator
-- Async functions: returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise); can be paused and resumed with the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator
-- Async generator functions: returns an [`AsyncGenerator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) object; both the `await` and `yield` operators can be used
+- Regular function: can return anything; always runs to completion after invocation
+- Generator function: returns a [`Generator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object; can be paused and resumed with the [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) operator
+- Async function: returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise); can be paused and resumed with the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator
+- Async generator function: returns an [`AsyncGenerator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) object; both the `await` and `yield` operators can be used
 
 For every kind of function, there are three ways to define it:
 
@@ -128,7 +128,7 @@ All syntaxes do approximately the same thing, but there are some subtle behavior
 - The `Function()` constructor cannot access any local variables — it only has access to the global scope.
 - The `Function()` constructor causes runtime compilation and is often slower than other syntaxes.
 
-For `function` expressions, there is a distinction between the function name and the variable the function is assigned to. The function name cannot be changed, while the variable the function is assigned to can be reassigned. The function name can be different from the variable the function is assigned to — they have no relation to each other. The function name can be used only within the function's body. Attempting to use it outside the function's body results in an error (or get another value, if the same name is declared elsewhere). For example:
+For `function` expressions, there is a distinction between the function name and the variable the function is assigned to. The function name cannot be changed, while the variable the function is assigned to can be reassigned. The function name can be different from the variable the function is assigned to — they have no relation to each other. The function name can be used only within the function's body. Attempting to use it outside the function's body results in an error (or gets another value, if the same name is declared elsewhere). For example:
 
 ```js
 const y = function x() {};
@@ -183,7 +183,7 @@ myFunc();
 // 5 (for 'cons' by Function constructor (global scope))
 ```
 
-Functions defined by function expressions and function declarations are parsed only once, while those defined by the `Function` constructor parses the string passed to it each and every time the constructor is called. Although a function expression creates a closure every time, the function body is not reparsed, so function expressions are still faster than `new Function(...)`. Therefore the `Function` constructor should generally be avoided whenever possible.
+Functions defined by function expressions and function declarations are parsed only once, while a function defined by the `Function` constructor parses the string passed to it each and every time the constructor is called. Although a function expression creates a closure every time, the function body is not reparsed, so function expressions are still faster than `new Function(...)`. Therefore the `Function` constructor should generally be avoided whenever possible.
 
 A function declaration may be unintentionally turned into a function expression when it appears in an expression context.
 
@@ -311,7 +311,7 @@ if (shouldDefineZero) {
 }
 ```
 
-The semantics of this in strict mode is well-specified — `zero` only ever exists within that scope of the `if` block. If `shouldDefineZero` is false, then `zero` should never be defined, since the block never executes. However, historically, this was left unspecified, so different browsers implemented it differently in non-strict mode. For more information, see the [`function` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function#block-level_function_declaration) reference.
+The semantics of this in strict mode are well-specified — `zero` only ever exists within that scope of the `if` block. If `shouldDefineZero` is false, then `zero` should never be defined, since the block never executes. However, historically, this was left unspecified, so different browsers implemented it differently in non-strict mode. For more information, see the [`function` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function#block-level_function_declaration) reference.
 
 A safer way to define functions conditionally is to assign a function expression to a variable:
 

--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -14,386 +14,134 @@ browser-compat: javascript.functions
 
 {{jsSidebar("Functions")}}
 
-Generally speaking, a function is a "subprogram" that can be _called_ by code
-external (or internal in the case of recursion) to the function. Like the program
-itself, a function is composed of a sequence of statements called the _function
-body_. Values can be _passed_ to a function, and the function
-will _return_ a value.
+Generally speaking, a function is a "subprogram" that can be _called_ by code external (or internal, in the case of recursion) to the function. Like the program itself, a function is composed of a sequence of statements called the _function body_. Values can be _passed_ to a function as parameters, and the function will _return_ a value.
 
-In JavaScript, functions are first-class objects, because they can have properties and
-methods just like any other object. What distinguishes them from other objects is that
-functions can be called. In brief, they are
-[`Function`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-objects.
+In JavaScript, functions are [first-class objects](/en-US/docs/Glossary/First-class_Function), because they can be passed to other functions, returned from functions, and assigned to variables and properties. They can also have properties and methods just like any other object. What distinguishes them from other objects is that functions can be called.
 
-For more examples and explanations,
-see the [JavaScript guide about functions](/en-US/docs/Web/JavaScript/Guide/Functions).
+For more examples and explanations, see the [JavaScript guide about functions](/en-US/docs/Web/JavaScript/Guide/Functions).
 
 ## Description
 
-Every function in JavaScript is a `Function` object. See
-{{jsxref("Function")}} for information on properties and methods of
-`Function` objects.
+Function values are typically instances of [`Function`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function). See {{jsxref("Function")}} for information on properties and methods of `Function` objects. Callable values cause [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) to return `"function"` instead of `"object"`.
 
-To return a value other than the default, a function must have a
-[`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return)
-statement that specifies the value to return. A function without a return statement
-will return a default value. In the case of a [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor)
-called with the
-[`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)
-keyword, the default value is the value of its `this` parameter. For all
-other functions, the default return value is {{jsxref("undefined")}}.
+> **Note:** Not all callable values are `instanceof Function`. For example, the `Function.prototype` object is callable but not an instance of `Function`. You can also manually set the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of your function so it no longer inherits from `Function.prototype`. However, such cases are extremely rare.
 
-The parameters of a function call are the function's _arguments_. Arguments may be passed _by value_
-(in the case of [primitive values](/en-US/docs/Web/JavaScript/Data_structures#primitive_values))
-or _by reference_ (in the case of [objects](/en-US/docs/Web/JavaScript/Data_structures#objects)).
-This means that if a function reassigns a primitive type parameter, the value won't change outside the function. In the case of
-an object type parameter, if its properties are mutated, the change will impact outside of the function.
-See the following example:
+By default, if a function's execution doesn't end at a [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement, or if the `return` keyword doesn't have an expression after it, then the return value is {{jsxref("undefined")}}. The `return` statement allows you to return an arbitrary value from the function. One function call can only return one value, but you can simulate the effect of returning multiple values by returning an object or array and [destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the result.
+
+> **Note:** Constructors called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) have a different set of logic to determine their return values.
+
+[Parameters and arguments](<https://en.wikipedia.org/wiki/Parameter_(computer_programming)#Parameters_and_arguments>) have slightly different meanings, but in MDN web docs, we often use them interchangeably. For a quick reference:
 
 ```js
-/* Declare the function 'myFunc' */
-function myFunc(theObject) {
-  theObject.brand = "Toyota";
+function formatNumber(num) {
+  return num.toFixed(2);
 }
 
-/*
- * Declare variable 'mycar';
- * create and initialize a new Object;
- * assign reference to it to 'mycar'
- */
-const mycar = {
+formatNumber(2);
+```
+
+In this example, the `num` variable is called the function's _parameter_: it's declared in the bracket-enclosed list of the function's definition. The function expects the `num` parameter to be a number — although this is not enforceable in JavaScript without writing runtime validation code. In the `formatNumber(2)` call, the number `2` is the function's _argument_: it's the value that is actually passed to the function in the function call. The argument value can be accessed inside the function body through the corresponding parameter name or the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object.
+
+Arguments are always [_passed by value_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_reference) and never _passed by reference_. This means that if a function reassigns a parameter, the value won't change outside the function. More precisely, object arguments are [_passed by sharing_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing), which means if the object's properties are mutated, the change will impact the outside of the function. For example:
+
+```js
+function updateBrand(obj) {
+  // Mutating the object is visible outside the function
+  obj.brand = "Toyota";
+  // Try to reassign the parameter, but this won't affect
+  // the variable's value outside the function
+  obj = null;
+}
+
+const car = {
   brand: "Honda",
   model: "Accord",
-  year: 1998
+  year: 1998,
 };
 
-/* Logs 'Honda' */
-console.log(mycar.brand);
+console.log(car.brand); // Honda
 
-/* Pass object reference to the function */
-myFunc(mycar);
+// Pass object reference to the function
+updateBrand(car);
 
-/*
- * Logs 'Toyota' as the value of the 'brand' property
- * of the object, as changed to by the function.
- */
-console.log(mycar.brand);
+// updateBrand mutates car
+console.log(car.brand); // Toyota
 ```
 
-The [`this` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this)
-does not refer to the currently executing function, so you must refer to
-`Function` objects by name, even within the function body.
+The [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) keyword refers to the object that the function is accessed on — it does not refer to the currently executing function, so you must refer to the function value by name, even within the function body.
 
-## Defining functions
+### Defining functions
 
-There are several ways to define functions:
+Broadly speaking, JavaScript has four kinds of functions:
 
-### The function declaration
+- Regular functions: can return anything; always runs to completion after invocation
+- Generator functions: returns a [`Generator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object; can be paused and resumed with the [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) operator
+- Async functions: returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise); can be paused and resumed with the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator
+- Async generator functions: returns an [`AsyncGenerator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) object; both the `await` and `yield` operators can be used
 
-There is a special syntax for declaring functions
-(see [function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function) for details):
+For every kind of function, there are three ways to define it:
 
-```js
-function name([param[, param[, ... param]]]) {
-  statements
-}
-```
+- Declaration
+  - : [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function), [`function*`](/en-US/docs/Web/JavaScript/Reference/Statements/function*), [`async function`](/en-US/docs/Web/JavaScript/Reference/Statements/async_function), [`async function*`](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*)
+- Expression
+  - : [`function`](/en-US/docs/Web/JavaScript/Reference/Operators/function), [`function*`](/en-US/docs/Web/JavaScript/Reference/Operators/function*), [`async function`](/en-US/docs/Web/JavaScript/Reference/Operators/async_function), [`async function*`](/en-US/docs/Web/JavaScript/Reference/Operators/async_function*)
+- Constructor
+  - : [`Function()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function), [`GeneratorFunction()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/GeneratorFunction), [`AsyncFunction()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/AsyncFunction), [`AsyncGeneratorFunction()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction/AsyncGeneratorFunction)
 
-- `name`
-  - : The function name.
-- `param`
-  - : The name of an argument to be passed to the function.
-- `statements`
-  - : The statements comprising the body of the function.
-
-### The function expression
-
-A function expression is similar to and has the same syntax as a function declaration
-(see [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) for details).
-A function expression may be a part of a larger expression.
-One can define "named" function expressions (where the name of the
-expression might be used in the call stack for example) or "anonymous" function
-expressions. Function expressions are not _hoisted_ onto the beginning of the
-scope, therefore they cannot be used before they appear in the code.
+In addition, there are special syntaxes for defining [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and [methods](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions), which provide more precise semantics for their usage. [Classes](/en-US/docs/Web/JavaScript/Reference/Classes) are conceptually not functions (because they throw an error when called without `new`), but they also inherit from `Function.prototype` and have `typeof MyClass === "function"`.
 
 ```js
-function [name]([param[, param[, ... param]]]) {
-  statements
-}
-```
+// Constructor
+const multiply = new Function("x", "y", "return x * y");
 
-- `name`
-  - : The function name. Can be omitted, in which case the function becomes known as an
-    anonymous function.
-- `param`
-  - : The name of an argument to be passed to the function.
-- `statements`
-  - : The statements comprising the body of the function.
-
-Here is an example of an **anonymous** function expression (the
-`name` is not used):
-
-```js
-const myFunction = function () {
-  statements
-}
-```
-
-It is also possible to provide a name inside the definition in order to create a
-**named** function expression:
-
-```js
-const myFunction = function namedFunction() {
-  statements
-}
-```
-
-One of the benefits of creating a named function expression is that in case we
-encountered an error, the stack trace will contain the name of the function, making it
-easier to find the origin of the error.
-
-As we can see, both examples do not start with the `function` keyword.
-Statements involving functions which do not start with `function` are
-function expressions.
-
-When functions are used only once, a common pattern is an [IIFE (Immediately Invoked Function Expression)](/en-US/docs/Glossary/IIFE).
-
-```js
-(function () {
-  statements
-})();
-```
-
-IIFE are function expressions that are invoked as soon as the function is declared.
-
-### The generator function (function\*) declaration
-
-There is a special syntax for generator function declarations (see
-{{jsxref('Statements/function*', 'function* statement')}} for details):
-
-```js
-function* name([param[, param[, ... param]]]) {
-  statements
-}
-```
-
-- `name`
-  - : The function name.
-- `param`
-  - : The name of an argument to be passed to the function.
-- `statements`
-  - : The statements comprising the body of the function.
-
-### The generator function (function\*) expression
-
-A generator function expression is similar to and has the same syntax as a generator
-function declaration (see {{jsxref('Operators/function*', 'function* expression')}} for
-details):
-
-```js
-function* [name]([param[, param[, ... param]]]) {
-  statements
-}
-```
-
-- `name`
-  - : The function name. Can be omitted, in which case the function becomes known as an
-    anonymous function.
-- `param`
-  - : The name of an argument to be passed to the function.
-- `statements`
-  - : The statements comprising the body of the function.
-
-### The arrow function expression (=>)
-
-An arrow function expression has a shorter syntax and lexically binds its `this` value
-(see [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) for details):
-
-```js
-([param[, param]]) => {
-  statements
-}
-
-param => expression
-
-(param) => expression
-```
-
-- `param`
-  - : The name of an argument. Zero arguments need to be indicated with `()`.
-    For exactly one argument, the parentheses are not required.
-    (like `foo => 1`)
-- `statements` or `expression`
-  - : Multiple statements need to be enclosed in brackets. A single expression requires
-    no brackets. The expression is also the implicit return value of the function.
-
-### The Function constructor
-
-> **Note:** Using the `Function` constructor to create
-> functions is not recommended since it needs the function body as a string which may
-> prevent some JS engine optimizations and can also cause other problems.
-
-As all other objects, {{jsxref("Function")}} objects can be created using the
-`new` operator:
-
-```js
-new Function (arg1, arg2, ... argN, functionBody)
-```
-
-- `arg1, arg2, ... argN`
-  - : Zero or more names to be used by the function as formal parameters. Each must be a
-    proper JavaScript identifier.
-- `functionBody`
-  - : A string containing the JavaScript statements comprising the function body.
-
-Invoking the `Function` constructor as a function (without using the
-`new` operator) has the same effect as invoking it as a constructor.
-
-### The GeneratorFunction constructor
-
-> **Note:** `GeneratorFunction` is not a global object, but
-> could be obtained from generator function instance (see
-> {{jsxref("GeneratorFunction")}} for more detail).
-
-> **Note:** Using the `GeneratorFunction` constructor to
-> create functions is not recommended since it needs the function body as a string
-> which may prevent some JS engine optimizations and can also cause other problems.
-
-As all other objects, {{jsxref("GeneratorFunction")}} objects can be created using the
-`new` operator:
-
-```js
-new GeneratorFunction (arg1, arg2, ... argN, functionBody)
-```
-
-- `arg1, arg2, ... argN`
-  - : Zero or more names to be used by the function as formal argument names. Each must
-    be a string that conforms to the rules for a valid JavaScript identifier or a list
-    of such strings separated with a comma; for example `"x"`, `"theValue"`, or `"a,b"`.
-- `functionBody`
-  - : A string containing the JavaScript statements comprising the function definition.
-
-Invoking the `GeneratorFunction` constructor as a function (without using
-the `new` operator) has the same effect as invoking it as a constructor.
-
-## Function parameters
-
-### Default parameters
-
-Default function parameters allow formal parameters to be initialized with default
-values if no value or `undefined` is passed. For more details,
-see [default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters).
-
-### Rest parameters
-
-The rest parameter syntax allows representing an indefinite number of arguments as an array.
-For more details, see [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters).
-
-## The arguments object
-
-You can refer to a function's arguments within the function by using the
-`arguments` object. See [arguments](/en-US/docs/Web/JavaScript/Reference/Functions/arguments).
-
-- [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
-  - : An array-like object containing the arguments passed to the currently executing function.
-- [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
-  - : The currently executing function.
-- [`arguments.length`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/length)
-  - : The number of arguments passed to the function.
-
-## Defining method functions
-
-### Getter and setter functions
-
-You can define getters (accessor methods) and setters (mutator methods) on any standard
-built-in object or user-defined object that supports the addition of new properties.
-The syntax for defining getters and setters uses the object literal syntax.
-
-- [get](/en-US/docs/Web/JavaScript/Reference/Functions/get)
-  - : Binds an object property to a function that will be called when that property is
-    looked up.
-- [set](/en-US/docs/Web/JavaScript/Reference/Functions/set)
-  - : Binds an object property to a function to be called when there is an attempt to set
-    that property.
-
-### Method definition syntax
-
-In object literals, you are able to define own methods in a shorter syntax, similar to the getters and setters. See [method definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) for more information.
-
-```js
-const obj = {
-  foo() {},
-  bar() {},
-};
-```
-
-## Constructor vs. declaration vs. expression
-
-Compare the following:
-
-A function defined with the `Function` _constructor_ assigned to the
-variable `multiply`:
-
-```js
-const multiply = new Function('x', 'y', 'return x * y');
-```
-
-A _function declaration_ of a function named `multiply`:
-
-```js
+// Declaration
 function multiply(x, y) {
   return x * y;
-} // there is no semicolon here
-```
+} // No need for semicolon here
 
-A _function expression_ of an anonymous function assigned to the variable
-`multiply`:
-
-```js
+// Expression; the function is anonymous but assigned to a variable
 const multiply = function (x, y) {
   return x * y;
 };
-```
-
-A _function expression_ of a function named `funcName` assigned to
-the variable `multiply`:
-
-```js
+// Expression; the function has its own name
 const multiply = function funcName(x, y) {
   return x * y;
 };
+
+// Arrow function
+const multiply = (x, y) => x * y;
+
+// Method
+const obj = {
+  multiply(x, y) {
+    return x * y;
+  },
+};
 ```
 
-### Differences
+All syntaxes do approximately the same thing, but there are some subtle behavior differences.
 
-All do approximately the same thing, with a few subtle differences:
+- The `Function()` constructor, `function` expression, and `function` declaration syntaxes create full-fledged function objects, which can be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). However, arrow functions and methods cannot be constructed. Async functions, generator functions, and async generator functions are not constructible regardless of syntax.
+- The `function` declaration creates functions that are [_hoisted_](/en-US/docs/Web/JavaScript/Guide/Functions#function_hoisting). Other syntaxes do not hoist the function and the function value is only visible after the definition.
+- The arrow function and `Function()` constructor always create _anonymous_ functions, which means they can't easily call themselves recursively. One way to call an arrow function recursively is by assigning it to a variable.
+- The arrow function syntax does not have access to `arguments` or `this`.
+- The `Function()` constructor cannot access any local variables — it only has access to the global scope.
+- The `Function()` constructor causes runtime compilation and is often slower than other syntaxes.
 
-There is a distinction between the function name and the variable the function is
-assigned to. The function name cannot be changed, while the variable the function is
-assigned to can be reassigned. The function name can be used only within the function's
-body. Attempting to use it outside the function's body results in an error (or get another value, if the same name is declared elsewhere). For example:
+For `function` expressions, there is a distinction between the function name and the variable the function is assigned to. The function name cannot be changed, while the variable the function is assigned to can be reassigned. The function name can be different from the variable the function is assigned to — they have no relation to each other. The function name can be used only within the function's body. Attempting to use it outside the function's body results in an error (or get another value, if the same name is declared elsewhere). For example:
 
 ```js
 const y = function x() {};
 console.log(x); // ReferenceError: x is not defined
 ```
 
-The function name also appears when the function is serialized via its
-[`toString()` method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString).
+On the other hand, the variable the function is assigned to is limited only by its scope, which is guaranteed to include the scope in which the function is declared.
 
-On the other hand, the variable the function is assigned to is limited only by its
-scope, which is guaranteed to include the scope in which the function is declared.
-
-As the `const y = function x() {}` example shows, the function name can be different from the variable the
-function is assigned to. They have no relation to each other. A function declaration
-also creates a variable with the same name as the function name. Thus, unlike those
-defined by function expressions, functions defined by function declarations can be
-accessed by their name in the scope they were defined in, as well as in their own body.
+A function declaration also creates a variable with the same name as the function name. Thus, unlike those defined by function expressions, functions defined by function declarations can be accessed by their name in the scope they were defined in, as well as in their own body.
 
 A function defined by `new Function` will dynamically have its source assembled, which is observable when you serialize it. For example, `console.log(new Function().toString())` gives:
 
-```js
+```js-nolint
 function anonymous(
 ) {
 
@@ -406,36 +154,13 @@ This is the actual source used to compile the function. However, although the `F
 new Function("alert(anonymous);")();
 ```
 
-Unlike functions defined by function expressions or by the `Function`
-constructor, a function defined by a function declaration can be used before the
-function declaration itself. For example:
+A function defined by a function expression or by a function declaration inherits the current scope. That is, the function forms a closure. On the other hand, a function defined by a `Function` constructor does not inherit any scope other than the global scope (which all functions inherit).
 
 ```js
-foo(); // Logs "FOO!"
-function foo() {
-  console.log('FOO!');
-}
-```
-
-A function defined by a function expression or by a function declaration inherits the
-current scope. That is, the function forms a closure. On the other hand, a function
-defined by a `Function` constructor does not inherit any scope other than
-the global scope (which all functions inherit).
-
-```js
-/*
- * Declare and initialize a variable 'p' (global)
- * and a function 'myFunc' (to change the scope) inside which
- * declare a variable with same name 'p' (current) and
- * define three functions using three different ways:-
- *     1. function declaration
- *     2. function expression
- *     3. function constructor
- * each of which will log 'p'
- */
-// var declarations create properties on the global object
-var p = 5;
+// p is a global variable
+globalThis.p = 5;
 function myFunc() {
+  // p is a local variable
   const p = 9;
 
   function decl() {
@@ -444,7 +169,7 @@ function myFunc() {
   const expr = function () {
     console.log(p);
   };
-  const cons = new Function('\tconsole.log(p);');
+  const cons = new Function("\tconsole.log(p);");
 
   decl();
   expr();
@@ -452,90 +177,109 @@ function myFunc() {
 }
 myFunc();
 
-/*
- * Logs:-
- * 9  - for 'decl' by function declaration (current scope)
- * 9  - for 'expr' by function expression (current scope)
- * 5  - for 'cons' by Function constructor (global scope)
- */
+// Logs:
+// 9 (for 'decl' by function declaration (current scope))
+// 9 (for 'expr' by function expression (current scope))
+// 5 (for 'cons' by Function constructor (global scope))
 ```
 
-Functions defined by function expressions and function declarations are parsed only
-once, while those defined by the `Function` constructor are not. That is,
-the function body string passed to the `Function` constructor must be parsed
-each and every time the constructor is called. Although a function expression creates a
-closure every time, the function body is not reparsed, so function expressions are
-still faster than `new Function(...)`. Therefore the `Function`
-constructor should generally be avoided whenever possible.
+Functions defined by function expressions and function declarations are parsed only once, while those defined by the `Function` constructor parses the string passed to it each and every time the constructor is called. Although a function expression creates a closure every time, the function body is not reparsed, so function expressions are still faster than `new Function(...)`. Therefore the `Function` constructor should generally be avoided whenever possible.
 
-It should be noted, however, that function expressions and function declarations nested
-within the function generated by parsing a `Function()` constructor's string
-aren't parsed repeatedly. For example:
+A function declaration may be unintentionally turned into a function expression when it appears in an expression context.
 
 ```js
-const foo = (new Function("const bar = 'FOO!'; return function() { alert(bar); };"))();
-foo(); // The segment "function() { alert(bar); }" of the function body string is not re-parsed.
-```
-
-A function declaration is very easily (and often unintentionally) turned into a
-function expression. A function declaration ceases to be one when it either:
-
-- becomes part of an expression
-- is no longer a "source element" of a function or the script itself. A "source
-  element" is a non-nested statement in the script or a function body:
-
-```js
-let x = 0;               // source element
-if (x === 0) {           // source element
-  x = 10;                // not a source element
-  function boo() {}      // not a source element
+// A function declaration
+function foo() {
+  console.log("FOO!");
 }
-function foo() {         // source element
-  let y = 2;             // source element
-  function bar() {}      // source element
-  while (y < 10) {       // source element
-    function blah() {}   // not a source element
-    y++;                 // not a source element
+
+doSomething(
+  // A function expression passed as an argument
+  function foo() {
+    console.log("FOO!");
   }
+);
+```
+
+On the other hand, a function expression may also be turned into a function declaration. An expression statement cannot begin with the `function` or `async function` keywords, which is a common mistake when implementing [IIFEs](/en-US/docs/Glossary/IIFE) (Immediately Invoked Function Expressions).
+
+```js example-bad
+function () { // SyntaxError: Function statements require a function name
+  console.log("FOO!");
+}();
+
+function foo() {
+  console.log("FOO!");
+}(); // SyntaxError: Unexpected token ')'
+```
+
+Instead, start the expression statement with something else, so that the `function` keyword unambiguously starts a function expression. Common options include [grouping](/en-US/docs/Web/JavaScript/Reference/Operators/Grouping) and using [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void).
+
+```js example-good
+(function () {
+  console.log("FOO!");
+})();
+
+void function () {
+  console.log("FOO!");
+}();
+```
+
+### Function parameters
+
+Each function parameter is a simple identifier that you can access in the local scope.
+
+```js
+function myFunc(a, b, c) {
+  // You can access the values of a, b, and c here
 }
 ```
 
-### Examples
+There are three special parameter syntaxes:
+
+- [_Default parameters_](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) allow formal parameters to be initialized with default values if no value or `undefined` is passed.
+- The [_rest parameter_](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) allows representing an indefinite number of arguments as an array.
+- [_Destructuring_](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) allows unpacking elements from arrays, or properties from objects, into distinct variables.
 
 ```js
-// function declaration
-function foo() {}
-
-// function expression
-(function bar() {})
-
-// function expression
-x = function hello() {}
-
-if (x) {
-  // function expression
-  function world() {}
-}
-
-// function declaration
-function a() {
-  // function declaration
-  function b() {}
-  if (0) {
-    // function expression
-    function c() {}
-  }
+function myFunc({ a, b }, c = 1, ...rest) {
+  // You can access the values of a, b, c, and rest here
 }
 ```
 
-## Block-level functions
+There are some consequences if one of the above non-simple parameter syntaxes is used:
 
-In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), starting
-with ES2015, functions inside blocks are now scoped to that block. Prior to ES2015,
-block-level functions were forbidden in strict mode.
+- You cannot apply `"use strict"` to the function body — this causes a [syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params).
+- Even if the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object stops syncing with the named parameters, and [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee) throws an error when accessed.
+
+### The arguments object
+
+You can refer to a function's arguments within the function by using the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object.
+
+- [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
+  - : An array-like object containing the arguments passed to the currently executing function.
+- [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
+  - : The currently executing function.
+- [`arguments.length`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/length)
+  - : The number of arguments passed to the function.
+
+### Getter and setter functions
+
+You can define accessor properties on any standard built-in object or user-defined object that supports the addition of new properties. Within [object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) and [classes](/en-US/docs/Web/JavaScript/Reference/Classes), you can use special syntaxes to define the getter and setter of an accessor property.
+
+- [get](/en-US/docs/Web/JavaScript/Reference/Functions/get)
+  - : Binds an object property to a function that will be called when that property is looked up.
+- [set](/en-US/docs/Web/JavaScript/Reference/Functions/set)
+  - : Binds an object property to a function to be called when there is an attempt to set that property.
+
+Note that these syntaxes create an _object property_, not a _method_. The getter and setter functions themselves can only be accessed using reflective APIs such as {{jsxref("Object.getOwnPropertyDescriptor()")}}.
+
+### Block-level functions
+
+In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), functions inside blocks are scoped to that block. Prior to ES2015, block-level functions were forbidden in strict mode.
 
 ```js
-'use strict';
+"use strict";
 
 function f() {
   return 1;
@@ -554,30 +298,22 @@ f() === 1; // true
 
 ### Block-level functions in non-strict code
 
-In a word: Don't.
+In a word: **Don't.**
 
 In non-strict code, function declarations inside blocks behave strangely. For example:
 
 ```js
 if (shouldDefineZero) {
-  function zero() {     // DANGER: compatibility risk
+  function zero() {
+    // DANGER: compatibility risk
     console.log("This is zero.");
   }
 }
 ```
 
-ES2015 says that if `shouldDefineZero` is false, then `zero`
-should never be defined, since the block never executes. However, it's a new part of
-the standard. Historically, this was left unspecified, and some browsers would define
-`zero` whether the block executed or not.
+The semantics of this in strict mode is well-specified — `zero` only ever exists within that scope of the `if` block. If `shouldDefineZero` is false, then `zero` should never be defined, since the block never executes. However, historically, this was left unspecified, so different browsers implemented it differently in non-strict mode. For more information, see the [`function` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function#block-level_function_declaration) reference.
 
-In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), all
-browsers that support ES2015 handle this the same way: `zero` is defined
-only if `shouldDefineZero` is true, and only exists within that scope of the
-`if`-block.
-
-A safer way to define functions conditionally is to assign a function expression to a
-variable:
+A safer way to define functions conditionally is to assign a function expression to a variable:
 
 ```js
 // Using a var makes it available as a global variable,
@@ -594,13 +330,12 @@ if (shouldDefineZero) {
 
 ### Returning a formatted number
 
-The following function returns a string containing the formatted representation of a
-number padded with leading zeros.
+The following function returns a string containing the formatted representation of a number padded with leading zeros.
 
 ```js
 // This function returns a string padded with leading zeros
 function padZeros(num, totalLen) {
-  let numStr = num.toString();             // Initialize return value as string
+  let numStr = num.toString(); // Initialize return value as string
   const numZeros = totalLen - numStr.length; // Calculate no. of zeros
   for (let i = 1; i <= numZeros; i++) {
     numStr = `0${numStr}`;
@@ -609,32 +344,28 @@ function padZeros(num, totalLen) {
 }
 ```
 
-The following statements call the padZeros function.
+The following statements call the `padZeros` function.
 
 ```js
 let result;
 result = padZeros(42, 4); // returns "0042"
 result = padZeros(42, 2); // returns "42"
-result = padZeros(5, 4);  // returns "0005"
+result = padZeros(5, 4); // returns "0005"
 ```
 
 ### Determining whether a function exists
 
-You can determine whether a function exists by using the `typeof` operator.
-In the following example, a test is performed to determine if the `window`
-object has a property called `noFunc` that is a function. If so, it is used;
-otherwise, some other action is taken.
+You can determine whether a function exists by using the [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) operator. In the following example, a test is performed to determine if the `window` object has a property called `noFunc` that is a function. If so, it is used; otherwise, some other action is taken.
 
 ```js
-if (typeof window.noFunc === 'function') {
+if (typeof window.noFunc === "function") {
   // use noFunc()
 } else {
   // do something else
 }
 ```
 
-Note that in the `if` test, a reference to `noFunc` is used—there
-are no brackets "()" after the function name so the actual function is not called.
+Note that in the `if` test, a reference to `noFunc` is used — there are no brackets `()` after the function name so the actual function is not called.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This page contains some very confusing concepts. For example, it says "a function declaration inside a block is a function expression" is plain wrong. It also includes unnecessary details about function definition syntaxes, which is repeated from their own reference pages. It makes no mention of async functions and async generator functions, which are post-ES6. This PR cuts back a lot of redundant text in this page so that it appears more overview-y.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
