### PR TITLE
chore(deps): Remove dropped CSS rule, bump react versions & link to deploy

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/index.md
@@ -50,9 +50,9 @@ Your code will be richer and more professional as a result, and you'll be able t
 
 ## React tutorials
 
-> **Note:** React tutorials last tested in May 2020, with React/ReactDOM 16.13.1 and create-react-app 3.4.1.
+> **Note:** React tutorials last tested in January 2023, with React/ReactDOM 18.2.0 and create-react-app 5.0.1.
 >
-> If you need to check your code against our version, you can find a finished version of the sample React app code in our [todo-react repository](https://github.com/mdn/todo-react). For a running live version, see <https://mdn.github.io/todo-react-build/>.
+> If you need to check your code against our version, you can find a finished version of the sample React app code in our [todo-react repository](https://github.com/mdn/todo-react). For a running live version, see <https://mdn.github.io/todo-react/>.
 
 - [1. Getting started with React](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started)
   - : In this article we will say hello to React. We'll discover a little bit of detail about its background and use cases, set up a basic React toolchain on our local computer, and create and play with a simple starter app, learning a bit about how React works in the process.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.md
@@ -316,7 +316,7 @@ Most of the time, you can be an effective contributor to a React project even if
 
 `useRef()` and `useEffect()` are somewhat advanced features, and you should be proud of yourself for using them! Look out for opportunities to practice them more, because doing so will allow you to create inclusive experiences for users. Remember: our app would have been inaccessible to keyboard users without them!
 
-> **Note:** If you need to check your code against our version, you can find a finished version of the sample React app code in our [todo-react repository](https://github.com/mdn/todo-react). For a running live version, see <https://mdn.github.io/todo-react-build/>.
+> **Note:** If you need to check your code against our version, you can find a finished version of the sample React app code in our [todo-react repository](https://github.com/mdn/todo-react). For a running live version, see <https://mdn.github.io/todo-react>.
 
 In the very last article we'll present you with a list of React resources that you can use to go further in your learning.
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -131,14 +131,11 @@ function App(props) {
           <span className="visually-hidden"> tasks</span>
         </button>
       </div>
-      <h2 id="list-heading">
-        3 tasks remaining
-      </h2>
+      <h2 id="list-heading">3 tasks remaining</h2>
       <ul
         role="list"
         className="todo-list stack-large stack-exception"
-        aria-labelledby="list-heading"
-      >
+        aria-labelledby="list-heading">
         <li className="todo stack-small">
           <div className="c-cb">
             <input id="todo-0" type="checkbox" defaultChecked={true} />
@@ -234,7 +231,9 @@ Further down, you can find our [`<ul>`](/en-US/docs/Web/HTML/Element/ul) element
 <ul
   role="list"
   className="todo-list stack-large stack-exception"
-  aria-labelledby="list-heading">…</ul>
+  aria-labelledby="list-heading">
+  …
+</ul>
 ```
 
 The `role` attribute helps assistive technology explain what kind of element a tag represents. A `<ul>` is treated like a list by default, but the styles we're about to add will break that functionality. This role will restore the "list" meaning to the `<ul>` element. If you want to learn more about why this is necessary, you can check out [Scott O'Hara's article, "Fixing Lists"](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html).
@@ -465,10 +464,6 @@ body {
   [class*="__lg"] {
     font-size: 2.4rem;
   }
-}
-.filters {
-  width: 100%;
-  margin: unset auto;
 }
 /* Todo item styles */
 .todo {


### PR DESCRIPTION
This PR has the following changes:

* Broken link "https://mdn.github.io/todo-react-build" -> "https://mdn.github.io/todo-react"
* Remove dropped CSS rule
* Update last tested date

__Related issues and pull requests:__
- [ ] https://github.com/mdn/todo-react/pull/54