### PR TITLE
Don't use cssxref for SVG attributes

### DIFF
--- a/files/en-us/web/css/filter_effects/index.md
+++ b/files/en-us/web/css/filter_effects/index.md
@@ -48,7 +48,7 @@ To see the code for this filter effects sample, [view the source on Github](http
 
 - {{glossary("interpolation")}} glossary term
 
-- {{cssxref("color-interpolation-filters")}} SVG property
+- [`color-interpolation-filters`](/en-US/docs/Web/SVG/Attribute/color-interpolation-filters) SVG property
 
 ## Specifications
 


### PR DESCRIPTION
This is a SVG attribute used as a CSS property. `cssxref` doesn't work well with these, so I used a Markdown link instead.