### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/glossary/first_contentful_paint/index.md
+++ b/files/en-us/glossary/first_contentful_paint/index.md
@@ -9,7 +9,7 @@ tags:
 
 **First Contentful Paint** (FCP) is when the browser renders the first bit of content from the DOM, providing the first feedback to the user that the page is actually loading. The question "Is it happening?" is "yes" when the first contentful paint completes.
 
-_The First Contentful Paint_ time stamp is when the browser first rendered any text, image (including background images), video, canvas that had been drawn into, or non-empty SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
+_The First Contentful Paint_ timestamp is when the browser first rendered any text, image (including background images), video, canvas that had been drawn into, or non-empty SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.
 
 ## See also
 

--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
@@ -268,7 +268,7 @@ Serve the following file types with the `charset` parameter set to `UTF-8` using
 
 [mod_rewrite](https://httpd.apache.org/docs/current/mod/mod_rewrite.html) provides a way to modify incoming URL requests, dynamically, based on regular expression rules. This allows you to map arbitrary URLs onto your internal URL structure in any way you like.
 
-It supports an unlimited number of rules and an unlimited number of attached rule conditions for each rule to provide a really flexible and powerful URL manipulation mechanism. The URL manipulations can depend on various tests: server variables, environment variables, HTTP headers, time stamps, external database lookups, and various other external programs or handlers, can be used to achieve granular URL matching.
+It supports an unlimited number of rules and an unlimited number of attached rule conditions for each rule to provide a really flexible and powerful URL manipulation mechanism. The URL manipulations can depend on various tests: server variables, environment variables, HTTP headers, timestamps, external database lookups, and various other external programs or handlers, can be used to achieve granular URL matching.
 
 ### Enable mod_rewrite
 

--- a/files/en-us/web/api/domhighrestimestamp/index.md
+++ b/files/en-us/web/api/domhighrestimestamp/index.md
@@ -27,7 +27,7 @@ Further, if the device or operating system the user agent is running on doesn't 
 
 ## Reduced time precision
 
-To offer protection against timing attacks and fingerprinting, the precision of time stamps might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 µs in Firefox 59; in 60 it will be 2ms.
+To offer protection against timing attacks and fingerprinting, the precision of timestamps might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 µs in Firefox 59; in 60 it will be 2ms.
 
 ```js
 // reduced time precision (2ms) in Firefox 60

--- a/files/en-us/web/api/htmlformelement/reset_event/index.md
+++ b/files/en-us/web/api/htmlformelement/reset_event/index.md
@@ -49,7 +49,7 @@ This example uses {{domxref("EventTarget.addEventListener()")}} to listen for fo
 
 ```js
 function logReset(event) {
-  log.textContent = `Form reset! Time stamp: ${event.timeStamp}`;
+  log.textContent = `Form reset! Timestamp: ${event.timeStamp}`;
 }
 
 const form = document.getElementById('form');

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -65,7 +65,7 @@ This example uses {{domxref("EventTarget.addEventListener()")}} to listen for fo
 
 ```js
 function logSubmit(event) {
-  log.textContent = `Form Submitted! Time stamp: ${event.timeStamp}`;
+  log.textContent = `Form Submitted! Timestamp: ${event.timeStamp}`;
   event.preventDefault();
 }
 

--- a/files/en-us/web/api/rtcdatachannel/send/index.md
+++ b/files/en-us/web/api/rtcdatachannel/send/index.md
@@ -73,7 +73,7 @@ None ({{jsxref("undefined")}}).
 
 In this example, a routine called `sendMessage()` is created; it accepts an
 object as input and sends to the remote peer, over the {{domxref("RTCDataChannel")}}, a
-JSON string with the specified object and a time stamp.
+JSON string with the specified object and a timestamp.
 
 ```js
 const pc = new RTCPeerConnection();

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
@@ -10,7 +10,7 @@ tags:
   - RTP
   - Reference
   - Time
-  - Time stamp
+  - Timestamp
   - WebRTC
   - WebRTC API
   - lastPacketReceivedTimestamp

--- a/files/en-us/web/api/sensor/index.md
+++ b/files/en-us/web/api/sensor/index.md
@@ -44,7 +44,7 @@ Below is a list of interfaces based on the `Sensor` interface.
 - {{domxref('Sensor.hasReading')}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether the sensor has a reading.
 - {{domxref('Sensor.timestamp')}} {{ReadOnlyInline}}
-  - : Returns the time stamp of the latest sensor reading.
+  - : Returns the timestamp of the latest sensor reading.
 
 ## Instance methods
 

--- a/files/en-us/web/api/sensor/timestamp/index.md
+++ b/files/en-us/web/api/sensor/timestamp/index.md
@@ -17,7 +17,7 @@ browser-compat: api.Sensor.timestamp
 {{APIRef("Sensor API")}}
 
 The **`timestamp`** read-only property
-of the {{domxref("Sensor")}} interface returns the time stamp of the latest sensor
+of the {{domxref("Sensor")}} interface returns the timestamp of the latest sensor
 reading.
 
 Because {{domxref('Sensor')}} is a base class, `timestamp` may only be read

--- a/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
+++ b/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
@@ -36,7 +36,7 @@ The very fact that RTCP is defined in the same RFC as RTP is a clue as to just h
 RTP's primary benefits in terms of WebRTC include:
 
 - Generally low latency.
-- Packets are sequence-numbered and time-stamped for reassembly if they arrive out of order. This lets data sent using RTP be delivered on transports that don't guarantee ordering or even guarantee delivery at all.
+- Packets are sequence-numbered and timestamped for reassembly if they arrive out of order. This lets data sent using RTP be delivered on transports that don't guarantee ordering or even guarantee delivery at all.
 - This means RTP can be — but is not required to be — used atop {{Glossary("UDP")}} for its performance as well as its multiplexing and checksum features.
 - RTP supports multicast; while this isn't yet important for WebRTC, it's likely to matter in the future, when WebRTC is (hopefully) enhanced to support multi-user conversations.
 - RTP isn't limited to use in audiovisual communication. It can be used for any form of continuous or active data transfer, including data streaming, active badges or status display updates, or control and measurement information transport.

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -30,7 +30,7 @@ call `requestAnimationFrame()` again. This can be done from within the
 callback itself.
 
 The callback takes two parameters as inputs: an {{DOMxRef("XRFrame")}} describing the
-state of all tracked objects for the session, and a time stamp you can use to compute
+state of all tracked objects for the session, and a timestamp you can use to compute
 any animation updates needed.
 
 You can cancel a previously scheduled animation by calling

--- a/files/en-us/web/html/element/del/index.md
+++ b/files/en-us/web/html/element/del/index.md
@@ -85,7 +85,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 - {{htmlattrdef("cite")}}
   - : A URI for a resource that explains the change (for example, meeting minutes).
 - {{htmlattrdef("datetime")}}
-  - : This attribute indicates the time and date of the change and must be a valid date string with an optional time. If the value cannot be parsed as a date with an optional time string, the element does not have an associated time stamp. For the format of the string without a time, see [Date strings](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings). The format of the string if it includes both date and time is covered in [Local date and time strings](/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings).
+  - : This attribute indicates the time and date of the change and must be a valid date string with an optional time. If the value cannot be parsed as a date with an optional time string, the element does not have an associated timestamp. For the format of the string without a time, see [Date strings](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings). The format of the string if it includes both date and time is covered in [Local date and time strings](/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings).
 
 ## Examples
 

--- a/files/en-us/web/html/element/ins/index.md
+++ b/files/en-us/web/html/element/ins/index.md
@@ -84,7 +84,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - {{htmlattrdef("cite")}}
   - : This attribute defines the URI of a resource that explains the change, such as a link to meeting minutes or a ticket in a troubleshooting system.
 - {{htmlattrdef("datetime")}}
-  - : This attribute indicates the time and date of the change and must be a valid date with an optional time string. If the value cannot be parsed as a date with an optional time string, the element does not have an associated time stamp. For the format of the string without a time, see [Format of a valid date string](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings). The format of the string if it includes both date and time is covered in [Format of a valid local date and time string](/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings).
+  - : This attribute indicates the time and date of the change and must be a valid date with an optional time string. If the value cannot be parsed as a date with an optional time string, the element does not have an associated timestamp. For the format of the string without a time, see [Format of a valid date string](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings). The format of the string if it includes both date and time is covered in [Format of a valid local date and time string](/en-US/docs/Web/HTML/Date_and_time_formats#local_date_and_time_strings).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_date/index.md
@@ -58,7 +58,7 @@ For more details, see the {{jsxref("Date.parse()")}} documentation.
 
 ```js example-good
 new Date('05 October 2011 14:48 UTC');
-new Date(1317826080); // Unix Time Stamp for 05 October 2011 14:48:00 UTC
+new Date(1317826080); // Unix Timestamp for 05 October 2011 14:48:00 UTC
 ```
 
 ## See also

--- a/files/en-us/web/performance/navigation_and_resource_timings/index.md
+++ b/files/en-us/web/performance/navigation_and_resource_timings/index.md
@@ -340,7 +340,7 @@ const tcp = time.connectEnd - time.connectStart;
 
 ### SSL negotiation
 
-[`secureConnectionStart`](/en-US/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) will be `undefined` if not available, `0` if [https](/en-US/docs/Glossary/https) in not used, or a time stamp if available, and used. In other words, if a secure connection was used, `secureConnectionStart` will be [truthy](/en-US/docs/Glossary/Truthy), and the time between `secureConnectionStart` and `requestStart` will greater than 0.
+[`secureConnectionStart`](/en-US/docs/Web/API/PerformanceResourceTiming/secureConnectionStart) will be `undefined` if not available, `0` if [https](/en-US/docs/Glossary/https) in not used, or a timestamp if available, and used. In other words, if a secure connection was used, `secureConnectionStart` will be [truthy](/en-US/docs/Glossary/Truthy), and the time between `secureConnectionStart` and `requestStart` will greater than 0.
 
 ```js
 const ssl = time.requestStart - time.secureConnectionStart;
@@ -442,7 +442,7 @@ const request = timing.responseStart - timing.requestStart;
 
 ### Load event duration
 
-By subtracting the time stamp from immediately before the load event of the current document is fired from the time when the load event of the current document is completed, you can measure the duration of the load event.
+By subtracting the timestamp from immediately before the load event of the current document is fired from the time when the load event of the current document is completed, you can measure the duration of the load event.
 
 ```js
 const load = timing.loadEventEnd - timing.loadEventStart;


### PR DESCRIPTION
`time-stamp` -> `timestamp`
`time stamp` -> `timestamp`

Only 16 occurrences left in the repo.