### PR TITLE
Remove reference to stringification of the objects in console.log

### DIFF
--- a/files/en-us/web/api/console/log/index.md
+++ b/files/en-us/web/api/console/log/index.md
@@ -25,8 +25,8 @@ log(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these
-    objects are appended together in the order listed and output. Please be warned that if
+  - : A list of JavaScript objects to output.
+    Objects are outputted in the order listed. Please be warned that if
     you log objects in the latest versions of Chrome and Firefox what you get logged on
     the console is a _reference to the object_, which is not necessarily the
     'value' of the object at the moment in time you call `console.log()`, but

--- a/files/en-us/web/api/console/log/index.md
+++ b/files/en-us/web/api/console/log/index.md
@@ -26,8 +26,8 @@ log(msg, subst1, /* …, */ substN)
 
 - `obj1` … `objN`
   - : A list of JavaScript objects to output.
-    Objects are outputted in the order listed. Please be warned that if
-    you log objects in the latest versions of Chrome and Firefox what you get logged on
+    Objects are output in the order listed. Please be warned that if
+    you log objects in the latest versions of Chrome and Firefox, what you get logged on
     the console is a _reference to the object_, which is not necessarily the
     'value' of the object at the moment in time you call `console.log()`, but
     it is the value of the object at the moment you open the console.


### PR DESCRIPTION
### Description

I believe all modern browsers use in console an interactive object representation

### Motivation

I think the changed part is outdated

### Related issues and pull requests

Relates https://github.com/mdn/translated-content/pull/11802