### PR TITLE
Link to Chrome's official autosizing documentation

### DIFF
--- a/files/en-us/web/css/text-size-adjust/index.md
+++ b/files/en-us/web/css/text-size-adjust/index.md
@@ -82,5 +82,6 @@ p {
 ## See also
 
 - [Apple's documentation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW16)
+- [Google Chrome behavior description](http://tinyurl.com/TextAutosizer)
 - [Gecko's behavior description](https://dbaron.org/log/20111126-font-inflation), by L. David Baron
 - [Microsoft's documentation](<https://msdn.microsoft.com/library/windows/apps/ff462082(v=vs.105).aspx#BKMK_AdjustingTextSizewithCustomCSS>)


### PR DESCRIPTION
### Description

Added a link to Google's official documentation for text autosizing (sometimes called "font boosting") in Chrome, explaining the basic algorithm they use. It was last updated in 2014. Chrome uses a link shortener: [http://tinyurl.com/TextAutosizer](http://tinyurl.com/TextAutosizer).

### Motivation

It's useful to understand what factors on a page influence text autosizing, for debugging when browsers get it wrong. This link _almost_ explains, like, four of them. I mean, it's better than _nothing_? Barely?

### Additional details

I found this link [in Google Chrome's source code](https://chromium.googlesource.com/chromium/src/+/746621834ade23fdb2623caac91563375c0d90ed/third_party/WebKit/Source/core/layout/TextAutosizer.h#55). Checking the [most current version](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/layout/text_autosizer.h) shows it's still there, though the link destination is... dated.