### PR TITLE
FF111 RelNote: OPFS released + Remove from Expr. Features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1828,50 +1828,6 @@ Note that since locking the screen orientation isn't typically supported on desk
   </tbody>
 </table>
 
-### File System Access API
-
-#### StorageManager.getDirectory()
-
-The {{domxref("StorageManager.getDirectory()")}} method, obtained using `navigator.storage.getDirectory()` in a worker or the main thread, provides access to files stored in the [origin private file system](/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system).
-This data is origin-specific: permission prompts are not required to access files, and clearing data for the site/origin deletes the storage.
-See {{bug(1785123)}} for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version changed</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>110</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>97</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>97</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>97</td>
-      <td>No.</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.fs.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Prioritized Task Scheduling API
 
 The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -42,6 +42,11 @@ This article provides information about the changes in Firefox 111 that affect d
 
 ### APIs
 
+- [Origin private file system (OPFS)](/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system) is now supported when using the [File System Access API](/en-US/docs/Web/API/File_System_Access_API).
+  The data in this file system is origin-specific: permission prompts are not required to access files, and clearing data for the site/origin deletes the storage.
+  The OPFS is accessed with the {{domxref("StorageManager.getDirectory()")}} method, by calling `navigator.storage.getDirectory()` in a worker or the main thread.
+  See {{bug(1785123)}} for more details.
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF111 adds support in FF111 for OPFS "by default". This removes the experimental features record added in 110 and adds the information to the release note.

This could wait a bit before being merged since FF110 only gets released today. I think it doesn't matter so much though - as FF111 is available so there is no particular benefit in knowing that FF110 could also do this in nightly.

Other docs work for this can be tracked in #24388