### PR TITLE
FF110 Experimental Feat -OPFS storage

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1822,6 +1822,50 @@ Note that since locking the screen orientation isn't typically supported on desk
   </tbody>
 </table>
 
+### File System Access API
+
+#### StorageManager.getDirectory()
+
+The {{domxref("StorageManager.getDirectory()")}} method, obtained using `navigator.storage.getDirectory()` in a worker or the main thread, provides access to files stored in the [origin private file system](/Web/API/File_System_Access_API#origin_private_file_system).
+This data is origin-specific: permission prompts are not required to access files and clearing data for the site/origin deletes the storage.
+See {{bug(1785123)}} for more details.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version changed</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>110</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>97</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>97</td>
+      <td>No.</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.fs.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Prioritized Task Scheduling API
 
 The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1827,7 +1827,7 @@ Note that since locking the screen orientation isn't typically supported on desk
 #### StorageManager.getDirectory()
 
 The {{domxref("StorageManager.getDirectory()")}} method, obtained using `navigator.storage.getDirectory()` in a worker or the main thread, provides access to files stored in the [origin private file system](/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system).
-This data is origin-specific: permission prompts are not required to access files and clearing data for the site/origin deletes the storage.
+This data is origin-specific: permission prompts are not required to access files, and clearing data for the site/origin deletes the storage.
 See {{bug(1785123)}} for more details.
 
 <table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1826,7 +1826,7 @@ Note that since locking the screen orientation isn't typically supported on desk
 
 #### StorageManager.getDirectory()
 
-The {{domxref("StorageManager.getDirectory()")}} method, obtained using `navigator.storage.getDirectory()` in a worker or the main thread, provides access to files stored in the [origin private file system](/Web/API/File_System_Access_API#origin_private_file_system).
+The {{domxref("StorageManager.getDirectory()")}} method, obtained using `navigator.storage.getDirectory()` in a worker or the main thread, provides access to files stored in the [origin private file system](/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system).
 This data is origin-specific: permission prompts are not required to access files and clearing data for the site/origin deletes the storage.
 See {{bug(1785123)}} for more details.
 

--- a/files/en-us/web/api/file_system_access_api/index.md
+++ b/files/en-us/web/api/file_system_access_api/index.md
@@ -52,7 +52,7 @@ Storing data in the OPFS is similar to storing data in any other browser-provide
 
 Files can be manipulated inside the OPFS via a three-step process:
 
-1. The {{domxref("StorageManager.getDirectory()")}} method returns a reference to a {{domxref("FileSystemDirectoryHandle")}} object allowing access to a directory and its contents — this represents the root of the OPFS.
+1. The {{domxref("StorageManager.getDirectory()")}} method, which is obtained using [`navigator.storage.getDirectory()`](/en-US/docs/Web/API/Navigator/storage) in a worker or the main thread, returns a reference to a {{domxref("FileSystemDirectoryHandle")}} object allowing access to a directory and its contents — this represents the root of the OPFS.
 2. The {{domxref("FileSystemDirectoryHandle.getFileHandle()")}} method is invoked to return a {{domxref('FileSystemFileHandle')}} object representing a handle to a specific file in the directory.
 3. The {{domxref('FileSystemFileHandle.createSyncAccessHandle', 'createSyncAccessHandle()')}} method is invoked on that file handle, and returns a {{domxref('FileSystemSyncAccessHandle')}} object that can be used to read and write to the file. This is a high-performance handle for _synchronous_ read/write operations (the other handle types are asynchronous). The synchronous nature of this class brings performance advantages intended for use in contexts where asynchronous operations come with high overhead (for example, [WebAssembly](/en-US/docs/WebAssembly)). Note that it is only usable inside dedicated [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
@@ -206,7 +206,9 @@ writableStream.write({ type: "seek", position });
 writableStream.write({ type: "truncate", size });
 ```
 
-### Synchronously reading and writing a file
+### Synchronously reading and writing files in OPFS
+
+This example synchronously reads and writes a file to the [origin private file system](#origin_private_file_system).
 
 The following asynchronous event handler function is contained inside a Web Worker. On receiving a message from the main thread it:
 
@@ -221,7 +223,7 @@ onmessage = async (e) => {
   // retrieve message sent to work from main script
   const message = e.data;
 
-  // Get handle to draft file
+  // Get handle to draft file in OPFS
   const root = await navigator.storage.getDirectory();
   const draftHandle = await root.getFileHandle('draft.txt', { create: true });
   // Get sync access handle


### PR DESCRIPTION
FF110 supports OPFS in nightly by default  - see https://bugzilla.mozilla.org/show_bug.cgi?id=1785123

This adds and entry to the experimental features page.

The OPFS docs appear to be pretty good already (though a runnable example would be nice). All I have done there is better cross linked info on how you get the StorageManager (from navigator) and making it clear that the relevant example is using OPFS.

Other docs work for this can be tracked in #23688