### PR TITLE
FF110 permission api supports midi

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -42,6 +42,9 @@ This article provides information about the changes in Firefox 110 that will aff
 
 ### APIs
 
+- The `midi` permission of the [Permission API](/en-US/docs/Web/API/Permissions_API) is now supported.
+  This allows the permission status for using the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API) to be queried using [`navigator.permissions.query()`](/en-US/docs/Web/API/Permissions/query) ({{bug(1772166)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
The permission API can now be queried to find the permission status for Web MIDI - added inhttps://bugzilla.mozilla.org/show_bug.cgi?id=1437171

This adds a release note.

Other docs work can be tracked in #23680

