### PR TITLE
fix typos

### DIFF
--- a/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -222,10 +222,10 @@ This means that you have created a node of the type `TEXT_NODE` (a piece of text
 
 ### Inserting Elements with appendChild(..)
 
-So, by calling `myP.appendChild(node_element)`, you are making the element a new child of the second `<p>` element.
+So, by calling `secondParagraph.appendChild(node_element)`, you are making the element a new child of the second `<p>` element.
 
 ```js
-myP.appendChild(myTextNode);
+secondParagraph.appendChild(myTextNode);
 ```
 
 After testing this sample, note that the words hello and world are together: helloworld. So visually, when you see the HTML page it seems like the two text nodes hello and world are a single node, but remember that in the document model, there are two nodes. The second node is a new node of type `TEXT_NODE`, and it is the second child of the second `<p>` tag. The following figure shows the recently created Text Node object inside the document tree.
@@ -247,10 +247,10 @@ myBody.appendChild(myNewPTagNode);
 
 ### Removing nodes with the removeChild(..) method
 
-Nodes can be removed. The following code removes text node `myTextNode` (containing the word "world") from the second `<p>` element, `myP`.
+Nodes can be removed. The following code removes text node `myTextNode` (containing the word "world") from the second `<p>` element, `secondParagraph`.
 
 ```js
-myP.removeChild(myTextNode);
+secondParagraph.removeChild(myTextNode);
 ```
 
 Text node `myTextNode` (containing the word "world") still exists. The following code attaches `myTextNode` to the recently created `<p>` element, `myNewPTagNode`.


### PR DESCRIPTION
fixed inconsistent variable names (myP -> secondParagraph)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The variable in example was called `secondParagraph`, but then changed to `myP`. Probably the text was updated with a new example, but the whole synthax was not updated.

### Motivation
It's now confusing and takes time to understand the mismatch, especially for a beginner.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
