### PR TITLE
Removed redundant "value".

### DIFF
--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -52,7 +52,7 @@ Cross-Origin-Opener-Policy: same-origin
 
 ### Certain features depend on cross-origin isolation
 
-Certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers are only available if your document has a COOP header with the value `same-origin` value set.
+Certain features like {{jsxref("SharedArrayBuffer")}} objects or {{domxref("Performance.now()")}} with unthrottled timers are only available if your document has a COOP header with the value `same-origin` set.
 
 ```http
 Cross-Origin-Opener-Policy: same-origin


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Removed redundant word "value" from the sentence "with the value `same-origin` value set."

### Motivation
This change removes an unnecessary word which interrupts the flow of the sentence.

