### PR TITLE
Fix formatting of WebGLRenderingContext.bindBuffer's target parameter

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -31,17 +31,17 @@ bindBuffer(target, buffer)
         When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
         the following values are available additionally:
 
-      - `gl.COPY_READ_BUFFER`: Buffer for copying from one buffer object
-        to another.
-      - `gl.COPY_WRITE_BUFFER`: Buffer for copying from one buffer object
-        to another.
-      - `gl.TRANSFORM_FEEDBACK_BUFFER`: Buffer for transform feedback
-        operations.
-      - `gl.UNIFORM_BUFFER`: Buffer used for storing uniform blocks.
-      - `gl.PIXEL_PACK_BUFFER`: Buffer used for pixel transfer
-        operations.
-      - `gl.PIXEL_UNPACK_BUFFER`: Buffer used for pixel transfer
-        operations.
+    - `gl.COPY_READ_BUFFER`: Buffer for copying from one buffer object
+      to another.
+    - `gl.COPY_WRITE_BUFFER`: Buffer for copying from one buffer object
+      to another.
+    - `gl.TRANSFORM_FEEDBACK_BUFFER`: Buffer for transform feedback
+      operations.
+    - `gl.UNIFORM_BUFFER`: Buffer used for storing uniform blocks.
+    - `gl.PIXEL_PACK_BUFFER`: Buffer used for pixel transfer
+      operations.
+    - `gl.PIXEL_UNPACK_BUFFER`: Buffer used for pixel transfer
+      operations.
 
 - `buffer`
   - : A {{domxref("WebGLBuffer")}} to bind.

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -26,22 +26,21 @@ bindBuffer(target, buffer)
       - : Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.
     - `gl.ELEMENT_ARRAY_BUFFER`
-
       - : Buffer used for element indices.
-        When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
-        the following values are available additionally:
 
-    - `gl.COPY_READ_BUFFER`: Buffer for copying from one buffer object
-      to another.
-    - `gl.COPY_WRITE_BUFFER`: Buffer for copying from one buffer object
-      to another.
-    - `gl.TRANSFORM_FEEDBACK_BUFFER`: Buffer for transform feedback
-      operations.
-    - `gl.UNIFORM_BUFFER`: Buffer used for storing uniform blocks.
-    - `gl.PIXEL_PACK_BUFFER`: Buffer used for pixel transfer
-      operations.
-    - `gl.PIXEL_UNPACK_BUFFER`: Buffer used for pixel transfer
-      operations.
+    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the following values are available additionally:
+    - `gl.COPY_READ_BUFFER`
+      - : Buffer for copying from one buffer object to another.
+    - `gl.COPY_WRITE_BUFFER`
+      - : Buffer for copying from one buffer object to another.
+    - `gl.TRANSFORM_FEEDBACK_BUFFER`
+      - : Buffer for transform feedback operations.
+    - `gl.UNIFORM_BUFFER`
+      - : Buffer used for storing uniform blocks.
+    - `gl.PIXEL_PACK_BUFFER`
+      - : Buffer used for pixel transfer operations.
+    - `gl.PIXEL_UNPACK_BUFFER`
+      - : Buffer used for pixel transfer operations.
 
 - `buffer`
   - : A {{domxref("WebGLBuffer")}} to bind.


### PR DESCRIPTION


### Description

fix indention

### Motivation

the old indentation made it look like there were only two options for the target param
