### PR TITLE
Remove links to non-existent pages of type ::-ms-*

### DIFF
--- a/files/en-us/web/css/@media/-ms-high-contrast/index.md
+++ b/files/en-us/web/css/@media/-ms-high-contrast/index.md
@@ -88,7 +88,7 @@ Not part of any standard.
 
 As of Microsoft Edge 18, `-ms-high-contrast: none` is no longer supported. Microsoft Edge versions 18 and higher will be using the [`forced-colors` media feature](/en-US/docs/Web/CSS/@media/forced-colors) instead, but the `forced-colors` media feature specification is still being actively worked on.
 
-The `-ms-high-contrast` media feature works with the {{CSSxRef("-ms-high-contrast-adjust")}} property.
+The `-ms-high-contrast` media feature works with the `-ms-high-contrast-adjust` property.
 
 ## See also
 

--- a/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -53,7 +53,6 @@ Not part of any standard.
 ## See also
 
 - {{HTMLElement("progress")}}
-- {{ cssxref("::-ms-fill") }}
 - {{ cssxref("::-webkit-progress-bar") }}
 - {{ cssxref("::-webkit-progress-value") }}
 - {{ cssxref("::-webkit-progress-inner-element") }}

--- a/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
@@ -61,9 +61,5 @@ Not part of any standard.
   - {{cssxref("::-moz-range-thumb")}} represents the indicator that slides in the groove.
   - {{cssxref("::-moz-range-track")}} represents the groove in which the thumb slides.
 
-- Similar pseudo-elements used by other browsers:
-
-  - {{cssxref("::-ms-fill-upper")}}, pseudo-element supported by Internet Explorer and Edge
-
 - [CSS-Tricks: Styling Cross-Browser Compatible Range Inputs with CSS](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
 - [QuirksMode: Styling and scripting sliders](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -63,7 +63,6 @@ Not part of any standard.
 - Similar pseudo-elements used by other browsers:
 
   - {{cssxref("::-webkit-slider-thumb")}}, pseudo-element supported by WebKit and Blink (Safari, Chrome, and Opera)
-  - {{cssxref("::-ms-thumb")}}, pseudo-element supported by Internet Explorer and Edge
 
 - [CSS-Tricks: Styling Cross-Browser Compatible Range Inputs with CSS](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
 - [QuirksMode: Styling and scripting sliders](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
@@ -63,7 +63,6 @@ Not part of any standard.
 - Similar pseudo-elements used by other browsers:
 
   - {{cssxref("::-webkit-slider-runnable-track")}}, pseudo-element supported by WebKit and Blink (Safari, Chrome, and Opera)
-  - {{cssxref("::-ms-track")}}, pseudo-element supported by Internet Explorer and Edge
 
 - [CSS-Tricks: Styling Cross-Browser Compatible Range Inputs with CSS](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
 - [QuirksMode: Styling and scripting sliders](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -67,4 +67,3 @@ Not part of any standard.
   - {{ cssxref("::-webkit-progress-inner-element") }}
 
 - {{ cssxref("::-moz-progress-bar") }}
-- {{ cssxref("::-ms-fill") }}

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -73,4 +73,3 @@ Not part of any standard.
   - {{cssxref("::-webkit-progress-value")}}
 
 - {{cssxref("::-moz-progress-bar")}}
-- {{cssxref("::-ms-fill")}}

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -69,4 +69,3 @@ Not part of any standard.
   - {{ cssxref("::-webkit-progress-inner-element") }}
 
 - {{ cssxref("::-moz-progress-bar") }}
-- {{ cssxref("::-ms-fill") }}

--- a/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -29,5 +29,4 @@ Not part of any standard.
 
 ## See also
 
-- {{cssxref('::-ms-clear')}}
 - {{cssxref('::-webkit-search-results-button')}}

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -32,7 +32,6 @@ Not part of any standard.
 - {{CSSxRef("::-webkit-slider-thumb")}}
 - Similar pseudo-elements used by other browsers:
 
-  - {{CSSxRef("::-ms-track")}}
   - {{CSSxRef("::-moz-range-track")}}
 
 - [CSS-Tricks: Styling Cross-Browser Compatible Range Inputs with CSS](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -33,7 +33,6 @@ Not part of any standard.
 - Similar pseudo-elements used by other browsers:
 
   - {{cssxref("::-moz-range-thumb")}}
-  - {{cssxref("::-ms-thumb")}}
 
 - [CSS-Tricks: Styling Cross-Browser Compatible Range Inputs with CSS](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
 - [QuirksMode: Styling and scripting sliders](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)


### PR DESCRIPTION
These remove the (red) links to `::-ms-*`. This page was never written and will not be as it relates to the old IE engine.

Also, we try not to link to IE-only features and to remove IE-specific notes from our pages.