### PR TITLE
add autofocus info and a11y explanations

### DIFF
--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.md
@@ -17,7 +17,9 @@ browser-compat: api.ShadowRoot.delegatesFocus
 
 The **`delegatesFocus`** read-only property of the {{domxref("ShadowRoot")}} interface returns `true` if the shadow root delegates focus, and `false` otherwise.
 
-If `true`, when a non-focusable part of the shadow DOM is clicked, the first focusable part is given focus, and the shadow host is given any available `:focus` styling.
+If `true`, when a non-focusable part of the shadow DOM is clicked, or `.focus()` is called on the host element, the first focusable part is given focus, and the shadow host is given any available `:focus` styling.
+
+Focus is of particular importance for keyboard users (including most screen reader users). `delegatesFocus` default behavior to focus the first focusable element may be undesirable if that element is not part of the tabbing order (e.g. an element with `tabindex="-1"`). In that case, the `autofocus` attribute should be set on the element to focus. This should be done with caution as it may create accessibility issues. The tabbing order should always follow the DOM order.
 
 The property value is set using the `delegatesFocus` property of the object passed to {{domxref("Element.attachShadow()")}}).
 


### PR DESCRIPTION
### Description
When another element than the first focusable element should receive focus, it should be given the autofocus attribute. see WICG/webcomponents#977
I messed up a first PR, sorry about that. As discussed with @scottaohara I added more details on the a11y implications. I also added a precision concerning the effect of `delegatesFocus` on programmatic focus.
 
### Related issues and pull requests
First PR: https://github.com/mdn/content/pull/22985