### PR TITLE
Update template element shadowroot attribute to shadowrootmode

### DIFF
--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -25,11 +25,11 @@ Think of a template as a content fragment that is being stored for subsequent us
 
 ## Attributes
 
-The only standard attributes that the `template` element supports are the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+The only standard attributes that the `<template>` element supports are the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-In Chromium-based browsers, the `template` element also supports a non-standard [`shadowroot` attribute](https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md#syntax), as part of an experimental ["Declarative Shadow DOM"](https://web.dev/declarative-shadow-dom/) proposal. In those browsers, a `template` element with the `shadowroot` attribute is detected by the HTML parser and immediately applied as the shadow root of its parent element.
+In Chromium-based browsers, the `<template>` element also supports a non-standard [`shadowrootmode` attribute](https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md#syntax), as part of an experimental ["Declarative Shadow DOM"](https://developer.chrome.com/articles/declarative-shadow-dom/) proposal. In supporting browsers, a `<template>` element with the `shadowrootmode` attribute is detected by the HTML parser and immediately applied as the shadow root of its parent element. `shadowrootmode` can take a value of `open` or `closed`; these are equivalent to the `open` and `closed` values of the {{domxref("Element.attachShadow()")}} `mode` option.
 
-Also, the {{domxref("HTMLTemplateElement")}} has a standard {{domxref("HTMLTemplateElement.content", "content")}} property (without a corresponding content/markup attribute), which is a read-only {{domxref("DocumentFragment")}} containing the DOM subtree which the template represents. Note that directly using the value of the {{domxref("HTMLTemplateElement.content", "content")}} property could lead to unexpected behavior; for details, see the [Avoiding DocumentFragment pitfall](#avoiding_documentfragment_pitfall) section below.
+Also, the corresponding {{domxref("HTMLTemplateElement")}} interface has a standard {{domxref("HTMLTemplateElement.content", "content")}} property (without an equivalent content/markup attribute), which is a read-only {{domxref("DocumentFragment")}} containing the DOM subtree which the template represents. Note that directly using the value of the {{domxref("HTMLTemplateElement.content", "content")}} property could lead to unexpected behavior; for details, see the [Avoiding DocumentFragment pitfall](#avoiding_documentfragment_pitfall) section below.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Chrome 111, some changes have been made to the [Declarative Shadow DOM](https://chromestatus.com/feature/5191745052606464) proposal, to [better support streaming Declarative Shadow DOM](https://chromestatus.com/feature/5161240576393216).

While I don't think it is the right time to provide complete documentation of Declarative Shadow DOM on MDN (none of the subfeatures are in a spec yet), we do already mention the `<template>` element's `shadowroot` attribute, which has been changed to `shadowrootmode` by the new set of changes. 

This PR updates that detail on the `<template>` page, and makes sure that the latest developer.chrome.com post is linked to for up-to-date information on this proposal. This way it is on the map on MDN, so developers can still discover it up until the time it is full documented on MDN.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
