### PR TITLE
Add a note about exception

### DIFF
--- a/files/en-us/learn/server-side/django/admin_site/index.md
+++ b/files/en-us/learn/server-side/django/admin_site/index.md
@@ -110,7 +110,8 @@ From this list you can delete books by selecting the checkbox next to the book y
 
 You can edit a book by selecting its name in the link. The edit page for a book, shown below, is almost identical to the "Add" page. The main differences are the page title (_Change book_) and the addition of **Delete**, **HISTORY** and **VIEW ON SITE** buttons (this last button appears because we defined the `get_absolute_url()` method in our model).
 
-> **Note:** Clicking the **VIEW ON SITE** button raises a `NoReverseMatch` exception because we haven't created a URL or view for it yet. We'll get it working in [Django Tutorial Part 6: Generic list and detail views](/en-US/docs/Learn/Server-side/Django/Generic_views).
+> **Note:** Clicking the **VIEW ON SITE** button raises a `NoReverseMatch` exception because the `get_absolute_url()` method attempts to `reverse()` a named URL mapping ('book-detail') that has not yet been defined.
+> We'll define a URL mapping and associated view in [Django Tutorial Part 6: Generic list and detail views](/en-US/docs/Learn/Server-side/Django/Generic_views).
 
 ![Admin Site - Book Edit](admin_book_modify.png)
 

--- a/files/en-us/learn/server-side/django/admin_site/index.md
+++ b/files/en-us/learn/server-side/django/admin_site/index.md
@@ -110,7 +110,7 @@ From this list you can delete books by selecting the checkbox next to the book y
 
 You can edit a book by selecting its name in the link. The edit page for a book, shown below, is almost identical to the "Add" page. The main differences are the page title (_Change book_) and the addition of **Delete**, **HISTORY** and **VIEW ON SITE** buttons (this last button appears because we defined the `get_absolute_url()` method in our model).
 
-> **Note:** Clicking the **VIEW ON SITE** button raises a `NoReverseMatch` exception because we haven't created a url or view for it yet.  We'll get it working in [Django Tutorial Part 6: Generic list and detail views](/en-US/docs/Learn/Server-side/Django/Generic_views).
+> **Note:** Clicking the **VIEW ON SITE** button raises a `NoReverseMatch` exception because we haven't created a URL or view for it yet. We'll get it working in [Django Tutorial Part 6: Generic list and detail views](/en-US/docs/Learn/Server-side/Django/Generic_views).
 
 ![Admin Site - Book Edit](admin_book_modify.png)
 

--- a/files/en-us/learn/server-side/django/admin_site/index.md
+++ b/files/en-us/learn/server-side/django/admin_site/index.md
@@ -110,6 +110,8 @@ From this list you can delete books by selecting the checkbox next to the book y
 
 You can edit a book by selecting its name in the link. The edit page for a book, shown below, is almost identical to the "Add" page. The main differences are the page title (_Change book_) and the addition of **Delete**, **HISTORY** and **VIEW ON SITE** buttons (this last button appears because we defined the `get_absolute_url()` method in our model).
 
+> **Note:** Clicking the **VIEW ON SITE** button raises a `NoReverseMatch` exception because we haven't created a url or view for it yet.  We'll get it working in [Django Tutorial Part 6: Generic list and detail views](/en-US/docs/Learn/Server-side/Django/Generic_views).
+
 ![Admin Site - Book Edit](admin_book_modify.png)
 
 Now navigate back to the **Home** page (using the _Home_ link in the breadcrumb trail) and then view the **Author** and **Genre** lists — you should already have quite a few created from when you added the new books, but feel free to add some more.


### PR DESCRIPTION
Add a brief explanation of why the 'View on Site' button raises an exception when clicked at this point in the tutorial.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Lets the tutorial user know that the exception is expected and will be addressed in a later section of the tutorial

### Motivation

When I worked through this tutorial yesterday, I did not expect the 'View on Site' button to raise an exception.  [Posting to the Django forum](https://forum.djangoproject.com/t/view-on-site-link-gives-error/18310) helped me understand what was going on.

### Additional details

This is an excellent tutorial!  I hope this can make it a bit better.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
