### PR TITLE
Link entries() to the iterator protocol

### DIFF
--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CustomStateSet.entries
 
 {{APIRef("DOM")}}{{SeeCompatTable}}
 
-The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns a new {{jsxref("Iterator")}} object, containing an array of `[value,value]` for each element in the `CustomStateSet`.
+The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns a new [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) object, containing an array of `[value,value]` for each element in the `CustomStateSet`.
 
 ## Syntax
 


### PR DESCRIPTION
The link was broken and this one is better.