### PR TITLE
Update page type metadocs for HTML, SVG, Glossary

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
@@ -22,6 +22,7 @@ tags:
 > ---
 > title: Term being defined
 > slug: Glossary/Term_being_defined
+> page-type: glossary-definition OR glossary-disambiguation
 > tags:
 >   - Glossary
 >   - The term
@@ -34,6 +35,8 @@ tags:
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted as snake case of the title: `Glossary/Term_being_defined`.
+> - **page-type**
+>   - : `glossary-definition` for a definition page or `glossary-disambiguation` for a disambiguation page.
 > - **tags**
 >   - : Always include the following tags: **Glossary**, _Term being defined_.
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -23,6 +23,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > ---
 > title: "<NameOfTheElement>: The NameOfTheElement element"
 > slug: Web/HTML/Element/NameOfTheElement
+> page-type: html-element
 > tags:
 >   - NameOfTheElement
 >   - HTML
@@ -43,6 +44,8 @@ browser-compat: path.to.feature.NameOfTheElement
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/HTML/Element/NameOfTheElement`, where the element name is in _lower case_.
 >     For example, the [`<video>`](/en-US/docs/Web/HTML/Element/video) element has a _slug_ of `Web/HTML/Element/video`.
+> - **page-type**
+>   - : Always `html-element`.
 > - **tags**
 >
 >   - : Always include the following tags: **HTML**, **Element**, **Reference**, the _NameOfTheElement_ (e.g. **video**).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -34,24 +34,9 @@ These page types are not specific to a particular MDN technology area:
 - `guide`: a generic guide page with no specific structure. See [Conceptual page](#conceptual_page).
 - `landing-page`: a page that acts primarily as a navigation aid, listing links to other pages. See [Landing page](#landing_page).
 
-## Web API page types
+## Domain-specific page types
 
-This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
-
-- `web-api-overview`: gives an overview of a Web API, like the [Fetch API](/en-US/docs/Web/API/Fetch_API).
-- `web-api-global-function`: a global function, like [`fetch()`](/en-US/docs/Web/API/fetch).
-- `web-api-global-property`: a global property, like [`origin`](/en-US/docs/Web/API/origin).
-- `web-api-interface`: a Web API interface, like [`Request`](/en-US/docs/Web/API/Request).
-- `web-api-constructor`: a constructor, like [`Request()`](/en-US/docs/Web/API/Request/Request).
-- `web-api-instance-method`: an instance method, like [`cache.add()`](/en-US/docs/Web/API/Cache/add).
-- `web-api-instance-property`: an instance property, like [`request.headers`](/en-US/docs/Web/API/Request/headers).
-- `web-api-static-method`: a static method, like [`Response.error()`](/en-US/docs/Web/API/Response/error).
-- `web-api-static-property`: a static property, like [`Notification.permission`](/en-US/docs/Web/API/Notification/permission).
-- `web-api-event`: an event, like [`Notification.click`](/en-US/docs/Web/API/Notification/click_event). See [API reference subpage](#api_reference_subpage).
-- `webgl-extension`: a WebGL extension, like [`WEBGL_draw_buffers`](/en-US/docs/Web/API/WEBGL_draw_buffers).
-- `webgl-extension-method`: a WebGL extension method, like [`OES_vertex_array_object.bindVertexArrayOES()`](/en-US/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES).
-
-## CSS page types
+### CSS page types
 
 This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
@@ -69,7 +54,7 @@ This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/
 - `css-shorthand-property`: a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties), like {{cssxref("background")}}.
 - `css-type`: a [data type](/en-US/docs/Web/CSS/CSS_Types), like [`<color>`](/en-US/docs/Web/CSS/color_value).
 
-## JavaScript page types
+### JavaScript page types
 
 This section lists `page-type` values for pages under [Web/JavaScript](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
@@ -88,3 +73,20 @@ This section lists `page-type` values for pages under [Web/JavaScript](/en-US/do
 - `javascript-static-accessor-property`: a static accessor property, like [`RegExp.lastMatch`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch).
 - `javascript-static-data-property`: a static data property, like [`Math.E`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E).
 - `javascript-static-method`: a static method, like [`Array.from()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+
