### PR TITLE
Remove link to a never-implemented descriptor

### DIFF
--- a/files/en-us/web/css/font-feature-settings/index.md
+++ b/files/en-us/web/css/font-feature-settings/index.md
@@ -118,7 +118,6 @@ td.tabular {
 - {{cssxref("@font-face/font-stretch", "font-stretch")}}
 - {{cssxref("@font-face/font-style", "font-style")}}
 - {{cssxref("@font-face/font-weight", "font-weight")}}
-- {{cssxref("@font-face/font-variant", "font-variant")}}
 - {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}
 - {{cssxref("@font-face/src", "src")}}
 - {{cssxref("@font-face/unicode-range", "unicode-range")}}


### PR DESCRIPTION
The `font-variant` descriptor has been removed in 2018 from the spec (see note in the MDN article) and has never been implemented by browsers.

We should just remove it from this list.