### PR TITLE
relnote(109): 'unsafe-hashes' CSP source expression

### DIFF
--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -40,6 +40,11 @@ No notable changes.
   They have been removed from the SVG2 specification and are likely to be removed entirely from Firefox in a future release.
   ({{bug(1133174)}}).
 
+### HTTP
+
+- The `'unsafe-hashes'` value for {{HTTPHeader("Content-Security-Policy")}} source directives is now supported.
+  For more information, see [CSP unsafe-hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_hashes) ({{bug(1343950)}}).
+
 ### APIs
 
 - The `scrollend` events are now supported, which indicate that the user has completed scrolling in {{domxref("Element")}} and {{domxref("Document")}} objects.

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -34,9 +34,6 @@ This article provides information about the changes in Firefox 110 that will aff
 
 ### HTTP
 
-- The `'unsafe-hashes'` value for {{HTTPHeader("Content-Security-Policy")}} source directives is now supported.
-  For more information, see [CSP unsafe-hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_hashes) ({{bug(1343950)}}).
-
 #### Removals
 
 ### Security


### PR DESCRIPTION
The target milestone for this feature was 110, but it was expedited to 109

__Related issues and bugs:__
- [x] initially added for 110 https://github.com/mdn/content/pull/23930
- [x] BCD update https://github.com/mdn/browser-compat-data/pull/18787 

__Other info:__
Highlighted by author in https://github.com/mdn/browser-compat-data/pull/18759#issuecomment-1407372232