### PR TITLE
Fix issue 22942: transfer syntax description

### DIFF
--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -135,8 +135,7 @@ const int32View2 = new Int32Array(object2.buffer);
 int32View2[0] = 42;
 console.log(int32View2[0]);
 
-// Create an array from the original buffer
-// throws a TypeError
+// Creating an array from the original buffer throws a TypeError
 const int32View1 = new Int32Array(object1.buffer);
 ```
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -108,14 +108,11 @@ const mushrooms1 = {
 
 const mushrooms2 = structuredClone(mushrooms1);
 
-mushrooms2["amanita"].push("pantherina");
-mushrooms1["amanita"].pop();
+mushrooms2.amanita.push("pantherina");
+mushrooms1.amanita.pop();
 
-console.log(mushrooms2["amanita"]);
-//"muscaria", "virosa", "pantherina"
-
-console.log(mushrooms1["amanita"]);
-//"muscaria"
+console.log(mushrooms2.amanita); // ["muscaria", "virosa", "pantherina"]
+console.log(mushrooms1.amanita); // ["muscaria"]
 ```
 
 ### Transferring an object

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -24,7 +24,7 @@ Transferred objects are detached from the original object and attached to the ne
 
 ```js-nolint
 structuredClone(value)
-structuredClone(value, transferables)
+structuredClone(value, options)
 ```
 
 ### Parameters
@@ -32,8 +32,10 @@ structuredClone(value, transferables)
 - `value`
   - : The object to be cloned.
     This can be any [structured-clonable type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types).
-- `transferables` {{optional_inline}}
-  - : An array of {{Glossary("transferable objects")}} in `value` that will be moved rather than cloned to the returned object.
+- `options` {{optional_inline}}
+  - : An object with the following properties:
+    - `transfer`
+      - : An array of {{Glossary("transferable objects")}} that will be moved rather than cloned to the returned object.
 
 ### Return value
 
@@ -64,8 +66,7 @@ console.assert(clone.itself === clone); // and the circular reference is preserv
 
 ### Transferring values
 
-{{Glossary("Transferable objects")}} (only) can be transferred rather than duplicated in the cloned object, using the optional parameter's `transfer` value.
-Transferring makes the original object unusable.
+{{Glossary("Transferable objects")}} (only) can be transferred rather than duplicated in the cloned object, using the `transfer` property of the `options` parameter. Transferring makes the original object unusable.
 
 > **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
 > To avoid the buffer being modified before the data is saved, you can clone the buffer and validate that data.
@@ -78,8 +79,10 @@ On return, the original `uInt8Array.buffer` will be cleared.
 // 16MB = 1024 * 1024 * 16
 const uInt8Array = Uint8Array.from({ length: 1024 * 1024 * 16 }, (v, i) => i);
 
-const transferred = structuredClone(uInt8Array, { transfer: [uInt8Array.buffer] });
-console.log(uInt8Array.byteLength);  // 0
+const transferred = structuredClone(uInt8Array, {
+  transfer: [uInt8Array.buffer],
+});
+console.log(uInt8Array.byteLength); // 0
 ```
 
 You can clone any number of objects and transfer any subset of those objects.
@@ -87,8 +90,59 @@ For example, the code below would transfer `arrayBuffer1` from the passed in val
 
 ```js
 const transferred = structuredClone(
-   { x: { y: { z: arrayBuffer1, w: arrayBuffer2 } } },
-   { transfer: [arrayBuffer1] });
+  { x: { y: { z: arrayBuffer1, w: arrayBuffer2 } } },
+  { transfer: [arrayBuffer1] }
+);
+```
+
+## Examples
+
+### Cloning an object
+
+In this example we clone an object with one member, which is an array. After cloning, changes to each object do not affect the other object.
+
+```js
+const mushrooms1 = {
+  amanita: ["muscaria", "virosa"],
+};
+
+const mushrooms2 = structuredClone(mushrooms1);
+
+mushrooms2["amanita"].push("pantherina");
+mushrooms1["amanita"].pop();
+
+console.log(mushrooms2["amanita"]);
+//"muscaria", "virosa", "pantherina"
+
+console.log(mushrooms1["amanita"]);
+//"muscaria"
+```
+
+### Transferring an object
+
+In this example we create an {{jsxref("ArrayBuffer")}} and then clone the object it is a member of, transferring the buffer. We can use the buffer in the cloned object, but if we try to use the original buffer we will get an exception.
+
+```js
+// Create an ArrayBuffer with a size in bytes
+const buffer1 = new ArrayBuffer(16);
+
+const object1 = {
+  buffer: buffer1,
+};
+
+// Clone the object containing the buffer, and transfer it
+const object2 = structuredClone(object1, { transfer: [buffer1] });
+
+// Create an array from the cloned buffer
+const int32View2 = new Int32Array(object2.buffer);
+int32View2[0] = 42;
+console.log(int32View2[0]);
+
+// Create an array from the original buffer
+// throws with:
+// "attempting to access detached ArrayBuffer" or
+// "Cannot perform Construct on a detached ArrayBuffer"
+const int32View1 = new Int32Array(object1.buffer);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -136,9 +136,7 @@ int32View2[0] = 42;
 console.log(int32View2[0]);
 
 // Create an array from the original buffer
-// throws with:
-// "attempting to access detached ArrayBuffer" or
-// "Cannot perform Construct on a detached ArrayBuffer"
+// throws a TypeError
 const int32View1 = new Int32Array(object1.buffer);
 ```
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -99,7 +99,7 @@ const transferred = structuredClone(
 
 ### Cloning an object
 
-In this example we clone an object with one member, which is an array. After cloning, changes to each object do not affect the other object.
+In this example, we clone an object with one member, which is an array. After cloning, changes to each object do not affect the other object.
 
 ```js
 const mushrooms1 = {


### PR DESCRIPTION
Fixes #22942: correct the `transfer` option syntax. Also added a couple of examples.