### PR TITLE
Update Expression Statement definition

### DIFF
--- a/files/en-us/web/javascript/reference/statements/expression_statement/index.md
+++ b/files/en-us/web/javascript/reference/statements/expression_statement/index.md
@@ -7,7 +7,7 @@ spec-urls: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-
 
 {{jsSidebar("Statements")}}
 
-An **expression statement** evaluates an expression and discards its result. It allows the expression to perform side effects, such as executing a function or updating a variable.
+Wherever JavaScript expects a statement, you can also write an expression. Such a statement is called an **expression statement**. The reverse does not hold: you cannot write a statement where JavaScript expects an expression.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/statements/expression_statement/index.md
+++ b/files/en-us/web/javascript/reference/statements/expression_statement/index.md
@@ -7,7 +7,7 @@ spec-urls: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-
 
 {{jsSidebar("Statements")}}
 
-Wherever JavaScript expects a statement, you can also write an expression. Such a statement is called an **expression statement**. The reverse does not hold: you cannot write a statement where JavaScript expects an expression.
+An **expression statement** is an expression used in a place where a statement is expected. The expression is evaluated and its result is discarded — therefore, it makes sense only for expressions that have side effects, such as executing a function or updating a variable.
 
 ## Syntax
 


### PR DESCRIPTION
Please, consider the offered definition for JavaScript `Expression Statement`. It looks more clear to me.

I picked up this definition from [here](https://2ality.com/2012/09/expressions-vs-statements.html).

<blockquote>
Wherever JavaScript expects a statement, you can also write an expression. Such a statement is called an expression statement. The reverse does not hold: you cannot write a statement where JavaScript expects an expression.
</blockquote>

