### PR TITLE
Fix 23394 - fix CSS Painting API examples

### DIFF
--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -106,7 +106,7 @@ We can then add the fancy class to any element on the page to add a yellow box a
 
 The following example will look like the image above in [browsers supporting the CSS Painting API](/en-US/docs/Web/API/CSS/paintWorklet#browser_compatibility).
 
-{{EmbedLiveSample("Using_the_paint_worklet", 120, 120)}}
+{{EmbedGHLiveSample("dom-examples/css-painting/half-highlight-fixed-size/", 120, 120)}}
 
 While you can't play with the worklet's script, you can alter the `background-size` and `background-position` to change the size and location of the background image.
 
@@ -186,7 +186,7 @@ CSS.paintWorklet.addModule(
 
 In [browsers that support the CSS Paint API](/en-US/docs/Web/API/CSS/paintWorklet#browser_compatibility), the elements in the example below should get yellow backgrounds proportional to their font size.
 
-{{EmbedLiveSample("Using_the_paint_worklet_2", 300, 300)}}
+{{EmbedGHLiveSample("dom-examples/css-painting/half-highlight-paintsize", 200, 200)}}
 
 ## Custom properties
 
@@ -324,7 +324,7 @@ CSS.paintWorklet.addModule(
 
 While you can't play with the worklet's script, you can alter the custom property values in DevTools to change the colors and width of the background image.
 
-{{EmbedGHLiveSample("css-examples/houdini/css_painting_api/example-boxbg.html", '100%', 400)}}
+{{EmbedGHLiveSample("dom-examples/css-painting/custom-properties/", '100%', 400)}}
 
 ## Adding complexity
 
@@ -421,7 +421,7 @@ CSS.paintWorklet.addModule(
 );
 ```
 
-{{EmbedLiveSample("Using_the_paint_worklet_4", 300, 300)}}
+{{EmbedGHLiveSample("dom-examples/css-painting/fancy-header-highlight/", 200, 200)}}
 
 While you can't edit the worklet itself, you can play around with the CSS and HTML. Maybe try [`float`](/en-US/docs/Web/CSS/float) and [`clear`](/en-US/docs/Web/CSS/clear) on the headers?
 
@@ -650,7 +650,7 @@ CSS.paintWorklet.addModule(
 );
 ```
 
-{{EmbedLiveSample("Using_the_paint_worklet_5", 300, 300)}}
+{{EmbedGHLiveSample("dom-examples/css-painting/hollow-highlight", 400, 400)}}
 
 ## See also
 

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -74,16 +74,14 @@ The setup and design of our paint worklet took place in the external script show
 CSS.paintWorklet.addModule("nameOfPaintWorkletFile.js");
 ```
 
-This can be done using the paint worklet's `addModule()` method in a `<script>` within the main HTML or in an external JavaScript file linked to from the document.
+This can be done using the paint worklet's `addModule()` method in a `<script>` within the main HTML or in an external JavaScript file linked from the document.
 
 ## Using the paint worklet
 
-In our example, the paintworklet is stored on GitHub. To use it, we first register it:
+In our example, the paintworklet is stored alongside the main script file. To use it, we first register it:
 
 ```js
-CSS.paintWorklet.addModule(
-  "https://mdn.github.io/houdini-examples/cssPaint/intro/01partOne/header-highlight.js"
-);
+CSS.paintWorklet.addModule("header-highlight.js");
 ```
 
 ### Reference the paint worklet in CSS
@@ -177,9 +175,7 @@ While you can't play with the worklet's script, you can alter the element's `fon
 #### JavaScript
 
 ```js
-CSS.paintWorklet.addModule(
-  "https://mdn.github.io/houdini-examples/cssPaint/intro/02partTwo/header-highlight.js"
-);
+CSS.paintWorklet.addModule("header-highlight.js");
 ```
 
 #### Result
@@ -315,9 +311,7 @@ li:nth-of-type(3n + 1) {
 In our `<script>` we register the worklet:
 
 ```js
-CSS.paintWorklet.addModule(
-  "https://mdn.github.io/houdini-examples/cssPaint/intro/worklet/boxbg.js"
-);
+CSS.paintWorklet.addModule("boxbg.js");
 ```
 
 #### Result
@@ -416,16 +410,16 @@ h6 {
 And we register our worklet
 
 ```js
-CSS.paintWorklet.addModule(
-  "https://mdn.github.io/houdini-examples/cssPaint/intro/03partThree/header-highlight.js"
-);
+CSS.paintWorklet.addModule("header-highlight.js");
 ```
+
+The result looks like this:
 
 {{EmbedGHLiveSample("dom-examples/css-painting/fancy-header-highlight/", 200, 200)}}
 
 While you can't edit the worklet itself, you can play around with the CSS and HTML. Maybe try [`float`](/en-US/docs/Web/CSS/float) and [`clear`](/en-US/docs/Web/CSS/clear) on the headers?
 
-You could try making the background images above without the CSS paint API. It is doable, but you would have to declare a different, fairly complex linear gradient for each different color you wanted to create. With the CSS Paint API, one worklet can be re-used, with different colors passed in this case.
+You could try making the background images above without the CSS Paint API. It is doable, but you would have to declare a different, fairly complex linear gradient for each different color you wanted to create. With the CSS Paint API, one worklet can be reused, with different colors passed in this case.
 
 ## Passing parameters
 
@@ -464,23 +458,7 @@ paint(ctx, size, props, args) {
 }
 ```
 
-We can pass more than one argument.
-
-```css
-li {
-  background-image: paint(hollowHighlights, stroke, 10px);
-}
-```
-
-We can also specify that we want a particular type of argument. When we `get` our list of argument values, we ask specifically for a `<length>` unit.
-
-```js
-static get inputArguments() { return ['*', '<length>']; }
-```
-
-In this case, we specifically requested the `<length>` attribute. The first element in the returned array will be a [`CSSUnparsedValue`](/en-US/docs/Web/API/CSSUnparsedValue). The second will be a [`CSSStyleValue`](/en-US/docs/Web/API/CSSStyleValue).
-
-If the custom argument is a CSS value, for instance a unit, we can invoke Typed OM CSSStyleValue class (and sub classes) by using the value type keyword when we retrieve it in the `registerPaint()` function.
+We can also specify that we want a particular type of argument.
 
 Let's say we add a second argument with how many pixels wide we want the stroke to be:
 
@@ -495,6 +473,10 @@ When we `get` our list of argument values, we can ask specifically for a `<lengt
 ```js
 static get inputArguments() { return ['*', '<length>']; }
 ```
+
+In this case, we specifically requested the `<length>` attribute. The first element in the returned array will be a [`CSSUnparsedValue`](/en-US/docs/Web/API/CSSUnparsedValue). The second will be a [`CSSStyleValue`](/en-US/docs/Web/API/CSSStyleValue).
+
+If the custom argument is a CSS value, for instance a unit, we can invoke Typed OM CSSStyleValue class (and sub classes) by using the value type keyword when we retrieve it in the `registerPaint()` function.
 
 Now we can access the type and value properties, meaning we can get the number of pixels and a number type right out of the box. (Admittedly, `ctx.lineWidth` takes a float as a value rather than a value with length units, but for example's sake…)
 
@@ -532,7 +514,7 @@ registerPaint(
     }
     // Input arguments that can be passed to the `paint` function
     static get inputArguments() {
-      return ["*", ""];
+      return ["*", "<length>"];
     }
 
     static get contextOptions() {
@@ -645,9 +627,7 @@ li:nth-of-type(3n + 1) {
 In our `<script>` we register the worklet:
 
 ```js
-CSS.paintWorklet.addModule(
-  "https://mdn.github.io/houdini-examples/cssPaint/intro/worklets/hollow.js"
-);
+CSS.paintWorklet.addModule("hollow.js");
 ```
 
 {{EmbedGHLiveSample("dom-examples/css-painting/hollow-highlight", 400, 400)}}

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -23,6 +23,8 @@ To elaborate over these steps, we're going to start by creating a half-highlight
 
 ![Text reading 'My Cool Header' with a solid yellow background image block on the bottom left two thirds of the header](mycoolheader.png)
 
+> **Note:** The complete source for all the examples in this article can be found at [https://github.com/mdn/dom-examples/tree/main/css-painting](https://github.com/mdn/dom-examples/tree/main/css-painting), and the examples are running live at [https://mdn.github.io/dom-examples/css-painting/](https://mdn.github.io/dom-examples/css-painting/).
+
 ## CSS paint worklet
 
 In an external script file, we employ the [`registerPaint()`](/en-US/docs/Web/API/PaintWorklet/registerPaint) function to name our [CSS Paint worklet](/en-US/docs/Web/API/PaintWorklet). It takes two parameters. The first is the name we give the worklet — this is the name we will use in our CSS as the parameter of the `paint()` function when we want to apply this styling to an element. The second parameter is the class that does all the magic, defining the context options and what to paint to the two-dimensional canvas that will be our image.


### PR DESCRIPTION
This PR updates the MDN page to use the GitHub-hosted examples which were added in https://github.com/mdn/dom-examples/pull/200, so the examples work properly. Fixes https://github.com/mdn/content/issues/23394.

* changes `EmbedLiveSample` to `EmbedGHLiveSample`
* fixes paths to paint worklet
* fixes an error in `inputArguments` in the last paint worklet
* a few copy-edits, in particular one place in the last example where there was some odd repetition, like a copy/paste thing gone wrong. Please check I've not mangled the sense of this.

cc @Rumyra .