### PR TITLE
Normalize capitalization of titles and slugs in Glossary

### DIFF
--- a/files/en-us/glossary/accent/index.md
+++ b/files/en-us/glossary/accent/index.md
@@ -1,6 +1,6 @@
 ---
-title: accent
-slug: Glossary/accent
+title: Accent
+slug: Glossary/Accent
 tags:
   - Input
   - accent

--- a/files/en-us/glossary/advance_measure/index.md
+++ b/files/en-us/glossary/advance_measure/index.md
@@ -1,6 +1,6 @@
 ---
 title: Advance measure
-slug: Glossary/advance_measure
+slug: Glossary/Advance_measure
 tags:
   - Accessibility
 ---

--- a/files/en-us/glossary/application_context/index.md
+++ b/files/en-us/glossary/application_context/index.md
@@ -1,6 +1,6 @@
 ---
 title: Application Context
-slug: Glossary/application_context
+slug: Glossary/Application_context
 tags:
   - CodingScripting
 ---

--- a/files/en-us/glossary/array/index.md
+++ b/files/en-us/glossary/array/index.md
@@ -1,6 +1,6 @@
 ---
 title: Array
-slug: Glossary/array
+slug: Glossary/Array
 tags:
   - Array
   - CodingScripting

--- a/files/en-us/glossary/baseline/index.md
+++ b/files/en-us/glossary/baseline/index.md
@@ -1,6 +1,6 @@
 ---
 title: Baseline
-slug: Glossary/baseline
+slug: Glossary/Baseline
 tags:
   - CSS
   - SVG

--- a/files/en-us/glossary/beacon/index.md
+++ b/files/en-us/glossary/beacon/index.md
@@ -1,6 +1,6 @@
 ---
-title: beacon
-slug: Glossary/beacon
+title: Beacon
+slug: Glossary/Beacon
 tags:
   - Beacon
   - Reference

--- a/files/en-us/glossary/bounding_box/index.md
+++ b/files/en-us/glossary/bounding_box/index.md
@@ -1,6 +1,6 @@
 ---
 title: Bounding Box
-slug: Glossary/bounding_box
+slug: Glossary/Bounding_box
 tags:
   - Bounding Box
   - CodingScripting

--- a/files/en-us/glossary/brotli_compression/index.md
+++ b/files/en-us/glossary/brotli_compression/index.md
@@ -1,6 +1,6 @@
 ---
 title: Brotli
-slug: Glossary/brotli_compression
+slug: Glossary/Brotli_compression
 tags:
   - Brotli
   - Reference

--- a/files/en-us/glossary/buffer/index.md
+++ b/files/en-us/glossary/buffer/index.md
@@ -1,6 +1,6 @@
 ---
-title: buffer
-slug: Glossary/buffer
+title: Buffer
+slug: Glossary/Buffer
 tags:
   - Buffer
   - CodingScripting

--- a/files/en-us/glossary/cacheable/index.md
+++ b/files/en-us/glossary/cacheable/index.md
@@ -1,6 +1,6 @@
 ---
 title: Cacheable
-slug: Glossary/cacheable
+slug: Glossary/Cacheable
 tags:
   - WebMechanics
 ---

--- a/files/en-us/glossary/caret/index.md
+++ b/files/en-us/glossary/caret/index.md
@@ -1,6 +1,6 @@
 ---
-title: caret
-slug: Glossary/caret
+title: Caret
+slug: Glossary/Caret
 tags:
   - Cursor
   - Input

--- a/files/en-us/glossary/challenge/index.md
+++ b/files/en-us/glossary/challenge/index.md
@@ -1,6 +1,6 @@
 ---
 title: Challenge-response authentication
-slug: Glossary/challenge
+slug: Glossary/Challenge
 tags:
   - Security
 ---

--- a/files/en-us/glossary/character_encoding/index.md
+++ b/files/en-us/glossary/character_encoding/index.md
@@ -1,6 +1,6 @@
 ---
 title: Character encoding
