### PR TITLE
Fix the referenced name of the example function in the await article.

### DIFF
--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -298,7 +298,7 @@ async function noAwait() {
 }
 ```
 
-However, consider the case where `someAsyncTask` asynchronously throws an error.
+However, consider the case where `lastAsyncTask` asynchronously throws an error.
 
 ```js
 async function lastAsyncTask() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->


<!-- ✍️ Summarize your changes in one or two sentences -->

Fix the referenced name of the example function in the await article at the "Improving stack trace" section..

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was reading [en-US/docs/Web/JavaScript/Reference/Operators/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) and I didn't understand why the article was mentioning `someAsyncTask`.

Thank you.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
