### PR TITLE
currentColor: add definition and links

### DIFF
--- a/files/en-us/web/css/border-bottom-color/index.md
+++ b/files/en-us/web/css/border-bottom-color/index.md
@@ -97,3 +97,4 @@ The `border-bottom-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{Cssxref("border")}}, {{Cssxref("border-bottom")}}, and {{Cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{Cssxref("border-right-color")}}, {{Cssxref("border-top-color")}}, and {{Cssxref("border-left-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-bottom-style")}} and {{cssxref("border-bottom-width")}}.
+- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-bottom-color/index.md
+++ b/files/en-us/web/css/border-bottom-color/index.md
@@ -97,4 +97,4 @@ The `border-bottom-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{Cssxref("border")}}, {{Cssxref("border-bottom")}}, and {{Cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{Cssxref("border-right-color")}}, {{Cssxref("border-top-color")}}, and {{Cssxref("border-left-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-bottom-style")}} and {{cssxref("border-bottom-width")}}.
-- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.
+- The default [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-left-color/index.md
+++ b/files/en-us/web/css/border-left-color/index.md
@@ -97,4 +97,4 @@ The `border-left-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{Cssxref("border")}}, {{Cssxref("border-left")}}, and {{Cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{Cssxref("border-right-color")}}, {{Cssxref("border-bottom-color")}}, and {{Cssxref("border-top-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-left-style")}} and {{cssxref("border-left-width")}}.
-- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.
+- The default [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-left-color/index.md
+++ b/files/en-us/web/css/border-left-color/index.md
@@ -97,3 +97,4 @@ The `border-left-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{Cssxref("border")}}, {{Cssxref("border-left")}}, and {{Cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{Cssxref("border-right-color")}}, {{Cssxref("border-bottom-color")}}, and {{Cssxref("border-top-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-left-style")}} and {{cssxref("border-left-width")}}.
+- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-right-color/index.md
+++ b/files/en-us/web/css/border-right-color/index.md
@@ -97,3 +97,4 @@ The `border-right-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{cssxref("border")}}, {{cssxref("border-right")}}, and {{cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{cssxref("border-left-color")}}, {{cssxref("border-bottom-color")}}, and {{cssxref("border-top-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-right-style")}} and {{cssxref("border-right-width")}}.
+- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-right-color/index.md
+++ b/files/en-us/web/css/border-right-color/index.md
@@ -97,4 +97,4 @@ The `border-right-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{cssxref("border")}}, {{cssxref("border-right")}}, and {{cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{cssxref("border-left-color")}}, {{cssxref("border-bottom-color")}}, and {{cssxref("border-top-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-right-style")}} and {{cssxref("border-right-width")}}.
-- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.
+- The default [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-top-color/index.md
+++ b/files/en-us/web/css/border-top-color/index.md
@@ -97,4 +97,4 @@ The `border-top-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{cssxref("border")}}, {{cssxref("border-top")}}, and {{cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{cssxref("border-right-color")}}, {{cssxref("border-bottom-color")}}, and {{cssxref("border-left-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-top-style")}} and {{cssxref("border-top-width")}}.
-- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.
+- The default [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/border-top-color/index.md
+++ b/files/en-us/web/css/border-top-color/index.md
@@ -97,3 +97,4 @@ The `border-top-color` property is specified as a single value.
 - The border-related CSS shorthand properties: {{cssxref("border")}}, {{cssxref("border-top")}}, and {{cssxref("border-color")}}.
 - The color-related CSS properties for the other borders: {{cssxref("border-right-color")}}, {{cssxref("border-bottom-color")}}, and {{cssxref("border-left-color")}}.
 - The other border-related CSS properties applying to the same border: {{cssxref("border-top-style")}} and {{cssxref("border-top-width")}}.
+- The default [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) color value.

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -84,6 +84,8 @@ Note that the value must be a uniform {{cssxref("color")}}. It can't be a {{cssx
 
 - {{cssxref("&lt;color&gt;")}}
   - : Sets the color of the textual and decorative parts of the element.
+- [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
+  - : Normally sets the color to the element's `color` property value, but when set as the value of `color` it is treated as `inherit`.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -85,7 +85,7 @@ Note that the value must be a uniform {{cssxref("color")}}. It can't be a {{cssx
 - {{cssxref("&lt;color&gt;")}}
   - : Sets the color of the textual and decorative parts of the element.
 - [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
-  - : Sets the color to the element's `color` property value. However, if set as the value of `color`, `currentColor` is treated as `inherit`.
+  - : Sets the color to the element's `color` property value. However, if set as the value of `color`, `currentcolor` is treated as `inherit`.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -84,7 +84,7 @@ Note that the value must be a uniform {{cssxref("color")}}. It can't be a {{cssx
 
 - {{cssxref("&lt;color&gt;")}}
   - : Sets the color of the textual and decorative parts of the element.
-- [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
+- [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
   - : Normally sets the color to the element's `color` property value, but when set as the value of `color` it is treated as `inherit`.
 
 ## Accessibility concerns

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -85,7 +85,7 @@ Note that the value must be a uniform {{cssxref("color")}}. It can't be a {{cssx
 - {{cssxref("&lt;color&gt;")}}
   - : Sets the color of the textual and decorative parts of the element.
 - [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
-  - : Normally sets the color to the element's `color` property value, but when set as the value of `color` it is treated as `inherit`.
+  - : Sets the color to the element's `color` property value. However, if set as the value of `color`, `currentColor` is treated as `inherit`.
 
 ## Accessibility concerns
 


### PR DESCRIPTION
currentColor is used, but the definition is nearly impossible to find, and many people don't know what it is. So, surfacing it. Also, it has special meaning in `color`, so defining it there.

Also, note I used `currentColor` and not `currentcolor` intentionally. Setting camel case enables screen readers to read it in a more helpful way. The spec has it lowercase, as do the rest of the docs, so am asking screen reader users what they prefer.

Is this similar to the rule to always remember to #camelCaseHashTagsWhereNormallyThereAreWordBreaks? Not sure.

DRAFT mode while waiting for feedback from the a11y folks I asked. But if there was already a discussion about this, please let me know.