### PR TITLE
Remove statement readable byte streams not supported

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -192,7 +192,8 @@ The first object can contain up to five members, only the first of which is requ
 1. `start(controller)` — A method that is called once, immediately after the `ReadableStream` is constructed. Inside this method, you should include code that sets up the stream functionality, e.g. beginning generation of data or otherwise getting access to the source.
 2. `pull(controller)` — A method that, when included, is called repeatedly until the stream's internal queue is full. This can be used to control the stream as more chunks are enqueued.
 3. `cancel()` — A method that, when included, will be called if the app signals that the stream is to be cancelled (e.g. if {{domxref("ReadableStream.cancel()")}} is called). The contents should do whatever is necessary to release access to the stream source.
-4. `type` and `autoAllocateChunkSize` — These are used — when included — to signify that the stream is to be a bytestream. Bytestreams will be covered separately in a future tutorial, as they are somewhat different in purpose and use case to regular (default) streams. They are also not implemented anywhere as yet.
+4. `type` and `autoAllocateChunkSize` — These are used — when included — to signify that the stream is to be a bytestream.
+   Bytestreams are covered separately in [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams), as they are somewhat different in purpose and use case to regular (default) streams.
 
 Looking at our simple example code again, you can see that our `ReadableStream()` constructor only includes a single method — `start()`, which serves to read all the data out of our fetch stream.
 


### PR DESCRIPTION
Fixes an out of date statement about readable byte streams not being supported, adding a link to the new doc on this topic.