### PR TITLE
fix: polymorphism code excerpt expectation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -44,7 +44,6 @@ Because of this polymorphic implementation, `@@species` of derived subclasses wo
 
 ```js
 class SubPromise extends Promise {}
-SubPromise[Symbol.species] === Promise; // false
 SubPromise[Symbol.species] === SubPromise; // true
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -44,7 +44,8 @@ Because of this polymorphic implementation, `@@species` of derived subclasses wo
 
 ```js
 class SubPromise extends Promise {}
-SubPromise[Symbol.species] === Promise; // true
+SubPromise[Symbol.species] === Promise; // false
+SubPromise[Symbol.species] === SubPromise; // true
 ```
 
 Promise chaining methods — [`then()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then), [`catch()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch), and [`finally()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally) — return new promise objects. They get the constructor to construct the new promise through `this.constructor[@@species]`. If `this.constructor` is `undefined`, or if `this.constructor[@@species]` is `undefined` or `null`, the default {{jsxref("Promise/Promise", "Promise()")}} constructor is used. Otherwise, the constructor returned by `this.constructor[@@species]` is used to construct the new promise object.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I typo in the code example demonstrating the interest in the polymorphic implementation of `Promise[@@species]`.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I've been coming to MDN to know what the standard is in JavaScript (which is more friendly than the official EcmaScript spec). I was also implementing a `Promise` from scratch before I tweaked it to my flavour... And my test case didn't match that code excerpt behaviour.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
