### PR TITLE
Fixes #23979 : Misleading Statement

### DIFF
--- a/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
@@ -78,7 +78,7 @@ In the following example, we have three inline boxes created by a paragraph with
 
 The boxes around the words before the `<strong>` element and after the `<strong>` element are referred to as anonymous boxes, boxes introduced to ensure that everything is wrapped in a box, but ones that we cannot target directly.
 
-The line box size in the block direction (so the height when working in English) is defined by the tallest box inside it. In the next example, I have made the `<strong>` element 300%; that content now defines the height of the line box on that line.
+The line box size in the block direction (so the height when working in English) is defined by the tallest box inside it. In the next example, I have made the `<strong>` element 300%; since that content spans two lines, it now defines the height of the line boxes on those two lines.
 
 {{EmbedGHLiveSample("css-examples/flow/block-inline/line-box.html", '100%', 500)}}
 

--- a/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
@@ -78,7 +78,7 @@ In the following example, we have three inline boxes created by a paragraph with
 
 The boxes around the words before the `<strong>` element and after the `<strong>` element are referred to as anonymous boxes, boxes introduced to ensure that everything is wrapped in a box, but ones that we cannot target directly.
 
-The line box size in the block direction (so the height when working in English) is defined by the tallest box inside it. In the next example, I have made the `<strong>` element 300%; since that content spans two lines, it now defines the height of the line boxes on those two lines.
+The line box size in the block direction (so the height when working in English) is defined by the tallest box inside it. In the next example, the `<strong>` element is 300%; since that content spans two lines, it now defines the height of the line boxes of those two lines.
 
 {{EmbedGHLiveSample("css-examples/flow/block-inline/line-box.html", '100%', 500)}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR fixes #23979 “Block and inline layout in normal flow”: Misleading Statement
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
There is a misleading statement in Block and inline layout in the normal flow guide under 
Elements participating in an inline formatting context 
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
