### PR TITLE
Fix red link to former mixin

### DIFF
--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -129,7 +129,7 @@ The following cross-origin access to `Location` properties is allowed:
 
 | Attributes                   |             |
 | ---------------------------- | ----------- |
-| {{domxref("URLUtils.href")}} | Write-only. |
+| {{domxref("location.href")}} | Write-only. |
 
 Some browsers allow access to more properties than the above.
 


### PR DESCRIPTION
URLUtils is a mixin, we don't have separate pages for these. From the context, it was obvious that `location.href` was the intended destination, and we have it documented!