### PR TITLE
Removal of “Other” section and tweaked dot in “Firefox 103 for developers” page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -82,7 +82,7 @@ No notable changes.
 
 ### Removals
 
-- Removed the ServiceWorker API in WebExtensions (`'serviceWorker' in navigator` now returns false when run inside an extension) ({{bug(1593931)}}).
+- Removed the ServiceWorker API in WebExtensions (`'serviceWorker' in navigator` now returns `false` when run inside an extension) ({{bug(1593931)}}).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -82,9 +82,7 @@ No notable changes.
 
 ### Removals
 
-- Removed the ServiceWorker API in WebExtensions (`'serviceWorker' in navigator` now returns false when run inside an extension). ({{bug(1593931)}})
-
-### Other
+- Removed the ServiceWorker API in WebExtensions (`'serviceWorker' in navigator` now returns false when run inside an extension) ({{bug(1593931)}}).
 
 ## Older versions
 


### PR DESCRIPTION
### Description
I made this PR, because I forgot to remove the “Other” (Not “Others”, I made a typo in commit, sorry) section from “Changes for add-on developers” and I tweaked one dot.

### Motivation
I'm doing this for making MDN better.

### Additional details
— https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/103

### Related issues and pull requests
— https://github.com/mdn/content/pull/24023