### PR TITLE
Very minor grammatical edits

### DIFF
--- a/files/en-us/web/javascript/memory_management/index.md
+++ b/files/en-us/web/javascript/memory_management/index.md
@@ -171,11 +171,11 @@ This algorithm is an improvement over the previous one since an object having ze
 
 Currently, all modern engines ship a mark-and-sweep garbage collector. All improvements made in the field of JavaScript garbage collection (generational/incremental/concurrent/parallel garbage collection) over the last few years are implementation improvements of this algorithm, but not improvements over the garbage collection algorithm itself nor its reduction of the definition of when "an object is no longer needed".
 
-The immediate benefit of this approach is that cycles is no longer a problem. In the first example above, after the function call returns, the two objects are no longer referenced by any resource that is reachable from the global object. Consequently, they will be found unreachable by the garbage collector and have their allocated memory reclaimed.
+The immediate benefit of this approach is that cycles are no longer a problem. In the first example above, after the function call returns, the two objects are no longer referenced by any resource that is reachable from the global object. Consequently, they will be found unreachable by the garbage collector and have their allocated memory reclaimed.
 
 However, the inability to manually control garbage collection remains. There are times when it would be convenient to manually decide when and what memory is released. In order to release the memory of an object, it needs to be made explicitly unreachable. It is also not possible to programmatically trigger garbage collection in JavaScript — and will likely never be within the core language, although engines may expose APIs behind opt-in flags.
 
-## Configuring engine memory model
+## Configuring an engine's memory model
 
 JavaScript engines typically offer flags that expose the memory model. For example, Node.js offers additional options and tools that expose the underlying V8 mechanisms for configuring and debugging memory issues. This configuration may not be available in browsers, and even less so for web pages (via HTTP headers, etc.).
 


### PR DESCRIPTION
Updated an "is" to "are" in order to match the plurality in the statement "... benefit of this approach is that cycles **are** no longer a problem."

Also reworded a header to flow more naturally, from "Configuring engine memory model" to "Configuring an engine's memory model".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR includes two minor grammatical changes: changing an "is" to "are" and rewording a header to flow more naturally. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

These changes are quite minor, but they may help readers stay in the flow of a statement (rather than needing a moment to interpret them). While the original statements are fully comprehensible, I think these changes help reduce potential confusion for the reader.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
