### PR TITLE
Fix two broken links to Cascade layers docs

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -199,6 +199,6 @@ In the following example, two layers are created with no rules applied, then CSS
 - [The `!important` flag](/en-US/docs/Web/CSS/important)
 - [The `revert-layer` keyword](/en-US/docs/Web/CSS/revert-layer)
 - [Introducing the CSS Cascade](/en-US/docs/Web/CSS/Cascade)
-- [CSS building block: cascade and inheritance](/en-US/docs/Web/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-- [CSS building block: cascade layers](/en-US/docs/Web/Learn/CSS/Building_blocks/Cascade_layers)
+- [CSS building block: cascade and inheritance](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
+- [CSS building block: cascade layers](/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers)
 - [The Future of CSS: Cascade Layers](https://www.bram.us/2021/09/15/the-future-of-css-cascade-layers-css-at-layer/)


### PR DESCRIPTION
There was an extraneous `/Web/` folder in each of the links resulting in a red link (404).