### PR TITLE
Update names of page break CSS attributes

### DIFF
--- a/files/en-us/web/css/paged_media/index.md
+++ b/files/en-us/web/css/paged_media/index.md
@@ -13,9 +13,9 @@ tags:
 
 **Paged media** properties control the presentation of content for print or any other media that splits content into discrete pages. It allows you to set page breaks, control printable area, style left and right pages differently, and control breaks inside elements. Widely supported properties include:
 
-- {{ cssxref("page-break-before") }}
-- {{ cssxref("page-break-after") }}
-- {{ cssxref("page-break-inside") }}
+- {{ cssxref("break-before") }}
+- {{ cssxref("break-after") }}
+- {{ cssxref("break-inside") }}
 - {{ cssxref("orphans") }}
 - {{ cssxref("widows") }}
 - {{ cssxref("@page") }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Since the previous links were to a page saying that the `page-break-*` properties had been renamed to remove the `page-` part, this just updates the links to go straight to the right place.

### Motivation

Because let's build good habits soonest.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
