### PR TITLE
Add `Security` section to Map-Object comparison

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -71,6 +71,21 @@ cases:
       </td>
     </tr>
     <tr>
+      <th scope="row">Security</th>
+      <td>
+        A <code>Map</code> is safe to use with user-provided keys and values.
+      </td>
+      <td>
+        <p>
+          Setting user-provided key-value pairs on an <code>Object</code> 
+          may allow an attacker to override the objects prototype, which
+          <a href="https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md">
+            can lead to a remote code execution vulnerability
+          </a>.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <th scope="row">Key Types</th>
       <td>
         A <code>Map</code>'s keys can be any value (including functions,

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -78,10 +78,11 @@ cases:
       <td>
         <p>
           Setting user-provided key-value pairs on an <code>Object</code> 
-          may allow an attacker to override the objects prototype, which
+          may allow an attacker to override the object's prototype, which
+          can lead to
           <a href="https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md">
-            can lead to a remote code execution vulnerability
-          </a>.
+            object injection attacks
+          </a>. This can also be mitigated by using a `null`-prototype object.
         </p>
       </td>
     </tr>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -82,7 +82,7 @@ cases:
           <a href="https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md">
             object injection attacks
           </a>. Like the accidental keys issue, this can also be mitigated by using
-          a `null`-prototype object.
+          a <code>null</code>-prototype object.
         </p>
       </td>
     </tr>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -77,12 +77,12 @@ cases:
       </td>
       <td>
         <p>
-          Setting user-provided key-value pairs on an <code>Object</code> 
-          may allow an attacker to override the object's prototype, which
-          can lead to
+          Setting user-provided key-value pairs on an <code>Object</code> may allow
+          an attacker to override the object's prototype, which can lead to
           <a href="https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md">
             object injection attacks
-          </a>. This can also be mitigated by using a `null`-prototype object.
+          </a>. Like the accidental keys issue, this can also be mitigated by using
+          a `null`-prototype object.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This adds a "Security" section to Map-Object comparison. The section mentions that `Object` may be unsafe as a key-value store with user-provided keys and values, and links to an article with more details.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Based on [this article](https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md), which is also linked from [the eval() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#specifications:~:text=However%2C%20beware%20that%20using%20bracket%20accessors%20with%20unconstrained%20input%20is%20not%20safe%20either%20%E2%80%94%20it%20may%20lead%20to%20object%20injection%20attacks.), using `Object` as a key-value store for arbitrary user-provided input may be unsafe, because the user could change the object's prototype. This isn't an issue with `Map`. 

This isn't yet mentioned in the `Map`-`Object` comparison, but it might be useful to help readers avoid writing potentially unsafe code.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
