### PR TITLE
Add the semicolon at the end of some JS statements

### DIFF
--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -23,7 +23,7 @@ keyword. The value of a constant can't be changed through reassignment (i.e. by 
 ## Syntax
 
 ```js-nolint
-const name1 = value1 [, name2 = value2 [, ... [, nameN = valueN]]]
+const name1 = value1 [, name2 = value2 [, ... [, nameN = valueN]]];
 ```
 
 - `nameN`

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -23,7 +23,9 @@ keyword. The value of a constant can't be changed through reassignment (i.e. by 
 ## Syntax
 
 ```js-nolint
-const name1 = value1 [, name2 = value2 [, ... [, nameN = valueN]]];
+const name1 = value1;
+const name1 = value1, name2 = value2;
+const name1 = value1, name2 = value2, /* …, */ nameN = valueN;
 ```
 
 - `nameN`

--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -23,7 +23,7 @@ at least once.
 ```js-nolint
 do
   statement
-while (condition)
+while (condition);
 ```
 
 - `statement`

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -22,7 +22,7 @@ The **`let`** declaration declares a block-scoped local variable, optionally ini
 ## Syntax
 
 ```js-nolint
-let name1 [= value1] [, name2 [= value2]] [, ..., nameN [= valueN]
+let name1 [= value1] [, name2 [= value2]] [, ..., nameN [= valueN]];
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -22,7 +22,11 @@ The **`let`** declaration declares a block-scoped local variable, optionally ini
 ## Syntax
 
 ```js-nolint
-let name1 [= value1] [, name2 [= value2]] [, ..., nameN [= valueN]];
+let name1;
+let name1 = value1;
+let name1 = value1, name2 = value2;
+let name1, name2 = value2;
+let name1 = value1, name2, /* …, */ nameN = valueN;
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/statements/return/index.md
+++ b/files/en-us/web/javascript/reference/statements/return/index.md
@@ -19,7 +19,8 @@ specifies a value to be returned to the function caller.
 ## Syntax
 
 ```js-nolint
-return [expression]
+return;
+return expression;
 ```
 
 - `expression`

--- a/files/en-us/web/javascript/reference/statements/throw/index.md
+++ b/files/en-us/web/javascript/reference/statements/throw/index.md
@@ -23,7 +23,7 @@ the program will terminate.
 ## Syntax
 
 ```js-nolint
-throw expression
+throw expression;
 ```
 
 - `expression`

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -20,7 +20,7 @@ globally-scoped variable, optionally initializing it to a value.
 ## Syntax
 
 ```js-nolint
-var varname1 [= value1] [, varname2 [= value2] ... [, varnameN [= valueN]]]
+var varname1 [= value1] [, varname2 [= value2] ... [, varnameN [= valueN]]];
 ```
 
 - `varnameN`

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -20,10 +20,14 @@ globally-scoped variable, optionally initializing it to a value.
 ## Syntax
 
 ```js-nolint
-var varname1 [= value1] [, varname2 [= value2] ... [, varnameN [= valueN]]];
+var name1;
+var name1 = value1;
+var name1 = value1, name2 = value2;
+var name1, name2 = value2;
+var name1 = value1, name2, /* …, */ nameN = valueN;
 ```
 
-- `varnameN`
+- `nameN`
   - : Variable name. It can be any legal identifier.
 - `valueN` {{optional_inline}}
   - : Initial value of the variable. It can be any legal expression. Default value is


### PR DESCRIPTION
Add the semicolon at the end of some JS statements:

The [`let` and `const`](https://262.ecma-international.org/13.0/#sec-let-and-const-declarations) declarations require the semicolon 
The [`var`](https://262.ecma-international.org/13.0/#sec-variable-statement) statement requires the semicolon
The [`do...while`](https://262.ecma-international.org/13.0/#sec-do-while-statement) loop requires the semicolon
The [`return`](https://262.ecma-international.org/13.0/#sec-return-statement) and [`throw`](https://262.ecma-international.org/13.0/#sec-throw-statement) statement require the semicolon