### PR TITLE
DedicatedWorkerGlobalScope: add requestAnimationFrame and cancelAnimationFrame

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -68,6 +68,10 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Schedules the execution of a function every X milliseconds.
 - {{domxref("setTimeout")}}
   - : Sets a delay for executing a function.
+- {{domxref("Window/requestAnimationFrame", "requestAnimationFrame")}}
+  - : Requests the browser to execute a callback function before painting the next frame.
+- {{domxref("Window/cancelAnimationFrame", "cancelAnimationFrame")}}
+  - : Cancels a callback scheduled by requestAnimationFrame.
 
 ## Events
 


### PR DESCRIPTION
### Description

These are instance methods included by the AnimationFrameProvider mixin.

See https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames:dedicatedworkerglobalscope
