### PR TITLE
Remove reference to C's strcmp() in string docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -69,8 +69,7 @@ nor configurable. (See {{jsxref("Object.defineProperty()")}} for more informatio
 
 ### Comparing strings
 
-In C, the `strcmp()` function is used for comparing strings. In JavaScript,
-you just use the [less-than and greater-than operators](/en-US/docs/Web/JavaScript/Reference/Operators):
+Use the [less-than and greater-than operators](/en-US/docs/Web/JavaScript/Reference/Operators) to compare strings:
 
 ```js
 const a = "a";


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove reference to C's `strcmp()` in string docs comparison section

### Motivation

I don't think contrasting JavaScript's string comparison facility to C's is likely to be that useful to most MDN readers. Even if the reader is familiar with C (and they may be more familiar with other languages, so why C?) it doesn't seem to give them useful information compared to just saying what JavaScript does.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
