### PR TITLE
fix(tags): replace "Non standard" with "Non-standard"

### DIFF
--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -9,7 +9,7 @@ tags:
   - KeyboardEvent
   - Method
   - Reference
-  - Non Standard
+  - Non-standard
 ---
 
 {{APIRef("UI Events")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaces the last occurrence of the "Non standard" tag in favor of the "Non-standard" tag (with hyphen).

### Motivation

We use the tag "Non-standard" for non-standardized features, but historically yari has also supported "Non standard".

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Noticed as part of reviewing https://github.com/mdn/yari/pull/8059.
