### PR TITLE
refactor(prettier): Reverse .prettierignore to use as breakdown list

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,5 +17,5 @@ build/
 /files/en-us/web/web_components/**/*.md
 
 # The /web/api folder is so large, it has been divided into multiple parts
-/files/en-us/api/**/*.md
+/files/en-us/web/api/**/*.md
 !/files/en-us/web/api/[a-c]*/**/*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,22 +3,20 @@
 
 build/
 
-# Ignore markdown files till full pass is made on each folder
-*.md
-# The following paths have had a full pass
-!files/en-us/glossary/**/*.md
-!files/en-us/mdn/**/*.md
-!files/en-us/web/api/[a-c]*/**/*.md
-!files/en-us/web/css/**/*.md
-!files/en-us/web/events/**/*.md
-!files/en-us/web/guide/**/*.md
-!files/en-us/web/http/**/*.md
-!files/en-us/web/manifest/**/*.md
-!files/en-us/web/media/**/*.md
-!files/en-us/web/performance/**/*.md
-!files/en-us/web/privacy/**/*.md
-!files/en-us/web/security/**/*.md
-!files/en-us/web/webdriver/**/*.md
-!files/en-us/web/xml/**/*.md
-!files/en-us/web/xpath/**/*.md
-!files/en-us/web/xslt/**/*.md
+# A full pass on all Markdown files is being performed, the following folders
+# still need a full pass:
+/files/en-us/games/**/*.md
+/files/en-us/learn/**/*.md
+/files/en-us/mozilla/**/*.md
+/files/en-us/web/accessibility/**/*.md
+/files/en-us/web/html/**/*.md
+/files/en-us/web/javascript/**/*.md
+/files/en-us/web/mathml/**/*.md
+/files/en-us/web/progressive_web_apps/**/*.md
+/files/en-us/web/svg/**/*.md
+/files/en-us/web/text_fragments/**/*.md
+/files/en-us/web/web_components/**/*.md
+
+# The /web/api folder is so large, it has been divided into multiple parts
+/files/en-us/api/**/*.md
+!/files/en-us/web/api/[a-c]*/**/*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,6 @@ build/
 
 # A full pass on all Markdown files is being performed, the following folders
 # still need a full pass:
-/files/en-us/games/**/*.md
 /files/en-us/learn/**/*.md
 /files/en-us/mozilla/**/*.md
 /files/en-us/web/accessibility/**/*.md


### PR DESCRIPTION
This reverses the Prettier ignore, so that instead of ignoring all Markdown and making exceptions for folders we have performed a pass on, we only ignore the folders that are YET to be formatted.  This allows us to use the `.prettierignore` as a breakdown list of what still needs to be performed.

This also places slashes at the beginning of each ignore statement to ensure more explicit matching of files (see https://github.com/mdn/content/pull/20674/files#r1096228284 for more context).