### PR TITLE
Remove the reference to "beast" class in index.md

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -317,8 +317,8 @@ A common reason the `browser.tabs.executeScript()` call might fail is that you c
 
 If executing the content script is successful, we call `listenForClicks()`. This listens for clicks on the popup.
 
-- If the click was on a button with `class="beast"`, then we call `beastify()`.
 - If the click was on a button with `class="reset"`, then we call `reset()`.
+- If the click was on any other button (i.e. the beast buttons), then we call `beastify()`.
 
 The `beastify()` function does three things:
 


### PR DESCRIPTION
### Description

I've removed the reference to the `class="beast"` for the description of `listenForClicks()` in the "Your second extension" tutorial, as there's no button with a "beast" class, and the code doesn't check for any class other than "reset".

I've also changed the order of the list to make it read more clearly with the change I've made.

### Motivation

Readers might be confused as to what buttons the tutorial is referring to.
