### PR TITLE
Change broken link to pertinent link (about XML namespaces)

### DIFF
--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.namespace
 
 {{CSSRef}}
 
-**CSS Namespaces** is a CSS module that allows authors to specify [XML namespaces](/en-US/docs/Namespaces) in CSS.
+**CSS Namespaces** is a CSS module that allows authors to specify [XML namespaces](/en-US/docs/Web/SVG/Namespaces_Crash_Course) in CSS.
 
 ## Reference
 


### PR DESCRIPTION
This is by far the best explanation about XML namespaces. It may move when we refactor the SVG area, but no need to wait for this to link for it (as the original link was a red link anyway).