### PR TITLE
Change two links in subresource_integrity for improvment

### DIFF
--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -127,8 +127,8 @@ Browsers handle SRI by doing the following:
 
 ## See also
 
-- Content Security Policy
-- {{httpheader("Content-Security-Policy")}}
+- [Content Security Policy](/en-US/docs/Web/HTTP/CSP)
+- The {{httpheader("Content-Security-Policy")}} HTTP header.
 - [A CDN that can not XSS you: Using Subresource Integrity](https://frederik-braun.com/using-subresource-integrity.html)
 - [Subresource Integrity test from W3C](https://w3c-test.org/subresource-integrity/subresource-integrity.html)
 - [SRI Hash Generator](https://www.srihash.org/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Mentioning just 'Content Security Policy' at 'See Also' part twice may confuse readers. For the first occurrence I pointed to CSP main page, for the second occurrence I clarified the context(the header content-security-policy).

### Motivation

Better navigation to related topics.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
