### PR TITLE
More logical division of various class element features

### DIFF
--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -15,78 +15,70 @@ browser-compat: javascript.classes
 
 {{JsSidebar("Classes")}}
 
-Classes are a template for creating objects.
-They encapsulate data with code to work on that data.
-Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics.
+Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on [prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) but also have some syntax and semantics that are unique to classes.
+
+For more examples and explanations, see the [Using classes](/en-US/docs/Web/JavaScript/Guide/Using_Classes) guide.
 
 ## Defining classes
 
-Classes are in fact "special {{jsxref("Functions", "functions", "", "true")}}", and just as you can define {{jsxref("Operators/function", "function expressions", "", "true")}} and {{jsxref("Statements/function", "function declarations", "", "true")}}, the class syntax has two components: {{jsxref("Operators/class", "class expressions", "", "true")}} and {{jsxref("Statements/class", "class declarations", "", "true")}}.
-
-### Class declarations
-
-One way to define a class is using a **class declaration**.
-To declare a class, you use the `class` keyword with the name of the class ("Rectangle" here).
+Classes are in fact "special [functions](/en-US/docs/Web/JavaScript/Reference/Functions)", and just as you can define [function expressions](/en-US/docs/Web/JavaScript/Reference/Operators/function) and [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function), a class can be defined in two ways: a [class expression](/en-US/docs/Web/JavaScript/Reference/Operators/class) or a [class declaration](/en-US/docs/Web/JavaScript/Reference/Statements/class).
 
 ```js
+// Declaration
 class Rectangle {
   constructor(height, width) {
     this.height = height;
     this.width = width;
   }
 }
-```
 
-#### Hoisting
-
-An important difference between **function declarations** and **class declarations** is that while functions can be called in code that appears before they are defined, classes must be defined before they can be constructed.
-Code like the following will throw a {{jsxref("ReferenceError")}}:
-
-```js example-bad
-const p = new Rectangle(); // ReferenceError
-
-class Rectangle {}
-```
-
-This occurs because while the class is {{Glossary("Hoisting", "hoisted")}} its values are not initialized.
-
-### Class expressions
-
-A **class expression** is another way to define a class.
-Class expressions can be named or unnamed.
-The name given to a named class expression is local to the class's body.
-However, it can be accessed via the {{jsxref("Function/name", "name")}} property.
-
-```js
-// unnamed
-let Rectangle = class {
+// Expression; the class is anonymous but assigned to a variable
+const Rectangle = class {
   constructor(height, width) {
     this.height = height;
     this.width = width;
   }
 };
-console.log(Rectangle.name); // "Rectangle"
 
-// named
-Rectangle = class Rectangle2 {
+// Expression; the class has its own name
+const Rectangle = class Rectangle2 {
   constructor(height, width) {
     this.height = height;
     this.width = width;
   }
 };
-console.log(Rectangle.name); // "Rectangle2"
 ```
 
