### PR TITLE
Clarify that `HashChangeEvent.prototype.{newURL,oldURL}` is a String

### DIFF
--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -33,7 +33,7 @@ A {{domxref("HashChangeEvent")}}. Inherits from {{domxref("Event")}}.
 ## Event properties
 
 - {{domxref("HashChangeEvent.newURL")}} {{ReadOnlyInline}}
-  - : The new URL to which the window is navigating. A {{jsxref("String")}}.
+  - : A string representing the new URL the window is navigating to.
 - {{domxref("HashChangeEvent.oldURL")}} {{ReadOnlyInline}}
   - : The previous URL from which the window was navigated. A {{jsxref("String")}}.
 

--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -35,7 +35,7 @@ A {{domxref("HashChangeEvent")}}. Inherits from {{domxref("Event")}}.
 - {{domxref("HashChangeEvent.newURL")}} {{ReadOnlyInline}}
   - : A string representing the new URL the window is navigating to.
 - {{domxref("HashChangeEvent.oldURL")}} {{ReadOnlyInline}}
-  - : The previous URL from which the window was navigated. A {{jsxref("String")}}.
+  - : A string representing the previous URL from which the window was navigated.
 
 ## Event handler aliases
 

--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -33,9 +33,9 @@ A {{domxref("HashChangeEvent")}}. Inherits from {{domxref("Event")}}.
 ## Event properties
 
 - {{domxref("HashChangeEvent.newURL")}} {{ReadOnlyInline}}
-  - : The new URL to which the window is navigating.
+  - : The new URL to which the window is navigating. A {{jsxref("String")}}.
 - {{domxref("HashChangeEvent.oldURL")}} {{ReadOnlyInline}}
-  - : The previous URL from which the window was navigated.
+  - : The previous URL from which the window was navigated. A {{jsxref("String")}}.
 
 ## Event handler aliases
 


### PR DESCRIPTION
### Description

Existing text unclear whether `newURL` and `oldURL` properties are URL or String objects.

They are String's. Add link.

### Motivation

Make the https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent page quicker to understand.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
