### PR TITLE
CSSKeyframe -> CSSKeyframeRule

### DIFF
--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -27,7 +27,7 @@ _No specific methods; inherits methods from its ancestor {{domxref("CSSRule")}}.
 ## Examples
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
-`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual `CSSKeyFrame` objects for each keyframe.
+`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual `CSSKeyFrameRule` objects for each keyframe.
 
 ```css
 @keyframes slidein {

--- a/files/en-us/web/api/csskeyframerule/keytext/index.md
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.md
@@ -21,7 +21,7 @@ A string.
 ## Examples
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
-`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual {{domxref("CSSKeyFrame")}} objects for each keyframe.
+`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual {{domxref("CSSKeyFrameRule")}} objects for each keyframe.
 
 ```css
 @keyframes slidein {

--- a/files/en-us/web/api/csskeyframerule/style/index.md
+++ b/files/en-us/web/api/csskeyframerule/style/index.md
@@ -25,7 +25,7 @@ A {{domxref("CSSStyleDeclaration")}} object, with the following properties:
 ## Examples
 
 The CSS includes a {{cssxref("@keyframes")}} at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
-`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual `CSSKeyFrame` objects for each keyframe.
+`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object, which will contain individual {{domxref("CSSKeyFrameRule")}} objects for each keyframe.
 
 ```css
 @keyframes slidein {

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -34,7 +34,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 ## Example
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
-`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object.
+`myRules[0]` returns a `CSSKeyframesRule` object.
 
 ```css
 @keyframes slidein {


### PR DESCRIPTION
There is no interface `CSSKeyframe`. They are `CSSKeyframeRule` interface part of a `CSSKeyframesRule`interface.

This fixes this.