-slug: Glossary/character_encoding
+slug: Glossary/Character_encoding
 tags:
   - Composing
 ---

--- a/files/en-us/glossary/character_set/index.md
+++ b/files/en-us/glossary/character_set/index.md
@@ -1,6 +1,6 @@
 ---
 title: Character set
-slug: Glossary/character_set
+slug: Glossary/Character_set
 tags:
   - character encoding
   - character set

--- a/files/en-us/glossary/document_environment/index.md
+++ b/files/en-us/glossary/document_environment/index.md
@@ -1,6 +1,6 @@
 ---
-title: document environment
-slug: Glossary/document_environment
+title: Document environment
+slug: Glossary/Document_environment
 tags:
   - CodingScripting
   - JavaScript

--- a/files/en-us/glossary/event/index.md
+++ b/files/en-us/glossary/event/index.md
@@ -1,6 +1,6 @@
 ---
 title: Event
-slug: Glossary/event
+slug: Glossary/Event
 tags:
   - CodingScripting
 ---

--- a/files/en-us/glossary/firewall/index.md
+++ b/files/en-us/glossary/firewall/index.md
@@ -1,6 +1,6 @@
 ---
-title: firewall
-slug: Glossary/firewall
+title: Firewall
+slug: Glossary/Firewall
 tags:
   - DDoS
   - Firewall

--- a/files/en-us/glossary/first_meaningful_paint/index.md
+++ b/files/en-us/glossary/first_meaningful_paint/index.md
@@ -1,6 +1,6 @@
 ---
 title: First Meaningful Paint
-slug: Glossary/first_meaningful_paint
+slug: Glossary/First_meaningful_paint
 tags:
   - Reference
   - Web Performance

--- a/files/en-us/glossary/fps/index.md
+++ b/files/en-us/glossary/fps/index.md
@@ -1,5 +1,5 @@
 ---
-title: frame rate (FPS)
+title: Frame rate (FPS)
 slug: Glossary/FPS
 tags:
   - Animation

--- a/files/en-us/glossary/gif/index.md
+++ b/files/en-us/glossary/gif/index.md
@@ -1,6 +1,6 @@
 ---
 title: GIF
-slug: Glossary/gif
+slug: Glossary/GIF
 tags:
   - Composing
 ---

--- a/files/en-us/glossary/gzip_compression/index.md
+++ b/files/en-us/glossary/gzip_compression/index.md
@@ -1,5 +1,5 @@
 ---
-title: gzip compression
+title: GZip compression
 slug: Glossary/GZip_compression
 tags:
   - compression

--- a/files/en-us/glossary/hash/index.md
+++ b/files/en-us/glossary/hash/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hash
-slug: Glossary/hash
+slug: Glossary/Hash
 tags:
   - CodingScripting
   - Cryptography

--- a/files/en-us/glossary/https/index.md
+++ b/files/en-us/glossary/https/index.md
@@ -1,6 +1,6 @@
 ---
 title: HTTPS
-slug: Glossary/https
+slug: Glossary/HTTPS
 tags:
   - HTTPS
   - Infrastructure

--- a/files/en-us/glossary/https_rr/index.md
+++ b/files/en-us/glossary/https_rr/index.md
@@ -1,6 +1,6 @@
 ---
 title: HTTPS RR
-slug: Glossary/https_rr
+slug: Glossary/HTTPS_RR
 tags:
   - HTTPS
   - HTTPS RR

--- a/files/en-us/glossary/jpeg/index.md
+++ b/files/en-us/glossary/jpeg/index.md
@@ -1,6 +1,6 @@
 ---
 title: JPEG
-slug: Glossary/jpeg
+slug: Glossary/JPEG
 tags:
   - Beginner
   - Composing

--- a/files/en-us/glossary/loop/index.md
+++ b/files/en-us/glossary/loop/index.md
@@ -1,6 +1,6 @@
 ---
 title: Loop
-slug: Glossary/loop
+slug: Glossary/Loop
 tags:
   - CodingScripting
   - control flow

