### PR TITLE
Rewrite docs for `AnimationEffect.getComputedTiming()`

### DIFF
--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -17,13 +17,6 @@ browser-compat: api.AnimationEffect.getComputedTiming
 
 The `getComputedTiming()` method of the {{domxref("AnimationEffect")}} interface returns the calculated timing properties for this animation effect.
 
-Although many of the attributes of the returned object are common to the object returned by the {{domxref("AnimationEffect.getTiming()")}} method, the values returned by this object differ in the following ways:
-
-- `duration`
-  - : Returns the calculated value of the iteration duration. If [`duration`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) is the string `auto`, this attribute will return `0`.
-- `fill`
-  - : The `auto` value is replaced with the appropriate [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) value.
-
 > **Note:** These values are comparable to the computed styles of an Element returned using `window.getComputedStyle(elem)`.
 
 ## Syntax
@@ -38,18 +31,20 @@ None.
 
 ### Return value
 
-An object which contains the following properties:
+An object which contains:
 
-- endTime
-  - : The end time of the animation in milliseconds from the animation's start (if the {{domxref("KeyframeEffect")}} is associated with an {{domxref("Animation")}}). (Also includes `endDelay` in that calculation.)
-- activeDuration
-  - : The length of time in milliseconds that the animation's effects will run. This is equal to the [iteration duration](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) multiplied by the [iteration count](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect).
-- localTime
-  - : The [current time](/en-US/docs/Web/API/AnimationTimeline/currentTime) of the animation in milliseconds. If the `KeyframeEffect` is not associated with an `Animation`, its value is `null`.
-- progress
-  - : Indicates how far along the animation is through its current iteration with values between `0` and `1`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
-- currentIteration
-  - : The number of times this animation has looped, starting from `0`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
+- all of the properties of the object returned by {{domxref("AnimationEffect.getTiming()")}}, except that `"auto"` values are replaced with their computed value.
+- the following additional properties:
+  - `endTime`
+    - : The end time of the animation in milliseconds from the animation's start (if the {{domxref("KeyframeEffect")}} is associated with an {{domxref("Animation")}}). (Also includes `endDelay` in that calculation.)
+  - `activeDuration`
+    - : The length of time in milliseconds that the animation's effects will run. This is equal to the [iteration duration](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) multiplied by the [iteration count](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect).
+  - `localTime`
+    - : The [current time](/en-US/docs/Web/API/AnimationTimeline/currentTime) of the animation in milliseconds. If the `KeyframeEffect` is not associated with an `Animation`, its value is `null`.
+  - `progress`
+    - : Indicates how far along the animation is through its current iteration with values between `0` and `1`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
+  - `currentIteration`
+    - : The number of times this animation has looped, starting from `0`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -38,7 +38,7 @@ An object which contains:
   - `endTime`
     - : The end time of the animation in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.
   - `activeDuration`
