### PR TITLE
Remove mention of Document.insertAdjacentElement()

### DIFF
--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -37,7 +37,7 @@ This example uses the {{domxref("Element.insertAdjacentHTML()")}} method to inse
 >
 > - The {{domxref("Element.append()")}}/{{domxref("Element.prepend()")}} and {{domxref("Document.append()")}}/{{domxref("Document.prepend()")}} methods.
 > - The {{domxref("Element.replaceWith")}} method (to replace an existing node with the new one)
-> - The {{domxref("Document.insertAdjacentElement()")}} and {{domxref("Element.insertAdjacentElement()")}} methods.
+> - The {{domxref("Element.insertAdjacentElement()")}} method.
 
 Because `insertAdjacentHTML()` accepts a string and not a `Node` as its second parameter, `XMLSerializer` is used to first convert the node into a string.
 


### PR DESCRIPTION
Document.insertAdjacentElement() doesn't exists in spec or implementation, let's not speak about it!