### PR TITLE
fix: strict mode example for assigning values

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -137,8 +137,8 @@ For example, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) is
 "use strict";
 
 // Assignment to a non-writable global
-var undefined = 5; // TypeError
-var Infinity = 5; // TypeError
+undefined = 5; // TypeError
+Infinity = 5; // TypeError
 
 // Assignment to a non-writable property
 const obj1 = {};


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
In [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), we can't assign values to global variables e.g. `NaN = true` should throw error. This PR fixes the code snippet, which incorrectly declares a local variable with `var undefined = 5`, when it should be referencing global `undefined`. As a result, the code snippet on MDN throws error on `obj1.x = 9;` instead of earlier lines having comments as `TypeError`. (PS: let me know if I'm missing something, thanks.)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode
This updates the example code snippet, so it works as expected.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://codesandbox.io/s/nice-flower-kcg5m8

I've recreated the issue in attached codesandbox, the faulty demo section lists current snippet, it prints the error message `Cannot assign to read only property 'x' of object '#<Object>'`. 

The correct demo section prints the error message `Cannot assign to read only property 'undefined' of object '#<Window>'`,  which follows because assigning values to globals isn't allowed.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
