### PR TITLE
Remove pleonastic "for example"

### DIFF
--- a/files/en-us/glossary/api/index.md
+++ b/files/en-us/glossary/api/index.md
@@ -14,7 +14,7 @@ In Web development, an API is generally a set of code features (e.g. {{glossary(
 For example:
 
 - The [getUserMedia](/en-US/docs/Web/API/MediaDevices/getUserMedia) API can be used to grab audio and video from a user's webcam, which can then be used in any way the developer likes, for example, recording video and audio, broadcasting it to another user in a conference call, or capturing image stills from the video.
-- The [Geolocation API](/en-US/docs/Web/API/Geolocation) can be used to retrieve location information from whatever service the user has available on their device (e.g. GPS), which can then be used in conjunction with the [Google Maps APIs](https://developers.google.com/maps/) to for example plot the user's location on a custom map and show them what tourist attractions are in their area.
+- The [Geolocation API](/en-US/docs/Web/API/Geolocation) can be used to retrieve location information from whatever service the user has available on their device (e.g. GPS), which can then be used in conjunction with the [Google Maps APIs](https://developers.google.com/maps/) to plot the user's location on a custom map and show them what tourist attractions are in their area.
 - The [Twitter APIs](https://developer.twitter.com/en/docs) can be used to retrieve data from a user's twitter accounts, for example, to display their latest tweets on a web page.
 - The [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) can be used to animate parts of a web page — for example, to make images move around or rotate.
 


### PR DESCRIPTION


<!-- Just delete 'for example' in an API example.-->

### Motivation

<!-- In an example of API I found 'for example' unnecessary.  Users from non-native English countries will find it easy to understand! -->


