### PR TITLE
 “Scalable Vector Graphics (SVG) *are* an XML-based markup language” (not “is an XML-based markup language”)

### DIFF
--- a/files/en-us/web/svg/index.md
+++ b/files/en-us/web/svg/index.md
@@ -21,7 +21,7 @@ tags:
 
 ## Getting Started with SVG
 
-**Scalable Vector Graphics (SVG)** are an [XML](/en-US/docs/Web/XML)-based markup language for describing two-dimensional based [vector graphics](https://en.wikipedia.org/wiki/Vector_graphics).
+**Scalable Vector Graphics (SVG)** is an [XML](/en-US/docs/Web/XML)-based markup language for describing two-dimensional based [vector graphics](https://en.wikipedia.org/wiki/Vector_graphics).
 
 As such, it's a text-based, open Web standard for describing images that can be rendered cleanly at any size and are designed specifically to work well with other web standards including [CSS](/en-US/docs/Web/CSS), [DOM](/en-US/docs/Web/API/Document_Object_Model), [JavaScript](/en-US/docs/Web/JavaScript), and [SMIL](/en-US/docs/Web/SVG/SVG_animation_with_SMIL). SVG is, essentially, to graphics what [HTML](/en-US/docs/Web/HTML) is to text.
 


### PR DESCRIPTION
<!-- ✍️ Summarize your changes in one or two sentences -->

Make Scalable Vector Graphics take the singular verb _is_.

<!-- ❓ Why are you making these changes and how do they help readers? -->

I would argue that the noun Scalable Vector Graphics is singular in meaning. So it should take the singular verb, is.
In addition, there are other mentionings of the noun Scalable Vector Graphics in the docs, all of which take a singular verb. For example, the introductory sentence in the [SVG Tutorial](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial).

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->