### PR TITLE
Corrected grammar & made it readable

### DIFF
--- a/files/en-us/web/http/status/207/index.md
+++ b/files/en-us/web/http/status/207/index.md
@@ -13,9 +13,11 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.1
 > **Note:** The ability to return a _collection of resources_ is part of the {{Glossary("WebDAV")}} protocol (it may be recieved by web applications accessing a WebDAV server).
 > Browsers accessing web pages will never encounter this status code.
 
-The HTTP **`207 Multi-Status`** response code indicates that there might be mixture of responses.
-
 If not all have the same status the response get this `207 Multi-Status` code while the XML in the content of the response will list all individual response code.
+
+The HTTP **`207 Multi-Status`** response code indicates that there might be a mixture of responses.
+
+The response body is a `text/xml` or `application/xml` HTTP entity with a `multistatus` root element. The XML body will list all individual response codes.
 
 ## Status
 

--- a/files/en-us/web/http/status/207/index.md
+++ b/files/en-us/web/http/status/207/index.md
@@ -13,8 +13,6 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.1
 > **Note:** The ability to return a _collection of resources_ is part of the {{Glossary("WebDAV")}} protocol (it may be recieved by web applications accessing a WebDAV server).
 > Browsers accessing web pages will never encounter this status code.
 
-If not all have the same status the response get this `207 Multi-Status` code while the XML in the content of the response will list all individual response code.
-
 The HTTP **`207 Multi-Status`** response code indicates that there might be a mixture of responses.
 
 The response body is a `text/xml` or `application/xml` HTTP entity with a `multistatus` root element. The XML body will list all individual response codes.


### PR DESCRIPTION
### Description

1. Corrected grammar ("a") in the first sentence changed.
1. Replaced the second sentence to detail what the HTTP status actually does, the former text made no sense (to me at least) and wasn't helpful at all.

### Motivation

On trying to read the documentation for HTTP status 207 I found it made little sense and appeared to be written in broken English.

### Additional details

n/a

### Related issues and pull requests

Note I have another PR open on the same file at #24336
