### PR TITLE
Fix missing space in hasOwnProperty documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -119,7 +119,7 @@ The elements of an {{jsxref("Array")}} are defined as direct properties, so
 you can use `hasOwn()` method to check whether a particular index exists:
 
 ```js
-const fruits = ['Apple', 'Banana','Watermelon', 'Orange'];
+const fruits = ['Apple', 'Banana', 'Watermelon', 'Orange'];
 Object.hasOwn(fruits, 3);   // true ('Orange')
 Object.hasOwn(fruits, 4);   // false - not defined
 ```


### PR DESCRIPTION
### Description

Fixed a syntactical error (missing space in array definition) in the `hasOwnProperty` documentation.

### Motivation

It syncs up the code style according to the rest of the documentation, making the documentation easier to read.

### Additional details

n/a

### Related issues and pull requests

n/a