### PR TITLE
Add info about running a local server through an extension

### DIFF
--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -60,6 +60,7 @@ Some examples won't run if you open them as local files. This can be due to a va
 If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. In addition to automate the installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
 
 For VSCode, you can check the following free extension:
+
 - `vscode-preview-server`. You can check it on its [home page](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server).
 
 ## Running a simple local HTTP server

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -59,7 +59,7 @@ Some examples won't run if you open them as local files. This can be due to a va
 
 To get around the problem of async requests, we need to test such examples by running them through a local web server.
 
-### Using an extension in your code editor to run a local HTTP server
+### Using an extension in your code editor
 
 If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. As well as automating installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
 

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -57,7 +57,7 @@ Some examples won't run if you open them as local files. This can be due to a va
 
 ## Using an extension in your code editor to run a local HTTP server
 
-If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. In addition to automate the installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
+If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. As well as automating installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
 
 For VSCode, you can check the following free extension:
 

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -55,6 +55,13 @@ Some examples won't run if you open them as local files. This can be due to a va
 - **They include other files**. Browsers commonly treat requests to load resources using the `file://` schema as cross-origin requests.
   So if you load a local file that includes other local files, this may trigger a {{Glossary("CORS")}} error.
 
+## Using an extension in your code editor to run a local HTTP server
+
+If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. In addition to automate the installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
+
+For VSCode, you can check the following free extension:
+- `vscode-preview-server`. You can check it on its [home page](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server).
+
 ## Running a simple local HTTP server
 
 To get around the problem of async requests, we need to test such examples by running them through a local web server.

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -69,7 +69,7 @@ For VSCode, you can check the following free extension:
 
 ### Using Python
 
-Another way to do this for our purposes is to use Python's `http.server` module.
+Another way to achieve this is to use Python's `http.server` module.
 
 > **Note:** Older versions of Python (up to version 2.7) provided a similar module named `SimpleHTTPServer`. If you are using Python 2.x, you can follow this guide by replacing all uses of `http.server` with `SimpleHTTPServer`. However, we recommend you use the latest version of Python.
 

--- a/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -55,7 +55,11 @@ Some examples won't run if you open them as local files. This can be due to a va
 - **They include other files**. Browsers commonly treat requests to load resources using the `file://` schema as cross-origin requests.
   So if you load a local file that includes other local files, this may trigger a {{Glossary("CORS")}} error.
 
-## Using an extension in your code editor to run a local HTTP server
+## Running a simple local HTTP server
+
+To get around the problem of async requests, we need to test such examples by running them through a local web server.
+
+### Using an extension in your code editor to run a local HTTP server
 
 If you only need HTML, CSS and JavaScript, and no server-side language, the easiest way may be to check for extensions in your code editor. As well as automating installation and set-up for your local HTTP server, they also integrate nicely with your code editors. Testing local files in an HTTP server may be one click away.
 
@@ -63,10 +67,9 @@ For VSCode, you can check the following free extension:
 
 - `vscode-preview-server`. You can check it on its [home page](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server).
 
-## Running a simple local HTTP server
+### Using Python
 
-To get around the problem of async requests, we need to test such examples by running them through a local web server.
-One of the easiest ways to do this for our purposes is to use Python's `http.server` module.
+Another way to do this for our purposes is to use Python's `http.server` module.
 
 > **Note:** Older versions of Python (up to version 2.7) provided a similar module named `SimpleHTTPServer`. If you are using Python 2.x, you can follow this guide by replacing all uses of `http.server` with `SimpleHTTPServer`. However, we recommend you use the latest version of Python.
 


### PR DESCRIPTION
In https://github.com/mdn/webaudio-examples/pull/51#issuecomment-1302772264, @hamishwillee suggested extending the page with this information, as it is very convenient to test local pages.

So here it is. It could be extended with more extensions in the future, for VSCode or for other code editors.