### PR TITLE
Fix typo in documentation for Node.replaceChild()

### DIFF
--- a/files/en-us/web/api/node/replacechild/index.md
+++ b/files/en-us/web/api/node/replacechild/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Node.replaceChild
 
 {{APIRef("DOM")}}
 
-The **`replaceChild()`** method of the {{domxref("Node")}} element
+The **`replaceChild()`** method of the {{domxref("Node")}} interface
 replaces a child node within the given (parent) node.
 
 ## Syntax

--- a/files/en-us/web/api/node/replacechild/index.md
+++ b/files/en-us/web/api/node/replacechild/index.md
@@ -10,8 +10,7 @@ browser-compat: api.Node.replaceChild
 
 {{APIRef("DOM")}}
 
-The **`replaceChild()`** method of the {{domxref("Node")}} interface
-replaces a child node within the given (parent) node.
+The **`replaceChild()`** method of the {{domxref("Node")}} interfacebreplaces a child node within the given (parent) node.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

In the documentation for all other methods of the `Node` interface, `Node` is referred to as an interface but here it is referred to as an element.

### Motivation

Observed while reading documentation

### Additional details

n/a

### Related issues and pull requests

n/a