### PR TITLE
RTCRtpSender get/set params changes

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
@@ -18,9 +18,7 @@ browser-compat: api.RTCPeerConnection.addTrack
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCPeerConnection")}} method
-**`addTrack()`** adds a new media track to the set of tracks
-which will be transmitted to the other peer.>
+The {{domxref("RTCPeerConnection")}} method **`addTrack()`** adds a new media track to the set of tracks which will be transmitted to the other peer.
 
 > **Note:** Adding a track to a connection triggers renegotiation by
 > firing a {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event. See

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
@@ -22,11 +22,7 @@ browser-compat: api.RTCRtpReceiver.getParameters
 
 {{APIRef("WebRTC API")}}
 
-The **`getParameters()`** method of
-the {{domxref("RTCRtpReceiver")}} interface returns an
-{{domxref("RTCRtpReceiveParameters")}} object describing the current configuration for
-the encoding and transmission of media on the receiver's
-{{domxref("RTCRtpReceiver.track", "track")}}.
+The **`getParameters()`** method of the {{domxref("RTCRtpReceiver")}} interface returns an {{domxref("RTCRtpReceiveParameters")}} object describing the current configuration for the encoding and transmission of media on the receiver's {{domxref("RTCRtpReceiver.track", "track")}}.
 
 ## Syntax
 
@@ -40,13 +36,11 @@ None.
 
 ### Return value
 
-An {{domxref("RTCRtpReceiveParameters")}} object indicating the current configuration
-of the receiver.
+An {{domxref("RTCRtpReceiveParameters")}} object indicating the current configuration of the receiver.
 
 ## Examples
 
-This example obtains the canonical name (CNAME) being used for {{Glossary("RTCP")}} on
-an {{domxref("RTCRtpReceiver")}}.
+This example obtains the canonical name (CNAME) being used for {{Glossary("RTCP")}} on an {{domxref("RTCRtpReceiver")}}.
 
 ```js
 function getRtcpCNAME(receiver) {

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
@@ -22,7 +22,7 @@ browser-compat: api.RTCRtpReceiver.getParameters
 
 {{APIRef("WebRTC API")}}
 
-The **`getParameters()`** method of the {{domxref("RTCRtpReceiver")}} interface returns an {{domxref("RTCRtpReceiveParameters")}} object describing the current configuration for the encoding and transmission of media on the receiver's {{domxref("RTCRtpReceiver.track", "track")}}.
+The **`getParameters()`** method of the {{domxref("RTCRtpReceiver")}} interface returns an object describing the current configuration for the encoding and transmission of media on the receiver's {{domxref("RTCRtpReceiver.track", "track")}}.
 
 ## Syntax
 
@@ -36,7 +36,20 @@ None.
 
 ### Return value
 
-An {{domxref("RTCRtpReceiveParameters")}} object indicating the current configuration of the receiver.
+An object indicating the current configuration of the receiver. <!-- RTCRtpReceiveParameters in spec -->
+
+- `codecs`
+  - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the receiver will choose.
+    This parameter cannot be changed once initially set.
+- `headerExtensions`
+  - : An array of zero or more RTP header extensions, each identifying an extension supported by the sender or receiver.
+    Header extensions are described in {{RFC(3550, "", "5.3.1")}}. This parameter cannot be changed once initially set.
+- `rtcp`
+  - : An {{domxref("RTCRtcpParameters")}} object providing the configuration parameters used for {{Glossary("RTCP")}} on the sender or receiver.
+    This parameter cannot be changed once initially set.
+- `degradationPreference` {{deprecated_inline}} {{optional_inline}}
+  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`.
+    The default value is `balanced`.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.md
@@ -21,26 +21,30 @@ None.
 
 ### Return value
 
-An object indicating the current configuration of the sender. <!-- RTCRtpSendParameters, derived from RTCRtpParameters -->
+An object indicating the current configuration of the sender.
 
 <!-- spec defines following in RTCRtpSendParameters -->
 - `encodings`
-  - : An array of {{domxref("RTCRtpEncodingParameters")}} objects, each specifying the parameters and settings for a single codec that could be used to encode the track's media.
+  - : An array of {{domxref("RTCRtpEncodingParameters")}} objects, each specifying the parameters and settings that describe and configure a single [codec](#codecs) used to configure the {{domxref("RTCRtpSender")}}'s {{domxref("RTCRtpSender.track", "track")}} for a single destination (peer).
 
     In a connection in which there's only one remote peer, the `encodings` array will have just one object in it, describing the encoding to use when transmitting to that peer.
     For each peer you add the {{domxref("RTCRtpSender")}} to, another entry is added to `encodings` to describe its configuration.
-
-- {{domxref("RTCRtpSendParameters.transactionId", "transactionId")}}
-  - : A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}. Once this parameter is initially set, it cannot be changed.
+- `transactionId`
+  - : A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}.
+    Once this parameter is initially set, it cannot be changed.
 <!-- spec defines following in RTCRtpParameters -->
