### PR TITLE
Format /mozilla using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,10 +5,6 @@ build/
 /files/en-us/_githistory.json
 /tests/front-matter_test_files
 
-# A full pass on all Markdown files is being performed.
-# The following folders still need a full pass:
-/files/en-us/mozilla/add-ons/webextensions/api/**/*.md
-
 # XXX Ignored until https://github.com/prettier/prettier/issues/15032 is fixed
 /files/en-us/web/javascript/reference/operators/exponentiation/index.md
 /files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -43,8 +43,8 @@ let settingIcon = browser.action.setIcon(
         let settingIcon = browser.action.setIcon({
           imageData: {
             16: image16,
-            32: image32
-          }
+            32: image32,
+          },
         });
         ```
 
@@ -60,8 +60,8 @@ let settingIcon = browser.action.setIcon(
         let settingIcon = browser.action.setIcon({
           path: {
             16: "path/to/image16.jpg",
-            32: "path/to/image32.jpg"
-          }
+            32: "path/to/image32.jpg",
+          },
         });
         ```
 
@@ -100,7 +100,7 @@ function startListening() {
   browser.webRequest.onHeadersReceived.addListener(
     logResponseHeaders,
     { urls: ["<all_urls>"] },
-    ["responseHeaders"]
+    ["responseHeaders"],
   );
   browser.action.setIcon({ path: "icons/listening-on.svg" });
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
@@ -69,7 +69,7 @@ browser.contextMenus.create(
     contexts: ["all"],
     checked: true,
   },
-  onCreated
+  onCreated,
 );
 
 browser.contextMenus.create(
@@ -80,7 +80,7 @@ browser.contextMenus.create(
     contexts: ["all"],
     checked: false,
   },
-  onCreated
+  onCreated,
 );
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -41,8 +41,8 @@ let settingIcon = browser.browserAction.setIcon(
         let settingIcon = browser.action.setIcon({
           imageData: {
             16: image16,
-            32: image32
-          }
+            32: image32,
+          },
         });
         ```
 
@@ -58,8 +58,8 @@ let settingIcon = browser.browserAction.setIcon(
         let settingIcon = browser.action.setIcon({
           path: {
             16: "path/to/image16.jpg",
-            32: "path/to/image32.jpg"
-          }
+            32: "path/to/image32.jpg",
+          },
         });
         ```
 
