### PR TITLE
Remove redirecting duplicate links

### DIFF
--- a/files/en-us/web/css/css_logical_properties/index.md
+++ b/files/en-us/web/css/css_logical_properties/index.md
@@ -108,10 +108,10 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 
 ### Deprecated properties
 
-- {{CSSxRef("offset-block-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-end")}})
-- {{CSSxRef("offset-block-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-start")}})
-- {{CSSxRef("offset-inline-end")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-end")}})
-- {{CSSxRef("offset-inline-start")}} {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-start")}})
+- `offset-block-end` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-end")}})
+- `offset-block-start` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-start")}})
+- `offset-inline-end` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-end")}})
+- `offset-inline-start` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-start")}})
 
 ## Guides
 


### PR DESCRIPTION
These links were redirected to the same link as put in the explanation right after. These properties are gone and won't get their own pages. Mentioning them without the link is clearer: no surprise for the reader if they click on it. (They can't anymore), without loss of information.