### PR TITLE
CSS module landing page

### DIFF
--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -1,5 +1,5 @@
 ---
-title: Compositing and blending
+title: CSS compositing and blending
 slug: Web/CSS/Compositing_and_Blending
 page-type: css-module
 tags:
@@ -17,13 +17,11 @@ spec-urls:
 
 The **compositing and blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).
 
-Similar to blending effects available in many image editing applications, this module enables blending an element's background layers together and blending an element's content with that of its container. CSS can be used to define which blending mode should be used, if any, to blend an element's background images and colors into a single background image. It is also possible to define how an element's borders, background, and content, including text, emojis, and images, should be blended with the background of its container.
-
-This module provides for 16 different blending modes.
+The properties in this CSS module can be used to define the blending mode that should be used, if any, to blend an element's background images and colors into a single background image. This module provides 16 blending modes. You can also define how an element's borders, background, and content, including text, emojis, and images, should be blended with the background of its container.
 
 ### Compositing and blending in action
 
-In this example, a border and two striped background images with a background color are provided for each box, with a background of a solid color with circles cut out set on the entire example.
+In this example, each box has a border, two striped background images, and a solid color background. The common background for all the boxes contains a pattern of circles. The three boxes in the second row are set to blend with the background of the container. 
 
 ```html hidden
 <section>
@@ -84,7 +82,7 @@ span {
 
 {{ EmbedLiveSample('Compositing_and_blending_in_action', "630", "300") }}
 
- The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted. To see the code for this, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/compositing_and_blending/index.md?plain=1).
+ Notice how the background, border, and the content are all impacted as a result of the blending. To see the code for this sample, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/compositing_and_blending/index.md?plain=1).
 
 ## Reference
 
@@ -112,7 +110,7 @@ span {
 
 ## See also
 
-- [CSS filter effects](/en-US/docs/Web/CSS/Filter_Effects) module enables applying filter effects to images like blurring and changing color intensity.
+- Properties in the [CSS filter effects](/en-US/docs/Web/CSS/Filter_Effects) module enable applying filters effects, such as blurring and changing color intensity, to images, backgrounds, and borders.
 - [Compositing And Blending In CSS](https://www.sarasoueidan.com/blog/compositing-and-blending-in-css/) (2015)
 - [Editing Images in CSS: Blend Modes](https://code.tutsplus.com/tutorials/editing-images-in-css-blend-modes--cms-26058) (2022)
 - [web.dev: blend modes](https://web.dev/learn/css/blend-modes/) (2021)

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -95,12 +95,15 @@ span {
 ## Related concepts
 
 - {{cssxref("blend-mode")}} data type
-- {{cssxref("filter")}} CSS property
+
 - {{cssxref("backdrop-filter")}} CSS property
+- {{cssxref("filter")}} CSS property
 - {{cssxref("mask-composite")}} CSS property
 - {{cssxref("background-color")}} CSS property
 - {{cssxref("background-image")}} CSS property
+
 - {{glossary("stacking context")}} glossary term
+
 - {{ SVGElement("feBlend")}} SVG filter primitive
 - {{ SVGElement("feComposite")}} SVG filter primitive
 

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -21,7 +21,7 @@ The properties in this CSS module can be used to define the blending mode that s
 
 ### Compositing and blending in action
 
-In this example, each box has a border, two striped background images, and a solid color background. The common background for all the boxes contains a pattern of circles. The three boxes in the second row are set to blend with the background of the container. 
+In this example, each box has a border, two striped background images, and a solid color background. The common background for all the boxes contains a pattern of circles. The three boxes in the second row are set to blend with the background of the container.
 
 ```html hidden
 <section>

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -8,15 +8,76 @@ tags:
   - Guide
   - Overview
   - Reference
-browser-compat:
-  - css.properties.background-blend-mode
-  - css.properties.isolation
-  - css.properties.mix-blend-mode
+spec-urls: 
+  - https://drafts.fxtf.org/compositing/
+  - https://www.w3.org/TR/compositing-1/
 ---
 
 {{CSSRef}}
 
-**Compositing and Blending** is a CSS module that defines how shapes of different elements are combined into a single image.
+The **Compositing and Blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new {{glossary("stacking context")}}.
+
+Similar to blending effects available in many image editing applications, this module enables blending an element's background layers together and blending an element's content with that of its container. CSS can be used to define which blending mode should be used, if any, to blend an element's background images and colors into a single background image. It is also possible to define how an element's borders, background, and content, including text, emojis, and images, should be blended with the background of its container.
+
+This module provides for 16 different blending modes.
+
+### Example
+
+In this example, a border and two striped background images with a background color are provided for each box, with a background of a solid color with circles cut out set on the entire example.
+
+```html hidden
+<section>
+  <div><span>Normal, with no blending</span></div>
+  <div><span>Multiplies colors</span></div>
+  <div><span>Multiplies based on background color</span></div>
+  <div>Normal, with no blending</div>
+  <div>Multiplies colors</div>
+  <div>Multiplies based on background color</div>
+</section>
+```
+
+```css hidden
+div {
+  width: 200px;
+  height: 200px;
+  background-image: repeating-linear-gradient(45deg, red 0 15px, pink 15px 30px), repeating-linear-gradient(-45deg, blue 0 15px, lightblue 15px 30px);
+  background-size: 150px 150px;
+  background-repeat: no-repeat;
+  background-position: top left, bottom right;
+  background-color: palegoldenrod;
+  text-align: center;
+  padding-top: 150px;
+  font-family: sans-serif;
+  box-sizing: border-box;
+  border: 5px solid black;
+}
+div:nth-of-type(3n+1){
+  background-blend-mode: normal;
+}
+div:nth-of-type(3n+2){
+  background-blend-mode: multiply;
+}
+div:nth-of-type(3n+3){
+  background-blend-mode: overlay;
+}
+div:nth-of-type(n + 4) {
+  mix-blend-mode: difference;
+}
+section {
+  padding: 0.75em;
+  background: radial-gradient(circle, transparent 0 20px, rgb(255, 200, 200) 20px); background-size: 60px 60px; background-position: center;
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1em;
+}
+span {
+  background-color: #ffffff99;
+}
+```
+
+{{ EmbedLiveSample('Example', "630", "300") }}
+
+ The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted.
 
 ## Reference
 
@@ -30,10 +91,24 @@ browser-compat:
 
 - {{cssxref("&lt;blend-mode&gt;")}}
 
