### PR TITLE
Add PaymentResponse.toJSON()

### DIFF
--- a/files/en-us/web/api/paymentresponse/index.md
+++ b/files/en-us/web/api/paymentresponse/index.md
@@ -43,6 +43,8 @@ The **`PaymentResponse`** interface of the [Payment Request API](/en-US/docs/Web
   - : If something is wrong with the payment response's data (and there is a recoverable error), this method allows a merchant to request that the user retry the payment. The method takes an object as argument, which is used to signal to the user exactly what is wrong with the payment response so they can try to correct any issues.
 - {{domxref('PaymentResponse.complete()')}} {{SecureContext_Inline}}
   - : Notifies the user agent that the user interaction is over. This causes any remaining user interface to be closed. This method should only be called after the Promise returned by the {{domxref('PaymentRequest.show()')}} method.
+- {{domxref("PaymentResponse.toJSON()")}} {{SecureContext_Inline}}
+  - : Returns a [JSON object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) representing this `PaymentResponse` object.
 
 ## Events
 

--- a/files/en-us/web/api/paymentresponse/tojson/index.md
+++ b/files/en-us/web/api/paymentresponse/tojson/index.md
@@ -35,27 +35,10 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PaymentR
 In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceEventTiming` object.
 
 ```js
-const observer = new PerformanceObserver((list) => {
-  list.getEntries().forEach((entry) => {
-    console.log(entry.toJSON());
-  });
+payment.show().then((paymentResponse) => {
+  console.log(paymentResponse.toJSON())
+  };
 });
-
-observer.observe({type: "event", buffered: true});
-```
-
-This would log a JSON object like so:
-
-```json
-{
-  "name": "dragover",
-  "entryType": "event",
-  "startTime": 67090751.599999905,
-  "duration": 128,
-  "processingStart": 67090751.70000005,
-  "processingEnd": 67090751.900000095,
-  "cancelable": true
-}
 ```
 
 To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.

--- a/files/en-us/web/api/paymentresponse/tojson/index.md
+++ b/files/en-us/web/api/paymentresponse/tojson/index.md
@@ -41,7 +41,7 @@ payment.show().then((paymentResponse) => {
 });
 ```
 
-To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+To get a JSON string, you can use [`JSON.stringify(paymentResponse)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
 
 ## Specifications
 

--- a/files/en-us/web/api/paymentresponse/tojson/index.md
+++ b/files/en-us/web/api/paymentresponse/tojson/index.md
@@ -1,6 +1,6 @@
 ---
 title: PaymentResponse.toJSON()
-slug: Web/API/PaymentResponce/toJSON
+slug: Web/API/PaymentResponse/toJSON
 page-type: web-api-instance-method
 tags:
   - API

--- a/files/en-us/web/api/paymentresponse/tojson/index.md
+++ b/files/en-us/web/api/paymentresponse/tojson/index.md
@@ -1,0 +1,73 @@
+---
+title: PaymentResponse.toJSON()
+slug: Web/API/PaymentResponce/toJSON
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - Web Performance
+browser-compat: api.PaymentResponse.toJSON
+---
+
+{{SecureContext_Header}}{{APIRef("Payment Request API")}}
+
+The **`toJSON()`** method of the {{domxref("PaymentResponse")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PaymentResponse")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PaymentResponse")}} object.
+
+## Examples
+
+### Using the toJSON method
+
+In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceEventTiming` object.
+
+```js
+const observer = new PerformanceObserver((list) => {
+  list.getEntries().forEach((entry) => {
+    console.log(entry.toJSON());
+  });
+});
+
+observer.observe({type: "event", buffered: true});
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "name": "dragover",
+  "entryType": "event",
+  "startTime": 67090751.599999905,
+  "duration": 128,
+  "processingStart": 67090751.70000005,
+  "processingEnd": 67090751.900000095,
+  "cancelable": true
+}
+```
+
+To get a JSON string, you can use [`JSON.stringify(entry)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/paymentresponse/tojson/index.md
+++ b/files/en-us/web/api/paymentresponse/tojson/index.md
@@ -32,7 +32,7 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("PaymentR
 
 ### Using the toJSON method
 
-In this example, calling `entry.toJSON()` returns a JSON representation of the `PerformanceEventTiming` object.
+In this example, calling `paymentResponse.toJSON()` returns a JSON representation of the `PaymentResponse` object.
 
 ```js
 payment.show().then((paymentResponse) => {


### PR DESCRIPTION
This is part of openwebdocs/project#152

As for the other `toJSON()` pages, I used: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/toJSON as the template.