### PR TITLE
Remove link in prose to this very same page

### DIFF
--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -48,7 +48,7 @@ In summary:
 
 ![Example of stacking rules modified using z-index](understanding_zindex_04.png)
 
-In this example, every positioned element creates its own stacking context, because of their positioning and `z-index` values. The hierarchy of [stacking contexts](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) is organized as follows:
+In this example, every positioned element creates its own stacking context, because of their positioning and `z-index` values. The hierarchy of stacking contexts is organized as follows:
 
 - Root
 


### PR DESCRIPTION
Auto-linking is not good, especially in the prose (and not in ToC). Removing the link.