### PR TITLE
Express:MongoDb - fix up URLs used to specify database

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -393,11 +393,12 @@ Where possible it will use a version that has the same major version number.
 
 So far in this tutorial, we've used a single database that is hard-coded into **app.js**. Normally we'd like to be able to have a different database for production and development, so next we'll modify the LocalLibrary website to get the database URI from the OS environment (if it has been defined), and otherwise use our development database.
 
-Open **app.js** and find the line that sets the MongoDB connection variable. It will look something like this:
+Open **app.js** and find the line that sets the MongoDB connection variable.
+It will look something like this:
 
 ```js
 const mongoDB =
-  "mongodb+srv://your_user:your_password@cluster0-mbdj7.mongodb.net/local_library?retryWrites=true";
+  "mongodb+srv://your_user_name:your_password@cluster0.lz91hw2.mongodb.net/local_library?retryWrites=true&w=majority";
 ```
 
 Replace the line with the following code that uses `process.env.MONGODB_URI` to get the connection string from an environment variable named `MONGODB_URI` if has been set (use your own database URL instead of the placeholder below.)
@@ -405,7 +406,7 @@ Replace the line with the following code that uses `process.env.MONGODB_URI` to 
 ```js
 // Set up mongoose connection
 const dev_db_url =
-  "mongodb+srv://cooluser:coolpassword@cluster0-mbdj7.mongodb.net/local_library?retryWrites=true";
+  "mongodb+srv://your_user_name:your_password@cluster0.lz91hw2.mongodb.net/local_library?retryWrites=true&w=majority";
 const mongoDB = process.env.MONGODB_URI || dev_db_url;
 ```
 

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -578,15 +578,17 @@ After logging in, you'll be taken to the [home](https://cloud.mongodb.com/v2) sc
     - Select the Node driver and version as shown.
     - Click the **Copy** icon to copy the connection string.
     - Paste this in your local text editor.
-    - Update the password with your user's password.
+    - Update the username and password with your user's password.
+    - Insert the database name "local_library" in the path before the options (`...mongodb.net/local_library?retryWrites...`)
     - Save the file containing this string somewhere safe.
 
 You have now created the database, and have a URL (with username and password) that can be used to access it.
-This will look something like: `mongodb+srv://your_user_name:your_password@cluster0.lz91hw2.mongodb.net/?retryWrites=true&w=majority`
+This will look something like: `mongodb+srv://your_user_name:your_password@cluster0.lz91hw2.mongodb.net/local_library?retryWrites=true&w=majority`
 
 ## Install Mongoose
 
-Open a command prompt and navigate to the directory where you created your [skeleton Local Library website](/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website). Enter the following command to install Mongoose (and its dependencies) and add it to your **package.json** file, unless you have already done so when reading the [Mongoose Primer](#installing_mongoose_and_mongodb) above.
+Open a command prompt and navigate to the directory where you created your [skeleton Local Library website](/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website).
+Enter the following command to install Mongoose (and its dependencies) and add it to your **package.json** file, unless you have already done so when reading the [Mongoose Primer](#installing_mongoose_and_mongodb) above.
 
 ```bash
 npm install mongoose


### PR DESCRIPTION
Fixes up the URL to MongoDb in Express tutorial to include a database name. Without this the name defaults to "test".

This was pointed out by @blobtub in https://github.com/mdn/content/pull/22914#issuecomment-1352055223