### PR TITLE
Remove loads of LatinModern/mathfonts.css in some MathML examples

### DIFF
--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -31,13 +31,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 This example contains two MathML formula. The first one is rendered in its own centered block, taking as much space as needed. The second one is rendered inside the paragraph of text, with reduced size and spacing in order to minimize its height.
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <p>
   The infinite sum

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -65,12 +65,6 @@ denominator "3 − b":
 
 The following MathML code should render as a [binomial coefficient](https://en.wikipedia.org/wiki/Binomial_coefficient):
 
-```html hidden
-<link
-  rel="stylesheet"
-  href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css" />
-```
-
 ```html
 <math display="block">
   <mrow>

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -22,13 +22,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <mover accent="true">

--- a/files/en-us/web/mathml/element/mroot/index.md
+++ b/files/en-us/web/mathml/element/mroot/index.md
@@ -19,13 +19,6 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <mroot>

--- a/files/en-us/web/mathml/element/msqrt/index.md
+++ b/files/en-us/web/mathml/element/msqrt/index.md
@@ -19,13 +19,6 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <msqrt>

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -40,13 +40,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 The following example uses [global attributes](/en-US/docs/Web/MathML/Global_attributes) `displaystyle` and `mathcolor` to respectively override the [`math-style`](/en-US/docs/Web/CSS/math-style) and [`color`](/en-US/docs/Web/CSS/color) of the `<munder>` and `<munderover>` children:
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <mstyle displaystyle="false" mathcolor="teal">

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -26,13 +26,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <msup>

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -22,13 +22,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <munder accentunder="true">

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -26,13 +26,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Examples
 
-```html hidden
- <link
-   rel="stylesheet"
-   href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css"
-  />
-```
-
 ```html
 <math display="block">
   <munderover>


### PR DESCRIPTION
### Description

Some MathML examples load LatinModern/mathfonts.css to ensure correct rendering, but that's not necessary since STIX is also served as a web font.

### Motivation

See https://github.com/orgs/mdn/discussions/260#discussioncomment-4735762

### Additional details

See https://github.com/orgs/mdn/discussions/260#discussioncomment-4735762

### Related issues and pull requests

https://github.com/mdn/yari/issues/7607
https://github.com/orgs/mdn/discussions/260