### PR TITLE
Fix wrong definition

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -10,7 +10,7 @@ tags:
 spec-urls: https://w3c.github.io/aria/#aria-expanded
 ---
 
-The `aria-expanded` attribute is set on an element to indicate if a control is expanded or collapsed, and whether or not the controled elements are displayed or hidden.
+The `aria-expanded` attribute is set on an element to indicate if a control is expanded or collapsed, and whether or not the controlled elements are displayed or hidden.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -10,7 +10,7 @@ tags:
 spec-urls: https://w3c.github.io/aria/#aria-expanded
 ---
 
-The `aria-expanded` attribute is set on an element to indicate if a control is expanded or collapsed, and whether or not its child elements are displayed or hidden.
+The `aria-expanded` attribute is set on an element to indicate if a control is expanded or collapsed, and whether or not the controled elements are displayed or hidden.
 
 ## Description
 


### PR DESCRIPTION
It’s a common misunderstanding that the collapsed contents themselves (the content’s parent) would carry the `aria-expanded` attribute. The current definition supports that wrong impression.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
