### PR TITLE
Remove last tags from Glossary

### DIFF
--- a/files/en-us/glossary/browsing_context/index.md
+++ b/files/en-us/glossary/browsing_context/index.md
@@ -2,7 +2,6 @@
 title: Browsing context
 slug: Glossary/Browsing_context
 page-type: glossary-definition
-tags:
 ---
 
 A **browsing context** is an environment in which a browser displays a {{domxref("Document")}}. In modern browsers, it usually is a _tab_, but can be a _window_ or even only parts of a page, like a _frame_ or an _iframe_.

--- a/files/en-us/glossary/code_point/index.md
+++ b/files/en-us/glossary/code_point/index.md
@@ -2,7 +2,6 @@
 title: Code point
 slug: Glossary/Code_point
 page-type: glossary-definition
-tags:
 ---
 
 A **code point** is a number assigned to represent an abstract character in a system for representing text (such as Unicode). In Unicode, a code point is expressed in the form "U+1234" where "1234" is the assigned number. For example, the character "A" is assigned a code point of U+0041.

--- a/files/en-us/glossary/code_unit/index.md
+++ b/files/en-us/glossary/code_unit/index.md
@@ -2,7 +2,6 @@
 title: Code unit
 slug: Glossary/Code_unit
 page-type: glossary-definition
-tags:
 ---
 
 A **code unit** is the basic component used by a character encoding system (such as UTF-8 or UTF-16). A character encoding system uses one or more code units to encode a Unicode {{Glossary("code point")}}.

--- a/files/en-us/glossary/input_method_editor/index.md
+++ b/files/en-us/glossary/input_method_editor/index.md
@@ -2,7 +2,6 @@
 title: Input method editor
 slug: Glossary/Input_method_editor
 page-type: glossary-definition
-tags:
 ---
 
 An input method editor (IME) is a program that provides a specialized user interface for text input. Input method editors are used in many situations:

--- a/files/en-us/glossary/self-executing_anonymous_function/index.md
+++ b/files/en-us/glossary/self-executing_anonymous_function/index.md
@@ -2,7 +2,6 @@
 title: Self-Executing Anonymous Function
 slug: Glossary/Self-Executing_Anonymous_Function
 page-type: glossary-definition
-tags:
 ---
 
 A {{glossary("JavaScript")}} {{glossary("function")}} that runs as soon as it is defined. Also known as an {{glossary("IIFE")}} (Immediately Invoked Function Expression).


### PR DESCRIPTION
5 pages still had the YAML `tags:` entry.

It was empty (== no tag listed) so I guess this is why @hamishwillee's script didn't catch them.

With this PR, Glossary is tag-free too.