### PR TITLE
Show finished version of exercises

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Test your skills: HTML text basics'
+title: "Test your skills: HTML text basics"
 slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_HTML_text_basics
 tags:
   - Beginner
@@ -21,6 +21,10 @@ The aim of this skill test is to assess whether you understand how to [mark up t
 
 In this task, we want you to mark up the provided HTML using semantic heading and paragraph elements.
 
+The finished example should look like this:
+
+{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text1-finished.html", '100%', 300)}}
+
 Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text1.html", '100%', 700)}}
@@ -33,6 +37,10 @@ Try updating the live code below to recreate the finished example:
 
 In this task, we want you to turn the first un-marked up list into an unordered list, and the second one into an ordered list.
 
+The finished example should look like this:
+
+{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text2-finished.html", '100%', 400)}}
+
 Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text2.html", '100%', 700)}}
@@ -44,6 +52,10 @@ Try updating the live code below to recreate the finished example:
 ## Task 3
 
 In this task, you are provided with a paragraph, and your aim is to use some inline elements to mark up a couple of appropriate words with strong importance, and a couple with emphasis.
+
+The finished example should look like this:
+
+{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/basic-text/basic-text3-finished.html", '100%', 120)}}
 
 Try updating the live code below to recreate the finished example:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/21944.

This PR integrates the "finished" versions of the tasks into the page using `EmbedGHLiveSample`, just as we did for the "Advanced text" exercises in https://github.com/mdn/content/issues/23154.