### PR TITLE
onpagehide should not be a link

### DIFF
--- a/files/en-us/web/api/window/pagehide_event/index.md
+++ b/files/en-us/web/api/window/pagehide_event/index.md
@@ -69,7 +69,7 @@ window.addEventListener("pagehide", (event) => {
 }, false);
 ```
 
-This can also be written using the {{domxref("Window.onpagehide", "onpagehide")}} event handler property on the {{domxref("Window")}}:
+This can also be written using the `onpagehide` event handler property on the {{domxref("Window")}}:
 
 ```js
 window.onpagehide = (event) => {


### PR DESCRIPTION
We don't have separate pages for `onXYZ`, so, on this page, it shouldn't be a link. This PR fixes this.