### PR TITLE
Don't use a raw.githubusercontent.com-hosted video

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -546,7 +546,7 @@ The HTML looks like this:
 <div class="hidden">
   <video>
     <source
-      src="https://raw.githubusercontent.com/mdn/learning-area/master/javascript/building-blocks/events/rabbit320.webm"
+      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
       type="video/webm" />
     <p>
       Your browser doesn't support HTML video. Here is a
@@ -640,7 +640,7 @@ All we're doing here is calling `stopPropagation()` on the event object in the h
 
 <div class="hidden">
   <video>
-    <source src="https://raw.githubusercontent.com/mdn/learning-area/master/javascript/building-blocks/events/rabbit320.webm" type="video/webm">
+    <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm" type="video/webm">
     <p>Your browser doesn't support HTML video. Here is a <a href="rabbit320.mp4">link to the video</a> instead.</p>
   </video>
 </div>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/23181.

The reporter couldn't access https://raw.githubusercontent.com so they could not see the video. Although it doesn't seem likely that this is very common, it's not great to serve video from there. It would be better for https://github.com/mdn/yari/pull/7605 to be fixed so we can have video local to the page, but it isn't, so I thought https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm would be a better bet - we need people to be able to access that anyway, and it is a domain under our control.

