### PR TITLE
Fix the spelling of a word

### DIFF
--- a/files/en-us/learn/css/css_layout/index.md
+++ b/files/en-us/learn/css/css_layout/index.md
@@ -79,6 +79,6 @@ The following assessment will test your understanding of the CSS layout methods 
 ## See also
 
 - [Practical positioning examples](/en-US/docs/Learn/CSS/CSS_layout/Practical_positioning_examples)
-  - : This article shows how to build some real world examples to illustrate what kinds of things you can do with positioning.
+  - : This article shows how to build some real-world examples to illustrate what kinds of things you can do with positioning.
 - [CSS layout cookbook](/en-US/docs/Web/CSS/Layout_cookbook)
   - : The CSS layout cookbook aims to bring together recipes for common layout patterns, things you might need to implement in your sites. In addition to providing code you can use as a starting point in your projects, these recipes highlight the different ways layout specifications can be used and the choices you can make as a developer.

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -16,7 +16,7 @@ tags:
 
 {{LearnSidebar}}
 
-This article shows how to build some real world examples to illustrate what kinds of things you can do with positioning.
+This article shows how to build some real-world examples to illustrate what kinds of things you can do with positioning.
 
 <table>
   <tbody>

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -46,7 +46,7 @@ We want to set really clear expectations here: You won't be expected to learn Ja
 
 ## Thinking like a programmer
 
-One of the hardest things to learn in programming is not the syntax you need to learn, but how to apply it to solve real world problems. You need to start thinking like a programmer — this generally involves looking at descriptions of what your program needs to do, working out what code features are needed to achieve those things, and how to make them work together.
+One of the hardest things to learn in programming is not the syntax you need to learn, but how to apply it to solve real-world problems. You need to start thinking like a programmer — this generally involves looking at descriptions of what your program needs to do, working out what code features are needed to achieve those things, and how to make them work together.
 
 This requires a mixture of hard work, experience with the programming syntax, and practice — plus a bit of creativity. The more you code, the better you'll get at it. We can't promise that you'll develop "programmer brain" in five minutes, but we will give you plenty of opportunities to practice thinking like a programmer throughout the course.
 

--- a/files/en-us/related/imsc/basics/index.md
+++ b/files/en-us/related/imsc/basics/index.md
@@ -22,7 +22,7 @@ If you are not already familiar with XML or HTML, read up on them first and then
 - [XML Introduction](/en-US/docs/Web/XML/XML_introduction)
 - [HTML Basics](/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics)
 
-> **Note:** If you want to know what you can do with IMSC in real world scenarios have a look at the expanded example at the end of this tutorial.
+> **Note:** If you want to know what you can do with IMSC in real-world scenarios have a look at the expanded example at the end of this tutorial.
 
 ## Minimal IMSC document
 

--- a/files/en-us/related/imsc/namespaces/index.md
+++ b/files/en-us/related/imsc/namespaces/index.md
@@ -14,7 +14,7 @@ This article covers the subject of XML namespaces, giving you enough information
 
 Namespaces are basically the mechanism that you use in XML to differentiate different families of markup (which may have features with the same name), and allow them to be used in the same document.
 
-To help you understand what we mean by this, let's use a real world example — human family names. There are many people in the world called Mary. One way to tell them apart is by their full names — there can be a Mary Smith and a Mary Jones.
+To help you understand what we mean by this, let's use a real-world example — human family names. There are many people in the world called Mary. One way to tell them apart is by their full names — there can be a Mary Smith and a Mary Jones.
 
 In XML you can also give elements and attributes a "family name", which is their namespace. Namespaces define what family an XML vocabulary belongs to, and generally consist of an identifying string of characters. The `<p>` element is available in both HTML and IMSC, so perhaps you could use the namespace `html` to specify HTML's `<p>`, and `imsc` to specify IMSC's `<p>`?
 

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -101,7 +101,7 @@ Our perception of contrast is not only affected by surrounding elements and the 
 
 In a typical eye exam for acuity (ability to focus), legibility at a particular level means getting three out of five letters correct. This is wholly insufficient for fluent, easy reading.
 
