### PR TITLE
Document composition of content script global

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -197,6 +197,16 @@ When calling `tabs.remove()`:
 - **In Firefox:** When a content script makes an HTTP(S) request, you _must_ provide absolute URLs.
 - **In Chrome:** When a content script makes a request (for example, using [`fetch()`](/en-US/docs/Web/API/Fetch_API/Using_Fetch)) to a relative URL (like `/api`), it will be sent to `https://example.com/api`.
 
+#### Content script environment
+
+- **In Firefox:** The global scope of the [content script environment](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#content_script_environment) is not strictly equal to `window` ({{bug(1208775)}}). More specifically, the global scope (`globalThis`) is composed of standard JavaScript features as usual, plus `window` as the prototype of the global scope. Most DOM APIs are inherit from the page through `window`, through [Xray vision](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#xray_vision_in_firefox) to shield the content script from modifications by the web page. Content scripts may encounter JavaScript objects from its own global scope or Xray-wrapped versions from the web page.
+- **In Chrome:** The global scope is `window` and the available DOM APIs are generally independent of the web page (other than sharing the underlying DOM). Content scripts cannot directly access JavaScript objects from the web page.
+
+#### Executing code in web page from content script
+
+- **In Firefox:** {{jsxref("Global_Objects/eval", "eval")}} runs code in the context of the content script, and `window.eval` runs code in the context of the page. See [Using `eval` in content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#using_eval_in_content_scripts).
+- **In Chrome:** {{jsxref("Global_Objects/eval", "eval")}} and `window.eval` always runs code in the context of the content script, not in the context of the page.
+
 #### Sharing variables between content scripts
 
 - **In Firefox:** You cannot share variables between content scripts by assigning them to `this.{variableName}` in one script and then attempting to access them using `window.{variableName}` in another. This is a limitation created by the sandbox environment in Firefox. This limitation may be removed, see {{bug(1208775)}}.

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -67,7 +67,12 @@ However, content scripts get a "clean" view of the DOM. This means:
 - Content scripts cannot see JavaScript variables defined by page scripts.
 - If a page script redefines a built-in DOM property, the content script sees the original version of the property, not the redefined version.
 
-In Firefox, this behavior is called [Xray vision](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#xray_vision_in_firefox).
+As noted at ["Content script environment" at Chrome incompatibilities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#content_script_environment), the behavior differs across browsers:
+
+- In Firefox, this behavior is called [Xray vision](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#xray_vision_in_firefox).
+  Content scripts may encounter JavaScript objects from its own global scope or Xray-wrapped versions from the web page.
+
+- In Chrome this behavior is enforced through an [isolated world](https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/bindings/core/v8/V8BindingDesign.md#world), which uses a fundamentally different approach.
 
 Consider a web page like this:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Documents the composition of the content script global.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Content scripts in extensions behave somewhat consistently across browsers, except when they don't. This is currently not clearly documented, and occasionally confuses extension developers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Related bugs:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1208775 (and linked bugs)
- https://bugzilla.mozilla.org/show_bug.cgi?id=1288284

Examples of bugs showing confusion from extension developers:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1577400
- https://bugzilla.mozilla.org/show_bug.cgi?id=1681809
- https://bugzilla.mozilla.org/show_bug.cgi?id=1814898

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

None

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
