### PR TITLE
Fix link formatting

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
@@ -56,7 +56,7 @@ The table below details the differences between the methods available on the `Ob
         {{jsxref("Reflect.has()")}} returns <code>true</code> if the
         property exists on the object or on its prototype chain or
         <code>false</code> otherwise, similar to the
-        [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in).
+        {{jsxref("in")}} operator.
         Throws a <code>TypeError</code> if the target was not
         an <code>Object</code>.
       </td>

--- a/files/en-us/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
@@ -56,7 +56,7 @@ The table below details the differences between the methods available on the `Ob
         {{jsxref("Reflect.has()")}} returns <code>true</code> if the
         property exists on the object or on its prototype chain or
         <code>false</code> otherwise, similar to the
-        {{jsxref("in")}} operator.
+        {{jsxref("Operators/in", "in")}} operator.
         Throws a <code>TypeError</code> if the target was not
         an <code>Object</code>.
       </td>


### PR DESCRIPTION
Fix link to `in operator`
### Motivation

Before:
![image](https://user-images.githubusercontent.com/9786571/212609235-7e0dc666-d623-4904-91a7-5455d07d055b.png)

After:
![image](https://user-images.githubusercontent.com/9786571/212613806-9ee898e2-53f0-4891-a6c2-733f9225545f.png)
