### PR TITLE
Remove a few references to IE

### DIFF
--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -105,10 +105,6 @@ function previewFiles() {
 }
 ```
 
-> **Note:** The [`FileReader()`](/en-US/docs/Web/API/FileReader) constructor was
-> not supported by Internet Explorer for versions before 10. For a full compatibility code
-> you can see our [crossbrowser possible solution for image preview](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html). See also [this more powerful example](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html).
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -352,10 +352,9 @@ API instead.
 
 ### Maximum delay value
 
-Browsers including Internet Explorer, Chrome, Safari, and Firefox store the delay as a
-32-bit signed integer internally. This causes an integer overflow when using delays
-larger than 2,147,483,647 ms (about 24.8 days), resulting in the timeout being executed
-immediately.
+Browsers store the delay as a 32-bit signed integer internally. This causes an integer
+overflow when using delays larger than 2,147,483,647 ms (about 24.8 days), resulting in
+the timeout being executed immediately.
 
 ## Examples
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -40,7 +40,7 @@ To be able to use localStorage, we should first verify that it is supported and 
 
 ### Testing for availability
 
-> **Note:** This API is available in current versions of all major browsers. Testing for availability is necessary only if you must support very old browsers, such as Internet Explorer 6 or 7, or in the limited circumstances described below.
+> **Note:** This API is available in current versions of all major browsers. Testing for availability is necessary only if you must support very old browsers, or in the limited circumstances described below.
 
 Browsers that support localStorage have a property on the window object named `localStorage`. However, just asserting that the property exists may throw exceptions. If the `localStorage` object does exist, there is still no guarantee that the localStorage API is actually available, as various browsers offer settings that disable localStorage. So a browser may _support_ localStorage, but not make it _available_ to the scripts on the page.
 

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -34,7 +34,7 @@ elem.dispatchEvent(event);
 
 The above code example uses the [EventTarget.dispatchEvent()](/en-US/docs/Web/API/EventTarget/dispatchEvent) method.
 
-This constructor is supported in most modern browsers (with Internet Explorer being the exception). For a more verbose approach (which works with Internet Explorer), see [the old-fashioned way](#the_old-fashioned_way) below.
+This constructor is supported in most modern browsers. For a more verbose approach, see [the old-fashioned way](#the_old-fashioned_way) below.
 
 ### Adding custom data – CustomEvent()
 

--- a/files/en-us/web/javascript/memory_management/index.md
+++ b/files/en-us/web/javascript/memory_management/index.md
@@ -101,7 +101,9 @@ In this context, the notion of an "object" is extended to something broader than
 
 ### Reference-counting garbage collection
 
-This is the most naive garbage collection algorithm. This algorithm reduces the problem from determining whether or not an object is still needed to determining if an object still has any other objects referencing it. An object is said to be "garbage", or collectible if there are zero references pointing to it.
+> **Note:** no modern browser uses reference-counting for garbage collection anymore.
+
+This is the most naïve garbage collection algorithm. This algorithm reduces the problem from determining whether or not an object is still needed to determining if an object still has any other objects referencing it. An object is said to be "garbage", or collectible if there are zero references pointing to it.
 
 For example:
 
@@ -152,8 +154,6 @@ function f() {
 
 f();
 ```
-
-Internet Explorer 6 and 7 are known to have reference-counting garbage collectors, which have caused memory leaks with circular references. No modern engine uses reference-counting for garbage collection anymore.
 
 ### Mark-and-sweep algorithm
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -354,7 +354,7 @@ The `products` proxy object evaluates the passed value and converts it to an arr
 ```js
 const products = new Proxy(
   {
-    browsers: ["Internet Explorer", "Netscape"],
+    browsers: ["Firefox", "Chrome"],
   },
   {
     get(obj, prop) {
@@ -388,21 +388,21 @@ const products = new Proxy(
 );
 
 console.log(products.browsers);
-//  ['Internet Explorer', 'Netscape']
+//  ['Firefox', 'Chrome']
 
-products.browsers = "Firefox";
+products.browsers = "Safari";
 //  pass a string (by mistake)
 
 console.log(products.browsers);
-//  ['Firefox'] <- no problem, the value is an array
+//  ['Safari'] <- no problem, the value is an array
 
-products.latestBrowser = "Chrome";
+products.latestBrowser = "Edge";
 
 console.log(products.browsers);
-//  ['Firefox', 'Chrome']
+//  ['Safari', 'Edge']
 
 console.log(products.latestBrowser);
-//  'Chrome'
+//  'Edge'
 ```
 
 ### Finding an array item object by its property

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -67,12 +67,6 @@ It is important to consider the following scenarios:
   - Any variable declared with {{jsxref("Statements/var", "var")}} cannot be deleted from the global scope or from a function's scope, because while they may be attached to the [global object](/en-US/docs/Glossary/Global_object), they are not configurable.
   - Any variable declared with {{jsxref("Statements/let","let")}} or {{jsxref("Statements/const","const")}} cannot be deleted from the scope within which they were defined, because they are not attached to an object.
 
-### Cross-browser notes
-
-As of modern ECMAScript specification, the traversal order of object properties is well-defined and stable across implementations. However, in the case of Internet Explorer, when one uses `delete` on a property, some confusing behavior results, preventing other browsers from using simple objects like object literals as ordered associative arrays. In Explorer, while the property _value_ is indeed set to `undefined`, if one later adds back a property with the same name, the property will be iterated in its _old_ position — not at the end of the iteration sequence as one might expect after having deleted the property and then added it back.
-
-If you want to use an ordered associative array with support of old runtimes, use a {{jsxref("Map")}} object if available (through a polyfill, for example), or simulate this structure with two separate arrays (one for the keys and the other for the values), or build an array of single-property objects, etc.
-
 ## Examples
 
 ### Using delete

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -38,7 +38,7 @@ The following table summarizes the possible return values of `typeof`. For more 
 | [Function](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) (implements [[Call]] in ECMA-262 terms; [classes](/en-US/docs/Web/JavaScript/Reference/Statements/class) are functions as well) | `"function"`                        |
 | Any other object                                                                                                                                                                                         | `"object"`                          |
 
-This list of values is exhaustive. No spec-compliant engines are reported to produce (or had historically produced) values other than those listed. The old Internet Explorer was the only browser known to [implement additional return values](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872), before the spec removed the behavior of `typeof` returning implementation-defined strings for non-callable non-standard exotic objects.
+This list of values is exhaustive. No spec-compliant engines are reported to produce (or had historically produced) values other than those listed.
 
 ## Examples
 


### PR DESCRIPTION
This PR is a kind-of followup to #24722.  Doing a search for "Internet Explorer" yields many results, many of such including mentions of IE-specific compatibility issues and the likes.  This PR fixes a few of them (though there are still many, many more out there).
