### PR TITLE
Fix the explanation for the “revert vs unset” section

### DIFF
--- a/files/en-us/web/css/revert/index.md
+++ b/files/en-us/web/css/revert/index.md
@@ -41,7 +41,7 @@ Revert will not affect rules applied to children of an element you reset (but wi
 
 Although `revert` and `unset` are similar, they differ for some properties for some elements.
 
-So in the below example, we set custom [`font-weight`](/en-US/docs/Web/CSS/font-weight#formal_definition), but then try to `revert` and `unset` it inline in the HTML document. The `revert` keyword will revert the text to bold because that is the default value for headers in most browsers. The `unset` keyword will keep the text normal because that is the initial value for the `font-weight` property.
+So in the below example, we set custom [`font-weight`](/en-US/docs/Web/CSS/font-weight#formal_definition), but then try to `revert` and `unset` it inline in the HTML document. The `revert` keyword will revert the text to bold because that is the default value for headers in most browsers. The `unset` keyword will keep the text normal because, as an inherited property, the `font-weight` would then inherit its value from the body.
 
 #### HTML
 


### PR DESCRIPTION
### Description

Making the  explanation for why the `font-weight` gets its `normal` value to be correct for the [Revert vs unset section](https://developer.mozilla.org/en-US/docs/Web/CSS/revert#revert_vs_unset).

### Motivation

Because the `font-weight` is an inherited property, it would get its value from the parent, as it is an inherited property.

To quote [MDN article on `unset`](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) (can be also checked by changing the font-weight on the `body` in the example):

> The unset CSS keyword resets a property to its inherited value if the property naturally inherits from its parent, and to its [initial value](https://developer.mozilla.org/en-US/docs/Web/CSS/initial_value) if not. In other words, it behaves like the [inherit](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) keyword in the first case, when the property is an [inherited property](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance#inherited_properties), and like the [initial](https://developer.mozilla.org/en-US/docs/Web/CSS/initial) keyword in the second case, when the property is a [non-inherited property](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance#non-inherited_properties).

