### PR TITLE
Remove navigator prefix that broke the link

### DIFF
--- a/files/en-us/web/api/mediasession/setcameraactive/index.md
+++ b/files/en-us/web/api/mediasession/setcameraactive/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 Below is an example of updating the camera active state of the current
-{{domxref('MediaSession')}}, as well as listening to requests to change the camera status with {{domxref("navigator.mediaSession.setActionHandler", "setActionHandler")}}.
+{{domxref('MediaSession')}}, as well as listening to requests to change the camera status with {{domxref("MediaSession.setActionHandler", "setActionHandler()")}}.
 
 ```js
 let cameraActive = false;

--- a/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
+++ b/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 Below is an example of updating the microphone mute state of the current
-{{domxref('MediaSession')}}, as well as listening to requests to change the mute status with {{domxref("navigator.mediaSession.setActionHandler", "setActionHandler")}}.
+{{domxref('MediaSession')}}, as well as listening to requests to change the mute status with {{domxref("MediaSession.setActionHandler", "setActionHandler()")}}.
 
 ```js
 let microphoneActive = false;


### PR DESCRIPTION
The navigator prefix is used in practice, but the interface of the method is `MediaSession`. Fixing 2 red links.