### PR TITLE
Fix naming for consistency

### DIFF
--- a/files/en-us/web/css/_colon_nth-col/index.md
+++ b/files/en-us/web/css/_colon_nth-col/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-col"
+title: ":nth-col()"
 slug: Web/CSS/:nth-col
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-col
@@ -18,12 +18,12 @@ The **`:nth-col()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/C
 
 ## Syntax
 
-The `nth-col` pseudo-class is specified with a single argument, which represents the pattern for matching elements.
+The `nth-col()` pseudo-class is specified with a single argument, which represents the pattern for matching elements. It uses `:nth-col(An+B)` syntax.
 
 See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.
 
 ```
-:nth-col
+:nth-col(An+B)
 ```
 
 ## Examples

--- a/files/en-us/web/css/_colon_nth-last-col/index.md
+++ b/files/en-us/web/css/_colon_nth-last-col/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-last-col"
+title: ":nth-last-col()"
 slug: Web/CSS/:nth-last-col
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-last-col
@@ -18,12 +18,12 @@ The **`:nth-last-col()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/
 
 ## Syntax
 
-The `nth-last-col` pseudo-class is specified with a single argument, which represents the pattern for matching elements.
+The `nth-last-col()` pseudo-class is specified with a single argument, which represents the pattern for matching elements. It uses `:nth-last-col(An+B)` syntax.
 
 See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.
 
 ```
-:nth-last-col
+:nth-last-col(An+B)
 ```
 
 ## Examples


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix naming to keep consistency with CSSWG, reference here https://w3c.github.io/csswg-drafts/selectors/#nth-col-pseudo

### Motivation

Keeping naming of pseudo class to be consistent with CSSWG draft

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #23365 
