### PR TITLE
Web/ -Remove tags in many remaining web topics  (degmp*)

### DIFF
--- a/files/en-us/web/demos/index.md
+++ b/files/en-us/web/demos/index.md
@@ -1,17 +1,6 @@
 ---
 title: Demos of open web technologies
 slug: Web/Demos
-tags:
-  - 2D
-  - 3D
-  - Audio
-  - CSS
-  - Canvas
-  - Design
-  - HTML
-  - SVG
-  - VR
-  - Video
 ---
 
 Mozilla supports a wide variety of exciting open web technologies, and we encourage their use. This page offers links to interesting demonstrations of these technologies.

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -1,13 +1,6 @@
 ---
 title: Creating and triggering events
 slug: Web/Events/Creating_and_triggering_events
-tags:
-  - Advanced
-  - DOM
-  - Guide
-  - JavaScript
-  - NeedsContent
-  - events
 ---
 
 This article demonstrates how to create and dispatch DOM events. Such events are commonly called **synthetic events**, as opposed to the events fired by the browser itself.

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -1,10 +1,6 @@
 ---
 title: Event handling (overview)
 slug: Web/Events/Event_handlers
-tags:
-  - Beginner
-  - DOM
-  - DOM Beginner
 ---
 
 Events are signals fired inside the browser window that notify of changes in the browser or operating system environment. Programmers can create _event handler_ code that will run when an event fires, allowing web pages to respond appropriately to change.

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -1,10 +1,6 @@
 ---
 title: Event reference
 slug: Web/Events
-tags:
-  - Event
-  - Overview
-  - Reference
 spec-urls: https://html.spec.whatwg.org/multipage/indices.html#events-2
 ---
 

--- a/files/en-us/web/exslt/exsl/index.md
+++ b/files/en-us/web/exslt/exsl/index.md
@@ -1,10 +1,6 @@
 ---
 title: Common (exsl)
 slug: Web/EXSLT/exsl
-tags:
-  - EXSLT
-  - Overview
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/exsl/node-set/index.md
+++ b/files/en-us/web/exslt/exsl/node-set/index.md
@@ -1,10 +1,6 @@
 ---
 title: exsl:node-set()
 slug: Web/EXSLT/exsl/node-set
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/exsl/object-type/index.md
+++ b/files/en-us/web/exslt/exsl/object-type/index.md
@@ -1,10 +1,6 @@
 ---
 title: exsl:object-type()
 slug: Web/EXSLT/exsl/object-type
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/index.md
+++ b/files/en-us/web/exslt/index.md
@@ -1,9 +1,6 @@
 ---
 title: EXSLT
 slug: Web/EXSLT
-tags:
-  - EXSLT
-  - Landing
 ---
 
 EXSLT is a set of extensions to [XSLT](/en-US/docs/Web/XSLT). There are a number of modules; those that are supported by Firefox are listed below:

--- a/files/en-us/web/exslt/math/highest/index.md
+++ b/files/en-us/web/exslt/math/highest/index.md
@@ -1,10 +1,6 @@
 ---
 title: math:highest()
 slug: Web/EXSLT/math/highest
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/index.md
+++ b/files/en-us/web/exslt/math/index.md
@@ -1,10 +1,6 @@
 ---
 title: Math (math)
 slug: Web/EXSLT/math
-tags:
-  - EXSLT
-  - Overview
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/lowest/index.md
+++ b/files/en-us/web/exslt/math/lowest/index.md
@@ -1,10 +1,6 @@
 ---
 title: math:lowest()
 slug: Web/EXSLT/math/lowest
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/max/index.md
+++ b/files/en-us/web/exslt/math/max/index.md
@@ -1,10 +1,6 @@
 ---
 title: math:max()
 slug: Web/EXSLT/math/max
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -1,11 +1,6 @@
 ---
 title: math:min()
 slug: Web/EXSLT/math/min
-tags:
-  - EXSLT
-  - NeedsCompatTable
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/index.md
+++ b/files/en-us/web/exslt/regexp/index.md
@@ -1,10 +1,6 @@
 ---
 title: Regular expressions (regexp)
 slug: Web/EXSLT/regexp
-tags:
-  - EXSLT
-  - Overview
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -1,10 +1,6 @@
 ---
 title: regexp:match()
 slug: Web/EXSLT/regexp/match
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/replace/index.md
+++ b/files/en-us/web/exslt/regexp/replace/index.md
@@ -1,10 +1,6 @@
 ---
 title: regexp:replace()
 slug: Web/EXSLT/regexp/replace
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/test/index.md
+++ b/files/en-us/web/exslt/regexp/test/index.md
@@ -1,10 +1,6 @@
 ---
 title: regexp:test()
 slug: Web/EXSLT/regexp/test
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/difference/index.md
+++ b/files/en-us/web/exslt/set/difference/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:difference()
 slug: Web/EXSLT/set/difference
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/distinct/index.md
+++ b/files/en-us/web/exslt/set/distinct/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:distinct()
 slug: Web/EXSLT/set/distinct
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/has-same-node/index.md
+++ b/files/en-us/web/exslt/set/has-same-node/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:has-same-node()
 slug: Web/EXSLT/set/has-same-node
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/index.md
+++ b/files/en-us/web/exslt/set/index.md
@@ -1,10 +1,6 @@
 ---
 title: Sets (set)
 slug: Web/EXSLT/set
-tags:
-  - EXSLT
-  - Overview
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/intersection/index.md
+++ b/files/en-us/web/exslt/set/intersection/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:intersection()
 slug: Web/EXSLT/set/intersection
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/leading/index.md
+++ b/files/en-us/web/exslt/set/leading/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:leading()
 slug: Web/EXSLT/set/leading
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/trailing/index.md
+++ b/files/en-us/web/exslt/set/trailing/index.md
@@ -1,10 +1,6 @@
 ---
 title: set:trailing()
 slug: Web/EXSLT/set/trailing
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/concat/index.md
+++ b/files/en-us/web/exslt/str/concat/index.md
@@ -1,10 +1,6 @@
 ---
 title: str:concat()
 slug: Web/EXSLT/str/concat
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/index.md
+++ b/files/en-us/web/exslt/str/index.md
@@ -1,10 +1,6 @@
 ---
 title: Strings (str)
 slug: Web/EXSLT/str
