### PR TITLE
css/@media/pointer: give examples of coarse and fine pointers

### DIFF
--- a/files/en-us/web/css/@media/pointer/index.md
+++ b/files/en-us/web/css/@media/pointer/index.md
@@ -24,9 +24,9 @@ The `pointer` feature is specified as a keyword value chosen from the list below
 - `none`
   - : The primary input mechanism does not include a pointing device.
 - `coarse`
-  - : The primary input mechanism includes a pointing device of limited accuracy, such as a touchscreen or a smart TV remote.
+  - : The primary input mechanism includes a pointing device of limited accuracy, such as a finger on a touchscreen.
 - `fine`
-  - : The primary input mechanism includes an accurate pointing device, such as a mouse, a touchpad, or a stylus.
+  - : The primary input mechanism includes an accurate pointing device, such as a mouse.
 
 ## Examples
 

--- a/files/en-us/web/css/@media/pointer/index.md
+++ b/files/en-us/web/css/@media/pointer/index.md
@@ -24,9 +24,9 @@ The `pointer` feature is specified as a keyword value chosen from the list below
 - `none`
   - : The primary input mechanism does not include a pointing device.
 - `coarse`
-  - : The primary input mechanism includes a pointing device of limited accuracy.
+  - : The primary input mechanism includes a pointing device of limited accuracy, such as a touchscreen or a smart TV remote.
 - `fine`
-  - : The primary input mechanism includes an accurate pointing device.
+  - : The primary input mechanism includes an accurate pointing device, such as a mouse, a touchpad, or a stylus.
 
 ## Examples
 


### PR DESCRIPTION
The description of `coarse` and `fine` pointers did not provide examples, so the meaning of those terms was a bit vague and ambiguous. This change includes some concrete examples to help readers get a better sense of what an "accurate pointing device" can mean.