### PR TITLE
Synchronize list of DOM interfaces with its sidebar

### DIFF
--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -26,6 +26,9 @@ To learn more about what the DOM is and how it represents documents, see our art
 
 ## DOM interfaces
 
+- {{DOMxRef("AbortController")}}
+- {{DOMxRef("AbortSignal")}}
+- {{DOMxRef("AbstractRange")}}
 - {{DOMxRef("Attr")}}
 - {{DOMxRef("CDATASection")}}
 - {{DOMxRef("CharacterData")}}
@@ -37,7 +40,10 @@ To learn more about what the DOM is and how it represents documents, see our art
 - {{DOMxRef("DOMError")}} {{Deprecated_Inline}}
 - {{DOMxRef("DOMException")}}
 - {{DOMxRef("DOMImplementation")}}
-- {{DOMxRef("DOMStringList")}}
+- {{DOMxRef("DOMParser")}}
+- {{DOMxRef("DOMPoint")}}
+- {{DOMxRef("DOMPointReadOnly")}}
+- {{DOMxRef("DOMRect")}}
 - {{DOMxRef("DOMTokenList")}}
 - {{DOMxRef("Element")}}
 - {{DOMxRef("Event")}}
@@ -52,15 +58,13 @@ To learn more about what the DOM is and how it represents documents, see our art
 - {{DOMxRef("NodeList")}}
 - {{DOMxRef("ProcessingInstruction")}}
 - {{DOMxRef("Range")}}
+- {{DOMxRef("StaticRange")}}
 - {{DOMxRef("Text")}}
-- {{DOMxRef("TextDecoder")}} {{Experimental_Inline}}
-- {{DOMxRef("TextEncoder")}} {{Experimental_Inline}}
+- {{DOMxRef("TextDecoder")}}
+- {{DOMxRef("TextEncoder")}}
 - {{DOMxRef("TimeRanges")}}
 - {{DOMxRef("TreeWalker")}}
-- {{DOMxRef("URL")}}
-- {{DOMxRef("Window")}}
-- {{DOMxRef("Worker")}}
-- {{DOMxRef("XMLDocument")}} {{Experimental_Inline}}
+- {{DOMxRef("XMLDocument")}}
 
 ### Obsolete DOM interfaces
 


### PR DESCRIPTION
Fix #21453

The lists of interfaces in the article and in the sidebar are different. Even if we want at some point to have them automatically synchronized, there is no reason not to manually fix them now, especially as the DOM spec is pretty stable.