### PR TITLE
Correct 'files' description for executeScript

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -44,7 +44,7 @@ let results = await browser.scripting.executeScript(
     - `args`
       - : An array of arguments to carry into the function. This is only valid if the `func` parameter is specified. The arguments must be JSON-serializable.
     - `files`
-      - : `array` of `string`. An array of path of the JS files to inject, relative to the extension's root directory. Exactly one of `files` and `func` must be specified.
+      - : `array` of `string`. An array of paths to JS files to inject, relative to the script that executes the function call. Exactly one of `files` and `func` must be specified.
     - `func`
       - : `function`. A JavaScript function to inject. This function is serialized and then deserialized for injection. This means that any bound parameters and execution context are lost. Exactly one of `files` and `func` must be specified.
     - `injectImmediately` {{optional_inline}}


### PR DESCRIPTION
While migrating an extension from MV2 to MV3, I followed the guide and ran into an error. Updating the path to the same value that worked in MV2 (relative to the calling script) fixed the issue.

### Description

Updated the description of the `files` attribute for the executeScript parameter.

### Motivation

I encountered an error following the docs and found out where they went wrong.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
