### PR TITLE
Use STIX Two Math for the math-shift live sample

### DIFF
--- a/files/en-us/web/css/math-shift/index.md
+++ b/files/en-us/web/css/math-shift/index.md
@@ -58,13 +58,7 @@ math {
 
 ### MathML
 
-The following MathML displays two versions of "x squared" using the Latin Modern Math font. Browser implementing the `math-shift` property should raise the superscripts using slightly different shifts.
-
-```html hidden
-<link
-  rel="stylesheet"
-  href="https://fred-wang.github.io/MathFonts/LatinModern/mathfonts.css" />
-```
+The following MathML displays two versions of "x squared" using a font with an OpenType MATH table. Browser implementing the `math-shift` property should raise the superscripts using slightly different shifts.
 
 ```html
 <math style="font-size: 64pt;">


### PR DESCRIPTION
### Description

Remove load of LatinModern/mathfonts.css ; instead use the default font from MDN style (STIX Two Math)

### Motivation

Remove need for example to explicitly load a math font, now that STIX Two Math is served by default.

### Additional details

To make the example work, a font with an Open Type MATH table (containing the parameters for the script shift) is necessary. STIX Two Math is enough.

### Related issues and pull requests

See https://github.com/orgs/mdn/discussions/260
