### PR TITLE
Update URL.origin description and example usage

### DIFF
--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -33,7 +33,7 @@ A string.
 
 ```js
 const url = new URL("blob:https://mozilla.org:443/")
-console.log(url.origin); // Logs 'https://mozilla.org'
+console.log(url.origin); // Logs 'https://mozilla.org:443'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -17,7 +17,6 @@ varies depending on the type of URL:
 - For `http` or `https` URLs, the scheme followed by
   `'://'`, followed by the domain, followed by `':'`, followed by
   the port (if explicitly specified, unless it is the default port - `80` and `443` respectively).
-- 
 - For `file:` URLs, the value is browser dependent.
 - for `blob:` URLs, the origin of the URL following `blob:` will
   be used. For example, `"blob:https://mozilla.org"` will be returned as

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -16,8 +16,8 @@ varies depending on the type of URL:
 
 - For `http` or `https` URLs, the scheme followed by
   `'://'`, followed by the domain, followed by `':'`, followed by
-  the port (the default port, `80` and `443` respectively, if
-  explicitly specified).
+  the port (if explicitly specified, unless it is the default port - `80` and `443` respectively).
+- 
 - For `file:` URLs, the value is browser dependent.
 - for `blob:` URLs, the origin of the URL following `blob:` will
   be used. For example, `"blob:https://mozilla.org"` will be returned as
@@ -33,7 +33,13 @@ A string.
 
 ```js
 const url = new URL("blob:https://mozilla.org:443/")
-console.log(url.origin); // Logs 'https://mozilla.org:443'
+console.log(url.origin); // Logs 'https://mozilla.org'
+
+const url = new URL("http://localhost:80/")
+console.log(url.origin); // Logs 'http:/localhost'
+
+const url = new URL("https://mozilla.org:8080/")
+console.log(url.origin); // Logs 'https://mozilla.org:8080'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -35,7 +35,7 @@ const url = new URL("blob:https://mozilla.org:443/")
 console.log(url.origin); // Logs 'https://mozilla.org'
 
 const url = new URL("http://localhost:80/")
-console.log(url.origin); // Logs 'http:/localhost'
+console.log(url.origin); // Logs 'http://localhost'
 
 const url = new URL("https://mozilla.org:8080/")
 console.log(url.origin); // Logs 'https://mozilla.org:8080'


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The current example suggests the port is removed when using `URL.origin`, which is not always the case. Only when the scheme (http, https) matches its default port (80, 443), is the port removed.

The current structure description suggests default ports (http - 80, https - 443) would not be removed, however they are. 

For other scheme/port combinations, the port is not removed.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Additional example usage could help with understanding how `URL.origin` behaves in different circumstances.

The current structure description did not match actual behaviour, which could be confusing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Example usage: https://github.com/mdn/content/pull/24792#issuecomment-1441759015

### Related issues and pull requests

/

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
