### PR TITLE
Remove auto links

### DIFF
--- a/files/en-us/web/css/computed_value/index.md
+++ b/files/en-us/web/css/computed_value/index.md
@@ -16,7 +16,7 @@ The computation needed to reach a property's computed value typically involves c
 
 However, for some properties (those where percentages are relative to something that may require layout to determine, such as `width`, `margin-right`, `text-indent`, and `top`), percentage-specified values turn into percentage-computed values. Additionally, unitless numbers specified on the `line-height` property become the computed value, as specified. The relative values that remain in the computed value become absolute when the [used value](/en-US/docs/Web/CSS/used_value) is determined.
 
-> **Note:** The {{domxref("Window.getComputedStyle", "getComputedStyle()")}} DOM API returns the [resolved value](/en-US/docs/Web/CSS/resolved_value), which may either be the [computed value](/en-US/docs/Web/CSS/computed_value) or the [used value](/en-US/docs/Web/CSS/used_value), depending on the property.
+> **Note:** The {{domxref("Window.getComputedStyle", "getComputedStyle()")}} DOM API returns the [resolved value](/en-US/docs/Web/CSS/resolved_value), which may either be the computed value or the [used value](/en-US/docs/Web/CSS/used_value), depending on the property.
 
 ## Specifications
 

--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -73,7 +73,7 @@ There is another group of statements – the **nested statements**. These are st
 ## See also
 
 - CSS key concepts:
-  - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
+  - **CSS syntax**
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/inheritance)

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -11,7 +11,7 @@ The **used value** of a [CSS](/en-US/docs/Web/CSS) property is its value after a
 
 After the {{glossary("user agent")}} has finished its calculations, every CSS property has a used value. The used values of dimensions (e.g., {{cssxref("width")}}, {{cssxref("line-height")}}) are in pixels. The used values of shorthand properties (e.g., {{cssxref("background")}}) are consistent with those of their component properties (e.g., {{cssxref("background-color")}} or {{cssxref("background-size")}}) and with {{cssxref("position")}} and {{cssxref("float")}}.
 
-> **Note:** The {{domxref("Window.getComputedStyle", "getComputedStyle()")}} DOM API returns the [resolved value](/en-US/docs/Web/CSS/resolved_value), which may either be the [computed value](/en-US/docs/Web/CSS/computed_value) or the [used value](/en-US/docs/Web/CSS/used_value), depending on the property.
+> **Note:** The {{domxref("Window.getComputedStyle", "getComputedStyle()")}} DOM API returns the [resolved value](/en-US/docs/Web/CSS/resolved_value), which may either be the [computed value](/en-US/docs/Web/CSS/computed_value) or the used value, depending on the property.
 
 ## Example
 
@@ -113,7 +113,7 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
-    - [Used values](/en-US/docs/Web/CSS/used_value)
+    - **Used values**](/en-US/docs/Web/CSS/used_value)\*\*
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -113,7 +113,7 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
-    - **Used values**](/en-US/docs/Web/CSS/used_value)\*\*
+    - **Used values**
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -425,6 +425,6 @@ But not:
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
-  - **Value definition syntax**](/en-US/docs/Web/CSS/Value_definition_syntax)\*\*
+  - **Value definition syntax**
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
   - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -425,6 +425,6 @@ But not:
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
-  - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
+  - **Value definition syntax**](/en-US/docs/Web/CSS/Value_definition_syntax)\*\*
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
   - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-In CSS The **Visual Formatting Model** describes how user agents take the document tree, and process and display it for visual media. This includes {{glossary("continuous media")}} such as a computer screen and {{glossary("paged media")}} such as a book or document printed by browser print functions. Most of the information applies equally to continuous and paged media.
+In CSS The **Visual Formatting Model** describes how user agents take the document tree, and process and display it for visual media. This includes {{glossary("continuous media")}} such as a computer screen and [paged media](/en-US/docs/Web/CSS/Paged_Media) such as a book or document printed by browser print functions. Most of the information applies equally to continuous and paged media.
 
 In the visual formatting model, each element in the document tree generates zero or more boxes according to the box model. The layout of these boxes is governed by:
 
@@ -145,7 +145,7 @@ A block box is a block-level box that is also a block container. As described in
   - [Inheritance](/en-US/docs/Web/CSS/inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
-  - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
+  - **Visual formatting models**](/en-US/docs/Web/CSS/Visual_formatting_model)\*\*
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -145,7 +145,7 @@ A block box is a block-level box that is also a block container. As described in
   - [Inheritance](/en-US/docs/Web/CSS/inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
-  - **Visual formatting models**](/en-US/docs/Web/CSS/Visual_formatting_model)\*\*
+  - **Visual formatting models**
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)


### PR DESCRIPTION
Removed a few auto links (these _See also_ should be curated/modified/deleted at some point, but this is outside the scope of this PR.

I also did a drive-by fix to remove a red link (the glossary entry didn't exist).