-    - : The length of time in milliseconds that the effect will run. This is equal to `duration` multiplied by `iterations`.
+    - : The total length of all iterations of the effect. This is equal to `duration` multiplied by `iterations` (or zero if that product would be {{jsxref("NaN")}}).
   - `localTime`
     - : The length of time in milliseconds that the effect has run. This is equal to the {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
   - `progress`

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -38,7 +38,7 @@ An object which contains:
   - `endTime`
     - : The end time of the animation in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.
   - `activeDuration`
-    - : The length of time in milliseconds that the animation's effects will run. This is equal to the [iteration duration](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) multiplied by the [iteration count](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect).
+    - : The length of time in milliseconds that the effect will run. This is equal to `duration` multiplied by `iterations`.
   - `localTime`
     - : The [current time](/en-US/docs/Web/API/AnimationTimeline/currentTime) of the animation in milliseconds. If the `KeyframeEffect` is not associated with an `Animation`, its value is `null`.
   - `progress`

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -40,7 +40,7 @@ An object which contains:
   - `activeDuration`
     - : The length of time in milliseconds that the effect will run. This is equal to `duration` multiplied by `iterations`.
   - `localTime`
-    - : The {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
+    - : The length of time in milliseconds that the effect has run. This is equal to the {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
   - `progress`
     - : Indicates how far along the animation is through its current iteration with values between `0` and `1`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
   - `currentIteration`

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -33,7 +33,7 @@ None.
 
 An object which contains:
 
-- all of the properties of the object returned by {{domxref("AnimationEffect.getTiming()")}}, except that `"auto"` values are replaced with their computed value.
+- all of the properties of the object returned by {{domxref("AnimationEffect.getTiming()")}}, except that any `"auto"` values are replaced by computed values that may depend on the type of {{domxref("AnimationEffect")}}.
 - the following additional properties:
   - `endTime`
     - : A `number` indicating the end time of the effect in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -40,7 +40,7 @@ An object which contains:
   - `activeDuration`
     - : The length of time in milliseconds that the effect will run. This is equal to `duration` multiplied by `iterations`.
   - `localTime`
-    - : The [current time](/en-US/docs/Web/API/AnimationTimeline/currentTime) of the animation in milliseconds. If the `KeyframeEffect` is not associated with an `Animation`, its value is `null`.
+    - : The {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
   - `progress`
     - : Indicates how far along the animation is through its current iteration with values between `0` and `1`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
   - `currentIteration`

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -36,7 +36,7 @@ An object which contains:
 - all of the properties of the object returned by {{domxref("AnimationEffect.getTiming()")}}, except that `"auto"` values are replaced with their computed value.
 - the following additional properties:
   - `endTime`
-    - : The end time of the animation in milliseconds from the animation's start (if the {{domxref("KeyframeEffect")}} is associated with an {{domxref("Animation")}}). (Also includes `endDelay` in that calculation.)
+    - : The end time of the animation in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.
   - `activeDuration`
     - : The length of time in milliseconds that the animation's effects will run. This is equal to the [iteration duration](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect) multiplied by the [iteration count](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect).
   - `localTime`

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -36,11 +36,13 @@ An object which contains:
 - all of the properties of the object returned by {{domxref("AnimationEffect.getTiming()")}}, except that `"auto"` values are replaced with their computed value.
 - the following additional properties:
   - `endTime`
-    - : The end time of the animation in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.
+    - : A `number` indicating the end time of the effect in milliseconds from the effect's start. This is equal to `activeDuration` plus `delay` and `endDelay`.
   - `activeDuration`
-    - : The total length of all iterations of the effect. This is equal to `duration` multiplied by `iterations` (or zero if that product would be {{jsxref("NaN")}}).
+    - : A `number` indicating the total duration in milliseconds of all iterations of the effect. This is equal to `duration` multiplied by `iterations` (or zero if that product would be {{jsxref("NaN")}}).
   - `localTime`
-    - : The length of time in milliseconds that the effect has run. This is equal to the {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
+    - : A `number` or `null`.
+
+      Indicates the length of time in milliseconds that the effect has run. This is equal to the {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
   - `progress`
     - : `null` or a `number` at least `0` and less than `1`.
 

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -42,9 +42,17 @@ An object which contains:
   - `localTime`
     - : The length of time in milliseconds that the effect has run. This is equal to the {{domxref("Animation.currentTime","currentTime")}} of the associated animation, or `null` if the effect is not associated with an animation.
   - `progress`
-    - : Indicates how far along the animation is through its current iteration with values between `0` and `1`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
+    - : `null` or a `number` at least `0` and less than `1`.
+
+      Indicates the effect's progress through its current iteration. At the start of the `activeDuration`, this equals the fractional part of `iterationStart`.
+
+      Returns `null` if the effect isn't mid-iteration, for example because the effect is in the `delay` or `endDelay` periods, the effect is finished, or `localTime` is `null`.
   - `currentIteration`
-    - : The number of times this animation has looped, starting from `0`. Returns `null` if the animation is not running or its `KeyframeEffect` isn't associated with an `Animation`.
+    - : `null` or an integer `number`.
+
+      Indicates the index of the current iteration. At the start of the `activeDuration`, this equals the integer part of `iterationStart`.
+
+      Returns `null` whenever `progress` is `null`.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Fix formatting and organization, clarify several imprecise statements, explain more of the relationships between timing properties.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Existing docs make heavy reference to `KeyframeEffect`, which won't always be the only subtype of `AnimationEffect`, and isn't as near a parallel for `getComputedTiming()`'s use of timing properties as is `getTiming()`; use several terms without defining them; use vague terms like "not running"; don't cover a number of edge cases; miss several opportunities to document the dependencies/relationships between timing properties.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

More details on individual edits in the long commit notes.
