### PR TITLE
FF109 Relnote SVGGraphicsElement

### DIFF
--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -32,6 +32,19 @@ This article provides information about the changes in Firefox 109 that will aff
 
 #### Removals
 
+### SVG
+
+#### Removals
+
+- `SVGGraphicsElement.getTransformToElement()` has been removed.
+  This follows its removal from the SVG2 specification in 2015, and other from major browsers.
+  ({{bug(1803790)}}).
+
+- The `SVGGraphicsElement.nearestViewportElement` and `SVGGraphicsElement.farthestViewportElement` attributes have been disabled by default in nightly and early beta builds (behind preference `svg.nearestAndFarthestViewportElement.enabled`).
+  [`SVGElement.viewportElement`](/en-US/docs/Web/API/SVGElement#svgelement.viewportelement) can be used as an alternative to `SVGGraphicsElement.nearestViewportElement`.
+  They have been removed from the SVG2 specification and are likely to be removed entirely from Firefox in a future release.
+  ({{bug(1133174)}}).
+
 ### HTTP
 
 #### Removals


### PR DESCRIPTION
FF109 Release note to record that `SVGGraphicsElement.getTransformToElement` was removed, and `SVGGraphicsElement.nearestViewportElement` and `SVGGraphicsElement.farthestViewportElement` were moved behind a preference that is disable by default in nightly.

Other docs work for this can be tracked in #22737