### PR TITLE
Update phrase for status 413 to Content Too Large

### DIFF
--- a/files/en-us/web/http/status/413/index.md
+++ b/files/en-us/web/http/status/413/index.md
@@ -1,5 +1,5 @@
 ---
-title: 413 Payload Too Large
+title: 413 Content Too Large
 slug: Web/HTTP/Status/413
 tags:
   - Client error
@@ -12,12 +12,14 @@ spec-urls: https://httpwg.org/specs/rfc9110.html#status.413
 
 {{HTTPSidebar}}
 
-The HTTP **`413 Payload Too Large`** response status code indicates that the request entity is larger than limits defined by server; the server might close the connection or return a {{HTTPHeader("Retry-After")}} header field.
+The HTTP **`413 Content Too Large`** response status code indicates that the request entity is larger than limits defined by server; the server might close the connection or return a {{HTTPHeader("Retry-After")}} header field.
+
+Prior to RFC 9110 the response phrase for the status was **`Payload Too Large`**.  That name is still widely used. 
 
 ## Status
 
 ```http
-413 Payload Too Large
+413 Content Too Large
 ```
 
 ## Specifications

--- a/files/en-us/web/http/status/413/index.md
+++ b/files/en-us/web/http/status/413/index.md
@@ -14,7 +14,7 @@ spec-urls: https://httpwg.org/specs/rfc9110.html#status.413
 
 The HTTP **`413 Content Too Large`** response status code indicates that the request entity is larger than limits defined by server; the server might close the connection or return a {{HTTPHeader("Retry-After")}} header field.
 
-Prior to RFC 9110 the response phrase for the status was **`Payload Too Large`**.  That name is still widely used. 
+Prior to RFC 9110 the response phrase for the status was **`Payload Too Large`**. That name is still widely used.
 
 ## Status
 


### PR DESCRIPTION
RFC 9110 uses phrase ‘Content Too Large’ for status code 413.  Update
the document and mention that the rename happened.
