### PR TITLE
Remove incorrect `DocumentTimeline` example

### DIFF
--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -33,23 +33,6 @@ new DocumentTimeline(options)
         as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} time of the active document
         for the current browsing context.
 
-## Examples
-
-We could share a single `documentTimeline` among multiple animations, thus allowing us to manipulate just that group of animations via their shared timeline. This bit of code would start all the cats animating 500 milliseconds into their animations:
-
-```js
-let cats = document.querySelectorAll('.sharedTimelineCat');
-cats = Array.prototype.slice.call(cats);
-
-const sharedTimeline = new DocumentTimeline({ originTime: 500 });
-
-cats.forEach((cat) => {
-  const catKeyframes = new KeyframeEffect(cat, keyframes, timing);
-  const catAnimation = new Animation(catKeyframes, sharedTimeline);
-  catAnimation.play();
-});
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/index.md
@@ -33,21 +33,6 @@ _This interface inherits its property from its parent, {{domxref("AnimationTimel
 - {{domxref("AnimationTimeline.currentTime")}}
   - : Returns the time value in milliseconds for this timeline or `null` if it is inactive.
 
-## Examples
-
-We could share a single `documentTimeline` among multiple animations, thus allowing us to manipulate just that group of animations via their shared timeline. This bit of code would start all the cats animating 500 milliseconds into their animations:
-
-```js
-const cats = document.querySelectorAll('.sharedTimelineCat');
-const sharedTimeline = new DocumentTimeline({ originTime: 500 });
-
-for (const cat of cats) {
-  const catKeyframes = new KeyframeEffect(cat, keyframes, timing);
-  const catAnimation = new Animation(catKeyframes, sharedTimeline);
-  catAnimation.play();
-}
-```
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Remove the example from [`DocumentTimeline`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentTimeline) and [`new DocumentTimeline()`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentTimeline/DocumentTimeline).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The example doesn't demonstrate anything, and most of what it claims appears to be inaccurate.

This example actually produces identical results whether using `document.timeline` or a different `DocumentTimeline`. It also does not start the animations "500 milliseconds into their animations".

There isn't (currently) any way to actually manipulate `DocumentTimeline`s afaict, so while one *can* set a non-default timeline, the only benefit would be to sync `Animation.startTime` with some other clock. I don't see much practical benefit to replacing this example with another.