### PR TITLE
Made initial arc radius and slider position match

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -201,8 +201,6 @@ Then a `lineTo()` call completes the path to _p2_.
 ```js
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
-let radius = 100;
-
 const controlOut = document.getElementById("radius-output");
 const control = document.getElementById("radius");
 control.oninput = () => {
@@ -215,6 +213,8 @@ const p0 = { x: 0, y: 50 };
 const p1 = { x: 100, y: 100 };
 const p2 = { x: 150, y: 50 };
 const p3 = { x: 200, y: 100 };
+
+let radius = control.value; // match with init control value
 
 function labelPoint(p, offset, i = 0) {
   const { x, y } = offset;


### PR DESCRIPTION
The initial arc radius was 100 while the slider's initial value was 50. This change reads the initial slider value to set the initial radius value so they will always match.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
