### PR TITLE
Add note about repeating classes on .class page.

### DIFF
--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -44,6 +44,8 @@ Note that this is equivalent to the following {{Cssxref("Attribute_selectors", "
 [class~=class_name] { style properties }
 ```
 
+> **Note:** A selector with a class name repeated, such as `.class_name.class_name`, will match an element with that same class, even if the element only has the class once. It will however increase [specificity](/en-US/docs/Web/CSS/Specificity).
+
 ## Examples
 
 ### CSS


### PR DESCRIPTION
### Description

Added a note explaining that .class.class will match the same elements as just .class, but will have more specificity

### Motivation

This will help newer CSS devs understand how class selectors work.

### Additional details

If the official documentation states this, i haven't been able to find it, however there are multiple sources around the web which say so, and i have find out by myself.

For example, here is [an article about it](https://redfin.engineering/a-neat-little-css-hack-duplicates-in-chained-selectors-a24f87b1247).
