### PR TITLE
Fix name of a function for DataTransferItemList

### DIFF
--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -26,7 +26,7 @@ This interface has no constructor.
   - : Removes the drag item from the list at the given index.
 - {{domxref("DataTransferItemList.clear()")}}
   - : Removes all of the drag items from the list.
-- {{domxref("DataTransferItemList.DataTransferItem()")}}
+- {{domxref("DataTransferItemList.operator[]")}}
   - : Getter that returns a {{domxref("DataTransferItem")}} at the given index.
 
 ## Example


### PR DESCRIPTION
The name of the legacy indexed getter function has been misread in the WebIdl: it has been given the name of its return type rather than its correct mapping in JavaScript, the operator `[]`. 

Unlike the non-legacy indexed getters, there is no `item()` method associated with the operator, so it needs its own page.