### PR TITLE
xyz values issue23338

### DIFF
--- a/files/en-us/web/css/transform-function/rotate3d/index.md
+++ b/files/en-us/web/css/transform-function/rotate3d/index.md
@@ -42,13 +42,13 @@ rotate3d(x, y, z, a)
 
 - `x`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the x-coordinate of the vector denoting the axis of rotation which
-    could be between 0 and 1.
+    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
 - `y`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the y-coordinate of the vector denoting the axis of rotation which
-    could be between 0 and 1.
+    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
 - `z`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the z-coordinate of the vector denoting the axis of rotation which
-    could be between 0 and 1.
+    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
 - `a`
   - : Is an {{ cssxref("&lt;angle&gt;") }} representing the angle of the rotation. A positive angle denotes a clockwise
     rotation, a negative angle a counter-clockwise one.

--- a/files/en-us/web/css/transform-function/rotate3d/index.md
+++ b/files/en-us/web/css/transform-function/rotate3d/index.md
@@ -42,13 +42,13 @@ rotate3d(x, y, z, a)
 
 - `x`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the x-coordinate of the vector denoting the axis of rotation which
-    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
+    can be a positive or negative number.
 - `y`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the y-coordinate of the vector denoting the axis of rotation which
-    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
+    can be a positive or negative number.
 - `z`
   - : Is a {{cssxref("&lt;number&gt;")}} describing the z-coordinate of the vector denoting the axis of rotation which
-    could be between &nbsp;-1 and 1. Using a negative value will rotate the element in a counter-clockwise direction.
+    can be a positive or negative number.
 - `a`
   - : Is an {{ cssxref("&lt;angle&gt;") }} representing the angle of the rotation. A positive angle denotes a clockwise
     rotation, a negative angle a counter-clockwise one.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed the text under the values section.

### Motivation

The text specified that numbers for the x, y, and z axis can be between 0 and 1. That would be incorrect even when looking at the examples provided in the article. The examples include negative numbers and numbers bigger than 1. X,y and z can be any number, negative or positive. 



### Related issues and pull requests
#23338 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
