### PR TITLE
chore(CI): don't add 'needs triage' label if there's an assignee

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -14,3 +14,4 @@ jobs:
         uses: andymckay/labeler@master
         with:
           add-labels: "needs triage"
+          ignore-if-assigned: true


### PR DESCRIPTION
Workflow docs: https://github.com/andymckay/labeler#ignore-if-assigned

__Background:__
I would like to disable adding the `needs triage` label if I create an issue with an assignee. That avoids the following case:

![image](https://user-images.githubusercontent.com/43580235/211560275-20b8f031-f48f-4ddc-9d18-d3b71925edfe.png)


