### PR TITLE
Document OES_draw_buffers_indexed

### DIFF
--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
@@ -9,7 +9,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendEquationiOES
 
 The `blendEquationiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets both the RGB blend equation and alpha blend equation for a particular draw buffer.
 
-See {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}} for setting RBG and alpha separately and {{DOMxRef("WebGLRenderingContext.blendEquation()")}} for the WebGL 1 version of this method.
+See {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}} for setting RGB and alpha separately and {{DOMxRef("WebGLRenderingContext.blendEquation()")}} for the WebGL 1 version of this method.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
@@ -1,0 +1,72 @@
+---
+title: OES_draw_buffers_indexed.blendEquationiOES()
+slug: Web/API/OES_draw_buffers_indexed/blendEquationiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.blendEquationiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `blendEquationiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets both the RGB blend equation and alpha blend equation for a particular draw buffer.
+
+See {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}} for setting RBG and alpha separately and {{DOMxRef("WebGLRenderingContext.blendEquation()")}} for the WebGL 1 version of this method.
+
+## Syntax
+
+```js-nolint
+blendEquationiOES(buf, mode)
+```
+
+### Parameters
+
+- `buf`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+- `mode`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying how source and destination colors are combined. Accepts the same enums as the `mode` parameter in {{DOMxRef("WebGLRenderingContext.blendEquation()")}}.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `buf` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+- If `mode` is not one of the possible values, a `gl.INVALID_ENUM` error is thrown.
+
+## Examples
+
+### Setting and getting blend equations
+
+You can set the blend equations for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers like this:
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.blendEquationiOES(0, gl.FUNC_ADD);
+ext.blendEquationiOES(1, gl.FUNC_SUBTRACT);
+```
+
+To get the blend equations for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers, query the `BLEND_EQUATION_RGB` and `BLEND_EQUATION_ALPHA` constants using {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}:
+
+```js
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 0);
+
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}}
+- {{DOMxRef("WebGLRenderingContext.blendEquation()")}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendEquationiOES
 
 {{APIRef("WebGL")}}
 
-The `blendEquationiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets both the RGB blend equation and alpha blend equation for a particular draw buffer.
+The `blendEquationiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets both the RGB blend and alpha blend equations for a particular draw buffer.
 
 See {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}} for setting RGB and alpha separately and {{DOMxRef("WebGLRenderingContext.blendEquation()")}} for the WebGL 1 version of this method.
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
@@ -1,0 +1,74 @@
+---
+title: OES_draw_buffers_indexed.blendEquationSeparateiOES()
+slug: Web/API/OES_draw_buffers_indexed/blendEquationSeparateiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.blendEquationSeparateiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `blendEquationSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets the RGB blend equation and alpha blend equation separately for a particular draw buffer.
+
+See {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}} for setting RBG and alpha together and {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}} for the WebGL 1 version of this method.
+
+## Syntax
+
+```js-nolint
+blendEquationSeparateiOES(buf, modeRGB, modeAlpha)
+```
+
+### Parameters
+
+- `buf`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+- `modeRGB`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying how source and destination RGB color components are combined. Accepts the same enums as the `modeRGB` parameter in {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}}.
+- `modeAlpha`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying how source and destination alpha color components are combined. Accepts the same enums as the `modeAlpha` parameter in {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}}.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `buf` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+- If `modeRGB` or `modeAlpha` are not set to one of the possible values, a `gl.INVALID_ENUM` error is thrown.
+
+## Examples
+
+### Setting and getting blend equations
+
+The following sets the blend equations for the draw buffers `gl.DRAW_BUFFER0` (call where `buf` is 0) and `gl.DRAW_BUFFER1` (call where `buf` is 1).
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.blendEquationSeparateiOES(0, gl.FUNC_ADD, gl.FUNC_SUBTRACT);
+ext.blendEquationSeparateiOES(1, gl.FUNC_ADD, gl.FUNC_SUBTRACT);
+```
+
+To get the blend equations for `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1`, query the `BLEND_EQUATION_RGB` and `BLEND_EQUATION_ALPHA` constants using {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}:
+
+```js
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 0);
+
+// for gl.DRAW_BUFFER1
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}}
+- {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendEquationSeparateiOES
 
 {{APIRef("WebGL")}}
 
-The `blendEquationSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets the RGB blend equation and alpha blend equation separately for a particular draw buffer.
+The `blendEquationSeparateiOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension sets the RGB and alpha blend equations separately for a particular draw buffer.
 
 See {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}} for setting RGB and alpha together and {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}} for the WebGL 1 version of this method.
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendequationseparateioes/index.md
@@ -9,7 +9,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendEquationSeparateiOES
 
 The `blendEquationSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets the RGB blend equation and alpha blend equation separately for a particular draw buffer.
 
