### PR TITLE
Minor edits and clarifications in the color-gamut page

### DIFF
--- a/files/en-us/web/css/@media/color-gamut/index.md
+++ b/files/en-us/web/css/@media/color-gamut/index.md
@@ -13,18 +13,18 @@ browser-compat: css.at-rules.media.color-gamut
 
 {{CSSRef}}
 
-The **`color-gamut`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) can be used to test the approximate range of colors that are supported by the {{glossary("user agent")}} and the output device.
+The **`color-gamut`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is used to apply CSS styles based on the approximate range of color {{glossary("gamut")}} supported by the {{glossary("user agent")}} and the output device.
 
 ## Syntax
 
-The `color-gamut` feature is specified as a keyword value chosen from the list below.
+The `color-gamut` feature is specified as one of the following keyword values:
 
 - `srgb`
-  - : The output device can support approximately the [sRGB](https://en.wikipedia.org/wiki/SRGB) {{glossary("gamut")}} or more. This includes the vast majority of color displays.
+  - : The user agent and the output device can support approximately the [sRGB](https://en.wikipedia.org/wiki/SRGB) gamut or more. This includes the vast majority of color displays.
 - `p3`
-  - : The output device can support approximately the {{glossary("gamut")}} specified by the [Display P3](https://www.color.org/chardata/rgb/DisplayP3.xalter) Color Space or more. The p3 gamut is larger than and includes the srgb gamut.
+  - : The user agent and the output device can support approximately the gamut specified by the [Display P3](https://www.color.org/chardata/rgb/DisplayP3.xalter) color space or more. The P3 gamut is larger than and includes the sRGB gamut.
 - `rec2020`
-  - : The output device can support approximately the {{glossary("gamut")}} specified by the [ITU-R Recommendation BT.2020 Color Space](https://en.wikipedia.org/wiki/Rec._2020) or more. The rec2020 gamut is larger than and includes the p3 gamut.
+  - : The user agent and the output device can support approximately the gamut specified by the [ITU-R Recommendation BT.2020](https://en.wikipedia.org/wiki/Rec._2020) color space or more. The REC. 2020 gamut is larger than and includes the P3 gamut.
 
 ## Examples
 
@@ -58,5 +58,5 @@ The `color-gamut` feature is specified as a keyword value chosen from the list b
 
 ## See also
 
-- [Using Media Queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
-- [@media](/en-US/docs/Web/CSS/@media)
+- [@media](/en-US/docs/Web/CSS/@media) at-rule that is used to specify the color-gamut expression.
+- [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) to understand when and how to use a media query.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

FF110 now supports `color-gamut`.
The feature documentation already exists: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/color-gamut

Some key edits done in this pull request:
- Instead of repeating the link to the glossary term 'gamut' in all descriptions, the link has been moved to the intro description
- The spec mentions both 'UA' and the output device support in each of the keyword values: https://drafts.csswg.org/mediaqueries-4/#color-gamut. Added that bit to the descriptions of the values.

### Related issues and pull requests

Doc issue tracker: https://github.com/mdn/content/issues/23681
