### PR TITLE
Clarify that it's element.openOrClosedShadowRoot in Firefox

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
@@ -20,13 +20,9 @@ browser-compat: webextensions.api.dom.openOrClosedShadowRoot
 
 Gets the open shadow root or the closed shadow root hosted by the specified element. If the shadow root isn't attached to the element, it will return `null`.
 
-> **Note:** In Firefox, the equivalent `dom.openOrClosedShadowRoot` read-only
-> property represents the shadow root hosted by the element, regardless of whether its
-> {{DOMxRef("ShadowRoot.mode", "mode")}} is `open` or
-> `closed`.
+> **Note:** In Firefox, the equivalent property is `element.openOrClosedShadowRoot`. This read-only property represents the shadow root hosted by the element, regardless of whether its {{DOMxRef("ShadowRoot.mode", "mode")}} is `open` or `closed`.
 >
-> Use {{DOMxRef("Element.attachShadow()")}} to add a shadow
-> root to an element.
+> Use {{DOMxRef("Element.attachShadow()")}} to add a shadow root to an element.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Amended the note on `dom.openOrClosedShadowRoot` to clarify that the equivalent in Firefox is element.openOrClosedShadowRoot.

### Motivation

Addresses feedback provided [here](https://github.com/mdn/browser-compat-data/pull/18989#pullrequestreview-1309348767).
