### PR TITLE
Uniformly describe deprecated parameters on RTCPeerConnection methods

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -23,7 +23,8 @@ This is covered in more detail in the articles [WebRTC connectivity](/en-US/docs
 
 ```js-nolint
 addIceCandidate(candidate)
-addIceCandidate(candidate, successCallback)
+
+addIceCandidate(candidate, successCallback) // deprecated
 addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 ```
 

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -106,7 +106,7 @@ addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 In older code and documentation, you may see a callback-based version of this function.
 This has been deprecated and its use is **strongly** discouraged. You
 should update any existing code to use the {{jsxref("Promise")}}-based version of
-`addIceCandidate()` instead. The parameters for this form of
+`addIceCandidate()` instead. The parameters for the older form of
 `addIceCandidate()` are described below, to aid in updating existing code.
 
 - `successCallback` {{deprecated_inline}}

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
@@ -22,8 +22,8 @@ the negotiation process.
 createAnswer()
 createAnswer(options)
 
-createAnswer(successCallback, failureCallback)
-createAnswer(successCallback, failureCallback, options)
+createAnswer(successCallback, failureCallback) // deprecated
+createAnswer(successCallback, failureCallback, options) // deprecated
 ```
 
 ### Parameters

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
@@ -36,7 +36,7 @@ createAnswer(successCallback, failureCallback, options) // deprecated
 In older code and documentation, you may see a callback-based version of this function.
 This has been deprecated and its use is **strongly** discouraged. You
 should update any existing code to use the {{jsxref("Promise")}}-based version of
-`createAnswer()` instead. The parameters for this form of
+`createAnswer()` instead. The parameters for the older form of
 `createAnswer()` are described below, to aid in updating existing code.
 
 - `successCallback` {{deprecated_inline}}

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -30,8 +30,8 @@ offer.
 createOffer()
 createOffer(options)
 
-createOffer(successCallback, failureCallback)
-createOffer(successCallback, failureCallback, options)
+createOffer(successCallback, failureCallback) // deprecated
+createOffer(successCallback, failureCallback, options) // deprecated
 ```
 
 ### Parameters

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -56,7 +56,7 @@ createOffer(successCallback, failureCallback, options) // deprecated
 In older code and documentation, you may see a callback-based version of this function.
 This has been deprecated and its use is **strongly** discouraged. You
 should update any existing code to use the {{jsxref("Promise")}}-based version of
-`createOffer()` instead. The parameters for this form of
+`createOffer()` instead. The parameters for the older form of
 `createOffer()` are described below, to aid in updating existing code.
 
 - `successCallback` {{deprecated_inline}}

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -17,6 +17,8 @@ providing statistics about either the overall connection or about the specified
 ```js-nolint
 getStats()
 getStats(selector)
+
+getStats(selector, successCallback, failureCallback) // deprecated
 ```
 
 ### Parameters

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -28,11 +28,18 @@ getStats(selector, successCallback, failureCallback) // deprecated
     `null` (the default value), statistics will be gathered for the entire
     {{domxref("RTCPeerConnection")}}.
 
-### Return value
+### Deprecated parameters
 
-A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
-providing connection statistics. The contents of the report depend on the
-`selector` as well as other details of the connection.
+In older code and documentation, you may see a callback-based version of this function.
+This has been deprecated and its use is **strongly** discouraged. You
+should update any existing code to use the {{jsxref("Promise")}}-based version of
+`getStats()` instead. The parameters for the older form of
+`getStats()` are described below, to aid in updating existing code.
+
+- `successCallback` {{deprecated_inline}}
+  - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has been successfully generated.
+- `failureCallback` {{deprecated_inline}}
+  - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has failed to be generated.
 
 ### Exceptions
 
@@ -44,36 +51,11 @@ one of the following errors:
     `track` matches the specified `selector`, or
     `selector` matches more than one sender or receiver.
 
-### Obsolete syntax
+### Return value
 
-Previously, `getStats()` used success and failure callbacks to report the
-results to you, instead of using a promise.
-
-This version of `getStats()` is obsolete; in addition, the data it returns
-is entirely different from the current specification, and the form of that data was
-never documented. This form of `getStats()` has been or will soon be removed
-from most browsers; you _should not use it, and should update existing code to use
-the new promise-based version_. Check the [Browser compatibility](#browser_compatibility) table
-to verify the state of this method.
-
-```js
-promise = rtcPeerConnection.getStats(selector, successCallback, failureCallback) // deprecated
-```
-
-#### Parameters
-
-- `selector` {{optional_inline}}
-  - : A {{domxref("MediaStreamTrack")}} for which to gather statistics. If this is
-    `null` (the default value), statistics will be gathered for the entire
-    {{domxref("RTCPeerConnection")}}.
-- `successCallback`
-  - : A callback function to call when the stats have been retrieved. The function
-    receives as input a single parameter: an {{domxref("RTCStatsReport")}} with the
-    collected statistics. No output is expected from the function.
-- `failureCallback`
-  - : A function to call when an error occurs while attempting to collect statistics. The
-    callback receives as input the exception (a {{domxref("DOMException")}} object
-    describing the error which occurred. No return value is expected from the callback.
+A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
+providing connection statistics. The contents of the report depend on the
+`selector` as well as other details of the connection.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -44,6 +44,7 @@ should update any existing code to use the {{jsxref("Promise")}}-based version o
 A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
 providing connection statistics. The report's contents depend on the
 `selector` and other details of the connection.
+
 ### Exceptions
 
 This method does not throw exceptions; instead, it rejects the returned promise with

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -57,7 +57,6 @@ one of the following errors:
     `track` matches the specified `selector`, or
     `selector` matches more than one sender or receiver.
 
-
 ## Examples
 
 This example creates a periodic function using

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -40,7 +40,9 @@ should update any existing code to use the {{jsxref("Promise")}}-based version o
   - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has been successfully generated.
 - `failureCallback` {{deprecated_inline}}
   - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has failed to be generated.
+
 ### Return value
+
 A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
 providing connection statistics. The report's contents depend on the
 `selector` and other details of the connection.

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -40,7 +40,10 @@ should update any existing code to use the {{jsxref("Promise")}}-based version o
   - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has been successfully generated.
 - `failureCallback` {{deprecated_inline}}
   - : A [callback function](/en-US/docs/Glossary/Callback_function) called once the report has failed to be generated.
-
+### Return value
+A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
+providing connection statistics. The report's contents depend on the
+`selector` and other details of the connection.
 ### Exceptions
 
 This method does not throw exceptions; instead, it rejects the returned promise with
@@ -51,11 +54,6 @@ one of the following errors:
     `track` matches the specified `selector`, or
     `selector` matches more than one sender or receiver.
 
-### Return value
-
-A {{jsxref("Promise")}} which resolves with an {{domxref("RTCStatsReport")}} object
-providing connection statistics. The contents of the report depend on the
-`selector` as well as other details of the connection.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
@@ -27,6 +27,7 @@ negotiation is complete. Only then does the agreed-upon configuration take effec
 ```js-nolint
 setLocalDescription()
 setLocalDescription(sessionDescription)
+
 setLocalDescription(sessionDescription, successCallback, errorCallback) // deprecated
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This ensures parallel structure on RTCPeerConnection methods with deprecated parameters. The docs for `getStats()` were especially out of sync, but now the Syntax and Deprecated parameters sections are uniform for all. Additionally, the `getStats()` page now has the same section orders as the others in this PR. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This helps to clarify for readers older syntax that they might encounter. It also clears up some ambiguity and miscues in `getStats()` that threw me for a personal loop this afternoon :)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

None.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

I searched the open issues and other PRs, but did not find any reference to this page.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
