### PR TITLE
chore(ci): limit where PR labeler workflow can run

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,9 +1,13 @@
-name: "Pull Request Labeler"
+name: "Pull request labeler"
 on:
-  - pull_request_target
+  pull_request:
+    branches:
+      - main
 
 jobs:
   triage:
+    # do not run on forks
+    if: github.repository == 'mdn/content'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,8 +3,7 @@
 # to upload all the files that were built to our Dev environment.
 # This way, if the tests passed, you'll be able to review the built
 # pages on a public URL.
-
-name: PR Test
+name: PR test
 
 on:
   pull_request:
@@ -16,6 +15,8 @@ on:
 
 jobs:
   tests:
+    # do not run on forks
+    if: github.repository == 'mdn/content'
     runs-on: ubuntu-latest
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -37,7 +38,7 @@ jobs:
       - name: Get changed files
         run: |
           # Use the GitHub API to get the list of changed files
-          # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
+          # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,7 +3,8 @@
 # to upload all the files that were built to our Dev environment.
 # This way, if the tests passed, you'll be able to review the built
 # pages on a public URL.
-name: PR test
+
+name: PR Test
 
 on:
   pull_request:
@@ -15,8 +16,6 @@ on:
 
 jobs:
   tests:
-    # do not run on forks
-    if: github.repository == 'mdn/content'
     runs-on: ubuntu-latest
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -38,7 +37,7 @@ jobs:
       - name: Get changed files
         run: |
           # Use the GitHub API to get the list of changed files
-          # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
+          # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 


### PR DESCRIPTION
Currently the pr labeler workflow runs on forks, see https://github.com/bsmth/content/pull/2/checks

__changes:__
* Check that it's running against `mdn/content` repo
* prefer `pull_request` with branches instead of `pull_request_target`. See [keeping actions secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
* Sentence-case workflow name