### PR TITLE
State that the wildcard exception also applies to Access-Control-Expose-Headers

### DIFF
--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -356,6 +356,8 @@ When responding to a credentialed request:
 
 - The server **must not** specify the "`*`" wildcard for the `Access-Control-Allow-Methods` response-header value, but must instead specify an explicit list of method names; for example, `Access-Control-Allow-Methods: POST, GET`
 
+- The server **must not** specify the "`*`" wildcard for the `Access-Control-Expose-Headers` response-header value, but must instead specify an explicit list of header names; for example, `Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision`
+
 If a request includes a credential (most commonly a `Cookie` header) and the response includes an `Access-Control-Allow-Origin: *` header (that is, with the wildcard), the browser will block access to the response, and report a CORS error in the devtools console.
 
 But if a request does include a credential (like the `Cookie` header) and the response includes an actual origin rather than the wildcard (like, for example, `Access-Control-Allow-Origin: https://example.com`), then the browser will allow access to the response from the specified origin.


### PR DESCRIPTION
### Description

This change states that the wildcard exception also applies to the `Access-Control-Expose-Headers`, and not just to headers `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers`.

### Motivation

This omission may lead readers of MDN Web Docs to (incorrectly) conclude that the wildcard exception doesn't apply to the `Access-Control-Expose-Headers` header, and increases their chances of using a dysfunctional CORS configuration.

### Additional details

See [section 3.2.4 of the Fetch standard](https://fetch.spec.whatwg.org/#http-new-header-syntax).