### PR TITLE
fix: html DOM Text node content

### DIFF
--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -29,14 +29,11 @@ To understand what a text node is, consider the following document:
 
 In that document, there are five text nodes, with the following contents:
 
-- "`\n`" (after the `<head>` start tag, a newline followed by a space)
-- "`Aliens?`" (the contents of the `title` element)
-- "`\n`" (after the `</head>` end tag, a newline followed by a space)
-- "`\n`" (after the `<body>` start tag, a newline followed by a space)
-- "`\n Why yes.\n \n\n`":
-  - "`\n`" (a newline followed by a space)
-  - "`Why yes.\n`" (the contents of the body element)
-  - "`\n\n`" (after the `</body>` and `</html>` end tags)
+- `"\n    "` (after the `<head>` start tag, a newline followed by four spaces)
+- `"Aliens?"` (the contents of the `title` element)
+- `"\n  "` (after the `</head>` end tag, a newline followed by two spaces)
+- `"\n  "` (after the `<body>` start tag, a newline followed by two spaces)
+- `"\n Why yes.\n \n\n"` (the contents of the `body` element)
 
 Each of those text nodes is an object that has the properties and methods documented in this article.
 

--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -27,11 +27,16 @@ To understand what a text node is, consider the following document:
 </html>
 ```
 
-In that document, there are three text nodes, with the following contents:
+In that document, there are five text nodes, with the following contents:
 
+- "`\n`" (after the `<head>` start tag, a newline followed by a space)
 - "`Aliens?`" (the contents of the `title` element)
 - "`\n`" (after the `</head>` end tag, a newline followed by a space)
-- "`Why yes.\n`" (the contents of the `body` element)
+- "`\n`" (after the `<body>` start tag, a newline followed by a space)
+- "`\n Why yes.\n \n\n`":
+  - "`\n`" (a newline followed by a space)
+  - "`Why yes.\n`" (the contents of the body element)
+  - "`\n\n`" (after the `</body>` and `</html>` end tags)
 
 Each of those text nodes is an object that has the properties and methods documented in this article.
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Opening a file and running a TreeWalker resulted at least 5 text nodes rather than 3. So, updated the explaining text to keep consistent with the new code block.

### Motivation

Clear out the confusion for readers

### Additional details

HTML content:

```html
<html lang="en" class="e">
  <head>
    <title>Aliens?</title>
  </head>
  <body>
    Why yes.
  </body>
</html>
```

Tree Walker:

```js
function textNodesUnder (el) {
  let node
  const res = []
  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false)
  while ((node = walker.nextNode())) res.push(node)
  console.log(res.map(({ nodeValue }) => nodeValue))
}

textNodesUnder(document) 
```

Result:

```
[
  "\n    ",
  "Aliens?",
  "\n  ",
  "\n  ",
  "\n    Why yes.\n  \n\n"
]
```

### Related issues and pull requests

Fixes #23353 
