### PR TITLE
Move extends reference into its own page

### DIFF
--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -701,7 +701,7 @@ class ColorWithAlpha extends Color {
 }
 ```
 
-A class can only extend from one class. This prevents problems in multiple inheritance like the [diamond problem](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem). However, due to the dynamic nature of JavaScript, it's still possible to achieve the effect of multiple inheritance through class composition and [mixins](/en-US/docs/Web/JavaScript/Reference/Classes#mix-ins).
+A class can only extend from one class. This prevents problems in multiple inheritance like the [diamond problem](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem). However, due to the dynamic nature of JavaScript, it's still possible to achieve the effect of multiple inheritance through class composition and [mixins](/en-US/docs/Web/JavaScript/Reference/Classes/extends#mix-ins).
 
 Instances of derived classes are also [instances of](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) the base class.
 

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -723,7 +723,7 @@ const p = new Person("Maria");
 console.log(p.sayHello());
 ```
 
-JavaScript classes are just functions that must be instantiated with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. Every time a class is instantiated, it returns an object containing the methods and properties that the class specified. Classes don't enforce any code organization — for example, you can have functions returning classes, or you can have multiple classes per file. Here's an example of how ad hoc the creation of a class can be: it's just an expression returned from an arrow function. This pattern is called a [mixin](/en-US/docs/Web/JavaScript/Reference/Classes#mix-ins).
+JavaScript classes are just functions that must be instantiated with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. Every time a class is instantiated, it returns an object containing the methods and properties that the class specified. Classes don't enforce any code organization — for example, you can have functions returning classes, or you can have multiple classes per file. Here's an example of how ad hoc the creation of a class can be: it's just an expression returned from an arrow function. This pattern is called a [mixin](/en-US/docs/Web/JavaScript/Reference/Classes/extends#mix-ins).
 
 ```js
 const withAuthentication = (cls) =>

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -12,9 +12,7 @@ browser-compat: javascript.classes.extends
 
 {{jsSidebar("Classes")}}
 
-The **`extends`** keyword is used in [class declarations](/en-US/docs/Web/JavaScript/Reference/Statements/class) or
-[class expressions](/en-US/docs/Web/JavaScript/Reference/Operators/class) to
-create a class that is a child of another class.
+The **`extends`** keyword is used in [class declarations](/en-US/docs/Web/JavaScript/Reference/Statements/class) or [class expressions](/en-US/docs/Web/JavaScript/Reference/Operators/class) to create a class that is a child of another class.
 
 {{EmbedInteractiveExample("pages/js/classes-extends.html")}}
 
@@ -24,11 +22,14 @@ create a class that is a child of another class.
 class ChildClass extends ParentClass { /* … */ }
 ```
 
+- `ParentClass`
+  - : An expression that evaluates to a constructor function (including a class) or `null`.
+
 ## Description
 
 The `extends` keyword can be used to subclass custom classes as well as built-in objects.
 
