### PR TITLE
Update FF110 release note for input type color list attribute

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -25,6 +25,7 @@ This article provides information about the changes in Firefox 110 that will aff
 - Container queries and container query length units are now supported by default.
   For more information on these queries and the related units of length, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_Container_Queries#container_query_length_units) documentation ({{bug(1809720)}}).
 - The [color-gamut media query](/en-US/docs/Web/CSS/@media/color-gamut) is now supported ({{bug(1422237)}}).
+- The [`list`](/en-US/docs/Web/HTML/Element/datalist#color_type) attribute of the `<input>` element type `color` is now supported in Windows and Linux ({{bug(960984)}}).
 
 #### Removals
 


### PR DESCRIPTION
Firefox 110 supports the list attribute on Windows and Linux via https://bugzilla.mozilla.org/show_bug.cgi?id=960984.
This pull request updates the release note.

MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist#color_type

Doc issue tracker: https://github.com/mdn/content/issues/23684