### PR TITLE
Consistently describe `Animation.replaceState` and `Animation.playState` as read-only

### DIFF
--- a/files/en-us/web/api/animation/index.md
+++ b/files/en-us/web/api/animation/index.md
@@ -42,7 +42,7 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
   - : Gets or sets the playback rate of the animation.
 - {{domxref("Animation.ready")}} {{ReadOnlyInline}}
   - : Returns the current ready Promise for this animation.
-- {{domxref("animation.replaceState")}}
+- {{domxref("animation.replaceState")}} {{ReadOnlyInline}}
   - : Returns the replace state of the animation. This will be `active` if the animation has been replaced, or `persisted` if {{domxref("Animation.persist()")}} has been invoked on it.
 - {{domxref("Animation.startTime")}}
   - : Gets or sets the scheduled time when an animation's playback should begin.

--- a/files/en-us/web/api/animation/playstate/index.md
+++ b/files/en-us/web/api/animation/playstate/index.md
@@ -15,9 +15,7 @@ browser-compat: api.Animation.playState
 
 {{APIRef("Web Animations")}}
 
-The **`Animation.playState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns and sets an enumerated value describing the playback state of an animation.
-
-> **Note:** This property is read-only for CSS Animations and Transitions.
+The read-only **`Animation.playState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns an enumerated value describing the playback state of an animation.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

On the doc page for [`Animation.playState`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/playState), clarify that the property is always read-only, not just when the `Animation` represents a CSS Animation or Transition.

On the doc page for [`Animation`](https://developer.mozilla.org/en-US/docs/Web/API/Animation), mark `Animation.replaceState` as read-only.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

For consistency with the spec and the rest of the documentation.

Currently the `Animation` page lists `playState` as read-only and not `replaceState`, while their dedicated doc pages say approximately the reverse.
