### PR TITLE
Remove deprecated "page-break-inside" property

### DIFF
--- a/files/en-us/learn/css/css_layout/multiple-column_layout/index.md
+++ b/files/en-us/learn/css/css_layout/multiple-column_layout/index.md
@@ -378,7 +378,6 @@ To control this behavior, we can use properties from the [CSS Fragmentation](/en
 ```css
 .card {
   break-inside: avoid;
-  page-break-inside: avoid;
   background-color: rgb(207, 232, 220);
   border: 2px solid rgb(79, 185, 227);
   padding: 10px;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed "page-break-inside" property from CSS.

### Motivation

The `page-break-inside` is a deprecated property and is nowhere mentioned in the article. It should not be there in the article unless it specifically mentions that this is a deprecated property and functions as an alias to `break-inside`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
