### PR TITLE
added link to elements in their interface pages

### DIFF
--- a/files/en-us/web/api/htmloptionelement/index.md
+++ b/files/en-us/web/api/htmloptionelement/index.md
@@ -58,3 +58,4 @@ _Doesn't implement any specific method, but inherits methods from its parent, {{
 ## See also
 
 - The HTML element implementing this interface: {{HTMLElement("option")}}.
+- The {{domxref("HTMLOptionsCollection")}} interface.

--- a/files/en-us/web/api/htmltablecaptionelement/index.md
+++ b/files/en-us/web/api/htmltablecaptionelement/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableCaptionElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTableCaptionElement`** interface provides special properties (beyond the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating table caption elements.
+The **`HTMLTableCaptionElement`** interface provides special properties (beyond the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating table {{HTMLElement("caption")}} elements.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -16,7 +16,7 @@ browser-compat: api.HTMLTableCellElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTableCellElement`** interface provides special properties and methods (beyond the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of table cells, either header or data cells, in an HTML document.
+The **`HTMLTableCellElement`** interface provides special properties and methods (beyond the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of table cells, either header cells ({{HTMLElement("th")}})) or data cells ({{HTMLElement("td")}}), in an HTML document.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmltablesectionelement/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableSectionElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTableSectionElement`** interface provides special properties and methods (beyond the {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies  ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, and {{HTMLElement("tbody")}}, respectively) in an HTML table.
+The **`HTMLTableSectionElement`** interface provides special properties and methods (beyond the {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, and {{HTMLElement("tbody")}}, respectively) in an HTML table.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmltablesectionelement/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableSectionElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTableSectionElement`** interface provides special properties and methods (beyond the {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies, in an HTML table.
+The **`HTMLTableSectionElement`** interface provides special properties and methods (beyond the {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies  ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, and {{HTMLElement("tbody")}}, respectively) in an HTML table.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmltitleelement/index.md
+++ b/files/en-us/web/api/htmltitleelement/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTitleElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTitleElement`** interface contains the title for a document. This element inherits all of the properties and methods of the {{domxref("HTMLElement")}} interface.
+The **`HTMLTitleElement`** interface is implemented by a document's {{ HTMLElement( "title" )}}. This element inherits all of the properties and methods of the {{domxref("HTMLElement")}} interface.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmlulistelement/index.md
+++ b/files/en-us/web/api/htmlulistelement/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLUListElement
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLUListElement`** interface provides special properties (beyond those defined on the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating unordered list elements.
+The **`HTMLUListElement`** interface provides special properties (beyond those defined on the regular {{domxref("HTMLElement")}} interface it also has available to it by inheritance) for manipulating unordered list ({{HTMLElement("ul")}}) elements.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmlvideoelement/index.md
+++ b/files/en-us/web/api/htmlvideoelement/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLVideoElement
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLVideoElement`** interface provides special properties and methods for manipulating video objects. It also inherits properties and methods of {{domxref("HTMLMediaElement")}} and {{domxref("HTMLElement")}}.
+Implementing by the {{HTMLElement("video")}} element, the **`HTMLVideoElement`** interface provides special properties and methods for manipulating video objects. It also inherits properties and methods of {{domxref("HTMLMediaElement")}} and {{domxref("HTMLElement")}}.
 
 The list of [supported media formats](/en-US/docs/Web/Media/Formats) varies from one browser to the other. You should either provide your video in a single format that all the relevant browsers supports, or provide multiple video sources in enough different formats that all the browsers you need to support are covered.
 

--- a/files/en-us/web/api/htmlvideoelement/index.md
+++ b/files/en-us/web/api/htmlvideoelement/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLVideoElement
 
 {{APIRef("HTML DOM")}}
 
-Implementing by the {{HTMLElement("video")}} element, the **`HTMLVideoElement`** interface provides special properties and methods for manipulating video objects. It also inherits properties and methods of {{domxref("HTMLMediaElement")}} and {{domxref("HTMLElement")}}.
+Implemented by the {{HTMLElement("video")}} element, the **`HTMLVideoElement`** interface provides special properties and methods for manipulating video objects. It also inherits properties and methods of {{domxref("HTMLMediaElement")}} and {{domxref("HTMLElement")}}.
 
 The list of [supported media formats](/en-US/docs/Web/Media/Formats) varies from one browser to the other. You should either provide your video in a single format that all the relevant browsers supports, or provide multiple video sources in enough different formats that all the browsers you need to support are covered.
 


### PR DESCRIPTION
The elements implementing the interface should be mentioned in the first sentence. Not sure all of these are the best edit. If you have a better suggestion, awesome. But the link to the element(s) that implement the interfaces should be in the first paragraph.

Also added a see also for options collection to option
