### PR TITLE
docs(CSS): Fix links to communication channels, minor cleanup

### DIFF
--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -18,7 +18,7 @@ A recipe consists of:
 
 1. A live example, stored in the [CSS Examples GitHub repo](https://github.com/mdn/css-examples).
 2. A downloadable version of that example, also stored in the CSS Examples repo.
-3. A page in the [CSS layout cookbook](/en-US/docs/Web/CSS/Layout_cookbook) section of the site that details:
+3. A page in the [CSS layout cookbook](/en-US/docs/Web/CSS/Layout_cookbook) section of the site that includes:
 
    1. Requirements
    2. The recipe
@@ -70,13 +70,11 @@ Make a PR on the [CSS Examples repo](https://github.com/mdn/css-examples). This 
 
 ### 5. Create your page
 
-Once your example is merged you can create your page. You will need an MDN account to do so with [page creation permissions](/en-US/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting#getting_page_creation_permissions), and you can then create the page as a subpage of the CSS Cookbook page. [There is a template for Cookbook pages here](/en-US/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template).
+Once your example is merged you can [open a pull request](/en-US/docs/MDN/Community/Pull_requests#open_a_pull_request) to create a new page for it in the [Layout Cookbook directory](https://github.com/mdn/content/tree/main/files/en-us/web/css/layout_cookbook).
+There is [a template for Cookbook pages](https://github.com/mdn/content/blob/main/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md?plain=1) that you should use.
+The template explains what should be part of each section, and you can refer to other cookbook examples for more help.
 
-The template explains what should be part of each section, and you can refer to other cookbook examples for more help. If you click to edit any of those pages then you will be able to see things such as the macros used to embed compat data, and live examples.
-
-If you need general guidance on using the MDN wiki, see the help pages available here.
-
-If you need to ask any questions, or want someone to take a look at your page then the [MDN Discourse forum](https://discourse.mozilla.org/c/mdn/236) is a good place to do this, or [chat with us on Matrix](/en-US/docs/MDN/Community/Conversations#synchronous_chat).
+If you need to ask any questions, or want someone to take a look at your page, get in touch with us on any of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/index.md
+++ b/files/en-us/web/css/layout_cookbook/index.md
@@ -27,4 +27,4 @@ The CSS layout cookbook aims to bring together recipes for common layout pattern
 
 ## Contribute a Recipe
 
-As with all of MDN we would love you to contribute a recipe in the same format as the ones shown above. [See this page](/en-US/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe) for a template and guidelines for writing your own example.
+As with all of MDN we would love you to contribute a recipe in the same format as the ones shown above. See the [guide for adding Layout Cookbook recipes](/en-US/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe) for a template and guidelines for writing your own example.


### PR DESCRIPTION
__Changes:__
* Link to communication channels page for easier maintenance of Matrix / Discord links
* Remove references to wiki editing processes
* Improve link text