### PR TITLE
Add details about the behavior of `Selection.setBaseAndExtent()` on text nodes

### DIFF
--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -31,12 +31,21 @@ setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
   - : The number of child nodes from the start of the anchor node that should be excluded
     from the selection. So for example, if the value is 0 the whole node is included. If
     the value is 1, the whole node minus the first child node is included. And so on.
+
+    If `anchorNode` is a {{domxref("Text")}} node, the offset refers to the number of
+    characters from the start of the node's {{domxref("Node.textContent")}} that should be
+    excluded from the selection.
+
 - `focusNode`
   - : The node at the end of the selection.
 - `focusOffset`
   - : The number of child nodes from the start of the focus node that should be included
     in the selection. So for example, if the value is 0 the whole node is excluded. If the
     value is 1, the first child node is included. And so on.
+
+    If `focusNode` is a {{domxref("Text")}} node, the offset refers to the number of
+    characters from the start of the node's {{domxref("Node.textContent")}} that should be
+    included in the selection.
 
 > **Note:** If the focus position appears before the anchor position in
 > the document, the direction of the selection is reversed — the caret is placed at the

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -33,7 +33,7 @@ setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
     the value is 1, the whole node minus the first child node is included. And so on.
 
     If `anchorNode` is a {{domxref("Text")}} node, the offset refers to the number of
-    characters from the start of the node's {{domxref("Node.textContent")}} that should be
+    characters from the start of the {{domxref("Node.textContent")}} that should be
     excluded from the selection.
 
 - `focusNode`
@@ -44,7 +44,7 @@ setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
     value is 1, the first child node is included. And so on.
 
     If `focusNode` is a {{domxref("Text")}} node, the offset refers to the number of
-    characters from the start of the node's {{domxref("Node.textContent")}} that should be
+    characters from the start of the {{domxref("Node.textContent")}} that should be
     included in the selection.
 
 > **Note:** If the focus position appears before the anchor position in


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding the details below will help us to merge your PR faster. -->

### Description
Include details in the parameter explanation for the cases of text nodes
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Add details on the special behavior on text nodes
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Tested according to issue #6623's description
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
![image](https://user-images.githubusercontent.com/41845017/211488944-8a8a98cb-c8b6-4b94-be5e-cc43f2b66fd5.png)
---
![image](https://user-images.githubusercontent.com/41845017/211489025-9e719b6b-96d7-4f15-a697-1bbc0433e988.png)
---
![image](https://user-images.githubusercontent.com/41845017/211489124-b595d683-dda9-403a-a3ca-9b48e61174ce.png)
---
![image](https://user-images.githubusercontent.com/41845017/211489905-7cc1543a-170f-4168-9e3b-24215132385c.png)

### Related issues and pull requests
Fixes #6623
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
