### PR TITLE
SVG Gradients

### DIFF
--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -12,7 +12,7 @@ tags:
 
 Perhaps more exciting than just fills and strokes is the fact that you can also create and apply gradients as either fills or strokes.
 
-There are two types of gradients: linear and radial. They are defined separately from where they are used, which promotes reusability. You **must** give each gradient an `id` attribute to allow other elements to reference it. Gradient definitions can be placed in a {{SVGElement('defs')}} element or an {{SVGElement('svg')}} element.
+There are two types of SVG gradients: linear and radial. They are defined separately from where they are used, which promotes reusability. You **must** give each gradient an `id` attribute to allow other elements to reference it. Gradient definitions can be placed in a {{SVGElement('defs')}} element or an {{SVGElement('svg')}} element.
 
 ## Linear Gradient
 

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -12,7 +12,7 @@ tags:
 
 Perhaps more exciting than just fills and strokes is the fact that you can also create and apply gradients as either fills or strokes.
 
-There are two types of gradients: linear and radial. You **must** give the gradient an `id` attribute; otherwise it can't be referenced by other elements inside the file. Gradients are defined in a {{SVGElement('defs')}} section as opposed to on a shape itself to promote reusability.
+There are two types of gradients: linear and radial. They are defined separately from where they are used, which promotes reusability. You **must** give each gradient an `id` attribute to allow other elements to reference it. Gradient definitions can be placed in a {{SVGElement('defs')}} element or an {{SVGElement('svg')}} element.
 
 ## Linear Gradient
 


### PR DESCRIPTION
Slight rewording, but most importantly it was clarified that gradient definitions can be placed in either defs elements or svg elements. See https://www.w3.org/TR/SVG/struct.html#DefsElement and https://www.w3.org/TR/SVG/struct.html#SVGElement

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
