### PR TITLE
Update CSS/atan2

### DIFF
--- a/files/en-us/web/css/atan2/index.md
+++ b/files/en-us/web/css/atan2/index.md
@@ -36,7 +36,7 @@ transform: rotate(atan2(e, 30));
 
 ### Parameters
 
-The `atan2(y, x)` function accepts two comma-separated values as its parameters. The values can be {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}} types, but both must be the same type.
+The `atan2(y, x)` function accepts two comma-separated values as its parameters. The values can be {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}} Both values must be of the same type but can be both {{cssxref("&lt;dimension&gt;")}} with different units (example: `atan2(100px, 5vw)`).
 
 - `y`
   - : The y coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.

--- a/files/en-us/web/css/atan2/index.md
+++ b/files/en-us/web/css/atan2/index.md
@@ -36,7 +36,7 @@ transform: rotate(atan2(e, 30));
 
 ### Parameters
 
-The `atan2(y, x)` function accepts two comma-separated values as its parameters. The values can be {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}} Both values must be of the same type but can be both {{cssxref("&lt;dimension&gt;")}} with different units (example: `atan2(100px, 5vw)`).
+The `atan2(y, x)` function accepts two comma-separated values as its parameters. Each value can be a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}. Both values must be of the same type, although if they are {{cssxref("&lt;dimension&gt;")}} they can be of different units (example: `atan2(100px, 5vw)` is valid).
 
 - `y`
   - : The y coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.


### PR DESCRIPTION
### Description

specify that mixed dimensions are allowed

### Motivation

Actually the article could imply that the two values must have the same unit (especially because of the examples), while they must only be of the same type (both [\<number>](https://developer.mozilla.org/en-US/docs/Web/CSS/number), both [\<dimension>](https://developer.mozilla.org/en-US/docs/Web/CSS/dimension), or both [\<percentage>](https://developer.mozilla.org/en-US/docs/Web/CSS/percentage)). they can therefore be of type [\<dimension>](https://developer.mozilla.org/en-US/docs/Web/CSS/dimension) but with mixed units (example: `atan2(100vw, 100vh`)