-"Normal" print is usually considered 11.5pt to 12pt, this is equivalent of 16px on screen. And this is for normal vision. To relate this to real world visual acuity, if you think of an eye doctor's chart, and focusing on a capital E. If that E is at the legibility or acuity limit for 20/20 vision, and that is at full contrast, it is equivalent to a Helvetica capital E that is 3.9px on screen, meaning a 5.5px CSS font-size. (In print, this is a 4pt font on coated paper).
+"Normal" print is usually considered 11.5pt to 12pt, this is equivalent of 16px on screen. And this is for normal vision. To relate this to real-world visual acuity, if you think of an eye doctor's chart, and focusing on a capital E. If that E is at the legibility or acuity limit for 20/20 vision, and that is at full contrast, it is equivalent to a Helvetica capital E that is 3.9px on screen, meaning a 5.5px CSS font-size. (In print, this is a 4pt font on coated paper).
 
 This is the minimum for "just making out" letters at \~70% accuracy. That is legibility, not readability. For readability, the lower case [x-height](https://kazdesignworks.com/graphic-design-terms-x-height-and-cap-height/) needs to be a minimum of twice that [cap height](https://kazdesignworks.com/graphic-design-terms-x-height-and-cap-height/). This is called the critical font size for readability.
 

--- a/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -15,7 +15,7 @@ tags:
 
 In this article, we'll build a mock blog which has a number of ads interspersed among the contents of the page, then use the [Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API) to track how much time each ad is visible to the user. When an ad exceeds one minute of visible time, it will be replaced with a new one.
 
-Although many aspects of this example will not match real world usage (in particular, the articles all have the same text and aren't loaded from a database, and there are just a handful of simple text-only ads that are selected from an array), this should provide enough understanding of the API to quickly learn how to apply the Intersection Observer API to your own site.
+Although many aspects of this example will not match real-world usage (in particular, the articles all have the same text and aren't loaded from a database, and there are just a handful of simple text-only ads that are selected from an array), this should provide enough understanding of the API to quickly learn how to apply the Intersection Observer API to your own site.
 
 There's a good reason why the notion of tracking visibility of ads is being used in this example. It turns out that one of the most common uses of Flash or other script in advertising on the Web is to record how long each ad is visible, for the purpose of billing and payment of revenues. Without the Intersection Observer API, this winds up being done using intervals and timeouts for each individual ad, or other techniques that tend to slow the page down. Using this API lets everything get streamlined by the browser to reduce the impact on performance substantially.
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -27,7 +27,7 @@ The system notification system will vary of course by platform and browser, but 
 
 One of the most obvious use cases for web notifications is a web-based mail or IRC application that needs to notify the user when a new message is received, even if the user is doing something else with another application. Many examples of this now exist, such as [Slack](https://slack.com/).
 
-We've written a real world example — a to-do list app — to give more of an idea of how web notifications can be used. It stores data locally using [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) and notifies users when tasks are due using system notifications. [Download the To-do list code](https://github.com/mdn/dom-examples/tree/main/to-do-notifications), or [view the app running live](https://mdn.github.io/dom-examples/to-do-notifications/).
+We've written a real-world example — a to-do list app — to give more of an idea of how web notifications can be used. It stores data locally using [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) and notifies users when tasks are due using system notifications. [Download the To-do list code](https://github.com/mdn/dom-examples/tree/main/to-do-notifications), or [view the app running live](https://mdn.github.io/dom-examples/to-do-notifications/).
 
 ## Requesting permission
 

--- a/files/en-us/web/api/storage/clear/index.md
+++ b/files/en-us/web/api/storage/clear/index.md
@@ -45,7 +45,7 @@ function populateStorage() {
 }
 ```
 
-> **Note:** For a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/getitem/index.md
+++ b/files/en-us/web/api/storage/getitem/index.md
@@ -55,7 +55,7 @@ function setStyles() {
 }
 ```
 
-> **Note:** To see this used within a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/key/index.md
+++ b/files/en-us/web/api/storage/key/index.md
@@ -55,7 +55,7 @@ for (let i = 0; i < localStorage.length; i++) {
 }
 ```
 
-> **Note:** For a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/length/index.md
+++ b/files/en-us/web/api/storage/length/index.md
@@ -37,7 +37,7 @@ function populateStorage() {
 }
 ```
 
-> **Note:** For a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/removeitem/index.md
+++ b/files/en-us/web/api/storage/removeitem/index.md
@@ -63,7 +63,7 @@ function populateStorage() {
 }
 ```
 
-> **Note:** To see this used within a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/setitem/index.md
+++ b/files/en-us/web/api/storage/setitem/index.md
@@ -52,7 +52,7 @@ function populateStorage() {
 }
 ```
 
-> **Note:** To see this used within a real world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
@@ -369,7 +369,7 @@ box.draw({
 
 ## Model transform
 
-Placing points directly into clip space is of limited use. In real world applications, you don't have all your source coordinates already in clip space coordinates. So most of the time, you need to transform the model data and other coordinates into clip space. The humble cube is an easy example of how to do this. Cube data consists of vertex positions, the colors of the faces of the cube, and the order of the vertex positions that make up the individual polygons (in groups of 3 vertices to construct the triangles composing the cube's faces). The positions and colors are stored in GL buffers, sent to the shader as attributes, and then operated upon individually.
+Placing points directly into clip space is of limited use. In real-world applications, you don't have all your source coordinates already in clip space coordinates. So most of the time, you need to transform the model data and other coordinates into clip space. The humble cube is an easy example of how to do this. Cube data consists of vertex positions, the colors of the faces of the cube, and the order of the vertex positions that make up the individual polygons (in groups of 3 vertices to construct the triangles composing the cube's faces). The positions and colors are stored in GL buffers, sent to the shader as attributes, and then operated upon individually.
 
 Finally a single model matrix is computed and set. This matrix represents the transformations to be performed on every point making up the model in order to move it into the correct space, and to perform any other needed transforms on each point in the model. This applies not just to each vertex, but to every single point on every surface of the model as well.
 

--- a/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
+++ b/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
@@ -21,7 +21,7 @@ There are many uses for bounded reference spaces, including projects such as vir
 
 ## Introduction
 
-A bounded reference space is one which represents an XR environment in which the user is able to move around physically in the real world while being tracked by the XR hardware, with their movements being then transposed into the simulation. The boundaries established by the bounded reference space, then, represent the edges of the safely passable, tracked space in the user's real world environment that are available for their movement while in the simulation.
+A bounded reference space is one which represents an XR environment in which the user is able to move around physically in the real world while being tracked by the XR hardware, with their movements being then transposed into the simulation. The boundaries established by the bounded reference space, then, represent the edges of the safely passable, tracked space in the user's real-world environment that are available for their movement while in the simulation.
 
 ### Requirements
 

--- a/files/en-us/web/api/webxr_device_api/index.md
+++ b/files/en-us/web/api/webxr_device_api/index.md
@@ -22,7 +22,7 @@ browser-compat: api.Navigator.xr
 
 **WebXR** is a group of standards which are used together to support rendering 3D scenes to hardware designed for presenting virtual worlds (**virtual reality**, or **VR**), or for adding graphical imagery to the real world, (**augmented reality**, or **AR**). The **WebXR Device API** implements the core of the WebXR feature set, managing the selection of output devices, render the 3D scene to the chosen device at the appropriate frame rate, and manage motion vectors created using input controllers.
 
-WebXR-compatible devices include fully-immersive 3D headsets with motion and orientation tracking, eyeglasses which overlay graphics atop the real world scene passing through the frames, and handheld mobile phones which augment reality by capturing the world with a camera and augment that scene with computer-generated imagery.
+WebXR-compatible devices include fully-immersive 3D headsets with motion and orientation tracking, eyeglasses which overlay graphics atop the real-world scene passing through the frames, and handheld mobile phones which augment reality by capturing the world with a camera and augment that scene with computer-generated imagery.
 
 To accomplish these things, the WebXR Device API provides the following key capabilities:
 

--- a/files/en-us/web/api/xrframe/createanchor/index.md
+++ b/files/en-us/web/api/xrframe/createanchor/index.md
@@ -18,7 +18,7 @@ browser-compat: api.XRFrame.createAnchor
 
 The **`createAnchor()`** method of the {{domxref("XRFrame")}} interface creates a free-floating {{domxref("XRAnchor")}} which will be fixed relative to the real world.
 
-See {{domxref("XRHitTestResult.createAnchor()")}} for creating an anchor from a hit test result that is attached to a real world object.
+See {{domxref("XRHitTestResult.createAnchor()")}} for creating an anchor from a hit test result that is attached to a real-world object.
 
 ## Syntax
 

--- a/files/en-us/web/api/xrhittestresult/createanchor/index.md
+++ b/files/en-us/web/api/xrhittestresult/createanchor/index.md
@@ -16,7 +16,7 @@ browser-compat: api.XRHitTestResult.createAnchor
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The **`createAnchor()`** method of the {{domxref("XRHitTestResult")}} interface creates an {{domxref("XRAnchor")}} from a hit test result that is attached to a real world object.
+The **`createAnchor()`** method of the {{domxref("XRHitTestResult")}} interface creates an {{domxref("XRAnchor")}} from a hit test result that is attached to a real-world object.
 
 ## Syntax
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -102,7 +102,7 @@ The following session features and reference spaces can be requested, either as 
 - `hand-tracking`
   - : Enable articulated hand pose information from hand-based input controllers (see {{domxref("XRHand")}} and {{domxref("XRInputSource.hand")}}).
 - `hit-test`
-  - : Enable hit testing features for performing hit tests against real world geometry.
+  - : Enable hit testing features for performing hit tests against real-world geometry.
 - `layers`
   - : Enable the ability to create various layer types (other than {{domxref("XRProjectionLayer")}}).
 - `light-estimation`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"Real world" should be hyphenated when used as an adjective.
