### PR TITLE
Remove link to the constants DONE and UNSENT

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -10,7 +10,7 @@ browser-compat: api.XMLHttpRequest.abort
 The **`XMLHttpRequest.abort()`** method aborts the request if
 it has already been sent. When a request is aborted, its
 {{domxref("XMLHttpRequest.readyState", "readyState")}} is changed to
-`UNSENT` (0) and the request's
+`XMLHttpRequest.UNSENT` (0) and the request's
 {{domxref("XMLHttpRequest.status", "status")}} code is set to 0.
 
 ## Syntax

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -10,7 +10,7 @@ browser-compat: api.XMLHttpRequest.abort
 The **`XMLHttpRequest.abort()`** method aborts the request if
 it has already been sent. When a request is aborted, its
 {{domxref("XMLHttpRequest.readyState", "readyState")}} is changed to
-{{domxref("XMLHttpRequest.UNSENT")}} (0) and the request's
+`UNSENT` (0) and the request's
 {{domxref("XMLHttpRequest.status", "status")}} code is set to 0.
 
 ## Syntax

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -24,7 +24,7 @@ data has not been completely received yet.
 
 You know the entire content has been received when the value of
 {{domxref("XMLHttpRequest.readyState", "readyState")}} becomes
-{{domxref("XMLHttpRequest.DONE", "XMLHttpRequest.DONE")}} (`4`), and
+`DONE` (`4`), and
 {{domxref("XMLHttpRequest.status", "status")}} becomes 200 (`"OK"`).
 
 ### Exceptions

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -24,7 +24,7 @@ data has not been completely received yet.
 
 You know the entire content has been received when the value of
 {{domxref("XMLHttpRequest.readyState", "readyState")}} becomes
-`DONE` (`4`), and
+`XMLHttpRequest.DONE` (`4`), and
 {{domxref("XMLHttpRequest.status", "status")}} becomes 200 (`"OK"`).
 
 ### Exceptions


### PR DESCRIPTION
We don't write separate pages for constants. Transforms the links to a simple text.