### PR TITLE
Replaces use of parallel with concurrent

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -197,7 +197,7 @@ async function getPrice() {
 }
 ```
 
-However, note that the execution of `promptForChoice` and `fetchPrices` don't depend on the result of each other. While the user is choosing their dish, it's fine for the prices to be fetched in the background, but in the code above, the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator causes the async function to pause until the choice is made, and then again until the prices are fetched. We can use `Promise.all` to run them in parallel, so that the user doesn't have to wait for the prices to be fetched before the result is given:
+However, note that the execution of `promptForChoice` and `fetchPrices` don't depend on the result of each other. While the user is choosing their dish, it's fine for the prices to be fetched in the background, but in the code above, the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator causes the async function to pause until the choice is made, and then again until the prices are fetched. We can use `Promise.all` to run them concurrently, so that the user doesn't have to wait for the prices to be fetched before the result is given:
 
 ```js example-good
 async function getPrice() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As later described in this page, `Promise.all()` achieves concurrency rather than parallelism due to the single-threaded nature of JavaScript. While the perceived effect is parallelism, it feels more correct to swap `parallel` for `concurrent` in this case.

### Motivation

To ensure that it is clear that JavaScript cannot achieve parallelism (single-threaded) but rather concurrency. The two terms are often use interchangeably but the latter is the only correct description.

### Additional details

N/A

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
