### PR TITLE
correct the description of the recommendation

### DIFF
--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -95,7 +95,7 @@ This blocks access to pages or subdomains that can only be served over HTTP.
 Strict-Transport-Security: max-age=31536000; includeSubDomains
 ```
 
-If a `max-age` of 1 year is acceptable for a domain, however, two years is the recommended value as explained on <https://hstspreload.org>.
+The `max-age` of 1 year is acceptable for a domain, however, two years is the recommended value as explained on <https://hstspreload.org>.
 
 In the following example, `max-age` is set to 2 years, and is suffixed with `preload`, which is necessary for inclusion in all major web browsers' HSTS preload lists, like Chromium, Edge, and Firefox.
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -95,7 +95,7 @@ This blocks access to pages or subdomains that can only be served over HTTP.
 Strict-Transport-Security: max-age=31536000; includeSubDomains
 ```
 
-The `max-age` of 1 year is acceptable for a domain, however, two years is the recommended value as explained on <https://hstspreload.org>.
+Although a `max-age` of 1 year is acceptable for a domain, two years is the recommended value as explained on <https://hstspreload.org>.
 
 In the following example, `max-age` is set to 2 years, and is suffixed with `preload`, which is necessary for inclusion in all major web browsers' HSTS preload lists, like Chromium, Edge, and Firefox.
 


### PR DESCRIPTION
### Description

Considering that the `max-age` above is 1 year, and the `max-age` in the following example (including the recommendation in https://hstspreload.org/) is 2 years, `If` should not be used here.
