### PR TITLE
Add more details to `crossOriginIsolated` property

### DIFF
--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -28,10 +28,14 @@ A boolean value.
 ## Examples
 
 ```js
+const myWorker = new Worker('worker.js');
+
 if (crossOriginIsolated) {
-  // Post SharedArrayBuffer
+  const buffer = new SharedArrayBuffer(16);
+  myWorker.postMessage(buffer);
 } else {
-  // Do something else
+  const buffer = new ArrayBuffer(16);
+  myWorker.postMessage(buffer);
 }
 ```
 

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -21,7 +21,7 @@ indicates whether the website is in cross origin isolation state. That state mit
 
 > **Warning:** Isolated state prevents assigning value to {{DOMxRef("Document.domain")}}.
 
-Website is in cross-origin isolated state, when response header {{HTTPHeader("Cross-Origin-Opener-Policy")}} has value `same-origin` and {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header has value `require-corp` or `credentialless`.
+A website is in a cross-origin isolated state, when the response header {{HTTPHeader("Cross-Origin-Opener-Policy")}} has the value `same-origin` and the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header has the value `require-corp` or `credentialless`.
 
 ## Value
 

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -19,8 +19,6 @@ indicates whether the website is in a cross-origin isolation state. That state m
 - {{DOMxRef("Performance.now()")}} offers better precision.
 - {{DOMxRef("Performance.measureUserAgentSpecificMemory()")}} can be accessed.
 
-> **Warning:** Isolated state prevents assigning value to {{DOMxRef("Document.domain")}}.
-
 A website is in a cross-origin isolated state, when the response header {{HTTPHeader("Cross-Origin-Opener-Policy")}} has the value `same-origin` and the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header has the value `require-corp` or `credentialless`.
 
 ## Value

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -13,11 +13,15 @@ browser-compat: api.crossOriginIsolated
 {{APIRef()}}
 
 The global **`crossOriginIsolated`** read-only property returns a boolean value that
-indicates whether a {{JSxRef("SharedArrayBuffer")}} can be sent via a
-{{DOMxRef("Window.postMessage()")}} call.
+indicates whether the website is in cross origin isolation state. That state mitigates the risk of side-channel attacks and unlocks a few capabilities:
 
-This value is dependent on any {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
-{{HTTPHeader("Cross-Origin-Embedder-Policy")}} headers present in the response.
+- {{JSxRef("SharedArrayBuffer")}} can be created and sent via a {{DOMxRef("Window.postMessage()")}} call.
+- {{DOMxRef("Performance.now()")}} offers better precision.
+- {{DOMxRef("Performance.measureUserAgentSpecificMemory()")}} can be accessed.
+
+> **Warning:** Isolated state prevents assigning value to {{DOMxRef("Document.domain")}}.
+
+Website is in cross-origin isolated state, when response header {{HTTPHeader("Cross-Origin-Opener-Policy")}} has value `same-origin` and {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header has value `require-corp` or `credentialless`.
 
 ## Value
 

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -13,7 +13,7 @@ browser-compat: api.crossOriginIsolated
 {{APIRef()}}
 
 The global **`crossOriginIsolated`** read-only property returns a boolean value that
-indicates whether the website is in cross origin isolation state. That state mitigates the risk of side-channel attacks and unlocks a few capabilities:
+indicates whether the website is in a cross-origin isolation state. That state mitigates the risk of side-channel attacks and unlocks a few capabilities:
 
 - {{JSxRef("SharedArrayBuffer")}} can be created and sent via a {{DOMxRef("Window.postMessage()")}} call.
 - {{DOMxRef("Performance.now()")}} offers better precision.

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -140,10 +140,14 @@ To check if cross origin isolation has been successful, you can test against the
 property available to window and worker contexts:
 
 ```js
+const myWorker = new Worker('worker.js');
+
 if (crossOriginIsolated) {
-  // Post SharedArrayBuffer
+  const buffer = new SharedArrayBuffer(16);
+  myWorker.postMessage(buffer);
 } else {
-  // Do something else
+  const buffer = new ArrayBuffer(16);
+  myWorker.postMessage(buffer);
 }
 ```
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -57,10 +57,14 @@ See also the {{HTTPHeader("Cross-Origin-Opener-Policy")}} header which you'll ne
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:
 
 ```js
+const myWorker = new Worker('worker.js');
+
 if (crossOriginIsolated) {
-  // Post SharedArrayBuffer
+  const buffer = new SharedArrayBuffer(16);
+  myWorker.postMessage(buffer);
 } else {
-  // Do something else
+  const buffer = new ArrayBuffer(16);
+  myWorker.postMessage(buffer);
 }
 ```
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -64,10 +64,14 @@ See also the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header which you'll 
 To check if cross-origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:
 
 ```js
+const myWorker = new Worker('worker.js');
+
 if (crossOriginIsolated) {
-  // Post SharedArrayBuffer
+  const buffer = new SharedArrayBuffer(16);
+  myWorker.postMessage(buffer);
 } else {
-  // Do something else
+  const buffer = new ArrayBuffer(16);
+  myWorker.postMessage(buffer);
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -53,10 +53,14 @@ Cross-Origin-Embedder-Policy: require-corp
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:
 
 ```js
+const myWorker = new Worker('worker.js');
+
 if (crossOriginIsolated) {
-  // Post SharedArrayBuffer
+  const buffer = new SharedArrayBuffer(16);
+  myWorker.postMessage(buffer);
 } else {
-  // Do something else
+  const buffer = new ArrayBuffer(16);
+  myWorker.postMessage(buffer);
 }
 ```
 


### PR DESCRIPTION
This PR adds some more details to [crossOriginIsolated](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated) property. I have checked the required header values by manual test in Chrome, but they are also [listed in the specification](https://html.spec.whatwg.org/multipage/document-sequences.html#cross-origin-isolation-mode). I have found the unlocked features by reading [web.dev article](https://web.dev/coop-coep/) and checked MDN existing pages.
