### PR TITLE
Add missing MediaList subpages

### DIFF
--- a/files/en-us/web/api/medialist/appendmedium/index.md
+++ b/files/en-us/web/api/medialist/appendmedium/index.md
@@ -26,7 +26,7 @@ None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
 
 ## Examples
 
-The following adss the media type `print` into the
+The following adds the media type `print` into the
 `MediaList` associated with the first stylesheet applied to the current document.
 
 ```js

--- a/files/en-us/web/api/medialist/appendmedium/index.md
+++ b/files/en-us/web/api/medialist/appendmedium/index.md
@@ -1,0 +1,43 @@
+---
+title: MediaList.appendMedium()
+slug: Web/API/MediaList/appendMedium
+page-type: web-api-instance-method
+browser-compat: api.MediaList.appendMedium 
+---
+
+{{APIRef("CSSOM")}}
+
+The `appendMedium()` method of the {{DomxRef("MediaList")}} interface add a media type to the list. If the media type is already in it, this method does nothing.
+
+## Syntax
+
+```js-nolint
+appendMedium(medium)
+```
+
+### Parameters
+
+- `medium`
+  - : A string containing the medium to add.
+
+### Return value
+
+None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
+
+## Examples
+
+The following adss the media type `print` into the
+`MediaList` associated with the first stylesheet applied to the current document.
+
+```js
+const stylesheet = document.styleSheets[0];
+stylesheet.media.appendMedium("print");
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/medialist/appendmedium/index.md
+++ b/files/en-us/web/api/medialist/appendmedium/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaList.appendMedium
 
 {{APIRef("CSSOM")}}
 
-The `appendMedium()` method of the {{DomxRef("MediaList")}} interface add a media query to the list. If the media query is already in the collection, this method does nothing.
+The `appendMedium()` method of the {{DomxRef("MediaList")}} interface adds a media query to the list. If the media query is already in the collection, this method does nothing.
 
 ## Syntax
 

--- a/files/en-us/web/api/medialist/appendmedium/index.md
+++ b/files/en-us/web/api/medialist/appendmedium/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaList.appendMedium
 
 {{APIRef("CSSOM")}}
 
-The `appendMedium()` method of the {{DomxRef("MediaList")}} interface add a media type to the list. If the media type is already in it, this method does nothing.
+The `appendMedium()` method of the {{DomxRef("MediaList")}} interface add a media query to the list. If the media query is already in the collection, this method does nothing.
 
 ## Syntax
 
@@ -18,7 +18,7 @@ appendMedium(medium)
 ### Parameters
 
 - `medium`
-  - : A string containing the medium to add.
+  - : A string containing the media query to add.
 
 ### Return value
 
@@ -26,7 +26,7 @@ None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
 
 ## Examples
 
-The following adds the media type `print` into the
+The following adds the media query `print` into the
 `MediaList` associated with the first stylesheet applied to the current document.
 
 ```js

--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -31,7 +31,7 @@ None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
 
 ## Examples
 
-The following removes the media query `print` into the
+The following removes the media query `print` from the
 `MediaList` associated with the first stylesheet applied to the current document.
 
 ```js

--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -7,7 +7,6 @@ browser-compat: api.MediaList.deleteMedium
 
 {{APIRef("CSSOM")}}
 
-TOWRITE: Complete the summary paragraph
 The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removed the media type given in parameter from the list.
 
 ## Syntax

