### PR TITLE
Remove mention of Edge/IE inserting control characters

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -162,16 +162,7 @@ console.log(date.toLocaleString("en-US", { hour12: false }));
 Most of the time, the formatting returned by `toLocaleString()` is
 consistent. However, this might change in the future, and isn't guaranteed for all
 languages; output variations are by design, and allowed by the specification.
-
-Most notably, the IE browsers insert bidirectional control characters around
-dates, so the output text will flow properly when concatenated with other text.
-
-For this reason, you cannot expect to be able to compare the results of
-`toLocaleString()` to a static value.
-
-> **Note:** See also this
-> [StackOverflow thread](https://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results)
-> for more details and examples.
+You should not compare the results of `toLocaleString()` to static values.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -52,6 +52,8 @@ A string representing the given date according to language-specific conventions.
 
 In implementations with `Intl.DateTimeFormat`, this is equivalent to `new Intl.DateTimeFormat(locales, options).format(date)`.
 
+> **Note:** Most of the time, the formatting returned by `toLocaleString()` is consistent. However, the output may vary with time, language, and implementation — output variations are by design and allowed by the specification. You should not compare the results of `toLocaleString()` to static values.
+
 ## Examples
 
 ### Using toLocaleString()
@@ -156,13 +158,6 @@ console.log(date.toLocaleString("en-US", options));
 console.log(date.toLocaleString("en-US", { hour12: false }));
 // "12/19/2012, 19:00:00"
 ```
-
-### Avoid comparing formatted date values to static values
-
-Most of the time, the formatting returned by `toLocaleString()` is
-consistent. However, this might change in the future, and isn't guaranteed for all
-languages; output variations are by design, and allowed by the specification.
-You should not compare the results of `toLocaleString()` to static values.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -163,18 +163,11 @@ Most of the time, the formatting returned by `toLocaleString()` is
 consistent. However, this might change in the future, and isn't guaranteed for all
 languages; output variations are by design, and allowed by the specification.
 
-Most notably, the IE and Edge browsers insert bidirectional control characters around
+Most notably, the IE browsers insert bidirectional control characters around
 dates, so the output text will flow properly when concatenated with other text.
 
 For this reason, you cannot expect to be able to compare the results of
-`toLocaleString()` to a static value:
-
-```js example-bad
-"1/1/2019, 01:00:00" ===
-  new Date("2019-01-01T01:00:00Z").toLocaleString("en-US");
-// true in Firefox and others
-// false in IE and Edge
-```
+`toLocaleString()` to a static value.
 
 > **Note:** See also this
 > [StackOverflow thread](https://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results)


### PR DESCRIPTION
### Description

- remove mention of Edge for inserting control characters. For the [EdgeHTML-based Edge's market share is lower than 0.02%](https://caniuse.com/usage-table), and the Chromium-based browser would not perform that.
- remove the example, for this may varies by different browser versions

### Related issues and pull requests

Fixes: #22977

