### PR TITLE
Repair the underline element

### DIFF
--- a/files/en-us/web/html/element/u/index.md
+++ b/files/en-us/web/html/element/u/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<u>: The Unarticulated Annotation (Underline) element'
+title: '<u>: The Underline element'
 slug: Web/HTML/Element/u
 tags:
   - Annotation
@@ -18,9 +18,7 @@ browser-compat: html.elements.u
 
 {{HTMLSidebar}}
 
-The **`<u>`** [HTML](/en-US/docs/Web/HTML) element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS.
-
-> **Warning:** This element used to be called the "Underline" element in older versions of HTML, and is still sometimes misused in this way. To underline text, you should instead apply a style that includes the CSS {{cssxref("text-decoration")}} property set to `underline`.
+The **`<u>`** [HTML](/en-US/docs/Web/HTML) element represents a span of inline text which should be underlined.
 
 {{EmbedInteractiveExample("pages/tabbed/u.html", "tabbed-shorter")}}
 
@@ -32,60 +30,25 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Usage notes
 
-Along with other pure styling elements, the original HTML Underline (`<u>`) element was deprecated in HTML 4; however, `<u>` was restored in HTML 5 with a new, semantic, meaning: to mark text as having some form of non-textual annotation applied.
-
-> **Note:** Avoid using the `<u>` element with its default styling (of underlined text) in such a way as to be confused with a hyperlink, which is also underlined by default.
-
-### Use cases
-
-Valid use cases for the `<u>` element include annotating spelling errors, applying a [proper name mark](https://en.wikipedia.org/wiki/Proper_name_mark) to denote proper names in Chinese text, and other forms of annotation.
-
-You should _not_ use `<u>` to underline text for presentation purposes, or to denote titles of books.
-
-### Other elements to consider using
-
-In most cases, you should use an element other than `<u>`, such as:
-
-- {{HTMLElement("em")}} to denote stress emphasis
-- {{HTMLElement("b")}} to draw attention to text
-- {{HTMLElement("mark")}} to mark key words or phrases
-- {{HTMLElement("strong")}} to indicate that text has strong importance
-- {{HTMLElement("cite")}} to mark the titles of books or other publications
-- {{HTMLElement("i")}} to denote technical terms, transliterations, thoughts, or names of vessels in Western texts
-
-To provide textual annotations (as opposed to the non-textual annotations created with `<u>`), use the {{HTMLElement("ruby")}} element.
-
-To apply an underlined appearance without any semantic meaning, use the {{cssxref("text-decoration")}} property's value `underline`.
+In general, `<u>` should not be used anymore.  Whereas it was re-added in HTML5, `<u>` was deprecated for more than a decade, in favor of the use of semantic tags and/or CSS to style elements instead; modern practice is to prefer tags like `<cite>`, `<strong>`, `<ref>`, or whatever is appropriate to your use case, then to style it with CSS using rules like [text-decoration: underline](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration), if necessary, instead.
 
 ## Examples
 
-### Indicating a spelling error
-
-This example uses the `<u>` element and some CSS to display a paragraph which includes a misspelled error, with the error indicated in the red wavy underline style which is fairly commonly used for this purpose.
-
-#### HTML
-
 ```html
-<p>This paragraph includes a <u class="spelling">wrnogly</u> spelled word.</p>
+<p>This paragraph includes <u>outdated code</u> that should be avoided.</p>
 ```
-
-In the HTML, we see the use of `<u>` with a class, `spelling`, which is used to indicate the misspelling of the word "wrongly".
 
 #### CSS
 
-```css
-u.spelling {
-  text-decoration: red wavy underline;
-}
+```html
+<p>This is an example of <span class="underline">CSS-based underlining</span>.</p>
 ```
 
-This CSS indicates that when the `<u>` element is styled with the class `spelling`, it should have a red wavy underline underneath its text. This is a common styling for spelling errors. Another common style can be presented using `red dashed underline`.
-
-#### Result
-
-The result should be familiar to anyone who has used any of the more popular word processors available today.
-
-{{EmbedLiveSample("Indicating_a_spelling_error", 650, 80)}}
+```css
+span.underline {
+  text-decoration: underline;
+}
+```
 
 ### Avoiding \<u>
 


### PR DESCRIPTION
### Description

Changes name of element to fit RFC; repairs history; fixes examples

### Motivation

`<u>` has never been "the Unarticulated Annotation element."  

There is no actual HTML1 standard.  When we say HTML1, we refer to [Tim Berners-Lee's original proposal](http://info.cern.ch/hypertext/WWW/MarkUp/Tags.html), which was actually called "HTML Tags," not "HTML."  A quick text search shows that underlining is never mentioned.

The `<u>` tag is introduced in HTML2 RFC 1866, along with most of the other direct text formatting tags, under section 5.7.2.  Unlike bold and italic, which have their own subheadings, underline is discussed directly in [the 5.7.2 example](https://datatracker.ietf.org/doc/html/rfc1866#section-5.7.2), which is clear that it means "underline."

No HTML standard ever published by W3C or WhatWG ever said anything otherwise.

The `<u>` tag is deprecated in [HTML 4](https://www.w3.org/TR/1998/REC-html40-19980424/), and removed in [HTML 4.01](https://www.w3.org/TR/html401/).

The `<u>` tag is re-added in HTML5.  HTML5 does not give titles to tags at all.  This does not give this documentation license to fabricate a new title in contrast with its historical title.

### Additional details

[HTML2 RFC 1866 section 5.7.2](https://datatracker.ietf.org/doc/html/rfc1866#section-5.7.2)

### Related issues and pull requests

* https://github.com/mdn/content/pull/23634 , regarding `<b>`, and 
* https://github.com/mdn/content/pull/23639 , regarding `<i>`