### PR TITLE
fixed dead JSON link and tag

### DIFF
--- a/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.md
+++ b/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.md
@@ -7,7 +7,7 @@ tags:
   - Add-ons
   - DOM
   - Extensions
-  - JXON
+  - JSON
   - NeedsUpdate
   - XML
 ---
@@ -146,7 +146,7 @@ You can use DOM trees to model data which isn't well-suited for RDF (or perhaps 
 ## See also
 
 - [XML](/en-US/docs/Web/XML)
-- [JXON](/en-US/docs/JXON)
+- [JSON](/en-US/docs/JSON)
 - [XPath](/en-US/docs/Web/XPath)
 - [Parsing and serializing XML](/en-US/docs/Web/Guide/Parsing_and_serializing_XML)
 - [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest)


### PR DESCRIPTION
JSON was titled "JXON" causing confusion on the name, as well as a dead URL in the "See Also" section

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
