### PR TITLE
Fixing the “Gecko” shortcut in Firefox 1.5 for developers page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/index.md
@@ -20,7 +20,7 @@ tags:
 
 {{FirefoxSidebar}}
 
-Based on the [Gecko](/en-US/docs/Gecko) 1.8 engine, Firefox 1.5 improved its already best in class standards support, and provided new capabilities to enable the next generation of web applications. Firefox 1.5 features improved support for CSS2 and CSS3, APIs for scriptable and programmable 2D graphics through [SVG](/en-US/docs/Web/SVG) 1.1 and [`<canvas>`](/en-US/docs/Web/API/Canvas_API), [XForms](/en-US/docs/XForms) and XML events, as well as many DHTML, JavaScript, and DOM enhancements.
+Based on the [Gecko](/en-US/docs/Glossary/Gecko) 1.8 engine, Firefox 1.5 improved its already best in class standards support, and provided new capabilities to enable the next generation of web applications. Firefox 1.5 features improved support for CSS2 and CSS3, APIs for scriptable and programmable 2D graphics through [SVG](/en-US/docs/Web/SVG) 1.1 and [`<canvas>`](/en-US/docs/Web/API/Canvas_API), [XForms](/en-US/docs/XForms) and XML events, as well as many DHTML, JavaScript, and DOM enhancements.
 
 ## Developer Tools
 


### PR DESCRIPTION
### Description

The “Gecko” shortcut have wrong link.

### Motivation

I'm doing this for making MDN better.

### Additional details

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5

### Related issues and pull requests

I think, that there are not any related issues.
