### PR TITLE
Clarify that value in double quotes are also strings

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -132,9 +132,9 @@ Note that variables may hold values that have different [data types](/en-US/docs
       <th scope="row">{{Glossary("String")}}</th>
       <td>
         This is a sequence of text known as a string. To signify that the value
-        is a string, enclose it in single quote marks.
+        is a string, enclose it in single or double quote marks.
       </td>
-      <td><code>let myVariable = 'Bob';</code></td>
+      <td><code>let myVariable = 'Bob';</code> or <code>let myVariable = "Bob";</code></td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Number")}}</th>

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -134,7 +134,7 @@ Note that variables may hold values that have different [data types](/en-US/docs
         This is a sequence of text known as a string. To signify that the value
         is a string, enclose it in single or double quote marks.
       </td>
-      <td><code>let myVariable = 'Bob';</code> or <code>let myVariable = "Bob";</code></td>
+      <td><code>let myVariable = 'Bob';</code> or <br/><code>let myVariable = "Bob";</code></td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Number")}}</th>


### PR DESCRIPTION
### Motivation

In the text prior, we're told that we can declare a variable like so:

```javascript
let myVariable = "Bob";
```

Based on the table, it isn't clear that `myVariable` is of type String, as the explanation only says that values in single quotes are strings.