### PR TITLE
Document `AnimationEffect.getTiming()` return value

### DIFF
--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -32,26 +32,52 @@ None.
 An object containing the following properties:
 
 - `delay`
-  - : A `number`.
+  - : The `number` of milliseconds of delay before the start of the effect.
+
     (Corresponds to {{cssxref("animation-delay")}}.)
 - `endDelay`
-  - : A `number`.
+  - : The `number` of milliseconds of delay after the end of the effect.
+
+    This is primarily of use when sequencing animations based on the end time of another animation.
 - `fill`
   - : `"none"`, `"forwards"`, `"backwards"`, "`both`", or `"auto"`.
+
+    Indicates whether the effect is reflected by its target(s) prior to playing
+    (`"backwards"`), retained after the effect has completed (`"forwards"`), `"both"`, or
+    neither (`"none"`).
+
+    The meaning of `"auto"` may differ depending on the type of effect; for
+    {{domxref("KeyframeEffect")}}, `"auto"` is the same as `"none"`.
+
     (Corresponds to {{cssxref("animation-fill-mode")}}.)
 - `iterationStart`
-  - : A `number`.
+  - : A `number` indicating at what point in the iteration the effect starts. For example, an effect with
+    an `iterationStart` of 0.5 and 2 `iterations` would start halfway through its first iteration
+    and end halfway through a third iteration.
 - `iterations`
-  - : A `number`.
+  - : The `number` of times the effect will repeat. A value of {{jsxref("Infinity")}} indicates that
+    the effect repeats indefinitely.
+
     (Corresponds to {{cssxref("animation-iteration-count")}}.)
 - `duration`
-  - : A `number` or the `string` `"auto"`.
+  - : A `number` of milliseconds or the `string` `"auto"`.
+
+    Indicates the time one iteration of the animation takes to complete.
+
+    The meaning of `"auto"` may differ depending on the type of effect; for {{domxref("KeyframeEffect")}}, `"auto"` is the same as `0`.
+
     (Corresponds to {{cssxref("animation-duration")}}.)
 - `direction`
   - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
+
+    Indicates whether the effect runs forwards (`"normal"`), backwards (`"reverse"`), switches direction
+    after each iteration (`"alternate"`), or runs backwards and switches direction after each iteration
+    (`"alternate-reverse"`).
+
     (Corresponds to {{cssxref("animation-direction")}}.)
 - `easing`
-  - : A `string` representing an {{cssxref("easing-function")}}.
+  - : A `string` representing an {{cssxref("easing-function")}} describing the rate of change of the effect over time.
+
     (Corresponds to {{cssxref("animation-timing-function")}}.)
 
 Several of these properties have corresponding [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) properties.

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -32,13 +32,21 @@ None.
 An object containing the following properties:
 
 - `delay`
+  - : A `number`.
 - `endDelay`
+  - : A `number`.
 - `fill`
+  - : `"none"`, `"forwards"`, `"backwards"`, "`both`", or `"auto"`.
 - `iterationStart`
+  - : A `number`.
 - `iterations`
+  - : A `number`.
 - `duration`
+  - : A `number` or the `string` `"auto"`.
 - `direction`
+  - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
 - `easing`