-- {{domxref("RTCRtpParameters.codecs", "codecs")}}
-  - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the sender or receiver will choose. This parameter cannot be changed once initially set.
-- {{domxref("RTCRtpParameters.headerExtensions", "headerExtensions")}}
-  - : An array of zero or more RTP header extensions, each identifying an extension supported by the sender or receiver. Header extensions are described in {{RFC(3550, "", "5.3.1")}}. This parameter cannot be changed once initially set.
-- {{domxref("RTCRtpParameters.rtcp", "rtcp")}}
-  - : An {{domxref("RTCRtcpParameters")}} object providing the configuration parameters used for {{Glossary("RTCP")}} on the sender or receiver. This parameter cannot be changed once initially set.
-- {{domxref("RTCRtpSendParameters.degradationPreference", "degradationPreference")}} {{deprecated_inline}} {{optional_inline}}
-  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`. The default value is `balanced`.
+- `codecs`
+  - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the sender or receiver will choose.
+    This parameter cannot be changed once initially set.
+- `headerExtensions`
+  - : An array of zero or more RTP header extensions, each identifying an extension supported by the sender or receiver.
+    Header extensions are described in {{RFC(3550, "", "5.3.1")}}. This parameter cannot be changed once initially set.
+- `rtcp`
+  - : An {{domxref("RTCRtcpParameters")}} object providing the configuration parameters used for {{Glossary("RTCP")}} on the sender or receiver.
+    This parameter cannot be changed once initially set.
+- `degradationPreference` {{deprecated_inline}} {{optional_inline}}
+  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`.
+    The default value is `balanced`.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.md
@@ -34,7 +34,7 @@ An object indicating the current configuration of the sender.
     Once this parameter is initially set, it cannot be changed.
 <!-- spec defines following in RTCRtpParameters -->
 - `codecs`
-  - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the sender or receiver will choose.
+  - : An array of {{domxref("RTCRtpCodecParameters")}} objects describing the set of codecs from which the sender will choose.
     This parameter cannot be changed once initially set.
 - `headerExtensions`
   - : An array of zero or more RTP header extensions, each identifying an extension supported by the sender or receiver.

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -21,16 +21,9 @@ browser-compat: api.RTCRtpSender.setParameters
 
 {{APIRef("WebRTC API")}}
 
-The **`setParameters()`** method of
-the {{domxref("RTCRtpSender")}} interface applies changes the configuration of
-sender's {{domxref("RTCRtpSender.track", "track")}}, which is the
-{{domxref("MediaStreamTrack")}} for which the `RTCRtpSender` is
-responsible.
+The **`setParameters()`** method of the {{domxref("RTCRtpSender")}} interface applies changes the configuration of sender's {{domxref("RTCRtpSender.track", "track")}}, which is the {{domxref("MediaStreamTrack")}} for which the `RTCRtpSender` is responsible.
 
-In other words, `setParameters()` updates the configuration of the
-{{Glossary("RTP")}} transmission as well as the encoding configuration for a specific
-outgoing media track on the [WebRTC](/en-US/docs/Web/API/WebRTC_API)
-connection.
+In other words, `setParameters()` updates the configuration of the {{Glossary("RTP")}} transmission as well as the encoding configuration for a specific outgoing media track on the [WebRTC](/en-US/docs/Web/API/WebRTC_API) connection.
 
 ## Syntax
 
@@ -42,44 +35,38 @@ setParameters(parameters)
 
 - `parameters`
 
-  - : A parameters object previously obtained by calling the same
-    sender's {{domxref("RTCRtpSender.getParameters", "getParameters()")}} method, with
-    the desired changes to the sender's configuration parameters. These parameters
-    include potential codecs that could be use for encoding the sender's
-    {{domxref("RTCRtpSender.track", "track")}}. The available parameters are:
+  - : A parameters object previously obtained by calling the same sender's {{domxref("RTCRtpSender.getParameters", "getParameters()")}} method, with the desired changes to the sender's configuration parameters.
+      These parameters include potential codecs that could be use for encoding the sender's {{domxref("RTCRtpSender.track", "track")}}.
+      The available parameters are:
 
     - `encodings`
       - : An array of {{domxref("RTCRtpEncodingParameters")}} objects, each specifying the parameters for a single codec that could be used to encode the track's media.
     - `transactionId`
