### PR TITLE
Remove mention of the deprecated WebVR outside WebVR

### DIFF
--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -9,7 +9,7 @@ browser-compat: api.DOMRect
 
 A **`DOMRect`** describes the size and position of a rectangle.
 
-The type of box represented by the `DOMRect` is specified by the method or property that returned it. For example, {{domxref("Range.getBoundingClientRect()"}} specifies the rectangle that bounds the content of the range using such objects.
+The type of box represented by the `DOMRect` is specified by the method or property that returned it. For example, {{domxref("Range.getBoundingClientRect()")}} specifies the rectangle that bounds the content of the range using such objects.
 
 It inherits from its parent, {{domxref("DOMRectReadOnly")}}.
 

--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -9,7 +9,7 @@ browser-compat: api.DOMRect
 
 A **`DOMRect`** describes the size and position of a rectangle.
 
-The type of box represented by the `DOMRect` is specified by the method or property that returned it. For example, {{domxref("VREyeParameters.renderRect")}} from the WebVR API specifies the viewport of a [canvas](/en-US/docs/Web/API/HTMLCanvasElement) into which visuals for one eye of a head mounted display should be rendered.
+The type of box represented by the `DOMRect` is specified by the method or property that returned it. For example, {{domxref("Range.getBoundingClientRect()"}} specifies the rectangle that bounds the content of the range using such objects.
 
 It inherits from its parent, {{domxref("DOMRectReadOnly")}}.
 


### PR DESCRIPTION
WebVR was used as an example. The link will never work, so I looked for another method returning this interface to use as an example.