### PR TITLE
[mathml] Document the largeop attribute of the mo element.

### DIFF
--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -21,6 +21,8 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) (i.e. drawn bigger and closer to the base expression).
 - `fence`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
+- `largeop`
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Attribute/Values#mathml-specific_types) indicating whether the operator should be drawn bigger when [`math-style`](/en-US/docs/Web/CSS/math-style) is set to `normal`.
 - `lspace`
   - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the amount of space before the operator.
 - `maxsize`


### PR DESCRIPTION
### Description

Document the largeop attribute of the mo element.

### Motivation

This is missing and was reported by users.

### Additional details

Attribute is documented here: https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo
And its (main) effect here: https://w3c.github.io/mathml-core/#layout-of-operators

### Related issues and pull requests

See #23669
Similar change should be done in BCD.
