### PR TITLE
Fix: Set line-height to 0, preventing overflow

### DIFF
--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -29,6 +29,7 @@ html,
 body,
 svg {
   height: 100%;
+  line-height: 0;
 }
 svg:not(:root) {
   display: inline-block;


### PR DESCRIPTION
Removes needless scroll-bar in example.

