### PR TITLE
Fix redirects caused by removal of dictionaries

### DIFF
--- a/files/en-us/web/api/authenticatorassertionresponse/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/index.md
@@ -17,8 +17,8 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 ## Instance properties
 
-- `AuthenticatorAssertionResponse.clientDataJSON` {{securecontext_inline}} {{ReadOnlyInline}}
-  - : The client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorAttestationResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
+_Also inherits properties from its parent, {{domxref("AuthenticatorResponse")}}._
+
 - {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} {{securecontext_inline}} {{ReadOnlyInline}}
   - : An {{jsxref("ArrayBuffer")}} containing information from the authenticator such as the Relying Party ID Hash (rpIdHash), a signature counter, test of user presence and user verification flags, and any extensions processed by the authenticator.
 - {{domxref("AuthenticatorAssertionResponse.signature")}} {{securecontext_inline}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.md
@@ -13,9 +13,9 @@ object which is an opaque identifier for the given user. Such an identifier can 
 by the relying party's server to link the user account with its corresponding
 credentials and other data.
 
-The same value may be found on the `id` property of the
-{{domxref("PublicKeyCredentialCreationOptions.user","options.user")}} object (used for
-the creation of the `PublicKeyCredential` instance).
+This value is set in the `id` field of the `user` options object passed in parameter of
+{{domxref("CredentialsContainer.create()")}}
+(used for the creation of the `PublicKeyCredential` instance).
 
 > **Note:** An `AuthenticatorAssertionResponse` instance is
 > available on {{domxref("PublicKeyCredential.response")}} after calling
@@ -59,5 +59,4 @@ navigator.credentials
 
 ## See also
 
-- {{domxref("PublicKeyCredentialCreationOptions.user")}} and its `id`
-  property which contains the same data
+- {{domxref("CredentialsContainer.create()")}} that sets the value of this property

--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
@@ -103,7 +103,6 @@ navigator.credentials
 
 ## See also
 
-- {{domxref("PublicKeyCredentialCreationOptions.challenge")}}: the cryptographic
-  challenge which signature by the authenticator is contained in `attStmt`
-- {{domxref("PublicKeyCredentialCreationOptions.attestation")}}: the attestation
-  statement transport option specified for the creation
+- {{domxref("CredentialsContainer.create()")}}: the method used to create a statement with
+  acryptographic `challenge` which signature by the authenticator is contained in `attStmt`,
+  with the specified `attestation` transport option.

--- a/files/en-us/web/api/authenticatorattestationresponse/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/index.md
@@ -17,15 +17,15 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 ## Instance properties
 
-- `AuthenticatorAttestationResponse.clientDataJSON` {{securecontext_inline}} {{ReadOnlyInline}}
-  - : Client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
+_Also inherits properties from its parent, {{domxref("AuthenticatorResponse")}}._
+
 - {{domxref("AuthenticatorAttestationResponse.attestationObject")}} {{securecontext_inline}} {{ReadOnlyInline}}
   - : An {{jsxref("ArrayBuffer")}} containing authenticator data and an attestation statement for a newly-created key pair.
 
 ## Instance methods
 
 - {{domxref("AuthenticatorAttestationResponse.getTransports()")}} {{securecontext_inline}}
-  - : Returns an {{jsxref("Array")}} of strings describing which transport methods (e.g. `usb`, `nfc`) are believed to be supported with the authenticator. The array may be empty if the information is not available.
+  - : Returns an {{jsxref("Array")}} of strings describing which transport methods (e.g., `usb`, `nfc`) are believed to be supported with the authenticator. The array may be empty if the information is not available.
 
 ## Examples
 

--- a/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
+++ b/files/en-us/web/api/authenticatorresponse/clientdatajson/index.md
@@ -31,9 +31,9 @@ After the `clientDataJSON` object is converted from an
 - `challenge`
   - : The [base64url](/en-US/docs/Glossary/Base64)
     encoded version of the cryptographic challenge sent from the relying party's server.
-    The original value is passed via
-    {{domxref("PublicKeyCredentialRequestOptions.challenge")}} or
-    {{domxref("PublicKeyCredentialCreationOptions.challenge")}}.
+    The original value are passed as the `challenge` option in
+    {{domxref("CredentialsContainer.get()")}} or
+    {{domxref("CredentialsContainer.create()")}}.
 - `origin`
   - : The fully qualified origin of the requester which has been given by the
     client/browser to the authenticator. We should expect the _relying party's


### PR DESCRIPTION
A few direct links to different dictionaries were left and became redirects.

I rephrased the sentences and linked them to the methods using these dictionaries.

There was also a "red link" to an inherited property. I changed the interfaces to use the standard way: not explaining the property there, and adding a sentence indicating the existence of inherited properties, getting rid of the red link.