### PR TITLE
Fix: Shortcut to open the Web Console for Mac

### DIFF
--- a/files/en-us/web/javascript/guide/introduction/index.md
+++ b/files/en-us/web/javascript/guide/introduction/index.md
@@ -87,7 +87,7 @@ The _Web Console_ tool built into Firefox is useful for experimenting with JavaS
 
 The [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) shows you information about the currently loaded Web page, and also includes a JavaScript interpreter that you can use to execute JavaScript expressions in the current page.
 
-To open the Web Console (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> on Windows and Linux or <kbd>Cmd</kbd>-<kbd>Option</kbd>-<kbd>K</kbd> on Mac), open the **Tools** menu in Firefox, and select "**Developer ▶ Web Console**".
+To open the Web Console (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> on Windows and Linux or <kbd>Cmd</kbd>-<kbd>Option</kbd>-<kbd>I</kbd> on Mac), open the **Tools** menu in Firefox, and select "**Developer ▶ Web Console**".
 
 The Web Console appears at the bottom of the browser window. Along the bottom of the console is an input line that you can use to enter JavaScript, and the output appears in the panel above:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Fixes the shortcut for opening the web console on Mac 

- Updates from `cmd` + `option` + `K` to `cmd` + `option` + `I`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

[Link to the JavaScript Introduction - Web Console section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Introduction#single-line_input_in_the_web_console)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
