### PR TITLE
docs(vue): Add hint that template tags cannot be empty

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
@@ -230,9 +230,9 @@ components: {
 }
 ```
 
-Your rendered app should no longer show an error, just a blank page, as we currently have no visible content inside `<template>`.
-
-Let's add a new `<h1>` inside `<div id="app">`. Since we're going to be creating a todo list app below, let's set our header text to "To-Do List". Add it like so:
+The `<template>` tag is empty now so you'll see an error saying `The template requires child element` in both the console and the rendered app.
+You can fix this by adding some content inside the `<template>` tag and we can start with a new `<h1>` element inside a `<div>`.
+Since we're going to be creating a todo list app below, let's set our heading to "To-Do List" like so:
 
 ```html
 <template>


### PR DESCRIPTION
Most people are using Vue 3 for the guide as this is the default when scaffolding apps using the Vue CLI (e.g. `vue create moz-todo-vue`). This PR adds a hint that you'll encounter an error with empty `<template>` tags when modifying the generated code and that it's to be expected.

__Related issues and PRs:__
- https://github.com/mdn/todo-vue/issues/65
- https://github.com/mdn/todo-vue/issues/64