### PR TITLE
Refactor `DocumentTimeline`'s discussion of time origin

### DIFF
--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -23,7 +23,7 @@ The `timeline` readonly property of the {{domxref("Document")}} interface repres
 
 This timeline is unique to each `document` and persists for the lifetime of the `document` including calls to {{domxref("Document.open()")}}.
 
-This timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
+This timeline expresses the time in milliseconds since {{domxref("Performance.timeOrigin")}}.
 Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
 > **Note:** A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be inactive.

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -19,11 +19,12 @@ browser-compat: api.Document.timeline
 
 {{ APIRef("Web Animations") }}
 
-The `timeline` readonly property of the {{domxref("Document")}} interface represents the default timeline of the current document. This timeline is a special instance of {{domxref("DocumentTimeline")}} that is automatically created on page load.
+The `timeline` readonly property of the {{domxref("Document")}} interface represents the default timeline of the current document. This timeline is a special instance of {{domxref("DocumentTimeline")}}.
 
 This timeline is unique to each `document` and persists for the lifetime of the `document` including calls to {{domxref("Document.open()")}}.
 
-The time values for this timeline are calculated as a fixed offset from the global clock such that the **zero time** corresponds to the {{domxref("PerformanceTiming.navigationStart", "navigationStart")}} moment plus a signed delta known as the **origin time.** Prior to establishing the `navigationStart` moment, the document timeline is **inactive**.
+The default timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
+Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
 > **Note:** A document timeline that is associated with a non-active document is also considered to be **inactive**.
 

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -26,7 +26,7 @@ This timeline is unique to each `document` and persists for the lifetime of the 
 This timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
 Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
-> **Note:** A document timeline that is associated with a non-active document is also considered to be **inactive**.
+> **Note:** A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be **inactive**.
 
 ## Value
 

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -26,7 +26,7 @@ This timeline is unique to each `document` and persists for the lifetime of the 
 This timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
 Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
-> **Note:** A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be **inactive**.
+> **Note:** A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be inactive.
 
 ## Value
 

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -23,7 +23,7 @@ The `timeline` readonly property of the {{domxref("Document")}} interface repres
 
 This timeline is unique to each `document` and persists for the lifetime of the `document` including calls to {{domxref("Document.open()")}}.
 
-The default timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
+This timeline expresses the time in milliseconds since the document's {{domxref("Performance.timeOrigin","time origin")}}.
 Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
 > **Note:** A document timeline that is associated with a non-active document is also considered to be **inactive**.

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -37,7 +37,9 @@ new DocumentTimeline(options)
 
 ### Origin time
 
-Since {{domxref("Document.timeline")}}'s zero time is {{domxref("Performance.timeOrigin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
+A {{domxref("DocumentTimeline")}} with an `originTime` of zero counts time
+starting from {{domxref("Performance.timeOrigin")}}. This is the same behavior
+as {{domxref("Document.timeline")}}.
 
 ```js
 const timeline = new DocumentTimeline();

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -29,7 +29,7 @@ new DocumentTimeline(options)
 - `options` {{optional_inline}}
   - : An object specifying options for the new timeline. The following properties are available:
     - `originTime` {{optional_inline}}
-      - : A number that specifies the zero time for the {{domxref("DocumentTimeline")}}
+      - : A `number` that specifies the zero time for the {{domxref("DocumentTimeline")}}
         as a number of milliseconds relative to {{domxref("Performance.timeOrigin")}}.
         Defaults to `0`.
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -30,8 +30,8 @@ new DocumentTimeline(options)
   - : An object specifying options for the new timeline. The following properties are available:
     - `originTime`
       - : A number that specifies the zero time for the `documentTimeline`
-        as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} time of the active document
-        for the current browsing context.
+        as a number of milliseconds relative to the {{domxref("Performance.timeOrigin","time origin")}} of the current {{domxref("Document")}}.
+        Defaults to `0`.
 
 ## Specifications
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -26,9 +26,9 @@ new DocumentTimeline(options)
 
 ### Parameters
 
-- `options`
+- `options` {{optional_inline}}
   - : An object specifying options for the new timeline. The following properties are available:
-    - `originTime`
+    - `originTime` {{optional_inline}}
       - : A number that specifies the zero time for the {{domxref("DocumentTimeline")}}
         as a number of milliseconds relative to {{domxref("Performance.timeOrigin")}}.
         Defaults to `0`.

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -30,14 +30,14 @@ new DocumentTimeline(options)
   - : An object specifying options for the new timeline. The following properties are available:
     - `originTime`
       - : A number that specifies the zero time for the {{domxref("DocumentTimeline")}}
-        as a number of milliseconds relative to the {{domxref("Performance.timeOrigin","time origin")}} of the current {{domxref("Document")}}.
+        as a number of milliseconds relative to {{domxref("Performance.timeOrigin")}}.
         Defaults to `0`.
 
 ## Examples
 
 ### Origin time
 
-Since {{domxref("Document.timeline")}}'s zero time is the {{domxref("Performance.timeOrigin","time origin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
+Since {{domxref("Document.timeline")}}'s zero time is {{domxref("Performance.timeOrigin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
 
 ```js
 const timeline = new DocumentTimeline();

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -37,7 +37,7 @@ new DocumentTimeline(options)
 
 ### Origin time
 
