### PR TITLE
Note control key on macos wheel event

### DIFF
--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -64,6 +64,8 @@ _This interface inherits properties from its ancestors, {{DOMxRef("MouseEvent")}
 - {{DOMxRef("WheelEvent.wheelDeltaY")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : Returns an integer representing the vertical scroll amount.
 
+> **Note:** On MacOS the {{DOMxRef("MouseEvent.ctrlKey")}} property is set to `true` if the user uses the trackpad to zoom instead of scrolling.
+
 ## Examples
 
 ### Scaling an element via the wheel


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

When listening on the `"wheel"` event on MacOS when using the trackpad `event.ctrlKey` is set to `true` when zooming. I have tested this on MacBook Air M1 on Firefox, Safari and Chrome.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I have spent half a day trying to figure out how to differentiate zoom and scroll events when using the `"wheel"` event. I'd love for others to not have to do that.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
