### PR TITLE
Remove the interactive example for the :root pseudo-class

### DIFF
--- a/files/en-us/web/css/_colon_root/index.md
+++ b/files/en-us/web/css/_colon_root/index.md
@@ -19,8 +19,6 @@ browser-compat: css.selectors.root
 
 The **`:root`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches the root element of a tree representing the document. In HTML, `:root` represents the {{HTMLElement("html")}} element and is identical to the selector `html`, except that its [specificity](/en-US/docs/Web/CSS/Specificity) is higher.
 
-{{EmbedInteractiveExample("pages/css/pseudo-class-root.html")}}
-
 ```css
 /* Selects the root element of the document:
    <html> in the case of HTML */


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/23083, fix https://github.com/mdn/content/issues/23256.

Because this example has some problems (https://github.com/mdn/content/issues/23083#issuecomment-1360547352) I've removed it and filed https://github.com/mdn/interactive-examples/issues/2393, rather than fix the macro call.
