### PR TITLE
Add SpeechSynthesisEvent.charLength

### DIFF
--- a/files/en-us/web/api/speechsynthesisevent/charlength/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/charlength/index.md
@@ -1,0 +1,42 @@
+---
+title: SpeechSynthesisEvent.charLength
+slug: Web/API/SpeechSynthesisEvent/charLength
+page-type: web-api-instance-property
+browser-compat: api.SpeechSynthesisEvent.charLength
+---
+
+{{APIRef("Web Speech API")}}
+
+The read-only **`charLength`** property of the {{DOMxRef("SpeechSynthesisEvent")}} interface returns the number of characters left to be spoken after the character at the {{DOMxRef("SpeechSynthesisEvent.charIndex", "charIndex")}} position.
+
+If the speech engine can't determine it, it returns 0.
+
+## Value
+
+An integer.
+
+## Examples
+
+```js
+utterThis.onpause = (event) => {
+  const char = event.utterance.text.charAt(event.charIndex);
+  const charLeft = event.charLength;
+  if (charLeft) {
+    console.log(
+      `Speech paused. There are still ${charLeft} characters to be spoken.`
+    );
+  } else {
+    console.log(
+      "Speech paused. The underlying speech engine can't tell how many characters are left."
+    );
+  }
+};
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -26,7 +26,7 @@ _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from
 - {{domxref("SpeechSynthesisEvent.charIndex")}} {{ReadOnlyInline}}
   - : Returns the index position of the character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
 - {{domxref("SpeechSynthesisEvent.charLength")}} {{ReadOnlayInline}}
-  - : Returns the number of characters left to be spoken after the `charIndex` position if the speaking engine supports it. Returns 0 if the speaking engine can't tell the information.
+  - : Returns the number of characters left to be spoken after the `charIndex` position, if the speaking engine supports it. Returns 0 if the speaking engine can't provide the information.
 - {{domxref("SpeechSynthesisEvent.elapsedTime")}} {{ReadOnlyInline}}
   - : Returns the elapsed time in seconds after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken that the event was triggered at.
 - {{domxref("SpeechSynthesisEvent.name")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -25,6 +25,8 @@ _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from
 
 - {{domxref("SpeechSynthesisEvent.charIndex")}} {{ReadOnlyInline}}
   - : Returns the index position of the character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
+- {{domxref("SpeechSynthesisEvent.charLength")}} {{ReadOnlayInline}}
+  - : Returns the number of characters left to be spoken after the `charIndex` position if the speaking engine supports it. Returns 0 if the speaking engine can't tell the information.
 - {{domxref("SpeechSynthesisEvent.elapsedTime")}} {{ReadOnlyInline}}
   - : Returns the elapsed time in seconds after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken that the event was triggered at.
 - {{domxref("SpeechSynthesisEvent.name")}} {{ReadOnlyInline}}


### PR DESCRIPTION
This project is part of openwebdocs/project#152

This PR:
- Adds `SpeechSynthesisEvent.charLength` that was missing
- Adds it to the list of properties in the `SpeechSynthesisEvent` interface