### PR TITLE
Use accurate language for BigInt.asIntN()|BigInt.asUintN()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.BigInt.asIntN
 
 {{JSRef}}
 
-The **`BigInt.asIntN`** static method returns the given number of least significant bits of a `BigInt` value as a signed integer.
+The **`BigInt.asIntN()`** static method truncates a `BigInt` value to the given number of least significant bits and returns that value as a signed integer.
 
 {{EmbedInteractiveExample("pages/js/bigint-asintn.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.BigInt.asIntN
 
 {{JSRef}}
 
-The **`BigInt.asIntN`** static method clamps a `BigInt` value to the given number of bits, and returns that value as a signed integer.
+The **`BigInt.asIntN`** static method returns the given number of least significant bits of a `BigInt` value as a signed integer.
 
 {{EmbedInteractiveExample("pages/js/bigint-asintn.html", "taller")}}
 
@@ -28,7 +28,7 @@ BigInt.asIntN(bits, bigint)
 - `bits`
   - : The amount of bits available for the returned BigInt. Should be an integer between 0 and 2<sup>53</sup> - 1, inclusive.
 - `bigint`
-  - : The BigInt value to clamp to fit into the supplied bits.
+  - : The BigInt value to truncate to fit into the supplied bits.
 
 ### Return value
 
@@ -41,11 +41,11 @@ The value of `bigint` modulo 2^`bits`, as a signed integer.
 
 ## Description
 
-The `BigInt.asIntN` method clamps a `BigInt` value to the given number of bits, and interprets the result as a signed integer. For example, for `BigInt.asIntN(3, 25n)`, the value `25n` is clamped to `1n`:
+The `BigInt.asIntN` method truncates a `BigInt` value to the given number of bits, and interprets the result as a signed integer. For example, for `BigInt.asIntN(3, 25n)`, the value `25n` is truncated to `1n`:
 
 ```plain
 25n = 00011001 (base 2)
-          ^=== Clamp to three remaining bits
+          ^=== Use only the three remaining bits
 ===>       001 (base 2) = 1n
 ```
 
@@ -53,7 +53,7 @@ If the leading bit of the remaining number is `1`, the result is negative. For e
 
 ```plain
 25n = 00011001 (base 2)
-         ^==== Clamp to four remaining bits
+         ^==== Use only the four remaining bits
 ===>      1001 (base 2) = -7n
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.BigInt.asUintN
 
 {{JSRef}}
 
-The **`BigInt.asUintN`** static method clamps a `BigInt` value to the given number of bits, and returns that value as an unsigned integer.
+The **`BigInt.asUintN`** static method returns the given number of least significant bits of a `BigInt` value as an unsigned integer.
 
 {{EmbedInteractiveExample("pages/js/bigint-asuintn.html", "taller")}}
 
@@ -28,7 +28,7 @@ BigInt.asUintN(bits, bigint)
 - `bits`
   - : The amount of bits available for the returned BigInt. Should be an integer between 0 and 2<sup>53</sup> - 1, inclusive.
 - `bigint`
-  - : The BigInt value to clamp to fit into the supplied bits.
+  - : The BigInt value to truncate to fit into the supplied bits.
 
 ### Return value
 
@@ -41,11 +41,11 @@ The value of `bigint` modulo 2^`bits`, as an unsigned integer.
 
 ## Description
 
-The `BigInt.asUintN` method clamps a `BigInt` value to the given number of bits, and interprets the result as an unsigned integer. Unsigned integers have no sign bits and are always non-negative. For example, for `BigInt.asUintN(4, 25n)`, the value `25n` is clamped to `9n`:
+The `BigInt.asUintN` method truncates a `BigInt` value to the given number of bits, and interprets the result as an unsigned integer. Unsigned integers have no sign bits and are always non-negative. For example, for `BigInt.asUintN(4, 25n)`, the value `25n` is truncated to `9n`:
 
 ```plain
 25n = 00011001 (base 2)
-         ^==== Clamp to four remaining bits
+         ^==== Use only the four remaining bits
 ===>      1001 (base 2) = 9n
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.BigInt.asUintN
 
 {{JSRef}}
 
-The **`BigInt.asUintN`** static method returns the given number of least significant bits of a `BigInt` value as an unsigned integer.
+The **`BigInt.asUintN()`** static method truncates a `BigInt` value to the given number of least significant bits and returns that value as an unsigned integer.
 
 {{EmbedInteractiveExample("pages/js/bigint-asuintn.html", "taller")}}
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Do not use “clamp” to describe the functions mentioned above, since the word is not accurate in this context. Use “truncate” or explicitly spelling out the operation instead.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

5f174593bf1b8b97 already updated this language to use “clamp” instead of “wrap”. However, this was a misleading change, since “clamp” is generally _always_ used to indicate an entirely different operation (namely, `Min(Max(·, a), b)` for some `a` and `b`) rather than what these functions actually do (namely, `· mod 2^n`).

Some examples of how “clamp” is used to refer to this other operation include:

- https://developer.mozilla.org/en-US/docs/Web/CSS/clamp
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
- https://en.wikipedia.org/wiki/Clamping_(graphics) (and, of course, the actual “clamp” tool that gave rise to this metaphor in the first place.)

I agree that “wrap” was maybe not the most intuitive choice of word here. Consequently, this commit uses “truncate”, a more accurate and hopefully also a more intuitive word, and rewords the introductory sentences and examples to be more precise instead of using a choice of word that JS developers may not be familiar with anyway.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Relevant previous PR (that is essentially being undone here): https://github.com/mdn/content/pull/3355

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to #3355
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
