### PR TITLE
Change link to point to MDN

### DIFF
--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -454,7 +454,7 @@ Spacing may be created using CSS properties like {{CSSxRef("margin")}}.
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("link")}} when <code>href</code> attribute is
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a> when <code>href</code> attribute is
         present, otherwise
         <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
           >no corresponding role</a
@@ -466,16 +466,16 @@ Spacing may be created using CSS properties like {{CSSxRef("margin")}}.
       <td>
         <p>When <code>href</code> attribute is present:</p>
         <ul>
-          <li>{{ARIARole("button")}}</li>
-          <li>{{ARIARole("checkbox")}}</li>
-          <li>{{ARIARole("menuitem")}}</li>
-          <li>{{ARIARole("menuitemcheckbox")}}</li>
-          <li>{{ARIARole("menuitemradio")}}</li>
-          <li>{{ARIARole("option")}}</li>
-          <li>{{ARIARole("radio")}}</li>
-          <li>{{ARIARole("switch")}}</li>
-          <li>{{ARIARole("tab")}}</li>
-          <li>{{ARIARole("treeitem")}}</li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></li>
+          <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></li>
         </ul>
         <p>When <code>href</code> attribute is not present:</p>
         <ul>

--- a/files/en-us/web/html/element/area/index.md
+++ b/files/en-us/web/html/element/area/index.md
@@ -163,7 +163,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("link")}} when {{htmlattrxref("href", "area")}} attribute is present, otherwise <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">no corresponding role</a>
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a> when {{htmlattrxref("href", "area")}} attribute is present, otherwise <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">no corresponding role</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/article/index.md
+++ b/files/en-us/web/html/element/article/index.md
@@ -75,10 +75,10 @@ A given document can have multiple articles in it; for example, on a blog that s
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("feed")}}, {{ARIARole("main")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("region")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/document_role">document</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/main_role">main</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/region_role">region</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/aside/index.md
+++ b/files/en-us/web/html/element/aside/index.md
@@ -107,9 +107,9 @@ This example uses `<aside>` to mark up a paragraph in an article. The paragraph 
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("feed")}}, {{ARIARole("none")}},
-        {{ARIARole("note")}}, {{ARIARole("presentation")}},
-        {{ARIARole("region")}}, {{ARIARole("search")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/note_role">note</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/region_role">region</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/search_role">search</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -444,7 +444,7 @@ Also it's a good practice to provide some content (such as the direct download l
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>

--- a/files/en-us/web/html/element/br/index.md
+++ b/files/en-us/web/html/element/br/index.md
@@ -110,7 +110,7 @@ Use `<p>` elements, and use CSS properties like {{cssxref("margin")}} to control
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("none")}}, {{ARIARole("presentation")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -248,12 +248,12 @@ Whether clicking on a {{HTMLElement("button")}} or {{HTMLElement("input")}} butt
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("checkbox")}}, {{ARIARole("combobox")}},
-        {{ARIARole("link")}}, {{ARIARole("menuitem")}},
-        {{ARIARole("menuitemcheckbox")}},
-        {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
-        {{ARIARole("radio")}}, {{ARIARole("switch")}},
-        {{ARIARole("tab")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/dd/index.md
+++ b/files/en-us/web/html/element/dd/index.md
@@ -74,7 +74,7 @@ For examples, see the [examples provided for the `<dl>` element](/en-US/docs/Web
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("definition")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/definition_role">definition</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -245,7 +245,7 @@ This CSS creates a look similar to a tabbed interface, where activating the tab 
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -184,7 +184,7 @@ The output of the above code looks like this:
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("term")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/term_role">term</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -174,7 +174,7 @@ It is important to provide a mechanism to close a dialog within the `dialog` ele
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td>{{ARIARole("alertdialog")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>

--- a/files/en-us/web/html/element/dl/index.md
+++ b/files/en-us/web/html/element/dl/index.md
@@ -76,12 +76,12 @@ The **`<dl>`** [HTML](/en-US/docs/Web/HTML) element represents a description lis
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("group")}},
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>,
         <code
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role"
             >list</a
           ></code
-        >, {{ARIARole("none")}}, {{ARIARole("presentation")}}
+        >, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/dt/index.md
+++ b/files/en-us/web/html/element/dt/index.md
@@ -77,7 +77,7 @@ For examples, see the [examples provided for the `<dl>` element](/en-US/docs/Web
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("term")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/term_role">term</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/embed/index.md
+++ b/files/en-us/web/html/element/embed/index.md
@@ -102,9 +102,9 @@ Use the [`title` attribute](/en-US/docs/Web/HTML/Global_attributes/title) on an 
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("img")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/document_role">document</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/img_role">img</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/fieldset/index.md
+++ b/files/en-us/web/html/element/fieldset/index.md
@@ -135,13 +135,13 @@ This example shows a disabled `<fieldset>` with two controls inside it. Note how
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("radiogroup")}},
-        {{ARIARole("presentation")}}, {{ARIARole("none")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/figcaption/index.md
+++ b/files/en-us/web/html/element/figcaption/index.md
@@ -66,8 +66,8 @@ Please see the {{HTMLElement("figure")}} page for examples on `<figcaption>`.
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/footer/index.md
+++ b/files/en-us/web/html/element/footer/index.md
@@ -92,8 +92,8 @@ The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for 
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("presentation")}} or
-        {{ARIARole("none")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a> or
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -193,7 +193,7 @@ The following attributes control behavior during form submission.
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/search_role"
             >search</a
           ></code
-        >, {{ARIARole("none")}} or {{ARIARole("presentation")}}
+        >, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/header/index.md
+++ b/files/en-us/web/html/element/header/index.md
@@ -155,8 +155,8 @@ The `<header>` element defines a [`banner`](/en-US/docs/Web/Accessibility/ARIA/R
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("presentation")}} or
-        {{ARIARole("none")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a> or
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -63,8 +63,8 @@ The **`<h1>`** to **`<h6>`** [HTML](/en-US/docs/Web/HTML) elements represent six
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("tab")}}, {{ARIARole("presentation")}} or
-        {{ARIARole("none")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a> or
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/hr/index.md
+++ b/files/en-us/web/html/element/hr/index.md
@@ -90,12 +90,12 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("separator")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("presentation")}} or {{ARIARole("none")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -236,9 +236,9 @@ Without this title, they have to navigate into the `<iframe>` to determine what 
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("img")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/document_role">document</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/img_role">img</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -432,15 +432,15 @@ The value of the `title` attribute is usually presented to the user as a tooltip
                   ></code
                 >
               </li>
-              <li>{{ARIARole("link")}}</li>
-              <li>{{ARIARole("menuitem")}}</li>
-              <li>{{ARIARole("menuitemcheckbox")}}</li>
-              <li>{{ARIARole("menuitemradio")}}</li>
-              <li>{{ARIARole("option")}}</li>
-              <li>{{ARIARole("progressbar")}}</li>
-              <li>{{ARIARole("scrollbar")}}</li>
-              <li>{{ARIARole("separator")}}</li>
-              <li>{{ARIARole("slider")}}</li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role">progressbar</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role">scrollbar</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role">slider</a></li>
               <li>
                 <code
                   ><a
@@ -456,12 +456,12 @@ The value of the `title` attribute is usually presented to the user as a tooltip
                   ></code
                 >
               </li>
-              <li>{{ARIARole("treeitem")}}</li>
+              <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></li>
             </ul>
           </li>
           <li>
-            with empty <code>alt</code> attribute, {{ARIARole("none")}}
-            or {{ARIARole("presentation")}}
+            with empty <code>alt</code> attribute, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>
+            or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>
           </li>
           <li>
             with no <code>alt</code> attribute, no <code>role</code> permitted

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -1244,7 +1244,7 @@ Firefox uses the following heuristics to determine the locale to validate the us
                     href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                with <code>list</code> attribute: {{ARIARole("combobox")}}
+                with <code>list</code> attribute: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>
               </li>
             </ul>
           </li>
@@ -1254,10 +1254,10 @@ Firefox uses the following heuristics to determine the locale to validate the us
               ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code>
           </li>
           <li>
-            <code>type=number</code>: {{ARIARole("spinbutton")}}
+            <code>type=number</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role">spinbutton</a>
           </li>
-          <li><code>type=radio</code>: {{ARIARole("radio")}}</li>
-          <li><code>type=range</code>: {{ARIARole("slider")}}</li>
+          <li><code>type=radio</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></li>
+          <li><code>type=range</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role">slider</a></li>
           <li>
             <code>type=reset</code>:
             <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code>
@@ -1266,10 +1266,10 @@ Firefox uses the following heuristics to determine the locale to validate the us
             <code>type=search</code>
             <ul>
               <li>
-                with no <code>list</code> attribute: {{ARIARole("searchbox")}}
+                with no <code>list</code> attribute: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role">searchbox</a>
               </li>
               <li>
-                with <code>list</code> attribute:{{ARIARole("combobox")}}
+                with <code>list</code> attribute:<a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>
               </li>
             </ul>
           </li>
@@ -1286,7 +1286,7 @@ Firefox uses the following heuristics to determine the locale to validate the us
                 <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                with <code>list</code> attribute: {{ARIARole("combobox")}}
+                with <code>list</code> attribute: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>
               </li>
             </ul>
           </li>
@@ -1298,7 +1298,7 @@ Firefox uses the following heuristics to determine the locale to validate the us
                 <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                with <code>list</code> attribute: {{ARIARole("combobox")}}
+                with <code>list</code> attribute: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>
               </li>
             </ul>
           </li>
@@ -1311,7 +1311,7 @@ Firefox uses the following heuristics to determine the locale to validate the us
                   ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a ></code>
               </li>
               <li>
-                with <code>list</code> attribute: {{ARIARole("combobox")}}
+                with <code>list</code> attribute: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>
               </li>
             </ul>
           </li>
@@ -1327,35 +1327,35 @@ Firefox uses the following heuristics to determine the locale to validate the us
       <td>
         <ul>
           <li>
-            <code>type=button</code>: {{ARIARole("checkbox")}},
-            {{ARIARole("combobox")}},
-            {{ARIARole("link")}},
-            {{ARIARole("menuitem")}},
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("menuitemradio")}},
-            {{ARIARole("option")}}, {{ARIARole("radio")}},
-            {{ARIARole("switch")}}, {{ARIARole("tab")}}
+            <code>type=button</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a>
           </li>
           <li>
-            <code>type=checkbox</code>: {{ARIARole("button")}} when used
+            <code>type=checkbox</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a> when used
             with <code>aria-pressed</code>,
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("option")}}, {{ARIARole("switch")}}
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a>
           </li>
           <li>
-            <code>type=image</code>: {{ARIARole("link")}},
-            {{ARIARole("menuitem")}},
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("menuitemradio")}},
-            {{ARIARole("radio")}}, {{ARIARole("switch")}}
+            <code>type=image</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a>
           </li>
           <li>
