### PR TITLE
Update "Using custom elements" for clarity

### DIFF
--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -36,7 +36,7 @@ So for example, we can define a **customized built-in** [word-count element](htt
 customElements.define("word-count", WordCount, { extends: "p" });
 ```
 
-The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element.
+The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element and as such, it can only be constructed by setting it as the `is` attribute. For example: `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
 
 A custom element's class object is written using the `class` syntax. For example, `WordCount` is structured like so:
 
@@ -50,7 +50,7 @@ class WordCount extends HTMLParagraphElement {
   }
 }
 ```
-You can find the full [source code here](https://github.com/mdn/web-components-examples/tree/main/word-count-web-component).
+> **Note:** Find the [full JavaScript source](https://github.com/mdn/web-components-examples/blob/main/word-count-web-component/main.js) here.
 
 This is just a simple example, but there is more you can do here. It is possible to define specific lifecycle callbacks inside the class, which run at specific points in the element's lifecycle. For example, `connectedCallback` is invoked each time the custom element is appended into a document-connected element, while `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed.
 

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -36,7 +36,7 @@ So for example, we can define a **customized built-in** [word-count element](htt
 customElements.define("word-count", WordCount, { extends: "p" });
 ```
 
-The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element and as such, it can only be constructed by setting the `is` attribute in the extended element. For example: `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
+The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element and, as such, it can only be constructed by setting the `is` attribute in the extended element. For example: `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
 
 A custom element's class object is written using the `class` syntax. For example, `WordCount` is structured like so:
 

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -25,7 +25,12 @@ To register a custom element on the page, you use the {{domxref("CustomElementRe
 - A [class](/en-US/docs/Web/JavaScript/Reference/Classes) object that defines the behavior of the element.
 - {{optional_inline}} An options object containing an `extends` property, which specifies the built-in element your element inherits from, if any (only relevant to customized built-in elements; see the definition below).
 
-So for example, we can define a custom [word-count element](https://mdn.github.io/web-components-examples/word-count-web-component/) like this:
+There are two types of custom elements:
+
+- **Autonomous custom elements** are standalone — they don't inherit from standard HTML elements. You use these on a page by literally writing them out as an HTML element. For example `<popup-info>`, or `document.createElement("popup-info")`.
+- **Customized built-in elements** inherit from basic HTML elements. To create one of these, you have to specify which element they extend (as implied in the examples above), and they are used by writing out the basic element but specifying the name of the custom element in the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute (or property). For example `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
+
+So for example, we can define a **customized built-in** [word-count element](https://mdn.github.io/web-components-examples/word-count-web-component/) like this:
 
 ```js
 customElements.define("word-count", WordCount, { extends: "p" });
@@ -45,15 +50,11 @@ class WordCount extends HTMLParagraphElement {
   }
 }
 ```
+You can find the full [source code here](https://github.com/mdn/web-components-examples/tree/main/word-count-web-component).
 
 This is just a simple example, but there is more you can do here. It is possible to define specific lifecycle callbacks inside the class, which run at specific points in the element's lifecycle. For example, `connectedCallback` is invoked each time the custom element is appended into a document-connected element, while `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed.
 
 You'll learn more about these in the [Using the lifecycle callbacks](#using_the_lifecycle_callbacks) section below.
-
-There are two types of custom elements:
-
-- **Autonomous custom elements** are standalone — they don't inherit from standard HTML elements. You use these on a page by literally writing them out as an HTML element. For example `<popup-info>`, or `document.createElement("popup-info")`.
-- **Customized built-in elements** inherit from basic HTML elements. To create one of these, you have to specify which element they extend (as implied in the examples above), and they are used by writing out the basic element but specifying the name of the custom element in the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute (or property). For example `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
 
 ## Working through some simple examples
 

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -50,6 +50,7 @@ class WordCount extends HTMLParagraphElement {
   }
 }
 ```
+
 > **Note:** Find the [full JavaScript source](https://github.com/mdn/web-components-examples/blob/main/word-count-web-component/main.js) here.
 
 This is just a simple example, but there is more you can do here. It is possible to define specific lifecycle callbacks inside the class, which run at specific points in the element's lifecycle. For example, `connectedCallback` is invoked each time the custom element is appended into a document-connected element, while `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed.

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -36,7 +36,7 @@ So for example, we can define a **customized built-in** [word-count element](htt
 customElements.define("word-count", WordCount, { extends: "p" });
 ```
 
-The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element and as such, it can only be constructed by setting it as the `is` attribute. For example: `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
+The element is called `word-count`, its class object is `WordCount`, and it extends the {{htmlelement("p")}} element and as such, it can only be constructed by setting the `is` attribute in the extended element. For example: `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
 
 A custom element's class object is written using the `class` syntax. For example, `WordCount` is structured like so:
 


### PR DESCRIPTION
### Description
This attempts to clarify that the first example is a **customized built-in element** which can only be used through an `is` attribute.

See https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#high-level_view

### Motivation
The order of the article was really confusing as I tried to follow it from top to bottom, which resulted in me trying to debug why my custom component was not working for a while. By using the `extends` option, it blocks you from using the custom element as a regular HTML element.

### Additional details
I think that the article can be clarified much more but this is a start at least. If someone wants to change it up more, please feel free to :)
