### PR TITLE
Document the FormData constructor submitter parameter

### DIFF
--- a/files/en-us/glossary/submit_button/index.md
+++ b/files/en-us/glossary/submit_button/index.md
@@ -12,11 +12,11 @@ A **submit button** is an {{Glossary("element")}} in HTML that can be used to su
 - `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}`
 - `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`
 
-Beyond triggering a submission, a submit button can affect the submission's behavior and what data is sent.
+In addition to submitting a form, a submit button can affect the form's behavior and what data is sent.
 
-## Submission behavior
+## Overriding the form's behavior
 
-Submit buttons can override the default {{HTMLElement("form")}} submission behavior through various attributes:
+Submit buttons can override the form's submission behavior through various attributes:
 
 - `{{HtmlElement("button#attr-formaction", "formaction")}}`
 - `{{HtmlElement("button#attr-formenctype", "formenctype")}}`
@@ -26,10 +26,11 @@ Submit buttons can override the default {{HTMLElement("form")}} submission behav
 
 ## Form data entries
 
-If the submit button has a `name` attribute and is a {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}`, the form data set will include an entry for its `name` and `value`.
+If the submit button is a {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}` and has a `name` attribute, the form data set will include an entry for its `name` and `value`.
 
 If the submit button is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, the form data set will include entries for the X and Y coordinates that the user clicked on (e.g. `x=100&y=200` or `buttonName.x=123&buttonName.y=234`).
 
 ## See also
 
 - [Basic native form controls](/en-US/docs/Learn/Forms/Basic_native_form_controls)
+- [Sending form data](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data)

--- a/files/en-us/glossary/submit_button/index.md
+++ b/files/en-us/glossary/submit_button/index.md
@@ -18,11 +18,11 @@ In addition to submitting a form, a submit button can affect the form's behavior
 
 Submit buttons can override the form's submission behavior through various attributes:
 
-- `{{HtmlElement("button#attr-formaction", "formaction")}}`
-- `{{HtmlElement("button#attr-formenctype", "formenctype")}}`
-- `{{HtmlElement("button#attr-formmethod", "formmethod")}}`
-- `{{HtmlElement("button#attr-formnovalidate", "formnovalidate")}}`
-- `{{HtmlElement("button#attr-formtarget", "formtarget")}}`
+- `{{HtmlElement("button#attr-formaction", "formaction")}}`: Override the {{htmlattrxref("action","form")}} attribute of the form.
+- `{{HtmlElement("button#attr-formenctype", "formenctype")}}`: Override the {{htmlattrxref("enctype","form")}} attribute of the form.
+- `{{HtmlElement("button#attr-formmethod", "formmethod")}}`: Override the {{htmlattrxref("method","form")}} attribute of the form.
+- `{{HtmlElement("button#attr-formnovalidate", "formnovalidate")}}`: Override the {{htmlattrxref("novalidate","form")}} attribute of the form.
+- `{{HtmlElement("button#attr-formtarget", "formtarget")}}`: Override the {{htmlattrxref("target","form")}} attribute of the form.
 
 ## Form data entries
 

--- a/files/en-us/glossary/submit_button/index.md
+++ b/files/en-us/glossary/submit_button/index.md
@@ -2,8 +2,6 @@
 title: Submit button
 slug: Glossary/Submit_button
 page-type: glossary-definition
-tags:
-  - HTML
 ---
 
 A **submit button** is an {{Glossary("element")}} in HTML that can be used to submit a {{HTMLElement("form")}}. The native submit button elements are:

