### PR TITLE
Fix typo on 'ARIA: radio role' page

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -13,7 +13,7 @@ The `radio` role is one of a group of checkable radio buttons, in a `radiogroup`
 
 ## Description
 
-A radio button is a checkable input that when associated with other radio buttons, only one of which can be checked at a time. The radio buttons must be grouped together in a ['radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) to indicate which ones affect the same value.
+A radio button is a checkable input that when associated with other radio buttons, only one of which can be checked at a time. The radio buttons must be grouped together in a [`radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) to indicate which ones affect the same value.
 
 ```html
 <div role="radiogroup" aria-labelledby="legend25" id="radiogroup25">


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixes a typo on the 'ARIA: radio role' page, where an inverted comma was entered instead of a backtick.

<!-- ### Motivation -->

<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
