### PR TITLE
[UrlPatternApi] fix typo

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -131,14 +131,14 @@ Some regex patterns do not work as you may expect:
   ```
 
   ```js
-  // with `$` in protocol
+  // with `$` in hash
   const pattern = new URLPattern({ hash: '(hash$)' });
   console.log(pattern.test('https://example.com/#hash')); // true
   console.log(pattern.test('xhttps://example.com/#otherhash')); // false
   ```
 
   ```js
-  // without `$` in protocol
+  // without `$` in hash
   const pattern = new URLPattern({ hash: '(hash)' });
   console.log(pattern.test('https://example.com/#hash')); // true
   console.log(pattern.test('xhttps://example.com/#otherhash')); // false


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the page about `URL_Pattern_API`, i noticed that we mention `in protocol` in examples when the pattern is applied on the `hash` instead (wrong copy paste)

### Motivation

Fix typo / proper comment based on the example

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Doesn't relate to any other content.

### Related issues and pull requests

It doesn't relate to any other issue / PR.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
