### PR TITLE
Make param names consistent in CSSStyleValue»parseAll() doc

### DIFF
--- a/files/en-us/web/api/cssstylevalue/parseall/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.md
@@ -24,14 +24,14 @@ supplied values.
 ## Syntax
 
 ```js-nolint
-parseAll(property, cssText)
+parseAll(property, value)
 ```
 
 ### Parameters
 
 - `property`
   - : A CSS property to set.
-- `cssText`
+- `value`
   - : A comma-separated string containing one or more values that apply to the provided
     property.
 

--- a/files/en-us/web/api/cssstylevalue/parseall/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.md
@@ -24,7 +24,7 @@ supplied values.
 ## Syntax
 
 ```js-nolint
-parseAll(property, value)
+parseAll(property, cssText)
 ```
 
 ### Parameters


### PR DESCRIPTION
parameter names are inconsistent. parseAll(property, value) should be parseAll(property, cssText)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
