### PR TITLE
Fix broken link to Canvas API in See also

### DIFF
--- a/files/en-us/web/css/image/paint/index.md
+++ b/files/en-us/web/css/image/paint/index.md
@@ -123,4 +123,4 @@ We've included a custom property in the selector block defining a boxColor. Cust
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide)
 - {{cssxref("&lt;image&gt;")}}
-- {{domxref("canvas")}}
+- [Canvas API](/en-US/docs/Web/API/Canvas_API)


### PR DESCRIPTION
The page was moved years ago, and I guess no redirect was made.