### PR TITLE
Remove red links to MSLaunchURICallback

### DIFF
--- a/files/en-us/web/api/navigator/mslaunchuri/index.md
+++ b/files/en-us/web/api/navigator/mslaunchuri/index.md
@@ -30,9 +30,9 @@ msLaunchUri(uri, successCallback, noHandlerCallback)
 - `uri`
   - : A string specifying the URL containing including the protocol of the document or resource to be displayed.
 - `successCallback` {{optional_inline}}
-  - : A function matching the signature of {{DOMxRef("MSLaunchUriCallback")}} to be executed if the protocol handler is present.
+  - : A function without parameter to be executed if the protocol handler is present.
 - `noHandlerCallback` {{optional_inline}}
-  - : A function matching {{DOMxRef("MSLaunchUriCallback")}} to be executed if the protocol handler is _not_ present.
+  - : A function without parameter to be executed if the protocol handler is _not_ present.
 
 ### Return value
 
@@ -48,5 +48,4 @@ If the user's system does not have a program registered to handle a specific pro
 
 ## See also
 
-- {{DOMxRef("MSLaunchUriCallback")}}
 - [Microsoft API extensions](/en-US/docs/Web/API/Microsoft_Extensions)

--- a/files/en-us/web/api/navigator/mslaunchuri/index.md
+++ b/files/en-us/web/api/navigator/mslaunchuri/index.md
@@ -30,9 +30,9 @@ msLaunchUri(uri, successCallback, noHandlerCallback)
 - `uri`
   - : A string specifying the URL containing including the protocol of the document or resource to be displayed.
 - `successCallback` {{optional_inline}}
-  - : A function without parameter to be executed if the protocol handler is present.
+  - : A function without any parameters to be executed if the protocol handler is present.
 - `noHandlerCallback` {{optional_inline}}
-  - : A function without parameter to be executed if the protocol handler is _not_ present.
+  - : A function without any parameters to be executed if the protocol handler is _not_ present.
 
 ### Return value
 


### PR DESCRIPTION
We never document callbacks and this is for IE. Until we get to the point to delete the page, I replaced the link with some prose.