### PR TITLE
chore(meta): Renames file and slug of "Roles and teams" page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5395,6 +5395,7 @@
 /en-US/docs/MDC:How_to_Help	/en-US/docs/MDN/Contribute
 /en-US/docs/MDN/About	/en-US/docs/MDN/Writing_guidelines
 /en-US/docs/MDN/At_ten/Contributing_to_MDN	/en-US/docs/MDN/Contribute
+/en-US/docs/MDN/Community/Users_teams	/en-US/docs/MDN/Community/Roles_teams
 /en-US/docs/MDN/Contribute/Changelog	/en-US/docs/MDN/Changelog
 /en-US/docs/MDN/Contribute/Code_sample_guidelines	/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
 /en-US/docs/MDN/Contribute/Content	/en-US/docs/MDN/Writing_guidelines

--- a/files/en-us/mdn/community/roles_teams/index.md
+++ b/files/en-us/mdn/community/roles_teams/index.md
@@ -1,13 +1,12 @@
 ---
 title: MDN Web Docs roles and teams
-slug: MDN/Community/Users_teams
+slug: MDN/Community/Roles_teams
 page-type: mdn-community-guide
 tags:
   - meta
   - community-guidelines
   - governance
 ---
-
 {{MDNSidebar}}
 
 The success and growth of the MDN Web Docs project is, in large part, due to our community of contributors. Some contributors have committed a portion of their time to assist with the daily tasks of running MDN Web Docs. Changes to the site, including maintenance tasks, are performed by employees, contractors, and a network of partners who are all dedicated to the health, growth, and maintenance of MDN Web Docs. The project relies heavily on [roles](#roles) and [teams](#teams) in the [MDN organization on GitHub](https://github.com/mdn) to manage and incorporate changes from these different groups. A list of the organization's members can be [found here](https://github.com/orgs/mdn/people).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pull request is a follow up task from https://github.com/mdn/content/pull/22916 for the [Roles and teams page](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams):

- [x] Update file name: users_teams --> roles_teams
- [x] Update slug: MDN/Community/Users_teams --> MDN/Community/Roles_teams

