### PR TITLE
Update obsolete reference link

### DIFF
--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
@@ -28,7 +28,7 @@ ecosystems (for example, Android or TPM attestations).
 
 ## Value
 
-After decoding the [CBOR](https://datatracker.ietf.org/doc/html/rfc7049) encoded
+After decoding the [CBOR](https://datatracker.ietf.org/doc/html/rfc8949) encoded
 `ArrayBuffer`, the resulting JavaScript object will contain the following
 properties:
 
@@ -38,7 +38,7 @@ properties:
     that in {{domxref("AuthenticatorAssertionResponse")}}, the
     `authenticatorData` is exposed as a property in a JavaScript object while
     in {{domxref("AuthenticatorAttestationResponse")}}, the `authenticatorData`
-    is a property in a [CBOR](https://datatracker.ietf.org/doc/html/rfc7049) map.
+    is a property in a [CBOR](https://datatracker.ietf.org/doc/html/rfc8949) map.
 
     The same {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} field is
     used by both `AuthenticatorAttestationResponse` and by


### PR DESCRIPTION
### Description

This PR updates the obsolete reference link.

### Motivation

RFC7049 (CBOR) is replaced by RFC8949.

### Additional details

`N/A`

### Related issues and pull requests

`N/A`