### PR TITLE
Change broken link to Gecko

### DIFF
--- a/files/en-us/web/api/window/ondragdrop/index.md
+++ b/files/en-us/web/api/window/ondragdrop/index.md
@@ -18,7 +18,7 @@ An event handler for drag and drop events sent to the window.
 
 The event handler function to be registered.
 
-The `window.ondragdrop` property and the `ondragdrop` attribute are not implemented in [Gecko](/en-US/Gecko) ({{ Bug(112288) }}), you have to use `addEventListener`. See [addEventListener](/en-US/docs/Web/API/EventTarget/addEventListener) for details.
+The `window.ondragdrop` property and the `ondragdrop` attribute are not implemented in Firefox ({{ Bug(112288) }}), you have to use `addEventListener`. See [addEventListener](/en-US/docs/Web/API/EventTarget/addEventListener) for details.
 
 ## Examples
 


### PR DESCRIPTION
Changed the link from the engine name (the page moved), to the browser name, to be consistent with the rest of MDN.