### PR TITLE
update book_renew_librarian.html path in view

### DIFF
--- a/files/en-us/learn/server-side/django/forms/index.md
+++ b/files/en-us/learn/server-side/django/forms/index.md
@@ -403,7 +403,7 @@ def renew_book_librarian(request, pk):
         'book_instance': book_instance,
     }
 
-    return render(request, 'catalog/book_renew_librarian.html', context)
+    return render(request, 'book_renew_librarian.html', context)
 ```
 
 ### The template


### PR DESCRIPTION
### Description

The path to the book_renew_librarian.html path is incorrect and results in a TemplateNotFound error. This fixes the error. 
