### PR TITLE
Add alt. text to a few images

### DIFF
--- a/files/en-us/web/css/clip/index.md
+++ b/files/en-us/web/css/clip/index.md
@@ -57,21 +57,13 @@ clip: unset;
 
 ```html
 <p class="dotted-border">
-  <img
-    src="macarons.png"
-    title="Original graphic" />
-  <img
-    id="top-left"
-    src="macarons.png"
-    title="Graphic clipped to upper left" />
-  <img
-    id="middle"
-    src="macarons.png"
-    title="Graphic clipped towards middle" />
+  <img src="macarons.png" alt="Original graphic" />
+  <img id="top-left" src="macarons.png" alt="Graphic clipped to upper left" />
+  <img id="middle" src="macarons.png" alt="Graphic clipped towards middle" />
   <img
     id="bottom-right"
     src="macarons.png"
-    title="Graphic clipped to bottom right" />
+    alt="Graphic clipped to bottom right" />
 </p>
 ```
 

--- a/files/en-us/web/css/vertical-align/index.md
+++ b/files/en-us/web/css/vertical-align/index.md
@@ -158,22 +158,22 @@ img.middle {
 
 #### HTML
 
-```html
+```html-nolint
 <p>
-top:         <img style="vertical-align: top" src="star.png"/>
-middle:      <img style="vertical-align: middle" src="star.png"/>
-bottom:      <img style="vertical-align: bottom" src="star.png"/>
-super:       <img style="vertical-align: super" src="star.png"/>
-sub:         <img style="vertical-align: sub" src="star.png"/>
+top:         <img style="vertical-align: top" src="star.png" alt="star"/>
+middle:      <img style="vertical-align: middle" src="star.png" alt="star"/>
+bottom:      <img style="vertical-align: bottom" src="star.png" alt="star"/>
+super:       <img style="vertical-align: super" src="star.png" alt="star"/>
+sub:         <img style="vertical-align: sub" src="star.png" alt="star"/>
 </p>
 
 <p>
-text-top:    <img style="vertical-align: text-top" src="star.png"/>
-text-bottom: <img style="vertical-align: text-bottom" src="star.png"/>
-0.2em:       <img style="vertical-align: 0.2em" src="star.png"/>
--1em:        <img style="vertical-align: -1em" src="star.png"/>
-20%:         <img style="vertical-align: 20%" src="star.png"/>
--100%:       <img style="vertical-align: -100%" src="star.png"/>
+text-top:    <img style="vertical-align: text-top" src="star.png" alt="star"/>
+text-bottom: <img style="vertical-align: text-bottom" src="star.png" alt="star"/>
+0.2em:       <img style="vertical-align: 0.2em" src="star.png" alt="star"/>
+-1em:        <img style="vertical-align: -1em" src="star.png" alt="star"/>
+20%:         <img style="vertical-align: 20%" src="star.png" alt="star"/>
+-100%:       <img style="vertical-align: -100%" src="star.png" alt="star"/>
 </p>
 ```
 


### PR DESCRIPTION
This PR adds alt. text to a few images within examples.  This is cherry-picked from suggestions and commits from @estelle during the review of #24055.

Note: `-nolint` was added to a codeblock to ensure that Prettier does not alter the layout of code.
