### PR TITLE
Remove parentheses in link

### DIFF
--- a/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -24,7 +24,7 @@ The **`:-moz-locale-dir(ltr)`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US
 
 ## Examples
 
-This example doesn't work if you're not using Firefox, and may not work even in Firefox due to an issue with the selector not working properly with HTML content. It was designed for use with [XUL](/en-US/docs/Archive/Mozilla/XUL).
+This example doesn't work if you're not using Firefox, and may not work even in Firefox due to an issue with the selector not working properly with HTML content. It was designed for use with `XUL`.
 
 ### HTML
 

--- a/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -51,4 +51,4 @@ Not part of any standard.
 ## See also
 
 - {{CSSxRef(":dir", ":dir(…)")}}
-- {{CSSxRef(":-moz-locale-dir(rtl)")}}
+- {{CSSxRef(":-moz-locale-dir_rtl", ":-moz-locale-dir(rtl)")}}

--- a/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -50,6 +50,6 @@ Not part of any standard.
 
 ## See also
 
-- {{CSSxRef(":dir",":dir(…)")}}
-- {{CSSxRef(":-moz-locale-dir(ltr)")}}
+- {{CSSxRef(":dir", ":dir(…)")}}
+- {{CSSxRef(":-moz-locale-dir_ltr", ":-moz-locale-dir(ltr)")}}
 - [Making sure your theme works with RTL locales](/en-US/docs/Making_Sure_Your_Theme_Works_with_RTL_Locales)

--- a/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -52,4 +52,3 @@ Not part of any standard.
 
 - {{CSSxRef(":dir", ":dir(…)")}}
 - {{CSSxRef(":-moz-locale-dir_ltr", ":-moz-locale-dir(ltr)")}}
-- [Making sure your theme works with RTL locales](/en-US/docs/Making_Sure_Your_Theme_Works_with_RTL_Locales)

--- a/files/en-us/web/css/repeat/index.md
+++ b/files/en-us/web/css/repeat/index.md
@@ -100,7 +100,7 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
     - a {{cssxref("minmax", "minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
       - `max` given as a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
-    - a {{cssxref("fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
+    - a {{cssxref("fit-content_function", "fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
 - `auto`
   - : As a maximum, identical to `max-content`. As a minimum it represents the largest minimum size (as specified by {{cssxref("min-width")}}/{{cssxref("min-height")}}) of the grid items occupying the grid track.
 - `auto-fill`


### PR DESCRIPTION
These two pages still have links with parentheses in them, leading to one flaw each. This fixes it.