--- a/files/en-us/glossary/submit_button/index.md
+++ b/files/en-us/glossary/submit_button/index.md
@@ -1,0 +1,35 @@
+---
+title: Submit button
+slug: Glossary/Submit_button
+page-type: glossary-definition
+tags:
+  - HTML
+---
+
+A **submit button** is an {{Glossary("element")}} in HTML that can be used to submit a {{HTMLElement("form")}}. The native submit button elements are:
+
+- {{HtmlElement("button")}} (its default `type` is `"submit"`)
+- `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}`
+- `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`
+
+Beyond triggering a submission, a submit button can affect the submission's behavior and what data is sent.
+
+## Submission behavior
+
+Submit buttons can override the default {{HTMLElement("form")}} submission behavior through various attributes:
+
+- `{{HtmlElement("button#attr-formaction", "formaction")}}`
+- `{{HtmlElement("button#attr-formenctype", "formenctype")}}`
+- `{{HtmlElement("button#attr-formmethod", "formmethod")}}`
+- `{{HtmlElement("button#attr-formnovalidate", "formnovalidate")}}`
+- `{{HtmlElement("button#attr-formtarget", "formtarget")}}`
+
+## Form data entries
+
+If the submit button has a `name` attribute and is a {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}`, the form data set will include an entry for its `name` and `value`.
+
+If the submit button is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, the form data set will include entries for the X and Y coordinates that the user clicked on (e.g. `x=100&y=200` or `buttonName.x=123&buttonName.y=234`).
+
+## See also
+
+- [Basic native form controls](/en-US/docs/Learn/Forms/Basic_native_form_controls)

--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
@@ -46,7 +46,7 @@ An HTML form on a web page is nothing more than a convenient user-friendly way t
 
 ## On the client side: defining how to send the data
 
-The {{HTMLElement("form")}} element defines how the data will be sent. All of its attributes are designed to let you configure the request to be sent when a user hits a submit button. The two most important attributes are [`action`](/en-US/docs/Web/HTML/Element/form#action) and [`method`](/en-US/docs/Web/HTML/Element/form#method).
+The {{HTMLElement("form")}} element defines how the data will be sent. All of its attributes are designed to let you configure the request to be sent when a user hits a {{Glossary("submit button")}}. The two most important attributes are [`action`](/en-US/docs/Web/HTML/Element/form#action) and [`method`](/en-US/docs/Web/HTML/Element/form#method).
 
 ### The action attribute
 

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -54,6 +54,8 @@ This article provides information about the changes in Firefox 111 that affect d
 
 #### DOM
 
+- The {{domxref("FormData")}} constructor now accepts a second optional `submitter` parameter to specify a submit button. If the button has a name or is an image button, it will contribute to the form data set. This makes it possible to create a {{domxref("FormData")}} object with the same data set as a vanilla form submission triggered by the button. See [Firefox bug 1812696](https://bugzil.la/1812696) for more details.
+
 #### Media, WebRTC, and Web Audio
 
 - [`RTCInboundRtpStreamStats.trackIdentifier`](/en-US/docs/Web/API/RTCInboundRtpStreamStats#trackidentifier) is now supported.

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -16,12 +16,24 @@ The **`FormData()`** constructor creates a new {{domxref("FormData")}} object.
 ```js-nolint
 new FormData()
 new FormData(form)
