### PR TITLE
Add warning for CSS `image-orientation`'s limitation on cross-origin images

### DIFF
--- a/files/en-us/web/css/image-orientation/index.md
+++ b/files/en-us/web/css/image-orientation/index.md
@@ -39,6 +39,8 @@ image-orientation: unset;
 - `from-image`
   - : Default initial value. The [EXIF](https://en.wikipedia.org/wiki/EXIF) information contained in the image is used to rotate the image appropriately.
 
+> **Warning:** `image-orientation: none;` **does not** override the orientation of non-secure-origin images as encoded by their [EXIF](https://en.wikipedia.org/wiki/EXIF) information, due to security concerns. Find out more from [the CSS working group draft issue](https://github.com/w3c/csswg-drafts/issues/5165).
+
 ## Description
 
 This property is intended _only_ to be used for the purpose of correcting the orientation of images which were shot with the camera rotated. It should _not_ be used for arbitrary rotations. For any purpose other than correcting an image's orientation due to how it was shot or scanned, use a {{cssxref("transform")}} property with the `rotate` keyword to specify rotation. This includes any user-directed changes to the orientation of the image, or changes required for printing in portrait versus landscape orientation.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add a warning for CSS `image-orientation`'s limitation on cross-origin images
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The change wrt `image-orientation`'s limitation on cross-origin images may break many existing/future applications that depend on the previous behavior, hence this callout is necessary.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Related links:
- [Chrome blog annoucemet](https://blog.chromium.org/2021/01/#:~:text=Image%20Orientation%20with%20EXIF)
- [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1110330)
- [CSSWG draft issue](https://github.com/w3c/csswg-drafts/issues/5165)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #12484
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
