### PR TITLE
Fix examples

### DIFF
--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -39,19 +39,11 @@ The method returns `true` if the font list contains system or nonexistent fonts.
 
 ## Examples
 
-In the following example, the first line will print `true` if the Courier font is available at `12px`. The second line will print `true` if the font `MyFont` contains the "ß" character.
-
-```js
-console.log(document.fonts.check("12px courier"));
-
-console.log(document.fonts.check("12px MyFont", "ß"));
-```
-
-If the font given in the font specification does not exist, this function returns `false`:
+If the font given in the font specification does not exist, this function returns `true`:
 
 ```js
 console.log(document.fonts.check("12px NonExistingFont"));
-// false
+// true
 ```
 
 ## Specifications


### PR DESCRIPTION
The examples are incorrect.

`Curier` is not a web font, so the `check` call will return `true`. There is a [bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1416842) where it returns `false` for nonexistent fonts. Safari and Firefox have the correct behavior.
