### PR TITLE
Mention that canvas transforms multiply on the left of a column vector

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -43,6 +43,8 @@ The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>
 </mrow><annotation encoding="TeX">\left[ \begin{array}{ccc} a &#x26; c &#x26; e \\ b &#x26; d
 &#x26; f \\ 0 &#x26; 0 &#x26; 1 \end{array} \right]</annotation></semantics></math>
 
+This transformation matrix gets multiplied on the left of a column vector representing each point being drawn on the canvas to produce the final co-ordinate used on the canvas.
+
 ### Parameters
 
 `setTransform()` has two types of parameter that it can accept. The older

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -43,7 +43,7 @@ The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>
 </mrow><annotation encoding="TeX">\left[ \begin{array}{ccc} a &#x26; c &#x26; e \\ b &#x26; d
 &#x26; f \\ 0 &#x26; 0 &#x26; 1 \end{array} \right]</annotation></semantics></math>
 
-This transformation matrix gets multiplied on the left of a column vector representing each point being drawn on the canvas to produce the final co-ordinate used on the canvas.
+This transformation matrix gets multiplied on the left of a column vector representing each point being drawn on the canvas to produce the final coordinate used on the canvas.
 
 ### Parameters
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -43,7 +43,7 @@ The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>
 </mrow><annotation encoding="TeX">\left[ \begin{array}{ccc} a &#x26; c &#x26; e \\ b &#x26; d
 &#x26; f \\ 0 &#x26; 0 &#x26; 1 \end{array} \right]</annotation></semantics></math>
 
-This transformation matrix gets multiplied on the left of a column vector representing each point being drawn on the canvas to produce the final coordinate used on the canvas.
+This transformation matrix gets multiplied on the left of a column vector representing each point being drawn on the canvas, to produce the final coordinate used on the canvas.
 
 ### Parameters
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

When computing a matrix to transform the canvas by it's important to know whether it will be multiplied against a row or column vector. This clarifies things to state that it is a column vector that is multiplied with the transform matrix.

<!-- ✍️ Summarize your changes in one or two sentences -->

Add a sentence to make it clear the canvas transform is multiplying against a column vector.

<!-- ❓ Why are you making these changes and how do they help readers? -->

See above.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
