### PR TITLE
Remove word on HTML element link page

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -26,7 +26,7 @@ To link an external stylesheet, you'd include a `<link>` element inside your {{H
 <link href="main.css" rel="stylesheet" />
 ```
 
-This simple example provides the path to the stylesheet inside an `href` attribute, and a `rel` attribute with a value of `stylesheet`. The `rel` stands for "relationship", and is probably one of the key features of the `<link>` element — the value denotes how the item being linked to is related to the containing document.
+This simple example provides the path to the stylesheet inside an `href` attribute, and a `rel` attribute with a value of `stylesheet`. The `rel` stands for "relationship", and is one of the key features of the `<link>` element — the value denotes how the item being linked to is related to the containing document.
 As you'll see from our [Link types](/en-US/docs/Web/HTML/Link_types) reference, there are many kinds of relationship.
 
 There are a number of other common types you'll come across. For example, a link to the site's favicon:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed the word `probably` in 3rd paragraph.

### Motivation

That word in my opinion should not be there since it implies doubt, and is therefore confusing or misleading. I would think it _is_ one of the main features of the `rel` attribute.

### Additional details

MDN LINK: [<link>: The External Resource Link element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)

I've only contributed to freeCodeCamp in the past, and this is my first PR here. Please feel free to let me know if my PR title is not worded correctly, and if it is not, then any guidelines/resources would be great.

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
