### PR TITLE
fix: typo that resulted in different meaning

### DIFF
--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -29,7 +29,7 @@ Accept-CH: Width, Downlink, Sec-CH-UA
 This approach is efficient in that the server only requests the information that it is able to usefully handle.
 It is also relatively "privacy-preserving", in that it is up to the client to decide what information it can safely share.
 
-There is a small set of [low entropy client hint headers](#low_entropy_hints) that may be sent by a client event if not requested.
+There is a small set of [low entropy client hint headers](#low_entropy_hints) that may be sent by a client even if not requested.
 
 > **Note:** Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) attribute.
 >


### PR DESCRIPTION
Note: I'm fairly certain this _is_ actually a typo and that I'm not meant to be interpreting it according to the subtle and complicated meaning the typo yields.

- - -

The presumed typo saying `event` changed the original meaning: "There is a small set of low entropy client hint headers that may be sent by a client event if not requested." There it sounds like we're referring to requests as 'events' and that the low entropy hints are sent specifically when they are not requested, which has a distinct enough meaning that a reader might assume there's something very subtle they need to understand about this class of hints.

With the typo fixed, the meaning is different, accurate, and more straightforward for a reader to utilize: "There is a small set of low entropy client hint headers that may be sent by a client even if not requested."

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
