### PR TITLE
Minor update to README for ref style links in GitHub-only .md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![github-profile](https://user-images.githubusercontent.com/10350960/166113119-629295f6-c282-42c9-9379-af2de5ad4338.png)
 
-[MDN Web Docs](https://developer.mozilla.org/) is an open-source, collaborative project that documents web technologies including CSS, HTML, JavaScript, and Web APIs.
+[MDN Web Docs][] is an open-source, collaborative project that documents web technologies including CSS, HTML, JavaScript, and Web APIs.
 Alongside detailed reference documentation, we provide extensive learning resources for students and beginners getting started with web development.
 
 ## MDN's mission
@@ -47,3 +47,4 @@ By participating in and contributing to our projects and discussions, you acknow
 You can communicate with the MDN Web Docs team and community using the [communication channels][].
 
 [communication channels]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels
+[MDN Web Docs]: https://developer.mozilla.org/


### PR DESCRIPTION
GitHub-only .md should use reference-style links