### PR TITLE
Window.close can also be called on some windows opened by the user

### DIFF
--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -18,7 +18,7 @@ The **`Window.close()`** method closes the current window, or
 the window on which it was called.
 
 This method can only be called on windows that were opened by a script using the
-{{domxref("Window.open()")}} method. If the window was not opened by a script, an error
+{{domxref("Window.open()")}} method, or on top-level windows that have a single history entry. If the window doesn't match these requirements, an error
 similar to this one appears in the console:
 `Scripts may not close windows that were not opened by script.`
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the description of the method to also include the case of pages opened by the user with a single history entry.

### Motivation

The previous text was claiming that only pages opened via scripts could be closed through this method. 

### Additional details

However [the specs](https://html.spec.whatwg.org/multipage/nav-history-apis.html#script-closable) say that even "top-level traversable[s] whose session history entries's size is 1" can be closed this way.   You can see an example of that happening in https://closable-navigable.glitch.me/

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
