### PR TITLE
Proxy handlers are traps for internal methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.apply
 
 {{JSRef}}
 
-The **`handler.apply()`** method is a trap for a function call.
+The **`handler.apply()`** method is a trap for the `[[Call]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as function calls.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-apply.html", "taller")}}
 
@@ -41,8 +41,6 @@ The following parameters are passed to the `apply()` method. `this` is bound to 
 The `apply()` method can return any value.
 
 ## Description
-
-The **`handler.apply()`** method is a trap for a function call.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.construct
 
 {{JSRef}}
 
-The **`handler.construct()`** method is a trap for the {{jsxref("Operators/new", "new")}} operator. In order for the new operation to be valid on the resulting Proxy object, the target used to initialize the proxy must itself have a `[[Construct]]` internal method (i.e. `new target` must be valid).
+The **`handler.construct()`** method is a trap for the `[[Construct]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as the {{jsxref("Operators/new", "new")}} operator. In order for the new operation to be valid on the resulting Proxy object, the target used to initialize the proxy must itself be a valid constructor.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-construct.html", "taller")}}
 
@@ -41,8 +41,6 @@ The following parameters are passed to the `construct()` method. `this` is bound
 The `construct` method must return an object.
 
 ## Description
-
-The **`handler.construct()`** method is a trap for the {{jsxref("Operators/new", "new")}} operator.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.defineProperty
 
 {{JSRef}}
 
-The **`handler.defineProperty()`** method is a trap for
-{{jsxref("Object.defineProperty()")}}.
+The **`handler.defineProperty()`** method is a trap for the `[[DefineOwnProperty]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.defineProperty()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-defineproperty.html", "taller")}}
 
@@ -45,9 +44,6 @@ The `defineProperty()` method must return a {{jsxref("Boolean")}} indicating
 whether or not the property has been successfully defined.
 
 ## Description
-
-The **`handler.defineProperty()`** method is a trap for
-{{jsxref("Object.defineProperty()")}}.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.deleteProperty
 
 {{JSRef}}
 
-The **`handler.deleteProperty()`** method is a trap for the
-{{jsxref("Operators/delete", "delete")}} operator.
+The **`handler.deleteProperty()`** method is a trap for the `[[Delete]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as the {{jsxref("Operators/delete", "delete")}} operator.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-deleteproperty.html", "taller")}}
 
@@ -42,9 +41,6 @@ The `deleteProperty()` method must return a {{jsxref("Boolean")}} indicating
 whether or not the property has been successfully deleted.
 
 ## Description
-
-The **`handler.deleteProperty()`** method is a trap for the
-{{jsxref("Operators/delete", "delete")}} operator.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.get
 
 {{JSRef}}
 
-The **`handler.get()`** method is a trap for getting a property
-value.
+The **`handler.get()`** method is a trap for the `[[Get]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as [property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors).
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-get.html", "taller")}}
 
@@ -43,9 +42,6 @@ is bound to the handler.
 The `get()` method can return any value.
 
 ## Description
-
-The **`handler.get()`** method is a trap for getting a property
-value.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.getOwnPropertyDescriptor
 
 {{JSRef}}
 
-The **`handler.getOwnPropertyDescriptor()`** method is a trap for {{jsxref("Object.getOwnPropertyDescriptor()")}}.
+The **`handler.getOwnPropertyDescriptor()`** method is a trap for the `[[GetOwnProperty]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.getOwnPropertyDescriptor()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-getownpropertydescriptor.html", "taller")}}
 
@@ -39,8 +39,6 @@ The following parameters are passed to the `getOwnPropertyDescriptor()` method. 
 The `getOwnPropertyDescriptor()` method must return an object or `undefined`.
 
 ## Description
-
-The **`handler.getOwnPropertyDescriptor()`** method is a trap for {{jsxref("Object.getOwnPropertyDescriptor()")}}.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.getPrototypeOf
 
 {{JSRef}}
 
-The **`handler.getPrototypeOf()`** method is a trap for the
-`[[GetPrototypeOf]]` internal method.
+The **`handler.getPrototypeOf()`** method is a trap for the `[[GetPrototypeOf]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.getPrototypeOf()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-getprototypeof.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.has
 
 {{JSRef}}
 
-The **`handler.has()`** method is a trap for the
-{{jsxref("Operators/in", "in")}} operator.
+The **`handler.has()`** method is a trap for the `[[HasProperty]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as the {{jsxref("Operators/in", "in")}} operator.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-has.html", "taller")}}
 
@@ -41,9 +40,6 @@ bound to the handler.
 The `has()` method must return a boolean value.
 
 ## Description
-
-The **`handler.has()`** method is a trap for the
-{{jsxref("Operators/in", "in")}} operator.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.isExtensible
 
 {{JSRef}}
 
-The **`handler.isExtensible()`** method is a trap for
-{{jsxref("Object.isExtensible()")}}.
+The **`handler.isExtensible()`** method is a trap for the `[[IsExtensible]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.isExtensible()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-isextensible.html", "taller")}}
 
@@ -39,9 +38,6 @@ The following parameter is passed to the `isExtensible()` method.
 The `isExtensible()` method must return a boolean value.
 
 ## Description
-
-The **`handler.isExtensible()`** method is a trap for
-{{jsxref("Object.isExtensible()")}}.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.ownKeys
 
 {{JSRef}}
 
-The **`handler.ownKeys()`** method is a trap for
-{{jsxref("Reflect.ownKeys()")}}.
+The **`handler.ownKeys()`** method is a trap for the `[[OwnPropertyKeys]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.keys()")}}, {{jsxref("Reflect.ownKeys()")}}, etc.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-ownkeys.html", "taller")}}
 
@@ -39,9 +38,6 @@ The following parameter is passed to the `ownKeys()` method.
 The `ownKeys()` method must return an enumerable object.
 
 ## Description
-
-The **`handler.ownKeys()`** method is a trap for
-{{jsxref("Reflect.ownKeys()")}}.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.preventExtensions
 
 {{JSRef}}
 
-The **`handler.preventExtensions()`** method is a trap for {{jsxref("Object.preventExtensions()")}}.
+The **`handler.preventExtensions()`** method is a trap for the `[[PreventExtensions]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.preventExtensions()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-preventextensions.html", "taller")}}
 
@@ -37,8 +37,6 @@ The following parameter is passed to the `preventExtensions()` method. `this` is
 The `preventExtensions()` method must return a boolean value.
 
 ## Description
-
-The **`handler.preventExtensions()`** method is a trap for {{jsxref("Object.preventExtensions()")}}.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Proxy.handler.set
 
 {{JSRef}}
 
-The **`handler.set()`** method is a trap for setting a property
-value.
+The **`handler.set()`** method is a trap for the `[[Set]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as using [property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors) to set a property's value.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-set.html", "taller")}}
 
@@ -58,9 +57,6 @@ The `set()` method should return a boolean value.
   happened in strict-mode code, a {{jsxref("TypeError")}} will be thrown.
 
 ## Description
-
-The **`handler.set()`** method is a trap for setting property
-value.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -13,8 +13,7 @@ browser-compat: javascript.builtins.Proxy.handler.setPrototypeOf
 
 {{JSRef}}
 
-The **`handler.setPrototypeOf()`** method is a trap for the
-`[[SetPrototypeOf]]` internal method.
+The **`handler.setPrototypeOf()`** method is a trap for the `[[SetPrototypeOf]]` [object internal method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#object_internal_methods), which is used by operations such as {{jsxref("Object.setPrototypeOf()")}}.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-setprototypeof.html", "taller")}}
 
@@ -43,9 +42,6 @@ The `setPrototypeOf()` method returns `true` if the
 `[[Prototype]]` was successfully changed, otherwise `false`.
 
 ## Description
-
-The **`handler.setPrototypeOf()`** method is a trap for the
-`[[SetPrototypeOf]]` internal method.
 
 ### Interceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -13,8 +13,8 @@ browser-compat: javascript.builtins.Proxy.handler.setPrototypeOf
 
 {{JSRef}}
 
-The **`handler.setPrototypeOf()`** method is a trap for
-{{jsxref("Object.setPrototypeOf()")}}.
+The **`handler.setPrototypeOf()`** method is a trap for the
+`[[SetPrototypeOf]]` internal method.
 
 {{EmbedInteractiveExample("pages/js/proxyhandler-setprototypeof.html", "taller")}}
 
@@ -44,8 +44,8 @@ The `setPrototypeOf()` method returns `true` if the
 
 ## Description
 
-The **`handler.setPrototypeOf()`** method is a trap for
-{{jsxref("Object.setPrototypeOf()")}}.
+The **`handler.setPrototypeOf()`** method is a trap for the
+`[[SetPrototypeOf]]` internal method.
 
 ### Interceptions
 


### PR DESCRIPTION
Correct me if I'm wrong, but I'm pretty sure that the handler.setPrototypeOf method is a trap for the internal method [[SetPrototypeOf]], not for Object.setPrototypeOf: https://262.ecma-international.org/13.0/#table-proxy-handler-methods