-tags:
-  - EXSLT
-  - Overview
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/split/index.md
+++ b/files/en-us/web/exslt/str/split/index.md
@@ -1,10 +1,6 @@
 ---
 title: str:split()
 slug: Web/EXSLT/str/split
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/tokenize/index.md
+++ b/files/en-us/web/exslt/str/tokenize/index.md
@@ -1,10 +1,6 @@
 ---
 title: str:tokenize()
 slug: Web/EXSLT/str/tokenize
-tags:
-  - EXSLT
-  - NeedsSpecTable
-  - Reference
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/guide/ajax/community/index.md
+++ b/files/en-us/web/guide/ajax/community/index.md
@@ -1,8 +1,6 @@
 ---
 title: Community
 slug: Web/Guide/AJAX/Community
-tags:
-  - AJAX
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}

--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -1,13 +1,6 @@
 ---
 title: Getting started
 slug: Web/Guide/AJAX/Getting_Started
-tags:
-  - AJAX
-  - API
-  - Advanced
-  - JavaScript
-  - WebMechanics
-  - XMLHttpRequest
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}

--- a/files/en-us/web/guide/ajax/index.md
+++ b/files/en-us/web/guide/ajax/index.md
@@ -1,13 +1,6 @@
 ---
 title: Ajax
 slug: Web/Guide/AJAX
-tags:
-  - AJAX
-  - DOM
-  - JSON
-  - JavaScript
-  - References
-  - XMLHttpRequest
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
+++ b/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
@@ -1,9 +1,6 @@
 ---
 title: WAI ARIA Live Regions/API Support
 slug: Web/Guide/AJAX/WAI_ARIA_Live_Regions_API_Support
-tags:
-  - AJAX
-  - Accessibility
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Guide/AJAX")}}

--- a/files/en-us/web/guide/api/index.md
+++ b/files/en-us/web/guide/api/index.md
@@ -1,11 +1,6 @@
 ---
 title: Guide to Web APIs
 slug: Web/Guide/API
-tags:
-  - API
-  - Guide
-  - Landing
-  - Web
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -1,13 +1,6 @@
 ---
 title: Adding captions and subtitles to HTML video
 slug: Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
-tags:
-  - HTML
-  - Media
-  - WebVTT
-  - captions
-  - subtitles
-  - track
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -1,14 +1,6 @@
 ---
 title: Media buffering, seeking, and time ranges
 slug: Web/Guide/Audio_and_video_delivery/buffering_seeking_time_ranges
-tags:
-  - Apps
-  - Buffer
-  - HTML
-  - TimeRanges
-  - Video
-  - buffering
-  - seeking
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/cross-browser_audio_basics/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/cross-browser_audio_basics/index.md
@@ -1,13 +1,6 @@
 ---
 title: Cross-browser audio basics
 slug: Web/Guide/Audio_and_video_delivery/Cross-browser_audio_basics
-tags:
-  - Apps
-  - Audio
-  - Guide
-  - HTML
-  - Media
-  - events
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.md
@@ -1,11 +1,6 @@
 ---
 title: Creating a cross-browser video player
 slug: Web/Guide/Audio_and_video_delivery/cross_browser_video_player
-tags:
-  - Apps
-  - HTML
-  - Video
-  - full screen
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/index.md
@@ -1,12 +1,6 @@
 ---
 title: Audio and Video Delivery
 slug: Web/Guide/Audio_and_video_delivery
-tags:
-  - Audio
-  - Guide
-  - HTML
-  - Media
-  - Video
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -1,9 +1,6 @@
 ---
 title: Livestreaming web audio and video
 slug: Web/Guide/Audio_and_video_delivery/Live_streaming_web_audio_and_video
-tags:
-  - Guide
-  - adaptive streaming
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -1,14 +1,6 @@
 ---
 title: Setting up adaptive streaming media sources
 slug: Web/Guide/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources
-tags:
-  - Audio
-  - HLS
-  - HTML
-  - HTTP Live Streaming
-  - MPEG-DASH
-  - Video
-  - adaptive streaming
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -1,12 +1,6 @@
 ---
 title: Video player styling basics
 slug: Web/Guide/Audio_and_video_delivery/Video_player_styling_basics
-tags:
-  - Apps
-  - Guide
-  - Media
-  - Styling
-  - Video
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/web_audio_api_cross_browser/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/web_audio_api_cross_browser/index.md
@@ -1,8 +1,6 @@
 ---
 title: Writing Web Audio API code that works in every browser
 slug: Web/Guide/Audio_and_video_delivery/Web_Audio_API_cross_browser
-tags:
-  - API
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -1,12 +1,6 @@
 ---
 title: Web Audio playbackRate explained
 slug: Web/Guide/Audio_and_video_delivery/WebAudio_playbackRate_explained
-tags:
-  - Apps
-  - Audio
-  - Media
-  - Video
-  - playbackRate
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/en-us/web/guide/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/guide/audio_and_video_manipulation/index.md
@@ -1,17 +1,6 @@
 ---
 title: Audio and video manipulation
 slug: Web/Guide/Audio_and_video_manipulation
-tags:
-  - Audio
-  - Canvas
-  - Examples
-  - Guide
-  - HTML
-  - Media
-  - Video
-  - Web Audio API
-  - WebGL
-  - developer recommendation
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/css/block_formatting_context/index.md
+++ b/files/en-us/web/guide/css/block_formatting_context/index.md
@@ -1,13 +1,6 @@
 ---
 title: Block formatting context
 slug: Web/Guide/CSS/Block_formatting_context
-tags:
-  - CSS
-  - Guide
-  - NeedsBeginnerUpdate
-  - NeedsExample
-  - Reference
-  - Web
 spec-urls: https://drafts.csswg.org/css-display/#block-formatting-context
 ---
 

--- a/files/en-us/web/guide/css/css_layout/index.md
+++ b/files/en-us/web/guide/css/css_layout/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS Layout
 slug: Web/Guide/CSS/CSS_Layout
-tags:
-  - Guide
-  - CSS
-  - CSS Layout
-  - Overview
-  - Web
-  - Web Development
 ---
 
 There are a number of methods that you can use to lay out your web pages and applications. MDN contains a number of in-depth guides to the different methods, and this page provides an overview of them all.

