### PR TITLE
Remove <command> from HTML attributes page

### DIFF
--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -246,10 +246,9 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
-        <code><a href="/en-US/docs/Web/HTML/Attributes/checked">checked</a></code>
+        <code><a href="/en-US/docs/Web/HTML/Element/input#checked">checked</a></code>
       </td>
       <td>
-        {{ HTMLElement("command") }},
         {{ HTMLElement("input") }}
       </td>
       <td>Indicates whether the element should be checked on page load.</td>
@@ -484,7 +483,6 @@ Elements in HTML have **attributes**; these are additional values that configure
       </td>
       <td>
         {{ HTMLElement("button") }},
-        {{ HTMLElement("command") }},
         {{ HTMLElement("fieldset") }},
         {{ HTMLElement("input") }},
         {{ HTMLElement("keygen") }},
@@ -729,13 +727,6 @@ Elements in HTML have **attributes**; these are additional values that configure
       </td>
       <td>{{ HTMLElement("meta") }}</td>
       <td>Defines a pragma directive.</td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="/en-US/docs/Web/HTML/Element/command#attr-icon">icon</a></code>
-      </td>
-      <td>{{ HTMLElement("command") }}</td>
-      <td>Specifies a picture which represents the command.</td>
     </tr>
     <tr>
       <td>
@@ -1125,13 +1116,6 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
-        <code><a href="/en-US/docs/Web/HTML/Element/command#attr-radiogroup">radiogroup</a></code>
-      </td>
-      <td>{{ HTMLElement("command") }}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>
         <code><a href="/en-US/docs/Web/HTML/Attributes/readonly">readonly</a></code>
       </td>
       <td>
@@ -1427,7 +1411,6 @@ Elements in HTML have **attributes**; these are additional values that configure
       <td>
         {{ HTMLElement("button") }},
         {{ HTMLElement("input") }},
-        {{ HTMLElement("command") }},
         {{ HTMLElement("embed") }},
         {{ HTMLElement("object") }},
         {{ HTMLElement("ol") }},


### PR DESCRIPTION
command is not in the living spec, and there is no documentation on MDN about it.

* Removed links to the non-existant command page (a red link)
* Removed links to the attributes specific to command that aren't documented. (all red links)
* redirected the checked attribute to the definition on the input page (was a red link)