### PR TITLE
Fixes #2968 - adds exception for Chrome in UA lookup table

### DIFF
--- a/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
@@ -212,7 +212,7 @@ Also, pay attention not to use a simple regular expression on the BrowserName, u
 | ------------------------------- | ----------------------- | ------------------------------ |
 | Firefox                         | `Firefox/xyz`           | `Seamonkey/xyz`                |
 | Seamonkey                       | `Seamonkey/xyz`         |                                |
-| Chrome                          | `Chrome/xyz`            | `Chromium/xyz`                 |
+| Chrome                          | `Chrome/xyz`            | `Chromium/xyz` or `Edg.*/xyz`  |
 | Chromium                        | `Chromium/xyz`          |                                |
 | Safari                          | `Safari/xyz`            | `Chrome/xyz` or `Chromium/xyz` |
 | Opera 15+ (Blink-based engine)  | `OPR/xyz`               |                                |


### PR DESCRIPTION
### Description

The [current UA matching conditions for Chrome](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name) also [pass for Edge](https://www.whatismybrowser.com/guides/the-latest-user-agent/edge). Added exception.

### Motivation

[I want to publicly demonstrate my own skills to improve my chances of getting a job](https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette#think_about_why_you_are_contributing_to_an_osp)

### Additional details

Thanks @RomViR for reporting

### Related issues and pull requests

Fixes #2968
