### PR TITLE
Reference for...of statement before usage in example

### DIFF
--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -55,7 +55,13 @@ for (let i = 0, numFiles = fileList.length; i < numFiles; i++) {
 }
 ```
 
-This loop iterates over all the files in the file list.
+The above loop iterates over all the files in the file list. You can also iterate over all files using an equivalent but more compact for...of statement:
+
+```js
+for (const file of fileList) {
+  // …
+}
+```
 
 There are three attributes provided by the {{DOMxRef("File")}} object that contain useful information about the file.
 

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -46,22 +46,7 @@ The {{DOMxRef("FileList")}} object provided by the DOM lists all of the files se
 const numFiles = fileList.length;
 ```
 
-Individual {{DOMxRef("File")}} objects can be retrieved by accessing the list as an array:
-
-```js
-for (let i = 0, numFiles = fileList.length; i < numFiles; i++) {
-  const file = fileList[i];
-  // …
-}
-```
-
-The above loop iterates over all the files in the file list. You can also iterate over all files using an equivalent but more compact for...of statement:
-
-```js
-for (const file of fileList) {
-  // …
-}
-```
+Individual {{DOMxRef("File")}} objects can be retrieved by accessing the list as an array.
 
 There are three attributes provided by the {{DOMxRef("File")}} object that contain useful information about the file.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

The 'Showing file(s) size' example includes a `for...of` statement to iterate through the file array. However, this loop construct has not been introduced previously on the page; instead a classic `for` loop with an iteration variable is shown as a method of iterating through `FileList` entries.

<!-- ✍️ Summarize your changes in one or two sentences -->

To prevent potential confusion, this change mentions the `for...of` statement and gives a snippet of how to use it before it's referenced in the example.

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change prevents potential confusion caused by the current documentation using a different loop statement for the example than was used immediately prior.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