-            <code>type=radio</code>: {{ARIARole("menuitemradio")}}
+            <code>type=radio</code>: <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a>
           </li>
           <li>
             <code>type=text</code> with no <code>list</code> attribute:
-            {{ARIARole("combobox")}}, {{ARIARole("searchbox")}},
-            {{ARIARole("spinbutton")}}
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role">searchbox</a>,
+            <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role">spinbutton</a>
           </li>
           <li>
             <code>type=color|date|datetime-local|email|file|hidden|</code>

--- a/files/en-us/web/html/element/li/index.md
+++ b/files/en-us/web/html/element/li/index.md
@@ -129,12 +129,12 @@ For more detailed examples, see the {{htmlelement("ol")}} and {{htmlelement("ul"
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("menuitem")}},
-        {{ARIARole("menuitemcheckbox")}},
-        {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("radio")}}, {{ARIARole("separator")}},
-        {{ARIARole("tab")}}, {{ARIARole("treeitem")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -436,7 +436,7 @@ the rendering of the page will be blocked till the resource is fetched. For exam
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("link")}} with <code>href</code> attribute</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/link_role">link</a> with <code>href</code> attribute</td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -136,15 +136,15 @@ button {
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>,
         <code
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role"
             >listbox</a
           ></code
-        >, {{ARIARole("menu")}}, {{ARIARole("menubar")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}} or {{ARIARole("tree")}}
+        >, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -108,7 +108,7 @@ Note that a `type` field is normally specified, but is not needed for Youtube vi
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}}, {{ARIARole("image")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/document_role">document</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/image_role">image</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/ol/index.md
+++ b/files/en-us/web/html/element/ol/index.md
@@ -200,12 +200,12 @@ The above HTML will output:
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
-        {{ARIARole("listbox")}}, {{ARIARole("menu")}},
-        {{ARIARole("menubar")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}}, {{ARIARole("tree")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/optgroup/index.md
+++ b/files/en-us/web/html/element/optgroup/index.md
@@ -82,7 +82,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/option/index.md
+++ b/files/en-us/web/html/element/option/index.md
@@ -77,7 +77,7 @@ See {{HTMLElement("select")}} for examples.
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("option")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -106,7 +106,7 @@ Many browsers implement this element as an [`aria-live`](/en-US/docs/Web/Accessi
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("status")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/status_role">status</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -58,7 +58,7 @@ The **`<progress>`** [HTML](/en-US/docs/Web/HTML) element displays an indicator 
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
-      <td>{{ARIARole("progressbar")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role">progressbar</a></td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>

--- a/files/en-us/web/html/element/section/index.md
+++ b/files/en-us/web/html/element/section/index.md
@@ -156,16 +156,16 @@ Depending on the content, including a heading could also be good for SEO, so it 
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
-        {{ARIARole("application")}}, {{ARIARole("banner")}},
-        {{ARIARole("complementary")}},
-        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
-        {{ARIARole("document")}}, {{ARIARole("feed")}},
-        {{ARIARole("log")}}, {{ARIARole("main")}},
-        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
-        {{ARIARole("none")}}, {{ARIARole("note")}},
-        {{ARIARole("presentation")}}, {{ARIARole("search")}},
-        {{ARIARole("status")}}, {{ARIARole("tabpanel")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role">alert</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/banner_role">banner</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/complementary_role">complementary</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/contentinfo_role">contentinfo</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/document_role">document</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/log_role">log</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/main_role">main</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role">marquee</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role">navigation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/note_role">note</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/search_role">search</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/status_role">status</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role">tabpanel</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -600,16 +600,16 @@ document.forms[0].onsubmit = (e) => {
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("combobox")}} with <strong>no</strong>
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a> with <strong>no</strong>
         <code>multiple</code> attribute and <strong>no</strong>
         <code>size</code> attribute greater than 1, otherwise
-        {{ARIARole("listbox")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("menu")}} with <strong>no</strong>
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a> with <strong>no</strong>
         <code>multiple</code> attribute and <strong>no</strong>
         <code>size</code> attribute greater than 1, otherwise no
         <code>role</code> permitted

--- a/files/en-us/web/html/element/th/index.md
+++ b/files/en-us/web/html/element/th/index.md
@@ -153,7 +153,7 @@ See {{HTMLElement("table")}} for examples on `<th>`.
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("columnheader")}} or {{ARIARole("rowheader")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role">columnheader</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role">rowheader</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/ul/index.md
+++ b/files/en-us/web/html/element/ul/index.md
@@ -172,12 +172,12 @@ The above HTML will output:
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
-        {{ARIARole("listbox")}}, {{ARIARole("menu")}},
-        {{ARIARole("menubar")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}}, {{ARIARole("tree")}}
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role">none</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -526,7 +526,7 @@ Captions should not obstruct the main subject of the video. They can be position
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>


### PR DESCRIPTION
The links in the technical summary were pointing to an external link. We have these documented on MDN, so pointing internally.