### PR TITLE
Adjusting misleading ':not' selector description - :not selectors use…

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -68,8 +68,8 @@ body :not(p) {
   text-decoration: underline;
 }
 
-/* Elements that are not <div> and not <span> elements */
-body :not(div):not(span) {
+/* Elements that are not <div>s or `.fancy` */
+body :not(div):not(.fancy) {
   font-weight: bold;
 }
 


### PR DESCRIPTION
… 'or' logic, not 'and'

### Description

Updating a description and example for the `:not` CSS selector so it's more clear.

### Motivation

Checking through the `:not` documentation leads to a misleading selector example. 

![image](https://user-images.githubusercontent.com/30223207/221067446-9a663a0a-ef0c-4e11-a02e-56a969d968ee.png)


Take the following example: 
```
body :not(div, .fancy) {
  font-weight: bold;
}
```

In the docs, it claims that this uses 'and' logic, but if that were true, it would mean that an element such as `<span class="fancy"></span>` would show bold text. In practice, the text doesn't show as bold. The `:not` selector uses 'or' logic, and only one condition is needed to be true for it to activate. Whether the selectors inside `:not` are written comma-separated, or the selector is written as `:not(div):not(.fancy)`, the result is the same.

![image](https://user-images.githubusercontent.com/30223207/221066927-35d5e44d-01db-43f7-bab7-01b140022721.png)
![image](https://user-images.githubusercontent.com/30223207/221067293-f7d691fc-9430-4d6d-bfeb-8eefc19d5e67.png)
