### PR TITLE
Remove duplicate macro call in GestureEvent API page

### DIFF
--- a/files/en-us/web/api/gestureevent/index.md
+++ b/files/en-us/web/api/gestureevent/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: api.GestureEvent
 ---
 
-{{APIRef("UI Events")}}{{Non-standard_Header}}
+{{APIRef("UI Events")}}
 
 {{Non-standard_Header}}
 


### PR DESCRIPTION
This PR removes the duplicate call of `{{Non-standard_Header}}` in the GestureEvent API page.
