### PR TITLE
Fix typo on ConvolverNode constructor page.

### DIFF
--- a/files/en-us/web/api/convolvernode/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.md
@@ -31,7 +31,7 @@ new ConvolverNode(context, options)
 
   - : Options are as follows:
 
-    - `audioBuffer`
+    - `buffer`
       - : A mono, stereo, or
         4-channel {{domxref("AudioBuffer")}} containing the
         (possibly multichannel) impulse response used by the `ConvolverNode`


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The correct property name of the `options` object passed to the `ConvolverNode` constructor, to specify the impulse response `AudioBuffer`, is `buffer` instead of `audioBuffer`.

<!-- ✍️ Summarize your changes in one or two sentences -->


### Additional details

Spec: https://webaudio.github.io/web-audio-api/#ConvolverOptions

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
