### PR TITLE
Fix typos in Intl.DateTimeFormat example results

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -313,7 +313,7 @@ console.log(new Intl.DateTimeFormat().format(date));
 const shortTime = new Intl.DateTimeFormat("en", {
   timeStyle: "short"
 });
-console.log(shortTime.format(Date.now())); // "13:31 AM"
+console.log(shortTime.format(Date.now())); // "1:31 PM"
 
 const shortDate = new Intl.DateTimeFormat("en", {
   dateStyle: "short"
@@ -324,7 +324,7 @@ const mediumTime = new Intl.DateTimeFormat("en", {
   timeStyle: "medium",
   dateStyle: "short"
 });
-console.log(mediumTime.format(Date.now())); // "07/07/20, 13:31:55 AM"
+console.log(mediumTime.format(Date.now())); // "07/07/20, 1:31:55 PM"
 ```
 
 ### Using dayPeriod


### PR DESCRIPTION
The examples in the Using [timeStyle and dateStyle](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#using_timestyle_and_datestyle) section have expected output in comments. The expected output times are 24-hour times, which is not what my browser (Chrome 109) produces, with "AM" which is not only unexpected with a 24-hour time but also wrong.

I've changed it to 12-hour times with "PM".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