--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -1,0 +1,49 @@
+---
+title: MediaList.deleteMedium()
+slug: Web/API/MediaList/deleteMedium
+page-type: web-api-instance-method
+browser-compat: api.MediaList.deleteMedium 
+---
+
+{{APIRef("CSSOM")}}
+
+TOWRITE: Complete the summary paragraph
+The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removed the media type given in parameter from the list.
+
+## Syntax
+
+```js-nolint
+deleteMedium(medium)
+```
+
+### Parameters
+
+- `medium`
+  - : A string containing the media type to remove from the list.
+
+### Return value
+
+None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
+
+### Exceptions
+
+- `NotFoundError` {{domxref("DOMException")}}
+  - : Thrown when the media type to remove is not in the list.
+
+## Examples
+
+The following removes the media type `print` into the
+`MediaList` associated with the first stylesheet applied to the current document.
+
+```js
+const stylesheet = document.styleSheets[0];
+stylesheet.media.removeMedium("print");
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaList.deleteMedium
 
 {{APIRef("CSSOM")}}
 
-The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removed the media typquerye given in parameter from the list.
+The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removes from this `MediaList` the given media query.
 
 ## Syntax
 

--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaList.deleteMedium
 
 {{APIRef("CSSOM")}}
 
-The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removed the media type given in parameter from the list.
+The `deleteMedium()` method of the {{DOMxRef("MediaList")}} interface removed the media typquerye given in parameter from the list.
 
 ## Syntax
 
@@ -18,7 +18,7 @@ deleteMedium(medium)
 ### Parameters
 
 - `medium`
-  - : A string containing the media type to remove from the list.
+  - : A string containing the media query to remove from the list.
 
 ### Return value
 
@@ -27,11 +27,11 @@ None ([undefined](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
 ### Exceptions
 
 - `NotFoundError` {{domxref("DOMException")}}
-  - : Thrown when the media type to remove is not in the list.
+  - : Thrown when the media query to remove is not in the list.
 
 ## Examples
 
-The following removes the media type `print` into the
+The following removes the media query `print` into the
 `MediaList` associated with the first stylesheet applied to the current document.
 
 ```js

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -31,7 +31,7 @@ The **`MediaList`** interface represents the media queries of a stylesheet, e.g.
 - {{domxref("MediaList.deleteMedium()")}}
   - : Removes a media query from the `MediaList`.
 - {{domxref("MediaList.item()")}}
-  - : A getter that returns a string representing a media query as text, given the media query's index value inside the `MediaList`.
+  - : A getter that returns a string representing a media query as text, given the media query's index value inside the `MediaList`. This methods can also be called using the bracket (`[]`) syntax.
 
 ## Examples
 

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -31,7 +31,7 @@ The **`MediaList`** interface represents the media queries of a stylesheet, e.g.
 - {{domxref("MediaList.deleteMedium()")}}
   - : Removes a media query from the `MediaList`.
 - {{domxref("MediaList.item()")}}
-  - : A getter that returns a string representing a media query as text, given the media query's index value inside the `MediaList`. This methods can also be called using the bracket (`[]`) syntax.
+  - : A getter that returns a string representing a media query as text, given the media query's index value inside the `MediaList`. This method can also be called using the bracket (`[]`) syntax.
 
 ## Examples
 

--- a/files/en-us/web/api/medialist/item/index.md
+++ b/files/en-us/web/api/medialist/item/index.md
@@ -16,7 +16,7 @@ item(index)
 [index]
 ```
 
-> **Note:** The natural bracket (`[]`) syntax can be used instead of the more verbose `item()` syntax.
+> **Note:** The bracket (`[]`) syntax can be used instead of the `item()` syntax.
 
 ### Parameters
 

--- a/files/en-us/web/api/medialist/item/index.md
+++ b/files/en-us/web/api/medialist/item/index.md
@@ -16,7 +16,7 @@ item(index)
 [index]
 ```
 
-> **Note:** The `[]` syntax can be used instead of the more verbose `item()` syntax.
+> **Note:** The natural bracket (`[]`) syntax can be used instead of the more verbose `item()` syntax.
 
 ### Parameters
 
@@ -27,7 +27,7 @@ item(index)
 
 A string, or `null` if there is no entry for the index.
 
