### PR TITLE
Fix links to the global performance property

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -28,7 +28,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
   - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
 - {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
+- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
 
 ## Instance methods

--- a/files/en-us/web/api/navigation_timing_api/index.md
+++ b/files/en-us/web/api/navigation_timing_api/index.md
@@ -21,7 +21,7 @@ This API lets you measure data that was previously difficult to obtain, such as 
 ## Interfaces
 
 - {{domxref("Performance")}}
-  - : The {{domxref("window.performance")}} property returns a `Performance` object. While this interface is defined by the High Resolution Time API, the Navigation Timing API adds two properties: {{domxref("Performance.timing", "timing")}} and {{domxref("Performance.navigation", "navigation")}}, of the types below.
+  - : The {{domxref("performance_property", "window.performance")}} property returns a `Performance` object. While this interface is defined by the High Resolution Time API, the Navigation Timing API adds two properties: {{domxref("Performance.timing", "timing")}} and {{domxref("Performance.navigation", "navigation")}}, of the types below.
 - {{domxref("PerformanceNavigationTiming")}}
   - : Provides methods and properties to store and retrieve metrics regarding the browser's document navigation events. For example, this interface can be used to determine how much time it takes to load or unload a document.
 - {{domxref("PerformanceTiming")}} {{deprecated_inline}}

--- a/files/en-us/web/api/navigation_timing_api/using_navigation_timing/index.md
+++ b/files/en-us/web/api/navigation_timing_api/using_navigation_timing/index.md
@@ -12,7 +12,7 @@ Unlike other tools or libraries, the [Navigation Timing API](/en-US/docs/Web/API
 
 ## Collecting timing information
 
-Using the API is as simple as obtaining the {{domxref("Performance")}} object using {{domxref("window.performance")}} and looking up what you need within the object returned. For example, to measure the perceived loading time for a page:
+Using the API is as simple as obtaining the {{domxref("Performance")}} object using {{domxref("performance_property", "window.performance")}} and looking up what you need within the object returned. For example, to measure the perceived loading time for a page:
 
 ```js
 window.addEventListener("load", () => {
@@ -106,5 +106,5 @@ The values listed are for the {{HTMLElement("iframe")}} in which the sample is p
 ## See also
 
 - [Navigation Timing API](/en-US/docs/Web/API/Navigation_timing_API)
-- {{domxref("window.performance")}}
+- {{domxref("performance_property", "window.performance")}}
 - {{domxref("Performance")}}, {{domxref("PerformanceTiming")}}, and {{domxref("PerformanceNavigation")}}

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -28,7 +28,7 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
   - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
 - {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
+- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
 
 ## Instance methods

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -112,7 +112,7 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : An alias for {{domxref("window.scrollY")}}.
 - {{domxref("Window.parent")}} {{ReadOnlyInline}}
   - : Returns a reference to the parent of the current window or subframe.
-- {{domxref("Window.performance")}} {{ReadOnlyInline}}
+- {{domxref("performance_property", "Window.performance")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Performance")}} object, which includes the {{domxref("Performance.timing", "timing")}} and {{domxref("Performance.navigation", "navigation")}} attributes, each of which is an object providing [performance-related](/en-US/docs/Web/API/Navigation_timing_API) data. See also [Using Navigation Timing](/en-US/docs/Web/API/Navigation_timing_API/Using_Navigation_Timing) for additional information and examples.
 - {{domxref("Window.personalbar")}} {{ReadOnlyInline}}
   - : Returns the personalbar object.

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -30,7 +30,7 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
 
 ### Non-standard properties
 
-- {{domxref("WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
+- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("Performance")}} associated with the worker. It is a regular performance object, except that only a subset of its property and methods are available to workers.
 - {{domxref("WorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("console")}} associated with the worker.


### PR DESCRIPTION
This property has been move to the top level as it is inside several global scopes.