### PR TITLE
Fix typo in link name

### DIFF
--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -62,6 +62,6 @@ function onXRFrame(time, xrFrame) {
 
 ## See also
 
-- {{domxref("XRTransientInputHitResult")}}
+- {{domxref("XRTransientInputHitTestResult")}}
 - {{domxref("XRTransientInputHitTestSource")}}
 - {{domxref("XRRay")}}


### PR DESCRIPTION
`XRTransientInputHitTestResult` was missing the `Test` word. (It is correctly spelled in the first paragraph)