### PR TITLE
Add FetchEvent.handled

### DIFF
--- a/files/en-us/web/api/fetchevent/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.md
@@ -48,6 +48,8 @@ new FetchEvent(type, options)
       - : A string which identifies the client which is being replaced by `resultingClientId`. It defaults to `""`.
     - `resultingClientId` {{optional_inline}}
       - : A string containing the new `clientId` if the client changes as a result of the page load. It defaults to `""`
+    - `handled`
+      - : A _pending_ promise that will be fulfilled once the event has been handled.
 
 ## Return value
 

--- a/files/en-us/web/api/fetchevent/handled/index.md
+++ b/files/en-us/web/api/fetchevent/handled/index.md
@@ -1,0 +1,51 @@
+---
+title: FetchEvent.handled
+slug: Web/API/FetchEvent/handled
+page-type: web-api-instance-property
+browser-compat: api.FetchEvent.handled
+---
+
+{{APIRef("Service Workers API")}}
+
+The **`handled`** property of the {{DOMxRef("FetchEvent")}} interface returns a promise indicated if the event has been handled by the fetch algorithm or not. This property allows to execute code after the browser has consumed a response and is usually used together with the {{DOMxRef("ExtendableEvent.waitUntil", "waitUntil()")}} method.
+
+## Value
+
+A {{jsxref("Promise")}} that is pending while the event has not been handled, and fulfilled once it has.
+
+## Examples
+
+```js
+addEventListener("fetch", (event) => {
+  event.respondWith(
+    (async function () {
+      const response = await doCalculateAResponse(event.request);
+
+      event.waitUntil(
+        (async function () {
+          await doSomeAsyncStuff(); // optional
+
+          // Wait for the event to be consumed by the browser
+          await event.handled;
+
+          return doFinalStuff(); // Finalize AFTER the event has been consumed
+        })()
+      );
+
+      return response;
+    })()
+  );
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{DOMxRef("ExtendableEvent.waitUntil()")}}

--- a/files/en-us/web/api/fetchevent/handled/index.md
+++ b/files/en-us/web/api/fetchevent/handled/index.md
@@ -7,7 +7,7 @@ browser-compat: api.FetchEvent.handled
 
 {{APIRef("Service Workers API")}}
 
-The **`handled`** property of the {{DOMxRef("FetchEvent")}} interface returns a promise indicatinh if the event has been handled by the fetch algorithm or not. This property allows executinh code after the browser has consumed a response, and is usually used together with the {{DOMxRef("ExtendableEvent.waitUntil", "waitUntil()")}} method.
+The **`handled`** property of the {{DOMxRef("FetchEvent")}} interface returns a promise indicating if the event has been handled by the fetch algorithm or not. This property allows executing code after the browser has consumed a response, and is usually used together with the {{DOMxRef("ExtendableEvent.waitUntil", "waitUntil()")}} method.
 
 ## Value
 

--- a/files/en-us/web/api/fetchevent/handled/index.md
+++ b/files/en-us/web/api/fetchevent/handled/index.md
@@ -7,7 +7,7 @@ browser-compat: api.FetchEvent.handled
 
 {{APIRef("Service Workers API")}}
 
-The **`handled`** property of the {{DOMxRef("FetchEvent")}} interface returns a promise indicated if the event has been handled by the fetch algorithm or not. This property allows to execute code after the browser has consumed a response and is usually used together with the {{DOMxRef("ExtendableEvent.waitUntil", "waitUntil()")}} method.
+The **`handled`** property of the {{DOMxRef("FetchEvent")}} interface returns a promise indicatinh if the event has been handled by the fetch algorithm or not. This property allows executinh code after the browser has consumed a response, and is usually used together with the {{DOMxRef("ExtendableEvent.waitUntil", "waitUntil()")}} method.
 
 ## Value
 

--- a/files/en-us/web/api/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/index.md
@@ -30,6 +30,8 @@ _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
 - {{domxref("FetchEvent.clientId")}} {{ReadOnlyInline}}
   - : The {{domxref("Client.id", "id")}} of the same-origin {{domxref("Client", "client")}} that initiated the fetch.
+- {{domxref("FetchEvent.handled")}} {{ReadOnlyInline}}
+  - : A promise that is pending while the event has not been handled, and fulfilled once it has.
 - {{domxref("FetchEvent.preloadResponse")}} {{ReadOnlyInline}}
   - : A {{jsxref("Promise")}} for a {{domxref("Response")}}, or `undefined` if this fetch is not a navigation, or [navigation preload](/en-US/docs/Web/API/NavigationPreloadManager) is not enabled.
 - {{domxref("FetchEvent.replacesClientId")}} {{ReadOnlyInline}}


### PR DESCRIPTION
This is part of openwebdocs/project#152

This PR:
- adds a page for `FetchEvent.handled`
- adds it to the list of properties in the `FetchEvent` interface
- adds it to the list of object entries to the constructor `FetchEvent()`