### PR TITLE
Fix link to glossary entry Serialization

### DIFF
--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -66,7 +66,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 - {{jsxref("TypeError")}}
   - : Thrown if setting the cookie with the given values fails.
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the origin does not {{glossary("serialize")}} to a URL.
+  - : Thrown if the origin does not {{glossary("Serialization", "serialize")}} to a URL.
 
 ## Examples
 


### PR DESCRIPTION
This was a red link while the article actually existed.