### PR TITLE
Simplify prefers-color-scheme example

### DIFF
--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -49,12 +49,7 @@ The following HTML is used:
 <div class="scheme none">No scheme detected style</div>
 <br />
 
-<div class="scheme result">
-  Result:
-  <span class="result-text light">Light scheme</span>
-  <span class="result-text dark">Dark scheme</span>
-  <span class="result-text none">No scheme detected</span>
-</div>
+<div class="scheme result">Result: this is the active color scheme</div>
 ```
 
 The following CSS is used to style the elements above:
@@ -72,11 +67,6 @@ The following CSS is used to style the elements above:
 /* wider result shape */
 .scheme.result {
   width: 25.5em;
-}
-
-/* hide result labels (active scheme will un-hide the correct label) */
-.result-text {
-  display: none;
 }
 
 /* light scheme style */
@@ -97,27 +87,12 @@ The following CSS is used to style the elements above:
   color: black;
 }
 
-/* un-hide no scheme label */
-.result-text.none {
-  display: initial;
-}
-
 @media (prefers-color-scheme: dark) {
   /* dark scheme active */
   /* style result like dark scheme */
   .scheme.result {
     background: black;
     color: white;
-  }
-  
-  /* re-hide no scheme label */
-  .result-text.none {
-    display: none;
-  }
-  
-  /* un-hide dark scheme label */
-  .result-text.dark {
-    display: initial;
   }
 }
 
@@ -127,16 +102,6 @@ The following CSS is used to style the elements above:
   .scheme.result {
     background: #eee;
     color: black;
-  }
-  
-  /* re-hide no scheme label */
-  .result-text.none {
-    display: none;
-  }
-  
-  /* un-hide light scheme label */
-  .result-text.light {
-    display: initial;
   }
 }
 ```

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -41,57 +41,81 @@ The elements below have an initial color theme.
 They can be further themed according to the user's color scheme preference.
 
 ```html
-<div class="day">Day (initial)</div>
-<div class="day light-scheme">Day (changes in light scheme)</div>
-<div class="day dark-scheme">Day (changes in dark scheme)</div>
+<div class="scheme-example light-scheme">Light scheme style</div>
+<div class="scheme-example dark-scheme">Dark scheme style</div>
+<div class="scheme-example no-scheme">No scheme detected style</div>
 <br />
 
-<div class="night">Night (initial)</div>
-<div class="night light-scheme">Night (changes in light scheme)</div>
-<div class="night dark-scheme">Night (changes in dark scheme)</div>
+<div class="scheme-example result-scheme">Result: <span class="result-text light-scheme-text">Light scheme</span> <span class="result-text dark-scheme-text">Dark scheme</span> <span class="result-text no-scheme-text">No scheme detected</span></div>
 ```
 
 The following CSS is used to style the elements above:
 
 ```css
-.day {
-  background: #eee;
-  color: black;
-}
-.night {
-  background: #333;
-  color: white;
-}
 
-@media (prefers-color-scheme: dark) {
-  .day.dark-scheme {
-    background: #333;
-    color: white;
-  }
-  .night.dark-scheme {
-    background: black;
-    color: #ddd;
-  }
-}
-
-@media (prefers-color-scheme: light) {
-  .day.light-scheme {
-    background: white;
-    color: #555;
-  }
-  .night.light-scheme {
-    background: #eee;
-    color: black;
-  }
-}
-
-.day,
-.night {
+.scheme-example {
   display: inline-block;
   padding: 1em;
   width: 7em;
   height: 2em;
   vertical-align: middle;
+}
+
+.result-scheme {
+  width: 25.5em;
+}
+
+.result-text {
+  display: none;
+}
+
+.light-scheme {
+  background: #eee;
+  color: black;
+}
+
+.dark-scheme {
+  background: black;
+  color: white;
+}
+
+.no-scheme, .result-scheme {
+  background: #aaa;
+  color: black;
+}
+
+.no-scheme-text {
+  display: initial;
+}
+
+@media (prefers-color-scheme: dark) {
+  .result-scheme {
+    background: black;
+    color: white;
+  }
+  
+  .no-scheme-text {
+    display: none;
+  }
+  
+  .dark-scheme-text {
+    display: initial;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .result-scheme {
+    background: #eee;
+    color: black;
+  }
+  
+  .no-scheme-text {
+    display: none;
+  }
+  
+  .light-scheme-text {
+    display: initial;
+  }
 }
 ```
 

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -41,18 +41,22 @@ Three elements show the possible color schemes for a website: a light scheme, a 
 
 Below those three example elements is a "result" element showing the actual scheme that your browser selected, using the `prefers-color-scheme` media query.
 
-The following HTML is used:
+{{EmbedLiveSample("Detecting_a_dark_or_light_theme")}}
+
+The code used to generate this example:
+
+HTML:
 
 ```html
-<div class="scheme light">Light scheme style</div>
-<div class="scheme dark">Dark scheme style</div>
-<div class="scheme none">No scheme detected style</div>
+<div class="scheme light">Light color scheme</div>
+<div class="scheme dark">Dark color scheme</div>
+<div class="scheme none">No color scheme detected</div>
 <br />
 
 <div class="scheme result">Result: this is the active color scheme</div>
 ```
 
-The following CSS is used to style the elements above:
+CSS:
 
 ```css
 /* basic shape */
@@ -105,8 +109,6 @@ The following CSS is used to style the elements above:
   }
 }
 ```
