### PR TITLE
Add note about unspecified pattern resulting in input constraint violation

### DIFF
--- a/files/en-us/web/html/attributes/pattern/index.md
+++ b/files/en-us/web/html/attributes/pattern/index.md
@@ -37,6 +37,8 @@ When including a `pattern`, provide a description of the pattern in visible text
 If the input's value is not the empty string and the value does not match the entire regular expression, there is a constraint violation reported by the {{domxref('ValidityState')}} object's {{domxref('ValidityState.patternMismatch','patternMismatch')}} property being `true`.
 The pattern's regular expression, when matched against the value, must have its start anchored to the start of the string and its end anchored to the end of the string, which is slightly different from JavaScript regular expressions: in the case of pattern attribute, we are matching against the entire value, not just any subset, as if a `^(?:` were implied at the start of the pattern and `)$` at the end.
 
+> **Note:** If the `pattern` attribute is specified with no value, its value is implicitly the empty string. Thus, **any non-empty** input `value` will result in constraint violation.
+
 ## Examples
 
 ### Matching a phone number


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
When the `pattern` attribute is specified with no value, it is treated as value = "". This throws devs off if not careful.
This PR adds a note about the behavior, as suggested in the issue #21146
<!-- ✍️ Summarize your changes in one or two sentences -->
![image](https://user-images.githubusercontent.com/41845017/210765649-345bf014-4f3b-47c4-a704-61490d90467a.png)

### Motivation
Add a note about a potential problem when using the `pattern` attribute.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Related links
- https://stackoverflow.com/a/23752239/13725861
- manual testing:
![image](https://user-images.githubusercontent.com/41845017/210764479-4950e7e6-4d1d-4611-b5f6-4aee57b1acfc.png)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #21146
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
