### PR TITLE
Fix typo in “PushSubscription" article

### DIFF
--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.md
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.md
@@ -21,7 +21,7 @@ The **`subscriptionId`** read-only property of the
 {{domxref("PushSubscription")}} interface returns a string containing
 the subscription ID associated with the push subscription.
 
-> **Warning:** Instead of this feature, use the {{domxref("PushSubscription.endPoint")}} property on the same interface.
+> **Warning:** Instead of this feature, use the {{domxref("PushSubscription.endpoint")}} property on the same interface.
 
 ## Value
 


### PR DESCRIPTION
Simple typo fix

### Description

Better standardization of `PushSubscription.endpoint`

### Motivation

To improve reading and not end up looking for a property that does not exist

### Additional details

### Related issues and pull requests