### PR TITLE
At-rule functions

### DIFF
--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -59,7 +59,7 @@ The {{CSSxRef("@namespace")}} at-role specify XML namespaces to be used in a CSS
 
 ## @container functions
 
-The {{CSSxRef("@container")}} at-role specify styles to a containment context. 
+The {{CSSxRef("@container")}} at-role specify styles to a containment context.
 
 - {{CSSxRef("@container", "@container style()")}}
   - : Defines the containment context style.

--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -20,7 +20,7 @@ tags:
 }
 ```
 
-The syntax begins with the at symbol `@` and an at-rule identifier, such as `import`. This is followed by the **name of the at-rule function**, such as `url`, followed by a pair of opening and closing parentheses. One or more  arguments are specified inside the parentheses.
+The syntax begins with the at symbol `@` and an at-rule identifier, such as `import`. This is followed by the **name of the at-rule function**, such as `url`, followed by a pair of opening and closing parentheses. One or more arguments are specified inside the parentheses.
 
 Some at-rule functions can take multiple arguments, which are formatted similar to CSS property values. White space is allowed, but it is optional inside the parentheses. Multiple arguments can be separated using a comma or a space.
 

--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -1,6 +1,6 @@
 ---
 title: CSS at-rule functions
-slug: Web/CSS/At-rule_functions
+slug: Web/CSS/At-rule-functions
 page-type: guide
 tags:
   - CSS

--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -1,5 +1,5 @@
 ---
-title: At-rule functions
+title: CSS at-rule functions
 slug: Web/CSS/At-rule-functions
 page-type: guide
 tags:
@@ -11,7 +11,7 @@ tags:
 
 {{CSSRef}}
 
-**At-rule Functions** are [at-rule](/en-US/docs/Web/CSS/At-rule) statements that can represent more complex rules or invoke special data processing or calculations.
+**[CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) functions** are at-rule statements that can represent more complex rules or invoke special data processing or calculations.
 
 ## Syntax
 

--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -1,0 +1,65 @@
+---
+title: At-rule functions
+slug: Web/CSS/At-rule-functions
+page-type: guide
+tags:
+  - CSS
+  - Guide
+  - Functions
+  - Reference
+---
+
+{{CSSRef}}
+
+**At-rule Functions** are [at-rule](/en-US/docs/Web/CSS/At-rule) statements that can represent more complex rules or invoke special data processing or calculations.
+
+## Syntax
+
+```css
+@identifier function([argument]? [, argument]!) {
+}
+```
+
+The syntax starts with '`@`' (at statement), followed by an identifier. Then comes the **name of the at-role function**, followed by a left parenthesis `(`. Next up are the argument(s), and the function is finished off with a closing parenthesis `)`.
+
+Some at-role functions can take multiple arguments, which are formatted similarly to CSS property values. Whitespace is allowed, but they are optional inside the parentheses. In some functional notations multiple arguments are separated by commas, while others use spaces.
+
+## @import functions
+
+The {{CSSxRef("@import")}} at-role used to import styles from other stylesheets.
+
+- {{CSSxRef("@import", "@import url()")}}
+  - : Imports a stylesheet file from a specified URL.
+- {{CSSxRef("@import", "@import src()")}}
+  - : Imports a stylesheet file from a specified source.
+- {{CSSxRef("@import", "@import supports()")}}
+  - : Imports a stylesheet file based on browser support.
+- {{CSSxRef("@import", "@import layer()")}}
+  - : Imports a stylesheet file to a specific cascade layer.
+
+## @supports functions
+
+The {{CSSxRef("@supports")}} at-role specify CSS declarations that depend on a browser's support for CSS features.
+
+- {{CSSxRef("@supports", "@supports selector()")}}
+  - : Evaluates browser supports based on specified selector syntax.
+- {{CSSxRef("@supports", "@supports font-tech()")}}
+  - : Evaluates browser supports based on specified font technology for layout and rendering.
+- {{CSSxRef("@supports", "@supports font-format()")}}
+  - : Evaluates browser supports based on specified font format for layout and rendering.
+
+## @namespace functions
+
+The {{CSSxRef("@namespace")}} at-role specify XML namespaces to be used in a CSS stylesheet.
+
+- {{CSSxRef("@namespace", "@namespace url()")}}
+  - : Defines XML namespace from a specified URL.
+- {{CSSxRef("@namespace", "@namespace src()")}}
+  - : Defines XML namespace from a specified source.
+
+## @container functions
+
+The {{CSSxRef("@container")}} at-role specify styles to a containment context. 
+
+- {{CSSxRef("@container", "@container style()")}}
+  - : Defines the containment context style.

--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -1,6 +1,6 @@
 ---
 title: CSS at-rule functions
-slug: Web/CSS/At-rule-functions
+slug: Web/CSS/At-rule_functions
 page-type: guide
 tags:
   - CSS
@@ -11,7 +11,7 @@ tags:
 
 {{CSSRef}}
 
-**[CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) functions** are at-rule statements that can represent more complex rules or invoke special data processing or calculations.
+**[CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) functions** are at-rule statements that represent complex rules or can invoke special data processing or calculations.
 
 ## Syntax
 
@@ -20,46 +20,46 @@ tags:
 }
 ```
 
