### PR TITLE
Typo in macro name

### DIFF
--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -25,7 +25,7 @@ _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from
 
 - {{domxref("SpeechSynthesisEvent.charIndex")}} {{ReadOnlyInline}}
   - : Returns the index position of the character in the {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered.
-- {{domxref("SpeechSynthesisEvent.charLength")}} {{ReadOnlayInline}}
+- {{domxref("SpeechSynthesisEvent.charLength")}} {{ReadOnlyInline}}
   - : Returns the number of characters left to be spoken after the `charIndex` position, if the speaking engine supports it. Returns 0 if the speaking engine can't provide the information.
 - {{domxref("SpeechSynthesisEvent.elapsedTime")}} {{ReadOnlyInline}}
   - : Returns the elapsed time in seconds after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken that the event was triggered at.


### PR DESCRIPTION
Small typo in the macro name.