### PR TITLE
Link URL encoding and percent-encoding to relevant place

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -12,7 +12,7 @@ The
 string containing a `'#'` followed by the fragment
 identifier of the URL.
 
-The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
+The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -12,7 +12,7 @@ The
 string containing a `'#'` followed by the fragment
 identifier of the URL.
 
-The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
+The fragment is not [URL encoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/htmlareaelement/hash/index.md
+++ b/files/en-us/web/api/htmlareaelement/hash/index.md
@@ -12,7 +12,7 @@ The
 string containing a `'#'` followed by the fragment
 identifier of the URL.
 
-The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
+The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/htmlareaelement/hash/index.md
+++ b/files/en-us/web/api/htmlareaelement/hash/index.md
@@ -12,7 +12,7 @@ The
 string containing a `'#'` followed by the fragment
 identifier of the URL.
 
-The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
+The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/htmlmetaelement/charset/index.md
+++ b/files/en-us/web/api/htmlmetaelement/charset/index.md
@@ -7,7 +7,7 @@ page-type: web-api-instance-property
 {{APIRef("HTML DOM")}}
 
 The **`HTMLMetaElement.charset`** property is a string that specifies the {{Glossary("character_encoding", "character encoding")}} used in a document.
-Using **non-UTF-8 character encodings is strongly discouraged** as this can create unexpected results on form submission and URL encoding.
+Using **non-UTF-8 character encodings is strongly discouraged** as this can create unexpected results on form submission and [URL encoding](https://en.wikipedia.org/wiki/URL_encoding).
 For more details, see [Character encodings in HTML](/en-US/docs/Web/HTML/Element/meta#attr-charset).
 
 ## Value

--- a/files/en-us/web/api/location/hash/index.md
+++ b/files/en-us/web/api/location/hash/index.md
@@ -12,7 +12,7 @@ The **`hash`** property of the
 `'#'` followed by the fragment identifier of the URL — the ID on the page
 that the URL is trying to target.
 
-The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
+The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/location/hash/index.md
+++ b/files/en-us/web/api/location/hash/index.md
@@ -12,7 +12,7 @@ The **`hash`** property of the
 `'#'` followed by the fragment identifier of the URL — the ID on the page
 that the URL is trying to target.
 
-The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
+The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -11,7 +11,7 @@ The **`hash`** property of the
 {{domxref("URL")}} interface is a string containing a
 `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
+The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string — `""`.
 
 {{AvailableInWorkers}}

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -11,7 +11,7 @@ The **`hash`** property of the
 {{domxref("URL")}} interface is a string containing a
 `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
+The fragment is not [percent-decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string — `""`.
 
 {{AvailableInWorkers}}

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -53,7 +53,7 @@ This attribute is also available on [`<input type="submit">`](/en-US/docs/Web/HT
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after URL encoding the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -60,7 +60,7 @@ This attribute is also available on [`<input type="image">`](/en-US/docs/Web/HTM
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after URL encoding the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -26,14 +26,14 @@ data:[<mediatype>][;base64],<data>
 
 The `mediatype` is a [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) string, such as `'image/jpeg'` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`
 
-If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [percent-encoded](https://en.wikipedia.org/wiki/URL_encoding) (_aka_ "URL encoded").
+If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [URL encoded](https://en.wikipedia.org/wiki/URL_encoding) (_aka_ "URL encoded").
 
 If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data. You can find more info on MIME types [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
 A few examples:
 
 - `data:,Hello%2C%20World%21`
-  - : The text/plain data `Hello, World!`. Note how the comma is [percent-encoded](https://en.wikipedia.org/wiki/URL_encoding) as `%2C`, and the space character as `%20`.
+  - : The text/plain data `Hello, World!`. Note how the comma is [URl encoded](https://en.wikipedia.org/wiki/URL_encoding) as `%2C`, and the space character as `%20`.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`
@@ -120,7 +120,7 @@ lots of text…
 ## See also
 
 - [Base64](/en-US/docs/Glossary/Base64)
-- [Percent encoding](https://en.wikipedia.org/wiki/URL_encoding)
+- [URL encoding](https://en.wikipedia.org/wiki/URL_encoding)
 - {{domxref("atob","atob()")}}
 - {{domxref("btoa","btoa()")}}
 - [CSS `url()`](/en-US/docs/Web/CSS/url)

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -26,14 +26,14 @@ data:[<mediatype>][;base64],<data>
 
 The `mediatype` is a [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) string, such as `'image/jpeg'` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`
 
-If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [percent-encoded](/en-US/docs/Glossary/percent-encoding) (_aka_ "URL-encoded").
+If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [percent-encoded](https://en.wikipedia.org/wiki/URL_encoding) (_aka_ "URL encoded").
 
 If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data. You can find more info on MIME types [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
 A few examples:
 
 - `data:,Hello%2C%20World%21`
-  - : The text/plain data `Hello, World!`. Note how the comma is [percent-encoded](/en-US/docs/Glossary/percent-encoding) as `%2C`, and the space character as `%20`.
+  - : The text/plain data `Hello, World!`. Note how the comma is [percent-encoded](https://en.wikipedia.org/wiki/URL_encoding) as `%2C`, and the space character as `%20`.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`
@@ -120,7 +120,7 @@ lots of text…
 ## See also
 
 - [Base64](/en-US/docs/Glossary/Base64)
-- [Percent encoding](/en-US/docs/Glossary/percent-encoding)
+- [Percent encoding](https://en.wikipedia.org/wiki/URL_encoding)
 - {{domxref("atob","atob()")}}
 - {{domxref("btoa","btoa()")}}
 - [CSS `url()`](/en-US/docs/Web/CSS/url)

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -24,7 +24,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>` and [percent encoded](/en-US/docs/Glossary/percent-encoding).
+  - : The URI reference, must be enclosed between `<` and `>` and [percent encoded](https://en.wikipedia.org/wiki/URL_encoding).
 
 ### Parameters
 

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -24,7 +24,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>` and [percent encoded](https://en.wikipedia.org/wiki/URL_encoding).
+  - : The URI reference, must be enclosed between `<` and `>` and [URL encoded](https://en.wikipedia.org/wiki/URL_encoding).
 
 ### Parameters
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -69,7 +69,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding a control character, {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
 
-    **Encoding**: Many implementations perform URL encoding on cookie values.
+    **Encoding**: Many implementations perform [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) on cookie values.
     However, this is not required by the RFC specification.
     The URL encoding does help to satisfy the requirements of the characters allowed for `<cookie-value>`.
 

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -16,7 +16,7 @@ The difference between {{HTTPMethod("PUT")}} and `POST` is that `PUT` is idempot
 
 A `POST` request is typically sent via an [HTML form](/en-US/docs/Learn/Forms) and results in a change on the server. In this case, the content type is selected by putting the adequate string in the {{htmlattrxref("enctype", "form")}} attribute of the {{HTMLElement("form")}} element or the {{htmlattrxref("formenctype", "input")}} attribute of the {{HTMLElement("input") }} or {{HTMLElement("button")}} elements:
 
-- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [percent encoded](https://en.wikipedia.org/wiki/URL_encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
+- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [URL encoded](https://en.wikipedia.org/wiki/URL_encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
 - `multipart/form-data`: each value is sent as a block of data ("body part"), with a user agent-defined delimiter ("boundary") separating each part. The keys are given in the `Content-Disposition` header of each part.
 - `text/plain`
 

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -16,7 +16,7 @@ The difference between {{HTTPMethod("PUT")}} and `POST` is that `PUT` is idempot
 
 A `POST` request is typically sent via an [HTML form](/en-US/docs/Learn/Forms) and results in a change on the server. In this case, the content type is selected by putting the adequate string in the {{htmlattrxref("enctype", "form")}} attribute of the {{HTMLElement("form")}} element or the {{htmlattrxref("formenctype", "input")}} attribute of the {{HTMLElement("input") }} or {{HTMLElement("button")}} elements:
 
-- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are {{glossary("percent-encoding", "percent encoded")}}: this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
+- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [percent encoded](https://en.wikipedia.org/wiki/URL_encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
 - `multipart/form-data`: each value is sent as a block of data ("body part"), with a user agent-defined delimiter ("boundary") separating each part. The keys are given in the `Content-Disposition` header of each part.
 - `text/plain`
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -37,7 +37,7 @@ A new string in which certain characters have been escaped.
 
 The `escape()` function replaces all characters with escape sequences, with the exception of ASCII word characters (A–Z, a–z, 0–9, _) and `@*_+-./`. Characters are escaped by UTF-16 code units. If the code unit's value is less than 256, it is represented by a two-digit hexadecimal number in the format `%XX`, left-padded with 0 if necessary. Otherwise, it is represented by a four-digit hexadecimal number in the format `%uXXXX`, left-padded with 0 if necessary.
 
-> **Note:** This function was used mostly for URL encoding and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
+> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(3986)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -37,7 +37,7 @@ A new string in which certain characters have been escaped.
 
 The `escape()` function replaces all characters with escape sequences, with the exception of ASCII word characters (A–Z, a–z, 0–9, _) and `@*_+-./`. Characters are escaped by UTF-16 code units. If the code unit's value is less than 256, it is represented by a two-digit hexadecimal number in the format `%XX`, left-padded with 0 if necessary. Otherwise, it is represented by a four-digit hexadecimal number in the format `%uXXXX`, left-padded with 0 if necessary.
 
-> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(3986)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
+> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -37,7 +37,7 @@ A new string in which certain characters have been unescaped.
 
 The `unescape()` function replaces any escape sequence with the character that it represents. Specifically, it replaces any escape sequence of the form `%XX` or `%uXXXX` (where `X` represents one hexadecimal digit) with the character that has the hexadecimal value `XX`/`XXXX`. If the escape sequence is not a valid escape sequence (for example, if `%` is followed by one or no hex digit), it is left as-is.
 
-> **Note:** This function was used mostly for URL encoding and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
+> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(3986)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -37,7 +37,7 @@ A new string in which certain characters have been unescaped.
 
 The `unescape()` function replaces any escape sequence with the character that it represents. Specifically, it replaces any escape sequence of the form `%XX` or `%uXXXX` (where `X` represents one hexadecimal digit) with the character that has the hexadecimal value `XX`/`XXXX`. If the escape sequence is not a valid escape sequence (for example, if `%` is followed by one or no hex digit), it is left as-is.
 
-> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(3986)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
+> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
 
 ## Examples
 


### PR DESCRIPTION
Most were red links to a non-existent glossary entry that never existed.

The wikipedia page is of good quality, let's link to it instead.