### PR TITLE
Fix links in CSS Tutorials

### DIFF
--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -15,7 +15,7 @@ They are grouped by complexity so that you can choose the most appropriate for y
 
 ## Beginner-level CSS tutorials
 
-- [CSS basics](en-US/docs/Learn/Getting_started_with_the_web/CSS_basics)
+- [CSS basics](/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics)
   - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you.
     It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -23,7 +23,7 @@ They are grouped by complexity so that you can choose the most appropriate for y
 - [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
   - : CSS allows you to resize images used as an element's background.
     This tutorial describes how to achieve this in a simple way.
-- [Using media queries](en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
+- [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
   - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays.
     Media queries are the fundamental building blocks in building websites that render everywhere in their best quality.
 - [Understanding CSS z-index](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index)
@@ -36,7 +36,7 @@ After the release of CSS 2 (Level 1), new features have been added to CSS.
 Some of them are _fancy_ and are pretty self-contained.
 They are easy to use for anybody with a fair knowledge of basic concepts.
 
-- [CSS Counter Styles](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Counter_Styles)
+- [CSS Counter Styles](/en-US/docs/Web/API/CSS_Counter_Styles)
   - : Counting items and pages is an easy task in CSS. Learn to use {{cssxref("counter-reset")}}, {{cssxref("counter-increment")}}, {{cssxref("counters", "counters()")}}, and {{cssxref("counter", "counter()")}}.
 - [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
   - : CSS Animations allow you to define configurations of style, as [keyframes](/en-US/docs/Web/CSS/@keyframes), and to transition between them defining an animation.

--- a/files/en-us/web/css/tutorials/index.md
+++ b/files/en-us/web/css/tutorials/index.md
@@ -15,7 +15,7 @@ They are grouped by complexity so that you can choose the most appropriate for y
 
 ## Beginner-level CSS tutorials
 
-- [Getting started](/en-US/docs/Web/CSS/Getting_Started)
+- [CSS basics](en-US/docs/Learn/Getting_started_with_the_web/CSS_basics)
   - : This guide is aimed at complete beginners: You haven't written one single line of CSS? — this is for you.
     It explains the fundamental concepts of the language and guides you in writing basic stylesheets.
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds)
@@ -23,10 +23,10 @@ They are grouped by complexity so that you can choose the most appropriate for y
 - [Resizing background images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images)
   - : CSS allows you to resize images used as an element's background.
     This tutorial describes how to achieve this in a simple way.
-- [Media queries](/en-US/docs/Web/CSS/Media_Queries)
+- [Using media queries](en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
   - : The size of the screens, or the kind of devices like touchscreens or printed sheets vary greatly nowadays.
     Media queries are the fundamental building blocks in building websites that render everywhere in their best quality.
-- [Understanding z-index](/en-US/docs/Web/CSS/Understanding_z-index)
+- [Understanding CSS z-index](/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index)
   - : Controlling superposition of boxes is a basic feature that is very quickly needed by Web developers.
     Though not that difficult, it requires a basic knowledge of CSS.
 
@@ -36,15 +36,15 @@ After the release of CSS 2 (Level 1), new features have been added to CSS.
 Some of them are _fancy_ and are pretty self-contained.
 They are easy to use for anybody with a fair knowledge of basic concepts.
 
-- [CSS Counters](/en-US/docs/Web/CSS/counters)
+- [CSS Counter Styles](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Counter_Styles)
   - : Counting items and pages is an easy task in CSS. Learn to use {{cssxref("counter-reset")}}, {{cssxref("counter-increment")}}, {{cssxref("counters", "counters()")}}, and {{cssxref("counter", "counter()")}}.
-- [CSS Animations](/en-US/docs/Web/CSS/Tutorials/Using_CSS_animations)
+- [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
   - : CSS Animations allow you to define configurations of style, as [keyframes](/en-US/docs/Web/CSS/@keyframes), and to transition between them defining an animation.
-- [CSS Transitions](/en-US/docs/Web/CSS/Tutorials/Using_CSS_transitions)
+- [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
   - : CSS Transitions allow you to define an animation between several styles and to control the way this transition happens.
-- [CSS Transforms](/en-US/docs/Web/CSS/Tutorials/Using_CSS_transforms)
+- [CSS Transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
   - : Transforms allow you to change the position of elements by modifying their coordinate space: it allows for translating, rotating, and deforming them in the 2D or 3D spaces.
-- [CSS Gradients](/en-US/docs/Web/CSS/Using_CSS_gradients)
+- [CSS Gradients](/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients)
   - : Gradients are images that transition smoothly from one color to another.
     There are several types of gradients allowed in CSS: linear or radial, repeating or not.
     This tutorial describes how to use them.
@@ -54,9 +54,9 @@ They are easy to use for anybody with a fair knowledge of basic concepts.
 CSS also got new features allowing you to create complex layouts.
 Though the simplest way to achieve such layout, they are more complex to use for people without too much experience.
 
-- [CSS multi-column layouts](/en-US/docs/Web/CSS/Using_CSS_multi-column_layouts)
+- [CSS multi-column layouts](/en-US/docs/Web/CSS/CSS_Columns)
   - : CSS3 introduces a new layout allowing you to easily define multiple columns in an element.
     Though multi-column text is not that common on devices like screens, this is particularly useful on printed pages, or for indexes.
-- [CSS flexible boxes layouts](/en-US/docs/Web/CSS/Using_CSS_flexible_boxes)
+- [CSS flexible boxes layouts](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout)
   - : This new layout allow you to give boxes flexibility, allowing them to be resized smoothly.
     It is a powerful way to describe complex interfaces.


### PR DESCRIPTION
This page should be updated, but at least, with this PR, all links will be correct (especially the first one for complete beginners that was a red link!)