### PR TITLE
Remove mentioning of string parameters for the CSS color() function 

### DIFF
--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -30,11 +30,11 @@ color(display-p3 1 0.5 0 / .5);
 
 ### Values
 
-- Functional notation: `color( [ [<ident> | <dashed-ident>]? [ <number-percentage>+ | <string> ] [ / <alpha-value> ]? ] )`
+- Functional notation: `color( [ [<ident> | <dashed-ident>]? [ <number-percentage>+ ] [ / <alpha-value> ]? ] )`
 
-  - : `[<ident> | <dashed-ident>]` is an optional {{cssxref("ident")}} or {{cssxref("dashed-ident")}} denoting the colorspace. If this is an `<ident>` it denotes one of the predefined colorspaces (such as display-p3); if it is a \<dashed-ident> it denotes a custom colorspace, defined by a [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) rule.
+  - : `[<ident> | <dashed-ident>]` is an optional {{cssxref("ident")}} or {{cssxref("dashed-ident")}} denoting the colorspace. If this is an `<ident>` it denotes one of the predefined colorspaces (such as display-p3); if it is a `<dashed-ident>` it denotes a custom colorspace, defined by a [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) rule.
 
-    `[ <number-percentage>+ | <string> ]` is either one or more {{cssxref("number")}} or {{cssxref("percentage")}} values providing the parameter values that the colorspace takes, or a {{cssxref("string")}} giving the name of a color defined by the colorspace.
+    `[ <number-percentage>+ ]` is one or more {{cssxref("number")}} or {{cssxref("percentage")}} values providing the parameter values that the colorspace takes.
 
     `/ <alpha-value>` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Remove outdated content on string parameters for the CSS color() function.
- also making a slightly unrelated, minor cosmetic fix for a word ("dashed-ident") used on the same page to utilize inline code style

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix issue
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Nil
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #12209
Related to [w3c/csswg-drafts/issues/6095](https://github.com/w3c/csswg-drafts/issues/6095#:~:text=the%20color()%20property%20would%20be%20simplified%2C%20the%20whole%20part%20about%20string%20parameters%20would%20be%20removed) 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" --> 
<!-- 👉 Highlight related pull requests using "Relates to #123" --> 
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
