### PR TITLE
docs: add `Response.json` static method

### DIFF
--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -39,11 +39,11 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 
 ## Static methods
 
-- {{domxref("Response.error()")}}
+- {{domxref("Response.error_static","Response.error()")}}
   - : Returns a new `Response` object associated with a network error.
-- {{domxref("Response.redirect()")}}
+- {{domxref("Response.redirect_static", "Response.redirect()")}}
   - : Creates a new response with a different URL.
-- {{domxref("Response.json()")}}
+- {{domxref("Response.json_static", "Response.json()")}}
   - : Creates a new response whose body is the JSON-encoded data, and status, status message, and headers are provided by init.
 
 ## Instance methods

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -44,7 +44,7 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 - {{domxref("Response.redirect_static", "Response.redirect()")}}
   - : Creates a new response with a different URL.
 - {{domxref("Response.json_static", "Response.json()")}}
-  - : Creates a new response whose body is the JSON-encoded data, and status, status message, and headers are provided by init.
+  - : Creates a new `Response` object for returning the provided JSON encoded data.
 
 ## Instance methods
 

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -42,9 +42,9 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 - {{domxref("Response.error_static","Response.error()")}}
   - : Returns a new `Response` object associated with a network error.
 - {{domxref("Response.redirect_static", "Response.redirect()")}}
-  - : Creates a new response with a different URL.
+  - : Returns a new response with a different URL.
 - {{domxref("Response.json_static", "Response.json()")}}
-  - : Creates a new `Response` object for returning the provided JSON encoded data.
+  - : Returns a new `Response` object for returning the provided JSON encoded data.
 
 ## Instance methods
 

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -43,6 +43,8 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
   - : Returns a new `Response` object associated with a network error.
 - {{domxref("Response.redirect()")}}
   - : Creates a new response with a different URL.
+- {{domxref("Response.json()")}}
+  - : Creates a new response whose body is the JSON-encoded data, and status, status message, and headers are provided by init.
 
 ## Instance methods
 


### PR DESCRIPTION
### Description

Newer runtimes implement this method and so it should be documented. 

### Motivation

It is part of the spec, see: https://fetch.spec.whatwg.org/#response-class

### Additional details



### Related issues and pull requests

https://github.com/whatwg/fetch/commit/b3bfd0c877fd09da8c315b43cf1dd858f3ac1612

https://github.com/whatwg/fetch/issues/1389