### PR TITLE
`rem()` - New CSS functional notation

### DIFF
--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -18,7 +18,7 @@ browser-compat: css.types.rem
 
 The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a leftover when one operand is divided by a second operand. It always takes the sign of the dividend.
 
-> When dividing 27 by 5, the result is 25 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem(27, 5)` function returns the remainder of `2`.
+> When dividing 27 by 5, the result is 5 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem(27, 5)` function returns the remainder of `2`.
 
 ## Syntax
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -23,21 +23,21 @@ The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Fu
 ## Syntax
 
 ```css
-// Unitless values
-line-height: rem(21, 2);  // 1
-line-height: rem(14, 5);  // 4
-line-height: rem(5.5, 2); // 1.5
+/* Unitless values */
+line-height: rem(21, 2);  /* 1 */
+line-height: rem(14, 5);  /* 4 */
+line-height: rem(5.5, 2); /* 1.5 */
 
-// Unit based values
-margin: rem(14%, 3%);   // 2%
-margin: rem(18px, 5px); // 3px
-margin: rem(25vw, 7vw); // 4vw
+/* Unit based values */
+margin: rem(14%, 3%);   /* 2% */
+margin: rem(18px, 5px); /* 3px */
+margin: rem(25vw, 7vw); /* 4vw */
 
-// Negative/positive values
-rotate: rem(200deg, 30deg);  // 20deg
-rotate: rem(140deg, -90deg); // 50deg
-rotate: rem(-90deg, 20deg);  // -10deg
-rotate: rem(-90deg, -20deg); // -10deg
+/* Negative/positive values */
+rotate: rem(200deg, 30deg);  /* 20deg */
+rotate: rem(140deg, -90deg); /* 50deg */
+rotate: rem(-90deg, 20deg);  /* -10deg */
+rotate: rem(-55deg, -15deg); /* -10deg */
 ```
 
 ### Parameter

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -31,7 +31,7 @@ line-height: rem(5.5, 2); /* 1.5 */
 /* Unit based values */
 margin: rem(14%, 3%);   /* 2% */
 margin: rem(18px, 5px); /* 3px */
-margin: rem(25vw, 7vw); /* 4vw */
+margin: rem(25vmin, 7vmin); /* 4vmin */
 
 /* Negative/positive values */
 rotate: rem(200deg, 30deg);  /* 20deg */
@@ -52,7 +52,7 @@ The `rem(dividend, divisor)` function accepts two comma-separated values as its 
 
 ### Return value
 
