### PR TITLE
Remove ArrayBufferView that is a typedef

### DIFF
--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -31,7 +31,7 @@ new FontFace(family, source, descriptors)
     This can be either:
 
     - A URL to a font face file.
-    - Binary font face data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) (or {{domxref("ArrayBufferView")}}).
+    - Binary font face data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
 
 - `descriptors` {{optional_inline}}
 


### PR DESCRIPTION
The link was not working. `ArrayBufferView` is a typedef standing for `ArrayBuffer` or `TypedArray`. This makes it clear.