-See {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}} for setting RBG and alpha together and {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}} for the WebGL 1 version of this method.
+See {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}} for setting RGB and alpha together and {{DOMxRef("WebGLRenderingContext.blendEquationSeparate()")}} for the WebGL 1 version of this method.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncioes/index.md
@@ -1,0 +1,79 @@
+---
+title: OES_draw_buffers_indexed.blendFunciOES()
+slug: Web/API/OES_draw_buffers_indexed/blendFunciOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.blendFunciOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `blendFunciOES()` method of the `OES_draw_buffers_indexed` WebGL extension defines which function is used when blending pixels for a particular draw buffer.
+
+See {{DOMxRef("OES_draw_buffers_indexed.blendFuncSeparateiOES()")}} for setting RGB and alpha components separately and {{DOMxRef("WebGLRenderingContext.blendFunc()")}} for the WebGL 1 version of this method.
+
+## Syntax
+
+```js-nolint
+blendFunciOES(buf, src, dst)
+```
+
+### Parameters
+
+- `buf`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+- `src`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the source blending factors. Accepts the same enums as the `sfactor` parameter in {{DOMxRef("WebGLRenderingContext.blendFunc()")}}.
+- `dst`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the destination blending factors. Accepts the same enums as the `dfactor` parameter in {{DOMxRef("WebGLRenderingContext.blendFunc()")}}.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `buf` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+- If `src` or `dst` are not one of the possible values, a `gl.INVALID_ENUM` error is thrown.
+- The same blending limitations as for {{DOMxRef("WebGLRenderingContext.blendFunc()")}} apply: If a constant color and a constant alpha value are used together as source and destination factors, a `gl.INVALID_ENUM` error is thrown.
+
+## Examples
+
+### Setting and getting blend functions
+
+You can set the blend functions for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers like this:
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.blendFunciOES(0, gl.ONE, gl.ONE);
+ext.blendFunciOES(1, gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+```
+
+To get the blend functions for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers, query the `BLEND_SRC_RGB`, `BLEND_SRC_ALPHA`, `BLEND_DST_RGB`, and `BLEND_DST_ALPHA` constants using {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}:
+
+```js
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 0);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 0);
+
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 1);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{DOMxRef("OES_draw_buffers_indexed.blendFuncSeparateiOES()")}}
+- {{DOMxRef("WebGLRenderingContext.blendFunc()")}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendFunciOES
 
 {{APIRef("WebGL")}}
 
-The `blendFunciOES()` method of the `OES_draw_buffers_indexed` WebGL extension defines which function is used when blending pixels for a particular draw buffer.
+The `blendFunciOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension defines which function is used when blending pixels for a particular draw buffer.
 
 See {{DOMxRef("OES_draw_buffers_indexed.blendFuncSeparateiOES()")}} for setting RGB and alpha components separately and {{DOMxRef("WebGLRenderingContext.blendFunc()")}} for the WebGL 1 version of this method.
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
@@ -1,0 +1,83 @@
+---
+title: OES_draw_buffers_indexed.blendFuncSeparateiOES()
+slug: Web/API/OES_draw_buffers_indexed/blendFuncSeparateiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.blendFuncSeparateiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `blendFuncSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension defines which function is used when blending pixels for RGB and alpha components separately for a particular draw buffer.
+
+See {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}} for setting RBG and alpha together and {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}} for the WebGL 1 version of this method.
+
+## Syntax
+
+```js-nolint
+blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha)
+```
+
+### Parameters
+
+- `buf`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+- `srcRGB`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the red, green and blue (RGB) source blending factors. Accepts the same enums as the `srcRGB` parameter in {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}}.
+- `dstRGB`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the red, green and blue (RGB) destination blending factors. Accepts the same enums as the `dstRGB` parameter in {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}}.
+- `srcAlpha`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the alpha source blending factor. Accepts the same enums as the `srcAlpha` parameter in {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}}.
+- `dstAlpha`
+  - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying a multiplier for the alpha destination blending factor. Accepts the same enums as the `srcAlpha` parameter in {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}}.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `buf` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+- If `srcRGB`, `dstRGB`, `srcAlpha` or `dstAlpha` are not one of the possible values, a `gl.INVALID_ENUM` error is thrown.
+- The same blending limitations as for {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}} apply: If a constant color and a constant alpha value are used together as source and destination factors, a `gl.INVALID_ENUM` error is thrown.
+
+## Examples
+
+### Setting and getting blend functions
+
+The following sets the blend functions for the draw buffers `gl.DRAW_BUFFER0` (call where `buf` is 0) and `gl.DRAW_BUFFER1` (call where `buf` is 1).
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.blendFuncSeparateiOES(0, gl.ONE, gl.ONE, gl.ZERO, gl.ZERO);
+ext.blendFuncSeparateiOES(1, gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ZERO);
+```
+
+To get the blend functions for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers, query the `BLEND_SRC_RGB`, `BLEND_SRC_ALPHA`, `BLEND_DST_RGB`, and `BLEND_DST_ALPHA` constants using {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}:
+
+```js
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 0);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 0);
+
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 1);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}}
+- {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendFuncSeparateiOES
 
 {{APIRef("WebGL")}}
 
-The `blendFuncSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension defines which function is used when blending pixels for RGB and alpha components separately for a particular draw buffer.
+The `blendFuncSeparateiOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension defines which function is used when blending pixels for RGB and alpha components separately for a particular draw buffer.
 
 See {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}} for setting RGB and alpha together and {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}} for the WebGL 1 version of this method.
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/blendfuncseparateioes/index.md
@@ -9,7 +9,7 @@ browser-compat: api.OES_draw_buffers_indexed.blendFuncSeparateiOES
 
 The `blendFuncSeparateiOES()` method of the `OES_draw_buffers_indexed` WebGL extension defines which function is used when blending pixels for RGB and alpha components separately for a particular draw buffer.
 