@@ -102,7 +102,7 @@ function startListening() {
   browser.webRequest.onHeadersReceived.addListener(
     logResponseHeaders,
     { urls: ["<all_urls>"] },
-    ["responseHeaders"]
+    ["responseHeaders"],
   );
   browser.browserAction.setIcon({ path: "icons/listening-on.svg" });
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -71,7 +71,7 @@ browser.contextMenus.create(
     contexts: ["all"],
     checked: true,
   },
-  onCreated
+  onCreated,
 );
 
 browser.contextMenus.create(
@@ -82,7 +82,7 @@ browser.contextMenus.create(
     contexts: ["all"],
     checked: false,
   },
-  onCreated
+  onCreated,
 );
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -49,7 +49,7 @@ The following code snippet gets all cookie stores and then logs the total number
 browser.cookies.getAllCookieStores().then((stores) => {
   const incognitoStores = stores.map((store) => store.incognito);
   console.log(
-    `Of ${stores.length} cookie stores, ${incognitoStores.length} are incognito.`
+    `Of ${stores.length} cookie stores, ${incognitoStores.length} are incognito.`,
   );
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -68,7 +68,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
     `Cookie changed: \n` +
       ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n` +
       ` * Cause: ${changeInfo.cause}\n` +
-      ` * Removed: ${changeInfo.removed}`
+      ` * Removed: ${changeInfo.removed}`,
   );
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -38,7 +38,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
     `Cookie changed: \n` +
       ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n` +
       ` * Cause: ${changeInfo.cause}\n` +
-      ` * Removed: ${changeInfo.removed}`
+      ` * Removed: ${changeInfo.removed}`,
   );
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -55,7 +55,7 @@ browser.devtools.panels
   .create(
     "My Panel", // title
     "/icons/star.png", // icon
-    "/devtools/panel/panel.html" // content
+    "/devtools/panel/panel.html", // content
   )
   .then((newPanel) => {
     newPanel.onShown.addListener(handleShown);

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -49,7 +49,7 @@ function handleSelectedElement() {
 }
 
 browser.devtools.panels.elements.onSelectionChanged.addListener(
-  handleSelectedElement
+  handleSelectedElement,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -39,7 +39,7 @@ browser.devtools.panels
   .create(
     "My Panel", // title
     "icons/star.png", // icon
-    "devtools/panel/panel.html" // content
+    "devtools/panel/panel.html", // content
   )
   .then((newPanel) => {
     newPanel.onShown.addListener(handleShown);

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -184,7 +184,7 @@ function getNodes() {
     document,
     window.NodeFilter.SHOW_TEXT,
     null,
-    false
+    false,
   );
   const nodes = [];
   while ((node = walker.nextNode())) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -61,7 +61,7 @@ browser.history
       text: "https://example.org/",
       startTime: 0,
       maxResults: 1,
-    })
+    }),
   )
   .then(onGot);
 ```
@@ -91,7 +91,7 @@ browser.history
   .then(() =>
     browser.history.getVisits({
       url: "https://example.org/",
-    })
+    }),
   )
   .then(onGot);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -154,7 +154,7 @@ browser.menus.create(
     contexts: ["all"],
     checked: false,
   },
-  onCreated
+  onCreated,
 );
 
 browser.menus.create(
@@ -165,7 +165,7 @@ browser.menus.create(
     contexts: ["all"],
     checked: false,
   },
-  onCreated
+  onCreated,
 );
 
 let makeItBlue = 'document.body.style.border = "5px solid blue"';

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -59,7 +59,7 @@ browser.menus.create(
     title: browser.i18n.getMessage("menuItemRemoveMe"),
     contexts: ["all"],
   },
-  onCreated
+  onCreated,
 );
 
 browser.menus.create(
@@ -68,7 +68,7 @@ browser.menus.create(
     type: "separator",
     contexts: ["all"],
   },
-  onCreated
+  onCreated,
 );
 
 browser.menus.create(
@@ -83,7 +83,7 @@ browser.menus.create(
       32: "icons/paint-green-32.png",
     },
   },
-  onCreated
+  onCreated,
 );
 
 browser.menus.create(
@@ -98,7 +98,7 @@ browser.menus.create(
       32: "icons/paint-blue-32.png",
     },
   },
-  onCreated
+  onCreated,
 );
 
 browser.menus.create(
@@ -107,7 +107,7 @@ browser.menus.create(
     type: "separator",
     contexts: ["all"],
   },
-  onCreated
+  onCreated,
 );
 
 let checkedState = true;
@@ -120,7 +120,7 @@ browser.menus.create(
     contexts: ["all"],
     checked: checkedState,
   },
-  onCreated
+  onCreated,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
@@ -54,7 +54,7 @@ document.addEventListener(
       });
     }
   },
-  { capture: true }
+  { capture: true },
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -39,8 +39,8 @@ let settingIcon = browser.pageAction.setIcon(
         let settingIcon = browser.action.setIcon({
           imageData: {
             16: image16,
-            32: image32
-          }
+            32: image32,
+          },
         });
         ```
 
@@ -56,8 +56,8 @@ let settingIcon = browser.pageAction.setIcon(
         let settingIcon = browser.action.setIcon({
           path: {
             16: "path/to/image16.jpg",
-            32: "path/to/image32.jpg"
-          }
+            32: "path/to/image32.jpg",
+          },
         });
         ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -42,7 +42,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 let testPermissions1 = {
   origins: ["*://mozilla.org/"],
-  permissions: ["tabs"]
+  permissions: ["tabs"],
 };
 
 const testResult1 = await browser.permissions.contains(testPermissions1);
@@ -50,7 +50,7 @@ console.log(testResult1); // true
 
 let testPermissions2 = {
   origins: ["*://mozilla.org/"],
-  permissions: ["tabs", "alarms"]
+  permissions: ["tabs", "alarms"],
 };
 
 const testResult2 = await browser.permissions.contains(testPermissions2);
@@ -58,14 +58,14 @@ console.log(testResult2); // false, "alarms" doesn't match
 
 let testPermissions3 = {
   origins: ["https://developer.mozilla.org/"],
-  permissions: ["tabs", "webRequest"]
+  permissions: ["tabs", "webRequest"],
 };
 
 const testResult3 = await browser.permissions.contains(testPermissions3);
 console.log(testResult3); // true: "https://developer.mozilla.org/", matches: "*://*.mozilla.org/*"
 
 let testPermissions4 = {
-  origins: ["https://example.org/"]
+  origins: ["https://example.org/"],
 };
 
 const testResult4 = await browser.permissions.contains(testPermissions4);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -49,7 +49,7 @@ function handleBrowserUpdateAvailable() {
 }
 
 browser.runtime.onBrowserUpdateAvailable.addListener(
-  handleBrowserUpdateAvailable
+  handleBrowserUpdateAvailable,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -51,7 +51,7 @@ function forgetMostRecent(sessionInfos) {
   if (sessionInfo.tab) {
     browser.sessions.forgetClosedTab(
       sessionInfo.tab.windowId,
-      sessionInfo.tab.sessionId
+      sessionInfo.tab.sessionId,
     );
   } else {
     browser.sessions.forgetClosedWindow(sessionInfo.window.sessionId);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -48,7 +48,7 @@ function forgetMostRecent(sessionInfos) {
   if (sessionInfo.tab) {
     browser.sessions.forgetClosedTab(
       sessionInfo.tab.windowId,
-      sessionInfo.tab.sessionId
+      sessionInfo.tab.sessionId,
     );
   } else {
     browser.sessions.forgetClosedWindow(sessionInfo.window.sessionId);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -51,8 +51,8 @@ let settingIcon = browser.sidebarAction.setIcon(
         let settingIcon = browser.action.setIcon({
           imageData: {
             16: image16,
-            32: image32
-          }
+            32: image32,
+          },
         });
         ```
 
@@ -68,8 +68,8 @@ let settingIcon = browser.sidebarAction.setIcon(
         let settingIcon = browser.action.setIcon({
           path: {
             16: "path/to/image16.jpg",
-            32: "path/to/image32.jpg"
-          }
+            32: "path/to/image32.jpg",
+          },
         });
         ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -147,7 +147,7 @@ Or using a Promise
 
 ```js
 let gettingItem = new Promise((resolve) =>
-  chrome.storage.local.get("kitten", resolve)
+  chrome.storage.local.get("kitten", resolve),
 );
 gettingItem.then(onGot); // -> Object { kitten: Object }
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -59,7 +59,7 @@ Listen for and log move events:
 ```js
 function handleMoved(tabId, moveInfo) {
   console.log(
-    `Tab ${tabId} moved from ${moveInfo.fromIndex} to ${moveInfo.toIndex}`
+    `Tab ${tabId} moved from ${moveInfo.fromIndex} to ${moveInfo.toIndex}`,
   );
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -90,7 +90,7 @@ function logOnCreatedNavigationTarget(details) {
 
 browser.webNavigation.onCreatedNavigationTarget.addListener(
   logOnCreatedNavigationTarget,
-  filter
+  filter,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -77,7 +77,7 @@ function logOnDOMContentLoaded(details) {
 
 browser.webNavigation.onDOMContentLoaded.addListener(
   logOnDOMContentLoaded,
-  filter
+  filter,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -83,7 +83,7 @@ function logOnHistoryStateUpdated(details) {
 
 browser.webNavigation.onHistoryStateUpdated.addListener(
   logOnHistoryStateUpdated,
-  filter
+  filter,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -83,7 +83,7 @@ function logOnReferenceFragmentUpdated(details) {
 
 browser.webNavigation.onReferenceFragmentUpdated.addListener(
   logOnReferenceFragmentUpdated,
-  filter
+  filter,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -79,7 +79,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/*"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -54,7 +54,7 @@ async function logSubject(details) {
   try {
     let securityInfo = await browser.webRequest.getSecurityInfo(
       details.requestId,
-      {}
+      {},
     );
     console.log(details.url);
     if (securityInfo.state === "secure" || securityInfo.state === "weak") {
@@ -68,7 +68,7 @@ async function logSubject(details) {
 browser.webRequest.onHeadersReceived.addListener(
   logSubject,
   { urls: ["https://*.mozilla.org/*"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -79,12 +79,12 @@ async function logRoot(details) {
   try {
     let securityInfo = await browser.webRequest.getSecurityInfo(
       details.requestId,
-      { certificateChain: true }
+      { certificateChain: true },
     );
     console.log(details.url);
     if (securityInfo.state === "secure" || securityInfo.state === "weak") {
       console.log(
-        securityInfo.certificates[securityInfo.certificates.length - 1].issuer
+        securityInfo.certificates[securityInfo.certificates.length - 1].issuer,
       );
     }
   } catch (error) {
@@ -95,7 +95,7 @@ async function logRoot(details) {
 browser.webRequest.onHeadersReceived.addListener(
   logRoot,
   { urls: ["https://*.mozilla.org/*"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -254,7 +254,7 @@ function provideCredentialsSync(requestDetails) {
 browser.webRequest.onAuthRequired.addListener(
   provideCredentialsSync,
   { urls: [target] },
-  ["blocking"]
+  ["blocking"],
 );
 
 browser.webRequest.onCompleted.addListener(completed, { urls: [target] });
@@ -299,7 +299,7 @@ function provideCredentialsAsync(requestDetails) {
 browser.webRequest.onAuthRequired.addListener(
   provideCredentialsAsync,
   { urls: [target] },
-  ["blocking"]
+  ["blocking"],
 );
 
 browser.webRequest.onCompleted.addListener(completed, { urls: [target] });

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -207,7 +207,7 @@ function cancel(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
   cancel,
   { urls: [pattern], types: ["image"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -233,7 +233,7 @@ function redirect(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
   redirect,
   { urls: [pattern], types: ["image"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -263,7 +263,7 @@ function redirectAsync(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
   redirectAsync,
   { urls: [pattern], types: ["image"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -287,7 +287,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: [pattern], types: ["image"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -314,7 +314,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: [pattern], types: ["image"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -199,7 +199,7 @@ Make it "blocking" so we can modify the headers.
 browser.webRequest.onBeforeSendHeaders.addListener(
   rewriteUserAgentHeader,
   { urls: [targetPage] },
-  ["blocking", "requestHeaders"]
+  ["blocking", "requestHeaders"],
 );
 ```
 
@@ -246,7 +246,7 @@ Make it "blocking" so we can modify the headers.
 browser.webRequest.onBeforeSendHeaders.addListener(
   rewriteUserAgentHeaderAsync,
   { urls: [targetPage] },
-  ["blocking", "requestHeaders"]
+  ["blocking", "requestHeaders"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -187,7 +187,7 @@ function setCookie(e) {
 browser.webRequest.onHeadersReceived.addListener(
   setCookie,
   { urls: [targetPage] },
-  ["blocking", "responseHeaders"]
+  ["blocking", "responseHeaders"],
 );
 ```
 
@@ -220,7 +220,7 @@ function setCookieAsync(e) {
 browser.webRequest.onHeadersReceived.addListener(
   setCookieAsync,
   { urls: [targetPage] },
-  ["blocking", "responseHeaders"]
+  ["blocking", "responseHeaders"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -157,7 +157,7 @@ function logCookies(e) {
 browser.webRequest.onSendHeaders.addListener(
   logCookies,
   { urls: [targetPage] },
-  ["requestHeaders"]
+  ["requestHeaders"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -52,7 +52,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -50,7 +50,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -31,7 +31,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["<all_urls>"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -101,7 +101,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -48,7 +48,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/*"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -84,7 +84,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -117,7 +117,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -147,7 +147,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -175,7 +175,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -208,7 +208,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -246,7 +246,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -276,7 +276,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -308,7 +308,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -35,7 +35,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["<all_urls>"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -32,7 +32,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
@@ -36,7 +36,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/*"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 
@@ -64,7 +64,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -50,7 +50,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -55,7 +55,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/*"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -50,7 +50,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.org/"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -57,7 +57,7 @@ function listener(details) {
 browser.webRequest.onBeforeRequest.addListener(
   listener,
   { urls: ["https://example.com/*"], types: ["main_frame"] },
-  ["blocking"]
+  ["blocking"],
 );
 ```
 


### PR DESCRIPTION
This PR is a part of a project to format all of the documents using Prettier, and then enforce Prettier formatting for the files going forward.  This PR formats the `/mozilla` folder.

Note: all of the remaining changes are simply adding trailing commas now; the documentation is otherwise formatted!