### PR TITLE
Corrected formatting error

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -189,7 +189,7 @@ The amount of specificity a selector has is measured using three different value
 
 > **Note:** The universal selector ([`*`](/en-US/docs/Web/CSS/Universal_selectors)), [combinators](/en-US/docs/Learn/CSS/Building_blocks//selectors/combinators) (`+`, `>`, `~`, ' '), and specificity adjustment selector ([`:where()`](/en-US/docs/Web/CSS/:where)) along with its parameters, have no effect on specificity.
 
-The negation ([`:not()`](/en-US/docs/Web/CSS/:not)), relational selector (`:has()`](/en-US/docs/Web/CSS/:has)), and the matches-any ([`:is()`](/en-US/docs/Web/CSS/:is)) pseudo-classes themselves don't have effect on specificity, but their parameters do. The specificity that each contributes to the specificity algorithm is the specificity of the selector in the parameter that has the greatest weight.
+The negation ([`:not()`](/en-US/docs/Web/CSS/:not)), relational selector ([`:has()`](/en-US/docs/Web/CSS/:has)), and the matches-any ([`:is()`](/en-US/docs/Web/CSS/:is)) pseudo-classes themselves don't have effect on specificity, but their parameters do. The specificity that each contributes to the specificity algorithm is the specificity of the selector in the parameter that has the greatest weight.
 
 The following table shows a few isolated examples to get you in the mood. Try going through these, and make sure you understand why they have the specificity that we have given them. We've not covered selectors in detail yet, but you can find details of each selector on the MDN [selectors reference](/en-US/docs/Web/CSS/CSS_Selectors).
 


### PR DESCRIPTION
### Description

Corrected a formatting error, where a link element in Markdown did not have opening square braces, causing it to have the link location displayed in text.

### Before

> (`:has`](en-US/docs/Web/CSS/:has))

### After
> ([`:has`](en-US/docs/Web/CSS/:has))