-      - : A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}. Once this parameter is initially set, it cannot be changed.
+      - : A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}.
+        Once this parameter is initially set, it cannot be changed.
     - `degradationPreference` {{deprecated_inline}}
       - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`. The default value is `balanced`.
     - `priority` {{deprecated_inline}}
-      - : A string that indicates the encoding's priority. It is one of: `very-low`, `low`, `medium`, or `high`. The default value is `low`.
+      - : A string that indicates the encoding's priority. It is one of: `very-low`, `low`, `medium`, or `high`.
+        The default value is `low`.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves when the {{domxref("RTCRtpSender.track")}}
-property is updated with the given parameters.
+A {{jsxref("Promise")}} that resolves when the {{domxref("RTCRtpSender.track")}} property is updated with the given parameters.
 
 ### Exceptions
 
-If an error occurs, the returned promise is rejected with the appropriate exception
-from the list below.
+If an error occurs, the returned promise is rejected with the appropriate exception from the list below.
 
 - `InvalidModificationError` {{domxref("DOMException")}}
   - : Returned if one of the following problems is detected:
-    - The number of encodings specified in the `parameters` object's
-      {{domxref("RTCRtpSendParameters.encodings", "encodings")}} property does not match
-      the number of encodings currently listed for the `RTCRtpSender`. You
-      cannot change the number of encoding options after the sender has been created.
-    - The order of the specified `encodings` has changed from the current
-      list's order.
-    - An attempt has been made to alter a property that cannot be changed after the
-      sender is first created.
+
+    - The number of encodings specified in the `parameters` object's {{domxref("RTCRtpSendParameters.encodings", "encodings")}} property does not match the number of encodings currently listed for the `RTCRtpSender`.
+      You cannot change the number of encoding options after the sender has been created.
+    - The order of the specified `encodings` has changed from the current list's order.
+    - An attempt has been made to alter a property that cannot be changed after the sender is first created.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the transceiver, of which the `RTCRtpSender` is a part, is not running or
-    has no parameters to set.
+  - : Returned if the transceiver, of which the `RTCRtpSender` is a part, is not running or has no parameters to set.
 - `OperationError` {{domxref("DOMException")}}
   - : Returned if an error occurs that does not match the ones specified here.
 - {{jsxref("RangeError")}}
@@ -89,35 +76,22 @@ In addition, if a WebRTC error occurs while configuring or accessing the media, 
 
 ## Description
 
-It's important to keep in mind that you can't create an
-{{domxref("RTCRtpSendParameters")}} object yourself and expect it to work. Instead, you
-_must_ first call {{domxref("RTCRtpSender.getParameters", "getParameters()")}},
-modify the received parameters object, then pass that object into
-`setParameters()`. WebRTC uses the parameters object's
-`transactionId` property to ensure that when you set parameters, your changes
-are based on the most recent parameters rather than an out of date configuration.
+It's important to keep in mind that you can't create an {{domxref("RTCRtpSendParameters")}} object yourself and expect it to work.
+Instead, you _must_ first call {{domxref("RTCRtpSender.getParameters", "getParameters()")}}, modify the received parameters object, then pass that object into `setParameters()`.
+WebRTC uses the parameters object's `transactionId` property to ensure that when you set parameters, your changes are based on the most recent parameters rather than an out of date configuration.
 
 ## Examples
 
-One use case for `setParameters()` is to try to reduce network bandwidth use
-in constrained environments by altering the resolution and/or bit rate of the media
-being transmitted by the {{domxref("RTCRtpSender")}}.
+One use case for `setParameters()` is to try to reduce network bandwidth use in constrained environments by altering the resolution and/or bit rate of the media being transmitted by the {{domxref("RTCRtpSender")}}.
 
-Currently, some browsers have limitations on their implementations that may cause
-issues. For that reason, two examples are given here. The first shows how to use
-`setParameters()` when all browsers fully support the parameters being used,
-while the second example demonstrates workarounds to help solve limitations in browsers
-with incomplete support for the {{domxref("RTCRtpEncodingParameters.maxBitrate",
-  "maxBitrate")}} and {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy",
-  "scaleResolutionDownBy")}} parameters.
+Currently, some browsers have limitations on their implementations that may cause issues. For that reason, two examples are given here. The first shows how to use `setParameters()` when all browsers fully support the parameters being used, while the second example demonstrates workarounds to help solve limitations in browsers with incomplete support for the {{domxref("RTCRtpEncodingParameters.maxBitrate", "maxBitrate")}} and {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} parameters.
 
 ### By the specification
 
-Once all browsers implement the spec fully, this implementation of
-`setVideoParams()` will do the job. This demonstrates how everything
-_should_ work. You should probably use the second example, below, for now. But
-this is a clearer demonstration of the basic concept of first fetching the parameters,
-then altering them, then setting them.
+Once all browsers implement the spec fully, this implementation of `setVideoParams()` will do the job. This demonstrates how everything
+_should_ work.
+You should probably use the second example, below, for now.
+But this is a clearer demonstration of the basic concept of first fetching the parameters, then altering them, then setting them.
 
 ```js
 async function setVideoParams(sender, height, bitrate) {
@@ -130,27 +104,19 @@ async function setVideoParams(sender, height, bitrate) {
 }
 ```
 
-In calling this function, you specify a sender, as well as the height you wish to
-scale the sender's video to, as well as a maximum bitrate to permit the sender to
-transmit. A scaling factor for the size of the video, `scaleRatio`, is
-computed. Then the sender's current parameters are fetched using
-{{domxref("RTCRtpSender.getParameters", "getParameters()")}}.
+In calling this function, you specify a sender, as well as the height you wish to scale the sender's video to, as well as a maximum bitrate to permit the sender to transmit.
+A scaling factor for the size of the video, `scaleRatio`, is computed. Then the sender's current parameters are fetched using {{domxref("RTCRtpSender.getParameters", "getParameters()")}}.
 
-The parameters are then altered by changing the first
-{{domxref("RTCRtpSendParameters.encodings", "encodings")}} object's
-{{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}}
-and {{domxref("RTCRtpEncodingParameters.maxBitrate", "maxBitrate")}} to the calculated
-scaling factor and the specified maximum `bitrate`.
+The parameters are then altered by changing the first {{domxref("RTCRtpSendParameters.encodings", "encodings")}} object's {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}}
+and {{domxref("RTCRtpEncodingParameters.maxBitrate", "maxBitrate")}} to the calculated scaling factor and the specified maximum `bitrate`.
 
-The changed parameters are then saved by calling the sender's
-`setParameters()` method.
+The changed parameters are then saved by calling the sender's `setParameters()` method.
 
 ### Currently compatible implementation
 
 As mentioned above, the previous example shows how things are meant to work.
-Unfortunately, there are implementation issues preventing this in many browsers right
-now. For that reason, if you want to be compatible with iPhone and other devices running
-Safari, and with Firefox, use code more like this:
+Unfortunately, there are implementation issues preventing this in many browsers right now.
+For that reason, if you want to be compatible with iPhone and other devices running Safari, and with Firefox, use code more like this:
 
 ```js
 async function setVideoParams(sender, height, bitrate) {
@@ -179,16 +145,11 @@ async function setVideoParams(sender, height, bitrate) {
 
 The differences here:
 
-- If `encodings` is `null`, we create it, in order to ensure
-  that we can then set the parameters successfully without crashing.
-- If, after setting the parameters, the value of `scaleResolutionDownBy` is
-  still 1, we call the sender's track's {{domxref("MediaStreamTrack.applyConstraints",
-    "applyConstraints()")}} method to constrain the track's height to `height`.
-  This compensates for an unimplemented `scaleResolutionDownBy` (as is the
-  case in Safari as of this writing).
+- If `encodings` is `null`, we create it, in order to ensure that we can then set the parameters successfully without crashing.
+- If, after setting the parameters, the value of `scaleResolutionDownBy` is still 1, we call the sender's track's {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} method to constrain the track's height to `height`.
+  This compensates for an unimplemented `scaleResolutionDownBy` (as is the case in Safari as of this writing).
 
-This code will cleanly fall back and work the normal way if the browser fully
-implements the used features.
+This code will cleanly fall back and work the normal way if the browser fully implements the used features.
 
 ## Specifications
 


### PR DESCRIPTION
This is updates to bring the WebRTC pages around getting params to current way of doing things. Part of #23677