### PR TITLE
Correcting the `writing-mode` description

### DIFF
--- a/files/en-us/web/css/writing-mode/index.md
+++ b/files/en-us/web/css/writing-mode/index.md
@@ -46,9 +46,9 @@ The `writing-mode` property is specified as one of the values listed below. The 
 - `vertical-lr`
   - : For `ltr` scripts, content flows vertically from top to bottom, and the next vertical line is positioned to the right of the previous line. For `rtl` scripts, content flows vertically from bottom to top, and the next vertical line is positioned to the left of the previous line.
 - `sideways-rl` {{experimental_inline}}
-  - : For `ltr` scripts, content flows vertically from bottom to top. For `rtl` scripts, content flows vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways toward the right.
+  - : For `ltr` scripts, content flows vertically from top to bottom. For `rtl` scripts, content flows vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways toward the right.
 - `sideways-lr` {{experimental_inline}}
-  - : For `ltr` scripts, content flows vertically from top to bottom. For `rtl` scripts, content flows vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways toward the left.
+  - : For `ltr` scripts, content flows vertically from bottom to top. For `rtl` scripts, content flows vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways toward the left.
 - `lr` {{deprecated_inline}}
   - : Deprecated except for SVG1 documents. For CSS, use `horizontal-tb` instead.
 - `lr-tb` {{deprecated_inline}}


### PR DESCRIPTION
### Description

This PR corrects the descriptions of the `sideways-rl` and `sideways-lr` values of the `writing-mode` property.

### Motivation

The existing descriptions are incorrect by the spec, and can be seen from the examples shown on the MDN page for this property.

### Additional details

The relevant section in the CSS Writing Modes Level 4:
https://w3c.github.io/csswg-drafts/css-writing-modes/#block-flow
The examples on the MDN page for `writing-mode`:
https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode#result