### PR TITLE
Add note about the necessary inclusion of `sizes` when `srcset` with width descriptor is used

### DIFF
--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -35,7 +35,7 @@ The `srcset` property, along with the {{domxref("HTMLImageElement.sizes",
 can be used together to make pages that use appropriate images for the rendering
 situation.
 
-> **Note:** If the {{htmlattrdef("srcset")}} attribute uses width descriptors, the `sizes` attribute must also be present, or the `srcset` itself will be ignored.
+> **Note:** If the {{htmlattrxref("srcset", "img")}} attribute uses width descriptors, the `sizes` attribute must also be present, or the `srcset` itself will be ignored.
 
 ## Value
 

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -35,6 +35,8 @@ The `srcset` property, along with the {{domxref("HTMLImageElement.sizes",
 can be used together to make pages that use appropriate images for the rendering
 situation.
 
+> **Note:** If the {{htmlattrdef("srcset")}} attribute uses width descriptors, the `sizes` attribute must also be present, or the `srcset` itself will be ignored.
+
 ## Value
 
 A string containing a comma-separated list of one or more image


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Add note about the necessary inclusion of `sizes` when `srcset` with width descriptor is used
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Make content clearer
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #16136

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
