### PR TITLE
Update explanation of access-control-allow-headers

### DIFF
--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -94,7 +94,7 @@ The server now can respond if it will accept a request under these circumstances
 - {{HTTPHeader("Access-Control-Allow-Methods")}}
   - : {{HTTPMethod("POST")}}, {{HTTPMethod("GET")}}, and `OPTIONS` are permitted methods for the URL. (This header is similar to the {{HTTPHeader("Allow")}} response header, but used only for [CORS](/en-US/docs/Web/HTTP/CORS).)
 - {{HTTPHeader("Access-Control-Allow-Headers")}}
-  - : `X-PINGOTHER` and `Content-Type` are permitted headers for the URL.
+  - : `X-PINGOTHER` and `Content-Type` are permitted request headers for the URL.
 - {{HTTPHeader("Access-Control-Max-Age")}}
   - : The above permissions may be cached for 86,400 seconds (1 day).
 

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -94,7 +94,7 @@ The server now can respond if it will accept a request under these circumstances
 - {{HTTPHeader("Access-Control-Allow-Methods")}}
   - : {{HTTPMethod("POST")}}, {{HTTPMethod("GET")}}, and `OPTIONS` are permitted methods for the URL. (This header is similar to the {{HTTPHeader("Allow")}} response header, but used only for [CORS](/en-US/docs/Web/HTTP/CORS).)
 - {{HTTPHeader("Access-Control-Allow-Headers")}}
-  - : Any script inspecting the response is permitted to read the values of the `X-PINGOTHER` and `Content-Type` headers.
+  - : `X-PINGOTHER` and `Content-Type` are permitted headers for the URL.
 - {{HTTPHeader("Access-Control-Max-Age")}}
   - : The above permissions may be cached for 86,400 seconds (1 day).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Make the explanation clearer that the access-control-allow-headers indicate that the specified headers are permitted, to avoid confusion with the use and meaning of access-ccontrol-expose-headers.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix issue.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
- https://http.dev/access-control-allow-headers
- https://http.dev/access-control-expose-headers
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #24272
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
