### PR TITLE
Fix Prism language in HTTP's WWW-Authenticate article

### DIFF
--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -155,7 +155,7 @@ WWW-Authenticate: Basic realm="Access to the staging site", charset="UTF-8"
 A user-agent receiving this header would first prompt the user for their username and password, and then re-request the resource: this time including the (encoded) credentials in the {{HTTPHeader("Authorization")}} header.
 The {{HTTPHeader("Authorization")}} header might look like this:
 
-```https
+```http
 Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 ```
 


### PR DESCRIPTION
There is no `https` language in Prism.js. This is likely a typo and should be `http` like the other snippets on the page.

Found in the error log when building the page:

`Unable to find a Prism grammar for 'https' found in /en-US/docs/Web/HTTP/Headers/WWW-Authenticate`