### PR TITLE
Correct example code

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -74,7 +74,7 @@ Note that this same set of values can be used in all {{Glossary("fetch directive
 Given this CSP header:
 
 ```http
-Content-Security-Policy: script-src-attr 'none'
+Content-Security-Policy: style-src-attr 'none'
 ```
 
 …the inline style applied to the element below not be applied:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This doc is about `style-src-attr` (CSS), so this is probably supposed to be in the example, instead of `script-src-attr` (JS)

### Motivation

This makes the example code snippet correct and valuable for copy-paste usage


