### PR TITLE
Fix link to glossary

### DIFF
--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -149,7 +149,7 @@ The example below shows a three-column track grid with new rows created at a min
   - [Grid area](/en-US/docs/Glossary/Grid_Areas)
   - [Gutters](/en-US/docs/Glossary/Gutters)
   - [Grid axis](/en-US/docs/Glossary/Grid_Axis)
-  - [Grid row](/en-US/docs/Glossary/Grid_Rows)
+  - [Grid row](/en-US/docs/Glossary/Grid_Row)
   - [Grid column](/en-US/docs/Glossary/Grid_Column)
 - [Grid by Example](https://gridbyexample.com/) - A collection of usage examples and video tutorials
 - [CSS Grid Reference - Codrops](https://tympanus.net/codrops/css_reference/grid/)


### PR DESCRIPTION
The article's title use the singular, hence the red link as the link was to the plural version of the word.