### PR TITLE
Fix example

### DIFF
--- a/files/en-us/web/api/barcode_detection_api/index.md
+++ b/files/en-us/web/api/barcode_detection_api/index.md
@@ -277,7 +277,7 @@ This example uses the `detect()` method to detect the barcodes within the given 
 barcodeDetector
   .detect(imageEl)
   .then((barcodes) => {
-    barcodes.forEach((barcode) => console.log(barcode.rawData));
+    barcodes.forEach((barcode) => console.log(barcode.rawValue));
   })
   .catch((err) => {
     console.log(err);


### PR DESCRIPTION
Per the documentation (https://developer.mozilla.org/en-US/docs/Web/API/BarcodeDetector/detect) the `detect()` method returns an object with `rawValue`, not `rawData`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
