### PR TITLE
Repair italic element by renaming, removing false claims, rewriting core text

### DIFF
--- a/files/en-us/web/html/element/i/index.md
+++ b/files/en-us/web/html/element/i/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<i>: The Idiomatic Text element'
+title: '<i>: The Italic element'
 slug: Web/HTML/Element/i
 tags:
   - Element
@@ -13,7 +13,7 @@ browser-compat: html.elements.i
 
 {{HTMLSidebar}}
 
-The **`<i>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the `<i>` naming of this element.
+The **`<i>`** [HTML](/en-US/docs/Web/HTML) element represents an italicized range of text, for reasons such as references, and technical terms, among others. 
 
 {{EmbedInteractiveExample("pages/tabbed/i.html", "tabbed-shorter")}}
 
@@ -23,24 +23,11 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Usage notes
 
-- Use the `<i>` element for text that is set off from the normal prose for readability reasons. This would be a range of text with different semantic meaning than the surrounding text. Among the use cases for the `<i>` element are spans of text representing a different quality or mode of text, such as:
+Historically, this tag was used to indicate italic text, frequently for purposes of emphasis, to support style guides, to make document references, to indicate stress in dialogue, and so forth.  `<p>Usage looked <i>like this</i></p>.`
 
-  - Alternative voice or mood
-  - Taxonomic designations (such as the genus and species "_Homo sapiens_")
-  - Idiomatic terms from another language (such as "_et cetera_"); these should include the {{htmlattrxref("lang")}} attribute to identify the language
-  - Technical terms
-  - Transliterations
-  - Thoughts (such as "She wondered, _What is this writer talking about, anyway?_")
-  - Ship or vessel names in Western writing systems (such as "They searched the docks for the _Empress of the Galaxy_, the ship to which they were assigned.")
+However, this tag has been deprecated since 1999, and the modern approach is typically to use semantic elements indicating intent, rather than presentational elements to define appearance, so that readers with different needs can be supported.  Prefer tags like `<ref>`, `<cite>`, `<em>`, `<dfn>`, and so forth, as appropriate.
 
-- In earlier versions of the HTML specification, the `<i>` element was merely a presentational element used to display text in italics, much like the `<b>` element was used to display text in bold letters. This is no longer true, as these tags now define semantics rather than typographic appearance. A browser will typically still display the contents of the `<i>` element in italic type, but is, by definition, no longer required to do so. To display text in italic type, authors should use the CSS {{cssxref("font-style")}} property.
-- Be sure the text in question is not actually more appropriately marked up with another element.
-
-  - Use {{HTMLElement("em")}} to indicate stress emphasis.
-  - Use {{HTMLElement("strong")}} to indicate importance, seriousness, or urgency.
-  - Use {{HTMLElement("mark")}} to indicate relevance.
-  - Use {{HTMLElement("cite")}} to mark up the name of a work, such as a book, play, or song.
-  - Use {{HTMLElement("dfn")}} to mark up the defining instance of a term.
+Direct support for specific formatting is best handled with CSS, through rules like [`font-style: italic`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style), instead.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Changes name of element to fit RFC; repairs history; fixes examples

### Motivation

`<i>` has never been "the Idiomatic Text element."  

There is no actual HTML1 standard.  When we say HTML1, we refer to [Tim Berners-Lee's original proposal](http://info.cern.ch/hypertext/WWW/MarkUp/Tags.html), which was actually called "HTML Tags," not "HTML."  A quick text search shows that the only mention of italics is in a suggestion to browser implementers about how to display `<address>`.

The `<i>` tag is introduced in HTML2 RFC 1866, along with most of the other direct text formatting tags, under section 5.7.2.  `<i>` is specified by [5.7.2.2](https://datatracker.ietf.org/doc/html/rfc1866#section-5.7.2.2), which is clear that this means "italics."

No HTML standard ever published by W3C or WhatWG ever said anything otherwise.

The `<i>` tag is deprecated in [HTML 4](https://www.w3.org/TR/1998/REC-html40-19980424/), and removed in [HTML 4.01](https://www.w3.org/TR/html401/).

In the meantime, much of the explanatory text is also false.

Italics are not used for readability; [they significantly reduce readability](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3866130/).

Whereas rules for when italics are appropriate vary between traditions (eg the lists here for CMoS, SaW, APS, and MLAS are actually quite different,) none of them support almost any of these usage claims.  Given that there is not a clear right and wrong, and that this tag is disavowed, it seems inappropriate to give usage contexts at all, but rather that suggestions should be to avoid its use, and to explain its historical use.

The claims about `<i>` somehow "no longer meaning italic because semantics" have been wholesale removed.  `<i>` has never meant anything other than italic.  It went from italic in html2 to removed in html4.01, and there was never anything inbetween.  This was just fabricated, and it has propagated to other documentation.

### Additional details

[HTML2 RFC 1866 section 5.7.2.2](https://datatracker.ietf.org/doc/html/rfc1866#section-5.7.2.2)

### Related issues and pull requests

https://github.com/mdn/content/pull/23634 , regarding `<b>`