### PR TITLE
Fix: HTTP 103 is experimental

### DIFF
--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -34,7 +34,7 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
   - : This code is sent in response to an {{HTTPHeader("Upgrade")}} request header from the client and indicates the protocol the server is switching to.
 - {{HTTPStatus(102, "102 Processing")}} ({{Glossary("WebDAV")}})
   - : This code indicates that the server has received and is processing the request, but no response is available yet.
-- {{HTTPStatus(103, "103 Early Hints")}}
+- {{HTTPStatus(103, "103 Early Hints")}} {{experimental_inline}}
   - : This status code is primarily intended to be used with the {{HTTPHeader("Link")}} header, letting the user agent start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources while the server prepares a response.
 
 ## Successful responses


### PR DESCRIPTION
Sources:
- browser compatibility table (end of page)
- HTTP 103 code article (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103)
- RFC8297 (https://httpwg.org/specs/rfc8297.html)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The section for the HTTP 103 response code didn't mark the code as experimental. Now it does.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was writing a TypeScript enum for response codes (marking the millionth time someone has done so) and wanted to prefix experimental/deprecated members. I noticed the compatibility table marks 103 as experimental, as does the MDN article for the response code, and after quick research so does the RFC.
The section in the page however did not, so I fixed it. 
Mostly inconsequential, but it's good to know as there are several browsers which don't support 103.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Nothing to report.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