--- a/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
+++ b/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
@@ -1,9 +1,6 @@
 ---
 title: Challenge solutions
 slug: Web/Guide/CSS/Getting_started/Challenge_solutions
-tags:
-  - Beginner
-  - NeedsUpdate
 ---
 
 This page provides solutions to the challenges posed in the [CSS Getting Started](/en-US/docs/Learn/CSS/First_steps) tutorial. These are not the only possible solutions. The sections below correspond to the titles of the tutorial sections.

--- a/files/en-us/web/guide/graphics/index.md
+++ b/files/en-us/web/guide/graphics/index.md
@@ -1,16 +1,6 @@
 ---
 title: Graphics on the Web
 slug: Web/Guide/Graphics
-tags:
-  - 2D
-  - 3D
-  - Canvas
-  - Graphics
-  - HTML
-  - SVG
-  - Web
-  - WebGL
-  - WebRTC
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/houdini/index.md
+++ b/files/en-us/web/guide/houdini/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS Houdini
 slug: Web/Guide/Houdini
-tags:
-  - API
-  - CSS
-  - Houdini
-  - JavaScript
-  - Landing
-  - Web
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/index.md
+++ b/files/en-us/web/guide/index.md
@@ -1,11 +1,6 @@
 ---
 title: Developer guides
 slug: Web/Guide
-tags:
-  - API
-  - Guide
-  - Landing
-  - Web
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/introduction_to_web_development/index.md
+++ b/files/en-us/web/guide/introduction_to_web_development/index.md
@@ -1,14 +1,6 @@
 ---
 title: Introduction to Web development
 slug: Web/Guide/Introduction_to_Web_development
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Development
-  - HTML
-  - JavaScript
-  - Web
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/mobile/a_hybrid_approach/index.md
+++ b/files/en-us/web/guide/mobile/a_hybrid_approach/index.md
@@ -1,10 +1,6 @@
 ---
 title: A hybrid approach
 slug: Web/Guide/Mobile/A_hybrid_approach
-tags:
-  - Mobile
-  - Responsive Design
-  - Web Development
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Mobile")}}

--- a/files/en-us/web/guide/mobile/index.md
+++ b/files/en-us/web/guide/mobile/index.md
@@ -1,9 +1,6 @@
 ---
 title: Mobile Web Development
 slug: Web/Guide/Mobile
-tags:
-  - Intermediate
-  - NeedsExample
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/mobile/mobile-friendliness/index.md
+++ b/files/en-us/web/guide/mobile/mobile-friendliness/index.md
@@ -1,9 +1,6 @@
 ---
 title: Mobile-friendliness
 slug: Web/Guide/Mobile/Mobile-friendliness
-tags:
-  - Mobile
-  - Web Development
 ---
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Guide/Mobile")}}

--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.md
@@ -1,23 +1,6 @@
 ---
 title: Parsing and serializing XML
 slug: Web/Guide/Parsing_and_serializing_XML
-tags:
-  - AJAX
-  - Add-ons
-  - DOM
-  - DOM Parsing
-  - Document
-  - Extensions
-  - Guide
-  - HTMLDocument
-  - JSON
-  - Parsing
-  - Parsing XML
-  - Serializing
-  - Serializing XML
-  - XML
-  - XMLDocument
-  - XMLHttpRequest
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/performance/index.md
+++ b/files/en-us/web/guide/performance/index.md
@@ -1,11 +1,6 @@
 ---
 title: Optimization and performance
 slug: Web/Guide/Performance
-tags:
-  - Landing
-  - Optimization
-  - Performance
-  - Web
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/printing/index.md
+++ b/files/en-us/web/guide/printing/index.md
@@ -1,12 +1,6 @@
 ---
 title: Printing
 slug: Web/Guide/Printing
-tags:
-  - DOM
-  - Guide
-  - NeedsContent
-  - NeedsRelocation
-  - printing
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/svg-in-opentype/index.md
+++ b/files/en-us/web/guide/svg-in-opentype/index.md
@@ -1,11 +1,6 @@
 ---
 title: SVG-in-OpenType
 slug: Web/Guide/SVG-in-OpenType
-tags:
-  - Draft
-  - Fonts
-  - Guide
-  - NeedsContent
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/user_input_methods/index.md
+++ b/files/en-us/web/guide/user_input_methods/index.md
@@ -1,16 +1,6 @@
 ---
 title: User input and controls
 slug: Web/Guide/User_input_methods
-tags:
-  - Screen Orientation
-  - contenteditable
-  - drag and drop
-  - fullscreen
-  - keyboard
-  - mouse
-  - pointer lock
-  - touch
-  - user input
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/guide/woff/index.md
+++ b/files/en-us/web/guide/woff/index.md
@@ -1,11 +1,6 @@
 ---
 title: The Web Open Font Format (WOFF)
 slug: Web/Guide/WOFF
-tags:
-  - Fonts
-  - NeedsMobileBrowserCompatibility
-  - WOFF
-  - WOFF2
 browser-compat:
   - css.at-rules.font-face.WOFF
   - css.at-rules.font-face.WOFF_2

--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -1,13 +1,6 @@
 ---
 title: Writing forward-compatible websites
 slug: Web/Guide/Writing_forward-compatible_websites
-tags:
-  - CSS
-  - Compatibility
-  - DOM
-  - HTML
-  - JavaScript
-  - Web Development
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/media/autoplay_guide/index.md
+++ b/files/en-us/web/media/autoplay_guide/index.md
@@ -1,23 +1,6 @@
 ---
 title: Autoplay guide for media and Web Audio APIs
 slug: Web/Media/Autoplay_guide
-tags:
-  - API
-  - Audio
-  - Draft
-  - Guide
-  - HTML
-  - JavaScript
-  - Media
-  - Muting
-  - Playback
-  - Video
-  - Web
-  - Web Audio API
-  - autoplay
-  - mute
-  - muted
-  - play
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/dash_adaptive_streaming_for_html_5_video/index.md
+++ b/files/en-us/web/media/dash_adaptive_streaming_for_html_5_video/index.md
@@ -1,9 +1,6 @@
 ---
 title: DASH Adaptive Streaming for HTML 5 Video
 slug: Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
