### PR TITLE
Make the guttering section more clear 

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -64,9 +64,7 @@ You may have heard great stories about negative margins. Don't even think. Nowad
 
 The gap property in CSS is a shorthand for `row-gap` and `column-gap`, specifying the size of gutters, which is the space between rows and columns within grid, flex, and multi-column layouts.
 
-In Flexbox, the `gap` property is applied on the flex-container. It creates a fixed space between the flex-items but not on the sides.
-However, the gap property is not the only thing that can put space between items. Margins, paddings, justify-content and align-content can also increase the size of the gutter and affect the actual gap value.  You should try out and see how the `gap` property differs from margin(in both axes) and how margin or padding affects it.
-
+In Flexbox, the `gap` property is applied on the flex-container. It creates a fixed space between the flex-items but not on the sides. However, the gap property is not the only thing that can put space between items. Margins, paddings, justify-content and align-content can also increase the size of the gutter and affect the actual gap value. You should try out and see how the `gap` property differs from margin(in both axes) and how margin or padding affects it.
 
 {{EmbedGHLiveSample("css-examples/flexbox/wrapping/gaps.html", '100%', 830)}}
 

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -60,7 +60,7 @@ If you need flex items to line up in the cross axis, controlling the width in th
 
 ## Creating gutters between items
 
-You may have heard great stories about negative margins. Don't even think. Nowadays we have the Flexbox `gap` property to make the said task super convenient.
+To create gaps or gutters between flex items, use the {{CSSXref('gap')}} property.
 
 The gap property in CSS is a shorthand for `row-gap` and `column-gap`, specifying the size of gutters, which is the space between rows and columns within grid, flex, and multi-column layouts.
 

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -60,9 +60,13 @@ If you need flex items to line up in the cross axis, controlling the width in th
 
 ## Creating gutters between items
 
-When wrapping flex items, the need to space them out is likely to arise. You can see from the live example below that in order to create gaps that do not also create a gap at the edges of the container, we need to use negative margins on the flex container itself. Any border on the flex container is then moved to a second wrapper in order that the negative margin can pull the items up to that wrapper element.
+You may have heard great stories about negative margins. Don't even think. Nowadays we have the Flexbox `gap` property to make the said task super convenient.
 
-A more robust way to perform the above tasks is to include the Flexbox `gap` property on the container to set equal space between all flex items. Try setting gaps using both negative margins and the `gap` property in the editor below.
+The gap property in CSS is a shorthand for `row-gap` and `column-gap`, specifying the size of gutters, which is the space between rows and columns within grid, flex, and multi-column layouts.
+
+In Flexbox, the `gap` property is applied on the flex-container. It creates a fixed space between the flex-items but not on the sides.
+However, the gap property is not the only thing that can put space between items. Margins, paddings, justify-content and align-content can also increase the size of the gutter and affect the actual gap value.  You should try out and see how the `gap` property differs from margin(in both axes) and how margin or padding affects it.
+
 
 {{EmbedGHLiveSample("css-examples/flexbox/wrapping/gaps.html", '100%', 830)}}
 

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -64,7 +64,7 @@ To create gaps or gutters between flex items, use the {{CSSXref('gap')}} propert
 
 The gap property in CSS is a shorthand for `row-gap` and `column-gap`, specifying the size of gutters, which is the space between rows and columns within grid, flex, and multi-column layouts.
 
-In Flexbox, the `gap` property is applied to the flex container. It creates a fixed space between adjacent flex items. However, the `gap` property is not the only thing that can put space between items. Margins, paddings, `justify-content`, and `align-content` can also increase the size of the gutter, affecting the actual size of the gap. 
+In Flexbox, the `gap` property is applied to the flex container. It creates a fixed space between adjacent flex items. However, the `gap` property is not the only thing that can put space between items. Margins, paddings, `justify-content`, and `align-content` can also increase the size of the gutter, affecting the actual size of the gap.
 
 To see how the `gap` property differs from `margin` in both axes, try adding a `gap` to the container `.box` and change the `margin` value on the `.box > *` flex items.
 

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -64,7 +64,9 @@ You may have heard great stories about negative margins. Don't even think. Nowad
 
 The gap property in CSS is a shorthand for `row-gap` and `column-gap`, specifying the size of gutters, which is the space between rows and columns within grid, flex, and multi-column layouts.
 
-In Flexbox, the `gap` property is applied on the flex-container. It creates a fixed space between the flex-items but not on the sides. However, the gap property is not the only thing that can put space between items. Margins, paddings, justify-content and align-content can also increase the size of the gutter and affect the actual gap value. You should try out and see how the `gap` property differs from margin(in both axes) and how margin or padding affects it.
+In Flexbox, the `gap` property is applied to the flex container. It creates a fixed space between adjacent flex items. However, the `gap` property is not the only thing that can put space between items. Margins, paddings, `justify-content`, and `align-content` can also increase the size of the gutter, affecting the actual size of the gap. 
+
+To see how the `gap` property differs from `margin` in both axes, try adding a `gap` to the container `.box` and change the `margin` value on the `.box > *` flex items.
 
 {{EmbedGHLiveSample("css-examples/flexbox/wrapping/gaps.html", '100%', 830)}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

A bit more structured approach on the guttering section that completely focuses on `gap`

### Motivation

The previous edition couldn't do justice as it was mostly negative margins

### Additional details

In order to make the changes complete, we must update the live editor. So this PR needs to be merged in mdn/css-examples:
https://github.com/mdn/css-examples/pull/102

### Related issues and pull requests

Fixes #23221


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
