### PR TITLE
Fix typo in the documentation for Document.getSelection()

### DIFF
--- a/files/en-us/web/api/document/getselection/index.md
+++ b/files/en-us/web/api/document/getselection/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Document.getSelection
 
 {{APIRef("DOM")}}
 
-The **`getSelection()`** property of
+The **`getSelection()`** method of
 the {{DOMxRef("Document")}} interface returns a {{DOMxRef("Selection")}}
 object representing the range of text selected by the user, or the current position of
 the caret.


### PR DESCRIPTION
### Description

Change from `property` to `method`.

### Motivation

n/a
### Additional details

n/a

### Related issues and pull requests

n/a