### PR TITLE
Note deprecation of `<param>` element

### DIFF
--- a/files/en-us/glossary/void_element/index.md
+++ b/files/en-us/glossary/void_element/index.md
@@ -26,10 +26,10 @@ The void elements in HTML are as follows:
 - {{HTMLElement("hr")}}
 - {{HTMLElement("img")}}
 - {{HTMLElement("input")}}
-- {{HTMLElement("keygen")}}(HTML 5.2 Draft removed)
+- {{HTMLElement("keygen")}} (HTML 5.2 Draft removed)
 - {{HTMLElement("link")}}
 - {{HTMLElement("meta")}}
-- {{HTMLElement("param")}}
+- {{HTMLElement("param")}} (Deprecated element)
 - {{HTMLElement("source")}}
 - {{HTMLElement("track")}}
 - {{HTMLElement("wbr")}}

--- a/files/en-us/glossary/void_element/index.md
+++ b/files/en-us/glossary/void_element/index.md
@@ -29,7 +29,7 @@ The void elements in HTML are as follows:
 - {{HTMLElement("keygen")}} (HTML 5.2 Draft removed)
 - {{HTMLElement("link")}}
 - {{HTMLElement("meta")}}
-- {{HTMLElement("param")}} (Deprecated element)
+- {{HTMLElement("param")}} {{deprecated_inline}}
 - {{HTMLElement("source")}}
 - {{HTMLElement("track")}}
 - {{HTMLElement("wbr")}}

--- a/files/en-us/glossary/void_element/index.md
+++ b/files/en-us/glossary/void_element/index.md
@@ -26,7 +26,7 @@ The void elements in HTML are as follows:
 - {{HTMLElement("hr")}}
 - {{HTMLElement("img")}}
 - {{HTMLElement("input")}}
-- {{HTMLElement("keygen")}} (HTML 5.2 Draft removed)
+- {{HTMLElement("keygen")}} {{deprecated_inline}}
 - {{HTMLElement("link")}}
 - {{HTMLElement("meta")}}
 - {{HTMLElement("param")}} {{deprecated_inline}}


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Leave a note about deprecation of `<param>` element on [Void element page](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)

### Motivation

Highlight the deprecation to make navigation easier.

### Additional details

Deprecation of `<param>` is stated [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param) for instance.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
