### PR TITLE
There's no such function `commit`

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -39,9 +39,6 @@ const offscreen = htmlCanvas.transferControlToOffscreen();
 const gl = offscreen.getContext('webgl');
 
 // Some drawing using the gl context…
-
-// Push frames back to the original HTMLCanvasElement
-gl.commit();
 ```
 
 The following example shows how to transfer control to an {{domxref("OffscreenCanvas")}} object on a worker.
@@ -64,4 +61,3 @@ worker.postMessage({ canvas: offscreen }, [offscreen]);
 
 - The interface defining this method, {{domxref("HTMLCanvasElement")}}
 - {{domxref("OffscreenCanvas")}}
-- {{domxref("WebGLRenderingContext.commit()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove references to `commit`

### Motivation

see https://jsgist.org/?src=f11d6ede9ad5c47a874f3c75a0ea164b

and the WebGL specs

https://registry.khronos.org/webgl/specs/latest/1.0/

https://registry.khronos.org/webgl/specs/latest/2.0/

Also, the implementation data is wrong. Firefox does not implement `commit`. Run the test at the top.

The HTML spec is wrong too. There are no plans to implement `commit`. Instead the decision was made the canvases in workers work the same as canvases in the main thread, they get "committed" automatically, or to put it another way they get "queued to be used in the next page render" (not precise but I don't want to have to quote pages of specs here)

### Additional details


### Related issues and pull requests

