### PR TITLE
Fix wrong wrapping in form example

### DIFF
--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -198,12 +198,10 @@ Let's put these ideas into practice and build a slightly more involved form — 
    <link href="payment-form.css" rel="stylesheet" />
    ```
 
-3. Next, create your form by adding the outer {{htmlelement("form")}} element:
+3. Next, create your form by adding the outer {{htmlelement("form")}} opening tag:
 
    ```html
    <form>
-     …
-   </form>
    ```
 
 4. Inside the `<form>` tags, add a heading and paragraph to inform users how required fields are marked:
@@ -320,6 +318,12 @@ Let's put these ideas into practice and build a slightly more involved form — 
        <button type="submit">Validate the payment</button>
      </p>
    </section>
+   ```
+
+8. Finally, complete your form by adding the outer {{htmlelement("form")}} closing tag:
+
+   ```html
+   </form>
    ```
 
 You can see the finished form in action below (also find it on GitHub — see our payment-form.html [source](https://github.com/mdn/learning-area/blob/main/html/forms/html-form-structure/payment-form.html) and [running live](https://mdn.github.io/learning-area/html/forms/html-form-structure/payment-form.html)):


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Previously, the code block indicates the form element with `<form> ... </form`, which does not play nice with the embed live sample macro. Let's fix it by splitting it into two steps to wrap the form content properly.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix example.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
nil
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #23737
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
