### PR TITLE
Add Mac keyboard modifier key for range count selection

### DIFF
--- a/files/en-us/web/api/selection/rangecount/index.md
+++ b/files/en-us/web/api/selection/rangecount/index.md
@@ -68,7 +68,7 @@ setInterval(() => {
 ### Result
 
 Open your console to see how many ranges are in the selection. In Gecko browsers, you
-can select multiple ranges across table cells by holding down <kbd>Ctrl</kbd> while
+can select multiple ranges across table cells by holding down <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> while
 dragging with the mouse.
 
 {{EmbedLiveSample("Examples")}}

--- a/files/en-us/web/api/selection/rangecount/index.md
+++ b/files/en-us/web/api/selection/rangecount/index.md
@@ -68,7 +68,7 @@ setInterval(() => {
 ### Result
 
 Open your console to see how many ranges are in the selection. In Gecko browsers, you
-can select multiple ranges across table cells by holding down <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> while
+can select multiple ranges across table cells by holding down <kbd>Ctrl</kbd> (or <kbd>Cmd</kbd> on MacOS) while
 dragging with the mouse.
 
 {{EmbedLiveSample("Examples")}}


### PR DESCRIPTION
### Description

This PR adds the Mac keyboard modifier key (`Cmd`) to the Result demo of [the selection rangeCount](https://developer.mozilla.org/en-US/docs/Web/API/Selection/rangeCount).

### Motivation

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Selection/rangeCount

### Related issues and pull requests
