### PR TITLE
Fix typo in IFrame credentialless section

### DIFF
--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -51,7 +51,7 @@ Ensuring that your website or open web application is secure is critical. Even s
 - [Referer header policy: privacy and security concerns](/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns)
   - : There are privacy and security risks associated with the [Referer HTTP header](/en-US/docs/Web/HTTP/Headers/Referer). This article describes them and offers advice on mitigating those risks.
 - [IFrame credentialless](/en-US/docs/Web/Security/IFrame_credentialless)
-  - : Iframe credentialless provides a mechanism for developers to load third-party resources in {{htmlelement("iframe")}}s using a new, ephemeral context. This context doesn't have access to the network, cookies, and storage data associated with is origin. It uses a new context local to the top-level document lifetime. In return, the {{httpheader("Cross-Origin-Embedder-Policy")}} (COEP) embedding rules can be lifted, so documents with COEP set can embed third-party documents that do not.
+  - : Iframe credentialless provides a mechanism for developers to load third-party resources in {{htmlelement("iframe")}}s using a new, ephemeral context. This context doesn't have access to the network, cookies, and storage data associated with its origin. It uses a new context local to the top-level document lifetime. In return, the {{httpheader("Cross-Origin-Embedder-Policy")}} (COEP) embedding rules can be lifted, so documents with COEP set can embed third-party documents that do not.
 
 ## Integrity
 


### PR DESCRIPTION
### Description

Fixing a typo in the Web security docs. Change `is` -> `its`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I noticed this typo while browsing the docs. Confirmed it was a typo by [mentioning it on the original PR](https://github.com/mdn/content/pull/23351#discussion_r1103556478). Now I'd like to fix it because typos are bad and I love MDN docs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The typo is currently here: https://developer.mozilla.org/en-US/docs/Web/Security#iframe_credentialless

<img width="786" alt="image" src="https://user-images.githubusercontent.com/27938023/218344047-6f226559-cff8-4956-a07b-863e593f01e9.png">


### Related issues and pull requests

<!-- 👉 Highlight related pull requests using "Relates to #123" -->
Relates to https://github.com/mdn/content/pull/23351

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

cc/ @sideshowbarker