### PR TITLE
Remove Function.prototype.prototype property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/index.md
@@ -30,8 +30,6 @@ Every JavaScript function is actually a `Function` object. This can be seen with
   - : Specifies the number of arguments expected by the function.
 - {{jsxref("Function.prototype.name")}}
   - : The name of the function.
-- {{jsxref("Function.prototype.prototype")}}
-  - : Used when the function is used as a constructor with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. It will become the new object's prototype.
 
 ## Instance methods
 


### PR DESCRIPTION
### MDN URL

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function

### What specific section or headline is this issue about?

Built-In Objects -> Function -> Function Instance Properties -> Function.prototype.prototype

### What information was incorrect, unhelpful, or incomplete?

Remove `Function.prototype.prototype` property from Docs. 

### Do you have any supporting proof?

 We can verify it as below, 

```JavaScript
const ownPropertyNames = Object.getOwnPropertyNames(Function.prototype)
console.log(ownPropertyNames)
```

Output
```
(9) ['length', 'name', 'arguments', 'caller', 'constructor', 'apply', 'bind', 'call', 'toString']
```

As you can see above, `Function.prototype` has no data property named with `prototype`.

Screenshot from browser console.

![Screenshot from 2022-12-28 19-57-45](https://user-images.githubusercontent.com/43786036/209827072-f7e501bb-2a27-46fd-a03e-26101e4bd41a.png)