### PR TITLE
setRequestHeader: using forbidden has no effect

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -35,10 +35,7 @@ If no {{HTTPHeader("Accept")}} header has been set using this, an `Accept`
 header with the type `"*/*"` is sent with the request when
 {{domxref("XMLHttpRequest.send", "send()")}} is called.
 
-For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
-and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
-These calls will be ignored without warning or error.
+For security reasons, there are several {{Glossary("Forbidden_header_name", "forbidden header names")}} whose values are controlled by the user agent. Any attempt to set a value for one of those headers from frontend JavaScript code will be ignored without warning or error.
 
 > **Note:** For your custom fields, you may encounter a "**not
 > allowed by Access-Control-Allow-Headers in preflight response**" exception

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -38,6 +38,7 @@ header with the type `"*/*"` is sent with the request when
 For security reasons, some headers can only be controlled by the user agent. These
 headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
+These calls will be ignored without warning or error.
 
 > **Note:** For your custom fields, you may encounter a "**not
 > allowed by Access-Control-Allow-Headers in preflight response**" exception


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Explain that calls to `XMLHttpRequest .setRequestHeader` with a _forbidden header_ will be ignored

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I would expect that an attempt to set a forbidden header will throw an error, so this detail must be rectified.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[Using a forbidden header for fun and profit](https://invent.kde.org/frameworks/kio/-/blob/master/autotests/ktcpsockettest.cpp#L192)
```sh
curl --header 'Host: www.example.com' http://www.iana.org
```
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
