### PR TITLE
ValidityState.typeMismatch - Making the EmbedLiveSample slightly bigger for readability.

### DIFF
--- a/files/en-us/web/api/validitystate/typemismatch/index.md
+++ b/files/en-us/web/api/validitystate/typemismatch/index.md
@@ -51,7 +51,7 @@ input:invalid {
 }
 ```
 
-{{EmbedLiveSample("Examples", 300, 40)}}
+{{EmbedLiveSample("Examples", 300, 110)}}
 
 The above each produce a `typeMismatch` because the email address is just a domain and the URL has no protocol
 


### PR DESCRIPTION

### Description

Basically, the example found here is too small in case of height of the example. It forces the user to scroll inside of it.

Current:
![annoying](https://user-images.githubusercontent.com/15019822/215046301-d0a640aa-87f6-456c-8b9e-17bc6fea700f.gif)


My suggested change:
![less_annoying](https://user-images.githubusercontent.com/15019822/215046331-c2d6ce7e-be57-422b-9322-01bc8701c8db.png)

### Motivation

It will make it more readable. 

### Additional details

... Thanks for making the docs so easy to read, makes me want to contribute in the future. 
