### PR TITLE
docs(API): cleanup element scrollend example

### DIFF
--- a/files/en-us/web/api/element/scrollend_event/index.md
+++ b/files/en-us/web/api/element/scrollend_event/index.md
@@ -37,13 +37,39 @@ A generic {{domxref("Event")}}.
 
 The following example shows how to use the `scrollend` event to detect when the user has stopped scrolling:
 
+```css hidden
+#scroll-box {
+  height: 100px;
+  width: 100px;
+  float: left;
+  overflow: scroll;
+  outline: 4px dotted;
+  margin: 4px;
+}
+
+#scroll-box-title {
+  position: fixed;
+  top: 5px;
+  left: 5px;
+  transform: translateX(0);
+}
+
+#large-element {
+  height: 200px;
+  width: 200px;
+}
+
+#output {
+  text-align: center;
+}
+```
+
 ```html
-<div
-  id="scroll-box"
-  style="overflow: scroll; height: 100px; width: 100px; float: left;">
-  <p style="height: 200px; width: 200px;">Scroll me!</p>
+<div id="scroll-box">
+  <p id="scroll-box-title">Scroll me!</p>
+  <p id="large-element"></p>
 </div>
-<p style="text-align: center;" id="output">Waiting on scroll events...</p>
+<p id="output">Waiting on scroll events...</p>
 ```
 
 ```js


### PR DESCRIPTION
### Description

 - Move the scrollend example inline css into a separate hidden css section
 - Add a border box to the element to clarify where the borders of the scrollable element is.

### Motivation

It isn't immediately clear where the scrollable element boundaries are. When I tested the element scrollend example I didn't know where the element was, so I initially attempted scrolls outside the scrollable element until I read the example implementation (something I probably should have done first 😃).

### Related issues and pull requests

Related to: #22814
