### PR TITLE
docs/web/html:-Changed quirks to backCompat

### DIFF
--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -53,4 +53,4 @@ If you serve XHTML-like content using the `text/html` MIME type, browsers will r
 
 If the page is rendered in quirks or limited-quirks mode, Firefox will log a warning to the console tab in the developer tools. If this warning is not shown, Firefox is using no-quirks mode.
 
-The value of `document.compatMode` in JavaScript will show whether or not the document is in quirks mode. If its value is `"quirks"`, the document is in quirks mode. If it isn't, it will have value `"CSS1Compat"`.
+The value of `document.compatMode` in JavaScript will show whether or not the document is in quirks mode. If its value is `"BackCompat"`, the document is in quirks mode. If it isn't, it will have value `"CSS1Compat"`.


### PR DESCRIPTION
Seems like the value if the browser is in Quirks mode is updated from `quirks` to `BackCompat`

tested the same by runing a html doc without the doctype at the beginning and the results were same for Chrome,Edge and Firefox

**Edge**



https://user-images.githubusercontent.com/72331432/218294970-005ae49b-5b86-44a1-b1e7-7c368032c898.mp4



**FireFox**


https://user-images.githubusercontent.com/72331432/218294590-e27d7d77-29ba-49b1-b0fc-9ccd904fb64a.mp4

**Chrome**


https://user-images.githubusercontent.com/72331432/218294778-429bb268-371c-4cb5-93e8-fb1e096fa4ff.mp4



