### PR TITLE
Fix: Prevents needless overflow

### DIFF
--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -29,6 +29,7 @@ html,
 body,
 svg {
   height: 100%;
+  vertical-align: top;
 }
 svg:not(:root) {
   display: inline-block;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Currently there is needless overflow as demonstrated by the scrollbar:

![image](https://user-images.githubusercontent.com/14880397/209828998-ea003ca2-c7cf-4de7-bec7-6d2af04a5eb8.png)

This change stops the overflow from happening and so the scrollbar does not needlessly appear.

Tested fix in Firefox and Chrome.