### PR TITLE
Corrected link

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_tasks/index.md
@@ -47,7 +47,7 @@ Try updating the live code below to recreate the finished example:
 
 > **Callout:**
 >
-> [Download the starting point for this task](https://raw.githubusercontent.com/mdn/css-examples/main/learn/tasks/cascade/cascadelayer-download.html) to work in your own editor or in an online editor.
+> [Download the starting point for this task](https://github.com/mdn/css-examples/blob/main/learn/tasks/cascade/cascadelayer-download.html) to work in your own editor or in an online editor.
 
 ## Assessment or further help
 


### PR DESCRIPTION
### Description

Each task in **Test your skills** or **Assessments** have a link to the Github page where the source code is available for download.

All such links open the source code in the Github editor, however, this one link opened the source code as *raw text*.

### Example of normal links

> https://github.com/mdn/css-examples/blob/main/learn/tasks/cascade/cascade-download.html

### This particular link

> https://raw.githubusercontent.com/mdn/css-examples/main/learn/tasks/cascade/cascadelayer-download.html

I do think that providing link to the *raw* version is the better choice, since readers want to copy paste the code into their code editor. However, all links should be modified then.