### PR TITLE
fix typo and correct the condition of `NotSupported` exception

### DIFF
--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -19,7 +19,7 @@ The **`deriveBits()`** method of the
 key.
 
 It takes as its arguments the base key, the derivation algorithm to use, and the length
-of the bit string to derive. It returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+of the bits to derive. It returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 which will be fulfilled with an
 [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
 containing the derived bits.
@@ -79,8 +79,7 @@ The promise is rejected when one of the following exceptions are encountered:
     `deriveBits`.
 - `NotSupported` {{domxref("DOMException")}}
   - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
-    derivation, or if the algorithm requested for the derived key doesn't define a key
-    length.
+    derivation.
 
 ## Supported algorithms
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix typo and correct the condition of `NotSupported` exception.

### Motivation

See the signature of `deriveBits()`. The `algorithm` param just does not need the `length` property. I thinks with description may from [`deriveKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey#exceptions) which actually need the `length` property.

![image](https://user-images.githubusercontent.com/15844309/213341052-6050be87-f3f5-460f-be24-48703007cb13.png)

![image](https://user-images.githubusercontent.com/15844309/213341097-5166404a-66e2-4aa5-901a-b4b144021695.png)

See also: https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits