### PR TITLE
Add a reference to `chrome.dom.openOrClosedShadowRoot`

### DIFF
--- a/files/en-us/web/api/element/openorclosedshadowroot/index.md
+++ b/files/en-us/web/api/element/openorclosedshadowroot/index.md
@@ -48,3 +48,4 @@ _This property is not part of any specification._
 ## See also
 
 - {{DOMxRef("Element.shadowRoot")}}
+- [`chrome.dom.openOrClosedShadowRoot`](https://developer.chrome.com/docs/extensions/reference/dom/#method-openOrClosedShadowRoot)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add a reference to chromium implementation of the extension API
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
It would be helpful for extension developers aiming for cross-browser compatibility or otherwise landing on the MDN page while developing for Chromium.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://stackoverflow.com/questions/70489914/open-the-closed-shadowroot-of-element-inserted-by-other-extension-in-chrome
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #11827

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
