### PR TITLE
Fix Typo in `hidden` Examples

### DIFF
--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -150,7 +150,7 @@ Note that although the content of the element is hidden, the element still has a
 
 Clicking the "Go to hidden content" button navigates to the hidden until found element. The `beforematch` event fires, the text content is updated, and the element content is displayed.
 
-To run the example again, click "Reload".
+To run the example again, click "Reset".
 
 {{EmbedLiveSample("Using until-found", "", 400)}}
 


### PR DESCRIPTION
### Description

Fix typo in examples section within HTML attribute `hidden` documentation.

### Motivation

Improve documentation.

### Additional details

See existing documentation (error is under Results):
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#examples

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->