### PR TITLE
remove adding linebreaks to base64 code

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -102,7 +102,7 @@ function b64ToUint6(nChr) {
 }
 
 function base64DecToArr(sBase64, nBlocksSize) {
-  const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, "");
+  const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, ""); //this step is only necessary if your base64 includes whitespace such as line breaks.
   const nInLen = sB64Enc.length;
   const nOutLen = nBlocksSize
     ? Math.ceil(((nInLen * 3 + 1) >> 2) / nBlocksSize) * nBlocksSize
@@ -153,9 +153,9 @@ function base64EncArr(aBytes) {
   let nUint24 = 0;
   for (let nIdx = 0; nIdx < nLen; nIdx++) {
     nMod3 = nIdx % 3;
-    if (nIdx > 0 && ((nIdx * 4) / 3) % 76 === 0) {
-      sB64Enc += "\r\n";
-    }
+//    if (nIdx > 0 && ((nIdx * 4) / 3) % 76 === 0) {  //include this if you want line breaks in your base64.
+//      sB64Enc += "\r\n";
+//    }
 
     nUint24 |= aBytes[nIdx] << ((16 >>> nMod3) & 24);
     if (nMod3 === 2 || aBytes.length - nIdx === 1) {

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -102,7 +102,7 @@ function b64ToUint6(nChr) {
 }
 
 function base64DecToArr(sBase64, nBlocksSize) {
-  const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, ""); //this step is only necessary if your base64 includes whitespace such as line breaks.
+  const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, ""); // Only necessary if the base64 includes whitespace such as line breaks.
   const nInLen = sB64Enc.length;
   const nOutLen = nBlocksSize
     ? Math.ceil(((nInLen * 3 + 1) >> 2) / nBlocksSize) * nBlocksSize

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -153,7 +153,8 @@ function base64EncArr(aBytes) {
   let nUint24 = 0;
   for (let nIdx = 0; nIdx < nLen; nIdx++) {
     nMod3 = nIdx % 3;
-//    if (nIdx > 0 && ((nIdx * 4) / 3) % 76 === 0) {  //include this if you want line breaks in your base64.
+// To break your base64 into several 80-character lines, add:
+//   if (nIdx > 0 && ((nIdx * 4) / 3) % 76 === 0) {
 //      sB64Enc += "\r\n";
 //    }
 


### PR DESCRIPTION
I think line breaks here are needlessly confusing and unnecessary.

1.  if line breaks are to be added, I think they should be done in a separate function *after* the base64 has been added. Such as this: `addLineBreaksEvery(base64EncArrWithoutLineBreaks(array), 76)`.

2. if there are line breaks that are added, then you must first remove the line breaks to use the base64 in for example cookies.

I am quite confident that these changes can be added as is, but it would be good if someone knowledgeable can double check my assumptions:)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
