### PR TITLE
FF110Relnote: ReadableStream async iteration

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 110 that will aff
 - The `midi` permission of the [Permission API](/en-US/docs/Web/API/Permissions_API) is now supported.
   This allows the permission status for using the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API) to be queried using [`navigator.permissions.query()`](/en-US/docs/Web/API/Permissions/query) ({{bug(1772166)}}).
 
+- {{domxref("ReadableStream")}} now supports [asynchronous iteration over the chunks in a stream](/en-US/docs/Web/API/ReadableStream#async_iteration) using the `for await...of` syntax ({{bug(1734244)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF110 adds support for iterating through the chunks in a ReadableStream using for await of syntax.

This adds a release note. Note that this links to the section in ReadableStream  that introduces the feature. Note that it hasn't merged yet, so the anchor won't work - see https://github.com/mdn/content/pull/24310

Other docs work can be tracked in #23678