+### Web API page types
+
+This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `web-api-overview`: gives an overview of a Web API, like the [Fetch API](/en-US/docs/Web/API/Fetch_API).
+- `web-api-global-function`: a global function, like [`fetch()`](/en-US/docs/Web/API/fetch).
+- `web-api-global-property`: a global property, like [`origin`](/en-US/docs/Web/API/origin).
+- `web-api-interface`: a Web API interface, like [`Request`](/en-US/docs/Web/API/Request).
+- `web-api-constructor`: a constructor, like [`Request()`](/en-US/docs/Web/API/Request/Request).
+- `web-api-instance-method`: an instance method, like [`cache.add()`](/en-US/docs/Web/API/Cache/add).
+- `web-api-instance-property`: an instance property, like [`request.headers`](/en-US/docs/Web/API/Request/headers).
+- `web-api-static-method`: a static method, like [`Response.error()`](/en-US/docs/Web/API/Response/error).
+- `web-api-static-property`: a static property, like [`Notification.permission`](/en-US/docs/Web/API/Notification/permission).
+- `web-api-event`: an event, like [`Notification.click`](/en-US/docs/Web/API/Notification/click_event). See [API reference subpage](#api_reference_subpage).
+- `webgl-extension`: a WebGL extension, like [`WEBGL_draw_buffers`](/en-US/docs/Web/API/WEBGL_draw_buffers).
+- `webgl-extension-method`: a WebGL extension method, like [`OES_vertex_array_object.bindVertexArrayOES()`](/en-US/docs/Web/API/OES_vertex_array_object/bindVertexArrayOES).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -36,6 +36,8 @@ These page types are not specific to a particular MDN technology area:
 
 ## Domain-specific page types
 
+This section lists page types that are specific to a single area of MDN.
+
 ### CSS page types
 
 This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
@@ -54,9 +56,24 @@ This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/
 - `css-shorthand-property`: a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties), like {{cssxref("background")}}.
 - `css-type`: a [data type](/en-US/docs/Web/CSS/CSS_Types), like [`<color>`](/en-US/docs/Web/CSS/color_value).
 
+### Glossary page types
+
+This section lists `page-type` values for pages under [Glossary](/en-US/docs/Glossary). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below.
+
+- `glossary-definition`: a page defining a term, like [Bézier curve](/en-US/docs/Glossary/Bezier_curve).
+- `glossary-disambiguation`: a page providing links to two or more definition pages for an ambiguous term, like [Node](/en-US/docs/Glossary/Node).
+
+### HTML page types
+
+This section lists `page-type` values for pages under [Web/HTML](/en-US/docs/Web/HTML). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `html-attribute`: an HTML attribute, like [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete).
+- `html-attribute-value`: a single value for an HTML attribute, like [`dns-prefetch`](/en-US/docs/Web/HTML/Attributes/rel/dns-prefetch).
+- `html-element`: an HTML element, like [`<button>`](/en-US/docs/Web/HTML/Element/button).
+
 ### JavaScript page types
 
-This section lists `page-type` values for pages under [Web/JavaScript](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/JavaScript](/en-US/docs/Web/JavaScript). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
 - `javascript-class`: a definition of a built-in object, like [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 - `javascript-constructor`: an object constructor, like [`Array()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array).
@@ -73,6 +90,13 @@ This section lists `page-type` values for pages under [Web/JavaScript](/en-US/do
 - `javascript-static-accessor-property`: a static accessor property, like [`RegExp.lastMatch`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch).
 - `javascript-static-data-property`: a static data property, like [`Math.E`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E).
 - `javascript-static-method`: a static method, like [`Array.from()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+
+### SVG page types
+
+This section lists `page-type` values for pages under [Web/SVG](/en-US/docs/Web/SVG). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `svg-attribute`: an SVG attribute, like [`crossorigin`](/en-US/docs/Web/SVG/Attribute/crossorigin).
+- `svg-element`: an SVG element, like [`<circle>`](/en-US/docs/Web/SVG/Element/circle).
 
 ### Web API page types
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -23,6 +23,7 @@ browser-compat: path.to.feature.NameOfTheElement
 > ---
 > title: <NameOfTheElement>
 > slug: Web/SVG/Element/NameOfTheElement
+> page-type: svg-element
 > tags:
 >   - NameOfTheElement
 >   - SVG
@@ -42,6 +43,8 @@ browser-compat: path.to.feature.NameOfTheElement
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/SVG/Element/NameOfTheElement`.
+> - **page-type**
+>   - : Always `svg-element`.
 > - **tags**
 >
 >   - : Always include the following tags: **SVG**, **Reference**, **Element**, the _NameOfTheElement_ (e.g. **g**).


### PR DESCRIPTION
A bit of housekeeping: updated the meta-docs to document page types for HTML, SVG, and Glossary, which were all added recently.

I've also split the main page on page-type into two main sections to better differentiate generic types from domain-specific ones, and ordered the domain-specific sections.