-tags:
-  - Guide
-  - HTML
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/audio_codecs/index.md
+++ b/files/en-us/web/media/formats/audio_codecs/index.md
@@ -1,27 +1,6 @@
 ---
 title: Web audio codec guide
 slug: Web/Media/Formats/Audio_codecs
-tags:
-  - AAC
-  - ALAC
-  - Apple Lossless
-  - Audio
-  - Codecs
-  - Compress
-  - Decompress
-  - Encoding
-  - FLAC
-  - Guide
-  - Media
-  - Opus
-  - Vorbis
-  - Web
-  - data
-  - decoding
-  - formats
-  - mp3
-  - mp4
-  - sound
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/audio_concepts/index.md
+++ b/files/en-us/web/media/formats/audio_concepts/index.md
@@ -1,21 +1,6 @@
 ---
 title: Digital audio concepts
 slug: Web/Media/Formats/Audio_concepts
-tags:
-  - AAC
-  - Audio
-  - Codecs
-  - Coding
-  - Compressed
-  - Guide
-  - MPEG
-  - Media
-  - Music
-  - compression
-  - formats
-  - mp3
-  - mp4
-  - sound
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -1,19 +1,6 @@
 ---
 title: The "codecs" parameter in common media types
 slug: Web/Media/Formats/codecs_parameter
-tags:
-  - Audio
-  - Codecs
-  - Containers
-  - MIME
-  - MIME Types
-  - Media
-  - Media Types
-  - Parameter
-  - Types
-  - Video
-  - Web
-  - formats
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -1,17 +1,6 @@
 ---
 title: Media container formats (file types)
 slug: Web/Media/Formats/Containers
-tags:
-  - Audio
-  - Containers
-  - File
-  - Filetypes
-  - Guide
-  - MIME Types
-  - MIMETypes
-  - Media
-  - Video
-  - formats
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -1,30 +1,6 @@
 ---
 title: Image file type and format guide
 slug: Web/Media/Formats/Image_types
-tags:
-  - APNG
-  - BMP
-  - Bitmap
-  - Diagrams
-  - File
-  - File Types
-  - Filetype
-  - Graphics
-  - Guide
-  - ICO
-  - Icons
-  - Image
-  - Images
-  - JPEG
-  - JPG
-  - Media
-  - PNG
-  - Photos
-  - SVG
-  - WebP
-  - AVIF
-  - gif
-  - icon
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/index.md
+++ b/files/en-us/web/media/formats/index.md
@@ -1,20 +1,6 @@
 ---
 title: "Media type and format guide: image, audio, and video content"
 slug: Web/Media/Formats
-tags:
-  - API
-  - Audio
-  - Codecs
-  - Containers
-  - File Types
-  - Files
-  - Filetypes
-  - Landing
-  - Media
-  - Types
-  - Video
-  - Web
-  - formats
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/support_issues/index.md
+++ b/files/en-us/web/media/formats/support_issues/index.md
@@ -1,19 +1,6 @@
 ---
 title: Handling media support issues in web content
 slug: Web/Media/Formats/Support_issues
-tags:
-  - Audio
-  - Guide
-  - HTMLAudioElement
-  - HTMLMediaElement
-  - HTMLVideoElement
-  - Intermediate
-  - Media
-  - Sources
-  - Video
-  - WebRTC
-  - fallbacks
-  - sound
 ---
 
 One of the realities of working with audio and video presentation and manipulation on the web is that there are a number of media formats available, of varying degrees of popularity and with a variety of capabilities. The availability of choices is good for the user, in that they can choose the format that suits their needs best. There is a drawback, however: because there are so many to choose from, with so many different kinds of licenses and design principles involved, each web browser developer is left to its own devices when deciding which media file types and codecs to support.

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1,26 +1,6 @@
 ---
 title: Web video codec guide
 slug: Web/Media/Formats/Video_codecs
-tags:
-  - AV1
-  - Codecs
-  - Encoder
-  - Encoding
-  - Guide
-  - H.264
-  - MPEG
-  - Media
-  - Theora
-  - VP8
-  - VP9
-  - Video
-  - compression
-  - data
-  - decoding
-  - h.263
-  - h.265
-  - mp4
-  - streaming
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/video_concepts/index.md
+++ b/files/en-us/web/media/formats/video_concepts/index.md
@@ -1,25 +1,6 @@
 ---
 title: Digital video concepts
 slug: Web/Media/Formats/Video_concepts
-tags:
-  - Beginner
-  - Chroma
-  - Digital
-  - Eye
-  - Guide
-  - Image
-  - Light
-  - Luma
-  - Sampling
-  - Subsampling
-  - Video
-  - Vision
-  - Y'CbCr
-  - Y'UV
-  - YCbCr
-  - YUV
-  - color
-  - rgb
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/formats/webrtc_codecs/index.md
@@ -1,15 +1,6 @@
 ---
 title: Codecs used by WebRTC
 slug: Web/Media/Formats/WebRTC_codecs
-tags:
-  - Audio
-  - Codecs
-  - Guide
-  - Intermediate
-  - Media
-  - Video
-  - WebRTC
-  - WebRTC API
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/html_media/index.md
+++ b/files/en-us/web/media/html_media/index.md
@@ -1,15 +1,6 @@
 ---
 title: Using audio and video in HTML
 slug: Web/Media/HTML_media
-tags:
-  - Audio
-  - Beginner
-  - Guide
-  - HTML
-  - Media
-  - NeedsContent
-  - Video
-  - sound
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/images/index.md
+++ b/files/en-us/web/media/images/index.md
@@ -1,11 +1,6 @@
 ---
 title: Using images in HTML
 slug: Web/Media/images
-tags:
-  - HTML
-  - Images
-  - Landing
-  - Media
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/index.md
+++ b/files/en-us/web/media/index.md
@@ -1,12 +1,6 @@
 ---
 title: Web media technologies
 slug: Web/Media
-tags:
-  - Audio
-  - Landing
-  - Media
-  - Video
-  - Web
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/media/streaming/index.md
+++ b/files/en-us/web/media/streaming/index.md
@@ -1,14 +1,6 @@
 ---
 title: Guide to streaming audio and video
 slug: Web/Media/Streaming
