### PR TITLE
Document status code behavior for preflight CORS requests

### DIFF
--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -112,8 +112,8 @@ Connection: Keep-Alive
 ```
 
 ## Status Code
-Note that both [200 and 204](https://fetch.spec.whatwg.org/#ref-for-ok-status) are permitted status codes, but some browsers do not support 204s.
-See [here](https://github.com/mdn/content/issues/23571#issue-1530045601) for more details.
+
+Both {{HTTPStatus("200")}} OK and {{HTTPStatus("204") No Content are [permitted status codes](https://fetch.spec.whatwg.org/#ref-for-ok-status), but some browsers incorrectly believe `204 No Content` applies to the resource and do not send the subsequent request to fetch it.
 
 ## Specifications
 

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -61,7 +61,7 @@ curl -X OPTIONS https://example.org -i
 The response then contains an {{HTTPHeader("Allow")}} header that holds the allowed methods:
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 No Content
 Allow: OPTIONS, GET, HEAD, POST
 Cache-Control: max-age=604800
 Date: Thu, 13 Oct 2016 11:45:00 GMT
@@ -99,7 +99,7 @@ The server now can respond if it will accept a request under these circumstances
   - : The above permissions may be cached for 86,400 seconds (1 day).
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 No Content
 Date: Mon, 01 Dec 2008 01:15:39 GMT
 Server: Apache/2.0.61 (Unix)
 Access-Control-Allow-Origin: https://foo.example
@@ -110,6 +110,10 @@ Vary: Accept-Encoding, Origin
 Keep-Alive: timeout=2, max=100
 Connection: Keep-Alive
 ```
+
+## Status Code
+Note that both [200 and 204](https://fetch.spec.whatwg.org/#ref-for-ok-status) are permitted status codes, but some browsers do not support 204s.
+See [here](https://github.com/mdn/content/issues/23571#issue-1530045601) for more details.
 
 ## Specifications
 

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -113,7 +113,7 @@ Connection: Keep-Alive
 
 ## Status Code
 
-Both {{HTTPStatus("200")}} OK and {{HTTPStatus("204") No Content are [permitted status codes](https://fetch.spec.whatwg.org/#ref-for-ok-status), but some browsers incorrectly believe `204 No Content` applies to the resource and do not send the subsequent request to fetch it.
+Both {{HTTPStatus("200")}} OK and {{HTTPStatus("204")}} No Content are [permitted status codes](https://fetch.spec.whatwg.org/#ref-for-ok-status), but some browsers incorrectly believe `204 No Content` applies to the resource and do not send the subsequent request to fetch it.
 
 ## Specifications
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Document status code behavior for preflight CORS requests
Use 200 instead of 204 in examples
Link discussion in #23571 for context.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Current document uses 204 as the status code in the examples, which is not supported by all browsers, leading to developer frustration.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #23571
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
