### PR TITLE
Remove type="module" attribute from script tag

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -34,7 +34,7 @@ The "index.html" file should contain the following:
   <head>
     <meta charset="utf-8" />
     <title>WebGL Demo</title>
-    <script src="webgl-demo.js" type="module" defer></script>
+    <script src="webgl-demo.js" defer></script>
   </head>
 
   <body>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The code sample probably has an erroneous `type="module"` attribute. Removing it makes it work for me.

### Motivation

Hopefully it fixes an error.

### Additional details

When the attribute is present I'm getting the following messages in my console (just running firefox on the local files):

> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at file:///somepath/webgl-demo.js. (Reason: CORS request not http).

> Module source URI is not allowed in this document: “file:///somepath/webgl-demo.js”. index.html:6:1

### Related issues and pull requests

None.
