### PR TITLE
browser-compat -> spec-urls as it is a callback

### DIFF
--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -4,7 +4,7 @@ slug: Web/API/AudioWorkletProcessor/process
 page-type: web-api-instance-method
 status:
   - experimental
-browser-compat: api.AudioWorkletProcessor.process
+spec-urls: https://webaudio.github.io/web-audio-api/#process
 ---
 
 {{APIRef("Web Audio API")}}
@@ -192,7 +192,7 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
 
 ## Browser compatibility
 
-{{Compat}}
+This is not a method provided by the browsers, but a callback method that must be written in the client code.
 
 ## See also
 

--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -192,7 +192,7 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
 
 ## Browser compatibility
 
-This is not a method provided by the browsers, but a callback method that must be written in the client code.
+This is not a method provided by browsers, but a callback method that must be written in client code.
 
 ## See also
 


### PR DESCRIPTION
This is an unusual page.

It is about a _callback_ method that the client must write. It deserves its own page as it is not trivial.

Nevertheless, it explains why there is no BCD entry for this method. So I changed the YAML entry from `browser-compat` to `spec-urls`, and hardcoded an explanation in the _Browser compatibility_ section.