### PR TITLE
Document LinkStyle mixin

### DIFF
--- a/files/en-us/web/api/htmllinkelement/sheet/index.md
+++ b/files/en-us/web/api/htmllinkelement/sheet/index.md
@@ -13,7 +13,7 @@ A stylesheet is associated to an `HTMLLinkElement` if `rel="stylesheet"` is used
 
 ## Value
 
-A {{DOMxRef("StyleSheet)}} object, or `null` if none is associated with the element.
+A {{DOMxRef("StyleSheet")}} object, or `null` if none is associated with the element.
 
 ## Examples
 

--- a/files/en-us/web/api/htmllinkelement/sheet/index.md
+++ b/files/en-us/web/api/htmllinkelement/sheet/index.md
@@ -1,0 +1,35 @@
+---
+title: HTMLLinkElement.sheet
+slug: Web/API/HTMLLinkElement/sheet
+page-type: web-api-instance-property
+browser-compat: api.HTMLLinkElement.sheet
+---
+{{APIRef("HTML DOM")}}
+
+The read-only **`sheet`** property of the {{domxref("HTMLLinkElement")}} interface
+contains the stylesheet associated with that element.
+
+A stylesheet is associated to an `HTMLLinkElement` if `rel="stylesheet"` is used with `<link>`.
+
+## Value
+
+A {{DOMxRef("StyleSheet)}} object, or `null` if none is associated with the element.
+
+## Examples
+
+```html
+<html>
+  <header>
+    <link rel="stylesheet" href="styles.css" />
+…
+```
+
+The `sheet` property of the `HTMLLinkElement` object will return the {{domxref("StyleSheet")}} object describing `styles.css`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmlstyleelement/sheet/index.md
+++ b/files/en-us/web/api/htmlstyleelement/sheet/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLStyleElement.sheet
 The read-only **`sheet`** property of the {{domxref("HTMLStyleElement")}} interface
 contains the stylesheet associated with that element.
 
-An {{DOMxref("StyleSheet")}} is always associated with a {{domxref("HTMLStyleElement")}}, unless is `type` attribute is not `text/css`.
+An {{DOMxref("StyleSheet")}} is always associated with a {{domxref("HTMLStyleElement")}}, unless its `type` attribute is not `text/css`.
 
 ## Value
 

--- a/files/en-us/web/api/htmlstyleelement/sheet/index.md
+++ b/files/en-us/web/api/htmlstyleelement/sheet/index.md
@@ -1,0 +1,35 @@
+---
+title: HTMLStyleElement.sheet
+slug: Web/API/HTMLStyleElement/sheet
+page-type: web-api-instance-property
+browser-compat: api.HTMLStylelement.sheet
+---
+{{APIRef("HTML DOM")}}
+
+The read-only **`sheet`** property of the {{domxref("HTMLStyleElement")}} interface
+contains the stylesheet associated with that element.
+
+An {{DOMxref("StyleSheet")}} is always associated with a {{domxref("HTMLStyleElement")}}, unless is `type` attribute is not `text/css`.
+
+## Value
+
+A {{DOMxRef("StyleSheet)}} object, or `null` if none is associated with the element.
+
+## Examples
+
+```html
+<html>
+  <header>
+    <style media="print" />
+…
+```
+
+The `sheet` property of the associated `HTMLStyleElement` object will return the {{domxref("StyleSheet")}} object describing it.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmlstyleelement/sheet/index.md
+++ b/files/en-us/web/api/htmlstyleelement/sheet/index.md
@@ -13,7 +13,7 @@ An {{DOMxref("StyleSheet")}} is always associated with a {{domxref("HTMLStyleEle
 
 ## Value
 
-A {{DOMxRef("StyleSheet)}} object, or `null` if none is associated with the element.
+A {{DOMxRef("StyleSheet")}} object, or `null` if none is associated with the element.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlstyleelement/sheet/index.md
+++ b/files/en-us/web/api/htmlstyleelement/sheet/index.md
@@ -2,7 +2,7 @@
 title: HTMLStyleElement.sheet
 slug: Web/API/HTMLStyleElement/sheet
 page-type: web-api-instance-property
-browser-compat: api.HTMLStylelement.sheet
+browser-compat: api.HTMLStylElement.sheet
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/en-us/web/api/htmlstyleelement/sheet/index.md
+++ b/files/en-us/web/api/htmlstyleelement/sheet/index.md
@@ -2,7 +2,7 @@
 title: HTMLStyleElement.sheet
 slug: Web/API/HTMLStyleElement/sheet
 page-type: web-api-instance-property
-browser-compat: api.HTMLStylElement.sheet
+browser-compat: api.HTMLStyleElement.sheet
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -32,6 +32,9 @@ is a processing instruction whose `target` is `xml`.
 
 _This interface also inherits properties from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
+- {{domxref("ProcessingInstruction.sheet")}} {{ReadOnlyInline}}
+  - : Returns the associated {{domxref("StyleSheet")}} object, if any; or `null` if none.
+
 - {{domxref("ProcessingInstruction.target")}} {{ReadOnlyInline}}
   - : A name identifying the application to which the instruction is targeted.
 

--- a/files/en-us/web/api/processinginstruction/sheet/index.md
+++ b/files/en-us/web/api/processinginstruction/sheet/index.md
@@ -12,13 +12,13 @@ browser-compat: api.ProcessingInstruction.sheet
 {{ApiRef("DOM")}}
 
 The read-only **`sheet`** property of the {{domxref("ProcessingInstruction")}} interface
-represent the name of the stylesheet associated to the `ProcessingInstruction`.
+contains the stylesheet associated to the `ProcessingInstruction`.
 
 The `xml-stylesheet` processing instruction is used to associate a stylesheet in an XML file.
 
 ## Value
 
-A string containing the name of the associated stylesheet, or `null` if there are none.
+The associated {{DOMxref("Stylesheet")}} object, or `null` if there are none.
 
 ## Example
 
@@ -28,7 +28,7 @@ A string containing the name of the associated stylesheet, or `null` if there ar
 …
 ```
 
-The `sheet` property of the processing instruction will return `rule.css`.
+The `sheet` property of the processing instruction will return the {{domxref("StyleSheet")}} object describing `rule.css`.
 
 ## Specifications
 


### PR DESCRIPTION
This is part of #openwebdocs/project#152.

The `LinkStyle` mixin adds a `sheet` property. All three browser engines have implemented it for ages.

This PR:
- Update `ProcessingInstruction.sheet` that did exist but was slightly incorrect (it returns a `StyleSheet` object and not a string.
- Add it to the list of properties on `ProcessingInstruction`
- Add the missing `HTMLLinkElement.sheet`
- Add the missing `HTMLStyleElement.sheet`

I kept the examples very simple as this is not very suitable for a live example.