### PR TITLE
Tiny typo in link

### DIFF
--- a/files/en-us/glossary/round_trip_time/index.md
+++ b/files/en-us/glossary/round_trip_time/index.md
@@ -29,5 +29,5 @@ In the above example, the average round trip time is shown on the final line as 
 
 ## See also
 
-- [Time to First Byte (TTFB)](/en-US/docs/Glossary/time_to_first_byte)
+- [Time to First Byte (TTFB)](/en-US/docs/Glossary/Time_to_first_byte)
 - [Latency](/en-US/docs/Glossary/Latency)


### PR DESCRIPTION
The link should have a capital letter.