### PR TITLE
ci: use .nvmrc for setup-node versions

### DIFF
--- a/.github/workflows/interfacedata-updater.yml
+++ b/.github/workflows/interfacedata-updater.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Setup node.js
         uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
 
       - name: Checkout content
         uses: actions/checkout@v3

--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - .markdownlint-cli2.jsonc
+      - .nvmrc
       - package.json
       - yarn.lock
       - .github/workflows/markdown-lint.yml

--- a/.github/workflows/on-demand-preview-build.yml
+++ b/.github/workflows/on-demand-preview-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-check_javascript.yml
+++ b/.github/workflows/pr-check_javascript.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-check_javascript.yml
+++ b/.github/workflows/pr-check_javascript.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - "**/*.js"
       - "**/*.mjs"
       - .github/workflows/pr-check_javascript.yml

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - "**/*.json"
       - "**/*.jsonc"
       - .github/workflows/pr-check_json.yml

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - "**/*.md"
 
 jobs:

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - files/**
       - .github/workflows/pr-check_redirects.yml
 

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - package.json
       - yarn.lock
       - .github/workflows/pr-check_scripts.yml

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: yarn install
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: yarn install
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: yarn install
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: yarn install

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - yarn.lock
       - "**/*.yml"
       - .github/workflows/pr-check_yml.yml

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
     paths:
+      - .nvmrc
       - ".github/workflows/pr-test.yml"
       - "files/en-us/**"
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Since the `.nvmrc` file was added, makes sense to use it as the base for the CI operations. Not sure if there is any difference in the cache-key calculations when a major version changes, but that's pretty infrequent

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
