### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -82,7 +82,7 @@ The third way is to create a cascade layer with no name. For example:
 
 This creates an _anonymous cascade layer_. This layer functions in the same way as named layers; however, rules cannot be assigned to it later. The order of precedence for anonymous layers is the order in which layers are declared, named or not, and lower than the styles declared outside of a layer.
 
-Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except the `@charset` rules.
+Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except `@charset` and `@layer` rules.
 
 ```css
 @import "theme.css" layer(utilities);


### PR DESCRIPTION

### Description

Correction to text as per the documentation, `@layer` rules can go before `@import` too.

### Motivation

I had wondered this for a time now, it should be there.

### Additional details

As per [the documentation](https://w3c.github.io/csswg-drafts/css-cascade-5/#at-import): "Any @import rules must precede all other valid at-rules and style rules in a style sheet (ignoring @charset and @layer statement rules) and must not have any other valid at-rules or style rules between it and previous @import rules, or else the @import rule is invalid.".
