### PR TITLE
e-mail to email

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -65,7 +65,7 @@ inappropriate, than it is to follow every guideline to the letter.
    all bound by [our Code of Conduct](CODE_OF_CONDUCT.md) when contributing to
    MDN, which means adhering to Mozilla's [Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
    If anyone has engaged in behavior that is potentially illegal or makes
-   you or someone else feels unsafe, unwelcome, or uncomfortable, you are
+   you or someone else feel unsafe, unwelcome, or uncomfortable, you are
    encouraged to [report it](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/).
    We want MDN to be a welcoming, friendly community that we can all be
    proud of.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -25,7 +25,7 @@ out-of-date. This is being handled as follows:
    review owners", meaning that when a pull request comes in related to a
    particular topic area of the site (e.g. the CSS reference, or the learning
    area), it will be assigned to that area's topic review owner(s) and they
-   will receive an e-mail notification asking for a review. This is being
+   will receive an email notification asking for a review. This is being
    handled using a [CODEOWNERS](https://github.com/mdn/content/blob/main/.github/CODEOWNERS)
    file, in which particular content directories are assigned to the topics
    review owner's GitHub usernames.
@@ -65,7 +65,7 @@ inappropriate, than it is to follow every guideline to the letter.
    all bound by [our Code of Conduct](CODE_OF_CONDUCT.md) when contributing to
    MDN, which means adhering to Mozilla's [Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
    If anyone has engaged in behavior that is potentially illegal or makes
-   you or someone else feel unsafe, unwelcome, or uncomfortable, you are
+   you or someone else feels unsafe, unwelcome, or uncomfortable, you are
    encouraged to [report it](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/).
    We want MDN to be a welcoming, friendly community that we can all be
    proud of.
@@ -100,11 +100,11 @@ inappropriate, than it is to follow every guideline to the letter.
    assigned already. In such cases, the PR should be linked to an issue
    that explains all these details. If you are not sure, ask the submitter
    if they need a review of the content, and where the rationale behind the
-   change is explained. Ping our team on [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) to ask for help if you are still not sure, or if you think the
-   content is suspicious.
+   change is explained. Ping our team on [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) to ask for help if you are still not sure, or
+   if you think the content is suspicious.
 
-Note: You may encounter merge conflicts as you review pull requests, if a
-another pull request that touches some of the same files got merged before
+Note: You may encounter merge conflicts as you review pull requests, if another
+pull request that touches some of the same files got merged before
 the one you are reviewing.
 [Addressing merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts)
 is a useful resource to help you. Feel free also to ask your team(s) for help

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11879,7 +11879,7 @@
 /en-US/docs/Web/Guide/HTML/Drag_operations	/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations
 /en-US/docs/Web/Guide/HTML/Editable_content	/en-US/docs/Web/HTML/Global_attributes/contenteditable
 /en-US/docs/Web/Guide/HTML/Element	/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started
-/en-US/docs/Web/Guide/HTML/Email_links	/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#E-mail_links
+/en-US/docs/Web/Guide/HTML/Email_links	/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#email_links
 /en-US/docs/Web/Guide/HTML/Event_attributes	/en-US/docs/Learn/JavaScript/Building_blocks/Events#Inline_event_handlers_—_don't_use_these
 /en-US/docs/Web/Guide/HTML/Forms	/en-US/docs/Learn/Forms
 /en-US/docs/Web/Guide/HTML/Forms/Advanced_styling_for_HTML_forms	/en-US/docs/Learn/Forms/Advanced_form_styling

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -334,7 +334,7 @@ The list below describes some of the common situations where we need to be aware
 Hyphenated compounds should be used when the last letter of the prefix is a vowel and is the same as the first letter of the root.
 
 - **Correct**: email, re-elect, co-op
-- **Incorrect**: e-mail, reelect, coop
+- **Incorrect**: e&#45;mail, reelect, coop
 
 ### Spelling
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -331,10 +331,10 @@ The list below describes some of the common situations where we need to be aware
 
 ### Hyphens
 
-Hyphenated compounds should be used when the last letter of the prefix is a vowel and is the same as the first letter of the root.
+Compound words should be hyphenated only when the last letter of the prefix is a vowel and is the same as the first letter of the root.
 
-- **Correct**: email, re-elect, co-op
-- **Incorrect**: e&#45;mail, reelect, coop
+- **Correct**: re-elect, co-op, email
+- **Incorrect**: reelect, coop, e&#45;mail
 
 ### Spelling
 

--- a/files/en-us/web/api/navigator/webdriver/index.md
+++ b/files/en-us/web/api/navigator/webdriver/index.md
@@ -17,7 +17,7 @@ The **`webdriver`** read-only property
 of the {{domxref("navigator")}} interface indicates whether the user agent is
 controlled by automation.
 
-It defines a standard way for cooperating user agents to inform the document that it
+It defines a standard way for co-operating user agents to inform the document that it
 is controlled by [WebDriver](/en-US/docs/Web/WebDriver), for example, so that
 alternate code paths can be triggered during automation.
 

--- a/files/en-us/web/api/navigator/webdriver/index.md
+++ b/files/en-us/web/api/navigator/webdriver/index.md
@@ -17,7 +17,7 @@ The **`webdriver`** read-only property
 of the {{domxref("navigator")}} interface indicates whether the user agent is
 controlled by automation.
 
-It defines a standard way for co-operating user agents to inform the document that it
+It defines a standard way for cooperating user agents to inform the document that it
 is controlled by [WebDriver](/en-US/docs/Web/WebDriver), for example, so that
 alternate code paths can be triggered during automation.
 


### PR DESCRIPTION
Completes #23049

This PR
- updates e-mail in REVIEWING.md file. Some other fixes
- updates a broken redirect
- in writing guides page uses HTML code for hyphen so that linter won't flag the `e-mail` in the example