### PR TITLE
Link to the unprefixed feature when possible

### DIFF
--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -85,5 +85,5 @@ Not part of any standard.
 ## See also
 
 - {{cssxref("-moz-user-input")}}
-- {{cssxref("user-modify", "-moz-user-modify")}}
+- {{cssxref("user-modify")}}
 - {{cssxref("user-select", "-moz-user-select")}}

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -85,5 +85,5 @@ Not part of any standard.
 ## See also
 
 - {{cssxref("-moz-user-input")}}
-- {{cssxref("-moz-user-modify")}}
-- {{cssxref("-moz-user-select")}}
+- {{cssxref("user-modify", "-moz-user-modify")}}
+- {{cssxref("user-select", "-moz-user-select")}}

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -72,5 +72,5 @@ Not part of any standard.
 ## See also
 
 - {{CSSxRef("-moz-user-focus")}}
-- {{CSSxRef("-moz-user-modify")}}
-- {{CSSxRef("-moz-user-select")}}
+- {{CSSxRef("user-modify", "-moz-user-modify")}}
+- {{CSSxRef("user-select", "-moz-user-select")}}

--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.-webkit-line-clamp
 
 The **`-webkit-line-clamp`** CSS property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
 
-It only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("-webkit-box-orient")}} property set to `vertical`.
+It only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`.
 
 In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines.
 

--- a/files/en-us/web/css/-webkit-mask-composite/index.md
+++ b/files/en-us/web/css/-webkit-mask-composite/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.-webkit-mask-composite
 
 {{CSSRef}}{{Non-standard_header}}
 
-The **`-webkit-mask-composite`** property specifies the manner in which multiple mask images applied to the same element are composited with one another. Mask images are composited in the opposite order that they are declared with the {{CSSxRef("-webkit-mask-image")}} property.
+The **`-webkit-mask-composite`** property specifies the manner in which multiple mask images applied to the same element are composited with one another. Mask images are composited in the opposite order that they are declared with the {{CSSxRef("mask-image", "-webkit-mask-image")}} property.
 
 ```css
 /* Keyword values */

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -86,4 +86,4 @@ Not part of any standard.
 
 ## See also
 
-{{cssxref("-webkit-mask-position")}}, {{cssxref("-webkit-mask-position-y")}}, {{cssxref("-webkit-mask-origin")}}, {{cssxref("-webkit-mask-attachment")}}
+{{cssxref("mask-position", "-webkit-mask-position")}}, {{cssxref("-webkit-mask-position-y")}}, {{cssxref("mask-origin", "-webkit-mask-origin")}}, {{cssxref("-webkit-mask-attachment")}}

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -86,4 +86,4 @@ Not part of any standard.
 
 ## See also
 
-{{cssxref("-webkit-mask-position")}}, {{cssxref("-webkit-mask-position-x")}}, {{cssxref("-webkit-mask-origin")}}, {{cssxref("-webkit-mask-attachment")}}
+{{cssxref("mask-position", "-webkit-mask-position")}}, {{cssxref("-webkit-mask-position-x")}}, {{cssxref("mask-origin", "-webkit-mask-origin")}}, {{cssxref("-webkit-mask-attachment")}}

--- a/files/en-us/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-x/index.md
@@ -92,4 +92,4 @@ Not part of any standard.
 
 ## See also
 
-{{cssxref("-webkit-mask-repeat")}}, {{cssxref("-webkit-mask-repeat-y")}}
+{{cssxref("mask-repeat", "-webkit-mask-repeat")}}, {{cssxref("-webkit-mask-repeat-y")}}

--- a/files/en-us/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-y/index.md
@@ -92,4 +92,4 @@ Not part of any standard.
 
 ## See also
 
-{{cssxref("-webkit-mask-repeat")}}, {{cssxref("-webkit-mask-repeat-x")}}
+{{cssxref("mask-repeat", "-webkit-mask-repeat")}}, {{cssxref("-webkit-mask-repeat-x")}}

--- a/files/en-us/web/css/user-modify/index.md
+++ b/files/en-us/web/css/user-modify/index.md
@@ -79,4 +79,4 @@ Not part of any standard.
 
 - {{CSSxRef("-moz-user-focus")}}
 - {{CSSxRef("-moz-user-input")}}
-- {{CSSxRef("-moz-user-select")}}
+- {{CSSxRef("user-select", "-moz-user-select")}}


### PR DESCRIPTION
Some pages have been unprefixed, we can link directly to them. (A few flaws removed as it prevents some redirections)