### PR TITLE
Document `new KeyframeEffect()`'s `pseudoElement` option

### DIFF
--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
@@ -73,6 +73,8 @@ The multi-argument constructor (see above) creates a completely new {{domxref("K
       - : Determines how values build from iteration to iteration in this animation. Can be
         set to `accumulate` or `replace` (see above). Defaults
         to `replace`.
+    - `pseudoElement` {{optional_inline}}
+      - : A `string` containing a {{cssxref("pseudo-elements","pseudo-element")}} selector, such as `"::before"`. If present, the effect is applied to the selected pseudo-element of `target`, rather than to `target` itself.
 
 The single argument constructor (see above) creates a clone of an existing {{domxref("KeyframeEffect")}} object instance. Its parameter is as follows:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adds `pseudoElement` to the list of properties of the `options` parameter of [`new KeyframeEffect()`](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Completeness.

This feature is significant as it's the only way (to my knowledge) to use the Web Animations API with pseudo-elements.

It's implemented in at least firefox and chromium. It's already listed in the [browser compat data for `Element.animate()`](http://localhost:5042/en-US/docs/Web/API/Element/animate#browser_compatibility), though the bcd says it's experimental and that chromium support is behind a flag, which I believe is out of date (`pseudoElement` appears to have shipped in [chromium 84](https://chromestatus.com/feature/5126405660606464)). I'm working on figuring out how to fix that.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Currently this list is referenced from [`Element.animate()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate#syntax), which accepts a superset of the same options.

[Spec reference.](https://w3c.github.io/csswg-drafts/web-animations-1/#dom-keyframeeffect-pseudoelement)