### PR TITLE
Describe rgb and hsl forms consistently

### DIFF
--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -37,7 +37,7 @@ hsl(hue, saturation, lightness, alpha)
 
 The `hsl()` function accepts three space-separated values, representing respectively `hue`, `saturation`, and `lightness`. Optionally it may also be given a slash `/` followed by a fourth value, representing `alpha`.
 
-The function also accepts a legacy syntax in which all four values are separated with commas.
+The function also accepts a legacy syntax in which all values are separated with commas.
 
 ### Values
 

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -21,6 +21,8 @@ The **`hsl()`** functional notation expresses an {{glossary("RGB", "sRGB")}} col
 
 Defining _complementary colors_ with `hsl()` can be done with a single formula, as they are positioned on the same diameter of the {{glossary("color wheel")}}. If `theta` is the angle of a color, its complementary one will have `180deg-theta` as its _hue_ coordinate.
 
+> **Note:** The legacy {{cssxref("color_value/hsla", "hsla()")}} syntax is an alias for `hsl()`, accepting the same parameters and behaving in the same way.
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -95,7 +95,7 @@ div {
 
 {{EmbedLiveSample('Using hsl() with conic-gradient(), ', '100%', '140px')}}
 
-### Comma-separated syntax
+### Legacy syntax: comma-separated values
 
 For legacy reasons, the `hsl()` function accepts a form in which all values are separated using commas.
 
@@ -126,7 +126,7 @@ div.comma-separated {
 
 #### Result
 
-{{EmbedLiveSample('Comma-separated syntax, ', '100%', '150px')}}
+{{EmbedLiveSample('Legacy syntax: comma-separated values', '100%', '150px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -33,6 +33,10 @@ hsl(hue, saturation, lightness)
 hsl(hue, saturation, lightness, alpha)
 ```
 
+The `hsl()` function accepts three space-separated values, representing respectively `hue`, `saturation`, and `lightness`. Optionally it may also be given a slash `/` followed by a fourth value, representing `alpha`.
+
+The function also accepts a legacy syntax in which all four values are separated with commas.
+
 ### Values
 
 - `hue`
@@ -56,32 +60,71 @@ hsl(hue, saturation, lightness, alpha)
 
 ## Examples
 
+### Using `hsl()` with `conic-gradient()`
+
 The `hsl()` function works well with [`conic-gradient()`](/en-US/docs/Web/CSS/gradient/conic-gradient) as both deal with angles.
 
 ```html hidden
 <div></div>
 ```
 
+#### CSS
+
 ```css
 div {
   width: 100px;
   height: 100px;
   background: conic-gradient(
-    hsl(360, 100%, 50%),
-    hsl(315, 100%, 50%),
-    hsl(270, 100%, 50%),
-    hsl(225, 100%, 50%),
-    hsl(180, 100%, 50%),
-    hsl(135, 100%, 50%),
-    hsl(90, 100%, 50%),
-    hsl(45, 100%, 50%),
-    hsl(0, 100%, 50%)
+    hsl(360 100% 50%),
+    hsl(315 100% 50%),
+    hsl(270 100% 50%),
+    hsl(225 100% 50%),
+    hsl(180 100% 50%),
+    hsl(135 100% 50%),
+    hsl(90 100% 50%),
+    hsl(45 100% 50%),
+    hsl(0 100% 50%)
   );
   clip-path: circle(closest-side);
 }
 ```
 
-{{EmbedLiveSample('Examples', '100%', '140px')}}
+#### Result
+
+{{EmbedLiveSample('Using hsl() with conic-gradient(), ', '100%', '140px')}}
+
+### Comma-separated syntax
+
+For legacy reasons, the `hsl()` function accepts a form in which all values are separated using commas.
+
+#### HTML
+
+```html
+<div class="space-separated"></div>
+<div class="comma-separated"></div>
+```
+
+#### CSS
+
+```css
+div {
+  width: 100px;
+  height: 50px;
+  margin: 1rem;
+}
+
+div.space-separated {
+  background-color: hsl(0 100% 50% / 50%);
+}
+
+div.comma-separated {
+  background-color: hsl(0, 100%, 50%, 50%);
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Comma-separated syntax, ', '100%', '150px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -56,7 +56,7 @@ The function also accepts a legacy syntax in which all four values are separated
 
 ## Examples
 
-### Comma-separated syntax
+### Legacy syntax: comma-separated values
 
 For legacy reasons, the `rgb()` function accepts a form in which all values are separated using commas.
 
@@ -87,7 +87,7 @@ div.comma-separated {
 
 #### Result
 
-{{EmbedLiveSample('Comma-separated syntax, ', '100%', '150px')}}
+{{EmbedLiveSample('Legacy syntax: comma-separated values', '100%', '150px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -19,6 +19,8 @@ The **`rgb()`** functional notation expresses a color according to its red, gree
 
 {{EmbedInteractiveExample("pages/css/function-rgb.html")}}
 
+> **Note:** The legacy {{cssxref("color_value/rgba", "rgba()")}} syntax is an alias for `rgb()`, accepting the same parameters and behaving in the same way.
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -39,19 +39,12 @@ The function also accepts a legacy syntax in which all four values are separated
 
 ### Values
 
-- `red`
-  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the red component.
-- `green`
-  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the green component.
-- `blue`
-  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the blue component.
-- `alpha`
-  - : A {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}} representing opacity, where the number `1` corresponds to `100%` (full opacity).
+- Values for `red`, `green`, `blue` represent color channels and may each be a {{cssxref("&lt;number&gt;")}} clamped between 0 and 255 or a {{cssxref("&lt;percentage&gt;")}}, or the keyword `none`. For color channel values, it is not permissible to mix percentages and numbers, so:
 
-For the color component values `red`, `green`, and `blue`, it is not permissible to mix percentages and numbers, so:
+  - if any color channel value is a number, then all color channel values must be numbers or `none`
+  - if any color channel value is a percentage, then all color channel values must be percentages or `none`.
 
-- if any color component value is a number, then all color component values must be numbers or `none`
-- if any color component value is a percentage, then all color component values must be percentages or `none`.
+- The value for `alpha` is a {{cssxref("&lt;number&gt;")}} clamped between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}. It represents opacity, where the number `1` corresponds to `100%` (full opacity). It defaults to 100%.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -19,29 +19,75 @@ The **`rgb()`** functional notation expresses a color according to its red, gree
 
 {{EmbedInteractiveExample("pages/css/function-rgb.html")}}
 
-> **Note:** CSS Colors Level 4 made some changes to `rgb()`. In browsers that support the standard {{cssxref("color_value/rgba","rgba()")}} is an alias for `rgb()`, they accept the same parameters and behave the same way.
->
-> The Level 4 specification also allows for space-separated in addition to comma-separated values.
-
 ## Syntax
 
 ```css
-rgb(255, 255, 255) /* white */
-rgb(255, 255, 255,.5) /* white with 50% opacity */
-rgb(255 255 255) /* CSS Colors 4 space-separated values */
-rgb(255 255 255 / .5); /* white with 50% opacity, using CSS Colors 4 space-separated values */
+/* Syntax with space-separated values */
+rgb(255 255 255)
+rgb(255 255 255 / .5)
+
+/* Syntax with comma-separated values */
+rgb(255, 255, 255)
+rgb(255, 255, 255, .5)
 ```
+
+The `rgb()` function accepts three space-separated values, representing respectively values for `red`, `green`, and `blue`. Optionally it may also be given a slash `/` followed by a fourth value, representing `alpha`.
+
+The function also accepts a legacy syntax in which all four values are separated with commas.
 
 ### Values
 
-- Functional notation: `rgb(R, G, B[, A])`
-  - : `R` (red), `G` (green), and `B` (blue) can be either {{cssxref("&lt;number&gt;")}}s or {{cssxref("&lt;percentage&gt;")}}s, where the number `255` corresponds to `100%`. `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
-- Functional notation: `rgb(R G B[ / A])`
-  - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
+- `red`
+  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the red component.
+- `green`
+  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the green component.
+- `blue`
+  - : A {{cssxref("&lt;number&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, or the keyword `none`, representing the value of the blue component.
+- `alpha`
+  - : A {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}} representing opacity, where the number `1` corresponds to `100%` (full opacity).
 
 ### Formal syntax
 
 {{csssyntax}}
+
+## Examples
+
+### Comma-separated syntax
+
+For legacy reasons, the `rgb()` function accepts a form in which all values are separated using commas.
+
+#### HTML
+
+```html
+<div class="space-separated"></div>
+<div class="comma-separated"></div>
+```
+
+#### CSS
+
+```css
+div {
+  width: 100px;
+  height: 50px;
+  margin: 1rem;
+}
+
+div.space-separated {
+  background-color: rgb(255 0 0 / 0.5);
+}
+
+div.comma-separated {
+  background-color: rgb(255, 0, 0, 0.5);
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Comma-separated syntax, ', '100%', '150px')}}
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -35,7 +35,7 @@ rgb(255, 255, 255, .5)
 
 The `rgb()` function accepts three space-separated values, representing respectively values for `red`, `green`, and `blue`. Optionally it may also be given a slash `/` followed by a fourth value, representing `alpha`.
 
-The function also accepts a legacy syntax in which all four values are separated with commas.
+The function also accepts a legacy syntax in which all values are separated with commas.
 
 ### Values
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -48,6 +48,11 @@ The function also accepts a legacy syntax in which all four values are separated
 - `alpha`
   - : A {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}} representing opacity, where the number `1` corresponds to `100%` (full opacity).
 
+For the color component values `red`, `green`, and `blue`, it is not permissible to mix percentages and numbers, so:
+
+- if any color component value is a number, then all color component values must be numbers or `none`
+- if any color component value is a percentage, then all color component values must be percentages or `none`.
+
 ### Formal syntax
 
 {{csssyntax}}

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -39,12 +39,16 @@ The function also accepts a legacy syntax in which all four values are separated
 
 ### Values
 
-- Values for `red`, `green`, `blue` represent color channels and may each be a {{cssxref("&lt;number&gt;")}} clamped between 0 and 255 or a {{cssxref("&lt;percentage&gt;")}}, or the keyword `none`. For color channel values, it is not permissible to mix percentages and numbers, so:
+- `red`, `green`, `blue`
 
-  - if any color channel value is a number, then all color channel values must be numbers or `none`
-  - if any color channel value is a percentage, then all color channel values must be percentages or `none`.
+  - : These values represent color channels and may each be a {{cssxref("&lt;number&gt;")}}
+    clamped between 0 and 255, or a {{cssxref("&lt;percentage&gt;")}}, or the keyword `none`. You can't mix percentages and numbers, so:
 
-- The value for `alpha` is a {{cssxref("&lt;number&gt;")}} clamped between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}. It represents opacity, where the number `1` corresponds to `100%` (full opacity). It defaults to 100%.
+    - if any of these values is a number, then they must all be numbers or `none`
+    - if any of these values is a percentage, then they must all percentages or `none`.
+
+- `alpha`
+  - : A {{cssxref("&lt;number&gt;")}} clamped between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}. This value represents opacity, where the number `1` corresponds to `100%` (full opacity). It defaults to 100%.
 
 ### Formal syntax
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/23236.

This PR updates the pages for [`hsl()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl) and [`rgb()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb) to describe the space and comma separated forms more consistently. It follows the spec in describing the space separated form as the main form, and the comma-separated form as a legacy syntax.

There are some other structural questions about these pages (like, should they have Parameters and Results sections) that I've not gone into, because we don't have a template for CSS functional notation pages, and I wanted to keep this PR reasonably focused.
