### PR TITLE
Adding styling for .positioned class

### DIFF
--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -378,6 +378,13 @@ p {
 }
 ```
 
+```css hidden
+.positioned {
+  background: rgba(255, 84, 104, 0.3);
+  border: 2px solid rgb(255, 84, 104);
+}
+```
+
 The rendered output is as follows:
 
 {{ EmbedLiveSample('Simple_positioning_example', '100%', 300) }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Style `.positioned` class so that the box becomes dark red with border.

### Motivation

The first embed example does not mark the second box as red background (with class="positioned") while the next ones do. This will help standardize the boxes across examples and aid readers in better understanding.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #23450