-tags:
-  - Audio
-  - Guide
-  - Media
-  - Networking
-  - Video
-  - streaming
-  - Draft
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
+++ b/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
@@ -1,9 +1,6 @@
 ---
 title: Animation performance and frame rate
 slug: Web/Performance/Animation_performance_and_frame_rate
-tags:
-  - CSS animation
-  - Web Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/critical_rendering_path/index.md
+++ b/files/en-us/web/performance/critical_rendering_path/index.md
@@ -1,9 +1,6 @@
 ---
 title: Critical rendering path
 slug: Web/Performance/Critical_rendering_path
-tags:
-  - Performance
-  - Reference
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/css_javascript_animation_performance/index.md
+++ b/files/en-us/web/performance/css_javascript_animation_performance/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS and JavaScript animation performance
 slug: Web/Performance/CSS_JavaScript_animation_performance
-tags:
-  - Animation
-  - Animations
-  - CSS
-  - FPS
-  - JavaScript
-  - Performance
-  - Transitions
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/dns-prefetch/index.md
+++ b/files/en-us/web/performance/dns-prefetch/index.md
@@ -1,9 +1,6 @@
 ---
 title: Using dns-prefetch
 slug: Web/Performance/dns-prefetch
-tags:
-  - Web Performance
-  - dns-prefetch
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/fundamentals/index.md
+++ b/files/en-us/web/performance/fundamentals/index.md
@@ -1,12 +1,6 @@
 ---
 title: Performance fundamentals
 slug: Web/Performance/Fundamentals
-tags:
-  - Apps
-  - Firefox
-  - Gecko
-  - Guide
-  - Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Populating the page: how browsers work"
 slug: Web/Performance/How_browsers_work
-tags:
-  - Browsers
-  - Compositing
-  - Critical rendering path
-  - DNS Lookup
-  - Navigation
-  - Page load
-  - Painting
-  - SSL/TLS Handshake
-  - TCP handshake
-  - Web Performance
-  - render
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/how_long_is_too_long/index.md
+++ b/files/en-us/web/performance/how_long_is_too_long/index.md
@@ -1,11 +1,6 @@
 ---
 title: "Recommended Web Performance Timings: How long is too long?"
 slug: Web/Performance/How_long_is_too_long
-tags:
-  - Performance
-  - Reference
-  - Tutorial
-  - Web Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -1,20 +1,6 @@
 ---
 title: Web performance
 slug: Web/Performance
-tags:
-  - API
-  - App
-  - App Performance
-  - HTML
-  - JavaScript
-  - Landing
-  - Mobile
-  - Mobile Performance
-  - Performance
-  - Performance Budget
-  - Start-Up Performance
-  - Web
-  - Web Performance
 ---
 
 {{QuickLinksWithSubPages}}

--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -1,16 +1,6 @@
 ---
 title: Lazy loading
 slug: Web/Performance/Lazy_loading
-tags:
-  - Content
-  - Images
-  - Layout
-  - Lazy
-  - Lazy-loading
-  - Loading
-  - Performance
-  - Web Performance
-  - rendering
 spec-urls: https://html.spec.whatwg.org/multipage/#lazy-loading-attributes
 ---
 

--- a/files/en-us/web/performance/navigation_and_resource_timings/index.md
+++ b/files/en-us/web/performance/navigation_and_resource_timings/index.md
@@ -1,12 +1,6 @@
 ---
 title: Navigation and resource timings
 slug: Web/Performance/Navigation_and_resource_timings
-tags:
-  - Navigation Timing
-  - Resource Timing
-  - Timings
-  - Web Performance
-  - performance APIs
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/optimizing_startup_performance/index.md
+++ b/files/en-us/web/performance/optimizing_startup_performance/index.md
@@ -1,10 +1,6 @@
 ---
 title: Optimizing startup performance
 slug: Web/Performance/Optimizing_startup_performance
-tags:
-  - Apps
-  - Games
-  - Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/performance_budgets/index.md
+++ b/files/en-us/web/performance/performance_budgets/index.md
@@ -1,11 +1,6 @@
 ---
 title: Performance budgets
 slug: Web/Performance/Performance_budgets
-tags:
-  - Budget
-  - Performance
-  - Performance Budget
-  - Web Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/rum-vs-synthetic/index.md
+++ b/files/en-us/web/performance/rum-vs-synthetic/index.md
@@ -1,10 +1,6 @@
 ---
 title: "Performance Monitoring: RUM vs. synthetic monitoring"
 slug: Web/Performance/Rum-vs-Synthetic
-tags:
-  - RUM
-  - Synthetic monitoring
-  - Web Performance
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/performance/understanding_latency/index.md
+++ b/files/en-us/web/performance/understanding_latency/index.md
@@ -1,11 +1,6 @@
 ---
 title: Understanding latency
 slug: Web/Performance/Understanding_latency
-tags:
-  - Connection
-  - Network
-  - Web Performance
-  - latency
 ---
 
 {{QuickLinksWithSubPages("Web/Performance")}}

--- a/files/en-us/web/privacy/firefox_tracking_protection/index.md
+++ b/files/en-us/web/privacy/firefox_tracking_protection/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox tracking protection
 slug: Web/Privacy/Firefox_tracking_protection
-tags:
-  - Privacy
-  - Private browsing
-  - blocking
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy")}}

--- a/files/en-us/web/privacy/index.md
+++ b/files/en-us/web/privacy/index.md
@@ -1,18 +1,6 @@
 ---
 title: Privacy, permissions, and information security
 slug: Web/Privacy
-tags:
-  - Information
-  - Permissions
-  - Personalize
-  - Privacy
-  - Protection
-  - Web
-  - allow
-  - allowlist
-  - data
-  - permission
-  - personal
 ---
 
 {{QuicklinksWithSubPages}}

--- a/files/en-us/web/privacy/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/partitioned_cookies/index.md
@@ -1,12 +1,8 @@
 ---
 title: Cookies Having Independent Partitioned State (CHIPS)
 slug: Web/Privacy/Partitioned_cookies
-tags:
-  - Cookies Having Independent Partitioned State
-  - CHIPS
-  - Partitioned cookies
-  - Privacy
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Set-Cookie.Partitioned
 ---
 

--- a/files/en-us/web/privacy/redirect_tracking_protection/index.md
+++ b/files/en-us/web/privacy/redirect_tracking_protection/index.md
@@ -1,11 +1,6 @@
 ---
 title: Redirect tracking protection
 slug: Web/Privacy/Redirect_tracking_protection
-tags:
-  - Firefox
-  - Mozilla
-  - Privacy
-  - redirect tracking protection
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy")}}

--- a/files/en-us/web/privacy/state_partitioning/index.md
+++ b/files/en-us/web/privacy/state_partitioning/index.md
@@ -1,12 +1,6 @@
 ---
 title: State Partitioning
 slug: Web/Privacy/State_Partitioning
-tags:
-  - Firefox
-  - Privacy
-  - Mozilla
-  - Storage
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedall/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedall/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Blocked: All storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedAll
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedbypermission/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedbypermission/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Blocked: Custom cookie permission"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedByPermission
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Blocked: All third-party storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedForeign
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedtracker/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedtracker/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Blocked: Storage access requests from trackers"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedTracker
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Partitioned: All third-party storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookiePartitionedForeign
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
-  - tracking
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/index.md
@@ -1,11 +1,6 @@
 ---
 title: Errors
 slug: Web/Privacy/Storage_Access_Policy/Errors
-tags:
-  - Cookies
-  - Errors
-  - Storage
-  - storage access policy
 ---
 
 {{QuicklinksWithSubPages}}

--- a/files/en-us/web/privacy/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/index.md
@@ -1,10 +1,6 @@
 ---
 title: "Storage access policy: Block cookies from trackers"
 slug: Web/Privacy/Storage_Access_Policy
-tags:
-  - Privacy
-  - storage access policy
-  - tracking protection
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy")}}

--- a/files/en-us/web/progressive_web_apps/add_to_home_screen/index.md
+++ b/files/en-us/web/progressive_web_apps/add_to_home_screen/index.md
@@ -1,14 +1,6 @@
 ---
 title: Add to Home screen
 slug: Web/Progressive_web_apps/Add_to_home_screen
-tags:
-  - Manifest
-  - PWA
-  - Progressive web apps
-  - Service Worker
-  - a2hs
-  - add to home screen
-  - icon
 ---
 
 Add to Home screen (or A2HS for short) is a feature available in modern browsers that allows a user to "install" a web app, i.e. add a shortcut to their Home screen representing their favorite web app (or site) so they can subsequently access it with a single tap. This guide explains how A2HS is used, and what you need to do as a developer to allow your users to take advantage of it.

--- a/files/en-us/web/progressive_web_apps/app_structure/index.md
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.md
@@ -1,15 +1,6 @@
 ---
 title: Progressive web app structure
 slug: Web/Progressive_web_apps/App_structure
-tags:
-  - App shell
-  - PWAs
-  - Progressive web apps
-  - Service Workers
-  - Streams
-  - Structure
-  - js13kGames
-  - progressive
 ---
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Introduction", "Web/Progressive_web_apps/Offline_Service_workers", "Web/Progressive_web_apps")}}

--- a/files/en-us/web/progressive_web_apps/index.md
+++ b/files/en-us/web/progressive_web_apps/index.md
@@ -1,14 +1,6 @@
 ---
 title: Progressive web apps (PWAs)
 slug: Web/Progressive_web_apps
-tags:
-  - App
-  - Application
-  - Apps
-  - PWA
-  - Progressive web apps
-  - Web app
-  - Web applications
 ---
 
 **Progressive Web Apps** (PWAs) are web apps that use [service workers](/en-US/docs/Web/API/Service_Worker_API), [manifests](/en-US/docs/Web/Manifest), and other web-platform features in combination with {{glossary("progressive enhancement")}} to give users an experience on par with native apps.

--- a/files/en-us/web/progressive_web_apps/installable_pwas/index.md
+++ b/files/en-us/web/progressive_web_apps/installable_pwas/index.md
@@ -1,14 +1,6 @@
 ---
 title: How to make PWAs installable
 slug: Web/Progressive_web_apps/Installable_PWAs
-tags:
-  - Installable
-  - PWAs
-  - Progressive web apps
-  - a2hs
-  - add to home screen
-  - js13kGames
-  - progressive
 ---
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Offline_Service_workers", "Web/Progressive_web_apps/Re-engageable_Notifications_Push", "Web/Progressive_web_apps")}}

--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -1,23 +1,6 @@
 ---
 title: Installing and uninstalling web apps
 slug: Web/Progressive_web_apps/Installing
-tags:
-  - Android
-  - Applications
-  - Apps
-  - Beginner
-  - Chrome
-  - Firefox
-  - Guide
-  - Home Screen
-  - Installing
-  - Launcher
-  - PWA
-  - Progressive web apps
-  - Samsung
-  - Springboard
-  - Uninstalling
-  - Web
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Progressive_web_apps/")}}

--- a/files/en-us/web/progressive_web_apps/introduction/index.md
+++ b/files/en-us/web/progressive_web_apps/introduction/index.md
@@ -1,17 +1,6 @@
 ---
 title: Introduction to progressive web apps
 slug: Web/Progressive_web_apps/Introduction
-tags:
-  - Applications
-  - Guide
-  - Intermediate
-  - Introduction
-  - PWA
-  - Progressive web apps
-  - Service Worker
-  - js13kGames
-  - progressive
-  - web manifest
 ---
 
 {{NextMenu("Web/Progressive_web_apps/App_structure", "Web/Progressive_web_apps")}}

--- a/files/en-us/web/progressive_web_apps/loading/index.md
+++ b/files/en-us/web/progressive_web_apps/loading/index.md
@@ -1,12 +1,6 @@
 ---
 title: Progressive loading
 slug: Web/Progressive_web_apps/Loading
-tags:
-  - Loading
-  - PWAs
-  - Progressive web apps
-  - js13kGames
-  - progressive
 ---
 
 {{PreviousMenu("Web/Progressive_web_apps/Re-engageable_Notifications_Push", "Web/Progressive_web_apps")}}

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.md
@@ -1,13 +1,6 @@
 ---
 title: Making PWAs work offline with Service workers
 slug: Web/Progressive_web_apps/Offline_Service_workers
-tags:
-  - Offline
-  - PWAs
-  - Progressive web apps
-  - Service Workers
-  - js13kGames
-  - progressive
 ---
 
 {{PreviousMenuNext("Web/Progressive_web_apps/App_structure", "Web/Progressive_web_apps/Installable_PWAs", "Web/Progressive_web_apps")}}

