### PR TITLE
changed link to page where the information is displayed

### DIFF
--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -18,7 +18,7 @@ browser-compat: api.HTMLInputElement.webkitdirectory
 {{APIRef("File and Directory Entries API")}}
 
 The **`HTMLInputElement.webkitdirectory`** is a property
-that reflects the {{htmlattrxref("webkitdirectory", "input/file")}} HTML attribute
+that reflects the [`webkitdirectory`](/en-US/docs/Web/HTML/Element/input/file#webkitdirectory) HTML attribute
 and indicates that the {{HTMLElement("input")}} element should let the user select directories instead of files.
 When a directory is selected, the directory and its entire hierarchy of contents are included in the set of selected items.
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -18,7 +18,7 @@ browser-compat: api.HTMLInputElement.webkitdirectory
 {{APIRef("File and Directory Entries API")}}
 
 The **`HTMLInputElement.webkitdirectory`** is a property
-that reflects the {{htmlattrxref("webkitdirectory", "input")}} HTML attribute
+that reflects the {{htmlattrxref("webkitdirectory", "input/file")}} HTML attribute
 and indicates that the {{HTMLElement("input")}} element should let the user select directories instead of files.
 When a directory is selected, the directory and its entire hierarchy of contents are included in the set of selected items.
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrected link to `webkitdirectory` attr.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The link did not go to the page with the information on it.