### PR TITLE
Fix links to CSS Descriptor glossary entry

### DIFF
--- a/files/en-us/web/css/@font-palette-values/base-palette/index.md
+++ b/files/en-us/web/css/@font-palette-values/base-palette/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.font-palette-values.base-palette
 
 {{CSSRef}}
 
-The **`base-palette`** CSS [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>) is used to specify the name or index of a pre-defined palette to be used for creating a new palette. If the specified `base-palette` does not exist, then the palette defined at index 0 will be used.
+The **`base-palette`** CSS [descriptor](/en-US/docs/Glossary/CSS_Descriptor) is used to specify the name or index of a pre-defined palette to be used for creating a new palette. If the specified `base-palette` does not exist, then the palette defined at index 0 will be used.
 
 ## Syntax
 
@@ -17,7 +17,7 @@ The **`base-palette`** CSS [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>)
 }
 ```
 
-The `base-palette` [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>) is specified using a zero-based index of the font-maker created palettes.
+The `base-palette` [descriptor](/en-US/docs/Glossary/CSS_Descriptor) is specified using a zero-based index of the font-maker created palettes.
 
 ### Values
 

--- a/files/en-us/web/css/@font-palette-values/font-family/index.md
+++ b/files/en-us/web/css/@font-palette-values/font-family/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.font-palette-values.font-family
 
 {{CSSRef}}
 
-The [@font-palette-values](/en-US/docs/Web/CSS/@font-palette-values) [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>) **`font-family`** is used to specify which font-family palette values are to be applied to. This need to match exactly the values used when setting the CSS [font-family](/en-US/docs/Web/CSS/font-family).
+The [@font-palette-values](/en-US/docs/Web/CSS/@font-palette-values) [descriptor](/en-US/docs/Glossary/CSS_Descriptor) **`font-family`** is used to specify which font-family palette values are to be applied to. This need to match exactly the values used when setting the CSS [font-family](/en-US/docs/Web/CSS/font-family).
 
 ## Syntax
 

--- a/files/en-us/web/css/@font-palette-values/override-colors/index.md
+++ b/files/en-us/web/css/@font-palette-values/override-colors/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.font-palette-values.override-colors
 
 {{CSSRef}}
 
-The **`override-colors`** CSS [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>) is used to override colors in the chosen [base-palette](/en-US/docs/Web/CSS/@font-palette-values/base-palette) for a color font.
+The **`override-colors`** CSS [descriptor](/en-US/docs/Glossary/CSS_Descriptor) is used to override colors in the chosen [base-palette](/en-US/docs/Web/CSS/@font-palette-values/base-palette) for a color font.
 
 ## Syntax
 
@@ -31,7 +31,7 @@ override-colors: 0 #f00, 1 #0f0, 2 #00f;
 override-colors: 0 #f00, 1 #0f0, 2 #00f;
 ```
 
-The `override-colors` [descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>) takes a comma-separated list of the color index and new color value.
+The `override-colors` [descriptor](/en-US/docs/Glossary/CSS_Descriptor) takes a comma-separated list of the color index and new color value.
 
 The color index is zero-based and any [color value](/en-US/docs/Web/CSS/color_value) can be used.
 

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -109,7 +109,7 @@ Combinators are selectors that establish a relationship between two or more simp
 - [At-rules](/en-US/docs/Web/CSS/At-rule)
 - [Cascade](/en-US/docs/Web/CSS/Cascade)
 - [Comments](/en-US/docs/Web/CSS/Comments)
-- [Descriptor](</en-US/docs/Glossary/Descriptor_(CSS)>)
+- [Descriptor](/en-US/docs/Glossary/CSS_Descriptor)
 - [Inheritance](/en-US/docs/Web/CSS/inheritance)
 - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
 - [Specificity](/en-US/docs/Web/CSS/Specificity)


### PR DESCRIPTION
It was `Descriptor_(CSS)` and now is `CSS_Descriptor`. (We got rid of parentheses).