### PR TITLE
OffscreenCanvas.getContext: change return type for "2d" contentType

### DIFF
--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -82,7 +82,7 @@ getContext(contextType, contextAttributes)
 
 A rendering context which is either a
 
-- {{domxref("CanvasRenderingContext2D")}} for `"2d"`,
+- {{domxref("OffscreenCanvasRenderingContext2D")}} for `"2d"`,
 - {{domxref("WebGLRenderingContext")}} for `"webgl"` and `"experimental-webgl"`,
 - {{domxref("WebGL2RenderingContext")}} for `"webgl2"` and `"experimental-webgl2"` {{experimental_inline}}, or
 - {{domxref("ImageBitmapRenderingContext")}} for `"bitmaprenderer"`.


### PR DESCRIPTION
### Description

`getContext` returns an `OffscreenCanvasRenderingContext2D`, not a basic `CanvasRenderingContext2D`.

See https://html.spec.whatwg.org/multipage/canvas.html#offscreen-context-type-2d

### Related issues and pull requests
N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
