### PR TITLE
Add toJSON() to PerformanceTiming and PerformanceNavigation

### DIFF
--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -51,7 +51,7 @@ _The `PerformanceNavigation` interface doesn't inherit any properties._
 _The `Performance` interface doesn't inherit any methods._
 
 - {{deprecated_inline}} {{domxref("PerformanceNavigation.toJSON()")}}
-  - : A jsonizer returning a JSON object representing the `PerformanceNavigation` object.
+  - : A {{Glossary("Serialization","serializer")}} returning a JSON object representing the `PerformanceNavigation` object.
 
 ## Specifications
 
@@ -65,4 +65,4 @@ Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 ## See also
 
 - The {{domxref("Performance")}} that allows access to an object of this type.
-- {{domxref("PerformanceNavigationTiming")}} (part of Navigation Timing Level 2) {{experimental_inline}}
+- {{domxref("PerformanceNavigationTiming")}} (part of Navigation Timing Level 2) that has superseded this API.

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -50,7 +50,7 @@ _The `PerformanceNavigation` interface doesn't inherit any properties._
 
 _The `Performance` interface doesn't inherit any methods._
 
-- {{deprecated_inline}} {{domxref("PerformanceNavigation.toJSON()")}}
+- {{domxref("PerformanceNavigation.toJSON()")}} {{deprecated_inline}}
   - : A {{Glossary("Serialization","serializer")}} returning a JSON object representing the `PerformanceNavigation` object.
 
 ## Specifications

--- a/files/en-us/web/api/performancenavigation/tojson/index.md
+++ b/files/en-us/web/api/performancenavigation/tojson/index.md
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Performance
+  - Deprecated
 browser-compat: api.PerformanceNavigation.toJSON
 ---
 

--- a/files/en-us/web/api/performancenavigation/tojson/index.md
+++ b/files/en-us/web/api/performancenavigation/tojson/index.md
@@ -1,0 +1,41 @@
+---
+title: PerformanceNavigation.toJSON()
+slug: Web/API/PerformanceNavigation/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+browser-compat: api.PerformanceNavigation.toJSON
+---
+
+{{APIRef("Performance API")}}
+
+The **`toJSON()`** method of the {{domxref("PerformanceENavigation")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigation")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceNavigation")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/performancenavigation/tojson/index.md
+++ b/files/en-us/web/api/performancenavigation/tojson/index.md
@@ -11,7 +11,10 @@ tags:
 browser-compat: api.PerformanceNavigation.toJSON
 ---
 
-{{APIRef("Performance API")}}
+{{APIRef("Performance API")}} {{deprecated_header}}
+
+ > **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+ > interface instead.
 
 The **`toJSON()`** method of the {{domxref("PerformanceNavigation")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigation")}} object.
 

--- a/files/en-us/web/api/performancenavigation/tojson/index.md
+++ b/files/en-us/web/api/performancenavigation/tojson/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceNavigation.toJSON
 
 {{APIRef("Performance API")}}
 
-The **`toJSON()`** method of the {{domxref("PerformanceENavigation")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigation")}} object.
+The **`toJSON()`** method of the {{domxref("PerformanceNavigation")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigation")}} object.
 
 ## Syntax
 

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -80,7 +80,7 @@ These properties are listed in the order in which they occur during the navigati
 
 _The `PerformanceTiming`_ _interface doesn't inherit any methods._
 
-- {{Deprecated_Inline}} {{domxref("PerformanceTiming.toJSON()")}}
+- {{domxref("PerformanceTiming.toJSON()")}} {{Deprecated_Inline}}
   - : Returns a [JSON object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) representing this `PerformanceTiming` object.
 
 ## Specifications
@@ -95,3 +95,4 @@ Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 ## See also
 
 - The {{domxref("Performance.timing")}} property that creates such an object.
+- {{domxref("PerformanceNavigationTiming")}} (part of Navigation Timing Level 2) that has superseded this API.

--- a/files/en-us/web/api/performancetiming/tojson/index.md
+++ b/files/en-us/web/api/performancetiming/tojson/index.md
@@ -1,0 +1,45 @@
+---
+title: PerformanceTiming.toJSON()
+slug: Web/API/PerformanceTiming/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+  - Deprecated
+browser-compat: api.PerformanceTiming.toJSON
+---
+
+{{APIRef("Performance API")}}{{deprecated_header}}
+
+> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> interface instead.
+
+The legacy **`toJSON()`** method of the {{domxref("PerformanceTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceTiming")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PerformanceTiming")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}


### PR DESCRIPTION
I used:  https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/toJSON as the template.

I didn't add an example as:
- these interfaces are deprecated
- all properties/methods documented for these interfaces don't have one.

Crafting new examples for these interfaces would have be a loss of time.

This is part of https://github.com/openwebdocs/project/issues/152