### PR TITLE
Add Request.signal

### DIFF
--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -52,6 +52,8 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
   - : Contains the referrer of the request (e.g., `client`).
 - {{domxref("Request.referrerPolicy")}} {{ReadOnlyInline}}
   - : Contains the referrer policy of the request (e.g., `no-referrer`).
+- {{domxref("Request.signal")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("AbortSignal")}} associated with the request
 - {{domxref("Request.url")}} {{ReadOnlyInline}}
   - : Contains the URL of the request.
 

--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -1,0 +1,51 @@
+---
+title: Request.signal
+slug: Web/API/Request/signal
+page-type: web-api-instance-property
+browser-compat: api.Request.signal
+---
+
+{{APIRef("Fetch API")}}
+
+The read-only **`signal`** property of the {{DOMxRef("Request")}} interface return the {{domxref("AbortSignal")}} associated with the request.
+
+## Value
+
+An {{DOMxRef("AbortSignal")}} object.
+
+## Examples
+
+```js
+// Create a new abort controller
+const controller = new AbortController();
+
+// Creatae a request we this controller's AbortSignal object
+const req = new Request('/', { signal: ctrl.signal });
+
+// Add an event handler logging a message in case of abort
+req.signal.addEventListener("signal",  () => { console.log('abort'); }
+
+// In case of abort, log the AbortSignal reason, if any
+fetch(req).catch(() => {
+  if (signal.aborted) {
+    if (signal.reason) {
+      console.log(`Request aborted with reason: ${signal.reason}`);
+    } else {
+      console.log("Request aborted but no reason was given.");
+    }
+  } else {
+    console.log("Request not aborted, but terminated abnormally");
+  }
+};
+
+// Actually abort the request
+controller.abort();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -23,7 +23,9 @@ const controller = new AbortController();
 const req = new Request('/', { signal: controller.signal });
 
 // Add an event handler logging a message in case of abort
-req.signal.addEventListener("signal",  () => { console.log('abort'); }
+req.signal.addEventListener("signal", () => {
+  console.log("abort");
+});
 
 // In case of abort, log the AbortSignal reason, if any
 fetch(req).catch(() => {

--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -7,7 +7,7 @@ browser-compat: api.Request.signal
 
 {{APIRef("Fetch API")}}
 
-The read-only **`signal`** property of the {{DOMxRef("Request")}} interface return the {{domxref("AbortSignal")}} associated with the request.
+The read-only **`signal`** property of the {{DOMxRef("Request")}} interface returns the {{domxref("AbortSignal")}} associated with the request.
 
 ## Value
 

--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -20,7 +20,7 @@ An {{DOMxRef("AbortSignal")}} object.
 const controller = new AbortController();
 
 // Creatae a request we this controller's AbortSignal object
-const req = new Request('/', { signal: ctrl.signal });
+const req = new Request('/', { signal: controller.signal });
 
 // Add an event handler logging a message in case of abort
 req.signal.addEventListener("signal",  () => { console.log('abort'); }
@@ -34,7 +34,7 @@ fetch(req).catch(() => {
       console.log("Request aborted but no reason was given.");
     }
   } else {
-    console.log("Request not aborted, but terminated abnormally");
+    console.log("Request not aborted, but terminated abnormally.");
   }
 };
 

--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -19,7 +19,7 @@ An {{DOMxRef("AbortSignal")}} object.
 // Create a new abort controller
 const controller = new AbortController();
 
-// Creatae a request we this controller's AbortSignal object
+// Create a request with this controller's AbortSignal object
 const req = new Request('/', { signal: controller.signal });
 
 // Add an event handler logging a message in case of abort


### PR DESCRIPTION
This is part of openwebdocs/project#152

I added:
- a new `Request.signal`
- an entry in the list of properties on `Request`.

The example is not live as it would need a server.