### PR TITLE
Remove IE-only, broken link in See also

### DIFF
--- a/files/en-us/web/css/scrollbar-width/index.md
+++ b/files/en-us/web/css/scrollbar-width/index.md
@@ -113,5 +113,4 @@ WCAG criterion 2.1.1 (Keyboard) has been in place for a long time to advise on b
 
 ## See also
 
-- {{CSSxRef("-ms-overflow-style")}}
 - {{CSSxRef("::-webkit-scrollbar")}}


### PR DESCRIPTION
The link was broken (the page was never written) and it was an IE-only feature that we won't document. Also, we remove IE-only comments on generic pages.