### PR TITLE
Using conformative cases for CSS transform functions

### DIFF
--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -59,7 +59,7 @@ Here is the MDN logo, skewed by 10 degrees and translated by 150 pixels on the X
 
 ```html
 <img
-  style="transform: skewx(10deg) translatex(150px);
+  style="transform: skewX(10deg) translateX(150px);
             transform-origin: bottom left;"
   src="logo.png"
   alt="MDN logo" />

--- a/files/en-us/web/css/image/image/index.md
+++ b/files/en-us/web/css/image/image/index.md
@@ -91,7 +91,7 @@ ul {
 }
 ```
 
-In the left-to-right list items — those with `dir="ltr"` set on the element itself or inheriting the directionality from an ancestor or default value for the page — the image will be used as-is. List items with `dir="rtl"` set on the `<li>` or inheriting the right-to-left directionality from an ancestor, such as documents set to Arabic or Hebrew, will have the bullet display on the right, horizontally flipped, as if `transform: scalex(-1)` had been set. The text will also be displayed left-to-right.
+In the left-to-right list items — those with `dir="ltr"` set on the element itself or inheriting the directionality from an ancestor or default value for the page — the image will be used as-is. List items with `dir="rtl"` set on the `<li>` or inheriting the right-to-left directionality from an ancestor, such as documents set to Arabic or Hebrew, will have the bullet display on the right, horizontally flipped, as if `transform: scaleX(-1)` had been set. The text will also be displayed left-to-right.
 
 {{EmbedLiveSample("Directionally-sensitive_images", "100%", 200)}}
 


### PR DESCRIPTION
### Description

Changes cases of CSS transform functions.

### Motivation

Using differently-cased names may confuse readers, and the cases should be aligned with the spec, even though both uppercase and lowercase forms will parse.

### Additional details

Transform functions in CSS Transforms Module Level 1:
https://w3c.github.io/csswg-drafts/css-transforms/#transform-functions
