### PR TITLE
Improve sentence style

### DIFF
--- a/files/en-us/web/javascript/guide/text_formatting/index.md
+++ b/files/en-us/web/javascript/guide/text_formatting/index.md
@@ -202,7 +202,7 @@ The following table summarizes the methods of {{jsxref("String")}} objects.
 
 [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) are string literals allowing embedded expressions. You can use multi-line strings and string interpolation features with them.
 
-Template literals are enclosed by back-tick characters (`` ` ``) ([grave accent](https://en.wikipedia.org/wiki/Grave_accent)) instead of double or single quotes. Template literals can contain place holders. These are indicated by the Dollar sign and curly braces (`${expression}`).
+Template literals are enclosed by backtick ([grave accent](https://en.wikipedia.org/wiki/Grave_accent)) characters (`` ` ``) instead of double or single quotes. Template literals can contain placeholders. These are indicated by the dollar sign and curly braces (`${expression}`).
 
 #### Multi-lines
 

--- a/files/en-us/web/javascript/guide/text_formatting/index.md
+++ b/files/en-us/web/javascript/guide/text_formatting/index.md
@@ -202,7 +202,7 @@ The following table summarizes the methods of {{jsxref("String")}} objects.
 
 [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) are string literals allowing embedded expressions. You can use multi-line strings and string interpolation features with them.
 
-Template literals are enclosed by the back-tick (\` \`) ([grave accent](https://en.wikipedia.org/wiki/Grave_accent)) character instead of double or single quotes. Template literals can contain place holders. These are indicated by the Dollar sign and curly braces (`${expression}`).
+Template literals are enclosed by back-tick characters (`` ` ``) ([grave accent](https://en.wikipedia.org/wiki/Grave_accent)) instead of double or single quotes. Template literals can contain place holders. These are indicated by the Dollar sign and curly braces (`${expression}`).
 
 #### Multi-lines
 


### PR DESCRIPTION
### Description

Fix a typo and improve a sentence

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

- Fix a typo "\` \`" to "`` ` ``", so that a back-tick character is shown as code
- Fix "the back-tick character" to "back-tick characters":
  - Remove "the"
  - Make plural
- Fix "place holders" to "placeholders"
- FIx "Dollar sign" to "dolllar sign"
