### PR TITLE
Added a gap to the parent grid (class:wrapper).

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -616,6 +616,7 @@ If I set `box1` to `display: grid` I can give it a track definition and it too w
 .wrapper {
   border: 2px solid #f76707;
   border-radius: 5px;
+  gap: 3px;
   background-color: #fff4e6;
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added `gap: 3px;` to the parent grid in the "Nesting without subgrid" section

### Motivation
The example matches the text underneath. Now the reader can see that the parent grid has a gap, but the subgrid does not have a gap.

### Related issues and pull requests

Fixes #22864 

