### PR TITLE
Use console.log in FileReader.onLoad example

### DIFF
--- a/files/en-us/web/api/filereader/error_event/index.md
+++ b/files/en-us/web/api/filereader/error_event/index.md
@@ -62,7 +62,7 @@ function handleSelected(e) {
         });
 
         reader.addEventListener('load', () => {
-            console.error(`File: ${selectedFile.name} read successfully`);
+            console.log(`File: ${selectedFile.name} read successfully`);
         });
 
         reader.readAsDataURL(selectedFile);


### PR DESCRIPTION
Since this is not an error, `console.log()` seems more appropriate.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
