### PR TITLE
Made the example useful

### DIFF
--- a/files/en-us/web/svg/attribute/xml_colon_space/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.md
@@ -30,13 +30,13 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 140 50" xmlns="http://www.w3.org/2000/svg">
-  <text y="20" xml:space="default">Default spacing</text>
-  <text y="40" xml:space="preserve">Preserved spacing</text>
+<svg viewBox="0 0 160 50" xmlns="http://www.w3.org/2000/svg">
+  <text y="20" xml:space="default">    Default    spacing</text>
+  <text y="40" xml:space="preserve">    Preserved    spacing</text>
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "120", "50")}}
+{{EmbedLiveSample("Example", "160", "50")}}
 
 ## Usage notes
 


### PR DESCRIPTION
While the existing example is not wrong, it does not in any way illustrate the effect of using the xml:space attribute. The changes added some additional spaces to show that the extra spaces are processed differently depending on the value given to the attribute.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
