### PR TITLE
Fix incorrect value in WASM reference `nearest`

### DIFF
--- a/files/en-us/webassembly/reference/numeric/nearest/index.md
+++ b/files/en-us/webassembly/reference/numeric/nearest/index.md
@@ -24,7 +24,7 @@ f32.const -2.7
 ;; round to the nearest integer
 f32.nearest
 
-;; the top item on the stack will now be -2
+;; the top item on the stack will now be -3
 ```
 
 | Instruction   | Binary opcode |


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Changes the `syntax` section to say that the last value on the stack will be `-3` rather than `-2`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
`f32.nearest (f32.const -2.7)` pushes `-3` to the stack and not `-2` - currently the section describes truncation.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
n/a

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
n/a


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
