### PR TITLE
Update BCD path for Nullish coalescing assignment and add alt. name

### DIFF
--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
@@ -9,12 +9,12 @@ tags:
   - Logical Operator
   - Operator
   - Reference
-browser-compat: javascript.operators.logical_nullish_assignment
+browser-compat: javascript.operators.nullish_coalescing_assignment
 ---
 
 {{jsSidebar("Operators")}}
 
-The **nullish coalescing assignment (`x ??= y`)** operator only assigns if `x` is {{Glossary("nullish")}} (`null` or `undefined`).
+The **nullish coalescing assignment (`x ??= y`)** operator, also known as the **logical nullish assignment** operator, only assigns if `x` is {{Glossary("nullish")}} (`null` or `undefined`).
 
 {{EmbedInteractiveExample("pages/js/expressions-logical-nullish-assignment.html")}}
 


### PR DESCRIPTION
This PR performs two changes to the "Nullish coalescing assignment" article:

- Updates the BCD path following https://github.com/mdn/browser-compat-data/pull/18700
- Adds a mention of its alternate name, "Logical nullish assignment", which had been completely removed during the article rename
