### PR TITLE
Clarify file drag and drop API

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -47,7 +47,7 @@ Lastly, an application may want to style the drop target element to visually ind
 }
 ```
 
-> **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}. 
+> **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
 
 ## Process the drop
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -84,7 +84,7 @@ function dropHandler(ev) {
 
 ## Prevent the browser's default drag behavior
 
-The following {{domxref("HTMLElement/dragover_event", "dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler. 
+The following {{domxref("HTMLElement/dragover_event", "dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler.
 
 ```js
 function dragOverHandler(ev) {

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -47,7 +47,7 @@ Lastly, an application may want to style the drop target element to visually ind
 }
 ```
 
-> **Note:** `dragstart` and `dragend` events are not fired when dragging a file into the browser from the OS.
+> **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}. 
 
 ## Process the drop
 
@@ -84,7 +84,7 @@ function dropHandler(ev) {
 
 ## Prevent the browser's default drag behavior
 
-The following {{domxref("HTMLElement/dragover_event", "dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler.
+The following {{domxref("HTMLElement/dragover_event", "dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler. 
 
 ```js
 function dragOverHandler(ev) {

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -47,7 +47,7 @@ Lastly, an application may want to style the drop target element to visually ind
 }
 ```
 
-> **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
+> **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser, use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
 
 ## Process the drop
 


### PR DESCRIPTION
### Description

Expanded note to clarify how OS file drag events can be detected by the browser.  

### Motivation

The original article includes a note explaining that the `dragstart` and `dragend` events can't be used to detect when OS files are dragged in and out of the browser. 

This pull request expands that note to link the event handlers that can detect OS files: `dragenter` and `dragleave`.  
