### PR TITLE
Fix example code to match live sample

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -489,7 +489,7 @@ Here we store a reference to the email input, then add an event listener to it t
 
 Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
 
-If the `validity.typeMismatch` property returns `false`, we call the `setCustomValidity()` method an empty string. This renders the input valid, so the form will submit.
+If the `validity.typeMismatch` property returns `false`, we call the `setCustomValidity()` method with an empty string. This renders the input valid, so the form will submit.
 
 You can try it out below:
 

--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -479,7 +479,6 @@ const email = document.getElementById("mail");
 email.addEventListener("input", (event) => {
   if (email.validity.typeMismatch) {
     email.setCustomValidity("I am expecting an email address!");
-    email.reportValidity();
   } else {
     email.setCustomValidity("");
   }
@@ -488,7 +487,7 @@ email.addEventListener("input", (event) => {
 
 Here we store a reference to the email input, then add an event listener to it that runs the contained code each time the value inside the input is changed.
 
-Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message which is displayed by calling {{domxref("HTMLInputElement.reportValidity","reportValidity()")}}. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
+Inside the contained code, we check whether the email input's `validity.typeMismatch` property returns `true`, meaning that the contained value doesn't match the pattern for a well-formed email address. If so, we call the {{domxref("HTMLInputElement.setCustomValidity()","setCustomValidity()")}} method with a custom message. This renders the input invalid, so that when you try to submit the form, submission fails and the custom error message is displayed.
 
 If the `validity.typeMismatch` property returns `false`, we call the `setCustomValidity()` method an empty string. This renders the input valid, so the form will submit.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example code in the markdown does not match the live sample that it's supposed to reference. I've modified the code block in the markdown and its accompanying description to fix this. I also fixed a typo.

### Motivation

Right now the page is a bit misleading. It claims the code block in the markdown and the live sample code are the same, when they're not. Additionally, I'm not sure when (if ever) you would want to call `.reportValidity` on the `input` event which fires on every keystroke on email inputs. If anything, it should probably only ever be done on a `change` event, but that would require further editing both the markdown and the live sample to produce a case when you'd actually want this.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Essentially this reverts PR #12154 which was supposed to fix issue #12110. I'm not sure if either of those were actually tested, as the [live sample code](https://github.com/mdn/learning-area/blob/main/html/forms/form-validation/custom-error-message.html) that the original issue was claiming didn't work [appears to work fine](https://mdn.github.io/learning-area/html/forms/form-validation/custom-error-message.html) either by (1) pushing enter with focus on the email input or (2) actually clicking submit. Maybe the original person who opened the issue was trying to submit the form with empty input in the email field or something?

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- Reverts #12154

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
