### PR TITLE
Remove links to RFC2616 (old HTTP spec)

### DIFF
--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -100,7 +100,7 @@ The full list of the `readyState` values is documented at [XMLHTTPRequest.readyS
 - 3 (interactive) or (**processing request**)
 - 4 (complete) or (**request finished and response is ready**)
 
-Next, check the [HTTP response status codes](/en-US/docs/Web/HTTP/Status) of the HTTP response. The possible codes are listed at the [W3C](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html). In the following example, we differentiate between a successful and unsuccessful AJAX call by checking for a [`200 OK`](/en-US/docs/Web/HTTP/Status#successful_responses) response code.
+Next, check the [HTTP response status codes](/en-US/docs/Web/HTTP/Status) of the HTTP response. In the following example, we differentiate between a successful and unsuccessful AJAX call by checking for a [`200 OK`](/en-US/docs/Web/HTTP/Status#successful_responses) response code.
 
 ```js
 if (httpRequest.status === 200) {

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -78,8 +78,8 @@ The following attributes control behavior during form submission.
   - : The [HTTP](/en-US/docs/Web/HTTP) method to submit the form with.
     The only allowed methods/values are (case insensitive):
 
-    - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
-    - `get` (default): The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side effects](/en-US/docs/Glossary/Idempotent).
+    - `post`: The {{HTTPMethod("POST")}} method; form data sent as the [request body](/en-US/docs/Web/API/Request/body).
+    - `get` (default): The {{HTTPMethod("GET")}}; form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side effects](/en-US/docs/Glossary/Idempotent).
     - `dialog`: When the form is inside a {{HTMLElement("dialog")}}, closes the dialog and throws a submit event on submission without submitting data or clearing the form.
 
     This value is overridden by {{htmlattrxref("formmethod", "button")}} attributes on {{HTMLElement("button")}}, [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit), or [`<input type="image">`](/en-US/docs/Web/HTML/Element/input/image) elements.

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -101,7 +101,7 @@ X-Forwarded-For: 203.0.113.195,2001:db8:85a3:8d3:1319:8a2e:370:7348,150.172.238.
 Improper parsing of the `X-Forwarded-For` header can result in spoofed values being used
 for security-related purposes, resulting in the negative consequences mentioned above.
 
-There may be multiple `X-Forwarded-For` headers present in a request (per [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)). The IP addresses in
+There may be multiple `X-Forwarded-For` headers present in a request. The IP addresses in
 these headers must be treated as a single list, starting with the first IP address of the
 first header and continuing to the last IP address of the last header. There are two ways
 of making this single list:

--- a/files/en-us/web/http/status/400/index.md
+++ b/files/en-us/web/http/status/400/index.md
@@ -28,4 +28,4 @@ The HyperText Transfer Protocol (HTTP) **`400 Bad Request`** response status cod
 
 ## See also
 
-- [HTTP/1.1: Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.400)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.400)

--- a/files/en-us/web/http/status/403/index.md
+++ b/files/en-us/web/http/status/403/index.md
@@ -39,4 +39,4 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 ## See also
 
 - {{HTTPStatus("401")}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.403)

--- a/files/en-us/web/http/status/405/index.md
+++ b/files/en-us/web/http/status/405/index.md
@@ -29,6 +29,6 @@ The server **must** generate an **`Allow`** header field in a 405 status code re
 ## See also
 
 - {{HTTPHeader("Allow")}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.405)
 - [How to Fix 405 Method Not Allowed](https://kinsta.com/blog/405-method-not-allowed-error/)
 - [Troubleshooting HTTP 405](https://docs.microsoft.com/aspnet/web-api/overview/testing-and-debugging/troubleshooting-http-405-errors-after-publishing-web-api-applications)

--- a/files/en-us/web/http/status/429/index.md
+++ b/files/en-us/web/http/status/429/index.md
@@ -37,5 +37,5 @@ Retry-After: 3600
 ## See also
 
 - {{HTTPHeader("Retry-After")}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.429)
 - Python solution: [How to avoid HTTP error 429 python](https://stackoverflow.com/questions/22786068/how-to-avoid-http-error-429-too-many-requests-python)

--- a/files/en-us/web/http/status/500/index.md
+++ b/files/en-us/web/http/status/500/index.md
@@ -30,4 +30,4 @@ This error response is a generic "catch-all" response. Usually, this indicates t
 
 ## See also
 
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.500)

--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -31,4 +31,4 @@ The HyperText Transfer Protocol (HTTP) **`502 Bad Gateway`** server error respon
 ## See also
 
 - {{HTTPStatus(504)}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.502)

--- a/files/en-us/web/http/status/503/index.md
+++ b/files/en-us/web/http/status/503/index.md
@@ -36,4 +36,4 @@ Caching-related headers that are sent along with this response should be taken c
 ## See also
 
 - {{HTTPHeader("Retry-After")}}
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.503)

--- a/files/en-us/web/http/status/504/index.md
+++ b/files/en-us/web/http/status/504/index.md
@@ -30,5 +30,5 @@ The HyperText Transfer Protocol (HTTP) **`504 Gateway Timeout`** server error re
 
 ## See also
 
-- [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+- [HTTP Status Code Definitions](https://httpwg.org/specs/rfc9110.html#status.504)
 - {{HTTPStatus(502)}}


### PR DESCRIPTION
In #24127, we noticed there were still some links to the outdated RFC2616.

This PR removes these links by:
- linking to the latest spec
- removing the link if it is not pertinent anymore

There is one link left to RFC2616 after this PR, in the article about the history of HTTP, where it is pertinent.