### PR TITLE
Update FF110 release note for color-gamut

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -24,7 +24,7 @@ This article provides information about the changes in Firefox 110 that will aff
 
 - Container queries and container query length units are now supported by default.
   For more information on these queries and the related units of length, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1809720)}}).
-- The [color-gamut media query](/en-US/docs/Web/CSS/@media/color-gamut) is now supported ({{bug(1422237)}})..
+- The [color-gamut media query](/en-US/docs/Web/CSS/@media/color-gamut) is now supported ({{bug(1422237)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -24,6 +24,7 @@ This article provides information about the changes in Firefox 110 that will aff
 
 - Container queries and container query length units are now supported by default.
   For more information on these queries and the related units of length, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1809720)}}).
+- The [color-gamut media query](/en-US/docs/Web/CSS/@media/color-gamut) is now supported ({{bug(1422237)}})..
 
 #### Removals
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->



Firefox 110 supports media query's color-gamut via https://bugzilla.mozilla.org/show_bug.cgi?id=1422237.
This pull request updates the release note.

MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/color-gamut

Doc issue tracker: https://github.com/mdn/content/issues/23681
