### PR TITLE
Add link to link rel="icon" MDN documentation to the page.

### DIFF
--- a/files/en-us/glossary/favicon/index.md
+++ b/files/en-us/glossary/favicon/index.md
@@ -19,6 +19,7 @@ They are used to improve user experience and enforce brand consistency. When a f
 ## See also
 
 - [Favicon](https://en.wikipedia.org/wiki/Favicon) on Wikipedia
+- The [link rel="icon"](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-icon) element documentation, used to add a favicon to a page.
 - Tools
 
   - [Free favicon generator](https://favicon.io/)

--- a/files/en-us/glossary/favicon/index.md
+++ b/files/en-us/glossary/favicon/index.md
@@ -19,7 +19,7 @@ They are used to improve user experience and enforce brand consistency. When a f
 ## See also
 
 - [Favicon](https://en.wikipedia.org/wiki/Favicon) on Wikipedia
-- The [link rel="icon"](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-icon) element documentation, used to add a favicon to a page.
+- The [link rel="icon"](/en-US/docs/Web/HTML/Attributes/rel#attr-icon) element documentation, used to add a favicon to a page.
 - Tools
 
   - [Free favicon generator](https://favicon.io/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a link to the MDN documentation for `<link rel="icon">`, which is used to add favicons to webpages.

### Motivation

I was looking for the MDN documentation for `<link rel="icon">` and found this page. I was surprised it did not link to the page I was looking for yet. Since the information is 100% relevant in this context, it makes sense to add this link IMHO.

### Additional details

N/A

### Related issues and pull requests

N/A
