### PR TITLE
CSS `counters()` - remove note about type-or-unit

### DIFF
--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -29,10 +29,6 @@ counters(countername, '.', upper-roman)
 
 A [counter](/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters) has no visible effect by itself. The `counters()` function (and {{cssxref("counter", "counter()")}} function) is what makes it useful by returning developer defined content.
 
-> **Note:** The `counters()` function can be used with any CSS property, but support for properties other than {{CSSxRef("content")}} is experimental, and support for the type-or-unit parameter is sparse.
->
-> Check the [Browser compatibility table](#browser_compatibility) carefully before using this in production.
-
 ### Values
 
 - {{cssxref("&lt;custom-ident&gt;")}}


### PR DESCRIPTION
### Description 

Remove the note about experimental support for non-`content` properties and the `type-or-unit` parameter.

### Motivation

This note appears to be inaccurate. There is no `type-or-unit` parameter in the spec, and support for `counters()` in places other than `content` does not appear to be experimental. (There's even a statement earlier in the article that `counters()` "can be used, theoretically, anywhere a `<string>` value is supported"). There is no corresponding note in the browser compatibility table.

### Additional details

[`counters()` spec](https://w3c.github.io/csswg-drafts/css-lists/#counter-functions).

### Related issues and pull requests

See also #12562, which fixed this same error in the corresponding article on [`counter()`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter).