### PR TITLE
Fix ellipse angles definition

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -36,7 +36,7 @@ the direction given by `counterclockwise` (defaulting to clockwise).
 - `rotation`
   - : The rotation of the ellipse, expressed in radians.
 - `startAngle`
-  - : The eccentric angle at which the ellipse starts, measured clockwise from the positive x-axis
+  - : The [eccentric angle](https://www.simply.science/index.php/math/geometry/conic-sections/ellipse/10022-eccentric-angle-and-parametric-equations-of-an-ellipse) at which the ellipse starts, measured clockwise from the positive x-axis
     and expressed in radians.
 - `endAngle`
   - : The eccentric angle at which the ellipse ends, measured clockwise from the positive x-axis and

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -39,7 +39,7 @@ the direction given by `counterclockwise` (defaulting to clockwise).
   - : The [eccentric angle](https://www.simply.science/index.php/math/geometry/conic-sections/ellipse/10022-eccentric-angle-and-parametric-equations-of-an-ellipse) at which the ellipse starts, measured clockwise from the positive x-axis
     and expressed in radians.
 - `endAngle`
-  - : The eccentric angle at which the ellipse ends, measured clockwise from the positive x-axis and
+  - : The [eccentric angle](https://www.simply.science/index.php/math/geometry/conic-sections/ellipse/10022-eccentric-angle-and-parametric-equations-of-an-ellipse) at which the ellipse ends, measured clockwise from the positive x-axis and
     expressed in radians.
 - `counterclockwise` {{optional_inline}}
   - : An optional boolean value which, if `true`, draws the ellipse

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -36,10 +36,10 @@ the direction given by `counterclockwise` (defaulting to clockwise).
 - `rotation`
   - : The rotation of the ellipse, expressed in radians.
 - `startAngle`
-  - : The angle at which the ellipse starts, measured clockwise from the positive x-axis
+  - : The eccentric angle at which the ellipse starts, measured clockwise from the positive x-axis
     and expressed in radians.
 - `endAngle`
-  - : The angle at which the ellipse ends, measured clockwise from the positive x-axis and
+  - : The eccentric angle at which the ellipse ends, measured clockwise from the positive x-axis and
     expressed in radians.
 - `counterclockwise` {{optional_inline}}
   - : An optional boolean value which, if `true`, draws the ellipse


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This fixes a the Canvas2D `ellipse()` methods angles definition. 
<!-- ✍️ Summarize your changes in one or two sentences -->
As was found in https://github.com/whatwg/html/issues/8408 the ellipse's `startAngle` and `endAngle` are not really angles on the ellipse, but angles on the eccentric circle of the ellipse.  
These are known as "eccentric angle" (e.g on [Wolfram](https://mathworld.wolfram.com/EccentricAngle.html)) , though this term *might* be a bit obscure at first sight, so I wouldn't mind a better proposition if reviewers have one.  
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
A couple of questions were opened on StackOverflow over this discrepancy between specs+docs vs implementations. (https://stackoverflow.com/questions/74111375, https://stackoverflow.com/questions/52149077) 

### Additional details
The specs got fixed in https://github.com/whatwg/html/pull/8495 but as can be seen, the fix was quite verbose and I'm not sure the docs need to get into that much details.   So I hope this little fix is both enough to lead the ones that could get surprised by the actual behavior to the proper understanding, and not too obscure to lose in details the ones that wouldn't notice.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
 &dash;
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
