### PR TITLE
Remove Response.trailers property

### DIFF
--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -39,8 +39,6 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
   - : The status code of the response. (This will be `200` for a success).
 - {{domxref("Response.statusText")}} {{ReadOnlyInline}}
   - : The status message corresponding to the status code. (e.g., `OK` for `200`).
-- {{domxref("Response.trailers")}}
-  - : A {{jsxref("Promise")}} resolving to a {{domxref("Headers")}} object, associated with the response with {{domxref("Response.headers")}} for values of the HTTP {{HTTPHeader("Trailer")}} header.
 - {{domxref("Response.type")}} {{ReadOnlyInline}}
   - : The type of the response (e.g., `basic`, `cors`).
 - {{domxref("Response.url")}} {{ReadOnlyInline}}


### PR DESCRIPTION
This is not documented, not in the spec, not implemented by anybody. Removing.

(Trailers don't exist in HTTP requests anymore with H2…)