### PR TITLE
Fixes #24012 syntax of avc1 codec parameter

### DIFF
--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -277,7 +277,7 @@ Thus, the syntaxes for each of the supported codecs look like this:
   - : Where `oo` is the Object Type Indication value describing the contents of the media more precisely and `A` is the one-digit _audio_ OTI. The possible values for the OTI can be found on the MP4 Registration Authority web site's [Object Types page](https://mp4ra.org/#/object_types). For example, Opus audio in an MP4 file is `mp4a.ad`. For further details, see [MPEG-4 audio](#mpeg-4_audio).
 - `mp4v.oo[.V]` (MPEG-4 video)
   - : Here, `oo` is again the OTI describing the contents more precisely, while `V` is the one-digit _video_ OTI.
-- `avc1.oo[.PPCCLL]` (AVC video)
+- `avc1[.PPCCLL]` (AVC video)
 
   - : `oo` is the OTI describing the contents, while `PPCCLL` is six hexadecimal digits specifying the profile number (`PP`), constraint set flags (`CC`), and level (`LL`). See [AVC profiles](#avc_profiles) for the possible values of `PP`.
 

--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -279,7 +279,7 @@ Thus, the syntaxes for each of the supported codecs look like this:
   - : Here, `oo` is again the OTI describing the contents more precisely, while `V` is the one-digit _video_ OTI.
 - `avc1[.PPCCLL]` (AVC video)
 
-  - : `oo` is the OTI describing the contents, while `PPCCLL` is six hexadecimal digits specifying the profile number (`PP`), constraint set flags (`CC`), and level (`LL`). See [AVC profiles](#avc_profiles) for the possible values of `PP`.
+  - : `PPCCLL` are six hexadecimal digits specifying the profile number (`PP`), constraint set flags (`CC`), and level (`LL`). See [AVC profiles](#avc_profiles) for the possible values of `PP`.
 
     The constraint set flags byte is comprised of one-bit Boolean flags, with the most significant bit being referred to as flag 0 (or `constraint_set0_flag`, in some resources), and each successive bit being numbered one higher. Currently, only flags 0 through 2 are used; the other five bits _must_ be zero. The meanings of the flags vary depending on the profile being used.
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I have updated the syntax of avc1 codec parameter as requested in #24012

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The syntax of avc1 codec parameter is not proper which might mislead the user hence I corrected the syntax as suggested in #24012
### Additional details
RFC 6381:

... the second element
(referred to as 'avcoti' in the formal syntax) is the hexadecimal
representation of the following three bytes in the (subset) sequence
parameter set Network Abstraction Layer (NAL) unit specified in
[[AVC](https://datatracker.ietf.org/doc/html/rfc6381#ref-AVC)]:
(1) profile_idc,
. (2) the byte containing the constraint_set flags (currently
constraint_set0_flag through constraint_set5_flag, and the
reserved_zero_2bits), and
(3) level_idc.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->



<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
