### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -44,7 +44,7 @@ In the [constructor](/en-US/docs/Web/JavaScript/Reference/Classes/constructor) b
 
 The "property lookup" form can be used to access methods and properties of an object literal's or class's [[Prototype]]. Within a class's body, the reference of `super` can be either the superclass's constructor itself, or the constructor's `prototype`, depending on whether the execution context is instance creation or class initialization. See the Examples section for more details.
 
-Note that the reference of `super` is determined by the class or object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the class or object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable, as explained above.)
+Note that the reference of `super` is determined by the class or object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the class or object literal scope, which the methods create a closure over. (But also beware that it's not actually a variable, as explained above.)
 
 When setting properties through `super`, the property is set on `this` instead.
 


### PR DESCRIPTION
### Description

Remove extra `not` in this sentence:

> ...it's not actually **not** a variable...

### Motivation

Fix typo.

### Additional details

None.

### Related issues and pull requests

None.