### PR TITLE
Revert django template location

### DIFF
--- a/files/en-us/learn/server-side/django/forms/index.md
+++ b/files/en-us/learn/server-side/django/forms/index.md
@@ -403,7 +403,7 @@ def renew_book_librarian(request, pk):
         'book_instance': book_instance,
     }
 
-    return render(request, 'book_renew_librarian.html', context)
+    return render(request, 'catalog/book_renew_librarian.html', context)
 ```
 
 ### The template


### PR DESCRIPTION
Revert "fix" added in #23529

This was just wrong. The original code worked, and this will not, given the settings configured for the project.
