### PR TITLE
correct PaymentRequestEvent methods that were wrongly called properties

### DIFF
--- a/files/en-us/web/api/paymentrequestevent/changepaymentmethod/index.md
+++ b/files/en-us/web/api/paymentrequestevent/changepaymentmethod/index.md
@@ -16,8 +16,7 @@ browser-compat: api.PaymentRequestEvent.changePaymentMethod
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}
 
-The **`changePaymentMethod()`** method of the
-{{domxref("PaymentRequestEvent")}} interface is used by the payment handler to get an updated total, given such payment method details as the billing address.
+The **`changePaymentMethod()`** method of the {{domxref("PaymentRequestEvent")}} interface is used by the payment handler to get an updated total, given such payment method details as the billing address.
 
 When this method is invoked, a {{domxref("PaymentMethodChangeEvent")}} is fired.
 

--- a/files/en-us/web/api/paymentrequestevent/changepaymentmethod/index.md
+++ b/files/en-us/web/api/paymentrequestevent/changepaymentmethod/index.md
@@ -16,7 +16,7 @@ browser-compat: api.PaymentRequestEvent.changePaymentMethod
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}
 
-The **`changePaymentMethod`** property of the
+The **`changePaymentMethod()`** method of the
 {{domxref("PaymentRequestEvent")}} interface is used by the payment handler to get an updated total, given such payment method details as the billing address.
 
 When this method is invoked, a {{domxref("PaymentMethodChangeEvent")}} is fired.

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.md
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.md
@@ -16,10 +16,7 @@ browser-compat: api.PaymentRequestEvent.openWindow
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}
 
-The **`openWindow`** property of the
-{{domxref("PaymentRequestEvent")}} interface opens the specified URL in a new window, if
-and only if the given URL is on the same origin as the calling page. It returns a
-{{jsxref("Promise")}} that resolves with a reference to a {{domxref("WindowClient")}}.
+The **`openWindow()`** method of the {{domxref("PaymentRequestEvent")}} interface opens the specified URL in a new window, only if the given URL is on the same origin as the calling page. It returns a {{jsxref("Promise")}} that resolves with a reference to a {{domxref("WindowClient")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.md
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.md
@@ -16,10 +16,7 @@ browser-compat: api.PaymentRequestEvent.respondWith
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}
 
-The **`respondWith`** property of the
-{{domxref("PaymentRequestEvent")}} interface prevents the default event handling and
-allows you to provide a {{jsxref("Promise")}} for a {{domxref("PaymentResponse")}}
-object yourself.
+The **`respondWith()`** method of the {{domxref("PaymentRequestEvent")}} interface prevents the default event handling and allows you to provide a {{jsxref("Promise")}} for a {{domxref("PaymentResponse")}} object yourself.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Another very quick fix — I noticed that I had somehow managed to refer to the methods of the `PaymentRequestEvent` class as "properties" in their ref pages. D'oh! 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
