### PR TITLE
Fix link to IE-only features

### DIFF
--- a/files/en-us/web/css/microsoft_extensions/index.md
+++ b/files/en-us/web/css/microsoft_extensions/index.md
@@ -86,10 +86,9 @@ Microsoft applications such as Edge and Internet Explorer support a number of sp
 ## CSS-related DOM APIs
 
 - `msContentZoomFactor`
-- {{DOMxRef("msGetPropertyEnabled")}}
-- {{DOMxRef("msGetRegionContent")}}
-- {{DOMxRef("MSRangeCollection")}}
-- {{DOMxRef("msRegionOverflow")}}
+- {{DOMxRef("CSSStyleDeclaration.msGetPropertyEnabled")}}
+- {{DOMxRef("Element.msGetRegionContent")}}
+- {{DOMxRef("Element.msRegionOverflow")}}
 
 ## See also
 


### PR DESCRIPTION
3 of them were moved from the top level inside their interface. The 4th was a constant that we are redirecting on the previous page, so I just removed one.

One day, this page will go away, but that's outside the scope of this PR.