### PR TITLE
fix navigation links order for css

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -12,7 +12,7 @@ tags:
   - specificity
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks")}}
 
 The aim of this lesson is to develop your understanding of some of the most fundamental concepts of CSS — the cascade, specificity, and inheritance — which control how CSS is applied to HTML and how conflicts between style declarations are resolved.
 
@@ -287,7 +287,7 @@ If you didn't fully understand the cascade, specificity, and inheritance, then d
 
 Refer back here if you start to come across strange issues with styles not applying as expected. It could be a specificity issue.
 
-{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks")}}
 
 ## In this module
 


### PR DESCRIPTION
### Description

> When clicking the next button in the bottom page of https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance, it navigates to [The box model](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model) instead of [CSS selectors](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors).

Fixed the links by replacing `"Learn/CSS/Building_blocks/The_box_model"` to `"Learn/CSS/Building_blocks/Selectors"`, so they are in order according to the content outline attached below:

### Motivation

Help readers to easily navigate and clear up the confusion

### Additional details

![screenshot showing the error in navigation links orders in MDN docs site](https://user-images.githubusercontent.com/96492656/210526548-0e989465-e402-4c3c-a70d-083521e21362.png)


### Related issues and pull requests

Fixes #23332 
