### PR TITLE
Fix punctuation and grammar

### DIFF
--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -54,7 +54,7 @@ The `list-style-type` property may be defined as any one of:
 
 - a `<custom-ident>` value,
 - a `symbols()` value,
-- a `<string>` value,
+- a `<string>` value, or
 - the keyword `none`.
 
 Note that:

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -52,9 +52,9 @@ list-style-type: unset;
 
 The `list-style-type` property may be defined as any one of:
 
-- a `<custom-ident>` value
-- a `symbols()` value
-- a `<string>` value
+- a `<custom-ident>` value,
+- a `symbols()` value,
+- a `<string>` value,
 - the keyword `none`.
 
 Note that:
@@ -119,11 +119,11 @@ Note that:
 - `gurmukhi`, `-moz-gurmukhi`
   - : Gurmukhi numbering.
 - `hebrew`
-  - : Traditional Hebrew numbering
+  - : Traditional Hebrew numbering.
 - `hiragana`
   - : Dictionary-order hiragana lettering.
 - `hiragana-iroha`
-  - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) hiragana lettering
+  - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) hiragana lettering.
 - `japanese-formal`
   - : Japanese formal numbering to be used in legal or financial documents. The kanjis are designed so that they can't be modified to look like another correct one.
 - `japanese-informal`
@@ -131,9 +131,9 @@ Note that:
 - `kannada`, `-moz-kannada`
   - : Kannada numbering.
 - `katakana`
-  - : Dictionary-order katakana lettering
+  - : Dictionary-order katakana lettering.
 - `katakana-iroha`
-  - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) katakana lettering
+  - : [Iroha-order](https://en.wikipedia.org/wiki/Iroha) katakana lettering.
 - `korean-hangul-formal`
   - : Korean hangul numbering.
 - `korean-hanja-formal`
@@ -153,7 +153,7 @@ Note that:
 - `oriya`, `-moz-oriya`
   - : Oriya numbering.
 - `persian`, `-moz-persian`
-  - : Persian numbering
+  - : Persian numbering.
 - `simp-chinese-formal`
   - : Simplified Chinese formal numbering.
 - `simp-chinese-informal`
@@ -179,7 +179,7 @@ Note that:
 
 ### Non-standard extensions
 
-A few more predefined types are provided by Mozilla (Firefox), Blink (Chrome and Opera) and WebKit (Safari) to support list types in other languages. See the compatibility table to check which browsers supports which extension.
+A few more predefined types are provided by Mozilla (Firefox), Blink (Chrome and Opera) and WebKit (Safari) to support list types in other languages. See the compatibility table to check which browsers support which extension.
 
 - `-moz-ethiopic-halehame`
 - `-moz-ethiopic-halehame-am`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Add missing commas and periods
- Change "supports" to "support", because it refers to plural "browsers".
