### PR TITLE
Fix broken link xhtml+xml -> XHTML

### DIFF
--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -19,7 +19,7 @@ parseFromString(string, mimeType)
 
 - `string`
   - : The string to be parsed. It must contain either an
-    {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("xhtml+xml")}}, or
+    {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("XHTML")}}, or
     {{Glossary("svg")}} document.
 - `mimeType`
 


### PR DESCRIPTION
The name of the type of the document is XHTML and `xhtml+xml` that is a fragment of its MIME type.