### PR TITLE
Fix (another) typo in `gesturestart`

### DIFF
--- a/files/en-us/web/api/element/gesturestart_event/index.md
+++ b/files/en-us/web/api/element/gesturestart_event/index.md
@@ -22,7 +22,7 @@ Use the event name in methods like {{domxref("EventTarget.addEventListener", "ad
 ```js
 addEventListener('gesturestart', (event) => {});
 
-onNameOfTheEvent = (event) => { };
+ongesturestart = (event) => { };
 ```
 
 ## Event type

--- a/files/en-us/web/api/element/gesturestart_event/index.md
+++ b/files/en-us/web/api/element/gesturestart_event/index.md
@@ -22,7 +22,7 @@ Use the event name in methods like {{domxref("EventTarget.addEventListener", "ad
 ```js
 addEventListener('gesturestart', (event) => {});
 
-ongesturestart = (event) => { };
+ongesturestart = (event) => {};
 ```
 
 ## Event type


### PR DESCRIPTION
### Description

My [last PR](#24238) missed another typo in `gesturestart`. This fixes that.
