### PR TITLE
Doc improved: Changes two wrong placed preferences

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1603,7 +1603,7 @@ The `GeometryUtils` methods `convertPointFromNode()`, `convertRectFromNode()`, a
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2"><code>layout.css.getBoxQuads.enabled</code></td>
+      <td colspan="2"><code>layout.css.convertFromNode.enable</code></td>
     </tr>
   </tbody>
 </table>
@@ -1643,7 +1643,7 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2"><code>layout.css.convertFromNode.enable</code></td>
+      <td colspan="2"><code>layout.css.getBoxQuads.enabled</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- preference for getBoxQuads() method is switched with convertQuadFromNode() method. As it was wrong placed.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #24278 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
