### PR TITLE
Remove See also link to this very same page

### DIFF
--- a/files/en-us/web/css/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/font-variant-ligatures/index.md
@@ -190,7 +190,6 @@ p {
 ## See also
 
 - [`font-variant`](/en-US/docs/Web/CSS/font-variant)
-- [`font-variant-alternates`](/en-US/docs/Web/CSS/font-variant-ligatures)
 - [`font-variant-caps`](/en-US/docs/Web/CSS/font-variant-caps)
 - [`font-variant-emoji`](/en-US/docs/Web/CSS/font-variant-emoji)
 - [`font-variant-east-asian`](/en-US/docs/Web/CSS/font-variant-east-asian)


### PR DESCRIPTION
If it is this page, it isn't something to _see also_.