--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -1,13 +1,6 @@
 ---
 title: How to make PWAs re-engageable using Notifications and Push
 slug: Web/Progressive_web_apps/Re-engageable_Notifications_Push
-tags:
-  - Notifications
-  - PWAs
-  - Progressive web apps
-  - Push
-  - js13kGames
-  - progressive
 ---
 
 {{PreviousMenuNext("Web/Apps/Progressive/Installable_PWAs", "Web/Apps/Progressive/Loading", "Web/Apps/Progressive")}}

--- a/files/en-us/web/progressive_web_apps/responsive/graphics_for_responsive_sites/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/graphics_for_responsive_sites/index.md
@@ -1,12 +1,6 @@
 ---
 title: Graphic design for responsive sites
 slug: Web/Progressive_web_apps/Responsive/Graphics_for_responsive_sites
-tags:
-  - CSS
-  - Graphics
-  - JavaScript
-  - SVG
-  - WebGL
 ---
 
 In 1996, many people involved in building the Web would have laughed at you if you had told them that less than 20 years in the future we would be developing websites that worked well on mobile phones, tablets, TVs, even cars and home lighting. But today it is very much a reality. This article provides a high level discussion aimed at helping you to choose the best option for your graphical needs.

--- a/files/en-us/web/progressive_web_apps/responsive/mobile_first/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/mobile_first/index.md
@@ -1,16 +1,6 @@
 ---
 title: Mobile first
 slug: Web/Progressive_web_apps/Responsive/Mobile_first
-tags:
-  - Apps
-  - CSS
-  - Development
-  - HTML
-  - Java
-  - JavaScript
-  - Mobile
-  - Mobile Development
-  - Mobile first
 ---
 
 This article provides a guide to implementing a website layout that follows the principle of **mobile first**. This means creating a layout where the default configuration is for narrow screen/mobile devices, and layout features for wider viewports are then layered on top of that default.

--- a/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
@@ -1,12 +1,6 @@
 ---
 title: The building blocks of responsive design
 slug: Web/Progressive_web_apps/Responsive/responsive_design_building_blocks
-tags:
-  - Apps
-  - CSS
-  - HTML
-  - Mobile
-  - Responsive Design
 ---
 
 In this article we will discuss the main essential components of responsive design, with some links to further information where necessary.

--- a/files/en-us/web/progressive_web_apps/responsive/responsive_navigation_patterns/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/responsive_navigation_patterns/index.md
@@ -1,12 +1,6 @@
 ---
 title: Responsive navigation patterns
 slug: Web/Progressive_web_apps/Responsive/Responsive_navigation_patterns
-tags:
-  - Guide
-  - Mobile
-  - Navigation
-  - Responsive Design
-  - patterns
 ---
 
 Need some help designing your app's navigation? These patterns are a great place to start. The following present several ways to handle navigation on large and small screens. Top and left navigation menus are common on larger screens, but are often not the optimal way to present information on small screens because of the reduced screen real estate. Therefore, it is necessary to consider the presentation of content and ease of navigation for all screen sizes.

--- a/files/en-us/web/progressive_web_apps/structural_overview/index.md
+++ b/files/en-us/web/progressive_web_apps/structural_overview/index.md
@@ -1,18 +1,6 @@
 ---
 title: Structural overview of progressive web apps
 slug: Web/Progressive_web_apps/Structural_overview
-tags:
-  - Applications
-  - Apps
-  - Guide
-  - Layout
-  - Overview
-  - PWAs
-  - Progressive web apps
-  - Structure
-  - Web
-  - Webapps
-  - contents
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Progressive_web_apps/")}}

--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -1,9 +1,6 @@
 ---
 title: Certificate Transparency
 slug: Web/Security/Certificate_Transparency
-tags:
-  - Security
-  - Web
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/firefox_security_guidelines/index.md
+++ b/files/en-us/web/security/firefox_security_guidelines/index.md
@@ -1,8 +1,6 @@
 ---
 title: Firefox security guidelines
 slug: Web/Security/Firefox_Security_Guidelines
-tags:
-  - Security
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -1,10 +1,6 @@
 ---
 title: Web security
 slug: Web/Security
-tags:
-  - Landing
-  - Security
-  - Web
 ---
 
 {{QuickLinksWithSubpages}}

--- a/files/en-us/web/security/insecure_passwords/index.md
+++ b/files/en-us/web/security/insecure_passwords/index.md
@@ -1,13 +1,6 @@
 ---
 title: Insecure passwords
 slug: Web/Security/Insecure_passwords
-tags:
-  - Insecure
-  - Intermediate
-  - Security
-  - Web
-  - password
-  - passwords
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/mixed_content/how_to_fix_website_with_mixed_content/index.md
+++ b/files/en-us/web/security/mixed_content/how_to_fix_website_with_mixed_content/index.md
@@ -1,9 +1,6 @@
 ---
 title: How to fix a website with blocked mixed content
 slug: Web/Security/Mixed_content/How_to_fix_website_with_mixed_content
-tags:
-  - HTTPS
-  - Security
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/mixed_content/index.md
+++ b/files/en-us/web/security/mixed_content/index.md
@@ -1,12 +1,6 @@
 ---
 title: Mixed content
 slug: Web/Security/Mixed_content
-tags:
-  - HTTP
-  - HTTPS
-  - Security
-  - Web
-  - console
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Referer header: privacy and security concerns"
 slug: Web/Security/Referer_header:_privacy_and_security_concerns
-tags:
-  - Privacy
-  - Referrer Policy
-  - Security
-  - referer
-  - referrer
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -1,15 +1,6 @@
 ---
 title: Same-origin policy
 slug: Web/Security/Same-origin_policy
-tags:
-  - CORS
-  - Host
-  - JavaScript
-  - Same-origin policy
-  - Security
-  - URL
-  - origin
-  - secure
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.md
@@ -1,15 +1,6 @@
 ---
 title: Features restricted to secure contexts
 slug: Web/Security/Secure_Contexts/features_restricted_to_secure_contexts
