### PR TITLE
Removal of unnecessary title in "Firefox 107 for developers" page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -64,8 +64,6 @@ No notable changes
 
 ## Changes for add-on developers
 
-### Removals
-
 ### Other
 
 - The `error` property returned when an error occurs in {{WebExtAPIRef("scripting.executeScript")}} now represents any value the script throws or rejects with, instead of being just an object with a message property {{bug(1740608)}}.


### PR DESCRIPTION
### Description

I removed the “Removals” title in “Changes for add-on developers” section.

### Motivation

I'm doing this for making MDN better.

### Additional details

— https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/107

### Related issues and pull requests

I think, that there are not any related issues/PRs at this time.
