### PR TITLE
Clean-up non-standard GestureEvent

### DIFF
--- a/files/en-us/web/api/gestureevent/index.md
+++ b/files/en-us/web/api/gestureevent/index.md
@@ -13,12 +13,9 @@ browser-compat: api.GestureEvent
 
 {{APIRef("UI Events")}}{{Non-standard_header}}
 
-{{Non-standard_Header}}
-
 The **`GestureEvent`** is a proprietary interface specific to WebKit which gives information regarding multi-touch gestures. Events using this interface include {{domxref("Element/gesturestart_event", "gesturestart")}}, {{domxref("Element/gesturechange_event", "gesturechange")}}, and {{domxref("Element/gestureend_event", "gestureend")}}.
 
-`GestureEvent` derives from {{domxref("UIEvent")}}, which in turn derives from {{domxref("Event")}}.
-
+{{InheritanceDiagram}}
 ## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
@@ -48,13 +45,3 @@ _Not part of any specification._ Apple has [a description at the Safari Develope
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- {{domxref("MSGestureEvent")}}
-- {{domxref("Element/MSGestureStart_event", "MSGestureStart")}}
-- {{domxref("Element/MSGestureEnd_event", "MSGestureEnd")}}
-- {{domxref("Element/MSGestureTap_event", "MSGestureTap")}}
-- {{domxref("Element/MSGestureHold_event", "MSGestureHold")}}
-- {{domxref("Element/MSGestureChange_event", "MSGestureChange")}}
-- {{domxref("Element/MSInertiaStart_event", "MSInertiaStart")}}

--- a/files/en-us/web/api/gestureevent/index.md
+++ b/files/en-us/web/api/gestureevent/index.md
@@ -16,6 +16,7 @@ browser-compat: api.GestureEvent
 The **`GestureEvent`** is a proprietary interface specific to WebKit which gives information regarding multi-touch gestures. Events using this interface include {{domxref("Element/gesturestart_event", "gesturestart")}}, {{domxref("Element/gesturechange_event", "gesturechange")}}, and {{domxref("Element/gestureend_event", "gestureend")}}.
 
 {{InheritanceDiagram}}
+
 ## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._


### PR DESCRIPTION
There were two _SeeCompatTable_ banners, and the _inheritance diagram_ was in prose instead of using the macro.

I also removed the links in See also to old-IE counterparts.