-If there is no entry for the given index, and using the `[]` syntax, `undefined` is returned.
+If there is no entry for the given index, and using the bracket (`[]`) syntax, `undefined` is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/medialist/item/index.md
+++ b/files/en-us/web/api/medialist/item/index.md
@@ -1,0 +1,52 @@
+---
+title: MediaList.item()
+slug: Web/API/MediaList/item
+page-type: web-api-instance-method
+browser-compat: api.MediaList.item
+---
+
+{{ APIRef("CSSOM") }}
+
+The **`item()`** method of the {{domxref("MediaList")}} interface returns the media query at the specified `index`, or `null` if the specified `index` doesn't exist.
+
+## Syntax
+
+```js-nolint
+item(index)
+[index]
+```
+
+> **Note:** The `[]` syntax can be used instead of the more verbose `item()` syntax.
+
+### Parameters
+
+- `index`
+  - : An integer.
+
+### Return value
+
+A string, or `null` if there is no entry for the index.
+
+If there is no entry for the given index, and using the `[]` syntax, `undefined` is returned.
+
+## Examples
+
+The following would log to the console each media query stored in the
+`MediaList` associated with the first stylesheet applied to the current document.
+
+```js
+const stylesheet = document.styleSheets[0];
+console.log(stylesheet.media.length);
+console.log(stylesheet.media.item(0)); // Returns a string like "print"
+console.log(stylesheet.media.item(5)); // Returns null if there is no 5th entry
+console.log(stylesheet.media[1]); // Returns a string like "print"
+console.log(stylesheet.media[5]); // Returns undefined if there is no 5th entry
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/medialist/item/index.md
+++ b/files/en-us/web/api/medialist/item/index.md
@@ -25,9 +25,7 @@ item(index)
 
 ### Return value
 
-A string, or `null` if there is no entry for the index.
-
-If there is no entry for the given index, and using the bracket (`[]`) syntax, `undefined` is returned.
+If the bracket (`[]`) syntax is used and there is no entry for the given index, `undefined` is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/medialist/length/index.md
+++ b/files/en-us/web/api/medialist/length/index.md
@@ -5,6 +5,7 @@ page-type: web-api-instance-property
 
 browser-compat: api.MediaList.length
 ---
+
 {{APIRef("CSSOM")}}
 
 The read-only **`length`** property of the {{DOMxRef("MediaList")}} interface returns the number of media queries in the list

--- a/files/en-us/web/api/medialist/length/index.md
+++ b/files/en-us/web/api/medialist/length/index.md
@@ -21,7 +21,7 @@ The following would log to the console the number of media queries stored in the
 
 ```js
 const stylesheets = document.styleSheets;
-let stylesheet = stylesheets[0];
+const stylesheet = stylesheets[0];
 console.log(stylesheet.media.length);
 ```
 

--- a/files/en-us/web/api/medialist/length/index.md
+++ b/files/en-us/web/api/medialist/length/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MediaList.length
 
 {{APIRef("CSSOM")}}
 
-The read-only **`length`** property of the {{DOMxRef("MediaList")}} interface returns the number of media queries in the list
+The read-only **`length`** property of the {{DOMxRef("MediaList")}} interface returns the number of media queries in the list.
 
 ## Value
 

--- a/files/en-us/web/api/medialist/length/index.md
+++ b/files/en-us/web/api/medialist/length/index.md
@@ -1,0 +1,33 @@
+---
+title: MediaList.length
+slug: Web/API/MediaList/length
+page-type: web-api-instance-property
+
+browser-compat: api.MediaList.length
+---
+{{APIRef("CSSOM")}}
+
+The read-only **`length`** property of the {{DOMxRef("MediaList")}} interface returns the number of media queries in the list
+
+## Value
+
+A positive integer.
+
+## Examples
+
+The following would log to the console the number of media queries stored in the
+`MediaList` associated with the first stylesheet applied to the current document.
+
+```js
+const stylesheets = document.styleSheets;
+let stylesheet = stylesheets[0];
+console.log(stylesheet.media.length);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -266,11 +266,11 @@
         "/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information"
       ],
       "interfaces": [
-        "AnimationEvent",
         "CaretPosition",
         "CSS",
         "CSSConditionRule",
         "CSSGroupingRule",
+        "CSSImportRule",
         "CSSKeyframeRule",
         "CSSKeyframesRule",
         "CSSMediaRule",
@@ -282,11 +282,11 @@
         "CSSStyleRule",
         "CSSStyleSheet",
         "CSSSupportsRule",
+        "MediaList",
         "MediaQueryList",
         "Screen",
         "StyleSheet",
-        "StyleSheetList",
-        "TransitionEvent"
+        "StyleSheetList"
       ],
       "dictionaries": ["ScrollToOptions"],
       "methods": [],


### PR DESCRIPTION
This is part of openwebdocs/project#152

Although supported by all three major engines, several methods, and properties, of the basic `MediaList` instance were not documented. This PR adds them.

Note that I have added non-live examples only as the result is not visual (and very complex as the stylesheet of the Live Sample gets in the way).