### PR TITLE
Add `Element.getAnimations()` to Web Animations API sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1566,7 +1566,11 @@
         "DocumentTimeline",
         "KeyframeEffect"
       ],
-      "methods": ["Document.getAnimations()", "Element.animate()"],
+      "methods": [
+        "Document.getAnimations()",
+        "Element.animate()",
+        "Element.getAnimations()"
+      ],
       "properties": ["Document.timeline"],
       "events": []
     },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adds a link to `Element.getAnimations()` in the `methods` section of the Web Animations API sidebar.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

`Element.getAnimations()` is defined in the Web Animations API spec (on the [`Animatable` mixin](https://w3c.github.io/csswg-drafts/web-animations-1/#the-animatable-interface-mixin) and returns Web Animations API types.