--- a/files/en-us/glossary/lossy_compression/index.md
+++ b/files/en-us/glossary/lossy_compression/index.md
@@ -1,6 +1,6 @@
 ---
-title: lossy compression
-slug: Glossary/lossy_compression
+title: Lossy compression
+slug: Glossary/Lossy_compression
 tags:
   - Beginner
   - Composing

--- a/files/en-us/glossary/ltr/index.md
+++ b/files/en-us/glossary/ltr/index.md
@@ -1,6 +1,6 @@
 ---
 title: LTR (Left To Right)
-slug: Glossary/ltr
+slug: Glossary/LTR
 tags:
   - Composing
   - Localization

--- a/files/en-us/glossary/markup/index.md
+++ b/files/en-us/glossary/markup/index.md
@@ -1,6 +1,6 @@
 ---
-title: markup
-slug: Glossary/markup
+title: Markup
+slug: Glossary/Markup
 tags:
   - Intro
   - Markup

--- a/files/en-us/glossary/mime/index.md
+++ b/files/en-us/glossary/mime/index.md
@@ -1,6 +1,6 @@
 ---
-title: mime
-slug: Glossary/mime
+title: MIME
+slug: Glossary/MIME
 tags:
   - Beginner
   - Infrastructure

--- a/files/en-us/glossary/minification/index.md
+++ b/files/en-us/glossary/minification/index.md
@@ -1,6 +1,6 @@
 ---
-title: minification
-slug: Glossary/minification
+title: Minification
+slug: Glossary/Minification
 tags:
   - Performance
   - Reference

--- a/files/en-us/glossary/modularity/index.md
+++ b/files/en-us/glossary/modularity/index.md
@@ -1,6 +1,6 @@
 ---
 title: Modularity
-slug: Glossary/modularity
+slug: Glossary/Modularity
 tags:
   - CodingScripting
 ---

--- a/files/en-us/glossary/non-normative/index.md
+++ b/files/en-us/glossary/non-normative/index.md
@@ -1,6 +1,6 @@
 ---
 title: Non-normative
-slug: Glossary/non-normative
+slug: Glossary/Non-normative
 tags:
   - Infrastructure
   - Specification

--- a/files/en-us/glossary/percent-encoding/index.md
+++ b/files/en-us/glossary/percent-encoding/index.md
@@ -1,6 +1,6 @@
 ---
 title: Percent-encoding
-slug: Glossary/percent-encoding
+slug: Glossary/Percent-encoding
 tags:
   - WebMechanics
 ---

--- a/files/en-us/glossary/prerender/index.md
+++ b/files/en-us/glossary/prerender/index.md
@@ -1,6 +1,6 @@
 ---
 title: Prerender
-slug: Glossary/prerender
+slug: Glossary/Prerender
 tags:
   - Prefetch
   - Security

--- a/files/en-us/glossary/privileged_code/index.md
+++ b/files/en-us/glossary/privileged_code/index.md
@@ -1,6 +1,6 @@
 ---
-title: privileged code
-slug: Glossary/privileged_code
+title: Privileged code
+slug: Glossary/Privileged_code
 tags:
   - privileged
 ---

--- a/files/en-us/glossary/property/css/index.md
+++ b/files/en-us/glossary/property/css/index.md
@@ -1,6 +1,6 @@
 ---
 title: Property (CSS)
-slug: Glossary/property/CSS
+slug: Glossary/Property/CSS
 tags:
   - CodingScripting
 ---

--- a/files/en-us/glossary/property/index.md
+++ b/files/en-us/glossary/property/index.md
@@ -1,6 +1,6 @@
 ---
 title: Property
-slug: Glossary/property
+slug: Glossary/Property
 tags:
   - Disambiguation
 ---

--- a/files/en-us/glossary/property/javascript/index.md
+++ b/files/en-us/glossary/property/javascript/index.md
@@ -1,6 +1,6 @@
 ---
 title: Property (JavaScript)