-tags:
-  - API
-  - Browsers
-  - Reference
-  - Secure contexts
-  - Security
-  - Web
-  - features
-  - support
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/index.md
@@ -1,9 +1,6 @@
 ---
 title: Secure contexts
 slug: Web/Security/Secure_Contexts
-tags:
-  - Secure contexts
-  - Security
 spec-urls: https://w3c.github.io/webappsec-secure-contexts/
 ---
 

--- a/files/en-us/web/security/securing_your_site/index.md
+++ b/files/en-us/web/security/securing_your_site/index.md
@@ -1,11 +1,6 @@
 ---
 title: Securing your site
 slug: Web/Security/Securing_your_site
-tags:
-  - HTTP
-  - Security
-  - Web Development
-  - Website Security
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/securing_your_site/turning_off_form_autocompletion/index.md
+++ b/files/en-us/web/security/securing_your_site/turning_off_form_autocompletion/index.md
@@ -1,11 +1,6 @@
 ---
 title: How to turn off form autocompletion
 slug: Web/Security/Securing_your_site/Turning_off_form_autocompletion
-tags:
-  - Forms
-  - Guide
-  - Security
-  - Web Development
 ---
 
 This article explains how a website can disable autocomplete for form fields.

--- a/files/en-us/web/security/subdomain_takeovers/index.md
+++ b/files/en-us/web/security/subdomain_takeovers/index.md
@@ -1,9 +1,6 @@
 ---
 title: Subdomain takeovers
 slug: Web/Security/Subdomain_takeovers
-tags:
-  - Guide
-  - Security
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -1,12 +1,6 @@
 ---
 title: Subresource Integrity
 slug: Web/Security/Subresource_Integrity
-tags:
-  - HTML
-  - HTTP
-  - Intro
-  - Networking
-  - Security
 browser-compat:
   - html.elements.link.integrity
   - html.elements.script.integrity

--- a/files/en-us/web/security/transport_layer_security/index.md
+++ b/files/en-us/web/security/transport_layer_security/index.md
@@ -1,15 +1,6 @@
 ---
 title: Transport Layer Security
 slug: Web/Security/Transport_Layer_Security
-tags:
-  - Authentication
-  - Cryptography
-  - Data Integrity
-  - Encryption
-  - Guide
-  - SSL
-  - Security
-  - TLS
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/security/weak_signature_algorithm/index.md
+++ b/files/en-us/web/security/weak_signature_algorithm/index.md
@@ -1,10 +1,6 @@
 ---
 title: Weak signature algorithms
 slug: Web/Security/Weak_Signature_Algorithm
-tags:
-  - Cryptography
-  - Guide
-  - Security
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}

--- a/files/en-us/web/webdriver/commands/closewindow/index.md
+++ b/files/en-us/web/webdriver/commands/closewindow/index.md
@@ -1,11 +1,6 @@
 ---
 title: Close Window
 slug: Web/WebDriver/Commands/CloseWindow
-tags:
-  - Close Window
-  - Command
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.CloseWindow
 ---
 

--- a/files/en-us/web/webdriver/commands/getelementattribute/index.md
+++ b/files/en-us/web/webdriver/commands/getelementattribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Element Attribute
 slug: Web/WebDriver/Commands/GetElementAttribute
-tags:
-  - Command
-  - Get Element Tag Name
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetElementAttribute
 ---
 

--- a/files/en-us/web/webdriver/commands/getelementproperty/index.md
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Element Property
 slug: Web/WebDriver/Commands/GetElementProperty
-tags:
-  - Command
-  - Get Element Property
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetElementProperty
 ---
 

--- a/files/en-us/web/webdriver/commands/getelementtagname/index.md
+++ b/files/en-us/web/webdriver/commands/getelementtagname/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Element Tag Name
 slug: Web/WebDriver/Commands/GetElementTagName
-tags:
-  - Command
-  - Get Element Tag Name
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetElementTagName
 ---
 

--- a/files/en-us/web/webdriver/commands/gettimeouts/index.md
+++ b/files/en-us/web/webdriver/commands/gettimeouts/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Timeouts
 slug: Web/WebDriver/Commands/GetTimeouts
-tags:
-  - Command
-  - Get Timeouts
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetTimeouts
 ---
 

--- a/files/en-us/web/webdriver/commands/getwindowhandles/index.md
+++ b/files/en-us/web/webdriver/commands/getwindowhandles/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Window Handles
 slug: Web/WebDriver/Commands/GetWindowHandles
-tags:
-  - Command
-  - Get Window Handles
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetWindowHandles
 ---
 

--- a/files/en-us/web/webdriver/commands/getwindowrect/index.md
+++ b/files/en-us/web/webdriver/commands/getwindowrect/index.md
@@ -1,11 +1,6 @@
 ---
 title: Get Window Rect
 slug: Web/WebDriver/Commands/GetWindowRect
-tags:
-  - Command
-  - Get Window Rect
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.GetWindowRect
 ---
 

--- a/files/en-us/web/webdriver/commands/index.md
+++ b/files/en-us/web/webdriver/commands/index.md
@@ -1,11 +1,6 @@
 ---
 title: Commands
 slug: Web/WebDriver/Commands
-tags:
-  - Reference
-  - Web
-  - WebDriver
-  - commands
 browser-compat: webdriver.commands
 ---
 

--- a/files/en-us/web/webdriver/commands/settimeouts/index.md
+++ b/files/en-us/web/webdriver/commands/settimeouts/index.md
@@ -1,11 +1,6 @@
 ---
 title: Set Timeouts
 slug: Web/WebDriver/Commands/SetTimeouts
-tags:
-  - Command
-  - Get Timeouts
-  - Reference
-  - WebDriver
 browser-compat: webdriver.commands.SetTimeouts
 ---
 

--- a/files/en-us/web/webdriver/commands/setwindowrect/index.md
+++ b/files/en-us/web/webdriver/commands/setwindowrect/index.md
@@ -1,11 +1,6 @@
 ---
 title: Set Window Rect
 slug: Web/WebDriver/Commands/SetWindowRect
-tags:
-  - Command
-  - Reference
-  - Set Window Rect
-  - WebDriver
 browser-compat: webdriver.commands.SetWindowRect
 ---
 


### PR DESCRIPTION
Remove tags /web/ folders starting with  degm or p.

But not manifest, or mathml or svg (which we can't do yet) as there is another PR out for those 