### PR TITLE
Remove onvisibilitychange link in See also

### DIFF
--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -63,5 +63,4 @@ computer's monitor.
 
 ## See also
 
-- {{DOMxRef("XRSession.onvisibilitychange")}}
 - {{DOMxRef("XRSession.visibilitychange_event","visibilitychange")}} event


### PR DESCRIPTION
This page doesn't exist and will never. The next entry in the See also is the `visibilitychange_event` that is the right URL to link; so I remove the first dead link.