### PR TITLE
Prettier: set "htmlWhitespaceSensitivity" to "ignore"

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
+  "htmlWhitespaceSensitivity": "ignore",
   "bracketSameLine": true
 }

--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -85,6 +85,7 @@ For example:
 Ensure sections follow the order defined in the CSS property template
 
 ### Description
+
 The CSS property page template is defined [here](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template).
 The task list in this issue will be used to compare the documented CSS properties with the template and track changes to the property pages for compliance.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -193,7 +193,10 @@ This will produce the following HTML:
 
 ```html
 <div class="notecard note">
-  <p><strong>Note:</strong> This is how you write a note.</p>
+  <p>
+    <strong>Note:</strong>
+    This is how you write a note.
+  </p>
   <p>It can have multiple lines.</p>
 </div>
 ```
@@ -216,7 +219,10 @@ This will produce the following HTML:
 
 ```html
 <div class="notecard warning">
-  <p><strong>Warning:</strong> This is how you write a warning.</p>
+  <p>
+    <strong>Warning:</strong>
+    This is how you write a warning.
+  </p>
   <p>It can have multiple paragraphs.</p>
 </div>
 ```
@@ -264,7 +270,10 @@ And this will produce:
 
 ```html
 <div class="notecard warning">
-  <p><strong>Warnung:</strong> So schreibt man eine Warnung.</p>
+  <p>
+    <strong>Warnung:</strong>
+    So schreibt man eine Warnung.
+  </p>
 </div>
 ```
 
@@ -288,7 +297,10 @@ This will produce the following HTML:
 
 ```html
 <div class="notecard note">
-  <p><strong>Note:</strong> This is how you write a note.</p>
+  <p>
+    <strong>Note:</strong>
+    This is how you write a note.
+  </p>
   <p>It can contain code blocks.</p>
   <pre class="brush: js">const s = "I'm in a code block";</pre>
   <p>Like that.</p>

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -32,24 +32,24 @@ For example, your quicklinks HTML might look like this:
         <summary>Style guides</summary>
         <ol>
           <li>
-            <a href="http://www.economist.com/research/StyleGuide/"
-              >The Economist style guide</a
-            >
+            <a href="http://www.economist.com/research/StyleGuide/">
+              The Economist style guide
+            </a>
           </li>
           <li>
-            <a href="https://www.amazon.com/gp/product/0226104036/"
-              >The Chicago manual of style</a
-            >
+            <a href="https://www.amazon.com/gp/product/0226104036/">
+              The Chicago manual of style
+            </a>
           </li>
           <li>
-            <a href="http://www.answers.com/library/Dictionary"
-              >Answers.com dictionary</a
-            >
+            <a href="http://www.answers.com/library/Dictionary">
+              Answers.com dictionary
+            </a>
           </li>
           <li>
-            <a href="http://www.wsu.edu/~brians/errors/"
-              >Common Errors in English</a
-            >
+            <a href="http://www.wsu.edu/~brians/errors/">
+              Common Errors in English
+            </a>
           </li>
         </ol>
       </details>

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -93,7 +93,10 @@ This represents an HTML resource whose contents are:
 
 ```html
 lots of text…
-<p><a name="bottom">bottom</a>?arg=val</p>
+<p>
+  <a name="bottom">bottom</a>
+  ?arg=val
+</p>
 ```
 
 - Syntax

--- a/files/en-us/web/http/basics_of_http/mime_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.md
@@ -259,10 +259,17 @@ The following `<form>`:
   action="http://localhost:8000/"
   method="post"
   enctype="multipart/form-data">
-  <label>Name: <input name="myTextField" value="Test" /></label>
-  <label><input type="checkbox" name="myCheckBox" /> Check</label>
   <label>
-    Upload file: <input type="file" name="myFile" value="test.txt" />
+    Name:
+    <input name="myTextField" value="Test" />
+  </label>
+  <label>
+    <input type="checkbox" name="myCheckBox" />
+    Check
+  </label>
+  <label>
+    Upload file:
+    <input type="file" name="myFile" value="test.txt" />
   </label>
   <button>Send the file</button>
 </form>

--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -108,15 +108,15 @@ money to another user of a site.
 ```html
 <form action="/send-payment" method="post">
   <p>
-    <label
-      >Who do you want to send the money to?
+    <label>
+      Who do you want to send the money to?
       <input type="text" name="recipient" />
     </label>
   </p>
 
   <p>
-    <label
-      >How much?
+    <label>
+      How much?
       <input type="number" name="amount" />
     </label>
   </p>

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -90,8 +90,8 @@ The following connections are blocked and won't load:
     navigator.sendBeacon("https://not-example.com/", {
       /* … */
     });
-  </script></a
->
+  </script>
+</a>
 ```
 
 ## Specifications

--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -250,8 +250,8 @@ It is worth giving the `src` value a special mention. We mentioned above that us
 
 ```html
 <iframe src="https://example.com" allow="geolocation 'src'">
-  <iframe src="https://example.com" allow="geolocation"></iframe
-></iframe>
+  <iframe src="https://example.com" allow="geolocation"></iframe>
+</iframe>
 ```
 
 ### Denying access to powerful features

--- a/files/en-us/web/http/permissions_policy/index.md
+++ b/files/en-us/web/http/permissions_policy/index.md
@@ -187,8 +187,8 @@ It is worth giving the `src` value a special mention. We mentioned above that us
 
 ```html
 <iframe src="https://example.com" allow="geolocation 'src'">
-  <iframe src="https://example.com" allow="geolocation"></iframe
-></iframe>
+  <iframe src="https://example.com" allow="geolocation"></iframe>
+</iframe>
 ```
 
 > **Note:** As you'll have noticed, the syntax for `<iframe>` policies is a bit different to the syntax for `Permissions-Policy` headers. The former still uses the same syntax as the older Feature Policy specification, which was superseded by Permissions Policy.

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -143,8 +143,8 @@ True if and only if there is no domain name in the hostname (no dots).
 #### Examples
 
 ```js
-isPlainHostName("www.mozilla.org") // false
-isPlainHostName("www") // true
+isPlainHostName("www.mozilla.org"); // false
+isPlainHostName("www"); // true
 ```
 
 ### `dnsDomainIs()`


### PR DESCRIPTION
This PR updates the Prettier config and sets the `htmlWhitespaceSensitivity` option to `ignore`, then runs `npx prettier -w .` to format all applicable files with the new rule.  This fixes odd styling issues such as https://github.com/mdn/content/pull/24051/files#r1093421150, and helps somewhat with legibility of HTML examples.  Note: this will require all open Prettier formatting PRs to be updated.
