### PR TITLE
Fix minor typo in docs

### DIFF
--- a/files/en-us/web/api/idbcursor/source/index.md
+++ b/files/en-us/web/api/idbcursor/source/index.md
@@ -33,7 +33,7 @@ iterating over.
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we
-log the source of the cursor, which will log our {{domxref("IDBobjectStore")}} object to
+log the source of the cursor, which will log our {{domxref("IDBObjectStore")}} object to
 the console, something like this:
 
 ```json


### PR DESCRIPTION
### Description

- Fixes minor typo in docs 
-  In  [IDBCursor.source](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/source) docs there multiple place where [`IDBObjectStore`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore) is used. So this [`IDBobjectStore`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore) seems like minor typo 