+  - : A `string` representing an {{cssxref("easing-function")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -34,7 +34,7 @@ An object containing the following properties:
 - `delay`
   - : The `number` of milliseconds of delay before the start of the effect.
 
-    (Corresponds to {{cssxref("animation-delay")}}.)
+    (See also {{cssxref("animation-delay")}}.)
 - `endDelay`
   - : The `number` of milliseconds of delay after the end of the effect.
 
@@ -49,7 +49,7 @@ An object containing the following properties:
     The meaning of `"auto"` may differ depending on the type of effect; for
     {{domxref("KeyframeEffect")}}, `"auto"` is the same as `"none"`.
 
-    (Corresponds to {{cssxref("animation-fill-mode")}}.)
+    (See also {{cssxref("animation-fill-mode")}}.)
 - `iterationStart`
   - : A `number` indicating at what point in the iteration the effect starts. For example, an effect with
     an `iterationStart` of 0.5 and 2 `iterations` would start halfway through its first iteration
@@ -58,7 +58,7 @@ An object containing the following properties:
   - : The `number` of times the effect will repeat. A value of {{jsxref("Infinity")}} indicates that
     the effect repeats indefinitely.
 
-    (Corresponds to {{cssxref("animation-iteration-count")}}.)
+    (See also {{cssxref("animation-iteration-count")}}.)
 - `duration`
   - : A `number` of milliseconds or the `string` `"auto"`.
 
@@ -66,7 +66,7 @@ An object containing the following properties:
 
     The meaning of `"auto"` may differ depending on the type of effect; for {{domxref("KeyframeEffect")}}, `"auto"` is the same as `0`.
 
-    (Corresponds to {{cssxref("animation-duration")}}.)
+    (See also {{cssxref("animation-duration")}}.)
 - `direction`
   - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
 
@@ -74,13 +74,11 @@ An object containing the following properties:
     after each iteration (`"alternate"`), or runs backwards and switches direction after each iteration
     (`"alternate-reverse"`).
 
-    (Corresponds to {{cssxref("animation-direction")}}.)
+    (See also {{cssxref("animation-direction")}}.)
 - `easing`
   - : A `string` representing an {{cssxref("easing-function")}} describing the rate of change of the effect over time.
 
-    (Corresponds to {{cssxref("animation-timing-function")}}.)
-
-Several of these properties have corresponding [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) properties.
+    (See also {{cssxref("animation-timing-function")}}.)
 
 ## Specifications
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -35,6 +35,26 @@ An object containing the following properties:
   - : The `number` of milliseconds of delay before the start of the effect.
 
     (See also {{cssxref("animation-delay")}}.)
+- `direction`
+  - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
+
+    Indicates whether the effect runs forwards (`"normal"`), backwards (`"reverse"`), switches direction
+    after each iteration (`"alternate"`), or runs backwards and switches direction after each iteration
+    (`"alternate-reverse"`).
+
+    (See also {{cssxref("animation-direction")}}.)
+- `duration`
+  - : A `number` of milliseconds or the `string` `"auto"`.
+
+    Indicates the time one iteration of the animation takes to complete.
+
+    The meaning of `"auto"` may differ depending on the type of effect; for {{domxref("KeyframeEffect")}}, `"auto"` is the same as `0`.
+
+    (See also {{cssxref("animation-duration")}}.)
+- `easing`
+  - : A `string` representing an {{cssxref("easing-function")}} describing the rate of change of the effect over time.
+
+    (See also {{cssxref("animation-timing-function")}}.)
 - `endDelay`
   - : The `number` of milliseconds of delay after the end of the effect.
 
@@ -50,35 +70,15 @@ An object containing the following properties:
     {{domxref("KeyframeEffect")}}, `"auto"` is the same as `"none"`.
 
     (See also {{cssxref("animation-fill-mode")}}.)
-- `iterationStart`
-  - : A `number` indicating at what point in the iteration the effect starts. For example, an effect with
-    an `iterationStart` of 0.5 and 2 `iterations` would start halfway through its first iteration
-    and end halfway through a third iteration.
 - `iterations`
   - : The `number` of times the effect will repeat. A value of {{jsxref("Infinity")}} indicates that
     the effect repeats indefinitely.
 
     (See also {{cssxref("animation-iteration-count")}}.)
-- `duration`
-  - : A `number` of milliseconds or the `string` `"auto"`.
-
-    Indicates the time one iteration of the animation takes to complete.
-
-    The meaning of `"auto"` may differ depending on the type of effect; for {{domxref("KeyframeEffect")}}, `"auto"` is the same as `0`.
-
-    (See also {{cssxref("animation-duration")}}.)
-- `direction`
-  - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
-
-    Indicates whether the effect runs forwards (`"normal"`), backwards (`"reverse"`), switches direction
-    after each iteration (`"alternate"`), or runs backwards and switches direction after each iteration
-    (`"alternate-reverse"`).
-
-    (See also {{cssxref("animation-direction")}}.)
-- `easing`
-  - : A `string` representing an {{cssxref("easing-function")}} describing the rate of change of the effect over time.
-
-    (See also {{cssxref("animation-timing-function")}}.)
+- `iterationStart`
+  - : A `number` indicating at what point in the iteration the effect starts. For example, an effect with
+    an `iterationStart` of 0.5 and 2 `iterations` would start halfway through its first iteration
+    and end halfway through a third iteration.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -29,7 +29,16 @@ None.
 
 ### Return value
 
-An object.
+An object containing the following properties:
+
+- `delay`
+- `endDelay`
+- `fill`
+- `iterationStart`
+- `iterations`
+- `duration`
+- `direction`
+- `easing`
 
 ## Specifications
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -17,6 +17,10 @@ browser-compat: api.AnimationEffect.getTiming
 
 The `AnimationEffect.getTiming()` method of the {{domxref("AnimationEffect")}} interface returns an object containing the timing properties for the Animation Effect.
 
+> **Note:** Several of the timing properties returned by `getTiming()` may take on the placeholder value `"auto"`. To obtain resolved values for use in timing computations, instead use {{domxref("AnimationEffect.getComputedTiming()")}}.
+>
+> In the future, `"auto"` or similar values might be added to the types of more timing properties, and new types of {{domxref("AnimationEffect")}} might resolve `"auto"` to different values.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -33,20 +33,28 @@ An object containing the following properties:
 
 - `delay`
   - : A `number`.
+    (Corresponds to {{cssxref("animation-delay")}}.)
 - `endDelay`
   - : A `number`.
 - `fill`
   - : `"none"`, `"forwards"`, `"backwards"`, "`both`", or `"auto"`.
+    (Corresponds to {{cssxref("animation-fill-mode")}}.)
 - `iterationStart`
   - : A `number`.
 - `iterations`
   - : A `number`.
+    (Corresponds to {{cssxref("animation-iteration-count")}}.)
 - `duration`
   - : A `number` or the `string` `"auto"`.
+    (Corresponds to {{cssxref("animation-duration")}}.)
 - `direction`
   - : `"normal"`, `"reverse"`, `"alternate"`, or `"alternate-reverse"`.
+    (Corresponds to {{cssxref("animation-direction")}}.)
 - `easing`
   - : A `string` representing an {{cssxref("easing-function")}}.
+    (Corresponds to {{cssxref("animation-timing-function")}}.)
+
+Several of these properties have corresponding [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) properties.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add documentation for the properties of [`AnimationEffect.getTiming()`'s return value](https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffect/getTiming#return_value), adapting the descriptions from [`KeyframeEffect()`'s `options` parameter](https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#options).

Add a warning that [`AnimationEffect.getComputedTiming()`](https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffect/getComputedTiming) is usually more helpful.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Completeness.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

If the edits wording meets with approval, we might want to apply a couple of the edits to other places where [`EffectTiming`](https://w3c.github.io/csswg-drafts/web-animations-1/#dictdef-effecttiming) gets documented; but that would be another PR.

The [`getComputedTiming()`](https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffect/getComputedTiming) page looks like it could use some work too.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
