### PR TITLE
Remove () in path

### DIFF
--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -11,7 +11,7 @@ To programmatically create an image used by a CSS stylesheet we need to work thr
 
 1. Define a paint worklet using the [`registerPaint()`](/en-US/docs/Web/API/PaintWorklet/registerPaint) function
 2. Register the worklet
-3. Include the `{{cssxref('image/paint()','paint()')}}` CSS function
+3. Include the `{{cssxref("image/paint","paint()")}}` CSS function
 
 To elaborate over these steps, we're going to start by creating a half-highlight background, like on this header:
 

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -11,7 +11,7 @@ The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini
 
 ## Concepts and usage
 
-Essentially, the CSS Painting API contains functionality allowing developers to create custom values for {{cssxref('paint()', 'paint()')}}, a CSS [`<image>`](/en-US/docs/Web/CSS/image) function. You can then apply these values to properties like {{cssxref("background-image")}} to set complex custom backgrounds on an element.
+Essentially, the CSS Painting API contains functionality allowing developers to create custom values for {{cssxref('paint', 'paint()')}}, a CSS [`<image>`](/en-US/docs/Web/CSS/image) function. You can then apply these values to properties like {{cssxref("background-image")}} to set complex custom backgrounds on an element.
 
 For example:
 

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSMathInvert.CSSMathInvert
 
 The **`CSSMathInvert()`** constructor creates a
 new {{domxref("CSSMathInvert")}} object which represents a CSS
-{{CSSXref('calc()','calc()')}} used as `calc(1 / value)`
+{{CSSXref('calc','calc()')}} used as `calc(1 / value)`
 
 ## Syntax
 

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSMathInvert
 
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 
-The **`CSSMathInvert`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents a CSS {{CSSXref('calc()','calc()')}} used as `calc(1 / <value>).` It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
+The **`CSSMathInvert`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / <value>).` It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.md
@@ -10,8 +10,7 @@ browser-compat: api.CSSMathMax.CSSMathMax
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 
 The **`CSSMathMax()`** constructor creates a
-new {{domxref("CSSMathMax")}} object which represents the CSS {{CSSXref('max()',
-  'max()')}} function.
+new {{domxref("CSSMathMax")}} object which represents the CSS {{CSSXref('max', 'max()')}} function.
 
 ## Syntax
 

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSMathMax
 
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 
-The **`CSSMathMax`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('max()','max()')}} function. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
+The **`CSSMathMax`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('max','max()')}} function. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSMathMin.CSSMathMin
 
 The **`CSSMathMin()`** constructor creates a
 new {{domxref("CSSMathMin")}} object which represents the CSS
-{{CSSXref('min()','min()')}} function.
+{{CSSXref('min','min()')}} function.
 
 ## Syntax
 

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSMathMin
 
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 
-The **`CSSMathMin`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('min()','min()')}} function. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
+The **`CSSMathMin`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents the CSS {{CSSXref('min','min()')}} function. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSUnparsedValue
 
 The **`CSSUnparsedValue`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} represents property values that reference [custom properties](/en-US/docs/Web/CSS/CSS_Variables). It consists of a list of string fragments and variable references.
 
-Custom properties are represented by `CSSUnparsedValue` and {{cssxref('var()')}} references are represented using {{domxref('CSSVariableReferenceValue')}}.
+Custom properties are represented by `CSSUnparsedValue` and {{cssxref("var", "var()")}} references are represented using {{domxref('CSSVariableReferenceValue')}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSVariableReferenceValue
 
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 
-The **`CSSVariableReferenceValue`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} allows you to create a custom name for a built-in CSS value. This object functionality is sometimes called a "CSS variable" and serves the same purpose as the {{cssxref('var()')}} function. The custom name must begin with two dashes.
+The **`CSSVariableReferenceValue`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} allows you to create a custom name for a built-in CSS value. This object functionality is sometimes called a "CSS variable" and serves the same purpose as the {{cssxref("var", "var()")}} function. The custom name must begin with two dashes.
 
 ## Constructor
 

--- a/files/en-us/web/api/paintworklet/registerpaint/index.md
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.md
@@ -78,7 +78,7 @@ the `CSS.paintWorklet.addModule()` method:
 </script>
 ```
 
-You can then use the `{{cssxref('paint()', 'paint()')}}` CSS function in your
+You can then use the `{{cssxref('image/paint', 'paint()')}}` CSS function in your
 CSS anywhere an `{{cssxref('&lt;image&gt;')}}` value is valid.
 
 ```css

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -67,7 +67,7 @@ audioWorklet.addModule('modules/bypassFilter.js', {
 CSS.paintWorklet.addModule('https://mdn.github.io/houdini-examples/cssPaint/intro/worklets/hilite.js');
 ```
 
-Once a {{domxref('paintWorklet')}} is included, the CSS {{cssxref('image/paint()')}} function
+Once a {{domxref('paintWorklet')}} is included, the CSS {{cssxref("image/paint", "paint()")}} function
 can be used to include the image created by the worklet:
 
 ```css

--- a/files/en-us/web/css/repeat/index.md
+++ b/files/en-us/web/css/repeat/index.md
@@ -88,10 +88,10 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
 - `<fixed-size>`
   - : One of the following forms:
     - a {{cssxref("&lt;length-percentage&gt;")}} value
-    - a {{cssxref("minmax()")}} function with:
+    - a {{cssxref("minmax", "minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value
       - `max` given as one of a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
-    - a {{cssxref("minmax()")}} function with:
+    - a {{cssxref("minmax", "minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
       - `max` given as a {{cssxref("&lt;length-percentage&gt;")}} value.
 - {{cssxref("&lt;flex&gt;")}}
@@ -105,7 +105,7 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
 - `<track-size>`
   - : One of the following forms:
     - a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
-    - a {{cssxref("minmax()")}} function with:
+    - a {{cssxref("minmax", "minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
       - `max` given as a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
     - a {{cssxref("fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.


### PR DESCRIPTION
We removed `()` in the URL of CSS functions. I found a few occurrences that we forgot to correct. This PR changes them.