### PR TITLE
Improve description of targetLength parameter

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
@@ -31,7 +31,7 @@ padEnd(targetLength, padString)
 
 - `targetLength`
   - : The length of the resulting string once the current `str` has
-    been padded. If the value is lower than `str.length`, the
+    been padded. If the value is less than or equal to `str.length`, the
     current string will be returned as-is.
 - `padString` {{optional_inline}}
   - : The string to pad the current `str` with. If

--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -34,7 +34,7 @@ padStart(targetLength, padString)
 
 - `targetLength`
   - : The length of the resulting string once the current `str` has
-    been padded. If the value is less than `str.length`, then
+    been padded. If the value is less than or equal to `str.length`, then
     `str` is returned as-is.
 - `padString` {{optional_inline}}
   - : The string to pad the current `str` with. If


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This was the provided example, where the `targetLength` of `1`, is less than `str1.length` of `2`.
Therefore, this will log `str1` as-is of `"55"`.

```
const str1 = '55';
console.log(str1.padStart(1, '0'));  // logs '55'
```

However, I also tried the following and noticed that if `targetLength` **equals** `str1.length`, this will also log `str1` as-is of `"55"`.
For example,
```
const str1 = '55';
console.log(str1.padStart(2, '0'));  // logs '55'
```
### Motivation

Clarification on the description of the `targetLength` parameter for the `String.prototype.padStart()` can help readers reduce the likelihood of introducing a bug into their codebase.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
