### PR TITLE
Explicitly indicate how object size may be determined

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -146,7 +146,7 @@ cases:
         {{jsxref("Map.prototype.size", "size")}} property.
       </td>
       <td>
-        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. Often this is done by using {{jsxref("Object.keys", "Object.keys")}}
+        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. A common way to do this is by using {{jsxref("Object.keys", "Object.keys")}}
         and checking the {{jsxref("Array.prototype.length", "length")}} property of the returned array.
       </td>
     </tr>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -146,8 +146,7 @@ cases:
         {{jsxref("Map.prototype.size", "size")}} property.
       </td>
       <td>
-        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. A common way to do it is by using {{jsxref("Object.keys", "Object.keys")}}
-        and checking the {{jsxref("Array.prototype.length", "length")}} property of the returned array.
+        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. A common way to do it is through the {{jsxref("Array/length", "length")}} of the array returned from {{jsxref("Object.keys()")}}.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -146,8 +146,8 @@ cases:
         {{jsxref("Map.prototype.size", "size")}} property.
       </td>
       <td>
-        The number of items in an <code>Object</code> must be determined
-        manually.
+        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. Often this is done by using {{jsxref("Object.keys", "Object.keys")}}
+        and checking the {{jsxref("Array.prototype.length", "length")}} property of the returned array.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -146,7 +146,7 @@ cases:
         {{jsxref("Map.prototype.size", "size")}} property.
       </td>
       <td>
-        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. A common way to do this is by using {{jsxref("Object.keys", "Object.keys")}}
+        Determining the number of items in an <code>Object</code> is more roundabout and less efficient. A common way to do it is by using {{jsxref("Object.keys", "Object.keys")}}
         and checking the {{jsxref("Array.prototype.length", "length")}} property of the returned array.
       </td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a bit more detail about getting the size of an object to the [Map page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).

Before - "The number of items in an `Object` must be determined manually."

![image](https://user-images.githubusercontent.com/4397296/215239645-746a0094-5f6c-444a-ae45-132f84d1c3b5.png)

After - "Determining the number of items in an `Object` is more roundabout and less efficient. A common way to do it is by using [Object.keys](http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) and checking the [length](http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length) property of the returned array."

![image](https://user-images.githubusercontent.com/4397296/215239885-19142b2c-0f4c-462d-a7fc-dcfcd5aa2f63.png)

### Motivation

I saw someone ask a question about what "manual" means here and I felt the existing language is vague.
