### PR TITLE
Add example to performance.timeOrigin

### DIFF
--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -42,7 +42,7 @@ self.addEventListener("connect", (event) => {
     const workerTaskEnd = performance.now();
   };
 
-  // Send worker-relative timestamps to window context
+  // Convert worker-relative timestamps to absolute timestamps, then send to the window
   port.postMessage({
     startTime: workerTaskStart + performance.timeOrigin,
     endTime: workerTaskEnd + performance.timeOrigin,
@@ -55,7 +55,7 @@ In main.js
 ```js
 const worker = new SharedWorker("worker.js");
 worker.port.addEventListener("message", (event) => {
-  // Translate worker-relative timestamps into window's time origin
+  // Convert absolute timestamps into window-relative timestamps
   const workerTaskStart = event.data.startTime - performance.timeOrigin;
   const workerTaskEnd = event.data.endTime - performance.timeOrigin;
 

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -14,15 +14,55 @@ browser-compat: api.Performance.timeOrigin
 
 {{APIRef("Performance API")}}
 
-The **`timeOrigin`** read-only property of the
-{{domxref("Performance")}} interface returns the high resolution timestamp of the
-start time of the performance measurement.
+The **`timeOrigin`** read-only property of the {{domxref("Performance")}} interface returns the high resolution timestamp that is used as the baseline for performance-related timestamps.
 
-{{AvailableInWorkers}}
+In Window contexts, this value represents the time when navigation has started. In {{domxref("Worker")}} and {{domxref("ServiceWorker")}} contexts, this value represents the time when the worker is run. You can use this property to synchronize the time origins between the contexts (see example below).
+
+> **Note:** The value of `performance.timeOrigin` may differ from the value returned by {{jsxref("Date.now()")}} executed at the time origin, because `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. The `timeOrigin` property is a [monotonic clock](https://w3c.github.io/hr-time/#sec-monotonic-clock) which current time never decreases and which isn't subject to these adjustments.
 
 ## Value
 
 A high resolution timestamp.
+
+## Examples
+
+### Synchronizing time between contexts
+
+To account for the different time origins in window and worker contexts, you can translate the timestamps coming from worker scripts with the help of the `timeOrigin` property, so the timings synchronize for the entire application.
+
+In worker.js
+
+```js
+onconnect = function (event) {
+  const port = event.ports[0];
+
+  port.onmessage = function (event) {
+    const workerTaskStart = performance.now();
+    // doSomeWork()
+    const workerTaskEnd = performance.now();
+  };
+
+  // Send worker-relative timestamps to window context
+  port.postMessage({
+    startTime: workerTaskStart + performance.timeOrigin,
+    endTime: workerTaskEnd + performance.timeOrigin,
+  });
+};
+```
+
+In main.js
+
+```js
+const worker = new SharedWorker("worker.js");
+worker.port.onmessage = function (event) {
+  // Translate worker-relative timestamps into window's time origin
+  const workerTaskStart = event.data.startTime - performance.timeOrigin;
+  const workerTaskEnd = event.data.endTime - performance.timeOrigin;
+
+  console.log("Worker task start: ", workerTaskStart);
+  console.log("Worker task end: ", workerTaskEnd);
+};
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -33,7 +33,7 @@ To account for the different time origins in window and worker contexts, you can
 In worker.js
 
 ```js
-onconnect = function (event) {
+self.addEventListener("connect", (event) => {
   const port = event.ports[0];
 
   port.onmessage = function (event) {
@@ -47,21 +47,21 @@ onconnect = function (event) {
     startTime: workerTaskStart + performance.timeOrigin,
     endTime: workerTaskEnd + performance.timeOrigin,
   });
-};
+});
 ```
 
 In main.js
 
 ```js
 const worker = new SharedWorker("worker.js");
-worker.port.onmessage = function (event) {
+worker.port.addEventListener("message", (event) => {
   // Translate worker-relative timestamps into window's time origin
   const workerTaskStart = event.data.startTime - performance.timeOrigin;
   const workerTaskEnd = event.data.endTime - performance.timeOrigin;
 
   console.log("Worker task start: ", workerTaskStart);
   console.log("Worker task end: ", workerTaskEnd);
-};
+});
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

This PR adds an example and a better description to the https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin page which is currently basically empty.

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I wanted to keep this page as practical as possible. I believe that if you need to know about the clock details then you have to read and understand the specification. If we think we should have more clock content here, let me know. (maybe it is better on the page for DOMHighResTimestamp, though).

### Related issues and pull requests

None.