### PR TITLE
Format /mdn/kitchensink using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,5 +9,3 @@ build/
 !files/en-us/glossary/**/*.md
 !files/en-us/mdn/**/*.md
 
-# TODO: check if formatting kitchensink breaks Yari tests
-files/en-us/mdn/kitchensink/index.md

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -50,7 +50,7 @@ Text that uses the `<kbd>` tag: <kbd>Shift</kbd>
 ### HTML
 
 ```html
-<pre>
+<pre></pre>
 ```
 
 ### JavaScript
@@ -275,8 +275,13 @@ if (5 < 30 && 55 > 20 && 5 < 20 && 55 > 10) {
 
 ```html
 <div id="cr-stage"></div>
-<p>Move the rectangle with arrow keys. Green means collision, blue means no collision.</p>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crafty/0.5.4/crafty-min.js"></script>
+<p>
+  Move the rectangle with arrow keys. Green means collision, blue means no
+  collision.
+</p>
+<script
+  type="text/javascript"
+  src="https://cdnjs.cloudflare.com/ajax/libs/crafty/0.5.4/crafty-min.js"></script>
 ```
 
 ```js


### PR DESCRIPTION
This PR is a part of a project to format all of the documents using Prettier, and then enforce Prettier formatting for the files going forward.  This PR formats the `/mdn/kitchensink` file.

(Note: Claas confirmed that this should not negatively impact Yari's tests.)
