### PR TITLE
fix(api/element): use correct browser-compat key

### DIFF
--- a/files/en-us/web/api/element/contentvisibilityautostatechanged_event/index.md
+++ b/files/en-us/web/api/element/contentvisibilityautostatechanged_event/index.md
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - Event
   - Reference
-browser-compat: api.element.contentvisibilityautostatechanged_event
+browser-compat: api.Element.contentvisibilityautostatechanged_event
 ---
 
 {{APIRef("CSS Containment")}}{{SeeCompatTable}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes the casing of the `browser-compat` key on the [Element: contentvisibilityautostatechanged event](https://developer.mozilla.org/en-US/docs/Web/API/Element/contentvisibilityautostatechanged_event) page.

### Motivation

Currently, the BCD table doesn't render:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/495429/209128463-be9c19f8-215e-4766-951a-26546264227d.png">

After this fix, it renders:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/495429/209128581-0cf37b25-9416-4ab9-8de6-3ef88b7c0972.png">

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
