### PR TITLE
fix typo on tutorial: Express Tutorial 5: Displaying library data > Author Detail page

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/author_detail_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/author_detail_page/index.md
@@ -77,7 +77,7 @@ block content
     h4 Books
 
     dl
-      each book in author_books
+      each book in authors_books
         dt
           a(href=book.url) #{book.title}
         dd #{book.summary}


### PR DESCRIPTION
the field defined in authorController is "authors_books" while the one used in author_detail.pug is "author_book". This leads to a 500 error because of the typo in the tutorial code. Please accept this fix on line 80.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
fix typo in field name in tutorial example code

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
I was studying the tutorial on MDN url: https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Author_detail_page
and I noticed this typo in the pug template code example so I am submitting a fix in the field name.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
