### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -36,7 +36,7 @@ The event object is a {{domxref("UIEvent")}} instance if it was generated from a
 
 Unlike other events, the `error` event is canceled by returning `true` from the handler instead of returning `false`. When canceled, the error won't appear in the console, but the current script will still stop executing.
 
-The event handler's signature is asymmetric between `addEventListener()` and `onerror`. The event handler passed to `addEventLister` receives a single {{domxref("ErrorEvent")}} object, while the `onerror` handler receives five arguments, matching the {{domxref("ErrorEvent")}} object's properties:
+The event handler's signature is asymmetric between `addEventListener()` and `onerror`. The event handler passed to `addEventListener` receives a single {{domxref("ErrorEvent")}} object, while the `onerror` handler receives five arguments, matching the {{domxref("ErrorEvent")}} object's properties:
 
 - `event`
   - : A string containing a human-readable error message describing the problem. Same as {{domxref("ErrorEvent.message")}}.

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -78,7 +78,7 @@ const myObj = Object.create({}, {
 });
 myObj.foo = 1;
 
-console.log(Object.getOwnPropertyNames(my_obj).sort()); // ["foo", "getFoo"]
+console.log(Object.getOwnPropertyNames(myObj).sort()); // ["foo", "getFoo"]
 ```
 
 If you want only the enumerable properties, see {{jsxref("Object.keys()")}} or use a {{jsxref("Statements/for...in", "for...in")}} loop (note that this will also return enumerable properties found along the prototype chain for the object unless the latter is filtered with {{jsxref("Object.hasOwn()", "hasOwn()")}}).


### PR DESCRIPTION
### Description

- addEventLister -> addEventListener (window/error_event)
- my_obj -> myObj (object/getownpropertynames)