### PR TITLE
FF109 Relnote: CSS system-color support Mark, MarkText, ButtonBorder

### DIFF
--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -24,6 +24,8 @@ This article provides information about the changes in Firefox 109 that will aff
 
 ### CSS
 
+- The [`<system-color>`](/en-US/docs/Web/CSS/system-color) CSS data type now supports the values [`Mark`](/en-US/docs/Web/CSS/system-color#mark), [`MarkText`](/en-US/docs/Web/CSS/system-color#marktext), and [`ButtonBorder`](/en-US/docs/Web/CSS/system-color#buttonborder) ({{bug(1638052)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
FF109 adds support for new [`<system-color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color#mark) values `Mark`, `MarkText`, `ButtonBorder` in https://bugzilla.mozilla.org/show_bug.cgi?id=1638052.
This is the release note.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/23334