### PR TITLE
Format /web/xslt using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,5 @@ build/
 !files/en-us/glossary/**/*.md
 !files/en-us/mdn/**/*.md
 !files/en-us/web/http/**/*.md
+!files/en-us/web/xslt/**/*.md
 

--- a/files/en-us/web/xslt/index.md
+++ b/files/en-us/web/xslt/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'XSLT: Extensible Stylesheet Language Transformations'
+title: "XSLT: Extensible Stylesheet Language Transformations"
 slug: Web/XSLT
 tags:
   - Landing


### PR DESCRIPTION
This PR is a part of a project to format all of the documents using Prettier, and then enforce Prettier formatting for the files going forward.  This PR formats the remaining files of the `/web/xslt` folder that have not already been touched by other PRs.