-Returns a {{CSSxREF("&lt;number&gt;")}} representing the remainder, that is, the operation left over.
+Returns a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} (the same type as the parameters) representing the remainder, that is, the operation left over.
 
 - If `divisor` is `0`, the result is `NaN`.
 - If `dividend` is `infinite`, the result is `NaN`.

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -1,0 +1,69 @@
+---
+title: rem()
+slug: Web/CSS/rem
+page-type: css-function
+tags:
+  - CSS
+  - CSS Function
+  - Function
+  - Math
+  - Reference
+  - Web
+  - rem
+  - Experimental
+browser-compat: css.types.rem
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a left over when one operand is divided by a second operand. It always takes the sign of the dividend.
+
+> When dividing 12 by 5, the result is 10 with a remainder of 2. The full calculation is `12 / 5 = 10 (2)`. The `rem()` function returns the reminder.
+
+## Syntax
+
+```css
+width: calc(100px * rem(21, 2));  // 100px
+width: calc(100px * rem(14, 5));  // 400px
+width: calc(100px * rem(5.5, 2)); // 150px
+
+margin: rem(-18px, 5px); // -3px
+
+rotate: rem(140deg, -90deg); // 50deg
+rotate: rem(140deg, -90deg); // 50deg
+rotate: rem(140deg, -90deg); // 50deg
+```
+
+### Parameter
+
+The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, or else the function is invalid.
+
+- `dividend`
+  - : A calculation that resolves to a  {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the dividend.
+  
+- `divisor`
+  - : A calculation that resolves to a  {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the divisor.
+
+### Return value
+
+Returns a {{CSSxREF("&lt;number&gt;")}} representing the remainder, that is, the operation left over.
+
+- If `divisor` is `0`, the result is `NaN`.
+- If `dividend` is `infinite`, the result is `NaN`.
+
+### Formal syntax
+
+{{CSSSyntax}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{CSSxRef("round")}}
+- {{CSSxRef("mod")}}

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -44,7 +44,7 @@ rotate: rem(-55deg, -15deg); /* -10deg */
 /* Calculations */
 scale: rem(10 * 2, 1.7);         /* 1.3 */
 rotate: rem(10turn, 18turn / 3); /* 4turn */
-transition-duration: rem(20s / 2, 3000ms * 2); /* 4s */	
+transition-duration: rem(20s / 2, 3000ms * 2); /* 4s */
 ```
 
 ### Parameter

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -18,7 +18,7 @@ browser-compat: css.types.rem
 
 The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a leftover when one operand is divided by a second operand. It always takes the sign of the dividend.
 
-> When dividing 12 by 5, the result is 10 with a remainder of 2. The full calculation is `12 / 5 = 10 (2)`. The `rem()` function returns the remainder.
+> When dividing 27 by 5, the result is 25 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem()` function returns the remainder.
 
 ## Syntax
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -23,15 +23,21 @@ The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Fu
 ## Syntax
 
 ```css
-width: calc(100px * rem(21, 2));  // 100px
-width: calc(100px * rem(14, 5));  // 400px
-width: calc(100px * rem(5.5, 2)); // 150px
+// Unitless values
+line-height: rem(21, 2);  // 1
+line-height: rem(14, 5);  // 4
+line-height: rem(5.5, 2); // 1.5
 
-margin: rem(-18px, 5px); // -3px
+// Unit based values
+margin: rem(14%, 3%);   // 2%
+margin: rem(18px, 5px); // 3px
+margin: rem(25vw, 7vw); // 4vw
 
+// Negative/positive values
 rotate: rem(200deg, 30deg);  // 20deg
 rotate: rem(140deg, -90deg); // 50deg
 rotate: rem(-90deg, 20deg);  // -10deg
+rotate: rem(-90deg, -20deg); // -10deg
 ```
 
 ### Parameter
@@ -50,6 +56,7 @@ Returns a {{CSSxREF("&lt;number&gt;")}} representing the remainder, that is, the
 
 - If `divisor` is `0`, the result is `NaN`.
 - If `dividend` is `infinite`, the result is `NaN`.
+- If `dividend` is positive the result is positive (`0⁺`), and if `dividend` is negative the result is negative (`0⁻`).
 
 ### Formal syntax
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -16,9 +16,9 @@ browser-compat: css.types.rem
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder left over when the first parameter is divided by the second parameter, similar to the JavaScript [remainder operator (`%`)](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder). The remainder is the value leftover when one operand, the dividend, is divided by a second operand, the divisor. It always takes the sign of the dividend.
+The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder left over when the first parameter is divided by the second parameter, similar to the JavaScript [remainder operator (`%`)](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder). The remainder is the value left over when one operand, the dividend, is divided by a second operand, the divisor. It always takes the sign of the dividend.
 
-> For example, the `rem(27, 5)` function returns the remainder of `2`. When dividing 27 by 5, the result is 5 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. 
+> For example, the CSS `rem(27, 5)` function returns the remainder of `2`. When dividing 27 by 5, the result is 5 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`.
 
 ## Syntax
 
@@ -53,7 +53,7 @@ The `rem(dividend, divisor)` function accepts two comma-separated values as its 
 
 ### Return value
 
-Returns a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} (corresponds to the parameters' type) representing the remainder, that is, the operation leftover.
+Returns a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} (corresponds to the parameters' type) representing the remainder, that is, the operation left over.
 
 - If `divisor` is `0`, the result is `NaN`.
 - If `dividend` is `infinite`, the result is `NaN`.

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -16,9 +16,9 @@ browser-compat: css.types.rem
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a leftover when one operand is divided by a second operand. It always takes the sign of the dividend.
+The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder left over when the first parameter is divided by the second parameter, similar to the JavaScript [remainder operator (`%`)](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder). The remainder is the value leftover when one operand, the dividend, is divided by a second operand, the divisor. It always takes the sign of the dividend.
 
-> When dividing 27 by 5, the result is 5 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem(27, 5)` function returns the remainder of `2`.
+> For example, the `rem(27, 5)` function returns the remainder of `2`. When dividing 27 by 5, the result is 5 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. 
 
 ## Syntax
 
@@ -43,7 +43,7 @@ rotate: rem(-55deg, -15deg); /* -10deg */
 
 ### Parameter
 
-The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type for the function to be valid.
+The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or [percentage](/en-US/docs/Web/CSS/percentage), for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
 
 - `dividend`
   - : A calculation that resolves to a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the dividend.

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -16,9 +16,9 @@ browser-compat: css.types.rem
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a left over when one operand is divided by a second operand. It always takes the sign of the dividend.
+The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a leftover when one operand is divided by a second operand. It always takes the sign of the dividend.
 
-> When dividing 12 by 5, the result is 10 with a remainder of 2. The full calculation is `12 / 5 = 10 (2)`. The `rem()` function returns the reminder.
+> When dividing 12 by 5, the result is 10 with a remainder of 2. The full calculation is `12 / 5 = 10 (2)`. The `rem()` function returns the remainder.
 
 ## Syntax
 
@@ -52,7 +52,7 @@ The `rem(dividend, divisor)` function accepts two comma-separated values as its 
 
 ### Return value
 
-Returns a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} (the same type as the parameters) representing the remainder, that is, the operation left over.
+Returns a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} (corresponds to the parameters' type) representing the remainder, that is, the operation leftover.
 
 - If `divisor` is `0`, the result is `NaN`.
 - If `dividend` is `infinite`, the result is `NaN`.

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -29,9 +29,9 @@ width: calc(100px * rem(5.5, 2)); // 150px
 
 margin: rem(-18px, 5px); // -3px
 
+rotate: rem(200deg, 30deg);  // 20deg
 rotate: rem(140deg, -90deg); // 50deg
-rotate: rem(140deg, -90deg); // 50deg
-rotate: rem(140deg, -90deg); // 50deg
+rotate: rem(-90deg, 20deg);  // -10deg
 ```
 
 ### Parameter

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -43,7 +43,7 @@ rotate: rem(-55deg, -15deg); /* -10deg */
 
 ### Parameter
 
-The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, or else the function is invalid.
+The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type for the function to be valid.
 
 - `dividend`
   - : A calculation that resolves to a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the dividend.

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -39,10 +39,10 @@ rotate: rem(140deg, -90deg); // 50deg
 The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, or else the function is invalid.
 
 - `dividend`
-  - : A calculation that resolves to a  {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the dividend.
-  
+  - : A calculation that resolves to a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the dividend.
+
 - `divisor`
-  - : A calculation that resolves to a  {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the divisor.
+  - : A calculation that resolves to a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}} representing the divisor.
 
 ### Return value
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -23,15 +23,16 @@ The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Fu
 ## Syntax
 
 ```css
-/* Unitless values */
+/* Unitless <number> */
 line-height: rem(21, 2);  /* 1 */
 line-height: rem(14, 5);  /* 4 */
 line-height: rem(5.5, 2); /* 1.5 */
 
-/* Unit based values */
-margin: rem(14%, 3%);   /* 2% */
-margin: rem(18px, 5px); /* 3px */
-margin: rem(25vmin, 7vmin); /* 4vmin */
+/* Unit based <percentage> and <dimension> */
+margin: rem(14%, 3%);       /* 2% */
+margin: rem(18px, 5px);     /* 3px */
+margin: rem(10rem, 6rem);   /* 4rem */
+margin: rem(26vmin, 7vmin); /* 5vmin */
 
 /* Negative/positive values */
 rotate: rem(200deg, 30deg);  /* 20deg */

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -33,12 +33,18 @@ margin: rem(14%, 3%);       /* 2% */
 margin: rem(18px, 5px);     /* 3px */
 margin: rem(10rem, 6rem);   /* 4rem */
 margin: rem(26vmin, 7vmin); /* 5vmin */
+margin: rem(1000px, 29rem); /* 72px - if root font-size is 16px */
 
 /* Negative/positive values */
 rotate: rem(200deg, 30deg);  /* 20deg */
 rotate: rem(140deg, -90deg); /* 50deg */
 rotate: rem(-90deg, 20deg);  /* -10deg */
 rotate: rem(-55deg, -15deg); /* -10deg */
+
+/* Calculations */
+scale: rem(10 * 2, 1.7);         /* 1.3 */
+rotate: rem(10turn, 18turn / 3); /* 4turn */
+transition-duration: rem(20s / 2, 3000ms * 2); /* 4s */	
 ```
 
 ### Parameter

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -18,7 +18,7 @@ browser-compat: css.types.rem
 
 The **`rem()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a remainder (with the same sign as the dividend) when dividing one number by another. The remainder is a leftover when one operand is divided by a second operand. It always takes the sign of the dividend.
 
-> When dividing 27 by 5, the result is 25 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem()` function returns the remainder.
+> When dividing 27 by 5, the result is 25 with a remainder of 2. The full calculation is `27 / 5 = 5 * 5 + 2`. The `rem(27, 5)` function returns the remainder of `2`.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Document the CSS `rem()` functional notation.

### Motivation

[Safari 15.4](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) already supports this CSS function.

[Firefox 109](https://bugzilla.mozilla.org/show_bug.cgi?id=1764850) adds support for this CSS function.

### Additional details

https://w3c.github.io/csswg-drafts/css-values/#funcdef-mod

### Related issues and pull requests

* BCD - https://github.com/mdn/browser-compat-data/pull/18480
* Syntaxes - https://github.com/mdn/data/pull/593
