### PR TITLE
Add formal syntax for color functions

### DIFF
--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -34,6 +34,10 @@ color-mix(in srgb, #34c9eb 20%, white);
 
     `<percentage>` is the percentage of that color to mix.
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -38,6 +38,10 @@ color(display-p3 1 0.5 0 / .5);
 
     `/ <alpha-value>` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/device-cmyk/index.md
+++ b/files/en-us/web/css/color_value/device-cmyk/index.md
@@ -36,6 +36,10 @@ device-cmyk(0 81% 81% 30% / .5, rgb(178 34 34));
 
     `<color>` is an optional fallback {{cssxref("&lt;color&gt;")}} to use if the user agent does not know how to translate the CMYK color to RGB.
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -50,6 +50,10 @@ hsl(hue, saturation, lightness, alpha)
 - `alpha` {{optional_inline}}
   - : A {{cssxref("&lt;percentage&gt;")}} or a {{cssxref("&lt;number&gt;")}} between `0` and `1`, where the number `1` corresponds to `100%` and means full opacity, while `0` corresponds to `0%` and means fully transparent.
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 The `hsl()` function works well with [`conic-gradient()`](/en-US/docs/Web/CSS/gradient/conic-gradient) as both deal with angles.

--- a/files/en-us/web/css/color_value/hsla/index.md
+++ b/files/en-us/web/css/color_value/hsla/index.md
@@ -42,6 +42,10 @@ hsla(235 100% 50% / 1); /* CSS Colors 4 space-separated values */
 - Functional notation: `hsla(H S L[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
+### Formal syntax
+
+{{csssyntax("hsl")}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/hwb/index.md
+++ b/files/en-us/web/css/color_value/hwb/index.md
@@ -40,6 +40,10 @@ hwb(194 0% 0% / .5) /* #00c3ff with 50% opacity */
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/lab/index.md
+++ b/files/en-us/web/css/color_value/lab/index.md
@@ -38,6 +38,10 @@ lab(52.2345% 40.1645 59.9971 / .5);
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -38,6 +38,10 @@ lch(52.2345% 72.2 56.2 / .5);
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -48,6 +48,10 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
 - alpha
   - : A {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity), representing the transparency (or alpha channel) of the color.
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Green with oklab()

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -38,6 +38,10 @@ oklch(59.69% 0.156 49.77 / .5)
 
     `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -39,6 +39,10 @@ rgb(255 255 255 / .5); /* white with 50% opacity, using CSS Colors 4 space-separ
 - Functional notation: `rgb(R G B[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
+### Formal syntax
+
+{{csssyntax}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -37,6 +37,10 @@ rgba(255 255 255 / 50%); /* CSS Colors 4 space-separated values by percentage */
 - Functional notation: `rgba(R G B[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
+### Formal syntax
+
+{{csssyntax("rgb")}}
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
This PR adds formal syntax for the color functions.

`hsla()` and `rgba()` get the syntax for `hsl()` and `rgb()` respectively, because they don't have a separate definition in the spec, and I omitted `color-contrast()` because webref doesn't include CSS colors level 6 yet.
