### PR TITLE
 `open=""` is valid to hide details

### DIFF
--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -40,7 +40,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : This Boolean attribute indicates whether the details — that is, the contents of the `<details>` element — are currently visible. The details are shown when this attribute exists, or hidden when this attribute is absent. By default this attribute is absent which means the details are not visible.
 
-    > **Note:** You have to remove this attribute entirely to make the details hidden. `open="false"` makes the details visible because this attribute is Boolean.
+    > **Note:** You have to remove this attribute entirely or set to a empty string `open=""` to make the details hidden. `open="false"` makes the details visible because this attribute is Boolean.
 
 ## Events
 


### PR DESCRIPTION
    > **Note:** You have to remove this attribute entirely or set it to an empty string, `open=""` to hide details. `open="false"` makes the details visible because this attribute is Boolean.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
 
`open=""` is valid to hide details as an empty string is falsy. 


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Just can be done without Element.removeAttribute("open")

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