-See {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}} for setting RBG and alpha together and {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}} for the WebGL 1 version of this method.
+See {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}} for setting RGB and alpha together and {{DOMxRef("WebGLRenderingContext.blendFuncSeparate()")}} for the WebGL 1 version of this method.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/colormaskioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/colormaskioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.colorMaskiOES
 
 {{APIRef("WebGL")}}
 
-The `colorMaskiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets which color components to enable or to disable when drawing or rendering for a particular draw buffer. It's the indexed version of WebGL 1's {{domxref("WebGLRenderingContext.colorMask()")}} method.
+The `colorMaskiOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension sets which color components to enable or to disable when drawing or rendering for a particular draw buffer. It's the indexed version of WebGL 1's {{domxref("WebGLRenderingContext.colorMask()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/colormaskioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/colormaskioes/index.md
@@ -1,0 +1,70 @@
+---
+title: OES_draw_buffers_indexed.colorMaskiOES()
+slug: Web/API/OES_draw_buffers_indexed/colorMaskiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.colorMaskiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `colorMaskiOES()` method of the `OES_draw_buffers_indexed` WebGL extension sets which color components to enable or to disable when drawing or rendering for a particular draw buffer. It's the indexed version of WebGL 1's {{domxref("WebGLRenderingContext.colorMask()")}} method.
+
+## Syntax
+
+```js-nolint
+colorMaskiOES(buf, r, g, b, a)
+```
+
+### Parameters
+
+- `buf`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+- `r`
+  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the red color component should be written into the draw buffer.
+- `g`
+  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the green color component should be written into the draw buffer.
+- `b`
+  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the blue color component should be written into the draw buffer.
+- `a`
+  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether or not the red alpha (transparency) component should be written into the draw buffer.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `buf`, `r`, `b`, `g`, or `a` are not a valid values, a `gl.INVALID_VALUE` error is thrown.
+
+## Examples
+
+### Setting and getting color masks
+
+You can set the color masks for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers like this:
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.colorMaskiOES(0, 1, 0, 0, 0);
+ext.colorMaskiOES(1, 0, 1, 0, 0);
+```
+
+To get the color masks for the `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1` draw buffers, query the `COLOR_WRITEMASK` constant using {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}:
+
+```js
+gl.getIndexedParameter(gl.COLOR_WRITEMASK, 0);
+gl.getIndexedParameter(gl.COLOR_WRITEMASK, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}
+- {{domxref("WebGLRenderingContext.colorMask()")}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/disableioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/disableioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.disableiOES
 
 {{APIRef("WebGL")}}
 
-The `disableiOES()` method of the `OES_draw_buffers_indexed` WebGL extension enables blending for a particular draw buffer.
+The `disableiOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension enables blending for a particular draw buffer.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/disableioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/disableioes/index.md
@@ -1,0 +1,58 @@
+---
+title: OES_draw_buffers_indexed.disableiOES()
+slug: Web/API/OES_draw_buffers_indexed/disableiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.disableiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `disableiOES()` method of the `OES_draw_buffers_indexed` WebGL extension enables blending for a particular draw buffer.
+
+## Syntax
+
+```js-nolint
+disableiOES(target, index)
+```
+
+### Parameters
+
+- `target`
+  - : Must be `gl.BLEND`.
+- `index`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `target` is not `gl.BLEND`, a `gl.INVALID_ENUM` error is thrown.
+- If `index` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+
+## Examples
+
+### Disabling blending for draw buffers
+
+The following two calls disable blending for the draw buffers `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1`.
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.disableiOES(gl.BLEND, 0);
+ext.disableiOES(gl.BLEND, 1);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("OES_draw_buffers_indexed.enableiOES()")}}
+- [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers)

--- a/files/en-us/web/api/oes_draw_buffers_indexed/enableioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/enableioes/index.md
@@ -1,0 +1,64 @@
+---
+title: OES_draw_buffers_indexed.enableiOES()
+slug: Web/API/OES_draw_buffers_indexed/enableiOES
+page-type: web-api-instance-method
+browser-compat: api.OES_draw_buffers_indexed.enableiOES 
+---
+
+{{APIRef("WebGL")}}
+
+The `enableiOES()` method of the `OES_draw_buffers_indexed` WebGL extension enables blending for a particular draw buffer.
+
+## Syntax
+
+```js-nolint
+enableiOES(target, index)
+```
+
+### Parameters
+
+- `target`
+  - : Must be `gl.BLEND`.
+- `index`
+  - : An integer `i` specifying the draw buffer associated with the constant `gl.DRAW_BUFFERi`, see [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers).
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- If `target` is not `gl.BLEND`, a `gl.INVALID_ENUM` error is thrown.
+- If `index` is not a valid value, a `gl.INVALID_VALUE` error is thrown.
+
+## Examples
+
+### Enabling blending for draw buffers
+
+The following two calls enable blending for the draw buffers `gl.DRAW_BUFFER0` and `gl.DRAW_BUFFER1`.
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+
+ext.enableiOES(gl.BLEND, 0);
+ext.enableiOES(gl.BLEND, 1);
+```
+
+You can use {{domxref("WebGLRenderingContext.getParameter()")}} to see how many draw buffers are available.
+
+```js
+const maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("OES_draw_buffers_indexed.disableiOES()")}}
+- [WebGL draw buffer constants](/en-US/docs/Web/API/WebGL_API/Constants#draw_buffers)

--- a/files/en-us/web/api/oes_draw_buffers_indexed/enableioes/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/enableioes/index.md
@@ -7,7 +7,7 @@ browser-compat: api.OES_draw_buffers_indexed.enableiOES
 
 {{APIRef("WebGL")}}
 
-The `enableiOES()` method of the `OES_draw_buffers_indexed` WebGL extension enables blending for a particular draw buffer.
+The `enableiOES()` method of the {{DOMxRef("OES_draw_buffers_indexed")}} WebGL extension enables blending for a particular draw buffer.
 
 ## Syntax
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/index.md
@@ -1,0 +1,92 @@
+---
+title: OES_draw_buffers_indexed
+slug: Web/API/OES_draw_buffers_indexed
+page-type: web-api-interface
+browser-compat: api.OES_draw_buffers_indexed
+---
+{{APIRef("WebGL")}}
+
+The **`OES_draw_buffers_indexed`** extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and enables use of different blend options when writing to multiple color buffers simultaneously.
+
+WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
+
+> **Note:** This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+
+## Instance methods
+
+- {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}}
+  - : Sets both the RGB blend equation and alpha blend equation for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}}
+  - : Sets the RGB blend equation and alpha blend equation separately for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}}
+  - : Defines which function is used when blending pixels for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.blendFuncSeparateiOES()")}}
+  - : Defines which function is used when blending pixels for RGB and alpha components separately for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.colorMaskiOES()")}}
+  - : Sets which color components to enable or to disable when drawing or rendering for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.disableiOES()")}}
+  - : Disables blending for a particular draw buffer.
+- {{DOMxRef("OES_draw_buffers_indexed.enableiOES()")}}
+  - : Enables blending for a particular draw buffer.
+
+## Examples
+
+### Using the `OES_draw_buffers_indexed` extension
+
+Enable the extension with a call to {{domxref("WebGLRenderingContext.getExtension()")}}.
+
+```js
+const ext = gl.getExtension("OES_draw_buffers_indexed");
+```
+
+You can now enable blending, set blending equation, blending function, and color mask for a particular draw buffer.
+
+```js
+// For gl.DRAW_BUFFER0
+ext.enableiOES(gl.BLEND, 0);
+ext.blendEquationiOES(0, gl.FUNC_ADD);
+ext.blendFunciOES(0, gl.ONE, gl.ONE);
+ext.colorMaskiOES(0, 1, 0, 0, 0);
+
+// For gl.DRAW_BUFFER1
+ext.enableiOES(gl.BLEND, 1);
+ext.blendEquationSeparateiOES(1, gl.FUNC_ADD, gl.FUNC_SUBTRACT);
+ext.blendFuncSeparateiOES(1, gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ZERO);
+ext.colorMaskiOES(1, 0, 1, 0, 0);
+```
+
+To retrieve settings for a particular draw buffer, use {{domxref("WebGL2RenderingContext.getIndexedParameter()")}}.
+
+```js
+// For gl.DRAW_BUFFER0
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 0);
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 0);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 0);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 0);
+gl.getIndexedParameter(gl.COLOR_WRITEMASK, 0);
+
+// For gl.DRAW_BUFFER1
+gl.getIndexedParameter(gl.BLEND_EQUATION_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_EQUATION_ALPHA, 1);
+gl.getIndexedParameter(gl.BLEND_SRC_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_SRC_ALPHA, 1);
+gl.getIndexedParameter(gl.BLEND_DST_RGB, 1);
+gl.getIndexedParameter(gl.BLEND_DST_ALPHA, 1);
+gl.getIndexedParameter(gl.COLOR_WRITEMASK, 1);
+```
+
+You can use {{domxref("WebGLRenderingContext.getParameter()")}} to see how many draw buffers are available.
+
+```js
+const maxDrawBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/oes_draw_buffers_indexed/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/index.md
@@ -6,7 +6,7 @@ browser-compat: api.OES_draw_buffers_indexed
 ---
 {{APIRef("WebGL")}}
 