-Since {{domxref("Document.timeline")}} is relative to the {{domxref("Performance.timeOrigin","time origin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
+Since {{domxref("Document.timeline")}}'s zero time is the {{domxref("Performance.timeOrigin","time origin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
 
 ```js
 const timeline = new DocumentTimeline();

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -46,7 +46,8 @@ const timeline = new DocumentTimeline();
 console.log(timeline.currentTime === document.timeline.currentTime); // true
 ```
 
-{{domxref("DocumentTimeline")}}s with a non-zero `originTime` will be offset from {{domxref("Document.timeline")}} by that amount.
+Setting a non-zero `originTime` will offset the {{domxref("DocumentTimeline")}}
+from {{domxref("Document.timeline")}} by that amount:
 
 ```js
 const offsetTimeline = new DocumentTimeline({ originTime: 500 });

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -33,6 +33,35 @@ new DocumentTimeline(options)
         as a number of milliseconds relative to the {{domxref("Performance.timeOrigin","time origin")}} of the current {{domxref("Document")}}.
         Defaults to `0`.
 
+## Examples
+
+### Origin time
+
+Since {{domxref("Document.timeline")}} is relative to the {{domxref("Performance.timeOrigin","time origin")}}, a `DocumentTimeline` with `originTime` `0` will show the same time as it.
+
+```js
+const timeline = new DocumentTimeline();
+console.log(timeline.currentTime === document.timeline.currentTime); // true
+```
+
+`DocumentTimeline`s with a non-zero `originTime` will be offset from {{domxref("Document.timeline")}} by that amount.
+
+```js
+const offsetTimeline = new DocumentTimeline({ originTime: 500 });
+console.log(
+  document.timeline.currentTime - offsetTimeline.currentTime
+); // 500
+```
+
+A `DocumentTimeline` relative to the current moment can be constructed with:
+
+```js
+const nowTimeline = new DocumentTimeline({
+  originTime: document.timeline.currentTime
+});
+console.log(nowTimeline.currentTime); // 0
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -29,7 +29,7 @@ new DocumentTimeline(options)
 - `options`
   - : An object specifying options for the new timeline. The following properties are available:
     - `originTime`
-      - : A number that specifies the zero time for the `documentTimeline`
+      - : A number that specifies the zero time for the {{domxref("DocumentTimeline")}}
         as a number of milliseconds relative to the {{domxref("Performance.timeOrigin","time origin")}} of the current {{domxref("Document")}}.
         Defaults to `0`.
 
@@ -37,14 +37,14 @@ new DocumentTimeline(options)
 
 ### Origin time
 
-Since {{domxref("Document.timeline")}} is relative to the {{domxref("Performance.timeOrigin","time origin")}}, a `DocumentTimeline` with `originTime` `0` will show the same time as it.
+Since {{domxref("Document.timeline")}} is relative to the {{domxref("Performance.timeOrigin","time origin")}}, a {{domxref("DocumentTimeline")}} with `originTime` `0` will show the same time as it.
 
 ```js
 const timeline = new DocumentTimeline();
 console.log(timeline.currentTime === document.timeline.currentTime); // true
 ```
 
-`DocumentTimeline`s with a non-zero `originTime` will be offset from {{domxref("Document.timeline")}} by that amount.
+{{domxref("DocumentTimeline")}}s with a non-zero `originTime` will be offset from {{domxref("Document.timeline")}} by that amount.
 
 ```js
 const offsetTimeline = new DocumentTimeline({ originTime: 500 });
@@ -53,7 +53,7 @@ console.log(
 ); // 500
 ```
 
-A `DocumentTimeline` relative to the current moment can be constructed with:
+A {{domxref("DocumentTimeline")}} relative to the current moment can be constructed with:
 
 ```js
 const nowTimeline = new DocumentTimeline({


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Replace references to `navigationStart` with `timeOrigin`. Move discussion of "origin time" from `Document.timeline` to `DocumentTimeline()`. Specify the default `originTime` in `DocumentTimline()`. Add examples showing how `originTime` works. Define "non-active document".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Clarity, completeness.

`navigationStart` is marked obsolete, doesn't match the terminology in the standard, and isn't terribly relevant to animation in any case.

The "origin time" discussion is redundant in `Document.timeline` because that timeline's origin time is always zero, and therefore not terribly observable.

"Origin time" and "time origin" are both confusing and easily confused (https://github.com/w3c/csswg-drafts/issues/2079); hopefully examples help with that a bit.