-> **Note:** Class **expressions** must be declared before they can be used (they are subject to the same hoisting restrictions as described in the [class declarations](#class_declarations) section).
+Like function expressions, class expressions may be anonymous, or have a name that's different from the variable that it's assigned to. However, unlike function declarations, class declarations have the same [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz) restrictions as `let` or `const` and behave as if they are [not hoisted](/en-US/docs/Web/JavaScript/Guide/Using_Classes#class_declaration_hoisting).
 
-## Class body and method definitions
+## Class body
 
-The body of a class is the part that is in curly brackets `{}`.
-This is where you define class members, such as methods or constructor.
+The body of a class is the part that is in curly brackets `{}`. This is where you define class members, such as methods or constructor.
 
-### Strict mode
+The body of a class is executed in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) even without the `"use strict"` directive.
 
-The body of a class is executed in {{jsxref("Strict_mode", "strict mode", "", "true")}}, i.e., code written here is subject to stricter syntax for increased performance, some otherwise silent errors will be thrown, and certain keywords are reserved for future versions of ECMAScript.
+A class element can be characterized by three aspects:
+
+- Kind: Getter, setter, method, or field
+- Location: Static or instance
+- Visibility: Public or private
+
+Together, they add up to 16 possible combinations. To divide the reference more logically and avoid overlapping content, the different elements are introduced in detail in different pages:
+
+- [Method definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
+  - : Public instance method
+- [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get)
+  - : Public instance getter
+- [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set)
+  - : Public instance setter
+- [Public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
+  - : Public instance field
+- [`static`](/en-US/docs/Web/JavaScript/Reference/Classes/static)
+  - : Public static method, getter, setter, and field
+- [Private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
+  - : Everything that's private
+
+In addition, there are two special class element syntaxes: [`constructor`](#constructor) and [static initialization blocks](#static_initialization_blocks), with their own references.
 
 ### Constructor
 
@@ -149,11 +141,11 @@ const pentagon = new Polygon(1,2,3,4,5);
 console.log([...pentagon.getSides()]); // [1,2,3,4,5]
 ```
 
-### Static methods and properties
+### Static methods and fields
 
-The {{jsxref("Classes/static", "static", "", "true")}} keyword defines a static method or property for a class.
-Static members (properties and methods) are called without instantiating their class and **cannot** be called through a class instance.
-Static methods are often used to create utility functions for an application, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
+The {{jsxref("Classes/static", "static")}} keyword defines a static method or field for a class.
+Static properties (fields and methods) are defined on the class itself instead of each instance.
+Static methods are often used to create utility functions for an application, whereas static fields are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
 
 ```js
 class Point {

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -11,186 +11,77 @@ browser-compat: javascript.classes.public_class_fields
 
 {{JsSidebar("Classes")}}
 
-Both static and instance public fields are writable, enumerable, and configurable
-properties. As such, unlike their private counterparts, they participate in prototype
-inheritance.
+Both static and instance public fields are writable, enumerable, and configurable properties. As such, unlike their private counterparts, they participate in prototype inheritance.
 
 ## Syntax
 
 ```js-nolint
-class ClassWithInstanceField {
-  instanceField = 'instance field';
-}
-
-class ClassWithStaticField {
-  static staticField = 'static field';
-}
-
-class ClassWithPublicInstanceMethod {
-  publicMethod() {
-    return 'hello world';
-  }
-}
-```
-
-## Examples
-
-### Public static fields
-
-Public static fields are useful when you want a field to exist only once per class, not
-on every class instance you create. This is useful for caches, fixed-configuration, or
-any other data you don't need to be replicated across instances.
-
-Public static fields are declared using the `static` keyword. They are added
-to the class constructor at the time of class evaluation using
-{{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}}. They are
-accessed again from the class constructor.
-
-```js
-class ClassWithStaticField {
-  static staticField = 'static field';
-}
-
-console.log(ClassWithStaticField.staticField); // "static field"
-```
-
-Fields without initializers are initialized to `undefined`.
-
-```js
-class ClassWithStaticField {
-  static staticField;
-}
-
-console.log(Object.hasOwn(ClassWithStaticField, 'staticField')); // true
-console.log(ClassWithStaticField.staticField); // "undefined"
-```
-
-Public static fields are not reinitialized on subclasses, but can be accessed via the
-prototype chain.
-
-```js
-class ClassWithStaticField {
-  static baseStaticField = 'base field';
-}
-
-class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = 'sub class field';
-}
-
-console.log(SubClassWithStaticField.subStaticField); // "sub class field"
-console.log(SubClassWithStaticField.baseStaticField); // "base field"
-```
-
-When initializing fields, `this` refers to the class constructor. You can
-also reference it by name, and use `super` to get the superclass constructor
-(if one exists).
-
-```js
-class ClassWithStaticField {
-  static baseStaticField = 'base static field';
-  static anotherBaseStaticField = this.baseStaticField;
-
-  static baseStaticMethod() { return 'base static method output'; }
-}
-
-class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = super.baseStaticMethod();
-}
-
-console.log(ClassWithStaticField.anotherBaseStaticField); // "base static field"
-
-console.log(SubClassWithStaticField.subStaticField); // "base static method output"
-```
-
-### Public instance fields
-
-Public instance fields exist on every created instance of a class. By declaring a
-public field, you can ensure the field is always present, and the class definition is
-more self-documenting.
-
-Public instance fields are added with {{jsxref("Global_Objects/Object/defineProperty",
-  "Object.defineProperty()")}} either at construction time in the base class (before the
-constructor body runs), or just after `super()` returns in a subclass.
-
-```js
-class ClassWithInstanceField {
-  instanceField = 'instance field';
-}
-
-const instance = new ClassWithInstanceField();
-console.log(instance.instanceField); // "instance field"
-```
-
-Fields without initializers are initialized to `undefined`.
-
-```js
-class ClassWithInstanceField {
+class ClassWithField {
   instanceField;
+  instanceFieldWithInitializer = "instance field";
+  static staticField;
+  static staticFieldWithInitializer = "static field";
 }
-
-const instance = new ClassWithInstanceField();
-console.assert(Object.hasOwn(instance, 'instanceField'));
-console.log(instance.instanceField); // "undefined"
 ```
 
-Like properties, field names may be computed.
+## Description
+
+This page introduces public instance fields in detail.
+
+- For public static fields, see [`static`](/en-US/docs/Web/JavaScript/Reference/Classes/static).
+- For private fields, see [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields).
+- For public methods, see [methods definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions).
+- For public accessors, see [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get) and [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set).
+
+Public instance fields exist on every created instance of a class. By declaring a public field, you can ensure the field is always present, and the class definition is more self-documenting.
+
+Public instance fields are added to the instance either at construction time in the base class (before the constructor body runs), or just after `super()` returns in a subclass. Fields without initializers are initialized to `undefined`. Like properties, field names may be computed.
 
 ```js
-const PREFIX = 'prefix';
+const PREFIX = "prefix";
 
-class ClassWithComputedFieldName {
-  [`${PREFIX}Field`] = 'prefixed field';
+class ClassWithField {
+  field;
+  fieldWithInitializer = "instance field";
+  [`${PREFIX}Field`] = "prefixed field";
 }
 
-const instance = new ClassWithComputedFieldName();
+const instance = new ClassWithField();
+console.log(Object.hasOwn(instance, "field")); // true
+console.log(instance.field); // undefined
+console.log(instance.fieldWithInitializer); // "instance field"
 console.log(instance.prefixField); // "prefixed field"
 ```
 
-When initializing fields `this` refers to the class instance under
-construction. Just as in public instance methods, if you're in a subclass you can access
-the superclass prototype using `super`.
+In the field initializer, [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) refers to the class instance under construction, and [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) refers to the `prototype` property of the base class, which contains the base class's instance methods, but not its instance fields.
 
 ```js
-class ClassWithInstanceField {
-  baseInstanceField = 'base field';
-  anotherBaseInstanceField = this.baseInstanceField;
-  baseInstanceMethod() { return 'base method output'; }
-}
-
-class SubClassWithInstanceField extends ClassWithInstanceField {
-  subInstanceField = super.baseInstanceMethod();
-}
-
-const base = new ClassWithInstanceField();
-const sub = new SubClassWithInstanceField();
-
-console.log(base.anotherBaseInstanceField); // "base field"
-
-console.log(sub.subInstanceField); // "base method output"
-```
-
-Because instance fields of a class are added before the respective constructor runs, you can access the fields' values within the constructor.
-
-```js
-class ClassWithInstanceField {
-  instanceField = 'instance field';
-
-  constructor() {
-    console.log(this.instanceField);
-    this.instanceField = 'new value';
+class Base {
+  baseField = "base field";
+  anotherBaseField = this.baseField;
+  baseMethod() {
+    return "base method output";
   }
 }
 
-const instance = new ClassWithInstanceField(); // Logs "instance field"
-console.log(instance.instanceField); // "new value"
+class Derived extends Base {
+  subField = super.baseMethod();
+}
+
+const base = new Base();
+const sub = new Derived();
+
+console.log(base.anotherBaseField); // "base field"
+
+console.log(sub.subField); // "base method output"
 ```
 
-However, because instance fields of a derived class are defined after `super()` returns, the base class's constructor does not have access to the derived class's fields.
+Because instance fields of a class are added before the respective constructor runs, you can access the fields' values within the constructor. However, because instance fields of a derived class are defined after `super()` returns, the base class's constructor does not have access to the derived class's fields.
 
 ```js
 class Base {
   constructor() {
-    console.log('Base constructor:', this.field);
+    console.log("Base constructor:", this.field);
   }
 }
 
@@ -198,13 +89,15 @@ class Derived extends Base {
   field = 1;
   constructor() {
     super();
-    console.log('Derived constructor:', this.field);
+    console.log("Derived constructor:", this.field);
+    this.field = 2;
   }
 }
 
 const instance = new Derived();
 // Base constructor: undefined
 // Derived constructor: 1
+console.log(instance.field); // 2
 ```
 
 Because class fields are added using the [`[[DefineOwnProperty]]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty) semantic (which is essentially {{jsxref("Object.defineProperty()")}}), field declarations in derived classes do not invoke setters in the base class. This behavior differs from using `this.field = …` in the constructor.
@@ -232,103 +125,7 @@ class DerivedWithConstructor extends Base {
 const instance2 = new DerivedWithConstructor(); // Logs 1
 ```
 
-> **Note:** Before the class fields specification was finalized with the `[[Define]]` semantic, most transpilers, including [Babel](https://babeljs.io/) and [tsc](https://www.typescriptlang.org/), transformed class fields to the `DerivedWithConstructor` form, which has caused subtle bugs after class fields were standardized.
-
-### Public methods
-
-#### Public static methods
-
-The **`static`** keyword defines a static method for a class.
-Static methods aren't called on instances of the class. Instead, they're called on the
-class itself. These are often utility functions, such as functions to create or clone
-objects.
-
-```js
-class ClassWithStaticMethod {
-  static staticMethod() {
-    return 'static method has been called.';
-  }
-}
-
-console.log(ClassWithStaticMethod.staticMethod()); // "static method has been called."
-```
-
-The static methods are added to the class constructor with
-{{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}} at class
-evaluation time. These methods are writable, non-enumerable, and configurable.
-
-#### Public instance methods
-
-As the name implies, public instance methods are methods available on class instances.
-
-```js
-class ClassWithPublicInstanceMethod {
-  publicMethod() {
-    return 'hello world';
-  }
-}
-
-const instance = new ClassWithPublicInstanceMethod();
-console.log(instance.publicMethod()); // "hello world"
-```
-
-Public instance methods are added to the class prototype at the time of class
-evaluation using {{jsxref("Global_Objects/Object/defineProperty",
-  "Object.defineProperty()")}}. They are writable, non-enumerable, and configurable.
-
-You may make use of generator, async, and async generator functions.
-
-```js
-class ClassWithFancyMethods {
-  *generatorMethod() { }
-  async asyncMethod() { }
-  async *asyncGeneratorMethod() { }
-}
-```
-
-Inside instance methods, `this` refers to the instance itself. In
-subclasses, `super` lets you access the superclass prototype, allowing you to
-call methods from the superclass.
-
-```js
-class BaseClass {
-  msg = 'hello world';
-  basePublicMethod() {
-    return this.msg;
-  }
-}
-
-class SubClass extends BaseClass {
-  subPublicMethod() {
-    return super.basePublicMethod();
-  }
-}
-
-const instance = new SubClass();
-console.log(instance.subPublicMethod()); // "hello world"
-```
-
-Getters and setters are special methods that bind to a class property and are called
-when that property is accessed or set. Use the [get](/en-US/docs/Web/JavaScript/Reference/Functions/get) and [set](/en-US/docs/Web/JavaScript/Reference/Functions/set) syntax to declare a
-public instance getter or setter.
-
-```js
-class ClassWithGetSet {
-  #msg = 'hello world';
-  get msg() {
-    return this.#msg;
-  }
-  set msg(x) {
-    this.#msg = `hello ${x}`;
- }
-}
-
-const instance = new ClassWithGetSet();
-console.log(instance.msg); // "hello world"
-
-instance.msg = 'cake';
-console.log(instance.msg); // "hello cake"
-```
+> **Note:** Before the class fields specification was finalized with the `[[DefineOwnProperty]]` semantic, most transpilers, including [Babel](https://babeljs.io/) and [tsc](https://www.typescriptlang.org/), transformed class fields to the `DerivedWithConstructor` form, which has caused subtle bugs after class fields were standardized.
 
 ## Specifications
 
@@ -341,5 +138,4 @@ console.log(instance.msg); // "hello cake"
 ## See also
 
 - [The Semantics of All JS Class Elements](https://rfrn.org/~shu/2018/05/02/the-semantics-of-all-js-class-elements.html)
-- [Public and private class fields](https://v8.dev/features/class-fields)
-  article at the v8.dev site
+- [Public and private class fields](https://v8.dev/features/class-fields) article at the v8.dev site

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -13,9 +13,7 @@ browser-compat: javascript.classes.static
 
 {{jsSidebar("Classes")}}
 
-The **`static`** keyword defines a [static method or property](/en-US/docs/Web/JavaScript/Reference/Classes#static_methods_and_properties) for a class, or a [static initialization block](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) (see the link for more information about this usage).
-Neither static methods nor static properties can be called on instances of the class.
-Instead, they're called on the class itself.
+The **`static`** keyword defines a [static method or field](/en-US/docs/Web/JavaScript/Reference/Classes#static_methods_and_properties) for a class, or a [static initialization block](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) (see the link for more information about this usage). Static properties cannot be directly accessed on instances of the class. Instead, they're accessed on the class itself.
 
 Static methods are often utility functions, such as functions to create or clone objects, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
 
@@ -35,6 +33,56 @@ class ClassWithStatic {
 }
 ```
 
+## Description
+
+This page introduces public static properties of classes, which include static methods, static accessors, and static fields.
+
+- For private static features, see [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields).
+- For instance features, see [methods definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions), [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get), [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set), and [public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields).
+
+Public static features are declared using the `static` keyword. They are added to the class constructor at the time of class evaluation using the [`[[DefineOwnProperty]]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty) semantic (which is essentially {{jsxref("Object.defineProperty()")}}). They are accessed again from the class constructor.
+
+Static methods are often utility functions, such as functions to create or clone instances. Public static fields are useful when you want a field to exist only once per class, not on every class instance you create. This is useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
+
+Static fields without initializers are initialized to `undefined`. Public static fields are not reinitialized on subclasses, but can be accessed via the prototype chain.
+
+```js
+class ClassWithStaticField {
+  static staticField;
+  static staticFieldWithInitializer = "static field";
+}
+
+class SubclassWithStaticField extends ClassWithStaticField {
+  static subStaticField = "subclass field";
+}
+
+console.log(Object.hasOwn(ClassWithStaticField, "staticField")); // true
+console.log(ClassWithStaticField.staticField); // undefined
+console.log(ClassWithStaticField.staticFieldWithInitializer); // "static field"
+console.log(SubclassWithStaticField.staticFieldWithInitializer); // "static field"
+console.log(SubclassWithStaticField.subStaticField); // "subclass field"
+```
+
+In the field initializer, [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) refers to the current class (which you can also access through its name), and [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) refers to the base class constructor.
+
+```js
+class ClassWithStaticField {
+  static baseStaticField = "base static field";
+  static anotherBaseStaticField = this.baseStaticField;
+
+  static baseStaticMethod() {
+    return "base static method output";
+  }
+}
+
+class SubClassWithStaticField extends ClassWithStaticField {
+  static subStaticField = super.baseStaticMethod();
+}
+
+console.log(ClassWithStaticField.anotherBaseStaticField); // "base static field"
+console.log(SubClassWithStaticField.subStaticField); // "base static method output"
+```
+
 ## Examples
 
 ### Using static members in classes
@@ -47,8 +95,8 @@ The following example demonstrates several things:
 
 ```js
 class Triple {
-  static customName = 'Tripler';
-  static description = 'I triple any number you provide';
+  static customName = "Tripler";
+  static description = "I triple any number you provide";
   static calculate(n = 1) {
     return n * 3;
   }
@@ -56,25 +104,25 @@ class Triple {
 
 class SquaredTriple extends Triple {
   static longDescription;
-  static description = 'I square the triple of any number you provide';
+  static description = "I square the triple of any number you provide";
   static calculate(n) {
     return super.calculate(n) * super.calculate(n);
   }
 }
 
-console.log(Triple.description);            // 'I triple any number you provide'
-console.log(Triple.calculate());            // 3
-console.log(Triple.calculate(6));           // 18
+console.log(Triple.description); // 'I triple any number you provide'
+console.log(Triple.calculate()); // 3
+console.log(Triple.calculate(6)); // 18
 
 const tp = new Triple();
 
-console.log(SquaredTriple.calculate(3));    // 81 (not affected by parent's instantiation)
-console.log(SquaredTriple.description);     // 'I square the triple of any number you provide'
+console.log(SquaredTriple.calculate(3)); // 81 (not affected by parent's instantiation)
+console.log(SquaredTriple.description); // 'I square the triple of any number you provide'
 console.log(SquaredTriple.longDescription); // undefined
-console.log(SquaredTriple.customName);      // 'Tripler'
+console.log(SquaredTriple.customName); // 'Tripler'
 
 // This throws because calculate() is a static member, not an instance member.
-console.log(tp.calculate());                // 'tp.calculate is not a function'
+console.log(tp.calculate()); // 'tp.calculate is not a function'
 ```
 
 ### Calling static members from another static method
@@ -83,7 +131,7 @@ In order to call a static method or property within another static method of the
 
 ```js
 class StaticMethodCall {
-  static staticProperty = 'static property';
+  static staticProperty = "static property";
   static staticMethod() {
     return `Static method and ${this.staticProperty} has been called`;
   }
@@ -116,9 +164,9 @@ class StaticMethodCall {
     console.log(this.constructor.staticMethod()); // 'static method has been called.'
   }
 
-  static staticProperty = 'static property';
+  static staticProperty = "static property";
   static staticMethod() {
-    return 'static method has been called.';
+    return "static method has been called.";
   }
 }
 ```

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -14,8 +14,7 @@ browser-compat: javascript.functions.get
 
 {{jsSidebar("Functions")}}
 
-The **`get`** syntax binds an object property to a function
-that will be called when that property is looked up.
+The **`get`** syntax binds an object property to a function that will be called when that property is looked up. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
 {{EmbedInteractiveExample("pages/js/functions-getter.html")}}
 
@@ -85,6 +84,32 @@ console.log(obj.latest); // "test"
 ```
 
 Note that attempting to assign a value to `latest` will not change it.
+
+### Using getters in classes
+
+You can use the exact same syntax to define public instance getters that are available on class instances. In classes, you don't need the comma separator between methods.
+
+```js
+class ClassWithGetSet {
+  #msg = "hello world";
+  get msg() {
+    return this.#msg;
+  }
+  set msg(x) {
+    this.#msg = `hello ${x}`;
+  }
+}
+
+const instance = new ClassWithGetSet();
+console.log(instance.msg); // "hello world"
+
+instance.msg = "cake";
+console.log(instance.msg); // "hello cake"
+```
+
+Getter properties are defined on the `prototype` property of the class and are thus shared by all instances of the class. Unlike getter properties in object literals, getter properties in classes are not enumerable.
+
+Static setters and private setters use similar syntaxes, which are described in the [`static`](/en-US/docs/Web/JavaScript/Reference/Classes/static) and [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) pages.
 
 ### Deleting a getter using the `delete` operator
 

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.functions.method_definitions
 
 {{JsSidebar("Functions")}}
 
-**Method definition** is a shorter syntax for defining a function property in an object initializer.
+**Method definition** is a shorter syntax for defining a function property in an object initializer. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
 {{EmbedInteractiveExample("pages/js/functions-definitions.html")}}
 
@@ -109,9 +109,48 @@ const obj = {
 console.log(obj.b()); // "foo"
 ```
 
+### Method definitions in classes
+
+You can use the exact same syntax to define public instance methods that are available on class instances. In classes, you don't need the comma separator between methods.
+
+```js
+class ClassWithPublicInstanceMethod {
+  publicMethod() {
+    return "hello world";
+  }
+}
+
+const instance = new ClassWithPublicInstanceMethod();
+console.log(instance.publicMethod()); // "hello world"
+```
+
+Public instance methods are defined on the `prototype` property of the class and are thus shared by all instances of the class. They are writable, non-enumerable, and configurable.
+
+Inside instance methods, [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) and [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) work like in normal methods. Usually, `this` refers to the instance itself. In subclasses, `super` lets you access the prototype of the object that the method is attached to, allowing you to call methods from the superclass.
+
+```js
+class BaseClass {
+  msg = "hello world";
+  basePublicMethod() {
+    return this.msg;
+  }
+}
+
+class SubClass extends BaseClass {
+  subPublicMethod() {
+    return super.basePublicMethod();
+  }
+}
+
+const instance = new SubClass();
+console.log(instance.subPublicMethod()); // "hello world"
+```
+
+Static methods and private methods use similar syntaxes, which are described in the [`static`](/en-US/docs/Web/JavaScript/Reference/Classes/static) and [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) pages.
+
 ### Computed property names
 
-The shorthand syntax also supports [computed property names](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names).
+The method syntax also supports [computed property names](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names).
 
 ```js
 const bar = {

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -13,9 +13,7 @@ browser-compat: javascript.functions.set
 
 {{jsSidebar("Functions")}}
 
-The **`set`** syntax binds an object
-property to a function to be called when there is an attempt to set that
-property.
+The **`set`** syntax binds an object property to a function to be called when there is an attempt to set that property. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
 {{EmbedInteractiveExample("pages/js/functions-setter.html")}}
 
@@ -74,6 +72,32 @@ console.log(language.log); // ['EN', 'FA']
 
 Note that `current` is not defined, and any attempts to access it will
 result in `undefined`.
+
+### Using setters in classes
+
+You can use the exact same syntax to define public instance setters that are available on class instances. In classes, you don't need the comma separator between methods.
+
+```js
+class ClassWithGetSet {
+  #msg = "hello world";
+  get msg() {
+    return this.#msg;
+  }
+  set msg(x) {
+    this.#msg = `hello ${x}`;
+  }
+}
+
+const instance = new ClassWithGetSet();
+console.log(instance.msg); // "hello world"
+
+instance.msg = "cake";
+console.log(instance.msg); // "hello cake"
+```
+
+Setter properties are defined on the `prototype` property of the class and are thus shared by all instances of the class. Unlike setter properties in object literals, setter properties in classes are not enumerable.
+
+Static setters and private setters use similar syntaxes, which are described in the [`static`](/en-US/docs/Web/JavaScript/Reference/Classes/static) and [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) pages.
 
 ### Removing a setter with the `delete` operator
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is significant overlapping between the different class feature references, because indeed, the `static`, public fields, and private features pages are orthogonal and result in a lot of possible combinations. In this PR, I'm separating each feature to be documented in one page, with sufficient cross-linking between.

I'm not introducing any extra content in this PR, but I will be in follow-ups. This PR ensures I know where to put each feature's documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
