### PR TITLE
order `padding` constituent properties in the same fashion as `margin`

### DIFF
--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -25,10 +25,10 @@ An element's padding area is the space between its content and its border.
 
 This property is a shorthand for the following CSS properties:
 
+- {{cssxref("padding-top")}}
+- {{cssxref("padding-right")}}
 - {{cssxref("padding-bottom")}}
 - {{cssxref("padding-left")}}
-- {{cssxref("padding-right")}}
-- {{cssxref("padding-top")}}
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Order `padding` constituent properties in the same fashion as `margin` throughout the `padding` documentation.

### Motivation

I always forget the order of these things and when I see an ordered list of the constituent properties I assume it is relevant.

For `margin` the documentation consistently uses the correct order.
For `padding` however it switches between 🔤 ordering and the shorthand order.

<img width="639" alt="Screenshot 2023-01-09 at 19 05 56" src="https://user-images.githubusercontent.com/11521496/211376929-ce9e0ab3-a87a-41a8-a345-a42b1b8582fe.png">

<img width="633" alt="Screenshot 2023-01-09 at 19 06 06" src="https://user-images.githubusercontent.com/11521496/211376960-02ac53a3-459b-4683-a817-e0139977637f.png">

This is confusing.

### Additional details

I am unsure if this change alone is sufficient to make the whole page consistent.

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
