### PR TITLE
Fix issue 22560: remove live sample

### DIFF
--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -99,8 +99,6 @@ The following attributes control behavior during form submission.
 
 ## Examples
 
-### HTML
-
 ```html
 <!-- Form which will send a GET request to the current URL -->
 <form method="get">
@@ -127,8 +125,6 @@ The following attributes control behavior during form submission.
   </fieldset>
 </form>
 ```
-
-{{ EmbedLiveSample('Examples', '100%', 110) }}
 
 ## Technical summary
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/22560, in which is is reported that submitting the form breaks the example because the server returns 403.

I don't really love this fix, but I don't think we can make this work as a live sample given CSP constraints, and I don't think it is very useful as a live sample anyway without being part of a larger example (with, say, some server-side component).
