### PR TITLE
WebAPI - fix up templates with status

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -24,10 +24,10 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > title: NameOfTheConstructor()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheParentInterface
 > page-type: web-api-constructor
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > browser-compat: path.to.feature.NameOfTheConstructor
 > ---
 > ```
@@ -42,8 +42,8 @@ browser-compat: path.to.feature.NameOfTheConstructor
 >     Note that the name of the constructor function in the slug omits the parenthesis (it ends in `NameOfTheParentInterface` not `NameOfTheParentInterface()`).
 > - **page-type**
 >   - : The `page-type` key for Web/API constructors is always `web-api-constructor`.
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 > - **browser-compat**
 >
 >   - : Replace the placeholder value `path.to.feature.NameOfTheConstructor` with the query string for the constructor in the [Browser compat data repo](https://github.com/mdn/browser-compat-data).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -24,10 +24,10 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > title: "NameOfTheParentInterface: NameOfTheEvent event"
 > slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event
 > page-type: web-api-event
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > browser-compat: path.to.feature.NameOfTheEvent_event
 > ---
 > ```
@@ -41,8 +41,8 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event`.
 > - **page-type**
 >   - : The `page-type` key for Web/API events is always `web-api-event`.
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 > - **browser-compat**
 >
 >   - : Replace the placeholder value `path.to.feature.NameOfTheEvent_event` with the query string for the event in the [Browser compat data repo](https://github.com/mdn/browser-compat-data).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -23,10 +23,10 @@ tags:
 > title: NameOfTheAPI API
 > slug: Web/API/NameOfTheAPI_API
 > page-type: web-api-overview
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > ---
 > ```
 >
@@ -40,8 +40,8 @@ tags:
 >     For example, the [WebXR Device API](/en-US/docs/Web/API/WebVR_API)'s slug is `Web/API/WebXR_Device_API`.
 > - **page-type**
 >   - : The `page-type` key for Web/API landing pages is always `web-api-overview`.
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -24,10 +24,10 @@ browser-compat: path.to.feature.NameOfTheMethod
 > title: NameOfTheParentInterface.NameOfTheMethod()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheMethod
 > page-type: web-api-instance-method OR web-api-static-method
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > browser-compat: path.to.feature.NameOfTheMethod
 > ---
 > ```
@@ -42,8 +42,8 @@ browser-compat: path.to.feature.NameOfTheMethod
 >     Note that the name of the method in the slug omits the parenthesis (it ends in `NameOfTheMethod` not `NameOfTheMethod()`).
 > - **page-type**
 >   - : The `page-type` key for Web/API methods is either `web-api-instance-method` (for instance methods) or `web-api-static-method` (for static methods).
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 > - **browser-compat**
 >
 >   - : Replace the placeholder value `path.to.feature.NameOfTheMethod` with the query string for the method in the [Browser compat data repo](https://github.com/mdn/browser-compat-data).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -24,10 +24,10 @@ browser-compat: path.to.feature.NameOfTheProperty
 > title: NameOfTheParentInterface.NameOfTheProperty
 > slug: Web/API/NameOfTheParentInterface/NameOfTheProperty
 > page-type: web-api-instance-property OR web-api-static-property
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > browser-compat: path.to.feature.NameOfTheProperty
 > ---
 > ```
@@ -41,8 +41,8 @@ browser-compat: path.to.feature.NameOfTheProperty
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheProperty`.
 > - **page-type**
 >   - : The `page-type` key for Web/API properties is either `web-api-instance-property` (for instance properties) or `web-api-static-property` (for static properties).
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 > - **browser-compat**
 >
 >   - : Replace the placeholder value `path.to.feature.NameOfTheProperty` with the query string for the property in the [Browser compat data repo](https://github.com/mdn/browser-compat-data).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -21,10 +21,10 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 > title: NameOfTheInterface
 > slug: Web/API/NameOfTheInterface
 > page-type: web-api-interface
-> tags:
->   - Experimental
->   - Deprecated
->   - Non-standard
+> status:
+>   - experimental
+>   - deprecated
+>   - non-standard
 > browser-compat: path.to.feature.NameOfTheInterface
 > ---
 > ```
@@ -35,8 +35,8 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/API/NameOfTheParentInterface`. For example, [Request](/en-US/docs/Web/API/Request) slug is "Web/API/Request".
 > - **page-type**
 >   - : The `page-type` key for Web/API interfaces is always `web-api-interface`.
-> - **tags**
->   - : Include (appropriate) technology status tags: **Experimental** (if [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), **Deprecated** (if [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete)), **Non-standard** if not on a standards track.
+> - **status**
+>   - : Include (appropriate) technology status keys: [**experimental**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated_and_obsolete), **non-standard** (if not on a standards track).
 > - **browser-compat**
 >
 >   - : Replace the placeholder value `path.to.feature.NameOfTheMethod` with the query string for the method in the [Browser compat data repo](https://github.com/mdn/browser-compat-data). The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the `\{{Compat}}` and `\{{Specifications}}` macros).


### PR DESCRIPTION
This fixes up the page structures for Web APIs to now refer to the status rather than tags.