### PR TITLE
Express - remove update book view code

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
@@ -172,28 +172,7 @@ This is very similar to the post route used when creating a Book. First we valid
 
 ## View
 
-Open **/views/book_form.pug** and update the section where the author form control is set to have the conditional code shown below.
-
-```pug
-    div.form-group
-      label(for='author') Author:
-      select#author.form-control(type='select' placeholder='Select author' name='author' required='true' )
-        - authors.sort(function(a, b) {let textA = a.family_name.toUpperCase(); let textB = b.family_name.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
-        for author in authors
-          if book
-            //- Handle GET form, where book.author is an object, and POST form, where it is a string.
-            option(
-              value=author._id
-              selected=(
-                author._id.toString()==book.author._id
-                || author._id.toString()==book.author
-              ) ? 'selected' : false
-            ) #{author.name}
-          else
-            option(value=author._id) #{author.name}
-```
-
-> **Note:** This code change is required so that the book_form can be used for both creating and updating book objects (without this, there is an error on the `GET` route when creating a form).
+There is no need to change the view for the form (**/views/book_form.pug**) as the same code works for both creating and updating the book.
 
 ## Add an update button
 


### PR DESCRIPTION
Fixes https://github.com/mdn/express-locallibrary-tutorial/issues/154

The book form was first defined in https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Create_book_form and then slightly modified for updating the form in https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Update_Book_form. 

The issue above asks why this change is needed when the "worked" project does not use it and the original code works (as does the new code). I have tested the original code and it does indeed work.

The modified code attempts to compare the `book.author` differently in GET and POST (see the comment): "//- Handle GET form, where book.author is an object, and POST form, where it is a string.". The original code simply forces the comparison always to be a string comparison, and is much easier to understand.

So I think this is an unnecessary change - the only benefit being to highlight that the book.author might be different in post and get. 

Upshot, to remove the confusion I have simply removed the whole section for updating the form. This is much cleaner.