### PR TITLE
Address Resize Observer error events

### DIFF
--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -20,8 +20,6 @@ The **`ResizeObserver`** interface reports changes to the dimensions of an {{dom
 
 > **Note:** The content box is the box in which content can be placed, meaning the border box minus the padding and border width. The border box encompasses the content, padding, and border. See [The box model](/en-US/docs/Learn/CSS/Building_blocks/The_box_model) for further explanation.
 
-`ResizeObserver` avoids infinite callback loops and cyclic dependencies that are often created when resizing via a callback function. It does this by only processing elements deeper in the DOM in subsequent frames. Implementations should, if they follow the specification, invoke resize events before paint and after layout.
-
 ## Constructor
 
 - {{domxref("ResizeObserver.ResizeObserver", "ResizeObserver()")}}
@@ -87,6 +85,30 @@ checkbox.addEventListener('change', () => {
 });
 ```
 
+## Observation Errors
+
+Implementations following the specification invoke resize events before paint (i.e. Before the frame is presented to the user). If there was any resize event, style and layout are re-evaluated, which, in turn, may trigger more resize events. Infinite loops from cyclic dependencies are addressed by only processing elements deeper in the DOM each iteration. Resize events not meeting this condition are deferred to the next paint, and an error event is fired on the {{domxref('Window')}} object, with the well-defined message string:
+
+**ResizeObserver loop completed with undelivered notifications.**
+
+Note that this only prevents user agent lockup, not the infinite loop itself. For example, the following code will cause the width of `divElem` to grow indefinitely, with the above error message in the console repeating every frame:
+
+```js
+const divElem = document.querySelector('body > div');
+
+const resizeObserver = new ResizeObserver((entries) => {
+  for (const entry of entries) {
+    entry.target.style.width = entry.contentBoxSize[0].inlineSize + 10 + 'px';
+  }
+});
+
+window.addEventListener('error', function(e) {
+  console.error(e.message);
+});
+```
+
+As long as the error event does not fire indefinitely, resize observer will settle and produce a stable, likely correct, layout. However, visitors may see a flash of broken layout, as a sequence of changes expected to happen in a single frame is instead happening over multiple frames.
+
 ## Specifications
 
 {{Specifications}}
@@ -100,3 +122,4 @@ checkbox.addEventListener('change', () => {
 - [The box model](/en-US/docs/Learn/CSS/Building_blocks/The_box_model)
 - {{domxref('PerformanceObserver')}}
 - {{domxref('IntersectionObserver')}} (part of the [Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API))
+- Upcoming [container queries](/en-US/docs/Web/CSS/CSS_Container_Queries) may be a viable alternative for implementing responsive design.

--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -91,7 +91,7 @@ Implementations following the specification invoke resize events before paint (t
 
 **ResizeObserver loop completed with undelivered notifications.**
 
-Note that this only prevents user agent lockup, not the infinite loop itself. For example, the following code will cause the width of `divElem` to grow indefinitely, with the above error message in the console repeating every frame:
+Note that this only prevents user-agent lockup, not the infinite loop itself. For example, the following code will cause the width of `divElem` to grow indefinitely, with the above error message in the console repeating every frame:
 
 ```js
 const divElem = document.querySelector('body > div');

--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -87,7 +87,7 @@ checkbox.addEventListener('change', () => {
 
 ## Observation Errors
 
-Implementations following the specification invoke resize events before paint (i.e. Before the frame is presented to the user). If there was any resize event, style and layout are re-evaluated, which, in turn, may trigger more resize events. Infinite loops from cyclic dependencies are addressed by only processing elements deeper in the DOM each iteration. Resize events not meeting this condition are deferred to the next paint, and an error event is fired on the {{domxref('Window')}} object, with the well-defined message string:
+Implementations following the specification invoke resize events before paint (that is, before the frame is presented to the user). If there was any resize event, style and layout are re-evaluated — which in turn may trigger more resize events. Infinite loops from cyclic dependencies are addressed by only processing elements deeper in the DOM during each iteration. Resize events that don't meet that condition are deferred to the next paint, and an error event is fired on the {{domxref('Window')}} object, with the well-defined message string:
 
 **ResizeObserver loop completed with undelivered notifications.**
 


### PR DESCRIPTION
### Description

Explains what seeing "ResizeObserver loop completed with undelivered notifications" may mean.

### Motivation

This revision provides the rationale for the error, as well as potential consequences. Hoping to reduce time to root cause & determine course of action for authors seeing this error.

Also suggests the upcoming container queries as a potential alternative that does not expose authors to the infinite loop problem.

### Additional details

Searching the error string returns many bug reports. 

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
