### PR TITLE
Consistency with other Object methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -23,7 +23,7 @@ If the property is inherited, or does not exist, the method returns `false`.
 ## Syntax
 
 ```js-nolint
-hasOwn(instance, prop)
+Object.hasOwn(obj, prop)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -28,7 +28,7 @@ Object.hasOwn(obj, prop)
 
 ### Parameters
 
-- `instance`
+- `obj`
   - : The JavaScript object instance to test.
 - `prop`
   - : The {{jsxref("String")}} name or [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) of the property to test.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This small change will keep this entry's syntax section consistent with other _static_ Object methods' syntax sections by using the word "Object" at the beginning and referring to the referenced object as "obj" instead of "instance."

### Motivation

To ease understanding and eliminate confusion.
