### PR TITLE
Document COEP:credentialless

### DIFF
--- a/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
+++ b/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
@@ -109,11 +109,11 @@ Your site needs to be in a [secure context](/en-US/docs/Web/Security/Secure_Cont
 Two headers need to be set to cross-origin isolate your site:
 
 - [`Cross-Origin-Opener-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) with `same-origin` as value (protects your origin from attackers)
-- [`Cross-Origin-Embedder-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) with `require-corp` as value (protects victims from your origin)
+- [`Cross-Origin-Embedder-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) with `require-corp` or `credentialless` as value (protects victims from your origin)
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 ```
 
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:

--- a/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
+++ b/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
@@ -113,7 +113,7 @@ Two headers need to be set to cross-origin isolate your site:
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -103,9 +103,9 @@ Starting with Firefox 79, high resolution timers can be used if you cross-origin
 isolate your document using the {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
 {{HTTPHeader("Cross-Origin-Embedder-Policy")}} headers:
 
-```plain
+```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
 These headers ensure a top-level document does not share a browsing context group with

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -105,7 +105,7 @@ isolate your document using the {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
 
 ```plain
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 ```
 
 These headers ensure a top-level document does not share a browsing context group with

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -127,12 +127,12 @@ memory is gated behind two HTTP headers:
 
 - {{HTTPHeader("Cross-Origin-Opener-Policy")}} with `same-origin` as value
   (protects your origin from attackers)
-- {{HTTPHeader("Cross-Origin-Embedder-Policy")}} with `require-corp` as
-  value (protects victims from your origin)
+- {{HTTPHeader("Cross-Origin-Embedder-Policy")}} with `require-corp` or
+  `credentialless` as value (protects victims from your origin)
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 ```
 
 To check if cross origin isolation has been successful, you can test against the

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -132,7 +132,7 @@ memory is gated behind two HTTP headers:
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
 To check if cross origin isolation has been successful, you can test against the

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -79,7 +79,7 @@ If you enable COEP using `require-corp` and have a cross origin resource that ne
 <img src="https://thirdparty.com/img.png" crossorigin />
 ```
 
-`COEP:credentialless` can also be used as an alternative.
+A COEP value of `credentialless` can be used as an alternative.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -12,7 +12,8 @@ browser-compat: http.headers.Cross-Origin-Embedder-Policy
 
 {{HTTPSidebar}}
 
-The HTTP **`Cross-Origin-Embedder-Policy`** (COEP) response header prevents a document from loading any cross-origin resources that don't explicitly grant the document permission (using [CORP](</en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)>) or [CORS](/en-US/docs/Web/HTTP/CORS)).
+The HTTP **`Cross-Origin-Embedder-Policy`** (COEP) response header configures
+embedding cross-origin resources into the document.
 
 <table class="properties">
   <tbody>
@@ -30,7 +31,7 @@ The HTTP **`Cross-Origin-Embedder-Policy`** (COEP) response header prevents a do
 ## Syntax
 
 ```http
-Cross-Origin-Embedder-Policy: unsafe-none | require-corp
+Cross-Origin-Embedder-Policy: unsafe-none | require-corp | credentialless
 ```
 
 ### Directives
@@ -40,6 +41,8 @@ Cross-Origin-Embedder-Policy: unsafe-none | require-corp
 - `require-corp`
   - : A document can only load resources from the same origin, or resources explicitly marked as loadable from another origin.
     If a cross origin resource supports CORS, the [`crossorigin`](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute or the {{HTTPHeader("Cross-Origin-Resource-Policy")}} header must be used to load it without being blocked by COEP.
+- `credentialless`
+  - : [no-cors](/en-US/docs/Web/API/Request/mode) cross-origin requests are sent without credentials. In particular, it means Cookies are omitted from the request, and ignored from the response. The responses are allowed **without** an explicit permission via the {{HTTPHeader("Cross-Origin-Resource-Policy")}} header. [Navigate](/en-US/docs/Web/API/Request/mode) responses behave similarly as the `require-corp` mode: They require {{HTTPHeader("Cross-Origin-Resource-Policy")}} response header.
 
 ## Examples
 
@@ -48,7 +51,7 @@ Cross-Origin-Embedder-Policy: unsafe-none | require-corp
 You can only access certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers, if your document has a COEP header with the value `require-corp` value set.
 
 ```http
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 Cross-Origin-Opener-Policy: same-origin
 ```
 
@@ -68,13 +71,15 @@ if (crossOriginIsolated) {
 }
 ```
 
-### Avoiding COEP blockage with CORS
+### Avoiding COEP:require-corp blockage with CORS
 
 If you enable COEP using `require-corp` and have a cross origin resource that needs to be loaded, it needs to support [CORS](/en-US/docs/Web/HTTP/CORS) and you need to explicitly mark the resource as loadable from another origin to avoid blockage from COEP. For example, you can use the [`crossorigin`](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute for this image from a third-party site:
 
 ```html
 <img src="https://thirdparty.com/img.png" crossorigin />
 ```
+
+`COEP:credentialless` can also be used as an alternative.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -51,7 +51,7 @@ Cross-Origin-Embedder-Policy: unsafe-none | require-corp | credentialless
 You can only access certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers, if your document has a COEP header with a value of `require-corp` or `credentialless` set.
 
 ```http
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -48,7 +48,7 @@ Cross-Origin-Embedder-Policy: unsafe-none | require-corp | credentialless
 
 ### Certain features depend on cross-origin isolation
 
-You can only access certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers, if your document has a COEP header with the value `require-corp` value set.
+You can only access certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers, if your document has a COEP header with a value of `require-corp` or `credentialless` set.
 
 ```http
 Cross-Origin-Embedder-Policy: require-corp | credentialless

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -71,7 +71,7 @@ if (crossOriginIsolated) {
 }
 ```
 
-### Avoiding COEP:require-corp blockage with CORS
+### Avoiding COEP blockage with CORS
 
 If you enable COEP using `require-corp` and have a cross origin resource that needs to be loaded, it needs to support [CORS](/en-US/docs/Web/HTTP/CORS) and you need to explicitly mark the resource as loadable from another origin to avoid blockage from COEP. For example, you can use the [`crossorigin`](/en-US/docs/Web/HTML/Attributes/crossorigin) attribute for this image from a third-party site:
 
@@ -79,7 +79,7 @@ If you enable COEP using `require-corp` and have a cross origin resource that ne
 <img src="https://thirdparty.com/img.png" crossorigin />
 ```
 
-A COEP value of `credentialless` can be used as an alternative.
+If CORS is not supported for some images, a COEP value of `credentialless` can be used as an alternative to load the image without any explicit opt-in from the cross-origin server, at the cost of requesting it without cookies.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -56,7 +56,7 @@ Certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Perf
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 ```
 
 See also the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header which you'll need to set as well.

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -56,10 +56,10 @@ Certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Perf
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
-See also the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header which you'll need to set as well.
+See also the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} header which you'll need to set to `require-corp` or `credentialless` as well.
 
 To check if cross-origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -47,7 +47,7 @@ For top-level documents, two headers need to be set to cross-origin isolate your
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp | credentialless
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -43,11 +43,11 @@ As a baseline requirement, your document needs to be in a [secure context](/en-U
 For top-level documents, two headers need to be set to cross-origin isolate your site:
 
 - [`Cross-Origin-Opener-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) with `same-origin` as value (protects your origin from attackers)
-- [`Cross-Origin-Embedder-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) with `require-corp` as value (protects victims from your origin)
+- [`Cross-Origin-Embedder-Policy`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) with `require-corp` or `credentialless` as value (protects victims from your origin)
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-corp | credentialless
 ```
 
 To check if cross origin isolation has been successful, you can test against the [`crossOriginIsolated`](/en-US/docs/Web/API/crossOriginIsolated) property available to window and worker contexts:


### PR DESCRIPTION
### Description

This PR adds documentation for `Cross-Origin-Embedder-Policy`: `credentialless` value.

### Motivation

This is part of the HTML specification + FETCH.
It is implemented by:
- Chrome: 96.
- Firefox: Nightly + origin trial.

### Additional details

In a follow-up, I am also going to fix the [Iframe.credentialless](https://github.com/mdn/content/pull/23097) documentation. I need refer to COEP:credentialless.

### Related issues and pull requests

Chrome status:
- https://chromestatus.com/feature/4918234241302528

Firefox status:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1731778

Past PR about COEP:
- https://github.com/mdn/content/pull/8871
- https://github.com/mdn/content/pull/23275