### PR TITLE
Fix erroneous split() separator description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
@@ -28,7 +28,7 @@ endsWith(searchString, endPosition)
 ### Parameters
 
 - `searchString`
-  - : The characters to be searched for at the end of `str`. Cannot be a regex.
+  - : The characters to be searched for at the end of `str`. Cannot [be a regex](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes). All values that are not regexes are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `endsWith()` to search for the string `"undefined"`, which is rarely what you want.
 - `endPosition` {{optional_inline}}
   - : The end position at which `searchString` is expected to be found (the index of `searchString`'s last character plus 1). Defaults to `str.length`.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
@@ -28,7 +28,7 @@ includes(searchString, position)
 ### Parameters
 
 - `searchString`
-  - : A string to be searched for within `str`. Cannot be a regex.
+  - : A string to be searched for within `str`. Cannot [be a regex](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes). All values that are not regexes are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `includes()` to search for the string `"undefined"`, which is rarely what you want.
 - `position` {{optional_inline}}
   - : The position within the string at which to begin searching for `searchString`. (Defaults to `0`.)
 

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -29,9 +29,7 @@ indexOf(searchString, position)
 
 - `searchString`
 
-  - : Substring to search for, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion).
-
-    If the method is called with no arguments, `searchString` is coerced to `"undefined"`. Therefore,`"undefined".indexOf()` returns `0` — because the substring `"undefined"` is found at position `0` in the string `"undefined"`. But `"undefine".indexOf()`, returns `-1` — because the substring `"undefined"` is not found in the string `"undefine"`.
+  - : Substring to search for. All values are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `indexOf()` to search for the string `"undefined"`, which is rarely what you want.
 
 - `position` {{optional_inline}}
 

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -29,9 +29,7 @@ lastIndexOf(searchString, position)
 
 - `searchString`
 
-  - : Substring to search for, [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion).
-
-    If the method is called with no arguments, `searchString` is coerced to `"undefined"`. Therefore,`"undefined".lastIndexOf()` returns `0` — because the substring `"undefined"` is found at position `0` in the string `"undefined"`. But `"undefine".lastIndexOf()`, returns `-1` — because the substring `"undefined"` is not found in the string `"undefine"`.
+  - : Substring to search for. All values are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `indexOf()` to search for the string `"undefined"`, which is rarely what you want.
 
 - `position` {{optional_inline}}
 

--- a/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -33,7 +33,7 @@ The `locales` and `options` parameters customize the behavior of the function an
 In implementations that support the [`Intl.Collator` API](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator), these parameters correspond exactly to the [`Intl.Collator()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator) constructor's parameters. Implementations without `Intl.Collator` support are asked to ignore both parameters, making the comparison result returned entirely implementation-dependent — it's only required to be _consistent_.
 
 - `compareString`
-  - : The string against which the `referenceStr` is compared.
+  - : The string against which the `referenceStr` is compared. All values are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `localeCompare()` to compare against the string `"undefined"`, which is rarely what you want.
 - `locales` {{optional_inline}}
 
   - : A string with a BCP 47 language tag, or an array of such strings. Corresponds to the [`locales`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#locales) parameter of the `Intl.Collator()` constructor.

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -22,15 +22,14 @@ The **`split()`** method takes a pattern and divides a {{jsxref("String")}} into
 ## Syntax
 
 ```js-nolint
-split()
 split(separator)
 split(separator, limit)
 ```
 
 ### Parameters
 
-- `separator` {{optional_inline}}
-  - : The pattern describing where each split should occur. Can be a string or an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method — the typical example being a {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}. If undefined, the original target string is returned wrapped in an array.
+- `separator`
+  - : The pattern describing where each split should occur. Can be a string or an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method — the typical example being a {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}. All values that are not objects with a `@@split` method are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `split()` to split by the string `"undefined"`, which is rarely what you want.
 - `limit` {{optional_inline}}
   - : A non-negative integer specifying a limit on the number of substrings to be included in the array. If provided, splits the string at each occurrence of the specified `separator`, but stops when `limit` entries have been placed in the array. Any leftover text is not included in the array at all.
     - The array may contain fewer entries than `limit` if the end of the string is reached before the limit is reached.
@@ -67,15 +66,13 @@ Any other value will be coerced to a string before being used as separator.
 
 ### Using split()
 
-When the string is empty and no separator is specified, `split()` returns an array containing one empty
-string, rather than an empty array. If the string and separator are both empty
-strings, an empty array is returned.
+When the string is empty and a non-empty separator is specified, `split()` returns `[""]`. If the string and separator are both empty strings, an empty array is returned.
 
 ```js
 const emptyString = "";
 
-// string is empty and no separator is specified
-console.log(emptyString.split());
+// string is empty and separator is non-empty
+console.log(emptyString.split("a"));
 // [""]
 
 // string and separator are both empty strings

--- a/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
@@ -29,7 +29,7 @@ startsWith(searchString, position)
 ### Parameters
 
 - `searchString`
-  - : The characters to be searched for at the start of this string. Cannot be a regex.
+  - : The characters to be searched for at the start of this string. Cannot [be a regex](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes). All values that are not regexes are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `startsWith()` to search for the string `"undefined"`, which is rarely what you want.
 - `position` {{optional_inline}}
   - : The start position at which `searchString` is expected to be found (the index of `searchString`'s first character). Defaults to `0`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There's no special handling for `undefined` and it's quite dangerous to omit `separator`.

### Motivation

A similar confusion can be seen in https://github.com/mdn/content/pull/23157

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
