### PR TITLE
update substr with substring

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -169,7 +169,7 @@ function base64EncArr(aBytes) {
     }
   }
   return (
-    sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) +
+    sB64Enc.substring(0, sB64Enc.length - 2 + nMod3) +
     (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==")
   );
 }


### PR DESCRIPTION
substr is deprecated, and in this instance I think substr should be replaceable with substring. Can you verify that this is true? https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr

When developers cut and paste this code, then substr is flagged as an issue in the ide that will take needless time to verify.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
