### PR TITLE
Add previousslide and nextslide MediaSession actions

### DIFF
--- a/files/en-us/web/api/media_session_api/index.md
+++ b/files/en-us/web/api/media_session_api/index.md
@@ -50,6 +50,8 @@ navigator.mediaSession.playbackState = "playing";
 
 ## Examples
 
+### Setting up action handlers for a music player
+
 The following example shows feature detection for the Media Session API. It then instantiates a metadata object for the session, and adds action handlers for the user control actions:
 
 ```js
@@ -92,6 +94,34 @@ playButton.addEventListener('pointerup', (event) => {
   .catch((error) => { console.error(error) });
 });
 ```
+
+### Using action handlers to control a slide presentation
+
+The `"previousslide"` and `"nextslide"` action handlers can be used to handle moving forward and backward through a slide presentation, for example when the user puts their presentation into a {{domxref("Picture-in-Picture API", "Picture-in-Picture", "", "nocode")}} window, and presses the browser-supplied controls for navigating through slides.
+
+```js
+try {
+  navigator.mediaSession.setActionHandler("previousslide", () => {
+    log('> User clicked "Previous Slide" icon.');
+    if (slideNumber > 1) slideNumber--;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "previousslide" media session action is not supported.');
+}
+
+try {
+  navigator.mediaSession.setActionHandler("nextslide", () => {
+    log('> User clicked "Next Slide" icon.');
+    slideNumber++;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "nextslide" media session action is not supported.');
+}
+```
+
+See [Presenting Slides / Media Session Sample](https://googlechrome.github.io/samples/media-session/slides.html) for a working example.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -36,6 +36,8 @@ For example, a smartphone might have a standard panel in its lock screen that pr
 
 ## Examples
 
+### Setting up action handlers for a music player
+
 The following example creates a new media session and assigns action handlers to it:
 
 ```js
@@ -107,6 +109,34 @@ for (const [action, handler] of actionHandlers) {
   }
 }
 ```
+
+### Using action handlers to control a slide presentation
+
+The `"previousslide"` and `"nextslide"` action handlers can be used to handle moving forward and backward through a slide presentation, for example when the user puts their presentation into a {{domxref("Picture-in-Picture API", "Picture-in-Picture", "", "nocode")}} window, and presses the browser-supplied controls for navigating through slides.
+
+```js
+try {
+  navigator.mediaSession.setActionHandler("previousslide", () => {
+    log('> User clicked "Previous Slide" icon.');
+    if (slideNumber > 1) slideNumber--;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "previousslide" media session action is not supported.');
+}
+
+try {
+  navigator.mediaSession.setActionHandler("nextslide", () => {
+    log('> User clicked "Next Slide" icon.');
+    slideNumber++;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "nextslide" media session action is not supported.');
+}
+```
+
+See [Presenting Slides / Media Session Sample](https://googlechrome.github.io/samples/media-session/slides.html) for a working example.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -34,12 +34,16 @@ setActionHandler(type, callback)
     of the following:
     - `hangup`
       - : End a call.
+    - `nextslide`
+      - : Moves to the next slide, when presenting a slide deck.
     - `nexttrack`
       - : Advances playback to the next track.
     - `pause`
       - : Pauses playback of the media.
     - `play`
       - : Begins (or resumes) playback of the media.
+    - `previousslide`
+      - : Moves to the previous slide, when presenting a slide deck.
     - `previoustrack`
       - : Moves back to the previous track.
     - `seekbackward`
@@ -88,6 +92,8 @@ To remove a previously-established action handler, call `setActionHandler()` aga
 The action handler receives as input a single parameter: an object which provides both the action type (so the same function can handle multiple action types), as well as data needed in order to perform the action.
 
 ## Examples
+
+### Setting up action handlers for a music player
 
 This example creates a new media session and assigns action handlers (which don't do anything) to it.
 
@@ -204,6 +210,34 @@ function handleSeek(details) {
 ```
 
 Here, the `handleSeek()` function handles both `seekbackward` and `seekforward` actions.
+
+### Using action handlers to control a slide presentation
+
+The `"previousslide"` and `"nextslide"` action handlers can be used to handle moving forward and backward through a slide presentation, for example when the user puts their presentation into a {{domxref("Picture-in-Picture API", "Picture-in-Picture", "", "nocode")}} window, and presses the browser-supplied controls for navigating through slides.
+
+```js
+try {
+  navigator.mediaSession.setActionHandler("previousslide", () => {
+    log('> User clicked "Previous Slide" icon.');
+    if (slideNumber > 1) slideNumber--;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "previousslide" media session action is not supported.');
+}
+
+try {
+  navigator.mediaSession.setActionHandler("nextslide", () => {
+    log('> User clicked "Next Slide" icon.');
+    slideNumber++;
+    updateSlide();
+  });
+} catch (error) {
+  log('Warning! The "nextslide" media session action is not supported.');
+}
+```
+
+See [Presenting Slides / Media Session Sample](https://googlechrome.github.io/samples/media-session/slides.html) for a working example.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds information and an example to explain the new `previousslide` and `nextslide` [MediaSession](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession) actions.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

@beaufortfrancois previously added the BCD for these features (see https://github.com/mdn/browser-compat-data/pull/18463 for the latest update), and I thought it would be good to add a complementary explanation to the docs.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
