### PR TITLE
Changing some sections in "Firefox 104 for developers" page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -20,6 +20,8 @@ No notable changes.
 
 ### CSS
 
+No notable changes.
+
 ### JavaScript
 
 - The methods {{jsxref("Array.prototype.findLast()")}}, {{jsxref("Array.prototype.findLastIndex()")}}, {{jsxref("TypedArray.prototype.findLast()")}}, and {{jsxref("TypedArray.prototype.findLastIndex()")}} are now supported.
@@ -50,8 +52,6 @@ No notable changes.
 
 - The `fontKerning` property is now supported on [`CanvasRenderingContext2D`](/en-US/docs/Web/API/CanvasRenderingContext2D/fontKerning) and [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D), enabling developers to specify how kerning is used when text is drawn to a canvas or an offscreen canvas ({{bug(1778908)}}).
 
-#### Media, WebRTC, and Web Audio
-
 #### SVG
 
 - The [`SVGStyleElement.disabled`](/en-US/docs/Web/API/SVGStyleElement/disabled) property can now be used to disable or enable an SVG style element, or to check its disabled state.
@@ -67,7 +67,7 @@ No notable changes.
 
 ### WebAssembly
 
-#### Removals
+No notable changes.
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -83,9 +83,7 @@ No notable changes.
 
 ## Changes for add-on developers
 
-### Removals
-
-### Other
+No notable changes.
 
 ## Older versions
 


### PR DESCRIPTION
### Description

There are some sections leftovers from beta/nightly stages of “Firefox 104 for developers” page.

### Motivation

I'm doing this for making MDN better.

### Additional details

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/104

### Related issues and pull requests

Related: https://github.com/mdn/content/pull/24023
