### PR TITLE
Remove link to dictionaries, typedef and mixins

### DIFF
--- a/files/en-us/web/api/media_capture_and_streams_api/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/index.md
@@ -27,19 +27,15 @@ In these reference articles, you'll find the fundamental information you'll need
 
 - {{domxref("CanvasCaptureMediaStreamTrack")}}
 - {{domxref("InputDeviceInfo")}}
-- {{domxref("MediaDeviceKind")}}
 - {{domxref("MediaDeviceInfo")}}
 - {{domxref("MediaDevices")}}
 - {{domxref("MediaStream")}}
 - {{domxref("MediaStreamEvent")}}
 - {{domxref("MediaStreamTrack")}}
 - {{domxref("MediaStreamTrackEvent")}}
-- {{domxref("MediaTrackCapabilities")}}
 - {{domxref("MediaTrackConstraints")}}
 - {{domxref("MediaTrackSettings")}}
 - {{domxref("MediaTrackSupportedConstraints")}}
-- {{domxref("NavigatorUserMedia")}}
-- {{domxref("NavigatorUserMediaError")}}
 - {{domxref("OverconstrainedError")}}
 - {{domxref("URL")}}
 


### PR DESCRIPTION
These entities are not interfaces, and won't have their own page. The red links would stay forever.