### PR TITLE
`new KeyframeEffect()` accepts any `<easing-function>`

### DIFF
--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
@@ -44,7 +44,7 @@ The multi-argument constructor (see above) creates a completely new {{domxref("K
     - `duration` {{optional_inline}}
       - : The number of milliseconds each iteration of the animation takes to complete. Defaults to 0. Although this is technically optional, keep in mind that your animation will not run if this value is 0.
     - `easing` {{optional_inline}}
-      - : The rate of the animation's change over time. Accepts the pre-defined values `"linear"`, `"ease"`, `"ease-in"`, `"ease-out"`, and `"ease-in-out"`, or a custom `"cubic-bezier"` value like `"cubic-bezier(0.42, 0, 0.58, 1)"`. Defaults to `"linear"`.
+      - : The rate of the animation's change over time. Accepts an {{cssxref("easing-function")}}, such as `"linear"`, `"ease-in"`, `"step-end"`, or `"cubic-bezier(0.42, 0, 0.58, 1)"`. Defaults to `"linear"`.
     - `endDelay` {{optional_inline}}
       - : The number of milliseconds to delay after the end of an animation. This is primarily of use when sequencing animations based on the end time of another animation. Defaults to 0.
     - `fill` {{optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Clarify that [`new KeyframeEffect()`](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect)'s `easing` option accepts any CSS `<easing-function>`, and link to the [`<easing-function>`](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function) documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Existing documentation misleadingly suggests that most `<easing-function>`s are disallowed. The change also makes it easier to find documentation on the option's semantics.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The relevant part of the standard is the [`EffectTiming` interface](https://w3c.github.io/csswg-drafts/web-animations-1/#dom-effecttiming-easing), from which [`KeyframeEffectOptions`](https://w3c.github.io/csswg-drafts/web-animations-1/#the-keyframeeffectoptions-dictionary) inherits.

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
