### PR TITLE
Improve self.performance page

### DIFF
--- a/files/en-us/web/api/performance/index.md
+++ b/files/en-us/web/api/performance/index.md
@@ -14,11 +14,9 @@ browser-compat: api.Performance
 
 {{APIRef("Performance API")}}
 
-The **`Performance`** interface provides access to performance-related information for the current page. It's part of the High Resolution Time API, but is enhanced by the [Performance Timeline API](/en-US/docs/Web/API/Performance_Timeline), the [Navigation Timing API](/en-US/docs/Web/API/Navigation_timing_API), the [User Timing API](/en-US/docs/Web/API/User_Timing_API), and the [Resource Timing API](/en-US/docs/Web/API/Resource_Timing_API).
+The **`Performance`** interface provides access to performance-related information for the current page.
 
-An object of this type can be obtained by calling the {{domxref("window.performance")}} read-only attribute.
-
-> **Note:** This interface and its members are available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) via [`WorkerGlobalScope.performance`](/en-US/docs/Web/API/performance_property), except where indicated below. Also, note that performance markers and measures are per context. If you create a mark on the main thread (or other worker), you cannot see it in a worker thread, and vice versa.
+An object of this type can be obtained by calling `window.performance` or `self.performance` in workers. Note that Performance entries are per context. If you create a mark on the main thread (or other worker), you cannot see it in a worker thread, and vice versa. See [`self.performance`](/en-US/docs/Web/API/performance_property) for which APIs are available in window and worker contexts.
 
 {{InheritanceDiagram}}
 
@@ -34,13 +32,9 @@ _The `Performance` interface doesn't inherit any properties._
 
   - : A legacy {{domxref("PerformanceNavigation")}} object that provides useful context about the operations included in the times listed in `timing`, including whether the page was a load or a refresh, how many redirections occurred, and so forth.
 
-    > **Note:** Not available in workers.
-
 - {{domxref("Performance.timing")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
 
   - : A legacy {{domxref("PerformanceTiming")}} object containing latency-related performance information.
-
-    > **Note:** Not available in workers.
 
 - {{domxref("Performance.memory")}} {{ReadOnlyInline}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : A _non-standard_ extension added in Chrome, this property provides an object with basic memory usage information. _You **should not use** this non-standard API._

--- a/files/en-us/web/api/performance_property/index.md
+++ b/files/en-us/web/api/performance_property/index.md
@@ -4,28 +4,47 @@ slug: Web/API/performance_property
 page-type: web-api-global-property
 tags:
   - API
-  - HTML DOM
-  - High Resolution Time
-  - High Resolution Time API
-  - Navigation Timing
-  - Navigation Timing API
-  - Optimization
   - Performance
   - Property
   - Reference
-  - Telemetry
-  - Window
 browser-compat: api.performance
 ---
 
 {{APIRef("Performance API")}}
 
-The global **`performance`** property returns a {{domxref("Performance")}} object, which can be used to gather performance information about the current document. It serves as the point of exposure for the Performance Timeline API, the High Resolution Time API, the [Navigation Timing API](/en-US/docs/Web/API/Navigation_timing_API), the [User Timing API](/en-US/docs/Web/API/User_Timing_API), and the [Resource Timing API](/en-US/docs/Web/API/Resource_Timing_API).
+The global **`performance`** property returns a {{domxref("Performance")}} object, which can be used to gather performance information about the context it is called in (window or worker).
+
+Performance entries are per context. If you create a mark on the main thread (or other worker), you cannot see it in a worker thread, and vice versa.
 
 ## Value
 
-A {{domxref("Performance")}} object offering access to the performance and
-timing-related information offered by the APIs it exposes.
+A {{domxref("Performance")}} object offering access to performance and timing-related information for the context it is called on (window or worker).
+
+## Performance API availability
+
+The following table provides an overview about the availability of the performance APIs in window and worker contexts.
+
+| API                                                        | Window | Worker |
+| ---------------------------------------------------------- | ------ | ------ |
+| {{domxref("LargestContentfulPaint")}}                      | x      |        |
+| {{domxref("LayoutShift")}}                                 | x      |        |
+| {{domxref("LayoutShiftAttribution")}}                      | x      |        |
+| {{domxref("Performance")}}                                 | x      | x      |
+| {{domxref("PerformanceElementTiming")}}                    | x      |        |
+| {{domxref("PerformanceEntry")}}                            | x      | x      |
+| {{domxref("PerformanceEventTiming")}}                      | x      |        |
+| {{domxref("PerformanceLongTaskTiming")}}                   | x      |        |
+| {{domxref("PerformanceMark")}}                             | x      | x      |
+| {{domxref("PerformanceMeasure")}}                          | x      | x      |
+| {{domxref("PerformanceNavigation")}} {{deprecated_inline}} | x      |        |
+| {{domxref("PerformanceNavigationTiming")}}                 | x      |        |
+| {{domxref("PerformanceObserver")}}                         | x      | x      |
+| {{domxref("PerformanceObserverEntryList")}}                | x      | x      |
+| {{domxref("PerformancePaintTiming")}}                      | x      |        |
+| {{domxref("PerformanceResourceTiming")}}                   | x      | x      |
+| {{domxref("PerformanceServerTiming")}}                     | x      | x      |
+| {{domxref("PerformanceTiming")}} {{deprecated_inline}}     | x      |        |
+| {{domxref("TaskAttributionTiming")}}                       | x      |        |
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This PR updates the https://developer.mozilla.org/en-US/docs/Web/API/performance_property to talk more about how Performance APIs are available in which context.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

Removed notes from the main Performance interface page. Worker availability seems not so much important that it is callout worthy. 

### Related issues and pull requests

None.