### PR TITLE
Remove a link from a heading

### DIFF
--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/javascript_xslt_bindings/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/javascript_xslt_bindings/index.md
@@ -13,6 +13,7 @@ tags:
 JavaScript can run XSLT transformations through the {{domxref('XSLTProcessor')}} object. Once instantiated, an {{domxref('XSLTProcessor')}} has an {{domxref('XSLTProcessor.importStylesheet()')}} method that takes as an argument the XSLT stylesheet to be used in the transformation. The stylesheet has to be passed in as an XML document, which means that the .xsl file has to be loaded by the page before calling {{domxref('XSLTProcessor.importStylesheet()')}}. This can be done via {{domxref('XMLHttpRequest')}} or {{domxref('XMLDocument.load()')}}.
 
 ### Instantiating an `XSLTProcessor`
+
 ```js
 const xsltProcessor = new XSLTProcessor();
 

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/javascript_xslt_bindings/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/javascript_xslt_bindings/index.md
@@ -12,8 +12,7 @@ tags:
 
 JavaScript can run XSLT transformations through the {{domxref('XSLTProcessor')}} object. Once instantiated, an {{domxref('XSLTProcessor')}} has an {{domxref('XSLTProcessor.importStylesheet()')}} method that takes as an argument the XSLT stylesheet to be used in the transformation. The stylesheet has to be passed in as an XML document, which means that the .xsl file has to be loaded by the page before calling {{domxref('XSLTProcessor.importStylesheet()')}}. This can be done via {{domxref('XMLHttpRequest')}} or {{domxref('XMLDocument.load()')}}.
 
-### Instantiating an {{domxref('XSLTProcessor')}}
-
+### Instantiating an `XSLTProcessor`
 ```js
 const xsltProcessor = new XSLTProcessor();
 


### PR DESCRIPTION
It doesn't work, and the link is in the text below.

(Fixing flaws, one at a time. Almost done with this type of flaw.