### PR TITLE
Eliminate space counted as message length

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -331,12 +331,13 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
+    # https://github.com/mdn/webextensions-examples/issues/509
     # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
     # https://stackoverflow.com/a/56563264
     # https://docs.python.org/3/library/json.html#basic-usage
     # To get the most compact JSON representation, you should specify 
     # (',', ':') to eliminate whitespace.
-    encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
+    encoded_content = json.dumps(message_content, separators=(',', ':')).encode('utf-8')
     encoded_length = struct.pack('=I', len(encoded_content))
     return {'length': encoded_length, 'content': encoded_content}
 
@@ -377,6 +378,7 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
+   # https://github.com/mdn/webextensions-examples/issues/509
    # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
    # https://stackoverflow.com/a/56563264
    # https://docs.python.org/3/library/json.html#basic-usage

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -331,7 +331,7 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
-    encoded_content = json.dumps(message_content)
+    encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
     encoded_length = struct.pack('=I', len(encoded_content))
     return {'length': encoded_length, 'content': encoded_content}
 
@@ -372,7 +372,7 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
-    encoded_content = json.dumps(message_content).encode("utf-8")
+    encoded_content = json.dumps(message_content, separators=(',', ':')).encode("utf-8")
     encoded_length = struct.pack('=I', len(encoded_content))
     #  use struct.pack("10s", bytes), to pack a string of the length of 10 characters
     return {'length': encoded_length, 'content': struct.pack(str(len(encoded_content))+"s",encoded_content)}

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -334,7 +334,8 @@ def encode_message(message_content):
     # https://docs.python.org/3/library/json.html#basic-usage
     # To get the most compact JSON representation, you should specify 
     # (',', ':') to eliminate whitespace.
-    # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
+    # We want the most compact representation because the browser rejects
+    # messages that exceed 1 MB.
     encoded_content = json.dumps(message_content, separators=(',', ':'))
     encoded_length = struct.pack('=I', len(encoded_content))
     return {'length': encoded_length, 'content': encoded_content}

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -331,6 +331,11 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
+    # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
+    # https://stackoverflow.com/a/56563264
+    # https://docs.python.org/3/library/json.html#basic-usage
+    # To get the most compact JSON representation, you should specify 
+    # (',', ':') to eliminate whitespace.
     encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
     encoded_length = struct.pack('=I', len(encoded_content))
     return {'length': encoded_length, 'content': encoded_content}
@@ -372,6 +377,11 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
+   # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
+   # https://stackoverflow.com/a/56563264
+   # https://docs.python.org/3/library/json.html#basic-usage
+   # To get the most compact JSON representation, you should specify 
+   # (',', ':') to eliminate whitespace.
     encoded_content = json.dumps(message_content, separators=(',', ':')).encode("utf-8")
     encoded_length = struct.pack('=I', len(encoded_content))
     #  use struct.pack("10s", bytes), to pack a string of the length of 10 characters

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -331,13 +331,11 @@ def get_message():
 
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
-    # https://github.com/mdn/webextensions-examples/issues/509
-    # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
-    # https://stackoverflow.com/a/56563264
     # https://docs.python.org/3/library/json.html#basic-usage
     # To get the most compact JSON representation, you should specify 
     # (',', ':') to eliminate whitespace.
-    encoded_content = json.dumps(message_content, separators=(',', ':')).encode('utf-8')
+    # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
+    encoded_content = json.dumps(message_content, separators=(',', ':'))
     encoded_length = struct.pack('=I', len(encoded_content))
     return {'length': encoded_length, 'content': encoded_content}
 
