### PR TITLE
Removing Media entry for -webkit-mask-box-image

### DIFF
--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -14,7 +14,6 @@ browser-compat: css.properties.-webkit-mask-box-image
 - {{ Xref_cssinitial() }}: none
 - Applies to: all elements
 - {{ Xref_cssinherited() }}: no
-- Media: {{ Xref_cssvisual() }}
 - {{ Xref_csscomputed() }}: as specified
 
 ## Syntax


### PR DESCRIPTION
This useless entry (creating a flaw) has been removed in the spec and in all other CSS pages.