### PR TITLE
Remove redundant contition

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
@@ -34,7 +34,7 @@ includes(searchString, position)
 
 ### Return value
 
-**`true`** if the search string is found anywhere within the given string, including when `searchString` is an empty string; otherwise, **`false`** if not.
+**`true`** if the search string is found anywhere within the given string, including when `searchString` is an empty string; otherwise, **`false`**.
 
 ### Exceptions
 


### PR DESCRIPTION
Remove "if not", which semantically duplicates "otherwise". This also makes this item consistent with the analogous items in the articles on startsWith and endsWith.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