@@ -356,7 +354,7 @@ while True:
 In Python 3, the received binary data must be decoded into a string. The content to be sent back to the addon must be encoded into binary data using a struct:
 
 ```python
-#!/usr/bin/env python
+#!/usr/bin/env -S python3 -u
 
 import sys
 import json
@@ -393,39 +391,7 @@ try:
     while True:
         receivedMessage = getMessage()
         if receivedMessage == "ping":
-            sendMessage(encodeMessage("pong3"))
-except AttributeError:
-    # Python 2.x version (if sys.stdin.buffer is not defined)
-    # Read a message from stdin and decode it.
-    def getMessage():
-        rawLength = sys.stdin.read(4)
-        if len(rawLength) == 0:
-            sys.exit(0)
-        messageLength = struct.unpack('@I', rawLength)[0]
-        message = sys.stdin.read(messageLength)
-        return json.loads(message)
-
-    # Encode a message for transmission,
-    # given its content.
-    def encodeMessage(messageContent):
-        # https://docs.python.org/3/library/json.html#basic-usage
-        # To get the most compact JSON representation, you should specify 
-        # (',', ':') to eliminate whitespace.
-        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
-        encodedContent = json.dumps(messageContent, separators=(',', ':'))
-        encodedLength = struct.pack('@I', len(encodedContent))
-        return {'length': encodedLength, 'content': encodedContent}
-
-    # Send an encoded message to stdout
-    def sendMessage(encodedMessage):
-        sys.stdout.write(encodedMessage['length'])
-        sys.stdout.write(encodedMessage['content'])
-        sys.stdout.flush()
-
-    while True:
-        receivedMessage = getMessage()
-        if receivedMessage == "ping":
-            sendMessage(encodeMessage("pong2"))
+            sendMessage(encodeMessage("pong"))
 ```
 
 ## Closing the native app

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -357,42 +357,44 @@ In Python 3, the received binary data must be decoded into a string. The content
 ```python
 #!/usr/bin/env -S python3 -u
 
+# Note that running python with the `-u` flag is required on Windows,
+# in order to ensure that stdin and stdout are opened in binary, rather
+# than text, mode.
+
 import sys
 import json
 import struct
 
-try:
-    # Python 3.x version
-    # Read a message from stdin and decode it.
-    def getMessage():
-        rawLength = sys.stdin.buffer.read(4)
-        if len(rawLength) == 0:
-            sys.exit(0)
-        messageLength = struct.unpack('@I', rawLength)[0]
-        message = sys.stdin.buffer.read(messageLength).decode('utf-8')
-        return json.loads(message)
+# Read a message from stdin and decode it.
+def getMessage():
+    rawLength = sys.stdin.buffer.read(4)
+    if len(rawLength) == 0:
+        sys.exit(0)
+    messageLength = struct.unpack('@I', rawLength)[0]
+    message = sys.stdin.buffer.read(messageLength).decode('utf-8')
+    return json.loads(message)
 
-    # Encode a message for transmission,
-    # given its content.
-    def encodeMessage(messageContent):
-        # https://docs.python.org/3/library/json.html#basic-usage
-        # To get the most compact JSON representation, you should specify 
-        # (',', ':') to eliminate whitespace.
-        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
-        encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
-        encodedLength = struct.pack('@I', len(encodedContent))
-        return {'length': encodedLength, 'content': encodedContent}
+# Encode a message for transmission,
+# given its content.
+def encodeMessage(messageContent):
+    # https://docs.python.org/3/library/json.html#basic-usage
+    # To get the most compact JSON representation, you should specify 
+    # (',', ':') to eliminate whitespace.
+    # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
+    encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
+    encodedLength = struct.pack('@I', len(encodedContent))
+    return {'length': encodedLength, 'content': encodedContent}
 
-    # Send an encoded message to stdout
-    def sendMessage(encodedMessage):
-        sys.stdout.buffer.write(encodedMessage['length'])
-        sys.stdout.buffer.write(encodedMessage['content'])
-        sys.stdout.buffer.flush()
+# Send an encoded message to stdout
+def sendMessage(encodedMessage):
+    sys.stdout.buffer.write(encodedMessage['length'])
+    sys.stdout.buffer.write(encodedMessage['content'])
+    sys.stdout.buffer.flush()
 
-    while True:
-        receivedMessage = getMessage()
-        if receivedMessage == "ping":
-            sendMessage(encodeMessage("pong"))
+while True:
+    receivedMessage = getMessage()
+    if receivedMessage == "ping":
+        sendMessage(encodeMessage("pong"))
 ```
 
 ## Closing the native app

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -310,7 +310,7 @@ Here's another example written in Python. It listens for messages from the exten
 This is the Python 2 version:
 
 ```python
-#!/usr/bin/python -u
+#!/usr/bin/env -S python2 -u
 
 # Note that running python with the `-u` flag is required on Windows,
 # in order to ensure that stdin and stdout are opened in binary, rather


### PR DESCRIPTION
When separators=(',', ':') is not passed to json.dumps() parameter the length for input from JavaScript (which is serialized to a JSON-like format by the application) port.postMessage(new Array(174763)); is read in Python as

1048578

which is greater than 1024*1024. Essentially space character formatting were being encoded as part of the length of the JSON.

When the length should be 

873816

when formatting space characters are excluded from the JSON.

Solved by passing separators=(',', ':') for “compact encoding” json — JSON encoder and decoder — Python 3.11.1 documentation.

Now we can write 1MB with

port.postMessage(new Array(209715));

from JavaScript and omit including and counting formatting space characters as part of encoded message length.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
