### PR TITLE
Fix typo on operator_precedence page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -29,7 +29,7 @@ The combination above has two possible interpretations:
 a OP1 (b OP2 c)
 ```
 
-Which one the language decides to adopt depends on the identity of `OP1` ad `OP2`.
+Which one the language decides to adopt depends on the identity of `OP1` and `OP2`.
 
 If `OP1` and `OP2` have different precedence levels (see the table below), the operator with the higher _precedence_ goes first and associativity does not matter. Observe how multiplication has higher precedence than addition and executed first, even though addition is written first in the code.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed grammar for the word "and" where the previous person had written "ad"


### Motivation

It will make it clearer even and make people with OCD have an easy time

