### PR TITLE
Adjust size of live sample

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -70,7 +70,7 @@ ctx.fillRect(20, 20, 200, 200);
 
 #### Rectangle result
 
-{{ EmbedLiveSample('Filling_a_rectangle_with_a_conic_gradient', 700, 200) }}
+{{ EmbedLiveSample('Filling_a_rectangle_with_a_conic_gradient', 240, 240) }}
 
 ## Specifications
 


### PR DESCRIPTION
The rectangle getting filled with a conic gradient extends from (20, 20) to (220, 220), and the size for the live sample was too small vertically to display properly and unnecessarily large horizontally.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
