### PR TITLE
Add docs for ExecutionWorld of scripting.executeScript API

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -41,16 +41,18 @@ let results = await browser.scripting.executeScript(
 
   - : An object describing the script to inject. It contains these properties:
 
-    - `args`
+    - `args` {{optional_inline}}
       - : An array of arguments to carry into the function. This is only valid if the `func` parameter is specified. The arguments must be JSON-serializable.
-    - `files`
+    - `files` {{optional_inline}}
       - : `array` of `string`. An array of path of the JS files to inject, relative to the extension's root directory. Exactly one of `files` and `func` must be specified.
-    - `func`
+    - `func` {{optional_inline}}
       - : `function`. A JavaScript function to inject. This function is serialized and then deserialized for injection. This means that any bound parameters and execution context are lost. Exactly one of `files` and `func` must be specified.
     - `injectImmediately` {{optional_inline}}
       - : `boolean`. Whether the injection into the target is triggered as soon as possible, but not necessarily prior to page load.
     - `target`
       - : {{WebExtAPIRef("scripting.InjectionTarget")}}. Details specifying the target to inject the script into.
+    - `world` {{optional_inline}}
+      - : {{WebExtAPIRef("scripting.ExecutionWorld")}}. The execution environment for a script to execute within.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -52,7 +52,7 @@ let results = await browser.scripting.executeScript(
     - `target`
       - : {{WebExtAPIRef("scripting.InjectionTarget")}}. Details specifying the target to inject the script into.
     - `world` {{optional_inline}}
-      - : {{WebExtAPIRef("scripting.ExecutionWorld")}}. The execution environment for a script to execute within.
+      - : {{WebExtAPIRef("scripting.ExecutionWorld")}}. The execution environment for a script to execute in.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -15,7 +15,7 @@ browser-compat: webextensions.api.scripting.ExecutionWorld
 
 {{AddonSidebar()}}
 
-Specifies the execution environment of a script injected with {{WebExtAPIRef("scripting.executeScript()")}},
+Specifies the execution environment of a script injected with {{WebExtAPIRef("scripting.executeScript()")}}
 or registered with {{WebExtAPIRef("scripting.registerContentScripts()")}}.
 
 ## Type

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -33,7 +33,7 @@ Values of this type are strings. Possible values are:
    Scripts in this environment do not have any access to APIs that are only available to content scripts.
 
    > **Warning:** Due to the lack of isolation, the web page can detect the executed code and interfere with it.
-   > Do not use the `MAIN` world unless it is acceptable for web pages to read, access or modify the logic or data that flows through the executed code.
+   > Do not use the `MAIN` world unless it is acceptable for web pages to read, access, or modify the logic or data that flows through the executed code.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -1,0 +1,44 @@
+---
+title: scripting.ExecutionWorld
+slug: Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - ExecutionWorld
+  - Reference
+  - Type
+  - WebExtensions
+  - scripting
+browser-compat: webextensions.api.scripting.ExecutionWorld
+---
+
+{{AddonSidebar()}}
+
+Specifies the execution environment of a script injected with {{WebExtAPIRef("scripting.executeScript()")}},
+or registered with {{WebExtAPIRef("scripting.registerContentScripts()")}}.
+
+## Type
+
+Values of this type are strings. Possible values are:
+
+- `ISOLATED`
+
+   The default execution environment of [content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts).
+   This environment is isolated from the page's context: while they share the same document, the global scopes and available APIs differ.
+
+- `MAIN`
+
+   The execution environment of the web page. This environment is shared with the web page, without isolation.
+   Scripts in this environment do not have any access to APIs that are only available to content scripts.
+
+   > **Warning:** Due to the lack of isolation, the web page can detect the executed code and interfere with it.
+   > Do not use the `MAIN` world unless it is acceptable for web pages to read, access or modify the logic or data that flows through the executed code.
+
+## Browser compatibility
+
+{{Compat}}
+
+{{WebExtExamples}}
+
+> **Note:** This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#type-ExecutionWorld) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -29,6 +29,8 @@ Alternatively, you can get permission temporarily in the active tab and only in 
 
 - {{WebExtAPIRef("scripting.ContentScriptFilter")}}
   - : Specifies the IDs of scripts to retrieve with {{WebExtAPIRef("scripting.getRegisteredContentScripts()")}} or to unregister with {{WebExtAPIRef("scripting.unregisterContentScripts()")}}.
+- {{WebExtAPIRef("scripting.ExecutionWorld")}}
+  - : Specifies the execution environment of a script injected with {{WebExtAPIRef("scripting.executeScript()")}} or registered with {{WebExtAPIRef("scripting.registerContentScripts()")}}.
 - {{WebExtAPIRef("scripting.InjectionTarget")}}
   - : Details of an injection target.
 - {{WebExtAPIRef("scripting.RegisteredContentScript")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This documents the `world` option in `scripting.executeScript` (and `registerContentScripts` too, in Chrome).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This feature is not documented and I saw a request for documentation at #22493.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1759932
Released in Firefox 102 with https://bugzilla.mozilla.org/show_bug.cgi?id=1766615

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #22493
I added more detail about the environment in https://github.com/mdn/content/pull/24215

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
