### PR TITLE
Fixes #24016 Link points to itself

### DIFF
--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -58,7 +58,7 @@ As the structure of at-rules varies widely, please see [At-rule](/en-US/docs/Web
 
 ## Index
 
-> **Note:** The property names in this index do **not** include the JavaScript names where they differ from the CSS standard names.
+> **Note:** The property names in this index do **not** include the JavaScript names which do differ from the CSS standard names.
 
 {{CSS_Ref}}
 

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -58,7 +58,7 @@ As the structure of at-rules varies widely, please see [At-rule](/en-US/docs/Web
 
 ## Index
 
-> **Note:** The property names in this index do **not** include the [JavaScript names](https://www.dummies.com/article/technology/programming-web-design/javascript/converting-css-property-names-to-javascript-142516/) where they differ from the CSS standard names.
+> **Note:** The property names in this index do **not** include the JavaScript names where they differ from the CSS standard names.
 
 {{CSS_Ref}}
 

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -58,7 +58,7 @@ As the structure of at-rules varies widely, please see [At-rule](/en-US/docs/Web
 
 ## Index
 
-> **Note:** The property names in this index do **not** include the [JavaScript names](/en-US/docs/Web/CSS/CSS_Properties_Reference) where they differ from the CSS standard names.
+> **Note:** The property names in this index do **not** include the [JavaScript names](https://www.dummies.com/article/technology/programming-web-design/javascript/converting-css-property-names-to-javascript-142516/) where they differ from the CSS standard names.
 
 {{CSS_Ref}}
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
On this part of the docs:- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference#index 
The Note has a link that points to itself, I have added a necessary link
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
When a reader clicks the link it does not provide any useful resource, instead, it points to itself, I have added a useful resource that helps the user better and gives a better understanding of it

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
