### PR TITLE
Type MediaStreamTrackAudioSource should be MediaStreamTrackAudioSourceNode

### DIFF
--- a/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
@@ -89,4 +89,4 @@ navigator.mediaDevices
 
 - Web Audio API
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
-- {{domxref("MediaStreamTrackAudioSource")}}
+- {{domxref("MediaStreamTrackAudioSourceNode")}}


### PR DESCRIPTION
This explains why it was a red link.