### PR TITLE
Fix common typos mistake

### DIFF
--- a/files/en-us/web/api/navigateevent/scroll/index.md
+++ b/files/en-us/web/api/navigateevent/scroll/index.md
@@ -39,7 +39,7 @@ None.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the current {{domxref("Document")}} is not yet active, if the navigation was not intercepted using {{domxref("NavigateEvent.intercept", "intercept()")}}, or if the default scroll behavior has already ocurred.
+  - : Thrown if the current {{domxref("Document")}} is not yet active, if the navigation was not intercepted using {{domxref("NavigateEvent.intercept", "intercept()")}}, or if the default scroll behavior has already occurred.
 
 ## Examples
 
@@ -51,7 +51,7 @@ In this example of intercepting a navigation, the `handler()` function starts by
 navigation.addEventListener('navigate', (event) => {
   if (shouldNotIntercept(navigateEvent)) {
     return;
-  } 
+  }
   const url = new URL(event.destination.url);
 
   if (url.pathname.startsWith('/articles/')) {

--- a/files/en-us/web/api/navigator/useractivation/index.md
+++ b/files/en-us/web/api/navigator/useractivation/index.md
@@ -22,7 +22,7 @@ A {{domxref("UserActivation")}} object.
 
 ### Checking if a user gesture was recently performed
 
-Use {{domxref("UserActivation.isActive")}} to check wether the user is currently interacting with the page ({{Glossary("Transient activation")}}).
+Use {{domxref("UserActivation.isActive")}} to check whether the user is currently interacting with the page ({{Glossary("Transient activation")}}).
 
 ```js
 if (navigator.userActivation.isActive) {
@@ -32,7 +32,7 @@ if (navigator.userActivation.isActive) {
 
 ### Checking if a user gesture was ever performed
 
-Use {{domxref("UserActivation.hasBeenActive")}} to check wether the user has ever interacted with the page ({{Glossary("Sticky activation")}}).
+Use {{domxref("UserActivation.hasBeenActive")}} to check whether the user has ever interacted with the page ({{Glossary("Sticky activation")}}).
 
 ```js
 if (navigator.userActivation.hasBeenActive) {

--- a/files/en-us/web/api/useractivation/hasbeenactive/index.md
+++ b/files/en-us/web/api/useractivation/hasbeenactive/index.md
@@ -22,7 +22,7 @@ A boolean.
 
 ### Checking if a user gesture was ever performed
 
-Use the `hasBeenActive` property to check wether the user has ever interacted with the page.
+Use the `hasBeenActive` property to check whether the user has ever interacted with the page.
 
 ```js
 if (navigator.userActivation.hasBeenActive) {

--- a/files/en-us/web/api/useractivation/index.md
+++ b/files/en-us/web/api/useractivation/index.md
@@ -36,7 +36,7 @@ This API is only available in the window context and not exposed to workers.
 
 ### Checking if a user gesture was recently performed
 
-Use {{domxref("UserActivation.isActive")}} to check wether the user is currently interacting with the page ({{Glossary("Transient activation")}}).
+Use {{domxref("UserActivation.isActive")}} to check whether the user is currently interacting with the page ({{Glossary("Transient activation")}}).
 
 ```js
 if (navigator.userActivation.isActive) {
@@ -46,7 +46,7 @@ if (navigator.userActivation.isActive) {
 
 ### Checking if a user gesture was ever performed
 
-Use {{domxref("UserActivation.hasBeenActive")}} to check wether the user has ever interacted with the page ({{Glossary("Sticky activation")}}).
+Use {{domxref("UserActivation.hasBeenActive")}} to check whether the user has ever interacted with the page ({{Glossary("Sticky activation")}}).
 
 ```js
 if (navigator.userActivation.hasBeenActive) {

--- a/files/en-us/web/api/useractivation/isactive/index.md
+++ b/files/en-us/web/api/useractivation/isactive/index.md
@@ -22,7 +22,7 @@ A boolean.
 
 ### Checking if a user gesture was recently performed
 
-Use the `isActive` property to check wether the user is currently interacting with the page.
+Use the `isActive` property to check whether the user is currently interacting with the page.
 
 ```js
 if (navigator.userActivation.isActive) {

--- a/files/en-us/web/api/web_share_api/index.md
+++ b/files/en-us/web/api/web_share_api/index.md
@@ -31,19 +31,19 @@ The **Web Share API** allows a site to share text, links, files, and other conte
 These share targets typically include the system clipboard, email, contacts or messaging applications, and Bluetooth or Wi-Fi channels.
 
 The API has just two methods.
-The {{domxref("navigator.canShare()")}} method may be used to first validate whether some data is "sharable", prior to passing it to {{domxref("navigator.share()")}} for sending.
+The {{domxref("navigator.canShare()")}} method may be used to first validate whether some data is "shareable", prior to passing it to {{domxref("navigator.share()")}} for sending.
 
 The {{domxref("navigator.share()")}} method invokes the native sharing mechanism of the underlying operating system and passes the specified data.
 It requires {{Glossary("transient activation")}}, and hence must be triggered off a UI event like a button click.
 Further, the method must specify valid data that is supported for sharing by the native implementation.
 
 The Web Share API is gated by the [web-share](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/web-share) Permissions Policy.
-If the policy is supported but has not been granted, both methods will indicate that the data is not sharable.
+If the policy is supported but has not been granted, both methods will indicate that the data is not shareable.
 
 ## Interfaces
 
 - {{domxref("navigator.canShare()")}}
-  - : Returns a boolean indicating whether the specified data is sharable.
+  - : Returns a boolean indicating whether the specified data is shareable.
 - {{domxref("navigator.share()")}}
   - : Returns a {{jsxref("Promise")}} that resolves if the passed data was successfully sent to a share target.
     This method must be called on a button click or other user activation (requires {{Glossary("transient activation")}}).


### PR DESCRIPTION
### Random Typos

Well, there were a lot of mistakes with `sharable`, `wether`, `ocurred` typos.