+## Associated content
+
+### Associated properties
+
+- {{cssxref("background-image")}}
+- {{cssxref("background-color")}}
+
+### Associated concepts
+
+- [Stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
+- SVG's {{ SVGElement("feBlend") }} filter primitive
+
 ## Specifications
 
 {{Specifications}}
 
-## Browser compatibility
+## See also
 
-{{Compat}}
+- [Compositing And Blending In CSS](https://www.sarasoueidan.com/blog/compositing-and-blending-in-css/) (2015)
+- [Editing Images in CSS: Blend Modes](https://code.tutsplus.com/tutorials/editing-images-in-css-blend-modes--cms-26058) (2022)
+- [web.dev: blend modes](https://web.dev/learn/css/blend-modes/) (2021)

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -84,7 +84,7 @@ span {
 
 {{ EmbedLiveSample('Compositing_and_blending_in_action', "630", "300") }}
 
- The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted. To see the code for this, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/Compositing_and_Blending/index.md).
+ The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted. To see the code for this, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/compositing_and_blending/index.md?plain=1).
 
 ## Reference
 
@@ -94,31 +94,17 @@ span {
 - {{cssxref("isolation")}}
 - {{cssxref("mix-blend-mode")}}
 
-### Functions
-
-- {{cssxref("")}}
-
-### Events
-
-- {{domxref("")}}
-
-### Interfaces
-
-- {{domxref("")}} (inherits from {{domxref("")}})
-  - : Including {{domxref("")}}, {{domxref("")}}, and {{domxref("")}}.
-
 ## Related concepts
-<!--
-- {{cssxref("")}} CSS property
-- {{glossary("")}} glossary term
-- [`<>`](foo) data type
-- [``](/en-US/docs/Web/CSS/@media/) media query
-  -->
-- {{cssxref("background-image")}} CSS property
+
+- {{cssxref("blend-mode")}} data type
+- {{cssxref("filter")}} CSS property
+- {{cssxref("backdrop-filter")}} CSS property
+- {{cssxref("mask-composite")}} CSS property
 - {{cssxref("background-color")}} CSS property
-- {{cssxref("&lt;blend-mode&gt;")}} data type
-- {{ SVGElement("feBlend") }} SVG filter primitive
+- {{cssxref("background-image")}} CSS property
 - {{glossary("stacking context")}} glossary term
+- {{ SVGElement("feBlend")}} SVG filter primitive
+- {{ SVGElement("feComposite")}} SVG filter primitive
 
 ## Specifications
 
@@ -126,6 +112,7 @@ span {
 
 ## See also
 
+- [CSS filter effects](/en-US/docs/Web/CSS/Filter_Effects) module
 - [Compositing And Blending In CSS](https://www.sarasoueidan.com/blog/compositing-and-blending-in-css/) (2015)
 - [Editing Images in CSS: Blend Modes](https://code.tutsplus.com/tutorials/editing-images-in-css-blend-modes--cms-26058) (2022)
 - [web.dev: blend modes](https://web.dev/learn/css/blend-modes/) (2021)

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -15,7 +15,7 @@ spec-urls:
 
 {{CSSRef}}
 
-The **Compositing and Blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new {{glossary("stacking context")}}.
+The **Compositing and Blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).
 
 Similar to blending effects available in many image editing applications, this module enables blending an element's background layers together and blending an element's content with that of its container. CSS can be used to define which blending mode should be used, if any, to blend an element's background images and colors into a single background image. It is also possible to define how an element's borders, background, and content, including text, emojis, and images, should be blended with the background of its container.
 
@@ -98,9 +98,9 @@ span {
 - {{cssxref("background-image")}}
 - {{cssxref("background-color")}}
 
-### Associated concepts
+### Associated concepts and glossary terms
 
-- [Stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
+- Glossary: {{glossary("stacking context")}}
 - SVG's {{ SVGElement("feBlend") }} filter primitive
 
 ## Specifications

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -112,7 +112,7 @@ span {
 
 ## See also
 
-- [CSS filter effects](/en-US/docs/Web/CSS/Filter_Effects) module
+- [CSS filter effects](/en-US/docs/Web/CSS/Filter_Effects) module enables applying filter effects to images like blurring and changing color intensity.
 - [Compositing And Blending In CSS](https://www.sarasoueidan.com/blog/compositing-and-blending-in-css/) (2015)
 - [Editing Images in CSS: Blend Modes](https://code.tutsplus.com/tutorials/editing-images-in-css-blend-modes--cms-26058) (2022)
 - [web.dev: blend modes](https://web.dev/learn/css/blend-modes/) (2021)

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -98,10 +98,13 @@ span {
 - {{cssxref("background-image")}}
 - {{cssxref("background-color")}}
 
-### Associated concepts and glossary terms
+### Associated concepts
+
+- SVG's {{ SVGElement("feBlend") }} filter primitive
+
+### Glossary terms
 
 - Glossary: {{glossary("stacking context")}}
-- SVG's {{ SVGElement("feBlend") }} filter primitive
 
 ## Specifications
 

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -91,7 +91,7 @@ span {
 
 - {{cssxref("&lt;blend-mode&gt;")}}
 
-## Associated content
+## Related content
 
 ### Associated properties
 

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -95,17 +95,12 @@ span {
 ## Related concepts
 
 - {{cssxref("blend-mode")}} data type
-
-
 - {{cssxref("backdrop-filter")}} CSS property
 - {{cssxref("filter")}} CSS property
 - {{cssxref("mask-composite")}} CSS property
 - {{cssxref("background-color")}} CSS property
 - {{cssxref("background-image")}} CSS property
-
-
 - {{glossary("stacking context")}} glossary term
-
 - {{ SVGElement("feBlend")}} SVG filter primitive
 - {{ SVGElement("feComposite")}} SVG filter primitive
 

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -96,11 +96,13 @@ span {
 
 - {{cssxref("blend-mode")}} data type
 
+
 - {{cssxref("backdrop-filter")}} CSS property
 - {{cssxref("filter")}} CSS property
 - {{cssxref("mask-composite")}} CSS property
 - {{cssxref("background-color")}} CSS property
 - {{cssxref("background-image")}} CSS property
+
 
 - {{glossary("stacking context")}} glossary term
 

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -1,5 +1,5 @@
 ---
-title: Compositing and Blending
+title: Compositing and blending
 slug: Web/CSS/Compositing_and_Blending
 page-type: css-module
 tags:
@@ -15,13 +15,13 @@ spec-urls:
 
 {{CSSRef}}
 
-The **Compositing and Blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).
+The **compositing and blending** CSS module defines how an element's background layers can be blended together, how an element can be blended with its container, and whether the element must create a new [stacking context](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).
 
 Similar to blending effects available in many image editing applications, this module enables blending an element's background layers together and blending an element's content with that of its container. CSS can be used to define which blending mode should be used, if any, to blend an element's background images and colors into a single background image. It is also possible to define how an element's borders, background, and content, including text, emojis, and images, should be blended with the background of its container.
 
 This module provides for 16 different blending modes.
 
-### Example
+### Compositing and blending in action
 
 In this example, a border and two striped background images with a background color are provided for each box, with a background of a solid color with circles cut out set on the entire example.
 
@@ -37,10 +37,13 @@ In this example, a border and two striped background images with a background co
 ```
 
 ```css hidden
+/* creates a div with two offset striped background images and a background color. */
 div {
   width: 200px;
   height: 200px;
-  background-image: repeating-linear-gradient(45deg, red 0 15px, pink 15px 30px), repeating-linear-gradient(-45deg, blue 0 15px, lightblue 15px 30px);
+  background-image: 
+    repeating-linear-gradient(45deg, red 0 15px, pink 15px 30px), 
+    repeating-linear-gradient(-45deg, blue 0 15px, lightblue 15px 30px);
   background-size: 150px 150px;
   background-repeat: no-repeat;
   background-position: top left, bottom right;
@@ -63,21 +66,25 @@ div:nth-of-type(3n+3){
 div:nth-of-type(n + 4) {
   mix-blend-mode: difference;
 }
+/* put a pink background with transparent round holes that covers the entire element, and lay the examples in two rows with three columns each */
 section {
   padding: 0.75em;
-  background: radial-gradient(circle, transparent 0 20px, rgb(255, 200, 200) 20px); background-size: 60px 60px; background-position: center;
+  background: radial-gradient(circle, transparent 0 20px, rgb(255, 200, 200) 20px); 
+  background-size: 60px 60px; 
+  background-position: center;
   display: inline-grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 1em;
 }
+/* make some of the text more legible */
 span {
   background-color: #ffffff99;
 }
 ```
 
-{{ EmbedLiveSample('Example', "630", "300") }}
+{{ EmbedLiveSample('Compositing_and_blending_in_action', "630", "300") }}
 
- The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted.
+ The last three boxes are set to blend with the background of the container. Note how the background, border, and the content are all impacted. To see the code for this, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/Compositing_and_Blending/index.md).
 
 ## Reference
 
@@ -87,24 +94,31 @@ span {
 - {{cssxref("isolation")}}
 - {{cssxref("mix-blend-mode")}}
 
-### Data types
+### Functions
 
-- {{cssxref("&lt;blend-mode&gt;")}}
+- {{cssxref("")}}
 
-## Related content
+### Events
 
-### Associated properties
+- {{domxref("")}}
 
-- {{cssxref("background-image")}}
-- {{cssxref("background-color")}}
+### Interfaces
 
-### Associated concepts
+- {{domxref("")}} (inherits from {{domxref("")}})
+  - : Including {{domxref("")}}, {{domxref("")}}, and {{domxref("")}}.
 
-- SVG's {{ SVGElement("feBlend") }} filter primitive
-
-### Glossary terms
-
-- Glossary: {{glossary("stacking context")}}
+## Related concepts
+<!--
+- {{cssxref("")}} CSS property
+- {{glossary("")}} glossary term
+- [`<>`](foo) data type
+- [``](/en-US/docs/Web/CSS/@media/) media query
+  -->
+- {{cssxref("background-image")}} CSS property
+- {{cssxref("background-color")}} CSS property
+- {{cssxref("&lt;blend-mode&gt;")}} data type
+- {{ SVGElement("feBlend") }} SVG filter primitive
+- {{glossary("stacking context")}} glossary term
 
 ## Specifications
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -318,7 +318,7 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 
 ### Associated properties
 
-- {{cssxref('will-change')}}
+- {{cssxref("will-change")}}
 
 ### Glossary terms
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -273,7 +273,7 @@ input:checked + label::before {
 
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
-This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md).
+This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
 
 ## Reference
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -91,3 +91,4 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 - [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
 - The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
+- The [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) enables constructing and controlling the playback of animations with JavaScript.

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -19,6 +19,8 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 ### Example
 
+`<STILL WORKING ON THIS>`
+
 ## Reference
 
 ### Properties

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -274,21 +274,22 @@ input:checked + label::before {
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
 This sample animation uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the cloud move back and forth, {{cssxref("animation-fill-mode")}} to raise the snow level in response to the cloud movement, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
-
+t
 ## Reference
 
 ### Properties
 
 - {{cssxref("animation")}} shorthand
-- {{cssxref("animation-composition")}}
+- {{cssxref("animation-composition")}} {{Experimental_Inline}}
 - {{cssxref("animation-delay")}}
 - {{cssxref("animation-direction")}}
 - {{cssxref("animation-duration")}}
 - {{cssxref("animation-fill-mode")}}
 - {{cssxref("animation-iteration-count")}}
 - {{cssxref("animation-name")}}
+- {{cssxref("animation-play-state")}}
 - {{cssxref("animation-timing-function")}}
-- {{cssxref("animation-timeline")}}
+- {{cssxref("animation-timeline")}}t
 
 ### At-rules
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -15,11 +15,11 @@ spec-urls:
 
 {{CSSRef}}
 
-The **CSS Animations** module lets you animate the values of CSS properties over time, using keyframes, providing properties to control the easing, duration, number of repetitions, play state, and other attributes of these keyframes.
+The animations CSS module lets you animate the values of CSS properties, such as background-position and transform, over time by using keyframes. Each keyframe describes how the animated element should render at a given time during the animation sequence. You can use the properties in the animations module to control the duration, number of repetitions, delayed start, and other aspects of an animation.
 
 ### Animations in action
 
-To view the animation in action, check the checkbox or hover over the example. The cloud will change shape, snowflakes will fall, and the snow level will rise. To pause the animation, uncheck the checkbox or move your mouse off of the example.
+To view the animation in the box below, click the checkbox 'Play the animation' or hover the cursor over the box. When the animating is active, the cloud at the top changes shape, snowflakes fall, and the snow level at the bottom rises. To pause the animation, uncheck the checkbox or move your cursor away from the box.
 
 ```html hidden
 <input type="checkbox" id="animate" aria-label="Toggle the play state of the animation"><!-- See aria-label: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label -->
@@ -273,7 +273,7 @@ input:checked + label::before {
 
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
-This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
+This sample animation uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the cloud move back and forth, {{cssxref("animation-fill-mode")}} to raise the snow level in response to the cloud movement, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
 
 ## Reference
 
@@ -296,11 +296,11 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 
 ### Functions
 
-- [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
+- [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll)
 
 ### Events
 
-Every animation, even those that are 0 seconds in duration, throw animation events:
+All animations, even those with 0 seconds duration, throw animation events.
 
 - {{domxref("Element/animationstart_event", "animationstart")}}
 - {{domxref("Element/animationend_event", "animationend")}}
@@ -317,9 +317,9 @@ Every animation, even those that are 0 seconds in duration, throw animation even
 ## Guides
 
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
-  - : Step-by-step tutorial about how to create animations using CSS. This article describes each relevant CSS property and at-rule and explains how they interact with each other.
+  - : Step-by-step tutorial on how to create animations using CSS. This article describes the animation-related CSS properties and at-rule and how they interact with each other.
 - [CSS animations tips and tricks](/en-US/docs/Web/CSS/CSS_Animations/Tips)
-  - : Tips and tricks to help you get the most out of CSS animations. Currently offers a technique for replaying an animation which has already run through to completion, which the API doesn't support inherently.
+  - : Tips and tricks to help you get the most out of CSS animations.
 
 ## Related concepts
 
@@ -335,6 +335,6 @@ Every animation, even those that are 0 seconds in duration, throw animation even
 ## See also
 
 - The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
-- [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
-- The HTML {{htmlelement("canvas")}} element along with the [canvas API](/en-US/docs/Web/API/Canvas_API) and [WebGL API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
-- [SVG](/en-US/docs/Web/SVG) and the {{domxref("SVGAnimationElement")}} interface, which is the base interface for all of the animation element interfaces: {{domxref("SVGAnimateElement")}}, {{domxref("SVGSetElement")}}, {{domxref("SVGAnimateColorElement")}}, {{domxref("SVGAnimateMotionElement")}} and {{domxref("SVGAnimateTransformElement")}}.
+- Properties in the [transitions](/en-US/docs/Web/CSS/CSS_Transitions) CSS module to trigger animations based on user actions
+- The {{htmlelement("canvas")}} HTML element along with [canvas API](/en-US/docs/Web/API/Canvas_API) and [WebGL API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations
+- The {{domxref("SVGAnimationElement")}} interface for all the animation-related element interfaces, including {{domxref("SVGAnimateElement")}}, {{domxref("SVGSetElement")}}, {{domxref("SVGAnimateColorElement")}}, {{domxref("SVGAnimateMotionElement")}}, and {{domxref("SVGAnimateTransformElement")}}

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -17,8 +17,6 @@ spec-urls:
 
 The **CSS Animations** module lets you animate the values of CSS properties over time, using keyframes, providing properties to control the easing, duration, number of repetitions, play state, and other attributes of these keyframes.
 
-`<STILL WORKING ON THIS>`
-
 ### Example
 
 To activate the clouds to start the snow fall and snow accumulation, hover over the example. When you move the mouse out of the example, the animation will pause.
@@ -218,6 +216,8 @@ div:hover * {
 
 {{ EmbedLiveSample('Example', "630", "630") }}
 
+This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation.
+
 ## Reference
 
 ### Properties
@@ -230,7 +230,6 @@ div:hover * {
 - {{cssxref("animation-fill-mode")}}
 - {{cssxref("animation-iteration-count")}}
 - {{cssxref("animation-name")}}
-- {{cssxref("animation-play-state")}}
 - {{cssxref("animation-timing-function")}}
 - {{cssxref("animation-timeline")}}
 
@@ -286,5 +285,5 @@ div:hover * {
 
 - [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
 - The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
-- The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query to enabled providing minimize motions for users requesting it.
+- The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query to enable minimizing animations for users requesting it.
 - The [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) enables constructing and controlling the playback of animations with JavaScript.

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -87,7 +87,7 @@ i {
   height: 16px;
   width: 16px;
   border-radius: 50%;
-  animation: falling 3s linear 2s infinite backwards;
+  animation: falling 3s linear 0s infinite backwards;
   background-image: 
     linear-gradient(180deg, transparent 40%, white 40%, white 60%, transparent 60%), 
     linear-gradient(90deg, transparent 40%, white 40%, white 60%, transparent 60%), 
@@ -175,7 +175,7 @@ i {
      -5px 15px 15px white, 
      0 20px 20px rgba(125 125 125 / 0.5);
 
-  animation: clouds ease 5s alternate infinite 2s;
+  animation: clouds ease 5s alternate infinite 0.2s, wind ease-out 4s alternate infinite;
 }
 .ground {
   background-image: linear-gradient(to top, white 0 97%, 99%, rgb(125 125 125) 100%);
@@ -193,10 +193,17 @@ i {
 @keyframes clouds {
   from {
     border-radius: 0 0 90px 33% / 0 0 45px 50px; 
-    height: 150px;
   }
   to {
     border-radius: 0 0 40px 50% / 0 0 55px 80px; 
+  }
+}
+
+@keyframes wind {
+  from {
+    height: 150px;
+  }
+  to {
     height: 100px;
   }
 }

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -180,7 +180,7 @@ i {
   animation: clouds ease 5s alternate infinite 2s;
 }
 .ground {
-  background-image: linear-gradient(to top, white 0 98%, rgba(125 125 125 / 0.5) 100%);
+  background-image: linear-gradient(to top, white 0 97%, 99%, rgb(125 125 125) 100%);
   background-position: center 580px;
   animation: snowpile linear 300s forwards;
   border: 1px solid grey;

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -21,7 +21,202 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 ### Example
 
-`<STILL WORKING ON THIS>`
+To activate the clouds to start the snow fall and snow accumulation, hover over the example. When you move the mouse out of the example, the animation will pause.
+
+```html hidden
+<div class="root">
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <i></i>
+  <div class="cloud"></div>
+  <div class="ground"><div>
+</div>
+```
+
+```css hidden
+i {
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  animation: falling 3s linear 2s infinite backwards;
+  background-image: 
+    linear-gradient(180deg, transparent 40%, white 40%, white 60%, transparent 60%), 
+    linear-gradient(90deg, transparent 40%, white 40%, white 60%, transparent 60%), 
+    linear-gradient(45deg, transparent 43%, white 43%, white 57%, transparent 57%), 
+    linear-gradient(135deg, transparent 43%, white 43%, white 57%, transparent 57%); 
+}
+ i:nth-of-type(4n) {
+    height: 30px;
+    width: 30px;
+    transform-origin: right -30px; }
+ i:nth-of-type(4n+1) {
+    height: 24px;
+    width: 24px;
+    transform-origin: left 30px; }
+ i:nth-of-type(4n+2) {
+    height: 10px;
+    width: 10px;
+    transform-origin: -30px 0; }
+ i:nth-of-type(4n+3) {
+    height: 40px;
+    width: 40px;
+    transform-origin: -50px 0; }
+ i:nth-of-type(4n) {
+    animation-duration: 5.3s;
+    animation-iteration-count: 12;
+    transform-origin: -10px -20px; }
+ i:nth-of-type(4n+1) {
+    animation-duration: 3.1s;
+    animation-iteration-count: 20;
+    transform-origin: 10px -20px; }
+ i:nth-of-type(4n+2) {
+    animation-duration: 1.7s;
+    animation-iteration-count: 35;
+    transform-origin: right -20px; }
+ i:nth-of-type(3n) {
+    animation-delay: 2.3s; }
+ i:nth-of-type(3n+1) {
+    animation-delay: 1.5s; }
+ i:nth-of-type(3n+2) {
+    animation-delay: 3.4s; }
+ i:nth-of-type(5n) {
+    animation-timing-function: ease-in-out; }
+ i:nth-of-type(5n+1) {
+    animation-timing-function: ease-out; }
+ i:nth-of-type(5n+2) {
+    animation-timing-function: ease; }
+ i:nth-of-type(5n+3) {
+    animation-timing-function: ease-in; }
+ i:nth-of-type(5n+4) {
+    animation-timing-function: linear; }
+ i:nth-of-type(11n) {
+    animation-timing-function: cubic-bezier(0.2, 0.3, 0.8, 0.9); }
+ i:nth-of-type(7n) {
+    opacity: 0.5; }
+ i:nth-of-type(7n+2) {
+    opacity: 0.3; }
+ i:nth-of-type(7n+4) {
+    opacity: 0.7; }
+ i:nth-of-type(7n+6) {
+    opacity: 0.6;
+    animation-timing-function: ease-in;
+    transform-origin: left 10px; }
+ i:nth-of-type(7n+1) {
+    opacity: 0.8; }
+
+.root {
+  height: 600px;
+  background-color: skyblue;
+  border: 1px solid darkgrey;
+  position: relative;
+  overflow: hidden;
+}
+.ground, .cloud {
+  position: absolute;
+  top: 0; right: 0; left: 0; bottom: 0;
+  background-repeat: no-repeat;
+}
+.cloud { 
+   width:100%;
+   height:150px;
+   background:#ffffff;
+   border-radius: 0 0 90px 33% / 0 0 45px 50px;
+   box-shadow: 
+     5px 15px 15px white, 
+     -5px 15px 15px white, 
+     0 20px 20px rgba(125 125 125 / 0.5);
+
+  animation: clouds ease 5s alternate infinite 2s;
+}
+.ground {
+  background-image: linear-gradient(to top, white 0 98%, rgba(125 125 125 / 0.5) 100%);
+  background-position: center 580px;
+  animation: snowpile linear 300s forwards;
+  border: 1px solid grey;
+  transform: translate3d(0, 0, 0);
+}
+
+@keyframes snowpile {
+  from {background-position: center 580px;}
+  to {background-position: center 280px;}
+}
+
+@keyframes clouds {
+  from {
+    border-radius: 0 0 90px 33% / 0 0 45px 50px; 
+    height: 150px;
+  }
+  to {
+    border-radius: 0 0 40px 50% / 0 0 55px 80px; 
+    height: 100px;
+  }
+}
+
+@keyframes falling {
+  from {
+    transform: translate(0, -50px) rotate(0deg) scale(0.9, 0.9); }
+  to {
+    transform: translate(30px, 600px) rotate(360deg) scale(1.1, 1.1); } 
+}
+
+i, div[class] {animation-play-state: paused;}
+div:hover * {
+  animation-play-state: running;
+}
+```
+
+{{ EmbedLiveSample('Example', "630", "630") }}
 
 ## Reference
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -8,19 +8,22 @@ tags:
   - Guide
   - Overview
   - Reference
-browser-compat: css.properties.animation
+spec-urls: 
+  - https://w3c.github.io/csswg-drafts/css-animations-2/
+  - https://w3c.github.io/csswg-drafts/css-animations/
 ---
 
 {{CSSRef}}
 
-**CSS Animations** is a module of CSS that lets you animate the values of CSS properties over time, using keyframes.
-The behavior of these keyframe animations can be controlled by specifying their timing function, duration, their number of repetitions, and other attributes.
+The **CSS Animations** module lets you animate the values of CSS properties over time, using keyframes, providing properties to control the easing, duration, number of repetitions, play state, and other attributes of these keyframes.
+
+### Example
 
 ## Reference
 
 ### Properties
 
-- {{cssxref("animation")}}
+- {{cssxref("animation")}} shorthand
 - {{cssxref("animation-composition")}}
 - {{cssxref("animation-delay")}}
 - {{cssxref("animation-direction")}}
@@ -29,14 +32,35 @@ The behavior of these keyframe animations can be controlled by specifying their 
 - {{cssxref("animation-iteration-count")}}
 - {{cssxref("animation-name")}}
 - {{cssxref("animation-play-state")}}
-- {{cssxref("animation-timeline")}}
 - {{cssxref("animation-timing-function")}}
-- {{cssxref('scroll-timeline-name')}}
-- {{cssxref('scroll-timeline-axis')}}
+- {{cssxref("animation-timeline")}}
 
 ### At-rules
 
 - {{cssxref("@keyframes")}}
+
+### Data types and values
+
+- {{cssxref("easing-function")}}
+- [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
+
+### Events
+
+- {{domxref("Element/animationstart_event", "animationstart")}}
+- {{domxref("Element/animationend_event", "animationend")}}
+- {{domxref("Element/animationcancel_event", "animationcancel")}},
+- {{domxref("Element/animationiteration_event", "animationiteration")}}
+
+### Interfaces
+
+- {{domxref("AnimationEvent")}} (inherits from {{domxref("Event")}})
+  - : Including {{domxref("AnimationEvent.animationName")}}, {{domxref("AnimationEvent.elapsedTime")}}, and {{domxref("AnimationEvent.pseudoElement")}} properties.
+- {{domxref("CSSKeyframeRule")}} (inherits from {{domxref("CSSRule")}})
+  - : Including {{domxref("CSSKeyframeRule.keyText")}} and {{domxref("CSSKeyframeRule.style")}}.
+- {{domxref("CSSKeyframesRule")}} (inherits from {{domxref("CSSRule")}})
+  - : Including {{domxref("CSSKeyframesRule.name")}}, {{domxref("CSSKeyframesRule.cssRules")}}, {{domxref("CSSKeyframesRule.appendRule()")}}, {{domxref("CSSKeyframesRule.deleteRule()")}}, and {{domxref("CSSKeyframesRule.findRule()")}}
+- {{DOMxRef("Element")}}
+  - : Including {{DOMxRef("Element.animate()")}} and {{DOMxRef("Element.getAnimations()")}}
 
 ## Guides
 
@@ -45,14 +69,21 @@ The behavior of these keyframe animations can be controlled by specifying their 
 - [CSS animations tips and tricks](/en-US/docs/Web/CSS/CSS_Animations/Tips)
   - : Tips and tricks to help you get the most out of CSS animations. Currently offers a technique for replaying an animation which has already run through to completion, which the API doesn't support inherently.
 
+## Associated content
+
+### Associated properties
+
+- {{cssxref('will-change')}}
+
+### Associated concepts and glossary terms
+
+- Glossary: {{glossary("Bézier curve")}}
+
 ## Specifications
 
 {{Specifications}}
 
-## Browser compatibility
-
-{{Compat}}
-
 ## See also
 
-- Related to CSS Animations, [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
+- [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
+- The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -286,4 +286,5 @@ div:hover * {
 
 - [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
 - The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
+- The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query to enabled providing minimize motions for users requesting it.
 - The [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) enables constructing and controlling the playback of animations with JavaScript.

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -274,7 +274,6 @@ input:checked + label::before {
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
 This sample animation uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the cloud move back and forth, {{cssxref("animation-fill-mode")}} to raise the snow level in response to the cloud movement, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
-t
 ## Reference
 
 ### Properties

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -252,13 +252,13 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 ### Interfaces
 
 - {{domxref("AnimationEvent")}} (inherits from {{domxref("Event")}})
-  - : Including {{domxref("AnimationEvent.animationName")}}, {{domxref("AnimationEvent.elapsedTime")}}, and {{domxref("AnimationEvent.pseudoElement")}} properties.
+  - : Including {{domxref("AnimationEvent.animationName")}}, {{domxref("AnimationEvent.elapsedTime")}}, and {{domxref("AnimationEvent.pseudoElement")}}.
 - {{domxref("CSSKeyframeRule")}} (inherits from {{domxref("CSSRule")}})
   - : Including {{domxref("CSSKeyframeRule.keyText")}} and {{domxref("CSSKeyframeRule.style")}}.
 - {{domxref("CSSKeyframesRule")}} (inherits from {{domxref("CSSRule")}})
-  - : Including {{domxref("CSSKeyframesRule.name")}}, {{domxref("CSSKeyframesRule.cssRules")}}, {{domxref("CSSKeyframesRule.appendRule()")}}, {{domxref("CSSKeyframesRule.deleteRule()")}}, and {{domxref("CSSKeyframesRule.findRule()")}}
+  - : Including {{domxref("CSSKeyframesRule.name")}}, {{domxref("CSSKeyframesRule.cssRules")}}, {{domxref("CSSKeyframesRule.appendRule()")}}, {{domxref("CSSKeyframesRule.deleteRule()")}}, and {{domxref("CSSKeyframesRule.findRule()")}}.
 - {{DOMxRef("Element")}}
-  - : Including {{DOMxRef("Element.animate()")}} and {{DOMxRef("Element.getAnimations()")}}
+  - : Including {{DOMxRef("Element.animate()")}} and {{DOMxRef("Element.getAnimations()")}}.
 
 ## Guides
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -267,7 +267,7 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 - [CSS animations tips and tricks](/en-US/docs/Web/CSS/CSS_Animations/Tips)
   - : Tips and tricks to help you get the most out of CSS animations. Currently offers a technique for replaying an animation which has already run through to completion, which the API doesn't support inherently.
 
-## Associated content
+## Related content
 
 ### Associated properties
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -22,7 +22,7 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 To view the animation in action, check the checkbox or hover over the example. The cloud will change shape, snowflakes will fall, and the snow level will rise. To pause the animation, uncheck the checkbox or move your mouse off of the example.
 
 ```html hidden
-<input type="checkbox" id="animate" aria-label="Toggle the play state of the animation">
+<input type="checkbox" id="animate" aria-label="Toggle the play state of the animation"><!-- See aria-label: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label -->
 <label for="animate">the animation</label>
 <div class="root">
   <i></i>
@@ -90,13 +90,14 @@ i {
   width: 16px;
   border-radius: 50%;
   animation: falling 3s linear 0s infinite backwards;
+  /* Snowflakes are made with CSS linear gradients (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients) */
   background-image: 
     linear-gradient(180deg, transparent 40%, white 40%, white 60%, transparent 60%), 
     linear-gradient(90deg, transparent 40%, white 40%, white 60%, transparent 60%), 
     linear-gradient(45deg, transparent 43%, white 43%, white 57%, transparent 57%), 
     linear-gradient(135deg, transparent 43%, white 43%, white 57%, transparent 57%); 
 }
- i:nth-of-type(4n) {
+ i:nth-of-type(4n) { /* using tree structural pseudoclasses to create randomness - https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type */
     height: 30px;
     width: 30px;
     transform-origin: right -30px; 
@@ -156,7 +157,8 @@ i {
     animation-timing-function: linear; 
     }
  i:nth-of-type(11n) {
-    animation-timing-function: cubic-bezier(0.2, 0.3, 0.8, 0.9); }
+    animation-timing-function: cubic-bezier(0.2, 0.3, 0.8, 0.9); 
+    }
  i:nth-of-type(7n) {
     opacity: 0.5; 
     }
@@ -184,19 +186,20 @@ i {
 }
 .ground, .cloud {
   position: absolute;
-  top: 0; right: 0; left: 0; 
+  top: 0; 
+  right: 0; 
+  left: 0; 
   background-repeat: no-repeat;
 }
 .cloud { 
-   width:100%;
-   height:150px;
-   background:#ffffff;
+   width: 100%;
+   height: 150px;
+   background: #ffffff;
    border-radius: 0 0 90px 33% / 0 0 45px 50px;
    box-shadow: 
      5px 15px 15px white, 
      -5px 15px 15px white, 
      0 20px 20px rgba(125 125 125 / 0.5);
-
   animation: 
     clouds ease 5s alternate infinite 0.2s, 
     wind ease-out 4s alternate infinite;
@@ -207,7 +210,8 @@ i {
   background-position: center 580px;
   animation: snowpile linear 300s forwards;
   border: 1px solid grey;
-  transform: translate3d(0, 0, 0);
+  /* put the ground into a 3D rendering context (because the snow flakes are in a 3d rendering context) */
+  transform: translate3d(0, 0, 0); 
 }
 
 @keyframes snowpile {
@@ -246,15 +250,21 @@ i {
     } 
 }
 
+/* by default, the animations are paused. */
 i, 
 div[class] {
   animation-play-state: paused;
 }
-div:hover *, input:checked ~ div * {
+/* When the div is hovered, the animation plays. Also, 
+when the input is checked, the animation coming after the checked checbox plays */
+div:hover *, 
+input:checked ~ div * { 
   animation-play-state: running;
 }
+
+/* Change the content of the label that comes right after the input. Included aria-label on the label to improve accessibility. */
 input + label::before {
-  content: "Play "
+  content: "Play " 
 }
 input:checked + label::before {
   content: "Pause "
@@ -263,7 +273,7 @@ input:checked + label::before {
 
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
-This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation.
+This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md).
 
 ## Reference
 
@@ -290,7 +300,7 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 
 ### Events
 
-Every animation, even those that are 0 seconds long, throw animation events:
+Every animation, even those that are 0 seconds in duration, throw animation events:
 
 - {{domxref("Element/animationstart_event", "animationstart")}}
 - {{domxref("Element/animationend_event", "animationend")}}
@@ -299,6 +309,7 @@ Every animation, even those that are 0 seconds long, throw animation events:
 
 ### Interfaces
 
+- [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)
 - {{domxref("AnimationEvent")}}
 - {{domxref("CSSKeyframeRule")}}
 - {{domxref("CSSKeyframesRule")}}
@@ -310,15 +321,12 @@ Every animation, even those that are 0 seconds long, throw animation events:
 - [CSS animations tips and tricks](/en-US/docs/Web/CSS/CSS_Animations/Tips)
   - : Tips and tricks to help you get the most out of CSS animations. Currently offers a technique for replaying an animation which has already run through to completion, which the API doesn't support inherently.
 
-## Related content
+## Related concepts
 
-### Properties
-
-- {{cssxref("will-change")}}
-
-### Glossary terms
-
-- {{glossary("Bézier curve")}}
+- {{cssxref("will-change")}} CSS property
+- {{glossary("Bézier curve")}} glossary term
+- [`<easing-function>`](foo) data type
+- [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query
 
 ## Specifications
 
@@ -326,7 +334,7 @@ Every animation, even those that are 0 seconds long, throw animation events:
 
 ## See also
 
-- [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
 - The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
-- The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query to enable minimizing animations for users requesting it.
-- The [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) enables constructing and controlling the playback of animations with JavaScript.
+- [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions) can trigger animations based on user actions.
+- The HTML {{htmlelement("canvas")}} element along with the [canvas API](/en-US/docs/Web/API/Canvas_API) and [WebGL API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
+- [SVG](/en-US/docs/Web/SVG) and the {{domxref("SVGAnimationElement")}} interface, which is the base interface for all of the animation element interfaces: {{domxref("SVGAnimateElement")}}, {{domxref("SVGSetElement")}}, {{domxref("SVGAnimateColorElement")}}, {{domxref("SVGAnimateMotionElement")}} and {{domxref("SVGAnimateTransformElement")}}.

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -334,7 +334,7 @@ All animations, even those with 0 seconds duration, throw animation events.
 
 ## See also
 
-- The CSS Scroll Timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
+- {{Experimental_Inline}} The CSS scroll timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
 - Properties in the [transitions](/en-US/docs/Web/CSS/CSS_Transitions) CSS module to trigger animations based on user actions
 - The {{htmlelement("canvas")}} HTML element along with [canvas API](/en-US/docs/Web/API/Canvas_API) and [WebGL API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations
 - The {{domxref("SVGAnimationElement")}} interface for all the animation-related element interfaces, including {{domxref("SVGAnimateElement")}}, {{domxref("SVGSetElement")}}, {{domxref("SVGAnimateColorElement")}}, {{domxref("SVGAnimateMotionElement")}}, and {{domxref("SVGAnimateTransformElement")}}

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -17,7 +17,7 @@ spec-urls:
 
 The **CSS Animations** module lets you animate the values of CSS properties over time, using keyframes, providing properties to control the easing, duration, number of repetitions, play state, and other attributes of these keyframes.
 
-### Example
+### Animations in action
 
 To view the animation in action, check the checkbox or hover over the example. The cloud will change shape, snowflakes will fall, and the snow level will rise. To pause the animation, uncheck the checkbox or move your mouse off of the example.
 
@@ -261,7 +261,7 @@ input:checked + label::before {
 }
 ```
 
-{{ EmbedLiveSample('Example', "630", "630") }}
+{{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
 This example uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the clouds move back and forth, {{cssxref("animation-fill-mode")}} to keep the snow level high once it has stopped growing, and {{cssxref("animation-play-state")}} to pause the animation.
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -43,7 +43,7 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 - {{cssxref("@keyframes")}}
 
-### Data types and values
+### Data types, functions, and values
 
 - {{cssxref("easing-function")}}
 - [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
@@ -79,9 +79,9 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 - {{cssxref('will-change')}}
 
-### Associated concepts and glossary terms
+### Glossary terms
 
-- Glossary: {{glossary("Bézier curve")}}
+- {{glossary("Bézier curve")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -324,9 +324,9 @@ Every animation, even those that are 0 seconds in duration, throw animation even
 ## Related concepts
 
 - {{cssxref("will-change")}} CSS property
-- {{glossary("Bézier curve")}} glossary term
-- [`<easing-function>`](foo) data type
+- [`<easing-function>`](/en-US/docs/Web/CSS/easing-function) data type
 - [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query
+- {{glossary("Bézier curve")}} glossary term
 
 ## Specifications
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Animations
+title: CSS animations
 slug: Web/CSS/CSS_Animations
 page-type: css-module
 tags:

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -19,9 +19,11 @@ The **CSS Animations** module lets you animate the values of CSS properties over
 
 ### Example
 
-To activate the clouds to start the snow fall and snow accumulation, hover over the example. When you move the mouse out of the example, the animation will pause.
+To view the animation in action, check the checkbox or hover over the example. The cloud will change shape, snowflakes will fall, and the snow level will rise. To pause the animation, uncheck the checkbox or move your mouse off of the example.
 
 ```html hidden
+<input type="checkbox" id="animate" aria-label="Toggle the play state of the animation">
+<label for="animate">the animation</label>
 <div class="root">
   <i></i>
   <i></i>
@@ -97,61 +99,81 @@ i {
  i:nth-of-type(4n) {
     height: 30px;
     width: 30px;
-    transform-origin: right -30px; }
+    transform-origin: right -30px; 
+    }
  i:nth-of-type(4n+1) {
     height: 24px;
     width: 24px;
-    transform-origin: left 30px; }
+    transform-origin: left 30px; 
+    }
  i:nth-of-type(4n+2) {
     height: 10px;
     width: 10px;
-    transform-origin: -30px 0; }
+    transform-origin: -30px 0; 
+    }
  i:nth-of-type(4n+3) {
     height: 40px;
     width: 40px;
-    transform-origin: -50px 0; }
+    transform-origin: -50px 0; 
+    }
  i:nth-of-type(4n) {
     animation-duration: 5.3s;
     animation-iteration-count: 12;
-    transform-origin: -10px -20px; }
+    transform-origin: -10px -20px; 
+    }
  i:nth-of-type(4n+1) {
     animation-duration: 3.1s;
     animation-iteration-count: 20;
-    transform-origin: 10px -20px; }
+    transform-origin: 10px -20px; 
+    }
  i:nth-of-type(4n+2) {
     animation-duration: 1.7s;
     animation-iteration-count: 35;
-    transform-origin: right -20px; }
+    transform-origin: right -20px; 
+    }
  i:nth-of-type(3n) {
-    animation-delay: 2.3s; }
+    animation-delay: 2.3s; 
+    }
  i:nth-of-type(3n+1) {
-    animation-delay: 1.5s; }
+    animation-delay: 1.5s; 
+    }
  i:nth-of-type(3n+2) {
-    animation-delay: 3.4s; }
+    animation-delay: 3.4s; 
+    }
  i:nth-of-type(5n) {
-    animation-timing-function: ease-in-out; }
+    animation-timing-function: ease-in-out; 
+    }
  i:nth-of-type(5n+1) {
-    animation-timing-function: ease-out; }
+    animation-timing-function: ease-out; 
+    }
  i:nth-of-type(5n+2) {
-    animation-timing-function: ease; }
+    animation-timing-function: ease; 
+    }
  i:nth-of-type(5n+3) {
-    animation-timing-function: ease-in; }
+    animation-timing-function: ease-in; 
+    }
  i:nth-of-type(5n+4) {
-    animation-timing-function: linear; }
+    animation-timing-function: linear; 
+    }
  i:nth-of-type(11n) {
     animation-timing-function: cubic-bezier(0.2, 0.3, 0.8, 0.9); }
  i:nth-of-type(7n) {
-    opacity: 0.5; }
+    opacity: 0.5; 
+    }
  i:nth-of-type(7n+2) {
-    opacity: 0.3; }
+    opacity: 0.3; 
+    }
  i:nth-of-type(7n+4) {
-    opacity: 0.7; }
+    opacity: 0.7; 
+    }
  i:nth-of-type(7n+6) {
     opacity: 0.6;
     animation-timing-function: ease-in;
-    transform-origin: left 10px; }
+    transform-origin: left 10px;
+    }
  i:nth-of-type(7n+1) {
-    opacity: 0.8; }
+    opacity: 0.8;
+    }
 
 .root {
   height: 600px;
@@ -162,7 +184,7 @@ i {
 }
 .ground, .cloud {
   position: absolute;
-  top: 0; right: 0; left: 0; bottom: 0;
+  top: 0; right: 0; left: 0; 
   background-repeat: no-repeat;
 }
 .cloud { 
@@ -175,10 +197,13 @@ i {
      -5px 15px 15px white, 
      0 20px 20px rgba(125 125 125 / 0.5);
 
-  animation: clouds ease 5s alternate infinite 0.2s, wind ease-out 4s alternate infinite;
+  animation: 
+    clouds ease 5s alternate infinite 0.2s, 
+    wind ease-out 4s alternate infinite;
 }
 .ground {
-  background-image: linear-gradient(to top, white 0 97%, 99%, rgb(125 125 125) 100%);
+  bottom: 0;
+  background-image: linear-gradient(to top, #fff 97%, 99%, #bbb 100%);
   background-position: center 580px;
   animation: snowpile linear 300s forwards;
   border: 1px solid grey;
@@ -186,8 +211,12 @@ i {
 }
 
 @keyframes snowpile {
-  from {background-position: center 580px;}
-  to {background-position: center 280px;}
+  from {
+    background-position: center 580px;
+    }
+  to {
+    background-position: center 280px;
+    }
 }
 
 @keyframes clouds {
@@ -210,14 +239,25 @@ i {
 
 @keyframes falling {
   from {
-    transform: translate(0, -50px) rotate(0deg) scale(0.9, 0.9); }
+    transform: translate(0, -50px) rotate(0deg) scale(0.9, 0.9); 
+    }
   to {
-    transform: translate(30px, 600px) rotate(360deg) scale(1.1, 1.1); } 
+    transform: translate(30px, 600px) rotate(360deg) scale(1.1, 1.1); 
+    } 
 }
 
-i, div[class] {animation-play-state: paused;}
-div:hover * {
+i, 
+div[class] {
+  animation-play-state: paused;
+}
+div:hover *, input:checked ~ div * {
   animation-play-state: running;
+}
+input + label::before {
+  content: "Play "
+}
+input:checked + label::before {
+  content: "Pause "
 }
 ```
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -17,6 +17,8 @@ spec-urls:
 
 The **CSS Animations** module lets you animate the values of CSS properties over time, using keyframes, providing properties to control the easing, duration, number of repetitions, play state, and other attributes of these keyframes.
 
+`<STILL WORKING ON THIS>`
+
 ### Example
 
 `<STILL WORKING ON THIS>`

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -297,7 +297,7 @@ Every animation, even those that are 0 seconds long, throw animation events:
 - {{domxref("Element/animationcancel_event", "animationcancel")}}
 - {{domxref("Element/animationiteration_event", "animationiteration")}}
 
-### Interfaces_
+### Interfaces
 
 - {{domxref("AnimationEvent")}}
 - {{domxref("CSSKeyframeRule")}}
@@ -312,7 +312,7 @@ Every animation, even those that are 0 seconds long, throw animation events:
 
 ## Related content
 
-### properties
+### Properties
 
 - {{cssxref("will-change")}}
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -289,11 +289,19 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 - {{cssxref("easing-function")}}
 - [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
 
+or
+
+### Functions
+
+- [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
+
 ### Events
+
+Every animation, even those that are 0 seconds long, throw animation events:
 
 - {{domxref("Element/animationstart_event", "animationstart")}}
 - {{domxref("Element/animationend_event", "animationend")}}
-- {{domxref("Element/animationcancel_event", "animationcancel")}},
+- {{domxref("Element/animationcancel_event", "animationcancel")}}
 - {{domxref("Element/animationiteration_event", "animationiteration")}}
 
 ### Interfaces
@@ -304,8 +312,14 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
   - : Including {{domxref("CSSKeyframeRule.keyText")}} and {{domxref("CSSKeyframeRule.style")}}.
 - {{domxref("CSSKeyframesRule")}} (inherits from {{domxref("CSSRule")}})
   - : Including {{domxref("CSSKeyframesRule.name")}}, {{domxref("CSSKeyframesRule.cssRules")}}, {{domxref("CSSKeyframesRule.appendRule()")}}, {{domxref("CSSKeyframesRule.deleteRule()")}}, and {{domxref("CSSKeyframesRule.findRule()")}}.
-- {{DOMxRef("Element")}}
-  - : Including {{DOMxRef("Element.animate()")}} and {{DOMxRef("Element.getAnimations()")}}.
+
+or
+
+### Interfaces_
+
+- {{domxref("AnimationEvent")}}
+- {{domxref("CSSKeyframeRule")}}
+- {{domxref("CSSKeyframesRule")}}
 
 ## Guides
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -284,13 +284,6 @@ This example uses {{cssxref("animation-iteration-count")}} to make the flakes fa
 
 - {{cssxref("@keyframes")}}
 
-### Data types, functions, and values
-
-- {{cssxref("easing-function")}}
-- [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
-
-or
-
 ### Functions
 
 - [`scroll()`](/en-US/docs/Web/CSS/animation-timeline/scroll) function
@@ -303,17 +296,6 @@ Every animation, even those that are 0 seconds long, throw animation events:
 - {{domxref("Element/animationend_event", "animationend")}}
 - {{domxref("Element/animationcancel_event", "animationcancel")}}
 - {{domxref("Element/animationiteration_event", "animationiteration")}}
-
-### Interfaces
-
-- {{domxref("AnimationEvent")}} (inherits from {{domxref("Event")}})
-  - : Including {{domxref("AnimationEvent.animationName")}}, {{domxref("AnimationEvent.elapsedTime")}}, and {{domxref("AnimationEvent.pseudoElement")}}.
-- {{domxref("CSSKeyframeRule")}} (inherits from {{domxref("CSSRule")}})
-  - : Including {{domxref("CSSKeyframeRule.keyText")}} and {{domxref("CSSKeyframeRule.style")}}.
-- {{domxref("CSSKeyframesRule")}} (inherits from {{domxref("CSSRule")}})
-  - : Including {{domxref("CSSKeyframesRule.name")}}, {{domxref("CSSKeyframesRule.cssRules")}}, {{domxref("CSSKeyframesRule.appendRule()")}}, {{domxref("CSSKeyframesRule.deleteRule()")}}, and {{domxref("CSSKeyframesRule.findRule()")}}.
-
-or
 
 ### Interfaces_
 
@@ -330,7 +312,7 @@ or
 
 ## Related content
 
-### Associated properties
+### properties
 
 - {{cssxref("will-change")}}
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -274,6 +274,7 @@ input:checked + label::before {
 {{ EmbedLiveSample('Animations_in_action', "630", "630") }}
 
 This sample animation uses {{cssxref("animation-iteration-count")}} to make the flakes fall repeatedly, {{cssxref("animation-direction")}} to make the cloud move back and forth, {{cssxref("animation-fill-mode")}} to raise the snow level in response to the cloud movement, and {{cssxref("animation-play-state")}} to pause the animation. To see the code for this animation, [view the source on Github](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md?plain=1).
+
 ## Reference
 
 ### Properties


### PR DESCRIPTION
Part of Q1-2023 project https://github.com/openwebdocs/project/issues/147


~~Note, https://github.com/w3c/browser-specs/pull/851 should fix the spec name appearing the same for 2 different specs on the blending and compositing page.~~



