### PR TITLE
changed `## see also` order

### DIFF
--- a/files/en-us/web/css/_colon_future/index.md
+++ b/files/en-us/web/css/_colon_future/index.md
@@ -74,6 +74,6 @@ This is the third caption
 
 ## See also
 
-- [Web Video Text Tracks Format (WebVTT)](/en-US/docs/Web/API/WebVTT_API)
 - {{cssxref(":current")}}
 - {{cssxref(":past")}}
+- [Web Video Text Tracks Format (WebVTT)](/en-US/docs/Web/API/WebVTT_API)


### PR DESCRIPTION
unclear why the link was broken. Reordered to help. Also, current and past are closely related, so the API should come last.

---------

There is a redirect, 

> /en-US/docs/Web/CSS/:current	/en-US/docs/Web/API/WebVTT_API

Anyone know why?