### PR TITLE
Fix typo in `gesturestart` event 

### DIFF
--- a/files/en-us/web/api/element/gesturestart_event/index.md
+++ b/files/en-us/web/api/element/gesturestart_event/index.md
@@ -20,7 +20,7 @@ It is a proprietary event specific to WebKit.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('NameOfTheEvent', (event) => {});
+addEventListener('gesturestart', (event) => {});
 
 onNameOfTheEvent = (event) => { };
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a simple typo for `gesturestart`

### Motivation

I noticed the typo while using these docs. 
