### PR TITLE
Fix setBaseAndExtent live example by removing additional whitespace

### DIFF
--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -90,7 +90,7 @@ selection into the output paragraph at the very bottom of the HTML.
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
 
-> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
+> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example)).
 
 The JavaScript looks like so:
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -90,7 +90,7 @@ selection into the output paragraph at the very bottom of the HTML.
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
 
-> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of `childNodes` expected. Find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
+> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
 
 The JavaScript looks like so:
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -90,7 +90,7 @@ selection into the output paragraph at the very bottom of the HTML.
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
 
-> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">`/`<p class="two">` and the `<span>` tag to prevent the insertion of a text node that may affect the number of `childNotes` expected. Find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
+> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of `childNodes` expected. Find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
 
 The JavaScript looks like so:
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -70,13 +70,9 @@ selection into the output paragraph at the very bottom of the HTML.
 ```html
 <h1>setBaseAndExtent example</h1>
 <div>
-  <p class="one">
-    <span>Fish</span><span>Dog</span><span>Cat</span><span>Bird</span>
-  </p>
+  <p class="one"><span>Fish</span><span>Dog</span><span>Cat</span><span>Bird</span></p>
   <p>MIDDLE</p>
-  <p class="two">
-    <span>Car</span><span>Bike</span><span>Boat</span><span>Plane</span>
-  </p>
+  <p class="two"><span>Car</span><span>Bike</span><span>Boat</span><span>Plane</span></p>
 </div>
 
 <div>
@@ -93,6 +89,8 @@ selection into the output paragraph at the very bottom of the HTML.
 
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
+
+> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">`/`<p class="two">` and the `<span>` tag to prevent the insertion of a text node that may affect the number of `childNotes` expected. Find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example).
 
 The JavaScript looks like so:
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -90,7 +90,7 @@ selection into the output paragraph at the very bottom of the HTML.
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
 
-> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example)).
+> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example)).
 
 The JavaScript looks like so:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The live example on [setBaseAndExtent](https://developer.mozilla.org/en-US/docs/Web/API/Selection/setBaseAndExtent#examples) is broken.
Let's
- fix the live example
- add a note about the whitespace issue that triggered the error

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Keep example accurate
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Test case:
- on the [MDNpage](https://developer.mozilla.org/en-US/docs/Web/API/Selection/setBaseAndExtent#examples), type in anchor offset = 1 and focus offset = 0, and press "capture selection"
  - output is "FishDogCatBird MIDDLE"
- on the [referenced original live example](https://chrisdavidmills.github.io/selection-api-examples/setBaseAndExtent.html), type in anchor offset = 1 and focus offset = 0, and press "capture selection"
  - output is "DogCatBird MIDDLE"

See screenshots below:
(MDN)
![image](https://user-images.githubusercontent.com/41845017/211119196-89cee4d5-6ac2-4c8e-aa7e-c26dd1dcea0f.png)
(Original example)
![image](https://user-images.githubusercontent.com/41845017/211119099-76ee6b91-6d3a-4a00-8b8a-92e0a409d4e1.png)

The reason why it is broken is due to the difference in the HTML formatting. the MDN live example formats the `<p class="one">` and `<p class="two">` tags and resulted in an extra text node added, hence disturbing the index of child notes.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
References
- [Node.firstChild](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild)
- [original example](https://github.com/chrisdavidmills/selection-api-examples/blob/master/setBaseAndExtent.html)

### Related issues and pull requests
Nil
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
