### PR TITLE
Removing remaining <command> links

### DIFF
--- a/files/en-us/web/html/attributes/disabled/index.md
+++ b/files/en-us/web/html/attributes/disabled/index.md
@@ -22,7 +22,7 @@ The Boolean **`disabled`** attribute, when present, makes the element not mutabl
 
 If the `disabled` attribute is specified on a form control, the element and its form control descendants do not participate in constraint validation. Often browsers grey out such controls and it won't receive any browsing events, like mouse clicks or focus-related ones.
 
-The `disabled` attribute is supported by {{ HTMLElement("button") }}, {{ HTMLElement("command") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }} and {{ HTMLElement("input")}}.
+The `disabled` attribute is supported by {{ HTMLElement("button") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }} and {{ HTMLElement("input")}}.
 
 This Boolean disabled attribute indicates that the user cannot interact with the control or its descendant controls. If this attribute is not specified, the control inherits its setting from the containing element, for example `fieldset`; if there is no containing element with the `disabled` attribute set, and the control itself does not have the attribute, then the control is enabled. If declared on an {{ HTMLElement("optgroup") }}, the select is still interactive (unless otherwise disabled), but none of the items in the option group are selectable.
 

--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -24,7 +24,7 @@ There are three types of content categories:
 
 Elements belonging to the _metadata content_ category modify the presentation or the behavior of the rest of the document, set up links to other documents, or convey other _out-of-band_ information.
 
-Elements belonging to this category are {{HTMLElement("base")}}, {{HTMLElement("command")}} {{deprecated_inline}}, {{HTMLElement("link")}}, {{HTMLElement("meta")}}, {{HTMLElement("noscript")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}} and {{HTMLElement("title")}}.
+Elements belonging to this category are {{HTMLElement("base")}}, {{HTMLElement("link")}}, {{HTMLElement("meta")}}, {{HTMLElement("noscript")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}} and {{HTMLElement("title")}}.
 
 ### Flow content
 
@@ -47,7 +47,6 @@ The flow elements are:
 - {{HTMLElement("canvas")}}
 - {{HTMLElement("cite")}}
 - {{HTMLElement("code")}}
-- {{HTMLElement("command")}} {{deprecated_inline}}
 - {{HTMLElement("data")}}
 - {{HTMLElement("datalist")}}
 - {{HTMLElement("del")}}
@@ -154,7 +153,6 @@ Elements belonging to this category are:
 - {{HTMLElement("canvas")}}
 - {{HTMLElement("cite")}}
 - {{HTMLElement("code")}}
-- {{HTMLElement("command")}} {{deprecated_inline}}
 - {{HTMLElement("data")}}
 - {{HTMLElement("datalist")}}
 - {{HTMLElement("dfn")}}

--- a/files/en-us/web/html/element/code/index.md
+++ b/files/en-us/web/html/element/code/index.md
@@ -111,6 +111,5 @@ A CSS rule can be defined for the `code` selector to override the browser's defa
 
 - {{HTMLElement("samp")}}
 - {{HTMLElement("kbd")}}
-- {{HTMLElement("command")}} (deprecated)
 - {{HTMLElement("var")}}
 - {{HTMLElement("pre")}}


### PR DESCRIPTION
`<command>` is long gone from the few browsers that may have it. No need to mention it on MDN (these links were broken as the page never existed).