### PR TITLE
chore: update XMLHttpRequest in KitchenSink

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -345,7 +345,7 @@ The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macr
 
 - [MDN Web Docs Glossary](/en-US/docs/Glossary):
 
-  - {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}
+  - {{Glossary("XMLHttpRequest")}}
 
 - [AJAX](https://en.wikipedia.org/wiki/AJAX) on Wikipedia
 - [Ajax](/en-US/docs/Web/Guide/AJAX)


### PR DESCRIPTION
Was getting some errors on the Yari CI after the file renames since I guess it wasn't expecting the extra redirect messages as part of KitchenSink https://github.com/mdn/yari/actions/runs/3990588983/jobs/6844411657