### PR TITLE
Fix type in example in padString() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -65,7 +65,7 @@ A {{jsxref("String")}} of the specified `targetLength` with
 // JavaScript version of: (unsigned)
 // printf "%0*d" width num
 function leftFillNum(num, targetLength) {
-  return num.toString().padStart(targetLength, 0);
+  return num.toString().padStart(targetLength, "0");
 }
 
 const num = 123;


### PR DESCRIPTION
### Description

Fixes the example in the `String.prototype.padStart()` documentation.

### Motivation

I noticed this and it may help others readers understand `String.prototype.padStart()`