### PR TITLE
Canvas -> HTMLCanvasElement

### DIFF
--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -64,7 +64,7 @@ function setClipboard(text) {
 The code begins by creating a new a {{domxref("Blob")}} object. This object is
 required to construct a {{domxref("ClipboardItem")}} object which is sent to the
 clipboard. The {{domxref("Blob")}} constructor takes in the content we want to copy
-and its type. This {{domxref("Blob")}} object can be derived from many sources, for example, a [canvas](/en-US/docs/Web/API/HTMLCanvasElement).
+and its type. This {{domxref("Blob")}} object can be derived from many sources; for example, a [canvas](/en-US/docs/Web/API/HTMLCanvasElement).
 
 Next, we create a new {{domxref("ClipboardItem")}} object into which the blob will be placed for sending to the clipboard.
 The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then `write()` is called, specifying both a fulfillment function

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -64,7 +64,7 @@ function setClipboard(text) {
 The code begins by creating a new a {{domxref("Blob")}} object. This object is
 required to construct a {{domxref("ClipboardItem")}} object which is sent to the
 clipboard. The {{domxref("Blob")}} constructor takes in the content we want to copy
-and its type. This {{domxref("Blob")}} object can be derived from many sources e.g. a {{domxref("HTMLCanvasElement", "Canvas")}}.
+and its type. This {{domxref("Blob")}} object can be derived from many sources, for example, a [canvas](/en-US/docs/Web/API/HTMLCanvasElement).
 
 Next, we create a new {{domxref("ClipboardItem")}} object into which the blob will be placed for sending to the clipboard.
 The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then `write()` is called, specifying both a fulfillment function

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -64,7 +64,7 @@ function setClipboard(text) {
 The code begins by creating a new a {{domxref("Blob")}} object. This object is
 required to construct a {{domxref("ClipboardItem")}} object which is sent to the
 clipboard. The {{domxref("Blob")}} constructor takes in the content we want to copy
-and its type. This {{domxref("Blob")}} object can be derived from many sources e.g. a {{domxref("Canvas")}}.
+and its type. This {{domxref("Blob")}} object can be derived from many sources e.g. a {{domxref("HTMLCanvasElement", "Canvas")}}.
 
 Next, we create a new {{domxref("ClipboardItem")}} object into which the blob will be placed for sending to the clipboard.
 The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then `write()` is called, specifying both a fulfillment function


### PR DESCRIPTION
In the Web/API world, there is not `Canvas` (interface), so I linked it to the real interface `HTMLCanvasElement`, but kept the word.