### PR TITLE
Add `@color-profile`, `@container` and `@font-palette-values` to the index

### DIFF
--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -68,10 +68,13 @@ Since each conditional group may also contain nested statements, there may be an
 ## Index
 
 - {{cssxref("@charset")}}
+- {{cssxref("@color-profile")}}
+- {{cssxref("@container")}}
 - {{cssxref("@counter-style")}}
 - {{cssxref("@document")}} {{deprecated_inline}}
 - {{cssxref("@font-face")}}
 - {{cssxref("@font-feature-values")}}
+- {{cssxref("@font-palette-values")}}
 - {{cssxref("@import")}}
 - {{cssxref("@keyframes")}}
 - {{cssxref("@layer")}}


### PR DESCRIPTION
### Description

Add missing at-rules to the index.

### Motivation

The index should include **all** the available at-rules, not **some** of them.