### PR TITLE
Fix a red link in SourceBuffer.appendBuffer()

### DIFF
--- a/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
@@ -32,7 +32,7 @@ appendBuffer(source)
 ### Parameters
 
 - `source`
-  - : Either an {{domxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} object
+  - : Either an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} object
     that contains the media segment data you want to add to the `SourceBuffer`.
 
 ### Return value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `ArrayBuffer` is a JavaScript global object, so it should be used {{jsxref}} instead of {{domxref}}.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
