### PR TITLE
CI: PR companion should not run on forks

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
+      ${{ github.repository == 'mdn/content' &&
+      github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
 
     steps:


### PR DESCRIPTION
We want this workflow to only run if the target repo is `mdn/content`.