### PR TITLE
update link to cotentvisibilityautostatechangeevent spec

### DIFF
--- a/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
+++ b/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ContentVisibilityAutoStateChangeEvent
 
 {{APIRef("CSS Containment")}}
 
-The **`ContentVisibilityAutoStateChangeEvent`** interface of the [CSS Containment Module Level 2](https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change) is the event object for the {{domxref("element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} event, which fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_Containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_Containment#skips_its_contents).
+The **`ContentVisibilityAutoStateChangeEvent`** interface is the event object for the {{domxref("element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} event, which fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_Containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_Containment#skips_its_contents).
 
 While the element is not relevant (between the start and end events), the user agent skips an element's rendering, including layout and painting.
 This can significantly improve page rendering speed.

--- a/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
+++ b/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ContentVisibilityAutoStateChangeEvent
 
 {{APIRef("CSS Containment")}}
 
-The **`ContentVisibilityAutoStateChangeEvent`** interface of the [CSS Containment Module Level 2](https://www.w3.org/TR/css-contain-2/#content-visibility-auto-state-changed) is the event object for the {{domxref("element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} event, which fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_Containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_Containment#skips_its_contents).
+The **`ContentVisibilityAutoStateChangeEvent`** interface of the [CSS Containment Module Level 2](https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change) is the event object for the {{domxref("element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} event, which fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_Containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_Containment#skips_its_contents).
 
 While the element is not relevant (between the start and end events), the user agent skips an element's rendering, including layout and painting.
 This can significantly improve page rendering speed.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the links to the spec definition of cotentvisibilityautostatechangeevent event in MDN.

CSSWG updated the draft and had the new URL for the event and corresponding definitions. https://github.com/w3c/csswg-drafts/pull/8413

### Motivation

So people can click or tap links to get the right information

### Additional details

This is a followup of https://github.com/mdn/content/pull/24263 ; at that time the spec hadn't updated :(

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
