### PR TITLE
FF110 RelNote: WebRTC changes RTPSender, addTransciever etc

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -42,6 +42,8 @@ No notable changes.
   Specifically, {{domxref("RTCPeerConnection.addTransceiver()")}} now supports using the [`sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) option in the [`init`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#init) parameter object, and [`RTCRtpEncodingParameters.active`](/en-US/docs/Web/API/RTCRtpEncodingParameters#active) can be used to determine whether or not the encoding is being used to send data.
   (See {{bug(1676855)}} for more details.)
 
+- WebRTC methods {{domxref("RTCRtpSender.getParameters()")}}, {{domxref("RTCRtpSender.setParameters()")}}, and {{domxref("RTCRtpReceiver.getParameters()")}} are now compliant with the specification ({{bug(1401592)}}).
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -38,6 +38,10 @@ No notable changes.
 
 - {{domxref("ReadableStream")}} now supports [asynchronous iteration over the chunks in a stream](/en-US/docs/Web/API/ReadableStream#async_iteration) using the `for await...of` syntax ({{bug(1734244)}}).
 
+- WebRTC now supports sending the set of available encodings when adding a tranceiver to a peer connection, and also getting the active encoding associated with a sender.
+  Specifically, {{domxref("RTCPeerConnection.addTransceiver()")}} now supports using the [`sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) option in the [`init`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#init) parameter object, and [`RTCRtpEncodingParameters.active`](/en-US/docs/Web/API/RTCRtpEncodingParameters#active) can be used to determine whether or not the encoding is being used to send data.
+  (See {{bug(1676855)}} for more details.)
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi


### PR DESCRIPTION
FF110 WebRTC supports sending the set of available encodings when adding a transceiver to a peer connection, and also getting the active encoding associated with a sender. In addition it brings the getParameters/setParameters methods for senders/receivers up to spec.

This adds a release notes for the above features.

Other docs work for this tracked in #23677