### PR TITLE
CSS `display` property: "two-value syntax" -> "multi-keyword syntax"

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11381,6 +11381,8 @@
 /en-US/docs/Web/CSS/counters()	/en-US/docs/Web/CSS/counters
 /en-US/docs/Web/CSS/cross-fade()	/en-US/docs/Web/CSS/cross-fade
 /en-US/docs/Web/CSS/default	/en-US/docs/Web/CSS/:default
+/en-US/docs/Web/CSS/display/multi-value_syntax_of_display	/en-US/docs/Web/CSS/display/multi-keyword_syntax_of_display
+/en-US/docs/Web/CSS/display/two-value_syntax_of_display	/en-US/docs/Web/CSS/display/multi-keyword_syntax_of_display
 /en-US/docs/Web/CSS/document	/en-US/docs/Web/CSS/@document
 /en-US/docs/Web/CSS/document/@-moz-document	/en-US/docs/Web/CSS/@document
 /en-US/docs/Web/CSS/dominant-baseline	/en-US/docs/Web/SVG/Attribute/dominant-baseline

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -84824,7 +84824,7 @@
       "chrisdavidmills"
     ]
   },
-  "Web/CSS/display/two-value_syntax_of_display": {
+  "Web/CSS/display/multi-keyword_syntax_of_display": {
     "modified": "2020-10-15T22:26:04.121Z",
     "contributors": [
       "ExE-Boss",

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -39,7 +39,7 @@ display: flow-root;
 display: none;
 display: contents;
 
-/* two-value syntax */
+/* multi-keyword syntax */
 display: block flow;
 display: inline flow;
 display: inline flow-root;
@@ -77,7 +77,7 @@ The keyword values can be grouped into six value categories.
     - `inline`
       - : The element generates one or more inline element boxes that do not generate line breaks before or after themselves. In normal flow, the next element will be on the same line if there is space.
 
-> **Note:** Browsers that support the two-value syntax, on finding the outer value only, such as when `display: block` or `display: inline` is specified, will set the inner value to `flow`.
+> **Note:** Browsers that support the multi-keyword syntax, on finding the outer value only, such as when `display: block` or `display: inline` is specified, will set the inner value to `flow`.
 > This will result in expected behavior; for example, if you specify an element to be block, you would expect that the children of that element would participate in block and inline normal flow layout.
 
 ### Inside
@@ -105,7 +105,7 @@ The keyword values can be grouped into six value categories.
     - `ruby` {{Experimental_Inline}}
       - : The element behaves like an inline element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
-> **Note:** Browsers that support the two-value syntax, on finding the inner value only, such as when `display: flex` or `display: grid` is specified, will set their outer value to `block`.
+> **Note:** Browsers that support the multi-keyword syntax, on finding the inner value only, such as when `display: flex` or `display: grid` is specified, will set their outer value to `block`.
 > This will result in expected behavior; for example, if you specify an element to be `display: grid`, you would expect that the box created on the grid container would be a block-level box.
 
 ### List Item
@@ -118,7 +118,7 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
 
 `list-item` can also be combined with any {{CSSxRef("&lt;display-outside&gt;")}} keyword and the `flow` or `flow-root` {{CSSxRef("&lt;display-inside&gt;")}} keywords.
 
-> **Note:** In browsers that support the two-value syntax, if no inner value is specified, it will default to `flow`.
+> **Note:** In browsers that support the multi-keyword syntax, if no inner value is specified, it will default to `flow`.
 > If no outer value is specified, the principal box will have an outer display type of `block`.
 
 ### Internal
@@ -217,7 +217,7 @@ This can currently be specified using a single value.
 }
 ```
 
-For more information on these changes to the specification, see the article [Adapting to the new two-value syntax of display](/en-US/docs/Web/CSS/display/two-value_syntax_of_display).
+For more information on these changes to the specification, see the article [Adapting to the new multi-keyword syntax of display](/en-US/docs/Web/CSS/display/multi-keyword_syntax_of_display).
 
 ### Global
 
@@ -232,7 +232,7 @@ display: unset;
 
 The individual pages for the different types of value that `display` can have set on it feature multiple examples of those values in action — see the [Syntax](#syntax) section. In addition, see the following material, which covers the various values of display in depth.
 
-- [Adapting to the new two-value syntax of display](/en-US/docs/Web/CSS/display/two-value_syntax_of_display)
+- [Adapting to the new multi-keyword syntax of display](/en-US/docs/Web/CSS/display/multi-keyword_syntax_of_display)
 
 ### CSS Flow Layout (display: block, display: inline)
 
@@ -306,7 +306,7 @@ In this example we have two block-level container elements, each one with three 
 
 We've included {{cssxref("padding")}} and {{cssxref("background-color")}} on the containers and their children, so that it is easier to see the effect the display values are having.
 
-> **Note:** We've not included any of the modern two-value syntax, as support for that is still fairly limited.
+> **Note:** We've not included any of the modern multi-keyword syntax, as support for that is still fairly limited.
 
 #### HTML
 

--- a/files/en-us/web/css/display/multi-keyword_syntax_of_display/index.md
+++ b/files/en-us/web/css/display/multi-keyword_syntax_of_display/index.md
@@ -1,6 +1,6 @@
 ---
-title: Adapting to the new two-value syntax of display
-slug: Web/CSS/display/two-value_syntax_of_display
+title: Adapting to the new multi-keyword syntax of display
+slug: Web/CSS/display/multi-keyword_syntax_of_display
 page-type: guide
 tags:
   - CSS
@@ -12,7 +12,9 @@ tags:
 
 {{CSSRef}}
 
-[CSS Display Module Level 3](https://drafts.csswg.org/css-display/) describes the two-value syntax for the [`display`](/en-US/docs/Web/CSS/display) property. This guide explains the change to the syntax, including the reasoning behind this change. It also details the in-built backwards compatibility for the `display` property.
+[CSS Display Module Level 3](https://drafts.csswg.org/css-display/) describes the multi-keyword syntax for the [`display`](/en-US/docs/Web/CSS/display) property. This guide explains the change to the syntax, including the reasoning behind this change. It also details the in-built backwards compatibility for the `display` property.
+
+> **Note:** this syntax may also be referred to as "two-value syntax" or "multi-value syntax."
 
 ## What happens when we change the value of the display property?
 
@@ -32,21 +34,21 @@ As an example, when we use `display: flex` we create a block-level container, wi
 
 The live example below has a `<span>` with `display: flex` applied. It has become a block-level box taking up all available space in the inline direction. You can now use `justify-content: space-between;` to put this space between the two flex items.
 
-{{EmbedGHLiveSample("css-examples/display/two-value/span-flex.html", '100%', 440)}}
+{{EmbedGHLiveSample("css-examples/display/multi-keyword/span-flex.html", '100%', 440)}}
 
 We can create inline flex containers. If you create a flex container using the single value of `inline-flex` you will have an inline-level box with flex children. The children behave in the same way as the flex children of a block-level container. The only thing that has changed is that the parent is now an inline-level box. It therefore behaves like other inline-level things, and doesn't take up the full width (or size in the inline dimension) that a block-level box does. This means that some following text could come up alongside the flex container.
 
-{{EmbedGHLiveSample("css-examples/display/two-value/inline-flex.html", '100%', 440)}}
+{{EmbedGHLiveSample("css-examples/display/multi-keyword/inline-flex.html", '100%', 440)}}
 
 The same is true when working with grid layout. Using `display: grid` will give you a block-level box, which creates a grid formatting context for the direct children. Using `display: inline-grid` will create an inline-level box, which creates a grid formatting context for the children.
 
-## The two-value syntax
+## The multi-keyword syntax
 
 As you can see from the above explanation, the `display` property has gained considerable new powers. In addition to indicating whether something is block-level or inline-level in relationship to other boxes on the page, it now also indicates the formatting context inside the box it is applied to. In order to better describe this behavior, the `display` property has been refactored to allow for two values — an outer and inner value — to be set on it, as well as the single values we are used to.
 
 This means that instead of setting `display: flex` to create a block-level box with flex children, we will use `display: block flex`. Instead of `display: inline-flex` to create an inline-level box with flex children, we will use `display: inline flex`. The example below, which will work in Firefox 70 and upwards, demonstrates these values.
 
-{{EmbedGHLiveSample("css-examples/display/two-value/two-value-flex.html", '100%', 640)}}
+{{EmbedGHLiveSample("css-examples/display/multi-keyword/multi-keyword-flex.html", '100%', 640)}}
 
 There are mappings for all of the existing values of `display`; the most common ones are listed in the table below. To see a full list take a look at the table found in the [`display` property specification](https://drafts.csswg.org/css-display/#display-value-summary).
 
@@ -63,25 +65,25 @@ There are mappings for all of the existing values of `display`; the most common 
 
 ## display: block flow-root and display: inline flow-root
 
-In terms of how these new values help to clarify CSS layout, we can take a look at a couple of values in the table that might seem less familiar. The two-value `display: block flow-root` maps to a fairly recent single value; `display: flow-root`. This value's only purpose is to create a new [Block Formatting Context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) (BFC). A BFC ensures that everything inside your box stays inside it, and things from outside the box cannot intrude into it. The most obvious use-case for creating a new BFC is to contain floats, and avoid the need for clearfix hacks.
+In terms of how these new values help to clarify CSS layout, we can take a look at a couple of values in the table that might seem less familiar. The multi-keyword `display: block flow-root` maps to a fairly recent single value; `display: flow-root`. This value's only purpose is to create a new [Block Formatting Context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) (BFC). A BFC ensures that everything inside your box stays inside it, and things from outside the box cannot intrude into it. The most obvious use-case for creating a new BFC is to contain floats, and avoid the need for clearfix hacks.
 
 In the example below we have a floated item inside a container. The float is contained by the bordered box, which wraps it and the text alongside. If you remove the line `display: flow-root` then the float will poke out of the bottom of the box. If you are using Firefox you can replace it with the newer `display: block flow-root`, which will achieve the same as the single `flow-root` value.
 
-{{EmbedGHLiveSample("css-examples/display/two-value/block-flow-root.html", '100%', 440)}}
+{{EmbedGHLiveSample("css-examples/display/multi-keyword/block-flow-root.html", '100%', 440)}}
 
 The `flow-root` value makes sense if you think about block and inline layout, which is sometimes called [normal flow](/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow). Our HTML page creates a new formatting context (floats and margins cannot extend out from the boundaries) and our content lays out in normal flow, using block and inline layout, unless we change the value of `display` to use some other formatting context. Creating a grid or flex container also creates a new formatting context (a grid or flex formatting context, respectively.) These also contain everything inside them. However, if you want to contain floats and margins but continue using block and inline layout, you can create a new flow root, and start over with block and inline layout. From that point downwards everything is contained inside the new flow root.
 
-The two-value syntax for `display: flow-root` being `display: block flow-root` therefore makes a lot of sense. You are creating a block formatting context, with a block-level box and children participating in normal flow. What about the matched pair `display: inline flow-root`? This is the new way of describing `display: inline-block`.
+The multi-keyword syntax for `display: flow-root` being `display: block flow-root` therefore makes a lot of sense. You are creating a block formatting context, with a block-level box and children participating in normal flow. What about the matched pair `display: inline flow-root`? This is the new way of describing `display: inline-block`.
 
 The value `display: inline-block` has been around since the early days of CSS. The reason we tend to use it is to allow padding to push inline items away from an element, when creating navigation items for example, or when wanting to add a background with padding to an inline element as in the example below.
 
-{{EmbedGHLiveSample("css-examples/display/two-value/inline-block.html", '100%', 440)}}
+{{EmbedGHLiveSample("css-examples/display/multi-keyword/inline-block.html", '100%', 440)}}
 
 An element with `display: inline-block` however, will also contain floats. It contains everything inside the inline-level box. Therefore `display: inline-block` does exactly what `display: flow-root` does, but with an inline-level, rather than a block-level box. The new syntax accurately describes what is happening with this value. In the example above, you can change `display: inline-block` to `display: inline flow-root` in Firefox and get the same result.
 
 ## What about the old values of display?
 
-The single values of `display` are described in the specification as legacy values, and currently you gain no benefit from using the two-value versions, as there is a direct mapping for each two-value version to a legacy version, as demonstrated in the table above.
+The single values of `display` are described in the specification as legacy values, and currently you gain no benefit from using the multi-keyword versions, as there is a direct mapping for each multi-keyword version to a legacy version, as demonstrated in the table above.
 
 To deal with single values of `display` [the specification](https://www.w3.org/TR/css-display-3/#outer-role) explains what to do if only the outer value of `block` or `inline` is used:
 
@@ -100,7 +102,7 @@ Finally, we have some legacy [pre-composed inline-level values](https://www.w3.o
 - `inline-flex`
 - `inline-grid`
 
-If a supporting browser comes across these as single values then it treats them the same as the two-value versions:
+If a supporting browser comes across these as single values then it treats them the same as the multi-keyword versions:
 
 - `inline flow-root`
 - `inline table`
@@ -109,8 +111,8 @@ If a supporting browser comes across these as single values then it treats them 
 
 So all of the current situations are neatly covered, meaning that we maintain compatibility of existing and new sites that use the single values, while allowing the spec to evolve.
 
-## Can I start to use the two-value syntax?
+## Can I start to use the multi-keyword syntax?
 
-As demonstrated above, there is not a lot of advantage in using the two-value version right now; if you did, your page would only work in Firefox! Other browsers do not yet implement the two-value versions. Therefore `display: block flex` will only get you flex layout in Firefox and will be ignored as invalid in Chrome. You can see current support in the **Multi-keyword values** row of the [browser compatibility table for the CSS `display` property](/en-US/docs/Web/CSS/display#browser_compatibility). See also the following [Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=804600).
+As demonstrated above, there is not a lot of advantage in using the multi-keyword version right now; if you did, your page would only work in Firefox! Other browsers do not yet implement the multi-keyword versions. Therefore `display: block flex` will only get you flex layout in Firefox and will be ignored as invalid in Chrome. You can see current support in the **Multi-keyword values** row of the [browser compatibility table for the CSS `display` property](/en-US/docs/Web/CSS/display#browser_compatibility). See also the following [Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=804600).
 
-There is value in thinking about the values of `display` in this two-value way however. If you consider the outer and inner values when you change the value of `display`, you will understand immediately what impact the value will have on the box itself, and how it displays and behaves in the layout, and the direct children.
+There is value in thinking about the values of `display` in this multi-keyword way however. If you consider the outer and inner values when you change the value of `display`, you will understand immediately what impact the value will have on the box itself, and how it displays and behaves in the layout, and the direct children.


### PR DESCRIPTION
This PR renames "two-value" syntax to "multi-keyword" syntax.  In our content, we use "two-value" as the name, but in both BCD and the spec, it is defined as "multi-keyword".

This fixes https://github.com/mdn/browser-compat-data/issues/6383 (or attempts to, at least).
Depends on https://github.com/mdn/css-examples/pull/115.