### PR TITLE
Fix link to Content Index API

### DIFF
--- a/files/en-us/web/api/contentindex/delete/index.md
+++ b/files/en-us/web/api/contentindex/delete/index.md
@@ -36,8 +36,7 @@ No exceptions are thrown.
 
 ## Examples
 
-Below is an asynchronous function, that removes an item from the {{domxref('Content
-  Index API','content index')}}. We receive a reference to the current
+Below is an asynchronous function, that removes an item from the [content index](/en-US/docs/Web/API/Content_Index_API). We receive a reference to the current
 {{domxref('ServiceWorkerRegistration')}}, which allows us to access the
 {{domxref('ServiceWorkerRegistration.index','index')}} property and thus access the
 `delete` method.


### PR DESCRIPTION
There was an extraneous space that translated into `_`; to use a MD link also fix the typography (no codeface needed here)