### PR TITLE
Fix broken glossary links

### DIFF
--- a/files/en-us/web/css/grid-template-rows/index.md
+++ b/files/en-us/web/css/grid-template-rows/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.grid-template-rows
 
 {{CSSRef}}
 
-The **`grid-template-rows`** CSS property defines the line names and track sizing functions of the {{glossary("grid rows", "grid rows")}}.
+The **`grid-template-rows`** CSS property defines the line names and track sizing functions of the {{glossary("grid_row", "grid rows")}}.
 
 {{EmbedInteractiveExample("pages/css/grid-template-rows.html")}}
 

--- a/files/en-us/web/css/grid-template/index.md
+++ b/files/en-us/web/css/grid-template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.grid-template
 
 {{CSSRef}}
 
-The **`grid-template`** CSS property is a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) for defining {{glossary("grid column", "grid columns")}}, {{glossary("grid rows", "grid rows")}}, and {{glossary("grid areas", "grid areas")}}.
+The **`grid-template`** CSS property is a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) for defining {{glossary("grid column", "grid columns")}}, {{glossary("grid_row", "grid rows")}}, and {{glossary("grid areas", "grid areas")}}.
 
 {{EmbedInteractiveExample("pages/css/grid-template.html")}}
 


### PR DESCRIPTION
Grid row is singular in the Glossary.