### PR TITLE
FF111 release note update for autocapitalize and translate attributes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -18,6 +18,9 @@ This article provides information about the changes in Firefox 111 that affect d
 
 ### HTML
 
+- The [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize) global attribute is now supported by default. The default value for the attribute is `none`, so no capitalization occurs ({{bug(1692007)}}).
+- The [`translate`](/en-US/docs/Web/HTML/Global_attributes/translate) global attribute is now supported ({{bug(1418449)}}).
+
 #### Removals
 
 ### CSS


### PR DESCRIPTION
Firefox 111 supports:

- autocapitalize attribute via https://bugzilla.mozilla.org/show_bug.cgi?id=1692007. This was earlier available under a flag.
MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
Doc issue tracker: https://github.com/mdn/content/issues/24401

- translate attribute via https://bugzilla.mozilla.org/show_bug.cgi?id=1418449
MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate
Doc issue tracker: https://github.com/mdn/content/issues/24394