-Any constructor that can be called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) (which means it must have the [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property) can be the candidate for the parent class.
+Any constructor that can be called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) and has the [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property can be the candidate for the parent class. The two conditions must both hold — for example, [bound functions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) and {{jsxref("Proxy")}} can be constructed, but they don't have a `prototype` property, so they cannot be subclassed.
 
 ```js
 function OldStyleClass() {
@@ -46,7 +47,7 @@ class ModernClass {
 class AnotherChildClass extends ModernClass {}
 ```
 
-The `prototype` of the `ParentClass` must be an {{jsxref("Object")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The `prototype` property of the `ParentClass` must be an {{jsxref("Object")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), but you would rarely worry about this in practice, because a non-object `prototype` doesn't behave as it should anyway. (It's ignored by the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.)
 
 ```js
 function ParentClass() {}
@@ -54,19 +55,19 @@ ParentClass.prototype = 3;
 
 class ChildClass extends ParentClass {}
 // Uncaught TypeError: Class extends value does not have valid prototype property 3
+
+console.log(Object.getPrototypeOf(new ParentClass()));
+// [Object: null prototype] {}
+// Not actually a number!
 ```
 
-> **Note:** You would rarely worry about this in practice, because a non-object `prototype` doesn't behave as it should anyway. (It's ignored by the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.)
->
-> ```js
-> function ParentClass() {}
-> ParentClass.prototype = 3;
-> console.log(Object.getPrototypeOf(new ParentClass()));
-> // [Object: null prototype] {}
-> // Not actually a number!
-> ```
+`extends` sets the prototype for both `ChildClass` and `ChildClass.prototype`.
 
-`extends` will set the prototype for both `ChildClass` and `ChildClass.prototype`.
+|                         | Prototype of `ChildClass` | Prototype of `ChildClass.prototype` |
+| ----------------------- | ------------------------- | ----------------------------------- |
+| `extends` clause absent | `Function.prototype`      | `Object.prototype`                  |
+| `extends null`          | `Function.prototype`      | `null`                              |
+| `extends ParentClass`   | `ParentClass`             | `ParentClass.prototype`             |
 
 ```js
 class ParentClass {}
@@ -78,7 +79,7 @@ Object.getPrototypeOf(ChildClass) === ParentClass;
 Object.getPrototypeOf(ChildClass.prototype) === ParentClass.prototype;
 ```
 
-The right-hand side of `extends` does not have to be an identifier. You can use any expression that evaluates to a constructor.
+The right-hand side of `extends` does not have to be an identifier. You can use any expression that evaluates to a constructor. This is often useful to create [mixins](#mix-ins).
 
 ```js
 class SomeClass extends class {
@@ -96,8 +97,6 @@ new SomeClass();
 // Base class
 // Derived class
 ```
-
-This is often useful to create [mixins](/en-US/docs/Web/JavaScript/Reference/Classes#mix-ins).
 
 While the base class may return anything from its constructor, the derived class must return an object or `undefined`, or a {{jsxref("TypeError")}} will be thrown.
 
@@ -123,12 +122,29 @@ console.log(new ChildClass()); // TypeError: Derived constructors may only retur
 
 If the parent class constructor returns an object, that object will be used as the `this` value for the derived class when further initializing [class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields). This trick is called ["return overriding"](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#returning_overriding_object), which allows a derived class's fields (including [private](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) ones) to be defined on unrelated objects.
 
+### Subclassing built-ins
+
+> **Warning:** The standard committee now holds the position that the built-in subclassing mechanism in previous spec versions is over-engineered and causes non-negligible performance and security impacts. New built-in methods consider less about subclasses, and engine implementers are [investigating whether to remove certain subclassing mechanisms](https://github.com/tc39/proposal-rm-builtin-subclassing). Consider using composition instead of inheritance when enhancing built-ins.
+
+Here are some things you may expect when extending a class:
+
+- When calling a static factory method (like {{jsxref("Promise.resolve()")}} or {{jsxref("Array.from()")}}) on a subclass, the returned instance is always an instance of the subclass.
+- When calling an instance method that returns a new instance (like {{jsxref("Promise.prototype.then()")}} or {{jsxref("Array.prototype.map()")}}) on a subclass, the returned instance is always an instance of the subclass.
+- Instance methods try to delegate to a minimal set of primitive methods where possible. For example, for a subclass of {{jsxref("Promise")}}, overriding {{jsxref("Promise/then", "then()")}} automatically causes the behavior of {{jsxref("Promise/catch", "catch()")}} to change; or for a subclass of {{jsxref("Map")}}, overriding {{jsxref("Map/set", "set()")}} automatically causes the behavior of the {{jsxref("Map/Map", "Map()")}} constructor to change.
+
+However, the above expectations take non-trivial efforts to implement properly.
+
+- The first one requires the static method to read the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) to get the constructor for constructing the returned instance. This means `[p1, p2, p3].map(Promise.resolve)` throws an error because the `this` inside `Promise.resolve` is `undefined`. A way to fix this is to fall back to the base class if `this` is not a constructor, like {{jsxref("Array.from()")}} does, but that still means the base class is special-cased.
+- The second one requires the instance method to read [`this.constructor`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) to get the constructor function. However, `new this.constructor()` may break legacy code, because the `constructor` property is both writable and configurable and is not protected in any way. Therefore, many copying built-in methods use the constructor's [`@@species`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species) property instead (which by default just returns `this`, the constructor itself). However, `@@species` allows running arbitrary code and creating instances of arbitrary type, which poses a security concern and greatly complicates subclassing semantics.
+- The third one leads to visible invocations of custom code, which makes a lot of optimizations harder to implement. For example, if the `Map()` constructor is called with an iterable of _x_ elements, then it must visibly invoke the `set()` method _x_ times, instead of just copying the elements into the internal storage.
+
+These problems are not unique to built-in classes. For your own classes, you will likely have to make the same decisions. However, for built-in classes, optimizability and security are a much bigger concern. New built-in methods always construct the base class and call as few custom methods as possible. If you want to subclass built-ins while achieving the above expectations, you need to override all methods that have the default behavior baked into them. Any addition of new methods on the base class may also break the semantics of your subclass because they are inherited by default. Therefore, a better way to extend built-ins is to use [_composition_](#avoiding_inheritance).
+
 ## Examples
 
 ### Using extends
 
-The first example creates a class called `Square` from a class called
-`Polygon`. This example is extracted from this [live demo](https://googlechrome.github.io/samples/classes-es6/index.html) [(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html).
+The first example creates a class called `Square` from a class called `Polygon`. This example is extracted from this [live demo](https://googlechrome.github.io/samples/classes-es6/index.html) [(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html).
 
 ```js
 class Square extends Polygon {
@@ -147,20 +163,141 @@ class Square extends Polygon {
 }
 ```
 
-### Using extends with built-in objects
+### Extending plain objects
 
-This example extends the built-in {{jsxref("Date")}} object.
-This example is extracted from this [live demo](https://googlechrome.github.io/samples/classes-es6/index.html)
-[(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html).
+Classes cannot extend regular (non-constructible) objects. If you want to inherit from a regular object by making all properties of this object available on inherited instances, you can instead use {{jsxref("Object.setPrototypeOf()")}}:
 
 ```js
-class myDate extends Date {
+const Animal = {
+  speak() {
+    console.log(`${this.name} makes a noise.`);
+  }
+};
+
+class Dog {
+  constructor(name) {
+    this.name = name;
+  }
+}
+
+Object.setPrototypeOf(Dog.prototype, Animal);
+
+const d = new Dog("Mitzie");
+d.speak(); // Mitzie makes a noise.
+```
+
+### Extending built-in objects
+
+This example extends the built-in {{jsxref("Date")}} object. This example is extracted from this [live demo](https://googlechrome.github.io/samples/classes-es6/index.html) [(source)](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html).
+
+```js
+class MyDate extends Date {
   getFormattedDate() {
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     return `${this.getDate()}-${months[this.getMonth()]}-${this.getFullYear()}`;
   }
 }
 ```
+
+### Species
+
+You might want to return {{jsxref("Array")}} objects in your derived array class `MyArray`. The species pattern lets you override default constructors.
+
+For example, when using methods such as {{jsxref("Array.prototype.map()")}} that returns the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object. The {{jsxref("Symbol.species")}} symbol lets you do this:
+
+```js
+class MyArray extends Array {
+  // Overwrite species to the parent Array constructor
+  static get [Symbol.species]() {
+    return Array;
+  }
+}
+
+const a = new MyArray(1, 2, 3);
+const mapped = a.map((x) => x * x);
+
+console.log(mapped instanceof MyArray); // false
+console.log(mapped instanceof Array);   // true
+```
+
+This behavior is implemented by many built-in copying methods. For caveats of this feature, see the [subclassing built-ins](#subclassing_built-ins) discussion.
+
+### Mix-ins
+
+Abstract subclasses or _mix-ins_ are templates for classes. A class can only have a single superclass, so multiple inheritance from tooling classes, for example, is not possible. The functionality must be provided by the superclass.
+
+A function with a superclass as input and a subclass extending that superclass as output can be used to implement mix-ins:
+
+```js
+const calculatorMixin = (Base) => class extends Base {
+  calc() {}
+};
+
+const randomizerMixin = (Base) => class extends Base {
+  randomize() {}
+};
+```
+
+A class that uses these mix-ins can then be written like this:
+
+```js
+class Foo {}
+class Bar extends calculatorMixin(randomizerMixin(Foo)) {}
+```
+
+### Avoiding inheritance
+
+Inheritance is a very strong coupling relationship in object-oriented programming. It means all behaviors of the base class are inherited by the subclass by default, which may not always be what you want. For example, consider the implementation of a `ReadOnlyMap`:
+
+```js
+class ReadOnlyMap extends Map {
+  set() {
+    throw new TypeError("A read-only map must be set at construction time.");
+  }
+}
+```
+
+It turns out that `ReadOnlyMap` is not constructible, because the [`Map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/Map) constructor calls the instance's `set()` method.
+
+```js
+const m = new ReadOnlyMap([["a", 1]]); // TypeError: A read-only map must be set at construction time.
+```
+
+We may get around this by using a private flag to indicate whether the instance is being constructed. However, a more significant problem with this design is that it breaks [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle), which states that a subclass should be substitutable for its superclass. If a function expects a `Map` object, it should be able to use a `ReadOnlyMap` object as well, which will break here.
+
+Inheritance often leads to [the circle-ellipse problem](https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem), because neither type perfectly entails the behavior of the other, although they share a lot of common traits. In general, unless there's a very good reason to use inheritance, it's better to use composition instead. Composition means that a class has a reference to an object of another class, and only uses that object as an implementation detail.
+
+```js
+class ReadOnlyMap {
+  #data;
+  constructor(values) {
+    this.#data = new Map(values);
+  }
+  get(key) {
+    return this.#data.get(key);
+  }
+  has(key) {
+    return this.#data.has(key);
+  }
+  get size() {
+    return this.#data.size;
+  }
+  *keys() {
+    yield* this.#data.keys();
+  }
+  *values() {
+    yield* this.#data.values();
+  }
+  *entries() {
+    yield* this.#data.entries();
+  }
+  *[Symbol.iterator]() {
+    yield* this.#data[Symbol.iterator]();
+  }
+}
+```
+
+In this case, the `ReadOnlyMap` class is not a subclass of `Map`, but it still implements most of the same methods. This means more code duplication, but it also means that the `ReadOnlyMap` class is not strongly coupled to the `Map` class, and does not easily break if the `Map` class is changed, avoiding the [semantic issues of built-in subclassing](#subclassing_built-ins). For example, if the `Map` class adds an [`emplace()`](https://github.com/tc39/proposal-upsert) method that does not call `set()`, it would cause the `ReadOnlyMap` class to no longer be read-only unless the latter is updated accordingly to override `emplace()` as well. Moreover, `ReadOnlyMap` objects do not have the `set` method at all, which is more accurate than throwing an error at runtime.
 
 ## Specifications
 
@@ -173,6 +310,6 @@ class myDate extends Date {
 ## See also
 
 - [Classes](/en-US/docs/Web/JavaScript/Reference/Classes)
-- [constructor](/en-US/docs/Web/JavaScript/Reference/Classes/constructor)
-- [super](/en-US/docs/Web/JavaScript/Reference/Operators/super)
+- [`constructor`](/en-US/docs/Web/JavaScript/Reference/Classes/constructor)
+- [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super)
 - [Anurag Majumdar - Super & Extends in JavaScript](https://medium.com/beginners-guide-to-mobile-web-development/super-and-extends-in-javascript-es6-understanding-the-tough-parts-6120372d3420)

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -203,7 +203,7 @@ class MyDate extends Date {
 
 You might want to return {{jsxref("Array")}} objects in your derived array class `MyArray`. The species pattern lets you override default constructors.
 
-For example, when using methods such as {{jsxref("Array.prototype.map()")}} that returns the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object. The {{jsxref("Symbol.species")}} symbol lets you do this:
+For example, when using methods such as {{jsxref("Array.prototype.map()")}} that return the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object. The {{jsxref("Symbol.species")}} symbol lets you do this:
 
 ```js
 class MyArray extends Array {

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -263,7 +263,7 @@ It turns out that `ReadOnlyMap` is not constructible, because the [`Map()`](/en-
 const m = new ReadOnlyMap([["a", 1]]); // TypeError: A read-only map must be set at construction time.
 ```
 
-We may get around this by using a private flag to indicate whether the instance is being constructed. However, a more significant problem with this design is that it breaks [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle), which states that a subclass should be substitutable for its superclass. If a function expects a `Map` object, it should be able to use a `ReadOnlyMap` object as well, which will break here.
+We may get around this by using a private flag to indicate whether the instance is being constructed. However, a more significant problem with this design is that it breaks the [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle), which states that a subclass should be substitutable for its superclass. If a function expects a `Map` object, it should be able to use a `ReadOnlyMap` object as well, which will break here.
 
 Inheritance often leads to [the circle-ellipse problem](https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem), because neither type perfectly entails the behavior of the other, although they share a lot of common traits. In general, unless there's a very good reason to use inheritance, it's better to use composition instead. Composition means that a class has a reference to an object of another class, and only uses that object as an implementation detail.
 

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -19,7 +19,9 @@ Classes are a template for creating objects. They encapsulate data with code to 
 
 For more examples and explanations, see the [Using classes](/en-US/docs/Web/JavaScript/Guide/Using_Classes) guide.
 
-## Defining classes
+## Description
+
+### Defining classes
 
 Classes are in fact "special [functions](/en-US/docs/Web/JavaScript/Reference/Functions)", and just as you can define [function expressions](/en-US/docs/Web/JavaScript/Reference/Operators/function) and [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function), a class can be defined in two ways: a [class expression](/en-US/docs/Web/JavaScript/Reference/Operators/class) or a [class declaration](/en-US/docs/Web/JavaScript/Reference/Statements/class).
 
@@ -51,7 +53,7 @@ const Rectangle = class Rectangle2 {
 
 Like function expressions, class expressions may be anonymous, or have a name that's different from the variable that it's assigned to. However, unlike function declarations, class declarations have the same [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz) restrictions as `let` or `const` and behave as if they are [not hoisted](/en-US/docs/Web/JavaScript/Guide/Using_Classes#class_declaration_hoisting).
 
-## Class body
+### Class body
 
 The body of a class is the part that is in curly brackets `{}`. This is where you define class members, such as methods or constructor.
 
@@ -80,23 +82,34 @@ Together, they add up to 16 possible combinations. To divide the reference more 
 
 In addition, there are two special class element syntaxes: [`constructor`](#constructor) and [static initialization blocks](#static_initialization_blocks), with their own references.
 
-### Constructor
+#### Constructor
 
-The {{jsxref("Classes/constructor", "constructor", "", "true")}} method is a special method for creating and initializing an object created with a `class`.
-There can only be one special method with the name "constructor" in a class.
-A {{jsxref("SyntaxError")}} will be thrown if the class contains more than one occurrence of a `constructor` method.
+The {{jsxref("Classes/constructor", "constructor")}} method is a special method for creating and initializing an object created with a class. There can only be one special method with the name "constructor" in a class — a {{jsxref("SyntaxError")}} is thrown if the class contains more than one occurrence of a `constructor` method.
 
-A constructor can use the `super` keyword to call the constructor of the super class.
+A constructor can use the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) keyword to call the constructor of the super class.
 
-### Static initialization blocks
+You can create instance properties inside the constructor:
 
-[Static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) allow flexible initialization of [static properties](#static_methods_and_properties) including the evaluation of statements during initialization, and granting access to private scope.
+```js
+class Rectangle {
+  constructor(height, width) {
+    this.height = height;
+    this.width = width;
+  }
+}
+```
 
-Multiple static blocks can be declared, and these can be interleaved with the declaration of static properties and methods (all static items are evaluated in declaration order).
+Alternatively, if your instance properties' values do not depend on the constructor's arguments, you can define them as [class fields](#public_field_declarations).
 
-### Prototype methods
+#### Static initialization blocks
 
-See also {{jsxref("Functions/Method_definitions", "method definitions", "", "true")}}.
+[Static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) allow flexible initialization of [static properties](#static_methods_and_fields), including the evaluation of statements during initialization, while granting access to the private scope.
+
+Multiple static blocks can be declared, and these can be interleaved with the declaration of static fields and methods (all static items are evaluated in declaration order).
+
+#### Methods
+
+Methods are defined on the prototype of each class instance and are shared by all instances. Methods can be plain functions, async functions, generator functions, or async generator functions. For more information, see [method definitions](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions).
 
 ```js
 class Rectangle {
@@ -112,40 +125,23 @@ class Rectangle {
   calcArea() {
     return this.height * this.width;
   }
+  *getSides() {
+    yield this.height;
+    yield this.width;
+    yield this.height;
+    yield this.width;
+  }
 }
 
 const square = new Rectangle(10, 10);
 
 console.log(square.area); // 100
+console.log([...square.getSides()]); // [10, 10, 10, 10]
 ```
 
-### Generator methods
+#### Static methods and fields
 
-See also [Iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators).
-
-```js
-class Polygon {
-  constructor(...sides) {
-    this.sides = sides;
-  }
-  // Method
-  *getSides() {
-    for (const side of this.sides) {
-      yield side;
-    }
-  }
-}
-
-const pentagon = new Polygon(1,2,3,4,5);
-
-console.log([...pentagon.getSides()]); // [1,2,3,4,5]
-```
-
-### Static methods and fields
-
-The {{jsxref("Classes/static", "static")}} keyword defines a static method or field for a class.
-Static properties (fields and methods) are defined on the class itself instead of each instance.
-Static methods are often used to create utility functions for an application, whereas static fields are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
+The {{jsxref("Classes/static", "static")}} keyword defines a static method or field for a class. Static properties (fields and methods) are defined on the class itself instead of each instance. Static methods are often used to create utility functions for an application, whereas static fields are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
 
 ```js
 class Point {
@@ -174,71 +170,9 @@ console.log(Point.displayName);      // "Point"
 console.log(Point.distance(p1, p2)); // 7.0710678118654755
 ```
 
-### Binding `this` with prototype and static methods
+#### Field declarations
 
-When a static or prototype method is called without a value for {{jsxref("Operators/this", "this")}}, such as by assigning the method to a variable and then calling it, the `this` value will be `undefined` inside the method.
-This behavior will be the same even if the {{jsxref("Strict_mode", "\"use strict\"")}} directive isn't present, because code within the `class` body's syntactic boundary is always executed in strict mode.
-
-```js
-class Animal {
-  speak() {
-    return this;
-  }
-  static eat() {
-    return this;
-  }
-}
-
-const obj = new Animal();
-obj.speak(); // the Animal object
-const speak = obj.speak;
-speak(); // undefined
-
-Animal.eat() // class Animal
-const eat = Animal.eat;
-eat(); // undefined
-```
-
-If we rewrite the above using traditional function-based syntax in non–strict mode, then `this` method calls are automatically bound to the initial `this` value, which by default is the {{Glossary("Global_object", "global object")}}.
-In strict mode, autobinding will not happen; the value of `this` remains as passed.
-
-```js
-function Animal() { }
-
-Animal.prototype.speak = function () {
-  return this;
-}
-
-Animal.eat = function () {
-  return this;
-}
-
-const obj = new Animal();
-const speak = obj.speak;
-speak(); // global object (in non–strict mode)
-
-const eat = Animal.eat;
-eat(); // global object (in non-strict mode)
-```
-
-### Instance properties
-
-Instance properties must be defined inside of class methods:
-
-```js
-class Rectangle {
-  constructor(height, width) {
-    this.height = height;
-    this.width = width;
-  }
-}
-```
-
-### Field declarations
-
-#### Public field declarations
-
-With the JavaScript field declaration syntax, the above example can be written as:
+With the class field declaration syntax, the [constructor](#constructor) example can be written as:
 
 ```js
 class Rectangle {
@@ -253,13 +187,11 @@ class Rectangle {
 
 Class fields are similar to object properties, not variables, so we don't use keywords such as `const` to declare them. In JavaScript, [private fields](#private_field_declarations) use a special identifier syntax, so modifier keywords like `public` and `private` should not be used either.
 
-By declaring fields up-front, class definitions become more self-documenting, and the fields are always present.
+As seen above, the fields can be declared with or without a default value. Fields without default values default to `undefined`. By declaring fields up-front, class definitions become more self-documenting, and the fields are always present, which help with optimizations.
 
-As seen above, the fields can be declared with or without a default value.
+See [public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) for more information.
 
-See {{jsxref("Classes/Public_class_fields", "public class fields", "", "true")}} for more information.
-
-#### Private field declarations
+#### Private class features
 
 Using private fields, the definition can be refined as below.
 
@@ -277,15 +209,13 @@ class Rectangle {
 It's an error to reference private fields from outside of the class; they can only be read or written within the class body.
 By defining things that are not visible outside of the class, you ensure that your classes' users can't depend on internals, which may change from version to version.
 
-> **Note:** Private fields can only be declared up-front in a field declaration.
+Private fields can only be declared up-front in a field declaration. They cannot be created later through assigning to them, the way that normal properties can.
 
-Private fields cannot be created later through assigning to them, the way that normal properties can.
+For more information, see [private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields).
 
-For more information, see {{jsxref("Classes/Private_class_fields", "private class features", "", "true")}}.
+### Inheritance
 
-## Sub classing with `extends`
-
-The {{jsxref("Classes/extends", "extends")}} keyword is used in _class declarations_ or _class expressions_ to create a class as a child of another class.
+The {{jsxref("Classes/extends", "extends")}} keyword is used in _class declarations_ or _class expressions_ to create a class as a child of another constructor (either a class or a function).
 
 ```js
 class Animal {
@@ -308,83 +238,11 @@ class Dog extends Animal {
   }
 }
 
-const d = new Dog('Mitzie');
+const d = new Dog("Mitzie");
 d.speak(); // Mitzie barks.
 ```
 
-If there is a constructor present in the subclass, it needs to first call super() before using "this".
-
-One may also extend traditional function-based "classes":
-
-```js
-function Animal(name) {
-  this.name = name;
-}
-
-Animal.prototype.speak = function () {
-  console.log(`${this.name} makes a noise.`);
-}
-
-class Dog extends Animal {
-  speak() {
-    console.log(`${this.name} barks.`);
-  }
-}
-
-const d = new Dog('Mitzie');
-d.speak(); // Mitzie barks.
-
-// For similar methods, the child's method takes precedence over parent's method
-```
-
-Note that classes cannot extend regular (non-constructible) objects.
-If you want to inherit from a regular object, you can instead use {{jsxref("Object.setPrototypeOf()")}}:
-
-```js
-const Animal = {
-  speak() {
-    console.log(`${this.name} makes a noise.`);
-  }
-};
-
-class Dog {
-  constructor(name) {
-    this.name = name;
-  }
-}
-
-// If you do not do this you will get a TypeError when you invoke speak
-Object.setPrototypeOf(Dog.prototype, Animal);
-
-const d = new Dog('Mitzie');
-d.speak(); // Mitzie makes a noise.
-```
-
-## Species
-
-You might want to return {{jsxref("Array")}} objects in your derived array class `MyArray`.
-The species pattern lets you override default constructors.
-
-For example, when using methods such as {{jsxref("Array.prototype.map()")}} that returns the default constructor, you want these methods to return a parent `Array` object, instead of the `MyArray` object.
-The {{jsxref("Symbol.species")}} symbol lets you do this:
-
-```js
-class MyArray extends Array {
-  // Overwrite species to the parent Array constructor
-  static get [Symbol.species]() { return Array; }
-}
-
-const a = new MyArray(1, 2, 3);
-const mapped = a.map((x) => x * x);
-
-console.log(mapped instanceof MyArray); // false
-console.log(mapped instanceof Array);   // true
-```
-
-## Super class calls with `super`
-
-The {{jsxref("Operators/super", "super")}} keyword is used to call corresponding methods of super class.
-This is one advantage over prototype-based inheritance.
+If there is a constructor present in the subclass, it needs to first call `super()` before using `this`. The {{jsxref("Operators/super", "super")}} keyword can also be used to call corresponding methods of super class.
 
 ```js
 class Cat {
@@ -404,43 +262,58 @@ class Lion extends Cat {
   }
 }
 
-const l = new Lion('Fuzzy');
+const l = new Lion("Fuzzy");
 l.speak();
 // Fuzzy makes a noise.
 // Fuzzy roars.
 ```
 
-## Mix-ins
+## Examples
 
-Abstract subclasses or _mix-ins_ are templates for classes.
-An ECMAScript class can only have a single superclass, so multiple inheritance from tooling classes, for example, is not possible.
-The functionality must be provided by the superclass.
+### Binding this with instance and static methods
 
-A function with a superclass as input and a subclass extending that superclass as output can be used to implement mix-ins in ECMAScript:
+When a static or instance method is called without a value for {{jsxref("Operators/this", "this")}}, such as by assigning the method to a variable and then calling it, the `this` value will be `undefined` inside the method. This behavior is the same even if the {{jsxref("Strict_mode", "\"use strict\"")}} directive isn't present, because code within the `class` body is always executed in strict mode.
 
 ```js
-const calculatorMixin = (Base) => class extends Base {
-  calc() { }
-};
+class Animal {
+  speak() {
+    return this;
+  }
+  static eat() {
+    return this;
+  }
+}
 
-const randomizerMixin = (Base) => class extends Base {
-  randomize() { }
-};
+const obj = new Animal();
+obj.speak(); // the Animal object
+const speak = obj.speak;
+speak(); // undefined
+
+Animal.eat() // class Animal
+const eat = Animal.eat;
+eat(); // undefined
 ```
 
-A class that uses these mix-ins can then be written like this:
+If we rewrite the above using traditional function-based syntax in non–strict mode, then `this` method calls are automatically bound to {{jsxref("globalThis")}}. In strict mode, the value of `this` remains as `undefined`.
 
 ```js
-class Foo { }
-class Bar extends calculatorMixin(randomizerMixin(Foo)) { }
+function Animal() {}
+
+Animal.prototype.speak = function () {
+  return this;
+}
+
+Animal.eat = function () {
+  return this;
+}
+
+const obj = new Animal();
+const speak = obj.speak;
+speak(); // global object (in non–strict mode)
+
+const eat = Animal.eat;
+eat(); // global object (in non-strict mode)
 ```
-
-## Re-running a class definition
-
-A class can't be redefined.
-Attempting to do so produces a `SyntaxError`.
-
-If you're experimenting with code in a web browser, such as the Firefox Web Console (**Tools** > **Web Developer** > **Web Console**) and you 'Run' a definition of a class with the same name twice, you'll get a `SyntaxError: redeclaration of let ClassName;`. (See further discussion of this issue in {{Bug(1428672)}}.) Doing something similar in Chrome Developer Tools gives you a message like `Uncaught SyntaxError: Identifier 'ClassName' has already been declared at <anonymous>:1:1`.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
@@ -26,7 +26,7 @@ The well-known symbol `@@species`.
 
 ## Description
 
-The `@@species` accessor property allows subclasses to override the default constructor for objects. This specifies a protocol about how instances should be copied. For example, when you use copying methods of arrays, such as {{jsxref("Array/map", "map()")}}. the `map()` method uses `instance.constructor[Symbol.species]` to get the constructor for constructing the new array.
+The `@@species` accessor property allows subclasses to override the default constructor for objects. This specifies a protocol about how instances should be copied. For example, when you use copying methods of arrays, such as {{jsxref("Array/map", "map()")}}. the `map()` method uses `instance.constructor[Symbol.species]` to get the constructor for constructing the new array. For more information, see [subclassing built-ins](/en-US/docs/Web/JavaScript/Reference/Classes/extends#subclassing_built-ins).
 
 All built-in implementations of `@@species` return the `this` value, which is the current instance's constructor. This allows copying methods to create instances of derived classes rather than the base class — for example, `map()` will return an array of the same type as the original array.
 

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -85,6 +85,8 @@ let Foo = class {};
 class Foo {} // Uncaught SyntaxError: Identifier 'Foo' has already been declared
 ```
 
+If you're experimenting in a REPL, such as the Firefox web console (**Tools** > **Web Developer** > **Web Console**), and you run two class declarations with the same name in two separate inputs, you may get the same re-declaration error. See further discussion of this issue in {{bug(1580891)}}. The Chrome console allows class re-declarations between different REPL inputs.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -59,6 +59,8 @@ apply to both {{jsxref("Statements/let", "let")}} and `const`. For this reason, 
 
 A constant cannot share its name with a function or a variable in the same scope.
 
+If you're experimenting in a REPL, such as the Firefox web console (**Tools** > **Web Developer** > **Web Console**), and you run two `const` declarations with the same name in two separate inputs, you may get a syntax error due to re-declaration. See further discussion of this issue in {{bug(1580891)}}. The Chrome console allows `const` re-declarations between different REPL inputs.
+
 Unlike `var`, `const` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
 
 ```js example-bad

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -121,7 +121,7 @@ switch(x) {
 }
 ```
 
-However, it's important to point out that a block nested inside a case clause will create a new block scoped lexical environment, which will not produce the redeclaration errors shown above.
+A block nested inside a case clause will create a new block scoped lexical environment, avoiding the redeclaration errors shown above.
 
 ```js
 let x = 1;
@@ -137,6 +137,8 @@ switch(x) {
   }
 }
 ```
+
+If you're experimenting in a REPL, such as the Firefox web console (**Tools** > **Web Developer** > **Web Console**), and you run two `let` declarations with the same name in two separate inputs, you may get the same re-declaration error. See further discussion of this issue in {{bug(1580891)}}. The Chrome console allows `let` re-declarations between different REPL inputs.
 
 ### Temporal dead zone (TDZ)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Since we have a class guide already, it's a bit weird to put class-related materials all over the place. In this PR I'm making the `Reference/Classes` page more like an overview by moving feature-specific information to their subpages. It also adds some more information about built-in subclassing to the `extends` page because of the `species` example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
