### PR TITLE
hidden attribute: Fix syntax in the "See also" section

### DIFF
--- a/files/en-us/web/html/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/global_attributes/hidden/index.md
@@ -166,5 +166,5 @@ To run the example again, click "Reset".
 
 - {{DOMxRef("HTMLElement.hidden")}}
 - All [global attributes](/en-US/docs/Web/HTML/Global_attributes)
-- [`aria-hidden` attribute](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
-- The [`beforematch](/en-US/docs/Web/API/Element/beforematch_event) event
+- The [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute
+- The [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event


### PR DESCRIPTION
There was a missing backtick in the last link. In addition to fixing that, I also changed the link above it to have the same structure.