### PR TITLE
Align intro of all static methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Array.of
 
 {{JSRef}}
 
-The **`Array.of()`** method creates a new `Array`
+The **`Array.of()`** static method creates a new `Array`
 instance from a variable number of arguments, regardless of number or type of the
 arguments.
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/isview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/isview/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.ArrayBuffer.isView
 
 {{JSRef}}
 
-The **`ArrayBuffer.isView()`** method determines whether the
+The **`ArrayBuffer.isView()`** static method determines whether the
 passed value is one of the `ArrayBuffer` views,
 such as [typed array objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
 or a {{jsxref("DataView")}}.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/add/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/add/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.add
 
 {{JSRef}}
 
-The static **`Atomics.add()`**
+The **`Atomics.add()`** static
 method adds a given value at a given position in the array and returns the old value at
 that position. This atomic operation guarantees that no other write happens until the
 modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/and/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.and
 
 {{JSRef}}
 
-The static **`Atomics.and()`**
+The **`Atomics.and()`** static
 method computes a bitwise AND with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Atomics.compareExchange
 
 {{JSRef}}
 
-The static
-**`Atomics.compareExchange()`**
+The **`Atomics.compareExchange()`** static
 method exchanges a given replacement value at a given position in the array, if a given
 expected value equals the old value. It returns the old value at that position whether
 it was equal to the expected value or not. This atomic operation guarantees that no

--- a/files/en-us/web/javascript/reference/global_objects/atomics/exchange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/exchange/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.exchange
 
 {{JSRef}}
 
-The static **`Atomics.exchange()`** method stores a given value
+The **`Atomics.exchange()`** static method stores a given value
 at a given position in the array and returns the old value at that position. This atomic
 operation guarantees that no other write happens between the read of the old value and
 the write of the new value.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/islockfree/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Atomics.isLockFree
 
 {{JSRef}}
 
-The static
-**`Atomics.isLockFree()`**
+The **`Atomics.isLockFree()`** static
 method is used to determine whether the `Atomics` methods use locks
 or atomic hardware operations when applied to typed arrays with the given element
 byte size.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/load/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/load/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.load
 
 {{JSRef}}
 
-The static **`Atomics.load()`**
+The **`Atomics.load()`** static
 method returns a value at a given position in the array.
 
 {{EmbedInteractiveExample("pages/js/atomics-load.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.notify
 
 {{JSRef}}
 
-The static **`Atomics.notify()`**
+The **`Atomics.notify()`** static
 method notifies up some agents that are sleeping in the wait queue.
 
 > **Note:** This operation works with a shared {{jsxref("Int32Array")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.or
 
 {{JSRef}}
 
-The static **`Atomics.or()`**
+The **`Atomics.or()`** static
 method computes a bitwise OR with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/store/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/store/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.store
 
 {{JSRef}}
 
-The static **`Atomics.store()`**
+The **`Atomics.store()`** static
 method stores a given value at the given position in the array and returns that value.
 
 {{EmbedInteractiveExample("pages/js/atomics-store.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/sub/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/sub/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.sub
 
 {{JSRef}}
 
-The static **`Atomics.sub()`** method subtracts a given value
+The **`Atomics.sub()`** static method subtracts a given value
 at a given position in the array and returns the old value at that position. This atomic
 operation guarantees that no other write happens until the modified value is written
 back.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.wait
 
 {{JSRef}}
 
-The static **`Atomics.wait()`**
+The **`Atomics.wait()`** static
 method verifies that a given position in an {{jsxref("Int32Array")}} still contains a
 given value and if so sleeps, awaiting a wakeup or a timeout. It returns a string which
 is either `"ok"`, `"not-equal"`, or `"timed-out"`.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.waitAsync
 
 {{JSRef}}
 
-The static **`Atomics.waitAsync()`** method waits asynchronously on a shared memory location and returns a {{jsxref("Promise")}}.
+The **`Atomics.waitAsync()`** static method waits asynchronously on a shared memory location and returns a {{jsxref("Promise")}}.
 
 Unlike {{jsxref("Atomics.wait()")}}, `waitAsync` is non-blocking and usable on the main thread.
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/xor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/xor/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Atomics.xor
 
 {{JSRef}}
 
-The static **`Atomics.xor()`**
+The **`Atomics.xor()`** static
 method computes a bitwise XOR with a given value at a given position in the array, and
 returns the old value at that position. This atomic operation guarantees that no other
 write happens until the modified value is written back.

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Date.now
 
 {{JSRef}}
 
-The static **`Date.now()`** method returns the number of milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps), which is defined as the midnight at the beginning of January 1, 1970, UTC.
+The **`Date.now()`** static method returns the number of milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps), which is defined as the midnight at the beginning of January 1, 1970, UTC.
 
 {{EmbedInteractiveExample("pages/js/date-now.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/date/parse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/parse/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Date.parse
 
 {{JSRef}}
 
-The **`Date.parse()`** method parses a string representation of
+The **`Date.parse()`** static method parses a string representation of
 a date, and returns the number of milliseconds since January 1, 1970, 00:00:00 UTC or
 `NaN` if the string is unrecognized or, in some cases, contains illegal date
 values (e.g. 2015-02-31).

--- a/files/en-us/web/javascript/reference/global_objects/date/utc/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/utc/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Date.UTC
 
 {{JSRef}}
 
-The **`Date.UTC()`** method accepts parameters similar to the
+The **`Date.UTC()`** static method accepts parameters similar to the
 {{jsxref("Date")}} constructor, but treats them as UTC. It returns the number of
 milliseconds since January 1, 1970, 00:00:00 UTC.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.Collator.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.Collator.supportedLocalesOf()`** method returns an
+The **`Intl.Collator.supportedLocalesOf()`** static method returns an
 array containing those of the provided locales that are supported in collation without
 having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.supportedLocalesOf()`** method
+The **`Intl.DateTimeFormat.supportedLocalesOf()`** static method
 returns an array containing those of the provided locales that are supported in date
 and time formatting without having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/supportedlocalesof/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.DisplayNames.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.DisplayNames.supportedLocalesOf()`** method returns
+The **`Intl.DisplayNames.supportedLocalesOf()`** static method returns
 an array containing those of the provided locales that are supported in display names
 without having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Intl.getCanonicalLocales
 
 {{JSRef}}
 
-The **`Intl.getCanonicalLocales()`** method returns an array
+The **`Intl.getCanonicalLocales()`** static method returns an array
 containing the canonical locale names. Duplicates will be omitted and elements will be
 validated as structurally valid language tags.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.ListFormat.supportedLocalesOf()`** method returns
+The **`Intl.ListFormat.supportedLocalesOf()`** static method returns
 an array containing those of the provided locales that are supported in list
 formatting without having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.NumberFormat.supportedLocalesOf()`** method returns
+The **`Intl.NumberFormat.supportedLocalesOf()`** static method returns
 an array containing those of the provided locales that are supported in number
 formatting without having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.PluralRules.supportedLocalesOf()`** method returns
+The **`Intl.PluralRules.supportedLocalesOf()`** static method returns
 an array containing those of the provided locales that are supported in plural
 formatting without having to fall back to the runtime's default locale.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.RelativeTimeFormat.supportedLocalesOf()`** method returns an array containing those of the provided locales that are supported in date and time formatting without having to fall back to the runtime's default locale.
+The **`Intl.RelativeTimeFormat.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in date and time formatting without having to fall back to the runtime's default locale.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-supportedlocalesof.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.supportedLocalesOf
 
 {{JSRef}}
 
-The **`Intl.Segmenter.supportedLocalesOf()`** method returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.
+The **`Intl.Segmenter.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.
 
 {{EmbedInteractiveExample("pages/js/intl-segmenter-supportedlocalesof.html", "shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Intl.supportedValuesOf
 
 {{JSRef}}
 
-The **`Intl.supportedValuesOf()`** method returns an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
+The **`Intl.supportedValuesOf()`** static method returns an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
 
 Duplicates are omitted and the array is sorted in ascending alphabetic order (or more precisely, using {{jsxref("Array/sort", "Array.prototype.sort()")}} with an `undefined` compare function)
 

--- a/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.JSON.parse
 
 {{JSRef}}
 
-The **`JSON.parse()`** method parses a JSON string, constructing the JavaScript value or object described by the string. An optional _reviver_ function can be provided to perform a transformation on the resulting object before it is returned.
+The **`JSON.parse()`** static method parses a JSON string, constructing the JavaScript value or object described by the string. An optional _reviver_ function can be provided to perform a transformation on the resulting object before it is returned.
 
 {{EmbedInteractiveExample("pages/js/json-parse.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.JSON.stringify
 
 {{JSRef}}
 
-The **`JSON.stringify()`** method converts a JavaScript value to a JSON string, optionally replacing values if a replacer function is specified or optionally including only the specified properties if a replacer array is specified.
+The **`JSON.stringify()`** static method converts a JavaScript value to a JSON string, optionally replacing values if a replacer function is specified or optionally including only the specified properties if a replacer array is specified.
 
 {{EmbedInteractiveExample("pages/js/json-stringify.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/abs/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.abs
 
 {{JSRef}}
 
-The **`Math.abs()`** function returns the absolute value of a number.
+The **`Math.abs()`** static method returns the absolute value of a number.
 
 {{EmbedInteractiveExample("pages/js/math-abs.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/acos/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.acos
 
 {{JSRef}}
 
-The **`Math.acos()`** function returns the inverse cosine (in radians) of a number. That is,
+The **`Math.acos()`** static method returns the inverse cosine (in radians) of a number. That is,
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>∊</mo><mo stretchy="false">[</mo><mrow><mo>−</mo><mn>1</mn></mrow><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚌𝚘𝚜</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">arccos</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mo>∊</mo><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mi>π</mi><mo stretchy="false">]</mo><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">cos</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x \in [{-1}, 1],\;\mathtt{\operatorname{Math.acos}(x)} = \arccos(x) = \text{the unique } y \in [0, \pi] \text{ such that } \cos(y) = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.acosh
 
 {{JSRef}}
 
-The **`Math.acosh()`** function returns the inverse hyperbolic cosine of a number. That is,
+The **`Math.acosh()`** static method returns the inverse hyperbolic cosine of a number. That is,
 
 <math display="block"><semantics><mtable columnalign="right left right left right left right left right left" columnspacing="0em" displaystyle="true"><mtr><mtd><mo>∀</mo><mi>x</mi><mo>≥</mo><mn>1</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚌𝚘𝚜𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow></mtd><mtd><mo>=</mo><mo lspace="0em" rspace="0.16666666666666666em">arcosh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mo>≥</mo><mn>0</mn><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">cosh</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mtd></mtr><mtr><mtd></mtd><mtd><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><msqrt><mrow><msup><mi>x</mi><mn>2</mn></msup><mo>−</mo><mn>1</mn></mrow></msqrt></mrow><mo>)</mo></mrow></mtd></mtr></mtable><annotation encoding="TeX">\begin{aligned}\forall x \geq 1,\;\mathtt{\operatorname{Math.acosh}(x)} &amp;= \operatorname{arcosh}(x) = \text{the unique } y \geq 0 \text{ such that } \cosh(y) = x\\&amp;= \ln\left(x + \sqrt{x^2 - 1}\right)\end{aligned}</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/asin/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.asin
 
 {{JSRef}}
 
-The **`Math.asin()`** function returns the inverse sine (in radians) of a number. That is,
+The **`Math.asin()`** static method returns the inverse sine (in radians) of a number. That is,
 
 <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>∊</mo><mo stretchy="false">[</mo><mrow><mo>−</mo><mn>1</mn></mrow><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚜𝚒𝚗</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">arcsin</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mo>∊</mo><mrow><mo>[</mo><mrow><mo>−</mo><mfrac><mi>π</mi><mn>2</mn></mfrac><mo>,</mo><mfrac><mi>π</mi><mn>2</mn></mfrac></mrow><mo>]</mo></mrow><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">sin</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x \in [{-1}, 1],\;\mathtt{\operatorname{Math.asin}(x)} = \arcsin(x) = \text{the unique } y \in \left[-\frac{\pi}{2}, \frac{\pi}{2}\right] \text{ such that } \sin(y) = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.asinh
 
 {{JSRef}}
 
-The **`Math.asinh()`** function returns the inverse hyperbolic sine of a number. That is,
+The **`Math.asinh()`** static method returns the inverse hyperbolic sine of a number. That is,
 
 <math display="block"><semantics><mtable columnalign="right left right left right left right left right left" columnspacing="0em" displaystyle="true"><mtr><mtd><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚜𝚒𝚗𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow></mtd><mtd><mo>=</mo><mo lspace="0em" rspace="0.16666666666666666em">arsinh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">sinh</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mtd></mtr><mtr><mtd></mtd><mtd><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><msqrt><mrow><msup><mi>x</mi><mn>2</mn></msup><mo>+</mo><mn>1</mn></mrow></msqrt></mrow><mo>)</mo></mrow></mtd></mtr></mtable><annotation encoding="TeX">\begin{aligned}\mathtt{\operatorname{Math.asinh}(x)} &amp;= \operatorname{arsinh}(x) = \text{the unique } y \text{ such that } \sinh(y) = x \\&amp;= \ln\left(x + \sqrt{x^2 + 1}\right)\end{aligned}
 </annotation></semantics></math>

--- a/files/en-us/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/atan/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.atan
 
 {{JSRef}}
 
-The **`Math.atan()`** function returns the inverse tangent (in radians) of a number, that is
+The **`Math.atan()`** static method returns the inverse tangent (in radians) of a number, that is
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚝𝚊𝚗</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">arctan</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mo>∊</mo><mrow><mo>[</mo><mrow><mo>−</mo><mfrac><mi>π</mi><mn>2</mn></mfrac><mo>,</mo><mfrac><mi>π</mi><mn>2</mn></mfrac></mrow><mo>]</mo></mrow><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">tan</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.atan}(x)} = \arctan(x) = \text{the unique } y \in \left[-\frac{\pi}{2}, \frac{\pi}{2}\right] \text{ such that } \tan(y) = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/atan2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/atan2/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.atan2
 
 {{JSRef}}
 
-The **`Math.atan2()`** function returns the angle in the plane (in radians) between the positive x-axis and the ray from (0, 0) to the point (x, y), for `Math.atan2(y, x)`.
+The **`Math.atan2()`** static method returns the angle in the plane (in radians) between the positive x-axis and the ray from (0, 0) to the point (x, y), for `Math.atan2(y, x)`.
 
 {{EmbedInteractiveExample("pages/js/math-atan2.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.atanh
 
 {{JSRef}}
 
-The **`Math.atanh()`** function returns the inverse hyperbolic tangent of a number. That is,
+The **`Math.atanh()`** static method returns the inverse hyperbolic tangent of a number. That is,
 
 <math display="block"><semantics><mtable columnalign="right left right left right left right left right left" columnspacing="0em" displaystyle="true"><mtr><mtd><mo>∀</mo><mi>x</mi><mo>∊</mo><mo stretchy="false">(</mo><mrow><mo>−</mo><mn>1</mn></mrow><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚊𝚝𝚊𝚗𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow></mtd><mtd><mo>=</mo><mo lspace="0em" rspace="0.16666666666666666em">artanh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><mo lspace="0em" rspace="0em">tanh</mo><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo><mo>=</mo><mi>x</mi></mtd></mtr><mtr><mtd></mtd><mtd><mo>=</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mspace width="0.16666666666666666em"></mspace><mo lspace="0em" rspace="0em">ln</mo><mrow><mo>(</mo><mfrac><mrow><mn>1</mn><mo>+</mo><mi>x</mi></mrow><mrow><mn>1</mn><mo>−</mo><mi>x</mi></mrow></mfrac><mo>)</mo></mrow></mtd></mtr></mtable><annotation encoding="TeX">\begin{aligned}\forall x \in ({-1}, 1),\;\mathtt{\operatorname{Math.atanh}(x)} &amp;= \operatorname{artanh}(x) = \text{the unique } y \text{ such that } \tanh(y) = x \\&amp;= \frac{1}{2}\,\ln\left(\frac{1+x}{1-x}\right)\end{aligned}
 </annotation></semantics></math>

--- a/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.cbrt
 
 {{JSRef}}
 
-The **`Math.cbrt()`** function returns the cube root of a number. That is
+The **`Math.cbrt()`** static method returns the cube root of a number. That is
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚌𝚋𝚛𝚝</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mroot><mi>x</mi><mn>3</mn></mroot><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><msup><mi>y</mi><mn>3</mn></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.cbrt}(x)} = \sqrt[3]{x} = \text{the unique } y \text{ such that } y^3 = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.ceil
 
 {{JSRef}}
 
-The **`Math.ceil()`** function always rounds up and returns the smaller integer greater than or equal to a given number.
+The **`Math.ceil()`** static method always rounds up and returns the smaller integer greater than or equal to a given number.
 
 {{EmbedInteractiveExample("pages/js/math-ceil.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.clz32
 
 {{JSRef}}
 
-The **`Math.clz32()`** function returns the number of leading zero bits in the 32-bit binary representation of a number.
+The **`Math.clz32()`** static method returns the number of leading zero bits in the 32-bit binary representation of a number.
 
 {{EmbedInteractiveExample("pages/js/math-clz32.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cos/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Math.cos
 
 {{JSRef}}
 
-The **`Math.cos()`** function returns the cosine of a number in radians.
+The **`Math.cos()`** static method returns the cosine of a number in radians.
 
 {{EmbedInteractiveExample("pages/js/math-cos.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.cosh
 
 {{JSRef}}
 
-The **`Math.cosh()`** function returns the hyperbolic cosine of a number. That is,
+The **`Math.cosh()`** static method returns the hyperbolic cosine of a number. That is,
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚌𝚘𝚜𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">cosh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mfrac><mrow><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup><mo>+</mo><msup><mi mathvariant="normal">e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.cosh}(x)} = \cosh(x) = \frac{\mathrm{e}^x + \mathrm{e}^{-x}}{2}</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/exp/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.exp
 
 {{JSRef}}
 
-The **`Math.exp()`** function returns [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E) raised to the power of a number. That is
+The **`Math.exp()`** static method returns [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E) raised to the power of a number. That is
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚎𝚡𝚙</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.exp}(x)} = \mathrm{e}^x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.expm1
 
 {{JSRef}}
 
-The **`Math.expm1()`** function returns [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E) raised to the power of a number, subtracted by 1. That is
+The **`Math.expm1()`** static method returns [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E) raised to the power of a number, subtracted by 1. That is
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚎𝚡𝚙𝚖𝟷</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup><mo>−</mo><mn>1</mn></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.expm1}(x)} = \mathrm{e}^x - 1</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/floor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/floor/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.floor
 
 {{JSRef}}
 
-The **`Math.floor()`** function always rounds down and returns the largest integer less than or equal to a given number.
+The **`Math.floor()`** static method always rounds down and returns the largest integer less than or equal to a given number.
 
 {{EmbedInteractiveExample("pages/js/math-floor.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/fround/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Math.fround
 
 {{JSRef}}
 
-The **`Math.fround()`** function returns the nearest [32-bit single precision](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) float representation of a number.
+The **`Math.fround()`** static method returns the nearest [32-bit single precision](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) float representation of a number.
 
 {{EmbedInteractiveExample("pages/js/math-fround.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.hypot
 
 {{JSRef}}
 
-The **`Math.hypot()`** function returns the square root of the sum of squares of its arguments. That is,
+The **`Math.hypot()`** static method returns the square root of the sum of squares of its arguments. That is,
 
 <math display="block"><semantics><mrow><mstyle mathvariant="monospace"><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚑𝚢𝚙𝚘𝚝</mo><mo stretchy="false">(</mo><msub><mi>v</mi><mn>1</mn></msub><mo>,</mo><msub><mi>v</mi><mn>2</mn></msub><mo>,</mo><mo>…</mo><mo>,</mo><msub><mi>v</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mstyle><mo>=</mo><msqrt><mrow><munderover><mo>∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><msubsup><mi>v</mi><mi>i</mi><mn>2</mn></msubsup></mrow></msqrt><mo>=</mo><msqrt><mrow><msubsup><mi>v</mi><mn>1</mn><mn>2</mn></msubsup><mo>+</mo><msubsup><mi>v</mi><mn>2</mn><mn>2</mn></msubsup><mo>+</mo><mo>…</mo><mo>+</mo><msubsup><mi>v</mi><mi>n</mi><mn>2</mn></msubsup></mrow></msqrt></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.hypot}(v_1, v_2, \dots, v_n)} = \sqrt{\sum\_{i=1}^n v_i^2} = \sqrt{v_1^2 + v_2^2 + \dots + v_n^2}</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.imul
 
 {{JSRef}}
 
-The **`Math.imul()`** function returns the result of the C-like 32-bit multiplication of the two parameters.
+The **`Math.imul()`** static method returns the result of the C-like 32-bit multiplication of the two parameters.
 
 {{EmbedInteractiveExample("pages/js/math-imul.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.log
 
 {{JSRef}}
 
-The **`Math.log()`** function returns the natural logarithm (base [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E)) of a number. That is
+The **`Math.log()`** static method returns the natural logarithm (base [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E)) of a number. That is
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>&gt;</mo><mn>0</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚕𝚘𝚐</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><msup><mi>e</mi><mi>y</mi></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x &gt; 0,\;\mathtt{\operatorname{Math.log}(x)} = \ln(x) = \text{the unique } y \text{ such that } e^y = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.log10
 
 {{JSRef}}
 
-The **`Math.log10()`** function returns the base 10 logarithm of a number. That is
+The **`Math.log10()`** static method returns the base 10 logarithm of a number. That is
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>&gt;</mo><mn>0</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚕𝚘𝚐𝟷𝟶</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>10</mn></msub><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><msup><mn>10</mn><mi>y</mi></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x &gt; 0,\;\mathtt{\operatorname{Math.log10}(x)} = \log\_{10}(x) = \text{the unique } y \text{ such that } 10^y = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.log1p
 
 {{JSRef}}
 
-The **`Math.log1p()`** function returns the natural logarithm (base [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E)) of `1 + x`, where `x` is the argument. That is:
+The **`Math.log1p()`** static method returns the natural logarithm (base [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E)) of `1 + x`, where `x` is the argument. That is:
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>&gt;</mo><mo>−</mo><mn>1</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚕𝚘𝚐𝟷𝚙</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mo stretchy="false">(</mo><mn>1</mn><mo>+</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><annotation encoding="TeX">\forall x &gt; -1,\;\mathtt{\operatorname{Math.log1p}(x)} = \ln(1 + x)</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.log2
 
 {{JSRef}}
 
-The **`Math.log2()`** function returns the base 2 logarithm of a number. That is
+The **`Math.log2()`** static method returns the base 2 logarithm of a number. That is
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>&gt;</mo><mn>0</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚕𝚘𝚐𝟸</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>2</mn></msub><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mtext>&nbsp;such that&nbsp;</mtext><msup><mn>2</mn><mi>y</mi></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x &gt; 0,\;\mathtt{\operatorname{Math.log2}(x)} = \log_2(x) = \text{the unique } y \text{ such that } 2^y = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Math.max
 
 {{JSRef}}
 
-The **`Math.max()`** function returns the largest of the numbers given as input parameters, or -{{jsxref("Infinity")}} if there are no parameters.
+The **`Math.max()`** static method returns the largest of the numbers given as input parameters, or -{{jsxref("Infinity")}} if there are no parameters.
 
 {{EmbedInteractiveExample("pages/js/math-max.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/min/index.md
@@ -19,7 +19,7 @@ browser-compat: javascript.builtins.Math.min
 
 {{JSRef}}
 
-The **`Math.min()`** function returns the smallest of the numbers given as input parameters, or {{jsxref("Infinity")}} if there are no parameters.
+The **`Math.min()`** static method returns the smallest of the numbers given as input parameters, or {{jsxref("Infinity")}} if there are no parameters.
 
 {{EmbedInteractiveExample("pages/js/math-min.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.pow
 
 {{JSRef}}
 
-The **`Math.pow()`** method returns the value of a base raised to a power. That is
+The **`Math.pow()`** static method returns the value of a base raised to a power. That is
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚙𝚘𝚠</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo>,</mo><mi>𝚢</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msup><mi>x</mi><mi>y</mi></msup></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.pow}(x, y)} = x^y</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.random
 
 {{JSRef}}
 
-The **`Math.random()`** function returns a floating-point, pseudo-random number that's greater than or equal to 0 and less than 1, with approximately uniform distribution over that range — which you can then scale to your desired range. The implementation selects the initial seed to the random number generation algorithm; it cannot be chosen or reset by the user.
+The **`Math.random()`** static method returns a floating-point, pseudo-random number that's greater than or equal to 0 and less than 1, with approximately uniform distribution over that range — which you can then scale to your desired range. The implementation selects the initial seed to the random number generation algorithm; it cannot be chosen or reset by the user.
 
 {{EmbedInteractiveExample("pages/js/math-random.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/round/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/round/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.round
 
 {{JSRef}}
 
-The **`Math.round()`** function returns the value of a number rounded to the nearest integer.
+The **`Math.round()`** static method returns the value of a number rounded to the nearest integer.
 
 {{EmbedInteractiveExample("pages/js/math-round.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Math.sign
 
 {{JSRef}}
 
-The **`Math.sign()`** function returns 1 or -1, indicating the sign of the number passed as argument. If the input is 0 or -0, it will be returned as-is.
+The **`Math.sign()`** static method returns 1 or -1, indicating the sign of the number passed as argument. If the input is 0 or -0, it will be returned as-is.
 
 {{EmbedInteractiveExample("pages/js/math-sign.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sin/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.sin
 
 {{JSRef}}
 
-The **`Math.sin()`** function returns the sine of a number in radians.
+The **`Math.sin()`** static method returns the sine of a number in radians.
 
 {{EmbedInteractiveExample("pages/js/math-sin.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.sinh
 
 {{JSRef}}
 
-The **`Math.sinh()`** function returns the hyperbolic sine of a number. That is,
+The **`Math.sinh()`** static method returns the hyperbolic sine of a number. That is,
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚜𝚒𝚗𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">sinh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mfrac><mrow><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup><mo>−</mo><msup><mi mathvariant="normal">e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup></mrow><mn>2</mn></mfrac></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.sinh}(x)} = \sinh(x) = \frac{\mathrm{e}^x - \mathrm{e}^{-x}}{2}</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.sqrt
 
 {{JSRef}}
 
-The **`Math.sqrt()`** function returns the square root of a number. That is
+The **`Math.sqrt()`** static method returns the square root of a number. That is
 
 <math display="block"><semantics><mrow><mo>∀</mo><mi>x</mi><mo>≥</mo><mn>0</mn><mo>,</mo><mspace width="0.2777777777777778em"></mspace><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚜𝚚𝚛𝚝</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><msqrt><mi>x</mi></msqrt><mo>=</mo><mtext>the unique&nbsp;</mtext><mi>y</mi><mo>≥</mo><mn>0</mn><mtext>&nbsp;such that&nbsp;</mtext><msup><mi>y</mi><mn>2</mn></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\forall x \geq 0,\;\mathtt{\operatorname{Math.sqrt}(x)} = \sqrt{x} = \text{the unique } y \geq 0 \text{ such that } y^2 = x</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/tan/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.tan
 
 {{JSRef}}
 
-The **`Math.tan()`** function returns the tangent of a number in radians.
+The **`Math.tan()`** static method returns the tangent of a number in radians.
 
 {{EmbedInteractiveExample("pages/js/math-tan.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.tanh
 
 {{JSRef}}
 
-The **`Math.tanh()`** function returns the hyperbolic tangent of a number. That is,
+The **`Math.tanh()`** static method returns the hyperbolic tangent of a number. That is,
 
 <math display="block"><semantics><mrow><mrow><mo lspace="0em" rspace="0.16666666666666666em">𝙼𝚊𝚝𝚑.𝚝𝚊𝚗𝚑</mo><mo stretchy="false">(</mo><mi>𝚡</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><mo lspace="0em" rspace="0em">tanh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mfrac><mrow><mo lspace="0em" rspace="0em">sinh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><mrow><mo lspace="0em" rspace="0em">cosh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mfrac><mo>=</mo><mfrac><mrow><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup><mo>−</mo><msup><mi mathvariant="normal">e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup></mrow><mrow><msup><mi mathvariant="normal">e</mi><mi>x</mi></msup><mo>+</mo><msup><mi mathvariant="normal">e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup></mrow></mfrac><mo>=</mo><mfrac><mrow><msup><mi mathvariant="normal">e</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup><mo>−</mo><mn>1</mn></mrow><mrow><msup><mi mathvariant="normal">e</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup><mo>+</mo><mn>1</mn></mrow></mfrac></mrow><annotation encoding="TeX">\mathtt{\operatorname{Math.tanh}(x)} = \tanh(x) = \frac{\sinh(x)}{\cosh(x)} = \frac{\mathrm{e}^x - \mathrm{e}^{-x}}{\mathrm{e}^x + \mathrm{e}^{-x}} = \frac{\mathrm{e}^{2x} - 1}{\mathrm{e}^{2x}+1}</annotation></semantics></math>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Math.trunc
 
 {{JSRef}}
 
-The **`Math.trunc()`** function returns the integer part of a number by removing any fractional digits.
+The **`Math.trunc()`** static method returns the integer part of a number by removing any fractional digits.
 
 {{EmbedInteractiveExample("pages/js/math-trunc.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.isFinite
 
 {{JSRef}}
 
-The **`Number.isFinite()`** method determines whether the passed value is a finite number — that is, it checks that a given value is a number, and the number is neither positive {{jsxref("Infinity")}}, negative `Infinity`, nor {{jsxref("NaN")}}.
+The **`Number.isFinite()`** static method determines whether the passed value is a finite number — that is, it checks that a given value is a number, and the number is neither positive {{jsxref("Infinity")}}, negative `Infinity`, nor {{jsxref("NaN")}}.
 
 {{EmbedInteractiveExample("pages/js/number-isfinite.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.isInteger
 
 {{JSRef}}
 
-The **`Number.isInteger()`** method determines whether the passed value is an integer.
+The **`Number.isInteger()`** static method determines whether the passed value is an integer.
 
 {{EmbedInteractiveExample("pages/js/number-isinteger.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Number.isNaN
 
 {{JSRef}}
 
-The **`Number.isNaN()`** method determines whether the passed value is the number value {{jsxref("NaN")}}, and returns `false` if the input is not of the Number type. It is a more robust version of the original, global {{jsxref("isNaN()")}} function.
+The **`Number.isNaN()`** static method determines whether the passed value is the number value {{jsxref("NaN")}}, and returns `false` if the input is not of the Number type. It is a more robust version of the original, global {{jsxref("isNaN()")}} function.
 
 {{EmbedInteractiveExample("pages/js/number-isnan.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.isSafeInteger
 
 {{JSRef}}
 
-The **`Number.isSafeInteger()`** method determines whether the provided value is a number that is a _safe integer_.
+The **`Number.isSafeInteger()`** static method determines whether the provided value is a number that is a _safe integer_.
 
 {{EmbedInteractiveExample("pages/js/number-issafeinteger.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.parseFloat
 
 {{JSRef}}
 
-The **`Number.parseFloat()`** method parses an argument and returns a floating point number. If a number cannot be parsed from the argument, it returns {{jsxref("NaN")}}.
+The **`Number.parseFloat()`** static method parses an argument and returns a floating point number. If a number cannot be parsed from the argument, it returns {{jsxref("NaN")}}.
 
 {{EmbedInteractiveExample("pages/js/number-parsefloat.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.parseInt
 
 {{JSRef}}
 
-The **`Number.parseInt()`** method parses a string argument and
+The **`Number.parseInt()`** static method parses a string argument and
 returns an integer of the specified radix or base.
 
 {{EmbedInteractiveExample("pages/js/number-parseint.html", "taller")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Object.assign
 
 {{JSRef}}
 
-The **`Object.assign()`** method
+The **`Object.assign()`** static method
 copies all {{jsxref("Object/propertyIsEnumerable", "enumerable", "", 1)}}
 {{jsxref("Object/hasOwn", "own properties", "", 1)}} from one or more
 _source objects_ to a _target object_. It returns the modified target

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Object.create
 
 {{JSRef}}
 
-The **`Object.create()`** method creates a new object, using an existing object as the prototype of the newly created object.
+The **`Object.create()`** static method creates a new object, using an existing object as the prototype of the newly created object.
 
 {{EmbedInteractiveExample("pages/js/object-create.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Object.defineProperties
 
 {{JSRef}}
 
-The **`Object.defineProperties()`** method defines new or
+The **`Object.defineProperties()`** static method defines new or
 modifies existing properties directly on an object, returning the object.
 
 {{EmbedInteractiveExample("pages/js/object-defineproperties.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.defineProperty
 
 {{JSRef}}
 
-The static method **`Object.defineProperty()`** defines a new
+The **`Object.defineProperty()`** static method defines a new
 property directly on an object, or modifies an existing property on an object, and
 returns the object.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.entries
 
 {{JSRef}}
 
-The **`Object.entries()`** method returns an array of a given object's own enumerable string-keyed property key-value pairs.
+The **`Object.entries()`** static method returns an array of a given object's own enumerable string-keyed property key-value pairs.
 
 {{EmbedInteractiveExample("pages/js/object-entries.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -19,7 +19,7 @@ browser-compat: javascript.builtins.Object.freeze
 
 {{JSRef}}
 
-The **`Object.freeze()`** method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
+The **`Object.freeze()`** static method _freezes_ an object. Freezing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned. `freeze()` returns the same object that was passed in.
 
 Freezing an object is the highest integrity level that JavaScript provides.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.fromEntries
 
 {{JSRef}}
 
-The **`Object.fromEntries()`** method transforms a list of key-value pairs into an object.
+The **`Object.fromEntries()`** static method transforms a list of key-value pairs into an object.
 
 {{EmbedInteractiveExample("pages/js/object-fromentries.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Object.getOwnPropertyDescriptor
 
 {{JSRef}}
 
-The **`Object.getOwnPropertyDescriptor()`** method returns an
+The **`Object.getOwnPropertyDescriptor()`** static method returns an
 object describing the configuration of a specific property on a given object (that is,
 one directly present on an object and not in the object's prototype chain). The object
 returned is mutable but mutating it has no effect on the original property's

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Object.getOwnPropertyDescriptors
 
 {{JSRef}}
 
-The **`Object.getOwnPropertyDescriptors()`** method returns all
+The **`Object.getOwnPropertyDescriptors()`** static method returns all
 own property descriptors of a given object.
 
 {{EmbedInteractiveExample("pages/js/object-getownpropertydescriptors.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Object.getOwnPropertyNames
 
 {{JSRef}}
 
-The **`Object.getOwnPropertyNames()`** method returns an array of all properties (including non-enumerable properties except for those which use Symbol) found directly in a given object.
+The **`Object.getOwnPropertyNames()`** static method returns an array of all properties (including non-enumerable properties except for those which use Symbol) found directly in a given object.
 
 {{EmbedInteractiveExample("pages/js/object-getownpropertynames.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.getOwnPropertySymbols
 
 {{JSRef}}
 
-The **`Object.getOwnPropertySymbols()`** method returns an array of all symbol properties found directly upon a given object.
+The **`Object.getOwnPropertySymbols()`** static method returns an array of all symbol properties found directly upon a given object.
 
 {{EmbedInteractiveExample("pages/js/object-getownpropertysymbols.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.getPrototypeOf
 
 {{JSRef}}
 
-The **`Object.getPrototypeOf()`** method returns the prototype
+The **`Object.getPrototypeOf()`** static method returns the prototype
 (i.e. the value of the internal `[[Prototype]]` property) of the specified
 object.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.Object.is
 
 {{JSRef}}
 
-The **`Object.is()`** method determines whether two values are [the same value](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#same-value_equality_using_object.is).
+The **`Object.is()`** static method determines whether two values are [the same value](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#same-value_equality_using_object.is).
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.isExtensible
 
 {{JSRef}}
 
-The **`Object.isExtensible()`** method determines if an object
+The **`Object.isExtensible()`** static method determines if an object
 is extensible (whether it can have new properties added to it).
 
 {{EmbedInteractiveExample("pages/js/object-isextensible.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Object.isFrozen
 
 {{JSRef}}
 
-The **`Object.isFrozen()`** determines if an object is
+The **`Object.isFrozen()`** method determines if an object is
 {{jsxref("Object.freeze()", "frozen", "", 1)}}.
 
 {{EmbedInteractiveExample("pages/js/object-isfrozen.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Object.isFrozen
 
 {{JSRef}}
 
-The **`Object.isFrozen()`** method determines if an object is
+The **`Object.isFrozen()`** static method determines if an object is
 {{jsxref("Object.freeze()", "frozen", "", 1)}}.
 
 {{EmbedInteractiveExample("pages/js/object-isfrozen.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.isSealed
 
 {{JSRef}}
 
-The **`Object.isSealed()`** method determines if an object is
+The **`Object.isSealed()`** static method determines if an object is
 sealed.
 
 {{EmbedInteractiveExample("pages/js/object-issealed.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Object.keys
 
 {{JSRef}}
 
-The **`Object.keys()`** method returns an array of a given object's own enumerable string-keyed property names.
+The **`Object.keys()`** static method returns an array of a given object's own enumerable string-keyed property names.
 
 {{EmbedInteractiveExample("pages/js/object-keys.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.preventExtensions
 
 {{JSRef}}
 
-The **`Object.preventExtensions()`** method prevents new
+The **`Object.preventExtensions()`** static method prevents new
 properties from ever being added to an object (i.e. prevents future extensions to the
 object). It also prevents the object's prototype from being re-assigned.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Object.seal
 
 {{JSRef}}
 
-The **`Object.seal()`** method _seals_ an object. Sealing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-configurable. A sealed object has a fixed set of properties: new properties cannot be added, existing properties cannot be removed, their enumerability and configurability cannot be changed, and its prototype cannot be re-assigned. Values of existing properties can still be changed as long as they are writable. `seal()` returns the same object that was passed in.
+The **`Object.seal()`** static method _seals_ an object. Sealing an object [prevents extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-configurable. A sealed object has a fixed set of properties: new properties cannot be added, existing properties cannot be removed, their enumerability and configurability cannot be changed, and its prototype cannot be re-assigned. Values of existing properties can still be changed as long as they are writable. `seal()` returns the same object that was passed in.
 
 {{EmbedInteractiveExample("pages/js/object-seal.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/values/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.values
 
 {{JSRef}}
 
-The **`Object.values()`** method returns an array of a given object's own enumerable string-keyed property values.
+The **`Object.values()`** static method returns an array of a given object's own enumerable string-keyed property values.
 
 {{EmbedInteractiveExample("pages/js/object-values.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Promise.all
 
 {{JSRef}}
 
-The **`Promise.all()`** method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when all of the input's promises fulfill (including when an empty iterable is passed), with an array of the fulfillment values. It rejects when any of the input's promises rejects, with this first rejection reason.
+The **`Promise.all()`** static method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when all of the input's promises fulfill (including when an empty iterable is passed), with an array of the fulfillment values. It rejects when any of the input's promises rejects, with this first rejection reason.
 
 {{EmbedInteractiveExample("pages/js/promise-all.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Promise.allSettled
 
 {{JSRef}}
 
-The **`Promise.allSettled()`** method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when all of the input's promises settle (including when an empty iterable is passed), with an array of objects that describe the outcome of each promise.
+The **`Promise.allSettled()`** static method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when all of the input's promises settle (including when an empty iterable is passed), with an array of objects that describe the outcome of each promise.
 
 {{EmbedInteractiveExample("pages/js/promise-allsettled.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Promise.any
 
 {{JSRef}}
 
-The **`Promise.any()`** method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when any of the input's promises fulfills, with this first fulfillment value. It rejects when all of the input's promises reject (including when an empty iterable is passed), with an {{jsxref("AggregateError")}} containing an array of rejection reasons.
+The **`Promise.any()`** static method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when any of the input's promises fulfills, with this first fulfillment value. It rejects when all of the input's promises reject (including when an empty iterable is passed), with an {{jsxref("AggregateError")}} containing an array of rejection reasons.
 
 {{EmbedInteractiveExample("pages/js/promise-any.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Promise.race
 
 {{JSRef}}
 
-The **`Promise.race()`** method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise settles with the eventual state of the first promise that settles.
+The **`Promise.race()`** static method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise settles with the eventual state of the first promise that settles.
 
 {{EmbedInteractiveExample("pages/js/promise-race.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/reject/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/reject/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Promise.reject
 
 {{JSRef}}
 
-The **`Promise.reject()`** method returns a `Promise` object that is rejected with a given reason.
+The **`Promise.reject()`** static method returns a `Promise` object that is rejected with a given reason.
 
 {{EmbedInteractiveExample("pages/js/promise-reject.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Promise.resolve
 
 {{JSRef}}
 
-The **`Promise.resolve()`** method "resolves" a given value to a {{jsxref("Promise")}}. If the value is a promise, that promise is returned; if the value is a [thenable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables), `Promise.resolve()` will call the `then()` method with two callbacks it prepared; otherwise the returned promise will be fulfilled with the value.
+The **`Promise.resolve()`** static method "resolves" a given value to a {{jsxref("Promise")}}. If the value is a promise, that promise is returned; if the value is a [thenable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables), `Promise.resolve()` will call the `then()` method with two callbacks it prepared; otherwise the returned promise will be fulfilled with the value.
 
 This function flattens nested layers of promise-like objects (e.g. a promise that fulfills to a promise that fulfills to something) into a single layer — a promise that fulfills to a non-thenable value.
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.apply
 
 {{JSRef}}
 
-The static **`Reflect.apply()`** method calls a target function
+The **`Reflect.apply()`** static method calls a target function
 with arguments as specified.
 
 {{EmbedInteractiveExample("pages/js/reflect-apply.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.construct
 
 {{JSRef}}
 
-The static **`Reflect.construct()`** method acts like the
+The **`Reflect.construct()`** static method acts like the
 {{jsxref("Operators/new", "new")}} operator, but as a function. It is equivalent to
 calling `new target(...args)`. It gives also the added option to specify a
 different prototype.

--- a/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.defineProperty
 
 {{JSRef}}
 
-The static **`Reflect.defineProperty()`** method is like
+The **`Reflect.defineProperty()`** static method is like
 {{jsxref("Object.defineProperty()")}} but returns a {{jsxref("Boolean")}}.
 
 {{EmbedInteractiveExample("pages/js/reflect-defineproperty.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -14,8 +14,7 @@ browser-compat: javascript.builtins.Reflect.deleteProperty
 
 {{JSRef}}
 
-The static
-**`Reflect.deleteProperty()`**
+The **`Reflect.deleteProperty()`** static
 method allows to delete properties. It is like the
 [`delete` operator](/en-US/docs/Web/JavaScript/Reference/Operators/delete)
 as a function.

--- a/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.get
 
 {{JSRef}}
 
-The static **`Reflect.get()`** method works like getting a
+The **`Reflect.get()`** static method works like getting a
 property from an object (`target[propertyKey]`) as a function.
 
 {{EmbedInteractiveExample("pages/js/reflect-get.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
@@ -14,8 +14,7 @@ browser-compat: javascript.builtins.Reflect.getOwnPropertyDescriptor
 
 {{JSRef}}
 
-The static
-**`Reflect.getOwnPropertyDescriptor()`** method is similar to
+The **`Reflect.getOwnPropertyDescriptor()`** static method is similar to
 {{jsxref("Object.getOwnPropertyDescriptor()")}}. It returns a property descriptor of
 the given property if it exists on the object, {{jsxref("undefined")}}
 otherwise.

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.getPrototypeOf
 
 {{JSRef}}
 
-The static **`Reflect.getPrototypeOf()`** method is almost the
+The **`Reflect.getPrototypeOf()`** static method is almost the
 same method as {{jsxref("Object.getPrototypeOf()")}}. It returns the prototype (i.e. the
 value of the internal `[[Prototype]]` property) of the specified object.
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/has/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.has
 
 {{JSRef}}
 
-The static **`Reflect.has()`** method works like the [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in)
+The **`Reflect.has()`** static method works like the [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in)
 as a function.
 
 {{EmbedInteractiveExample("pages/js/reflect-has.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.isExtensible
 
 {{JSRef}}
 
-The static **`Reflect.isExtensible()`** method determines if an object is extensible (whether it can have new properties added to it). It is similar to {{jsxref("Object.isExtensible()")}}, but with [some differences](#difference_with_object.isextensible).
+The **`Reflect.isExtensible()`** static method determines if an object is extensible (whether it can have new properties added to it). It is similar to {{jsxref("Object.isExtensible()")}}, but with [some differences](#difference_with_object.isextensible).
 
 {{EmbedInteractiveExample("pages/js/reflect-isextensible.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.ownKeys
 
 {{JSRef}}
 
-The static **`Reflect.ownKeys()`** method returns an array of
+The **`Reflect.ownKeys()`** static method returns an array of
 the `target` object's own property keys.
 
 {{EmbedInteractiveExample("pages/js/reflect-ownkeys.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.preventExtensions
 
 {{JSRef}}
 
-The static **`Reflect.preventExtensions()`** method prevents new properties from ever being added to an object (i.e., prevents future extensions to the object). It is similar to {{jsxref("Object.preventExtensions()")}}, but with [some differences](#difference_with_object.preventextensions).
+The **`Reflect.preventExtensions()`** static method prevents new properties from ever being added to an object (i.e., prevents future extensions to the object). It is similar to {{jsxref("Object.preventExtensions()")}}, but with [some differences](#difference_with_object.preventextensions).
 
 {{EmbedInteractiveExample("pages/js/reflect-preventextensions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Reflect.set
 
 {{JSRef}}
 
-The static **`Reflect.set()`** method works like setting a
+The **`Reflect.set()`** static method works like setting a
 property on an object.
 
 {{EmbedInteractiveExample("pages/js/reflect-set.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -14,8 +14,7 @@ browser-compat: javascript.builtins.Reflect.setPrototypeOf
 
 {{JSRef}}
 
-The static
-**`Reflect.setPrototypeOf()`** method is the same method as
+The **`Reflect.setPrototypeOf()`** static method is the same method as
 {{jsxref("Object.setPrototypeOf()")}}, except for its return type. It sets the
 prototype (i.e., the internal `[[Prototype]]` property) of a specified
 object to another object or to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), and returns `true` if

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.String.fromCharCode
 
 {{JSRef}}
 
-The static **`String.fromCharCode()`** method returns a string
+The **`String.fromCharCode()`** static method returns a string
 created from the specified sequence of UTF-16 code units.
 
 {{EmbedInteractiveExample("pages/js/string-fromcharcode.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.String.fromCodePoint
 
 {{JSRef}}
 
-The static **`String.fromCodePoint()`** method returns a string
+The **`String.fromCodePoint()`** static method returns a string
 created by using the specified sequence of code points.
 
 {{EmbedInteractiveExample("pages/js/string-fromcodepoint.html","shorter")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.String.raw
 
 {{JSRef}}
 
-The static **`String.raw()`** method is a tag function of [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals). This is similar to the `r` prefix in Python, or the `@` prefix in C# for string literals. It's used to get the raw string form of template literals — that is, substitutions (e.g. `${foo}`) are processed, but escape sequences (e.g. `\n`) are not.
+The **`String.raw()`** static method is a tag function of [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals). This is similar to the `r` prefix in Python, or the `@` prefix in C# for string literals. It's used to get the raw string form of template literals — that is, substitutions (e.g. `${foo}`) are processed, but escape sequences (e.g. `\n`) are not.
 
 {{EmbedInteractiveExample("pages/js/string-raw.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/for/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/for/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.for
 
 {{JSRef}}
 
-The **`Symbol.for(key)`** method searches for existing symbols
+The **`Symbol.for()`** static method searches for existing symbols
 in a runtime-wide symbol registry with the given key and returns it if found. Otherwise
 a new symbol gets created in the global symbol registry with this key.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/keyfor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/keyfor/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.keyFor
 
 {{JSRef}}
 
-The **`Symbol.keyFor(sym)`** method retrieves a shared symbol
+The **`Symbol.keyFor()`** static method retrieves a shared symbol
 key from the global symbol registry for the given symbol.
 
 {{EmbedInteractiveExample("pages/js/symbol-keyfor.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.TypedArray.from
 
 {{JSRef}}
 
-The **`TypedArray.from()`** method creates a new
+The **`TypedArray.from()`** static method creates a new
 [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects)
 from an array-like or iterable object. This method is nearly the same as
 {{jsxref("Array.from()")}}.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.TypedArray.of
 
 {{JSRef}}
 
-The **`TypedArray.of()`** method creates a new
+The **`TypedArray.of()`** static method creates a new
 [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) from a variable number of arguments. This method is nearly the same as
 {{jsxref("Array.of()")}}.
 


### PR DESCRIPTION
### Description

Adds the missing word "method" in the definition to align it with other entries.

### Motivation

Copy editing to increase understanding and clarity.