### PR TITLE
Added 'a' to 1st usage note

### DIFF
--- a/files/en-us/web/html/element/nav/index.md
+++ b/files/en-us/web/html/element/nav/index.md
@@ -86,7 +86,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Usage notes
 
-- It's not necessary for all links to be contained in a `<nav>` element. `<nav>` is intended only for major block of navigation links; typically the {{HTMLElement("footer")}} element often has a list of links that don't need to be in a {{HTMLElement("nav")}} element.
+- It's not necessary for all links to be contained in a `<nav>` element. `<nav>` is intended only for a major block of navigation links; typically the {{HTMLElement("footer")}} element often has a list of links that don't need to be in a {{HTMLElement("nav")}} element.
 - A document may have several {{HTMLElement("nav")}} elements, for example, one for site navigation and one for intra-page navigation. [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) can be used in such case to promote accessibility, see [example](/en-US/docs/Web/HTML/Element/Heading_Elements#labeling_section_content).
 - User agents, such as screen readers targeting disabled users, can use this element to determine whether to omit the initial rendering of navigation-only content.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added the article _a_ to make the 1st usage note.

### Motivation

The sentence was missing a word or needed to be rewritten. 

### Additional details

**MDN LINK**: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav

I chose to add _a_ before the words _major block_. Another option would be to make _block_ plural (_blocks_), or change the sentence to _the primary block of navigation links_. Either fix is fine IMO; I chose the simplest.

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
