### PR TITLE
Corrected link for next topic

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -408,6 +408,6 @@ You've reached the end of this article, but can you remember the most important 
 
 ## Summary
 
-If you understood most of this article, then well done — you're now familiar with the fundamental mechanics of CSS cascade layers. Next up, we'll look at [selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) in detail.
+If you understood most of this article, then well done — you're now familiar with the fundamental mechanics of CSS cascade layers. Next up, we'll look at [the box model](/en-US/docs/Learn/CSS/Building_blocks/The_box_model) in detail.
 
 {{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Seems this is left over from the recent change in where cascade_layers falls in the flow of the docs. 

### Motivation

These changes make it more clear of the order in which they are ideally meant to progress through the modules.

### Additional details

Changed the link in the summary section to correctly direct users to the next page.
Previously was pointing at Selectors, now it points at The_box_model

### Related issues and pull requests

Relates to: Pull Request #24654


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