-The syntax starts with '`@`' (at statement), followed by an identifier. Then comes the **name of the at-role function**, followed by a left parenthesis `(`. Next up are the argument(s), and the function is finished off with a closing parenthesis `)`.
+The syntax begins with the at symbol `@` and an at-rule identifier, such as `import`. This is followed by the **name of the at-rule function**, such as `url`, followed by a pair of opening and closing parentheses. One or more  arguments are specified inside the parentheses.
 
-Some at-role functions can take multiple arguments, which are formatted similarly to CSS property values. Whitespace is allowed, but they are optional inside the parentheses. In some functional notations multiple arguments are separated by commas, while others use spaces.
+Some at-rule functions can take multiple arguments, which are formatted similar to CSS property values. White space is allowed, but it is optional inside the parentheses. Multiple arguments can be separated using a comma or a space.
 
 ## @import functions
 
-The {{CSSxRef("@import")}} at-role used to import styles from other stylesheets.
+The {{CSSxRef("@import")}} at-rule is used to import styles from other stylesheets.
 
 - {{CSSxRef("@import", "@import url()")}}
-  - : Imports a stylesheet file from a specified URL.
+  - : Imports a stylesheet file from the specified URL.
 - {{CSSxRef("@import", "@import src()")}}
-  - : Imports a stylesheet file from a specified source.
+  - : Imports a stylesheet file from the specified source.
 - {{CSSxRef("@import", "@import supports()")}}
   - : Imports a stylesheet file based on browser support.
 - {{CSSxRef("@import", "@import layer()")}}
-  - : Imports a stylesheet file to a specific cascade layer.
+  - : Imports a stylesheet file into the specified cascade layer.
 
 ## @supports functions
 
-The {{CSSxRef("@supports")}} at-role specify CSS declarations that depend on a browser's support for CSS features.
+The {{CSSxRef("@supports")}} at-rule checks for a browser's support for the specified CSS feature and then applies the CSS styling.
 
 - {{CSSxRef("@supports", "@supports selector()")}}
-  - : Evaluates browser supports based on specified selector syntax.
+  - : Applies CSS rules after checking browser's support for the specified selector syntax.
 - {{CSSxRef("@supports", "@supports font-tech()")}}
-  - : Evaluates browser supports based on specified font technology for layout and rendering.
+  - : Applies CSS rules after checking browser's support for the specified font technology.
 - {{CSSxRef("@supports", "@supports font-format()")}}
-  - : Evaluates browser supports based on specified font format for layout and rendering.
+  - : Applies CSS rules after checking browser's support for the specified font format.
 
 ## @namespace functions
 
-The {{CSSxRef("@namespace")}} at-role specify XML namespaces to be used in a CSS stylesheet.
+The {{CSSxRef("@namespace")}} at-rule is used to specify XML namespaces to be used in a CSS stylesheet.
 
 - {{CSSxRef("@namespace", "@namespace url()")}}
-  - : Defines XML namespace from a specified URL.
+  - : Defines XML namespace from the specified URL.
 - {{CSSxRef("@namespace", "@namespace src()")}}
-  - : Defines XML namespace from a specified source.
+  - : Defines XML namespace from the specified source.
 
 ## @container functions
 
-The {{CSSxRef("@container")}} at-role specify styles to a containment context.
+The {{CSSxRef("@container")}} at-rule is used to specify styles for a containment context.
 
 - {{CSSxRef("@container", "@container style()")}}
   - : Defines the containment context style.


### PR DESCRIPTION
### Description

A page with all the available CSS [at-rules](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) functions.

### Motivation

CSS data-types have functions. They are documented in https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions

CSS at-rule have functions too, they are not documented yet. This PR adds a new page containing those functions.

### Additional details

Back in 2020, when we used the old platform before the migration to GitHub markdown, [I created the first page](https://github.com/mdn/sprints/issues/3838) listing all the available "[CSS functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions)". It contains dozens of data-type-functions in one place.

In 2023, I want to create the same page with all the available at-rule-functions in one place. Hopefully, spec writers will add new at-rule-functions in the future.