### PR TITLE
Remove ## Summary from TouchEvent.*Key

### DIFF
--- a/files/en-us/web/api/touchevent/altkey/index.md
+++ b/files/en-us/web/api/touchevent/altkey/index.md
@@ -9,14 +9,13 @@ tags:
   - Property
   - TouchEvent
   - touch
+  - Read-only
 browser-compat: api.TouchEvent.altKey
 ---
 
 {{APIRef("Touch Events") }}
 
-## Summary
-
-A boolean value indicating whether or not the <kbd>alt</kbd> (Alternate) key is enabled when the touch event is created. If the <kbd>alt</kbd> key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
+The read-only **`altKey`** property of the {{domxref("TouchEvent")}} interface returns a boolean value indicating whether or not the <kbd>alt</kbd> (Alternate) key is enabled when the touch event is created. If the <kbd>alt</kbd> key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
 
 This property is {{ReadOnlyInline}}.
 

--- a/files/en-us/web/api/touchevent/ctrlkey/index.md
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.md
@@ -9,14 +9,13 @@ tags:
   - Property
   - TouchEvent
   - touch
+  - Read-only
 browser-compat: api.TouchEvent.ctrlKey
 ---
 
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-A boolean value indicating whether the <kbd>control</kbd> (Control) key is enabled when the touch event is created. If this key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
+The read-only **`ctrlKey`** property of the {{domxref("TouchEvent")}} interface returns a boolean value indicating whether the <kbd>control</kbd> (Control) key is enabled when the touch event is created. If this key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
 
 This property is {{ReadOnlyInline}}.
 

--- a/files/en-us/web/api/touchevent/metakey/index.md
+++ b/files/en-us/web/api/touchevent/metakey/index.md
@@ -9,14 +9,13 @@ tags:
   - Property
   - TouchEvent
   - touch
+  - Read-only
 browser-compat: api.TouchEvent.metaKey
 ---
 
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-A boolean value indicating whether or not the <kbd>Meta</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
+The read-only **`metakey`** property of the {{domxref("TouchEvent")}} interface returns a boolean value indicating whether or not the <kbd>Meta</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
 
 This property is {{ReadOnlyInline}}.
 


### PR DESCRIPTION
We removed `## Summary` from reference pages years ago.

I found some of them for `TouchEvent.*Key`.

This PR removed them.