### PR TITLE
Fix link to next content page

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -281,7 +281,7 @@ You've reached the end of this article, but can you remember the most important 
 
 ## Summary
 
-If you understood most of this article, then well done — you've started getting familiar with the fundamental mechanics of CSS. Next up, we'll look at [the box model](/en-US/docs/Learn/CSS/Building_blocks/The_box_model) in detail.
+If you understood most of this article, then well done — you've started getting familiar with the fundamental mechanics of CSS. Next up, we'll take a deeper look at [Cascade Layers](/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers).
 
 If you didn't fully understand the cascade, specificity, and inheritance, then don't worry! This is definitely the most complicated thing we've covered so far in the course and is something that even professional web developers sometimes find tricky. We'd advise that you return to this article a few times as you continue through the course, and keep thinking about it.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Currently, this page states, in the summary, that the next topic of study is the box model. 

However, the 'next' button is linked to the Cascade_layers page, and topics in the sidebar on the left are listed in this order: 

...
-Cascade, specificity, and inheritance
-Cascade layers
-The box model
...

My proposal makes the links redundant, so maybe the best approach is to remove the link in the summary statement altogether.

<!-- ✍️ Summarize your changes in one or two sentences -->

Changed the link in the summary statement to go to the next topic, cascade layers, instead of the current linked page, the box model, which skips over a topic in the list. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

This could be intentional, but it feels strange to have a link after the words "Next up" and a link on the "Next" button go to different pages.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
