### PR TITLE
Move “Transferable objects” out of Glossary and into Web/API tree

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -3620,6 +3620,7 @@
 /en-US/docs/Glossary/Spartan	/en-US/docs/Glossary/Microsoft_Edge
 /en-US/docs/Glossary/Static_property	/en-US/docs/Glossary/property/JavaScript
 /en-US/docs/Glossary/Symbol	/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+/en-US/docs/Glossary/Transferable_objects	/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
 /en-US/docs/Glossary/Transmission_Control_Protocol_(TCP)	/en-US/docs/Glossary/TCP
 /en-US/docs/Glossary/URI/www_vs_non-www_URLs	/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
 /en-US/docs/Glossary/WWW	/en-US/docs/Glossary/World_Wide_Web

--- a/files/en-us/web/api/web_workers_api/transferable_objects/index.md
+++ b/files/en-us/web/api/web_workers_api/transferable_objects/index.md
@@ -1,13 +1,13 @@
 ---
 title: Transferable objects
-slug: Glossary/Transferable_objects
+slug: Web/API/Web_Workers_API/Transferable_objects
+page-type: guide
 tags:
   - Transferable
   - Serializable
   - Structured clone
   - Workers
 ---
-
 **Transferable objects** are objects that own resources that can be _transferred_ from one context to another, ensuring that the resources are only available in one context at a time.
 Following a transfer, the original object is no longer usable; it no longer points to the transferred resource, and any attempt to read or write the object will throw an exception.
 


### PR DESCRIPTION
See https://github.com/mdn/content/issues/23099#issuecomment-1359834232.  If this content were to remain the Glossary, that would continue to prevent us from being able to refine it further — because, as noted, glossary entries are meant to be brief, and this content is already much too long to be appropriate for having in the Glossary.