### PR TITLE
Fix typo on 'ARIA: radio role' page

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -106,7 +106,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 
 ## Associated WAI-ARIA Roles, States, and Properties
 
-- ['radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) role
+- [`radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) role
 
   - : The radio buttons are contained in or owned by an element with role `radiogroup`. If unable to be nested within a `radiogroup` within the markup, the `aria-owns` attribute of the `radiogroup` contains the `id` values of the non-nested radio buttons in the group.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixes a (second) typo on the 'ARIA: radio role' page, where an inverted comma was entered instead of a backtick (again). (I didn't scroll down that far when I first read the page a few weeks ago 😅)

<!-- ### Motivation -->

<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
Relates to #24156 
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