+new FormData(form, submitter)
 ```
 
 ### Parameters
 
 - `form` {{optional_inline}}
-  - : An HTML {{HTMLElement("form")}} element — when specified, the {{domxref("FormData")}} object will be populated with the form's current keys/values using the name property of each element for the keys and their submitted value for the values. It will also encode file input content.
+  - : An HTML {{HTMLElement("form")}} element — when specified, the {{domxref("FormData")}} object will be populated with the `form`'s current keys/values using the name property of each element for the keys and their submitted value for the values. It will also encode file input content.
+- `submitter` {{optional_inline}}
+  - : A {{Glossary("submit button")}} that is a member of the `form`. If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, it will be included in the form data set.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the specified `submitter` is not a {{Glossary("submit button")}}.
+- `NotFoundError` {{domxref("DOMException")}}
+  - : Thrown if the specified `submitter` isn't a member of the `form`. The `submitter` must be either a
+    descendant of the form element or must have a {{htmlattrxref("form", "input")}}
+    attribute referring to the form.
 
 ## Examples
 
@@ -41,7 +53,7 @@ formData.append("username", "Chris");
 
 ### Prepopulating from a HTML form element
 
-You can specify the optional `form` argument when creating the `FormData` object, to prepopulate it with values from the specified form.
+You can specify the optional `form` and `submitter` arguments when creating the `FormData` object, to prepopulate it with values from the specified form.
 
 > **Note:** Only successful form controls are included in a FormData object, i.e. those with a name and not in a disabled state.
 
@@ -53,6 +65,8 @@ You can specify the optional `form` argument when creating the `FormData` object
   <input type="text" name="text2" value="bar" />
   <input type="text" name="text2" value="baz" />
   <input type="checkbox" name="check" checked disabled />
+  <button name="intent" value="save">Save</button>
+  <button name="intent" value="saveAsCopy">Save As Copy</button>
 </form>
 
 <output id="output"></output>
@@ -73,7 +87,8 @@ output {
 
 ```js
 const form = document.getElementById("form");
-const formData = new FormData(form);
+const submitter = document.querySelector("button[value=save]");
+const formData = new FormData(form, submitter);
 
 const output = document.getElementById("output");
 

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -24,7 +24,7 @@ new FormData(form, submitter)
 - `form` {{optional_inline}}
   - : An HTML {{HTMLElement("form")}} element — when specified, the {{domxref("FormData")}} object will be populated with the `form`'s current keys/values using the name property of each element for the keys and their submitted value for the values. It will also encode file input content.
 - `submitter` {{optional_inline}}
-  - : A {{Glossary("submit button")}} that is a member of the `form`. If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, it will be included in the form data set.
+  - : A {{Glossary("submit button")}} that is a member of the `form`. If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, its data [will be included](/en-US/docs/Glossary/Submit_button#Form_data_entries) in the {{domxref("FormData")}} object (e.g. `btnName=btnValue`).
 
 ### Exceptions
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -22,8 +22,11 @@ requestSubmit(submitter)
 - `submitter` {{optional_inline}}
 
   - : A {{Glossary("submit button")}} that is a member of the form.
-    If the `submitter` specifies `form*` attributes, they will override the form's submission behavior (e.g. `formmethod="POST"`).
-    If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, it will be included in the form data set.
+
+    If the `submitter` specifies `form*` attributes, they [will override](/en-US/docs/Glossary/Submit_button#overriding_the_forms_behavior) the form's submission behavior (e.g. `formmethod="POST"`).
+
+    If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, its data [will be included](/en-US/docs/Glossary/Submit_button#form_data_entries) in the form submission (e.g. `btnName=btnValue`).
+
     If you omit the `submitter` parameter, the form element itself is used as the submitter.
 
 ### Return value

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -22,10 +22,9 @@ requestSubmit(submitter)
 - `submitter` {{optional_inline}}
 
   - : A {{Glossary("submit button")}} that is a member of the form.
-    If the `submitter` specifies `form*` attributes, they will override the form's default behavior (e.g. `formmethod="POST"`).
+    If the `submitter` specifies `form*` attributes, they will override the form's submission behavior (e.g. `formmethod="POST"`).
     If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, it will be included in the form data set.
-    If you omit the `submitter` parameter, the form element
-    itself is used as the submitter.
+    If you omit the `submitter` parameter, the form element itself is used as the submitter.
 
 ### Return value
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -21,11 +21,9 @@ requestSubmit(submitter)
 
 - `submitter` {{optional_inline}}
 
-  - : The submit button whose attributes describe the method by which the form is to be
-    submitted. This may be either an {{HTMLElement("input")}} or
-    {{HTMLElement("button")}} element whose `type` attribute
-    is `submit`.
-
+  - : A {{Glossary("submit button")}} that is a member of the form.
+    If the `submitter` specifies `form*` attributes, they will override the form's default behavior (e.g. `formmethod="POST"`).
+    If the `submitter` has a `name` attribute or is an `{{HtmlElement('input/image', '&lt;input type="image"&gt;')}}`, it will be included in the form data set.
     If you omit the `submitter` parameter, the form element
     itself is used as the submitter.
 
@@ -36,7 +34,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the specified `submitter` is not a submit button.
+  - : Thrown if the specified `submitter` is not a {{Glossary("submit button")}}.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if the specified `submitter` isn't a member of the form on
     which `requestSubmit()` was called. The submitter must be either a

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -11,7 +11,7 @@ The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
 Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}} inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
 
-The `submit` event fires when the user clicks a submit button ({{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}) or presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form. The event is not sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
+The `submit` event fires when the user clicks a {{Glossary("submit button")}}) or presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form. The event is not sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
 
 > **Note:** Trying to submit a form that does not pass [validation](/en-US/docs/Learn/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -11,7 +11,7 @@ The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
 Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}} inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
 
