### PR TITLE
Fix formatting error introduced by previous edit

### DIFF
--- a/files/en-us/web/html/element/i/index.md
+++ b/files/en-us/web/html/element/i/index.md
@@ -47,10 +47,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 This example demonstrates using the `<i>` element to mark text that is in another language.
 
 ```html
-<p>
-  The Latin phrase <i lang="la">Veni, vidi, vici</i> is often mentioned in music, art, and
-  literature.
-</p>
+<p>The Latin phrase <i lang="la">Veni, vidi, vici</i> is often mentioned in music, art, and literature.</p>
 ```
 
 ### Result


### PR DESCRIPTION
The text in the code example had an unnecessary line break. This edit removes it and normalizes formatting.

### Description

Fix example formatting.

### Motivation

Fix formatting error. Standardize line breaks with other examples on page.
