### PR TITLE
Fix spec and browser-compat tables for mask-border-mode

### DIFF
--- a/files/en-us/web/css/mask-border-mode/index.md
+++ b/files/en-us/web/css/mask-border-mode/index.md
@@ -2,7 +2,7 @@
 title: mask-border-mode
 slug: Web/CSS/mask-border-mode
 page-type: css-property
-browser-compat: css.properties.mask-border-mode
+spec-urls: https://drafts.fxtf.org/css-masking-1/#the-mask-border-mode
 ---
 
 {{CSSRef}}
@@ -39,24 +39,13 @@ mask-border-mode: unset;
 
 {{csssyntax}}
 
-## Examples
-
-### Basic usage
-
-This property doesn't yet seem to have support anywhere. When browsers support it, it will specify the type of blending mode used for the mask border — luminance or alpha:
-
-```css
-mask-border-mode: luminance;
-mask-border-mode: alpha;
-```
-
 ## Specifications
 
 {{Specifications}}
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any browser yet.
 
 ## See also
 


### PR DESCRIPTION
This property is unsupported:
- I used `spec_url` to fix the Specification table.
- I remove the `browser-compat` key and hardcoded the compat information. Once somebody implements it, this will come back. Our processes ensure that this will not be forgotten.
- I removed the example section as it wasn't an example but just a repetition of the syntax.

Note that, nowadays, we won't merge PRs for proposed features. But this dates from the Wiki era of MDN.