### PR TITLE
Fix off-by-one error in strToUTF8Arr

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -228,7 +228,7 @@ function strToUTF8Arr(sDOMStr) {
   for (let nMapIdx = 0; nMapIdx < nStrLen; nMapIdx++) {
     nChr = sDOMStr.codePointAt(nMapIdx);
 
-    if (nChr > 65536) {
+    if (nChr >= 0x10000) {
       nMapIdx++;
     }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example code on https://developer.mozilla.org/en-US/docs/Glossary/Base64 contains a function strToUTF8Arr that roughly transcodes from utf16 to utf8.  It contains a loop that attempts to calculate the number of bytes required to represent the utf8 encoding.  However, if it encounters code point `\u{10000}`, it will erroneously count the second half of the utf16 surrogate pair as its own code point because it uses `>` where it should use `>=`.  This can eventually cause the entire procedure to return a utf8 string ending with extra bytes, which might be malformed utf8 such as `\xfc\x80\x80`.

I also took the liberty of using the hex representation of 65536 to make the correlation with the other nearby uses of 0x10000 more obvious.

### Motivation

We attempted to use this example code and found a bug while testing it using some of the files from https://github.com/bits/UTF-8-Unicode-Test-Documents.

### Additional details

Credit to Peter Clain (pclain@grammatech.com) for doing much of the work finding and debugging this issue.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
