### PR TITLE
FF111 supports RTCInboundRtpStreamStats.trackIdentifier

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -46,6 +46,10 @@ This article provides information about the changes in Firefox 111 that affect d
 
 #### Media, WebRTC, and Web Audio
 
+- [`RTCInboundRtpStreamStats.trackIdentifier`](/en-US/docs/Web/API/RTCInboundRtpStreamStats#trackidentifier) is now supported.
+  This allows developers to associate `inbound-rtp` statistics with a particular track when using {{domxref("RTCPeerConnection.getStats()")}}.
+  (For more information see {{bug(1680606)}}.)
+
 #### Removals
 
 ### WebAssembly

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
@@ -55,7 +55,9 @@ The `RTCInboundRtpStreamStats` dictionary is based on the {{domxref("RTCReceived
   - : A string which identifies the {{domxref("RTCRemoteOutboundRtpStreamStats")}} object that provides statistics for the remote peer for this same SSRC. This ID is stable across multiple calls to `getStats()`.
 - {{domxref("RTCInboundRtpStreamStats.sliCount", "sliCount")}}
   - : An integer indicating the number of times the receiver sent a Slice Loss Indication (SLI) frame to the sender to tell it that one or more consecutive (in terms of scan order) video macroblocks have been lost or corrupted. Available only for video streams.
-- {{domxref("RTCInboundRtpStreamStats.trackId", "trackId")}}
+- `trackIdentifier`
+  - : A string that contains the {{domxref("MediaStreamTrack.id", "id")}} value of the `MediaStreamTrack` associated with the inbound stream.
+- {{domxref("RTCInboundRtpStreamStats.trackId", "trackId")}} {{deprecated_inline}}
   - : A string which identifies the statistics object representing the receiving track; this object is one of two types: {{domxref("RTCReceiverAudioTrackAttachmentStats")}} or {{domxref("RTCReceiverVideoTrackAttachmentStats")}}. This ID is stable across multiple calls to `getStats()`.
 
 ## Examples

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
@@ -3,38 +3,17 @@ title: RTCInboundRtpStreamStats.trackId
 slug: Web/API/RTCInboundRtpStreamStats/trackId
 page-type: web-api-instance-property
 tags:
-  - API
-  - Audio
-  - Media
-  - MediaStreamTrack
-  - Property
-  - RTCInboundRtpStreamStats
-  - RTP
-  - Reference
-  - Statistics
-  - Stats
-  - Video
-  - WebRTC
-  - WebRTC API
-  - trackId
+  - deprecated
 browser-compat: api.RTCInboundRtpStreamStats.trackId
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}} {{Deprecated_Header}}
 
-The **`trackId`** property of the
-{{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the
-{{domxref("RTCStats.id", "id")}} of the
-{{domxref("RTCReceiverAudioTrackAttachmentStats")}} or
-{{domxref("RTCReceiverVideoTrackAttachmentStats")}} object representing the
-{{domxref("MediaStreamTrack")}} which is receiving the incoming media.
+The **`trackId`** property of the {{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the {{domxref("RTCStats.id", "id")}} of the {{domxref("RTCReceiverAudioTrackAttachmentStats")}} or {{domxref("RTCReceiverVideoTrackAttachmentStats")}} object representing the {{domxref("MediaStreamTrack")}} which is receiving the incoming media.
 
 ## Value
 
-A string containing the ID of the
-{{domxref("RTCReceiverAudioTrackAttachmentStats")}} or
-{{domxref("RTCReceiverVideoTrackAttachmentStats")}} object representing the track which
-is receiving the media from this RTP session.
+A string containing the ID of the {{domxref("RTCReceiverAudioTrackAttachmentStats")}} or {{domxref("RTCReceiverVideoTrackAttachmentStats")}} object representing the track which is receiving the media from this RTP session.
 
 ## Specifications
 


### PR DESCRIPTION
FF111 supports `RTCInboundRtpStreamStats.trackIdentifier`. This adds a short description in the parent document - I didn't create a full property document, because there isn't that much that needs to be said here about the property. I'm also hoping that this will eventually not be a dictionary - in which case not having a lot of unnecessary information would be good.

In addition this adds a release note and also marks up another member `trackid` as obsoleted - as per the spec.

There is quite a bit more work required for this page, but it will follow more testing and BCD work.

Other docs work can be tracked in #24397