### PR TITLE
See also for `id` attribute

### DIFF
--- a/files/en-us/web/html/global_attributes/id/index.md
+++ b/files/en-us/web/html/global_attributes/id/index.md
@@ -34,3 +34,5 @@ The **`id`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) defines 
 
 - All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 - {{domxref("Element.id")}} that reflects this attribute.
+- The {{domxref("Document.getElementById")}} method.
+- CSS [ID selectors](/en-US/docs/Web/CSS/ID_selectors).


### PR DESCRIPTION
Will update the selectors in a separate PR to reflect how to escape weird id values that are valid in HTML but not as is in CSS.
