### PR TITLE
Register protocol handler documentation on browser implementation

### DIFF
--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -32,13 +32,11 @@ Where the parameters are:
 - The URL template, used as the handler. The "%s" is replaced with the `href` of the link and a GET is executed on the resultant URL.
 - The user friendly name for the protocol handler.
 
-When a browser executes this code, it should display a prompt to the user, asking permission to allow the web application to register as a handler for the protocol. Firefox displays a prompt in the notification bar area:
+When a browser executes this code, it should let the user choose how to handle the protocol. The browser could prompt the user for registration immediately or wait until the user clicks on a link that uses the protocol. Firefox displays a prompt in the notification bar area:
 
 ![Screenshot of a prompt that reads: Add Burger handler (google.co.uk) as an application for burger links. An Add Application button is next to the text.](protocolregister.png)
 
 > **Note:** The URL template supplied when registering **must** be of the same domain as the webpage attempting to perform the registration or the registration will fail. For example, `http://example.com/homepage.html` can register a protocol handler for `http://example.com/handle_mailto/%s`, but not for `http://example.org/handle_mailto/%s`.
-
-Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered.
 
 ### Example
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -32,7 +32,7 @@ Where the parameters are:
 - The URL template, used as the handler. The "%s" is replaced with the `href` of the link and a GET is executed on the resultant URL.
 - The user friendly name for the protocol handler.
 
-When a browser executes this code, it should let the user choose how to handle the protocol. The browser could prompt the user for registration immediately or wait until the user clicks on a link that uses the protocol. Firefox displays a prompt in the notification bar area:
+When a browser executes this code, it should let the user choose how to handle the protocol. The browser could prompt the user for registration immediately, or wait until the user clicks on a link that uses the protocol. Firefox displays a prompt in the notification bar area:
 
 ![Screenshot of a prompt that reads: Add Burger handler (google.co.uk) as an application for burger links. An Add Application button is next to the text.](protocolregister.png)
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -40,7 +40,7 @@ When a browser executes this code, it should display a prompt to the user, askin
 
 > **Note:** The URL template supplied when registering **must** be of the same domain as the webpage attempting to perform the registration or the registration will fail. For example, `http://example.com/homepage.html` can register a protocol handler for `http://example.com/handle_mailto/%s`, but not for `http://example.org/handle_mailto/%s`.
 
-Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered. Therefore, it is a good idea to guard your call to register the protocol handler with a check to see if it is already registered, such as in the example below.
+Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered.
 
 ### Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Removes the bits that assume a specific browser implementation and adds another bit explaining browser behavior might differ.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The reader should know the prompt might be displayed or not, depends on browser implementation.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://html.spec.whatwg.org/multipage/system-state.html#custom-handlers
The specification reads 

> User agents may, within the constraints described, do whatever they like. A user agent could, for instance, prompt the user and offer the user the opportunity to add the site to a shortlist of handlers, or make the handlers their default, or cancel the request. User agents could also silently collect the information, providing it only when relevant to the user.

### Related issues and pull requests

Fixes #1845
Relates to #15870
Relates to #15871
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
