### PR TITLE
Include recommended lang attribute in example

### DIFF
--- a/files/en-us/web/html/element/i/index.md
+++ b/files/en-us/web/html/element/i/index.md
@@ -48,7 +48,7 @@ This example demonstrates using the `<i>` element to mark text that is in anothe
 
 ```html
 <p>
-  The Latin phrase <i>Veni, vidi, vici</i> is often mentioned in music, art, and
+  The Latin phrase <i lang="la">Veni, vidi, vici</i> is often mentioned in music, art, and
   literature.
 </p>
 ```


### PR DESCRIPTION
The [usage notes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i#usage_notes) in this same document state the `<i>` element can be used to mark up—

> Idiomatic terms from another language (such as "et cetera"); these should include the `lang` attribute to identify the language.

The [code example](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i#examples) on this page is uses an idiomatic Latin term in english text. This pull request adds the `lang` attribute that should be present.

### Description

Modify example to add `lang` attribute that should be present. 

### Motivation

Align code example with stated best practices.
