### PR TITLE
Removed irrelevant Note about Chome

### DIFF
--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -82,9 +82,6 @@ When **`calc()`** is used where an {{cssxref("&lt;integer&gt;")}} is expected, t
 
 This will give `.modal` a final `z-index` value of 2.
 
-> **Note:** The Chrome browser currently won't accept some values returned by **`calc()`** when an integer is expected.
-> This includes any division, even if it results in an integer, i.e. `z-index: calc(4 / 2);` will not be accepted.
-
 ## Examples
 
 ### Positioning an object on screen with a margin


### PR DESCRIPTION
### Description
I've tried it: seems like Chrome now rounds up a non-integer value.

### Additional details
Chrome version:  109.0.5414.75 x64

In the dev tools I passed the following values:
z-index: calc(3 / 2);
In the 'computed' tab i see that it shows 2.
For calc(8 / 2) it shows 4
For calc( 9 / 2) it shows 5.

So it seems to me that it works as described in the article above, this note looks redundant.

Am i doing something wrong? 
Or does this information seems to be irrelevant?
