### PR TITLE
ReadableStream supports for-await-of: minimal doc

### DIFF
--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -76,12 +76,6 @@ for await (const chunk of stream.values({ preventCancel: true })) {
 // Acquire a reader for the stream and continue reading ...
 ```
 
-Notes:
-
-- The code in the loop is only run when the next chunk arrives.
-  If code from outside the loop triggers code in the loop, such as a `break`, there may be a delay before the code in the loop is executed.
-- Polyfills are available if this feature is not [supported on your browser](#browser_compatibility): [web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams).
-
 ## Examples
 
 ### Fetch stream
@@ -182,3 +176,4 @@ console.log(total);
 ## See also
 
 - [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
+- [web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -48,7 +48,8 @@ The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_
 
 ## Async Iteration
 
-`ReadableStream` supports asynchronous iteration over the chunks in a stream using the [for await...of](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax:
+`ReadableStream` implements the [async iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols).
+This enables asynchronous iteration over the chunks in a stream using the [for await...of](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax:
 
 ```js
 const stream = new ReadableStream(getSomeSource());
@@ -77,7 +78,6 @@ for await (const chunk of stream.values({ preventCancel: true })) {
 
 Notes:
 
-- `ReadableStream` implements the [async iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols).
 - You can abort processing of a stream prematurely triggering code to call `throw` or `break` in the loop.
   Note however that as each iteration is only run when the next chunk arrives, there can be a delay between signalling that you want to cancel, and the code getting to run.
   The fastest way to terminate the stream may be to abort the "underlying source" of the stream.

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -71,7 +71,7 @@ To continue to use a stream after exiting the loop, pass `{ preventCancel: true 
 ```js
 for await (const chunk of stream.values({ preventCancel: true })) {
   // Do something with 'chunk'
-  return;
+  break;
 }
 // Acquire a reader for the stream and continue reading ...
 ```

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -46,10 +46,10 @@ The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_
 - {{domxref("ReadableStream.tee()")}}
   - : The `tee` method [tees](https://streams.spec.whatwg.org/#tee-a-readable-stream) this readable stream, returning a two-element array containing the two resulting branches as new {{domxref("ReadableStream")}} instances. Each of those streams receives the same incoming data.
 
-## Async Iteration
+## Async iteration
 
 `ReadableStream` implements the [async iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols).
-This enables asynchronous iteration over the chunks in a stream using the [for await...of](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax:
+This enables asynchronous iteration over the chunks in a stream using the [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax:
 
 ```js
 const stream = new ReadableStream(getSomeSource());
@@ -60,10 +60,10 @@ for await (const chunk of stream) {
 ```
 
 The async iterator consumes the stream until it runs out of data or otherwise terminates.
-The loop can also exit early due to a `break`, `throw`, or `return`.
+The loop can also exit early due to a `break`, `throw`, or `return` statement.
 
 While iterating, the stream is locked to prevent other consumers from acquiring a reader (attempting to iterate over a stream that is already locked will throw a `TypeError`).
-This lock is released when the iterator exits the loop.
+This lock is released when the loop exits.
 
 By default, exiting the loop will also cancel the stream, so that it can no longer be used.
 To continue to use a stream after exiting the loop, pass `{ preventCancel: true }` to the stream's `values()` method:
@@ -152,9 +152,9 @@ function iteratorToStream(iterator) {
 
 This works with both async and non-async iterators.
 
-### Async iteration of stream (for-wait-of)
+### Async iteration of a stream using for await...of
 
-This example shows how you can process the `fetch()` response using a [for await...of](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop to iterate through the arriving chunks.
+This example shows how you can process the `fetch()` response using a [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop to iterate through the arriving chunks.
 
 ```js
 const response = await fetch("https://www.example.org");

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -79,7 +79,8 @@ for await (const chunk of stream.values({ preventCancel: true })) {
 Notes:
 
 - The code in the loop is only run when the next chunk arrives.
-  If a user signal some operation from outside the loop that is implemented in the loop, such as a `break`, there may be a delay.
+  If code from outside the loop triggers code in the loop, such as a `break`, there may be a delay before the code in the loop is executed.
+- Polyfills are available if this feature is not [supported on your browser](#browser_compatibility): [web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams).
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -78,9 +78,8 @@ for await (const chunk of stream.values({ preventCancel: true })) {
 
 Notes:
 
-- You can abort processing of a stream prematurely triggering code to call `throw` or `break` in the loop.
-  Note however that as each iteration is only run when the next chunk arrives, there can be a delay between signalling that you want to cancel, and the code getting to run.
-  The fastest way to terminate the stream may be to abort the "underlying source" of the stream.
+- The code in the loop is only run when the next chunk arrives.
+  If a user signal some operation from outside the loop that is implemented in the loop, such as a `break`, there may be a delay.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -58,9 +58,7 @@ When creating an API, remember that async iterables are designed to represent so
 
 ### Built-in async iterables
 
-The built-in JavaScript objects that have the `[Symbol.asyncIterator]` key set by default are:
-
-- [`ReadableStream`](/en-US/docs/Web/API/ReadableStream)
+[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in JavaScript object that has the `[Symbol.asyncIterator]` key set by default (at time of writing).
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -58,7 +58,7 @@ When creating an API, remember that async iterables are designed to represent so
 
 ### Built-in async iterables
 
-[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in JavaScript object that has the `[Symbol.asyncIterator]` key set by default (at time of writing).
+[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in JavaScript object that has the `Symbol.asyncIterator` method set by default at the time of writing.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -58,7 +58,9 @@ When creating an API, remember that async iterables are designed to represent so
 
 ### Built-in async iterables
 
-There are currently no built-in JavaScript objects that have the `[Symbol.asyncIterator]` key set by default. However, WHATWG Streams are set to be the first built-in object to be async iterable, with `[Symbol.asyncIterator]` recently landing in the spec.
+The built-in JavaScript objects that have the `[Symbol.asyncIterator]` key set by default are:
+
+- [`ReadableStream`](/en-US/docs/Web/API/ReadableStream)
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -128,7 +128,7 @@ The language specifies APIs that either produce or consume iterables and iterato
 ### Built-in iterables
 
 {{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, and [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) (returned by [`Intl.Segmenter.prototype.segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment)) are all built-in iterables, because each of their `prototype` objects implements an `@@iterator` method. In addition, the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object and some DOM collection types such as {{domxref("NodeList")}} are also iterables.
-[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in _async iterable_ (at time of writing).
+[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in async iterable at the time of writing.
 
 [Generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*) return [generator objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator), which are iterable iterators. [Async generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) return [async generator objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator), which are async iterable iterators.
 

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -127,7 +127,8 @@ The language specifies APIs that either produce or consume iterables and iterato
 
 ### Built-in iterables
 
-{{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, and [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) (returned by [`Intl.Segmenter.prototype.segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment)) are all built-in iterables, because each of their `prototype` objects implements an `@@iterator` method. In addition, the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object and some DOM collection types such as {{domxref("NodeList")}} are also iterables. There are no built-in async iterables currently.
+{{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, and [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) (returned by [`Intl.Segmenter.prototype.segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment)) are all built-in iterables, because each of their `prototype` objects implements an `@@iterator` method. In addition, the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object and some DOM collection types such as {{domxref("NodeList")}} are also iterables.
+[`ReadableStream`](/en-US/docs/Web/API/ReadableStream) is the only built-in _async iterable_ (at time of writing).
 
 [Generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*) return [generator objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator), which are iterable iterators. [Async generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) return [async generator objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator), which are async iterable iterators.
 


### PR DESCRIPTION
This updates `ReadableStream` with minimal docs for async iteration - enough to understand the API. I plan to follow this up with a more detailed example in another PR in the Using Readable streams doc.

Related docs work done in #23678