### PR TITLE
Update hanging-punctuation page

### DIFF
--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -62,13 +62,38 @@ The `hanging-punctuation` property may be specified with one, two, or three spac
 - `none`
   - : No character hangs.
 - `first`
-  - : An opening bracket or quote at the start of the first formatted line of an element hangs.
+
+  - : An opening bracket or quote at the start of the first formatted line of an element hangs. This applies to:
+
+    - all characters in the Unicode categories [Ps](https://unicodeplus.com/category/Ps), [Pf](https://unicodeplus.com/category/Pf), [Pi](https://unicodeplus.com/category/Pi)
+    - the quote marks `U+0027` APOSTROPHE (`'`) and `U+0022` QUOTATION MARK (`"`).
+
 - `last`
-  - : A closing bracket or quote at the end of the last formatted line of an element hangs.
+  - : A closing bracket or quote at the end of the last formatted line of an element hangs. This applies to:
+    - all characters in the Unicode categories [Pe](https://unicodeplus.com/category/Pe), [Pf](https://unicodeplus.com/category/Pf), [Pi](https://unicodeplus.com/category/Pi)
+    - the quote marks `U+0027` APOSTROPHE (`'`) and `U+0022` QUOTATION MARK (`"`).
 - `force-end`
   - : A stop or comma at the end of a line hangs.
 - `allow-end`
   - : A stop or comma at the end of a line hangs if it does not otherwise fit prior to justification.
+
+Stops and commas that are allowed to hang include:
+
+- `U+002C`, COMMA
+- `U+002E`, FULL STOP
+- `U+060C`, ARABIC COMMA
+- `U+06D4`, ARABIC FULL STOP
+- `U+3001`, IDEOGRAPHIC COMMA
+- `U+3002`, IDEOGRAPHIC FULL STOP
+- `U+FF0C`, FULLWIDTH COMMA
+- `U+FF0E`, FULLWIDTH FULL STOP
+- `U+FE50`, SMALL COMMA
+- `U+FE51`, SMALL IDEOGRAPHIC COMMA
+- `U+FE52`, SMALL FULL STOP
+- `U+FF61`, HALFWIDTH IDEOGRAPHIC FULL STOP
+- `U+FF64`, HALFWIDTH IDEOGRAPHIC COMMA
+
+User agents may include additional characters.
 
 ## Formal definition
 
@@ -86,9 +111,18 @@ The `hanging-punctuation` property may be specified with one, two, or three spac
 
 ```html
 <p>
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dignissim
-  nunc mauris, et sollicitudin est scelerisque sed. Praesent laoreet tortor
-  massa, sit amet vulputate nulla pharetra ut."
+  «For a moment, nothing happened. Then, after a second or so, nothing continued
+  to happen.»
+</p>
+
+<p class="hanging">
+  «For a moment, nothing happened. Then, after a second or so, nothing continued
+  to happen.»
+</p>
+
+<p class="hanging right">
+  «For a moment, nothing happened. Then, after a second or so, nothing continued
+  to happen.»
 </p>
 ```
 
@@ -96,14 +130,25 @@ The `hanging-punctuation` property may be specified with one, two, or three spac
 
 ```css
 p {
+  width: 15em;
+  border: 1px solid #cccccc;
+  font-size: 2rem;
+  font-style: italic;
+  margin: 1em;
+}
+
+p.hanging {
   hanging-punctuation: first last;
-  margin: 0.5rem;
+}
+
+p.right {
+  text-align: right;
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("Setting_opening_and_closing_quotes_to_hang")}}
+{{EmbedLiveSample("Setting_opening_and_closing_quotes_to_hang", "", 500)}}
 
 ## Specifications
 


### PR DESCRIPTION
This PR updates the page for https://developer.mozilla.org/en-US/docs/Web/CSS/hanging-punctuation, per the description in https://github.com/mdn/content/pull/22022#issuecomment-1308224584.