-The **`OES_draw_buffers_indexed`** extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and enables use of different blend options when writing to multiple color buffers simultaneously.
+The **`OES_draw_buffers_indexed`** extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and enables the use of different blend options when writing to multiple color buffers simultaneously.
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
@@ -15,9 +15,9 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 ## Instance methods
 
 - {{DOMxRef("OES_draw_buffers_indexed.blendEquationiOES()")}}
-  - : Sets both the RGB blend equation and alpha blend equation for a particular draw buffer.
+  - : Sets both the RGB and alpha blend equations for a particular draw buffer.
 - {{DOMxRef("OES_draw_buffers_indexed.blendEquationSeparateiOES()")}}
-  - : Sets the RGB blend equation and alpha blend equation separately for a particular draw buffer.
+  - : Sets the RGB and alpha blend equations separately for a particular draw buffer.
 - {{DOMxRef("OES_draw_buffers_indexed.blendFunciOES()")}}
   - : Defines which function is used when blending pixels for a particular draw buffer.
 - {{DOMxRef("OES_draw_buffers_indexed.blendFuncSeparateiOES()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
@@ -34,6 +34,15 @@ getIndexedParameter(target, index)
     - `gl.UNIFORM_BUFFER_SIZE`: Returns a {{domxref("WebGL_API/Types", "GLsizeiptr")}}.
     - `gl.UNIFORM_BUFFER_START`: Returns a {{domxref("WebGL_API/Types", "GLintptr")}}.
 
+     When using the {{domxref("OES_draw_buffers_indexed")}} WebGL 2 extension, the following values are available additionally:
+    - `gl.BLEND_EQUATION_RGB`: Returns the RBG blend equation for the draw buffer at `index`.
+    - `gl.BLEND_EQUATION_ALPHA`: Returns the alpha blend equation for the draw buffer at `index`.
+    - `gl.BLEND_SRC_RGB`: Returns the source RBG blend function for the draw buffer at `index`.
+    - `gl.BLEND_SRC_ALPHA`: Returns the source alpha blend function for the draw buffer at `index`.
+    - `gl.BLEND_DST_RGB`: Returns the destination RBG blend function for the draw buffer at `index`.
+    - `gl.BLEND_DST_ALPHA`: Returns the destination alpha blend function for the draw buffer at `index`.
+    - `gl.COLOR_WRITEMASK`: Returns an array containing color components are enabled for the draw buffer at `index`.
+
 - `index`
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the `target` that is
     queried.

--- a/files/en-us/web/api/webgl_api/index.md
+++ b/files/en-us/web/api/webgl_api/index.md
@@ -55,6 +55,7 @@ The {{HTMLElement("canvas")}} element is also used by the [Canvas API](/en-US/do
 - {{domxref("EXT_texture_filter_anisotropic")}}
 - {{domxref("EXT_texture_norm16")}}
 - {{domxref("KHR_parallel_shader_compile")}}
+- {{domxref("OES_draw_buffers_indexed")}}
 - {{domxref("OES_element_index_uint")}}
 - {{domxref("OES_fbo_render_mipmap")}}
 - {{domxref("OES_standard_derivatives")}}

--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -68,6 +68,7 @@ The current extensions are:
 - {{domxref("EXT_texture_filter_anisotropic")}}
 - {{domxref("EXT_texture_norm16")}}
 - {{domxref("KHR_parallel_shader_compile")}}
+- {{domxref("OES_draw_buffers_indexed")}}
 - {{domxref("OES_element_index_uint")}}
 - {{domxref("OES_fbo_render_mipmap")}}
 - {{domxref("OES_standard_derivatives")}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1842,7 +1842,8 @@
         "OES_vertex_array_object",
         "ANGLE_instanced_arrays",
         "EXT_blend_minmax",
-        "EXT_disjoint_timer_query"
+        "EXT_disjoint_timer_query",
+        "OES_draw_buffers_indexed"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
### Description

This documents the WebGL extension https://registry.khronos.org/webgl/extensions/OES_draw_buffers_indexed/

### Motivation

https://github.com/openwebdocs/project/issues/152 is a project in which Open Web Docs is trying to provide docs for all web platform features supported in all three major engines (Webkit, Gecko, Chromium).

### Additional details

None.