-
-{{EmbedLiveSample("Detecting_a_dark_or_light_theme")}}
 
 ### Color scheme inheritance
 

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -35,10 +35,13 @@ To learn more about SVGs, see the [SVG documentation](/en-US/docs/Web/SVG) and f
 
 ## Examples
 
-### Detecting a dark theme
+### Detecting a dark or light theme
 
-The elements below have an initial color theme.
-They can be further themed according to the user's color scheme preference.
+Three elements show the possible color schemes for a website: a light scheme, a dark scheme, and a default scheme (if the browser doesn't support this feature or can't determine a preferred color scheme).
+
+Below those three example elements is a "result" element showing the actual scheme that your browser selected, using the `prefers-color-scheme` media query.
+
+The following HTML is used:
 
 ```html
 <div class="scheme light">Light scheme style</div>
@@ -138,7 +141,7 @@ The following CSS is used to style the elements above:
 }
 ```
 
-{{EmbedLiveSample("Detecting_a_dark_theme")}}
+{{EmbedLiveSample("Detecting_a_dark_or_light_theme")}}
 
 ### Color scheme inheritance
 

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -41,79 +41,98 @@ The elements below have an initial color theme.
 They can be further themed according to the user's color scheme preference.
 
 ```html
-<div class="scheme-example light-scheme">Light scheme style</div>
-<div class="scheme-example dark-scheme">Dark scheme style</div>
-<div class="scheme-example no-scheme">No scheme detected style</div>
+<div class="scheme light">Light scheme style</div>
+<div class="scheme dark">Dark scheme style</div>
+<div class="scheme none">No scheme detected style</div>
 <br />
 
-<div class="scheme-example result-scheme">Result: <span class="result-text light-scheme-text">Light scheme</span> <span class="result-text dark-scheme-text">Dark scheme</span> <span class="result-text no-scheme-text">No scheme detected</span></div>
+<div class="scheme result">
+  Result:
+  <span class="result-text light">Light scheme</span>
+  <span class="result-text dark">Dark scheme</span>
+  <span class="result-text none">No scheme detected</span>
+</div>
 ```
 
 The following CSS is used to style the elements above:
 
 ```css
-
-.scheme-example {
+/* basic shape */
+.scheme {
   display: inline-block;
   padding: 1em;
   width: 7em;
-  height: 2em;
+  height: 3em;
   vertical-align: middle;
 }
 
-.result-scheme {
+/* wider result shape */
+.scheme.result {
   width: 25.5em;
 }
 
+/* hide result labels (active scheme will un-hide the correct label) */
 .result-text {
   display: none;
 }
 
-.light-scheme {
+/* light scheme style */
+.scheme.light {
   background: #eee;
   color: black;
 }
 
-.dark-scheme {
+/* dark scheme style */
+.scheme.dark {
   background: black;
   color: white;
 }
 
-.no-scheme, .result-scheme {
+/* no scheme style, also initial style for result */
+.scheme.none, .scheme.result {
   background: #aaa;
   color: black;
 }
 
-.no-scheme-text {
+/* un-hide no scheme label */
+.result-text.none {
   display: initial;
 }
 
 @media (prefers-color-scheme: dark) {
-  .result-scheme {
+  /* dark scheme active */
+  /* style result like dark scheme */
+  .scheme.result {
     background: black;
     color: white;
   }
   
-  .no-scheme-text {
+  /* re-hide no scheme label */
+  .result-text.none {
     display: none;
   }
   
-  .dark-scheme-text {
+  /* un-hide dark scheme label */
+  .result-text.dark {
     display: initial;
   }
 }
 
 @media (prefers-color-scheme: light) {
-  .result-scheme {
+  /* light scheme active */
+  /* style result like light scheme */
+  .scheme.result {
     background: #eee;
     color: black;
   }
   
-  .no-scheme-text {
+  /* re-hide no scheme label */
+  .result-text.none {
     display: none;
   }
   
-  .light-scheme-text {
+  /* un-hide light scheme label */
+  .result-text.light {
     display: initial;
   }
 }


### PR DESCRIPTION
### Description

The [main example for the `prefers-color-scheme` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme#examples) is needlessly confusing. This PR replaces it with a much simpler example, dealing only with color schemes.

### Motivation

The current example involves "day" and "night" classes mixed with the schemes. It makes it difficult for a reader to understand, and the reasoning behind its structure is not explained. It does a bad job of demonstrating the `prefers-color-scheme` media query and the simplest application of it.

The replacement example in this PR is straightforward and (hopefully) easy to understand and adapt to different websites. It uses the media query the way it was intended - to select a color scheme for content - without any extra complications.

### Additional details

~~Important: I tested this only using a fiddle website. I am not able to set up a node.js environment currently, but I did my best and I hope the result renders correctly. Since this is such a small change, I was hoping a maintainer (or automated system?) could just quickly check that it renders correctly, and if not let me know how to correct it. I'm sorry if this is a big no-no, the effort to set up an entire environment just to update/improve one example seems disproportionate.~~

Update: awesome, the GitHub bot generated a preview :)

~~As for the actual content change - I am wondering if I made it over-complicated by adding the text labels with `display: none/initial;`. It creates a nice output in the example, but at the cost of making the CSS significantly longer and more complex, defeating the purpose of this PR to make the example simpler. I did add comments to explain what each section does in order to help readers know which bits are important, but I welcome any feedback.~~

Update: I've removed that bit, I'm now confident it was unnecessary.

### Related issues and pull requests

Issue #22155 was possibly opened as a direct result of the confusing nature of the current example.