### PR TITLE
Correct "discord" to "Discord" in Communication Channels

### DIFF
--- a/files/en-us/mdn/community/communication_channels/index.md
+++ b/files/en-us/mdn/community/communication_channels/index.md
@@ -19,11 +19,11 @@ They are also great place to get to know other community members, share your wor
 
 ### Discord server
 
-MDN Web Docs community discord server is open to the public. This server is a great place to see what staff and members of the community are doing on a daily basis.
+MDN Web Docs community Discord server is open to the public. This server is a great place to see what staff and members of the community are doing on a daily basis.
 
 You can ask questions, seek clarifications, and find out how you can get involved. You can also join specific channels based on your areas of interest or expertise.
 
-Join the MDN Web Docs community on discord [here](https://discord.gg/apa6Rn7uEj).
+Join the MDN Web Docs community on Discord [here](https://discord.gg/apa6Rn7uEj).
 
 ### Matrix chat rooms
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
In line 22 and 26 in [communication_channels](https://github.com/mdn/content/blob/main/files/en-us/mdn/community/communication_channels/index.md?plain=1), "discord" should be spelled as "Discord" because it's referring to the communication service. This fixes that.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Same as above.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