-slug: Glossary/property/JavaScript
+slug: Glossary/Property/JavaScript
 tags:
   - CodingScripting
 ---

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -1,6 +1,6 @@
 ---
 title: Routers
-slug: Glossary/routers
+slug: Glossary/Routers
 tags:
   - Intro
 ---

--- a/files/en-us/glossary/rtl/index.md
+++ b/files/en-us/glossary/rtl/index.md
@@ -1,6 +1,6 @@
 ---
 title: RTL (Right to Left)
-slug: Glossary/rtl
+slug: Glossary/RTL
 tags:
   - Composing
   - Localization

--- a/files/en-us/glossary/speculative_parsing/index.md
+++ b/files/en-us/glossary/speculative_parsing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Speculative parsing
-slug: Glossary/speculative_parsing
+slug: Glossary/Speculative_parsing
 tags:
   - Advanced
   - HTML

--- a/files/en-us/glossary/strict_mode/index.md
+++ b/files/en-us/glossary/strict_mode/index.md
@@ -1,6 +1,6 @@
 ---
 title: Strict mode
-slug: Glossary/strict_mode
+slug: Glossary/Strict_mode
 tags:
   - JavaScript
   - Reference

--- a/files/en-us/glossary/time_to_first_byte/index.md
+++ b/files/en-us/glossary/time_to_first_byte/index.md
@@ -1,13 +1,13 @@
 ---
 title: Time to first byte
-slug: Glossary/time_to_first_byte
+slug: Glossary/Time_to_first_byte
 tags:
   - Performance
   - Reference
   - Web Performance
 ---
 
-**Time to First Byte** (TTFB) refers to the time between the browser requesting a page and when it receives the first byte of information from the server. This time includes [DNS](/en-US/docs/Glossary/DNS) lookup and establishing the connection using a [TCP](/en-US/docs/Glossary/TCP) handshake and [SSL](/en-US/docs/Glossary/SSL) handshake if the request is made over [https](/en-US/docs/Glossary/https).
+**Time to First Byte** (TTFB) refers to the time between the browser requesting a page and when it receives the first byte of information from the server. This time includes [DNS](/en-US/docs/Glossary/DNS) lookup and establishing the connection using a [TCP](/en-US/docs/Glossary/TCP) handshake and [SSL](/en-US/docs/Glossary/SSL) handshake if the request is made over [HTTPS](/en-US/docs/Glossary/HTTPS).
 
 TTFB is the time it takes between the start of the request and the start of the response, in milliseconds:
 

--- a/files/en-us/glossary/undefined/index.md
+++ b/files/en-us/glossary/undefined/index.md
@@ -1,6 +1,6 @@
 ---
-title: undefined
-slug: Glossary/undefined
+title: Undefined
+slug: Glossary/Undefined
 tags:
   - CodingScripting
   - JavaScript

--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -1,6 +1,6 @@
 ---
 title: WebM
-slug: Glossary/webm
+slug: Glossary/WebM
 tags:
   - Composing
   - Infrastructure

--- a/files/en-us/glossary/webp/index.md
+++ b/files/en-us/glossary/webp/index.md
@@ -1,6 +1,6 @@
 ---
 title: WebP
-slug: Glossary/webp
+slug: Glossary/WebP
 tags:
   - Beginner
   - Composing


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change normalizes the capitalization of the `title` and `slug` properties for entries in the Glossary to the most common pattern among those pages.

### Motivation

The `title`s and `slug`s of enties in the [Glossary](https://developer.mozilla.org/en-US/docs/Glossary) have inconsistent capitalization. Most of them capitalize the first letter, and otherwise apply the same capitalization of the title to the slug (URL). It would be desirable to have a consistent capitalization standard for these properties.

### Additional details

I can understand the desire to keep URLs lowercase, or that to make titles use lowercase if they're words that aren't proper nouns. I would be happy to perform the corresponding alternative changes to the glossary pages if consistently applying one (or both) of these properties is prefered. 

Note: since this change will affect URLs, I wonder if there's a way to provide redirects from the previous URLs so that links won't be broken.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
