### PR TITLE
Remove links to deleted WebGL/XR dictionaries

### DIFF
--- a/files/en-us/web/api/xrwebgllayer/antialias/index.md
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.md
@@ -37,7 +37,7 @@ method.
 Since this is a read-only property, you can set the anti-aliasing mode only when
 initially creating the `XRWebGLLayer`, by specifying the `antialias`
 property in the {{domxref("XRWebGLLayer.XRWebGLLayer", "XRWebGLLayer()")}}
-constructor's `layerInit` configuration object.
+constructor's `options` configuration object.
 
 ## Examples
 
@@ -67,4 +67,3 @@ if (!glLayer.antialias) {
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -49,17 +49,14 @@ framebuffer:
     "checkFramebufferStatus()")}} on the WebGL context from outside the animation frame
   callback causes the WebGL `FRAMEBUFFER_UNSUPPORTED` error (0x8CDD) to be
   reported.
-- Opaque framebuffers initialized with the {{domxref("WebXRLayerInit.depth",
-    "depth")}} property set to `false` will not have a depth buffer and will
+- Opaque framebuffers initialized with the `depth` property set to `false` will not have a depth buffer and will
   rely on the coordinates alone to determine distance.
-- Opaque framebuffers initialized without specifying a
-  {{domxref("WebXRLayerInit.stencil", "stencil")}} will not have a stencil buffer.
-- Opaque framebuffers will not have an alpha channel available unless the
-  {{domxref("WebGLLayerInit.alpha", "alpha")}} property is `true` when
+- Opaque framebuffers initialized without specifying a `stencil`")}}` will not have a stencil buffer.
+- Opaque framebuffers will not have an alpha channel available unless the `alpha` property is `true` when
   creating the layer.
 - The XR compositor assumes that opaque framebuffers use colors with premultiplied
   alpha, regardless of whether or not the WebGL context's
-  {{domxref("WebGLContextAttributes.premultipliedAlpha", "premultipliedAlpha")}} context
+ `premultipliedAlpha`")}}` context
   attribute is set.
 
 > **Note:** The `depth` and `stencil` properties are
@@ -98,5 +95,3 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}
-- {{domxref("WebGLContextAttributes")}}

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
@@ -45,4 +45,3 @@ frameHeight = glLayer.framebufferHeight;
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
@@ -45,4 +45,3 @@ frameHeight = glLayer.framebufferHeight;
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -93,4 +93,3 @@ function drawFrame(time, frame) {
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
@@ -16,7 +16,7 @@ buffer while rendering the scene. If the depth buffer is being used to determine
 position of vertices, this property is `false`.
 
 The value of `ignoreDepthValues` can only be set when the
-{{domxref("XRWebGLLayer")}} is instantiated, by setting the corresponding value in the [constructor's](/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer) `layerInit` parameter.
+{{domxref("XRWebGLLayer")}} is instantiated, by setting the corresponding value in the [constructor's](/en-US/docs/Web/API/XRWebGLLayer/XRWebGLLayer) `options` parameter.
 
 ## Value
 
@@ -73,6 +73,5 @@ let glLayer = new XRWebGLLayer(xrSession, gl, glLayerOptions);
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{domxref("WebGLLayerInit")}}
 - WebGL depth buffer related methods: {{domxref("WebGLRenderingContext.depthFunc",
     "depthFunc()")}}, {{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}}


### PR DESCRIPTION
A few dictionaries were removed long ago. There were a few links to them and a few mentions in the prose.

I removed/updated these.