-The `submit` event fires when the user clicks a {{Glossary("submit button")}}) or presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form. The event is not sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
+The `submit` event fires when the user clicks a {{Glossary("submit button")}} or presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form. The event is not sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
 
 > **Note:** Trying to submit a form that does not pass [validation](/en-US/docs/Learn/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
 

--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -579,7 +579,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         {{ HTMLElement("input") }}
       </td>
       <td>
-        If the button/input is a submit button (<code>type="submit"</code>),
+        If the button/input is a {{Glossary("submit button")}} (e.g. <code>type="submit"</code>),
         this attribute sets the encoding type to use during form submission. If
         this attribute is specified, it overrides the
         <code>enctype</code> attribute of the button's
@@ -595,7 +595,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         {{ HTMLElement("input") }}
       </td>
       <td>
-        If the button/input is a submit button (<code>type="submit"</code>),
+        If the button/input is a {{Glossary("submit button")}} (e.g. <code>type="submit"</code>),
         this attribute sets the submission method to use during form submission
         (<code>GET</code>, <code>POST</code>, etc.). If this attribute is
         specified, it overrides the <code>method</code> attribute of the
@@ -611,7 +611,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         {{ HTMLElement("input") }}
       </td>
       <td>
-        If the button/input is a submit button (<code>type="submit"</code>),
+        If the button/input is a {{Glossary("submit button")}} (e.g. <code>type="submit"</code>),
         this boolean attribute specifies that the form is not to be validated
         when it is submitted. If this attribute is specified, it overrides the
         <code>novalidate</code> attribute of the button's
@@ -627,7 +627,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         {{ HTMLElement("input") }}
       </td>
       <td>
-        If the button/input is a submit button (<code>type="submit"</code>),
+        If the button/input is a {{Glossary("submit button")}} (e.g. <code>type="submit"</code>),
         this attribute specifies the browsing context (for example, tab, window,
         or inline frame) in which to display the response that is received after
         submitting the form. If this attribute is specified, it overrides the


### PR DESCRIPTION
### Description

Document the FormData constructor submitter parameter. 

Also add a "Submit button" glossary page and link to it from various places to help facilitate a consistent and complete understanding of what a submit button is :)

### Motivation

This is a new feature which is landing in major browsers soon, so it would be useful to have it documented.

### Additional details

Spec: https://xhr.spec.whatwg.org/#interface-formdata
Spec PR (merged): https://github.com/whatwg/xhr/pull/366
Chromium implementation (landing in Chrome 112): https://chromium-review.googlesource.com/c/chromium/src/+/4189297
WebKit implementation (landing in Safari 16.4): https://github.com/WebKit/WebKit/pull/9188
Gecko implementation (landing in Firefox 111): https://phabricator.services.mozilla.com/D167576

### Related issues and pull requests

Fixes #23917