### PR TITLE
Set initial value in innerWidth & innerHeight examples

### DIFF
--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -91,12 +91,13 @@ The following figure shows the difference between `outerHeight` and
 const heightOutput = document.querySelector("#height");
 const widthOutput = document.querySelector("#width");
 
-function resizeListener() {
+function updateSize() {
   heightOutput.textContent = window.innerHeight;
   widthOutput.textContent = window.innerWidth;
 }
 
-window.addEventListener("resize", resizeListener);
+updateSize();
+window.addEventListener("resize", updateSize);
 ```
 
 ### Result

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -76,12 +76,13 @@ console.log(top.innerWidth);
 const heightOutput = document.querySelector("#height");
 const widthOutput = document.querySelector("#width");
 
-function resizeListener() {
+function updateSize() {
   heightOutput.textContent = window.innerHeight;
   widthOutput.textContent = window.innerWidth;
 }
 
-window.addEventListener("resize", resizeListener);
+updateSize();
+window.addEventListener("resize", updateSize);
 ```
 
 ### Result


### PR DESCRIPTION
While checking the innerWidth page, I have it annoying that the output of an example is unavailable, until opening dev tools or resizing the browser by some other means. I have made the example show window width & window height prior to resizing.