### PR TITLE
Use correct variable names in Promise.all example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -205,7 +205,7 @@ async function getPrice() {
     promptForDishChoice(),
     fetchPrices(),
   ]);
-  return pricesValue[choiceValue];
+  return prices[choice];
 }
 ```
 


### PR DESCRIPTION
### Description
The [Using Promise.all() with async functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all#using_promise.all_with_async_functions) section of the Promise.all() reference docs uses the variable names `pricesValue` & `choiceValue` in the return statement of one of the code snippet examples. Those variable are not referenced anywhere. It appears they are meant to be `prices` and `choice` respectively; those are variables assigned when destructuring the Array returned by `Promise.all()` above and this follows the pattern of other related snippets on the page.

The incorrectness can be demonstrated with a slight change to mock the call to `fetch` in the example.

```js
function promptForDishChoice() {
  return new Promise((resolve, reject) => {
    const dialog = document.createElement("dialog");
    dialog.innerHTML = `
<form method="dialog">
  <p>What would you like to eat?</p>
  <select>
    <option value="pizza">Pizza</option>
    <option value="pasta">Pasta</option>
    <option value="salad">Salad</option>
  </select>
  <menu>
    <li><button value="cancel">Cancel</button></li>
    <li><button type="submit" value="ok">OK</button></li>
  </menu>
</form>
    `;
    dialog.addEventListener("close", () => {
      if (dialog.returnValue === "ok") {
        resolve(dialog.querySelector("select").value);
      } else {
        reject(new Error("User cancelled dialog"));
      }
    });
    document.body.appendChild(dialog);
    dialog.showModal();
  });
}

async function fetchPrices() {
  const response = await mockedFetch(); // this line is modified
  return await response.json();
}

function mockedFetch() {
  return new Promise((resolve) => {
    resolve({
      json: () => (
        new Promise((resolve) => {
          resolve({ pizza: 1, pasta: 2, salad: 3 })
        })
      )
    })
  })
}
```

Invoking `getPrice` as currently defined in the docs
```js
async function getPrice() {
  const [choice, prices] = await Promise.all([
    promptForDishChoice(),
    fetchPrices(),
  ]);
  return pricesValue[choiceValue];
}
```

Will result in `Uncaught (in promise) ReferenceError: pricesValue is not defined at getPrice`

Whereas if `getPrice` is changed with the proposed changes here, you can demonstrate the expected behavior.

### Motivation
The `Promise.all()` docs are great and this is a really useful example, but some mental overhead is needed for readers to parse that this is a mistake in the docs.

### Additional details
This is a small change so following the contribution guidelines for [Simple Changes](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#simple-changes)

### Related issues and pull requests
Did not see any.