### PR TITLE
remove "right normal" and "left auto" examples

### DIFF
--- a/files/en-us/web/css/place-self/index.md
+++ b/files/en-us/web/css/place-self/index.md
@@ -39,8 +39,6 @@ place-self: self-start auto;
 place-self: self-end normal;
 place-self: flex-start auto;
 place-self: flex-end normal;
-place-self: left auto;
-place-self: right normal;
 
 /* Baseline alignment */
 place-self: baseline normal;


### PR DESCRIPTION
### Description

"right" and "left" can't be matched with align-self

Formal syntax:
place-self = <'align-self'> <'justify-self'>?

### Motivation

Wrong syntax example
