### PR TITLE
Add RTCCertificate.expires

### DIFF
--- a/files/en-us/web/api/rtccertificate/expires/index.md
+++ b/files/en-us/web/api/rtccertificate/expires/index.md
@@ -1,0 +1,43 @@
+---
+title: RTCCertificate.expires
+slug: Web/API/RTCCertificate/expires
+page-type: web-api-instance-property
+browser-compat: api.RTCCertificate.expires
+---
+{{APIRef("WebRTC")}}
+
+The read-only **`expires`** property of the {{domxref("RTCCertificate")}} interface returns the expiration date of the certificate.
+
+By default a new certificate is configured with `expires` set to a value of 2592000000 milliseconds, or 30 days.
+The expiration time cannot exceed 31536000000 milliseconds, or 365 days.
+It's also useful to note that browsers may further restrict the expiration time of certificates if they choose.
+
+## Value
+
+A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, containing the expiration date of the certicate.
+
+## Examples
+
+```js
+RTCPeerConnection.generateCertificate({
+    name: 'RSASSA-PKCS1-v1_5',
+    hash: 'SHA-256',
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1])
+}).then((cert) => {
+  const pc = new RTCPeerConnection({certificates: [cert]});
+  console.log(cert.expires); // 2592000000 (30 days, the default)
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("RTCPeerConnection.generateCertificate()")}}

--- a/files/en-us/web/api/rtccertificate/index.md
+++ b/files/en-us/web/api/rtccertificate/index.md
@@ -28,3 +28,7 @@ The interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides an ob
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("RTCPeerConnection.generateCertificate()")}}


### PR DESCRIPTION
This is part of openwebdocs/project#152.

This adds the `RTCCertificate.expires` property.

I also added a link to the method used to generate a certificate in its parent (as it wasn't obvious to find!)

The example is not live, as we can't do one for WebRTC (that needs a server).