### PR TITLE
Fix broken links to old-IE features

### DIFF
--- a/files/en-us/web/css/microsoft_extensions/index.md
+++ b/files/en-us/web/css/microsoft_extensions/index.md
@@ -12,70 +12,70 @@ Microsoft applications such as Edge and Internet Explorer support a number of sp
 
 ## Microsoft-only properties (avoid using on websites)
 
-> **Note:** These properties will only work in Microsoft applications, and are not on a standards track.
+> **Note:** These properties will only work in Internet Explorer and Microsoft applications based on the same engine, and are not on a standards track.
 
-- {{CSSxRef("-ms-accelerator")}}
-- {{CSSxRef("-ms-block-progression")}}
-- {{CSSxRef("-ms-content-zoom-chaining")}}
-- {{CSSxRef("-ms-content-zooming")}}
-- {{CSSxRef("-ms-content-zoom-limit")}}
-- {{CSSxRef("-ms-content-zoom-limit-max")}}
-- {{CSSxRef("-ms-content-zoom-limit-min")}}
-- {{CSSxRef("-ms-content-zoom-snap")}}
-- {{CSSxRef("-ms-content-zoom-snap-points")}}
-- {{CSSxRef("-ms-content-zoom-snap-type")}}
-- {{CSSxRef("-ms-filter")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-flow-from")}}
-- {{CSSxRef("-ms-flow-into")}}
-- {{CSSxRef("-ms-high-contrast-adjust")}}
-- {{CSSxRef("-ms-hyphenate-limit-chars")}}
-- {{CSSxRef("-ms-hyphenate-limit-lines")}}
-- {{CSSxRef("-ms-hyphenate-limit-zone")}}
-- {{CSSxRef("-ms-ime-align")}}
-- {{CSSxRef("-ms-overflow-style")}}
-- {{CSSxRef("-ms-scrollbar-3dlight-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-arrow-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-base-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-darkshadow-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-face-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-highlight-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-shadow-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scrollbar-track-color")}} {{deprecated_inline}}
-- {{CSSxRef("-ms-scroll-chaining")}}
-- {{CSSxRef("-ms-scroll-limit")}}
-- {{CSSxRef("-ms-scroll-limit-x-max")}}
-- {{CSSxRef("-ms-scroll-limit-x-min")}}
-- {{CSSxRef("-ms-scroll-limit-y-max")}}
-- {{CSSxRef("-ms-scroll-limit-y-min")}}
-- {{CSSxRef("-ms-scroll-rails")}}
-- {{CSSxRef("-ms-scroll-snap-points-x")}}
-- {{CSSxRef("-ms-scroll-snap-points-y")}}
-- {{CSSxRef("-ms-scroll-snap-x")}}
-- {{CSSxRef("-ms-scroll-snap-y")}}
-- {{CSSxRef("-ms-scroll-translation")}}
-- {{CSSxRef("-ms-text-autospace")}}
-- {{CSSxRef("-ms-touch-select")}}
-- {{CSSxRef("-ms-wrap-flow")}}
-- {{CSSxRef("-ms-wrap-margin")}}
-- {{CSSxRef("-ms-wrap-through")}}
+- `-ms-accelerator`
+- `-ms-block-progression`
+- `-ms-content-zoom-chaining`
+- `-ms-content-zooming`
+- `-ms-content-zoom-limit`
+- `-ms-content-zoom-limit-max`
+- `-ms-content-zoom-limit-min`
+- `-ms-content-zoom-snap`
+- `-ms-content-zoom-snap-points`
+- `-ms-content-zoom-snap-type`
+- `-ms-filter` {{deprecated_inline}}
+- `-ms-flow-from`
+- `-ms-flow-into`
+- `-ms-high-contrast-adjust`
+- `-ms-hyphenate-limit-chars`
+- `-ms-hyphenate-limit-lines`
+- `-ms-hyphenate-limit-zone`
+- `-ms-ime-align`
+- `-ms-overflow-style`
+- `-ms-scrollbar-3dlight-color` {{deprecated_inline}}
+- `-ms-scrollbar-arrow-color` {{deprecated_inline}}
+- `-ms-scrollbar-base-color` {{deprecated_inline}}
+- `-ms-scrollbar-darkshadow-color` {{deprecated_inline}}
+- `-ms-scrollbar-face-color` {{deprecated_inline}}
+- `-ms-scrollbar-highlight-color` {{deprecated_inline}}
+- `-ms-scrollbar-shadow-color` {{deprecated_inline}}
+- `-ms-scrollbar-track-color` {{deprecated_inline}}
+- `-ms-scroll-chaining`
+- `-ms-scroll-limit`
+- `-ms-scroll-limit-x-max`
+- `-ms-scroll-limit-x-min`
+- `-ms-scroll-limit-y-max`
+- `-ms-scroll-limit-y-min`
+- `-ms-scroll-rails`
+- `-ms-scroll-snap-points-x`
+- `-ms-scroll-snap-points-y`
+- `-ms-scroll-snap-x`
+- `-ms-scroll-snap-y`
+- `-ms-scroll-translation`
+- `-ms-text-autospace`
+- `-ms-touch-select`
+- `-ms-wrap-flow`
+- `-ms-wrap-margin`
+- `-ms-wrap-through`
 - {{CSSxRef("zoom")}}
 
 ## Pseudo-elements
 
 - {{CSSxRef("::file-selector-button","::-ms-browse")}}\*
-- {{CSSxRef("::-ms-check")}}
-- {{CSSxRef("::-ms-clear")}}
-- {{CSSxRef("::-ms-expand")}}
-- {{CSSxRef("::-ms-fill")}}
-- {{CSSxRef("::-ms-fill-lower")}}
-- {{CSSxRef("::-ms-fill-upper")}}
-- {{CSSxRef("::-ms-reveal")}}
-- {{CSSxRef("::-ms-thumb")}}
-- {{CSSxRef("::-ms-ticks-after")}}
-- {{CSSxRef("::-ms-ticks-before")}}
-- {{CSSxRef("::-ms-tooltip")}}
-- {{CSSxRef("::-ms-track")}}
-- {{CSSxRef("::-ms-value")}}
+- `::-ms-check`
+- `::-ms-clear`
+- `::-ms-expand`
+- `::-ms-fill`
+- `::-ms-fill-lower`
+- `::-ms-fill-upper`
+- `::-ms-reveal`
+- `::-ms-thumb`
+- `::-ms-ticks-after`
+- `::-ms-ticks-before`
+- `::-ms-tooltip`
+- `::-ms-track`
+- `::-ms-value`
 
 \* Now standard.
 
@@ -85,7 +85,7 @@ Microsoft applications such as Edge and Internet Explorer support a number of sp
 
 ## CSS-related DOM APIs
 
-- {{DOMxRef("msContentZoomFactor")}}
+- `msContentZoomFactor`
 - {{DOMxRef("msGetPropertyEnabled")}}
 - {{DOMxRef("msGetRegionContent")}}
 - {{DOMxRef("MSRangeCollection")}}
@@ -96,4 +96,3 @@ Microsoft applications such as Edge and Internet Explorer support a number of sp
 - [Mozilla CSS Extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
 - [WebKit CSS Extensions](/en-US/docs/Web/CSS/WebKit_Extensions)
 - [Microsoft API Extensions](/en-US/docs/Web/API/Microsoft_Extensions)
-- [Microsoft JavaScript Extensions](/en-US/docs/Web/JavaScript/Microsoft_JavaScript_extensions)


### PR DESCRIPTION
We keep this page for now as we remove IE stuff inside articles but still keep specific pages. (This will change at some point in the future)

So I removed the red links from it. Advantages:
- we declutter the flaw dashboard (>50 flaws)
- we avoid tempting people to document these
- we get a better-looking page, which is good for the overall MDN experience.