### PR TITLE
Tighten static properties intro paragraph format

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Array.@@species
 
 {{JSRef}}
 
-The **`Array[@@species]`** accessor property returns the constructor used to construct return values from array methods.
+The **`Array[@@species]`** static accessor property returns the constructor used to construct return values from array methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.ArrayBuffer.@@species
 
 {{JSRef}}
 
-The **`ArrayBuffer[@@species]`** accessor property returns the constructor used to construct return values from array buffer methods.
+The **`ArrayBuffer[@@species]`** static accessor property returns the constructor used to construct return values from array buffer methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/map/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@species/index.md
@@ -12,11 +12,11 @@ browser-compat: javascript.builtins.Map.@@species
 
 {{JSRef}}
 
-The **`Map[@@species]`** accessor property is an unused accessor property specifying how to copy `Map` objects.
+The **`Map[@@species]`** static accessor property is an unused accessor property specifying how to copy `Map` objects.
 
 ## Syntax
 
-```js
+```js-nolint
 Map[Symbol.species]
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/e/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.E
 
 {{JSRef}}
 
-The **`Math.E`** property represents Euler's number, the base of natural logarithms, e, which is approximately 2.718.
+The **`Math.E`** static data property represents Euler's number, the base of natural logarithms, e, which is approximately 2.718.
 
 {{EmbedInteractiveExample("pages/js/math-e.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ln10/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.LN10
 
 {{JSRef}}
 
-The **`Math.LN10`** property represents the natural logarithm of 10, approximately 2.302.
+The **`Math.LN10`** static data property represents the natural logarithm of 10, approximately 2.302.
 
 {{EmbedInteractiveExample("pages/js/math-ln10.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ln2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ln2/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.LN2
 
 {{JSRef}}
 
-The **`Math.LN2`** property represents the natural logarithm of 2, approximately 0.693:
+The **`Math.LN2`** static data property represents the natural logarithm of 2, approximately 0.693:
 
 {{EmbedInteractiveExample("pages/js/math-ln2.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.LOG10E
 
 {{JSRef}}
 
-The **`Math.LOG10E`** property represents the base 10 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 0.434.
+The **`Math.LOG10E`** static data property represents the base 10 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 0.434.
 
 {{EmbedInteractiveExample("pages/js/math-log10e.html", "shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.LOG2E
 
 {{JSRef}}
 
-The **`Math.LOG2E`** property represents the base 2 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 1.442.
+The **`Math.LOG2E`** static data property represents the base 2 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 1.442.
 
 {{EmbedInteractiveExample("pages/js/math-log2e.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/pi/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.PI
 
 {{JSRef}}
 
-The **`Math.PI`** property represents the ratio of the circumference of a circle to its diameter, approximately 3.14159.
+The **`Math.PI`** static data property represents the ratio of the circumference of a circle to its diameter, approximately 3.14159.
 
 {{EmbedInteractiveExample("pages/js/math-pi.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt1_2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt1_2/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.SQRT1_2
 
 {{JSRef}}
 
-The **`Math.SQRT1_2`** property represents the square root of 1/2, which is approximately 0.707.
+The **`Math.SQRT1_2`** static data property represents the square root of 1/2, which is approximately 0.707.
 
 {{EmbedInteractiveExample("pages/js/math-sqrt1_2.html", "shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt2/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.SQRT2
 
 {{JSRef}}
 
-The **`Math.SQRT2`** property represents the square root of 2, approximately 1.414.
+The **`Math.SQRT2`** static data property represents the square root of 2, approximately 1.414.
 
 {{EmbedInteractiveExample("pages/js/math-sqrt2.html", "shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.EPSILON
 
 {{JSRef}}
 
-The **`Number.EPSILON`** property represents the difference between 1 and the smallest floating point number greater than 1.
+The **`Number.EPSILON`** static data property represents the difference between 1 and the smallest floating point number greater than 1.
 
 {{EmbedInteractiveExample("pages/js/number-epsilon.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.MAX_SAFE_INTEGER
 
 {{JSRef}}
 
-The **`Number.MAX_SAFE_INTEGER`** constant represents the maximum safe integer in JavaScript (2<sup>53</sup> – 1).
+The **`Number.MAX_SAFE_INTEGER`** static data property represents the maximum safe integer in JavaScript (2<sup>53</sup> – 1).
 
 For larger integers, consider using {{jsxref("BigInt")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Number.MAX_VALUE
 
 {{JSRef}}
 
-The **`Number.MAX_VALUE`** property represents the maximum numeric value representable in JavaScript.
+The **`Number.MAX_VALUE`** static data property represents the maximum numeric value representable in JavaScript.
 
 {{EmbedInteractiveExample("pages/js/number-maxvalue.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Number.MIN_SAFE_INTEGER
 
 {{JSRef}}
 
-The **`Number.MIN_SAFE_INTEGER`** constant represents the minimum safe integer in JavaScript, or -(2<sup>53</sup> - 1).
+The **`Number.MIN_SAFE_INTEGER`** static data property represents the minimum safe integer in JavaScript, or -(2<sup>53</sup> - 1).
 
 To represent integers smaller than this, consider using {{jsxref("BigInt")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_value/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Number.MIN_VALUE
 
 {{JSRef}}
 
-The **`Number.MIN_VALUE`** property represents the smallest positive numeric value representable in JavaScript.
+The **`Number.MIN_VALUE`** static data property represents the smallest positive numeric value representable in JavaScript.
 
 {{EmbedInteractiveExample("pages/js/number-min-value.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/nan/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Number.NaN
 
 {{JSRef}}
 
-The **`Number.NaN`** property represents Not-A-Number, which is equivalent to {{jsxref("NaN")}}. For more information about the behaviors of `NaN`, see the [description for the global property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
+The **`Number.NaN`** static data property represents Not-A-Number, which is equivalent to {{jsxref("NaN")}}. For more information about the behaviors of `NaN`, see the [description for the global property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
 
 {{EmbedInteractiveExample("pages/js/number-nan.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Number.NEGATIVE_INFINITY
 
 {{JSRef}}
 
-The **`Number.NEGATIVE_INFINITY`** property represents the negative Infinity value.
+The **`Number.NEGATIVE_INFINITY`** static data property represents the negative Infinity value.
 
 {{EmbedInteractiveExample("pages/js/number-negative-infinity.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Number.POSITIVE_INFINITY
 
 {{JSRef}}
 
-The **`Number.POSITIVE_INFINITY`** property represents the positive Infinity value.
+The **`Number.POSITIVE_INFINITY`** static data property represents the positive Infinity value.
 
 {{EmbedInteractiveExample("pages/js/number-positive-infinity.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -13,13 +13,13 @@ browser-compat: javascript.builtins.Promise.@@species
 
 {{JSRef}}
 
-The **`Promise[@@species]`** accessor property returns the constructor used to construct return values from promise methods.
+The **`Promise[@@species]`** static accessor property returns the constructor used to construct return values from promise methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 
 ## Syntax
 
-```js
+```js-nolint
 Promise[Symbol.species]
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.RegExp.@@species
 
 {{JSRef}}
 
-The **`RegExp[@@species]`** accessor property returns the constructor used to construct copied regular expressions in certain `RegExp` methods.
+The **`RegExp[@@species]`** static accessor property returns the constructor used to construct copied regular expressions in certain `RegExp` methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@species/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Set.@@species
 
 {{JSRef}}
 
-The **`Set[@@species]`** accessor property is an unused accessor property specifying how to copy `Set` objects.
+The **`Set[@@species]`** static accessor property is an unused accessor property specifying how to copy `Set` objects.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/@@species/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.SharedArrayBuffer.@@species
 
 {{JSRef}}
 
-The **`SharedArrayBuffer[@@species]`** accessor property returns the constructor used to construct return values from `SharedArrayBuffer` methods.
+The **`SharedArrayBuffer[@@species]`** static accessor property returns the constructor used to construct return values from `SharedArrayBuffer` methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Symbol.asyncIterator
 
 {{JSRef}}
 
-The **`Symbol.asyncIterator`** well-known symbol specifies the default [async iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) for an object. If this property is set on an object, it is an async iterable and can be used in a [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop.
+The **`Symbol.asyncIterator`** static data property represents the well-known symbol specifying the method that returns the [async iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) for an object. If this property is set on an object, it is an async iterable and can be used in a [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop.
 
 {{EmbedInteractiveExample("pages/js/symbol-asynciterator.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.hasInstance
 
 {{JSRef}}
 
-The **`Symbol.hasInstance`** well-known symbol is used to determine if a constructor object recognizes an object as its instance. The {{jsxref("Operators/instanceof", "instanceof")}} operator's behavior can be customized by this symbol.
+The **`Symbol.hasInstance`** static data property represents the well-known symbol specifying the method used to determine if a constructor object recognizes an object as its instance. The {{jsxref("Operators/instanceof", "instanceof")}} operator's behavior can be customized by this symbol.
 
 {{EmbedInteractiveExample("pages/js/symbol-hasinstance.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.isConcatSpreadable
 
 {{JSRef}}
 
-The **`Symbol.isConcatSpreadable`** well-known symbol is used to configure if an object should be flattened to its array elements when using the {{jsxref("Array.prototype.concat()")}} method.
+The **`Symbol.isConcatSpreadable`** static data property represents the well-known symbol used to configure if an object should be flattened to its array elements when using the {{jsxref("Array.prototype.concat()")}} method.
 
 {{EmbedInteractiveExample("pages/js/symbol-isconcatspreadable.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.iterator
 
 {{JSRef}}
 
-The well-known **`Symbol.iterator`** symbol specifies the default iterator for an object. Used by [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of).
+The **`Symbol.iterator`** static data property represents the well-known symbol specifying the method that returns the iterator for an object. If this property is set on an object, it is an iterable and can be used in a [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop and various other syntaxes.
 
 {{EmbedInteractiveExample("pages/js/symbol-iterator.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.match
 
 {{JSRef}}
 
-The **`Symbol.match`** well-known symbol specifies the matching of a regular expression against a string. This function is called by the {{jsxref("String.prototype.match()")}} method.
+The **`Symbol.match`** static data property represents the well-known symbol specifying the method used to match an input string against the current object, making the object behave like a {{jsxref("RegExp")}}. This function is called by the {{jsxref("String.prototype.match()")}} method.
 
 For more information, see {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]()")}} and {{jsxref("String.prototype.match()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.matchAll
 
 {{JSRef}}
 
-The **`Symbol.matchAll`** well-known symbol specifies the method that returns an iterator, that yields matches of the regular expression against a string. This function is called by the {{jsxref("String.prototype.matchAll()")}} method.
+The **`Symbol.matchAll`** static data property represents the well-known symbol specifying the method that returns an iterator, that yields matches of the regular expression against a string. This function is called by the {{jsxref("String.prototype.matchAll()")}} method.
 
 For more information, see {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}} and {{jsxref("String.prototype.matchAll()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.replace
 
 {{JSRef}}
 
-The **`Symbol.replace`** well-known symbol specifies the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
+The **`Symbol.replace`** static data property represents the well-known symbol specifying the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
 
 For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}} and {{jsxref("String.prototype.replace()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.search
 
 {{JSRef}}
 
-The **`Symbol.search`** well-known symbol specifies the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
+The **`Symbol.search`** static data property represents the well-known symbol specifying the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
 
 For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}} and {{jsxref("String.prototype.search()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.species
 
 {{JSRef}}
 
-The well-known symbol **`Symbol.species`** specifies a function-valued property that the constructor function uses to create derived objects.
+The **`Symbol.species`** static data property represents the well-known symbol specifying the method that a constructor function uses to create derived objects.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.split
 
 {{JSRef}}
 
-The **`Symbol.split`** well-known symbol specifies the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
+The **`Symbol.split`** static data property represents the well-known symbol specifying the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
 
 For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}} and {{jsxref("String.prototype.split()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.toPrimitive
 
 {{JSRef}}
 
-The **`Symbol.toPrimitive`** well-known symbol specifies a method that accepts a preferred type and returns a primitive representation of an object. It is called in priority by all [type coercion](/en-US/docs/Web/JavaScript/Data_structures#type_coercion) algorithms.
+The **`Symbol.toPrimitive`** static data property represents the well-known symbol specifying the method that accepts a preferred type and returns a primitive representation of an object. It is called in priority by all [type coercion](/en-US/docs/Web/JavaScript/Data_structures#type_coercion) algorithms.
 
 {{EmbedInteractiveExample("pages/js/symbol-toprimitive.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Symbol.toStringTag
 
 {{JSRef}}
 
-The **`Symbol.toStringTag`** well-known symbol is a string valued property that is used in the creation of the default string description of an object. It is accessed internally by the {{jsxref("Object.prototype.toString()")}} method.
+The **`Symbol.toStringTag`** static data property represents the well-known symbol used in the creation of the default string description of an object. It is accessed internally by the {{jsxref("Object.prototype.toString()")}} method.
 
 {{EmbedInteractiveExample("pages/js/symbol-tostringtag.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Symbol.unscopables
 
 {{JSRef}}
 
-The **`Symbol.unscopables`** well-known symbol is used to specify an object value of whose own and inherited property names are excluded from the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) environment bindings of the associated object.
+The **`Symbol.unscopables`** static data property represents the well-known symbol used to specify properties of the associated object that should not become bindings within the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) environment.
 
 {{EmbedInteractiveExample("pages/js/symbol-unscopables.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.TypedArray.@@species
 
 {{JSRef}}
 
-The **`TypedArray[@@species]`** accessor property returns the constructor used to construct return values from typed array methods.
+The **`TypedArray[@@species]`** static accessor property returns the constructor used to construct return values from typed array methods.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.TypedArray.BYTES_PER_ELEMENT
 
 {{JSRef}}
 
-The **`TypedArray.BYTES_PER_ELEMENT`** property represents the size in bytes of each element in a typed array.
+The **`TypedArray.BYTES_PER_ELEMENT`** static data property represents the size in bytes of each element in a typed array.
 
 {{EmbedInteractiveExample("pages/js/typedarray-bytes-per-element.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.TypedArray.name
 
 {{JSRef}}
 
-The **`TypedArray.name`** property represents a string value of the typed array constructor name.
+The **`TypedArray.name`** static data property represents a string value of the typed array constructor name.
 
 {{EmbedInteractiveExample("pages/js/typedarray-name.html","shorter")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This updates all static properties' intro paragraphs to use the same format:

- "The **`Xxx.yyy`** static accessor property returns..."
- "The **`Xxx.yyy`** static data property represents..."
- "The **`Xxx.yyy()`** static method..."

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
