### PR TITLE
replace {{LandingPageListSubpages}} macro with web performance landin…

### DIFF
--- a/files/en-us/web/guide/performance/index.md
+++ b/files/en-us/web/guide/performance/index.md
@@ -24,5 +24,4 @@ The above resources also include web performance best practices. Making web perf
 ## See also
 
 - [Fast load times](https://web.dev/fast/) on _web.dev_
-
-{{LandingPageListSubpages}}
+- [Web performance](/en-US/docs/Web/Performance)


### PR DESCRIPTION
### Motivation

There is no subpages in section web/guide/performance, so the macro would not list any items. Replace the landingpagelist macro with `Web performance` landing page.

### Related issues and pull requests

Fixes: #24430
