### PR TITLE
Remove link to non-written deprecated page of WebVR

### DIFF
--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Gamepad.displayId
 
 The **`displayId`** read-only property of the {{domxref("Gamepad")}} interface _returns the {{domxref("VRDisplay.displayId")}} of the associated {{domxref("VRDisplay")}} — the `VRDisplay` that the gamepad is controlling the displayed scene of._
 
-A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the {{domxref("VRDisplay.pose")}}.
+A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the `VRDisplay.pose`.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute). It has been superseded by the [WebXR Gamepads Module](https://immersive-web.github.io/webxr-gamepads-module/).
 >
@@ -20,7 +20,7 @@ A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it r
 
 ## Value
 
-A number representing the associated `VRDisplay.displayId`. If the number is 0, then the gamepad is not associated with a VR display.
+A number representing the associated {{domxref("VRDisplay.displayId")}}. If the number is 0, then the gamepad is not associated with a VR display.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -20,7 +20,7 @@ A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it r
 
 ## Value
 
-A number representing the associated {{domxref("VRDisplay.displayId")}}. If the number is 0, then the gamepad is not associated with a VR display.
+A number representing the associated `VRDisplay.displayId`. If the number is 0, then the gamepad is not associated with a VR display.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Gamepad.displayId
 
 The **`displayId`** read-only property of the {{domxref("Gamepad")}} interface _returns the {{domxref("VRDisplay.displayId")}} of the associated {{domxref("VRDisplay")}} — the `VRDisplay` that the gamepad is controlling the displayed scene of._
 
-A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the `VRDisplay.pose`.
+A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the display's pose, see {{domxref("VRDisplay.getPose()")}}.
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute). It has been superseded by the [WebXR Gamepads Module](https://immersive-web.github.io/webxr-gamepads-module/).
 >


### PR DESCRIPTION
Both this page and WebVR are deprecated. The red link will never be written (WebVR is going 100% away for WebXR). So I kept the text but removed the link.