### PR TITLE
Adjusted sized for live sample

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -42,7 +42,7 @@ This example initializes a conic gradient using the `createConicGradient()` meth
 #### HTML
 
 ```html
-<canvas id="canvas"></canvas>
+<canvas id="canvas" width="240" height="240"></canvas>
 ```
 
 #### JavaScript
@@ -70,7 +70,7 @@ ctx.fillRect(20, 20, 200, 200);
 
 #### Rectangle result
 
-{{ EmbedLiveSample('Filling_a_rectangle_with_a_conic_gradient', 700, 200) }}
+{{ EmbedLiveSample('Filling_a_rectangle_with_a_conic_gradient', 240, 240) }}
 
 ## Specifications
 


### PR DESCRIPTION
The  canvas was too small to fit the square being rendered, so it was enlarged. Also, the extents for the EmbedLiveSample macro were set to match the canvas size.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
