### PR TITLE
<caption> has implicit role of "caption"

### DIFF
--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -130,7 +130,7 @@ td {
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/wai-aria-1.2/#caption">caption</a>
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles#structural_roles_with_html_equivalents">caption</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -130,9 +130,7 @@ td {
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >No corresponding role</a
-        >
+        <a href="https://www.w3.org/TR/wai-aria-1.2/#caption">caption</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description

Updates the HTML `<caption>` element's "Technical summary" table to reflect that the element has an implicit role of `"caption"`.

### Motivation

To bring this page into alignment with the [ARIA in HTML spec](https://www.w3.org/TR/html-aria/#el-caption).

### Additional details

As far as I can tell, MDN does not have a dedicated page for the "caption" role in its [WAI-ARIA roles section](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles), so I chose to link to the ARIA spec instead.

### Related issues and pull requests

Didn't see an existing issue.
