### PR TITLE
Update explanation of a form HTML element hiding the ` submit()`method.

### DIFF
--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -26,9 +26,7 @@ This method is similar, but not identical to, activating a form's submit
 The {{domxref("HTMLFormElement.requestSubmit()")}} method is identical to activating a
 form's submit {{HtmlElement("button")}} and does not have these differences.
 
-If a form control (such as a submit button) has a `name` or `id`
-of `submit`, this will mask the form's submit method. Trying to call `document.forms["myform"].submit();`
-throws an error `.submit is not a function` because in this case `submit` refers to the form control which has a `name` or `id` of `submit`.
+A form control (such as a submit button) with a `name` or `id` of `submit` will mask the form's `submit` method. Trying to call `myForm.submit();` throws an error "submit is not a function" because in this case `submit` refers to the form control which has a `name` or `id` of `submit`.
 
 {{HtmlElement("input")}} with attribute type="submit" will not be submitted with the
 form when using **`HTMLFormElement.submit()`**, but it would be

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -27,9 +27,8 @@ The {{domxref("HTMLFormElement.requestSubmit()")}} method is identical to activa
 form's submit {{HtmlElement("button")}} and does not have these differences.
 
 If a form control (such as a submit button) has a `name` or `id`
-of `submit`, this will mask the form's submit method. Trying to call `document.forms["myform"].submit();` will
-throw an error `.submit is not a function` because in this case `submit` will refer to the form control which has a `name` or `id`
-of `submit`.
+of `submit`, this will mask the form's submit method. Trying to call `document.forms["myform"].submit();`
+throws an error `.submit is not a function` because in this case `submit` refers to the form control which has a `name` or `id` of `submit`.
 
 {{HtmlElement("input")}} with attribute type="submit" will not be submitted with the
 form when using **`HTMLFormElement.submit()`**, but it would be

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -27,7 +27,9 @@ The {{domxref("HTMLFormElement.requestSubmit()")}} method is identical to activa
 form's submit {{HtmlElement("button")}} and does not have these differences.
 
 If a form control (such as a submit button) has a `name` or `id`
-of `submit`, this method will mask the form's submit method.
+of `submit`, this will mask the form's submit method. Trying to call `document.forms["myform"].submit();` will
+throw an error `.submit is not a function` because in this case `submit` will refer to the form control which has a `name` or `id`
+of `submit`.
 
 {{HtmlElement("input")}} with attribute type="submit" will not be submitted with the
 form when using **`HTMLFormElement.submit()`**, but it would be


### PR DESCRIPTION
### Description

Improved the description of how the submit method may be masked by a badly named element.

### Motivation

The existing language "this method" is incorrect. Perhaps "this usage" or "this form control" would be correct.
Adding the error message that happens helps users to understand the meaning of this "masking".