### PR TITLE
fixed a typo error of URL examples

### DIFF
--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -105,7 +105,7 @@ new URL("/a", "https://example.com/?query=1");
 // => 'https://example.com/a' (see relative URLs)
 
 new URL("//foo.com", "https://example.com");
-// => 'https://foo.com' (see relative URLs)
+// => 'https://foo.com/' (see relative URLs)
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I think the result of the latest case of URL examples is a typo error. 
I test the case in browser and nodejs environment, the result is `https://foo.com/`, just lost `/` character of there.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

fix a typo error

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
