### PR TITLE
fix(ci): move to 7z in github action

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Unzip what was downloaded
         run: |
-          unzip build.zip -d build
+          7z x build.zip -obuild -bb1
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

When we have unicode in markdown heading, the live sample with those id may not work in PR preview.

This is an known issue in [translated-content before](https://github.com/mdn/translated-content/pull/3628). I thinks it is still worth to use 7zip in content repo for the `PR review companion` in translated-content should be a [copy](https://github.com/mdn/translated-content/blob/3e30587bdd2ce02cb8cb36a72284f471711dbe50/.github/workflows/pr-review-companion.yml#L6-L7) of the one in content repo.

### Related issues and pull requests

mdn/translated-content#3618
