### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.md
@@ -29,7 +29,7 @@ system. Alternatively, you can just discard any cached positional information an
 recompute from scratch. The approach you take will depend on your needs.
 
 For details on what causes a `reset` event and how to respond, see the
-{{domxref("XRReferenceSpaceEvent.reset_event", "reset")}} event's documentation.
+{{domxref("XRReferenceSpace.reset_event", "reset")}} event's documentation.
 
 ## Examples
 


### PR DESCRIPTION
The event is sent on `XRReferenceSpace` and not on `XRReferenceSpaceEvent`, hence the dead link. This PR fixes it.