### PR TITLE
Remove / at end of a link

### DIFF
--- a/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility
 page-type: guide
 ---
 
-[**Media Queries**](/en-US/docs/Web/CSS/@media/) can be used to help users with disabilities better experience your website.
+[**Media Queries**](/en-US/docs/Web/CSS/@media) can be used to help users with disabilities better experience your website.
 
 ## Reduced Motion
 


### PR DESCRIPTION
This sounds ridiculous, but this raises a flaw in yari. Let's get rid of it.