### PR TITLE
Add info about indexOf(NaN) behavior

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -47,6 +47,8 @@ The `indexOf()` method compares `searchElement` to elements of the array using [
 
 The `indexOf()` method skips empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
 
+The `indexOf()` method skips [NaN values](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
+
 The `indexOf()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties.
 
 ## Examples
@@ -101,10 +103,12 @@ updateVegetablesCollection(veggies, "spinach");
 
 ### Using indexOf() on sparse arrays
 
-You cannot use `indexOf()` to search for empty slots in sparse arrays.
+You cannot use `indexOf()` to search for empty slots in sparse arrays and nor for NaN values.
 
 ```js
-console.log([1, , 3].indexOf(undefined)); // -1
+const arr = [1, , 3, NaN];
+console.log(arr.indexOf(undefined)); // -1
+console.log(arr.indexOf(NaN)); // -1
 ```
 
 ### Calling indexOf() on non-array objects

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -43,11 +43,9 @@ The first index of the element in the array; **-1** if not found.
 
 ## Description
 
-The `indexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator).
+The `indexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator). [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) values are never compared as equal, so `indexOf()` always returns `-1` when `searchElement` is `NaN`.
 
 The `indexOf()` method skips empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
-
-The `indexOf()` method skips [NaN values](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
 
 The `indexOf()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties.
 
@@ -64,6 +62,13 @@ array.indexOf(7); // -1
 array.indexOf(9, 2); // 2
 array.indexOf(2, -1); // -1
 array.indexOf(2, -3); // 0
+```
+
+You cannot use `indexOf()` to search for `NaN`.
+
+```js
+const array = [NaN];
+array.indexOf(NaN); // -1
 ```
 
 ### Finding all the occurrences of an element
@@ -103,12 +108,10 @@ updateVegetablesCollection(veggies, "spinach");
 
 ### Using indexOf() on sparse arrays
 
-You cannot use `indexOf()` to search for empty slots in sparse arrays and nor for NaN values.
+You cannot use `indexOf()` to search for empty slots in sparse arrays.
 
 ```js
-const arr = [1, , 3, NaN];
-console.log(arr.indexOf(undefined)); // -1
-console.log(arr.indexOf(NaN)); // -1
+console.log([1, , 3].indexOf(undefined)); // -1
 ```
 
 ### Calling indexOf() on non-array objects

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -43,7 +43,7 @@ The last index of the element in the array; **-1** if not found.
 
 ## Description
 
-The `lastIndexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator).
+The `lastIndexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator). [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) values are never compared as equal, so `lastIndexOf()` always returns `-1` when `searchElement` is `NaN`.
 
 The `lastIndexOf()` method skips empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
 
@@ -53,7 +53,7 @@ The `lastIndexOf()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Glo
 
 ### Using lastIndexOf()
 
-The following example uses `lastIndexOf` to locate values in an array.
+The following example uses `lastIndexOf()` to locate values in an array.
 
 ```js
 const numbers = [2, 5, 9, 2];
@@ -63,6 +63,13 @@ numbers.lastIndexOf(2, 3); // 3
 numbers.lastIndexOf(2, 2); // 0
 numbers.lastIndexOf(2, -2); // 0
 numbers.lastIndexOf(2, -1); // 3
+```
+
+You cannot use `lastIndexOf()` to search for `NaN`.
+
+```js
+const array = [NaN];
+array.lastIndexOf(NaN); // -1
 ```
 
 ### Finding all the occurrences of an element


### PR DESCRIPTION
I have added information about behavior of indexOf() with NaN passed as argument.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added a paragraph to Description. I also updated an example with sparse arrays, because the behavior of indexOf() with undefined and NaN have the same reason.

### Motivation

I have noticed that there are no mention about such nuance. Though it was indicated that indexOf() uses the strict equality algorithm, I have found the indication insufficient. I believe my amendment will make beginners pay attention to such aspect.

### Additional details

There are no additional detailes.

### Related issues and pull requests

There are no related issues nor pull requests.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
