### PR TITLE
Minor fix for "Node.js server without a framework"

### DIFF
--- a/files/en-us/learn/server-side/node_server_without_framework/index.md
+++ b/files/en-us/learn/server-side/node_server_without_framework/index.md
@@ -28,7 +28,7 @@ const PORT = 8000;
 const MIME_TYPES = {
   default: 'application/octet-stream',
   html: 'text/html; charset=UTF-8',
-  js: 'application/javascript; charset=UTF-8',
+  js: 'application/javascript',
   css: 'text/css',
   png: 'image/png',
   jpg: 'image/jpg',


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This removes the charset parameter for `application/javascript` MIME type in the server file example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was reading up on MIME types (also from MDN) and noticed that this example was at odds with what's described in the docs about the `text/javascript` MIME type:

> You may find some JavaScript content incorrectly served with a charset parameter as part of the MIME type — as an attempt to specify the character set for the script content. That charset parameter isn't valid for JavaScript content, and in most cases will result in a script failing to load. 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript

### Additional details

N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
