### PR TITLE
FF110Relnote: contentvisibilityautostatechanged event supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -51,6 +51,10 @@ This article provides information about the changes in Firefox 110 that will aff
 
 #### DOM
 
+- The {{domxref("element/contentvisibilityautostatechanged_event", "contentvisibilityautostatechanged")}} event and associated {{domxref("ContentVisibilityAutoStateChangedEvent")}} interface are now supported.
+  The event can be used by application code to stop processes related to rendering the element when the user agent is [skipping its contents](/en-US/docs/Web/CSS/CSS_Containment#skips_its_contents).
+  ({{bug(1798485)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
FF110 adds support for `ContentVisibilityAutoStateChangedEvent` object and the associated event `contentvisibilityautostatechanged_event` in https://bugzilla.mozilla.org/show_bug.cgi?id=1798485

This is the release note.

Other docs work can be tracked in #23687