### PR TITLE
Clarify replaceTrack never triggers renegotiation.

### DIFF
--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -75,14 +75,14 @@ rejection handler:
 
 ## Usage notes
 
-### Things that trigger negotiation
+### Things that require negotiation
 
-Not all track replacements require renegotiation. In fact, even changes that seem huge
-can be done without requiring negotiation. Here are the changes that can trigger
-negotiation:
+Most track replacements can be done without renegotiation. In fact, even changes that seem huge
+can be done without requiring negotiation. However, some changes may require
+negotiation and thus fail replaceTrack:
 
-- The new track has a resolution which is outside the bounds of the current track;
-  that is, the new track is either wider or taller than the current one.
+- The new track has a resolution which is outside the bounds of the dimensions negotiated with the peer;
+  however, most browser end-points allow resolution changes.
 - The new track's frame rate is high enough to cause the codec's block rate to be
   exceeded.
 - The new track is a video track and its raw or pre-encoded state differs from that of

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -79,7 +79,7 @@ rejection handler:
 
 Most track replacements can be done without renegotiation. In fact, even changes that seem huge
 can be done without requiring negotiation. However, some changes may require
-negotiation and thus fail replaceTrack:
+negotiation and thus fail `replaceTrack`:
 
 - The new track has a resolution which is outside the bounds of the dimensions negotiated with the peer;
   however, most browser end-points allow resolution changes.

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -79,7 +79,7 @@ rejection handler:
 
 Most track replacements can be done without renegotiation. In fact, even changes that seem huge
 can be done without requiring negotiation. However, some changes may require
-negotiation and thus fail `replaceTrack`:
+negotiation and thus fail `replaceTrack()`:
 
 - The new track has a resolution which is outside the bounds of the dimensions negotiated with the peer;
   however, most browser end points allow resolution changes.

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -82,7 +82,7 @@ can be done without requiring negotiation. However, some changes may require
 negotiation and thus fail `replaceTrack`:
 
 - The new track has a resolution which is outside the bounds of the dimensions negotiated with the peer;
-  however, most browser end-points allow resolution changes.
+  however, most browser end points allow resolution changes.
 - The new track's frame rate is high enough to cause the codec's block rate to be
   exceeded.
 - The new track is a video track and its raw or pre-encoded state differs from that of


### PR DESCRIPTION
### Description

- s/[Things that trigger negotiation](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#things_that_trigger_negotiation)/Things that require negotiation/ to avoid inferring replaceTrack triggers renegotiation.
- Clarify that resolution changes often work with replaceTrack (e.g. front/back cameras are a major use case and rarely the same dimensions) 

### Motivation

Clarify behavior

### Additional details

replaceTrack operates _"[without renegotiation](https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender-replacetrack)"_.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
