### PR TITLE
Deleting a stray angle bracket

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.uniform[1234][uif][v]()`**
 methods of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specify values of
 uniform variables.
 
-> **Note:** `ui` stands for _unsigned integer_, `i` for _integer,_ > `f` for _float_, and `v` for _vector._
+> **Note:** `ui` stands for _unsigned integer_, `i` for _integer_, `f` for _float_, and `v` for _vector_.
 > Not all combinations are valid: `u` cannot be combined with `f`.
 > See the syntax table below. Equivalent Regex: `uniform[1234](u?i|f)v?`
 


### PR DESCRIPTION
### Description

Deletes a stray angle bracket on https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform in the note section.

### Additional details

This angle bracket came in https://github.com/mdn/content/commit/2279e5ae6c229c707a014a22aa1ec4635a0f981f where the Markdown conversion seems to have been done by some automation script. Other stray characters might have also come in that huge commit.