### PR TITLE
Fix #55: “Componentizing our React app”: Error in Passing DATA as a prop

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
@@ -249,7 +249,12 @@ const DATA = [
 Next, we'll pass `DATA` to `<App />` as a prop, called `tasks`. The final line of `src/index.js` should read like this:
 
 ```jsx
-ReactDOM.render(<App tasks={DATA} />, document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <App tasks={DATA} />
+  </React.StrictMode>
+);
 ```
 
 This array is now available to the App component as `props.tasks`. You can `console.log()` it to check, if you'd like.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

-  closes [ mdn content issue #2241](https://github.com/mdn/content/issues/22411)
- closes [ todo react issue #55](https://github.com/mdn/todo-react/issues/55)
- **ReactDOM.render(<App tasks={DATA} />, document.getElementById("root"));** mentioned in docs results in TypeError: `react_dom_client__WEBPACK_IMPORTED_MODULE_1__.render is not a function`  in React version 18.2.0

### Motivation

Changes will sync the Componentizing our React app docs with sample React app code present in [todo-react repository](https://github.com/mdn/todo-react)

