### PR TITLE
added an explicit typecast for Ember Array

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
@@ -214,6 +214,8 @@ This is because Ember extends JavaScript's Array prototype by default, giving us
 There are dozens of these methods, including `pushObjects()`, `insertAt()`, or `popObject()`, which can be used with any type (not just Objects).
 Ember's [ArrayProxy](https://api.emberjs.com/ember/4.2/classes/ArrayProxy) also gives us more handy methods, like `isAny()`, `findBy()`, and `filterBy()` to make life easier.
 
+**Note:** If you receive a console error around the `pushObject()` function (e.g. `this.todos.pushObject is not a function`) you may need to explicitly typecast your JavaScript Array into an Ember Array using the `A()` method. Add `import { A } from '@ember/array';` at the top of the `todo-data.js` file, and replace `@tracked todos = []` with `@tracked todos = A()`.
+
 ## Using the service from our header component
 
 Now that we've defined a way to add todos, we can interact with this service from the `header.js` input component to actually start adding them.


### PR DESCRIPTION
This may be not be the best change, but I'm running Ember CLI 4.9.2 and needed to make this change to get past the error on `pushObject()` and enumeration. Is there a better way to fix this? Something got deprecated/changed in 4.x that is making your example (and most of what I find on StackOverflow) not work.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
