### PR TITLE
updated method find_element_by_name

### DIFF
--- a/files/en-us/web/webdriver/index.md
+++ b/files/en-us/web/webdriver/index.md
@@ -38,9 +38,6 @@ with webdriver.Firefox() as driver:
 
     wait = WebDriverWait(driver, 10)
     driver.get("http://google.com/ncr")
-    # This is outdated (results in an error; AttributeError: 'WebDriver' object has no attribute 'find_element_by_name'):
-    #driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
-    # Updated:
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
     wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>a")))
 

--- a/files/en-us/web/webdriver/index.md
+++ b/files/en-us/web/webdriver/index.md
@@ -38,8 +38,10 @@ with webdriver.Firefox() as driver:
 
     wait = WebDriverWait(driver, 10)
     driver.get("http://google.com/ncr")
-    driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
-
+    # This is outdated (results in an error; AttributeError: 'WebDriver' object has no attribute 'find_element_by_name'):
+    #driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN)
+    # Updated:
+    driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
     wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>a")))
 
     results = driver.find_elements_by_css_selector("h3>a")


### PR DESCRIPTION
## This is outdated (results in an error; AttributeError: 'WebDriver' object has no attribute 'find_element_by_name'): 

> driver.find_element_by_name("q").send_keys("cheese" + Keys.RETURN) 

## Updated Version:
> driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)


Works well for me and doesn't result in the above error.

Thanks.


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
One of the functions being used I believe is now deprecated and results in an error back.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The code I'm purposing doesn't result in an error.

### Additional details

Please execute the new code and let me know if you get an error back, thanks.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
