### PR TITLE
Change the new-issue auto-labeler to use “needs info” (no dash)

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -13,4 +13,4 @@ jobs:
       - name: initial labelling
         uses: andymckay/labeler@master
         with:
-          add-labels: "needs-triage"
+          add-labels: "needs triage"


### PR DESCRIPTION
We now have a “needs info” (no dash) label, but the new-issue auto-labeler is still using the label “needs-info” (dash).