### PR TITLE
Repair bold element

### DIFF
--- a/files/en-us/web/html/element/b/index.md
+++ b/files/en-us/web/html/element/b/index.md
@@ -26,8 +26,8 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Usage notes
 
-- Do not use the `<b>` element.  All direct styling elements were deprecated in 1999 by HTML4.01, in favor of the use of CSS.
-  
+- Do not use the `<b>` element. All direct styling elements were deprecated in 1999 by HTML4.01, in favor of the use of CSS.
+
 ## Examples
 
 ```html

--- a/files/en-us/web/html/element/b/index.md
+++ b/files/en-us/web/html/element/b/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<b>: The Bring Attention To element'
+title: '<b>: The Bold element'
 slug: Web/HTML/Element/b
 tags:
   - Attention
@@ -16,7 +16,7 @@ browser-compat: html.elements.b
 
 {{HTMLSidebar}}
 
-The **`<b>`** [HTML](/en-US/docs/Web/HTML) element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use `<b>` for styling text; instead, you should use the CSS {{cssxref("font-weight")}} property to create boldface text, or the {{HTMLElement("strong")}} element to indicate that text is of special importance.
+The **`<b>`** [HTML](/en-US/docs/Web/HTML) element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. You should not use `<b>` for styling text; instead, you should use the CSS {{cssxref("font-weight")}} property to create boldface text, or the {{HTMLElement("strong")}} element to indicate that text is of special importance.
 
 {{EmbedInteractiveExample("pages/tabbed/b.html", "tabbed-shorter")}}
 
@@ -26,13 +26,8 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Usage notes
 
-- Use the `<b>` for cases like keywords in a summary, product names in a review, or other spans of text whose typical presentation would be boldfaced (but not including any special importance).
-- Do not confuse the `<b>` element with the {{HTMLElement("strong")}}, {{HTMLElement("em")}}, or {{HTMLElement("mark")}} elements. The {{HTMLElement("strong")}} element represents text of certain _importance_, {{HTMLElement("em")}} puts some emphasis on the text and the {{HTMLElement("mark")}} element represents text of certain _relevance_. The `<b>` element doesn't convey such special semantic information; use it only when no others fit.
-- Similarly, do not mark titles and headings using the `<b>` element. For this purpose, use the {{HTMLElement("h1")}} to {{HTMLElement("h6")}} tags. Further, stylesheets can change the default style of these elements, with the result that they are not _necessarily_ displayed in bold.
-- It is a good practice to use the {{htmlattrxref("class")}} attribute on the `<b>` element in order to convey additional semantic information as needed (for example `<b class="lead">` for the first sentence in a paragraph). This makes it easier to manage multiple use cases of `<b>` if your stylistic needs change, without the need to change all of its uses in the HTML.
-- Historically, the `<b>` element was meant to make text boldface. Styling information has been deprecated since HTML4, so the meaning of the `<b>` element has been changed.
-- If there is no semantic purpose to using the `<b>` element, you should use the CSS {{cssxref("font-weight")}} property with the value `"bold"` instead in order to make text bold.
-
+- Do not use the `<b>` element.  All direct styling elements were deprecated in 1999 by HTML4.01, in favor of the use of CSS.
+  
 ## Examples
 
 ```html


### PR DESCRIPTION
This has never been called the "bring attention to" element in any HTML standard.

This is actually the `bold` element, and Mozilla documentation should not be getting this wrong.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrects the name of the `<b>` element in documentation.

Replaces the "when to use" section with one that says "do not use this, because it's been deprecated since 1999."  The previous "when to use" section gave instructions that have been wrong for 24 years.

### Motivation

Someone decided to pretend that this is called the "bring attention to" element.  This is not true, and never has been true.
