### PR TITLE
fix: add zh-cn community

### DIFF
--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -25,7 +25,7 @@ We have frozen all localized content (meaning that we won't accept any edits to 
 
 ### Chinese (zh-CN, zh-TW)
 
-- Discussions: [Telegram (MozTW L10n channel)](https://moztw.org/community/telegram/)
+- Discussions: [Telegram (MozTW L10n channel)](https://moztw.org/community/telegram/), [Telegram (Mozilla China channel)](https://t.me/mozilla_china)
 - Current contributors: [Irvin](https://github.com/irvin), [t7yang](https://github.com/t7yang), [yin1999](https://github.com/yin1999)
 
 ### French (fr)


### PR DESCRIPTION
As mentioned in https://github.com/mdn/translated-content/pull/10743, community addition should also be commited to English source article.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add community link of zh-cn localization team from China

### Motivation

Many times translator complaining that they can't find a discussion forum in Simplified Chinese in Taiwan's group

### Additional details

None.