### PR TITLE
Fix links to CSS image-related functions (like gradients)

### DIFF
--- a/files/en-us/web/css/css_images/index.md
+++ b/files/en-us/web/css/css_images/index.md
@@ -24,15 +24,15 @@ spec-urls:
 
 ### Functions
 
-- {{CSSxRef("linear-gradient", "linear-gradient()")}}
-- {{CSSxRef("radial-gradient", "radial-gradient()")}}
-- {{CSSxRef("repeating-linear-gradient", "repeating-linear-gradient()")}}
-- {{CSSxRef("repeating-radial-gradient", "repeating-radial-gradient()")}}
-- {{CSSxRef("conic-gradient")}}
-- {{CSSxRef("repeating-conic-gradient", "repeating-conic-gradient()")}}
+- {{CSSxRef("image/linear-gradient", "linear-gradient()")}}
+- {{CSSxRef("image/radial-gradient", "radial-gradient()")}}
+- {{CSSxRef("image/repeating-linear-gradient", "repeating-linear-gradient()")}}
+- {{CSSxRef("image/repeating-radial-gradient", "repeating-radial-gradient()")}}
+- {{CSSxRef("image/conic-gradient", "conic-gradient()")}}
+- {{CSSxRef("image/repeating-conic-gradient", "repeating-conic-gradient()")}}
 - {{CSSxRef("url", "url()")}}
 - {{CSSxRef("element", "element()")}}
-- {{CSSxRef("_image", "image()")}}
+- {{CSSxRef("image/image", "image()")}}
 - {{CSSxRef("cross-fade", "cross-fade()")}}
 
 ### Data types

--- a/files/en-us/web/css/css_images/index.md
+++ b/files/en-us/web/css/css_images/index.md
@@ -24,12 +24,12 @@ spec-urls:
 
 ### Functions
 
-- {{CSSxRef("image/linear-gradient", "linear-gradient()")}}
-- {{CSSxRef("image/radial-gradient", "radial-gradient()")}}
-- {{CSSxRef("image/repeating-linear-gradient", "repeating-linear-gradient()")}}
-- {{CSSxRef("image/repeating-radial-gradient", "repeating-radial-gradient()")}}
-- {{CSSxRef("image/conic-gradient", "conic-gradient()")}}
-- {{CSSxRef("image/repeating-conic-gradient", "repeating-conic-gradient()")}}
+- {{CSSxRef("gradient/linear-gradient", "linear-gradient()")}}
+- {{CSSxRef("gradient/radial-gradient", "radial-gradient()")}}
+- {{CSSxRef("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}}
+- {{CSSxRef("gradient/repeating-radial-gradient", "repeating-radial-gradient()")}}
+- {{CSSxRef("gradient/conic-gradient", "conic-gradient()")}}
+- {{CSSxRef("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}}
 - {{CSSxRef("url", "url()")}}
 - {{CSSxRef("element", "element()")}}
 - {{CSSxRef("image/image", "image()")}}


### PR DESCRIPTION
We moved them under image/ long ago. This PR fixes the links.