### PR TITLE
Use correct event name icegatheringstatechange

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
@@ -21,9 +21,9 @@ This event is not cancelable and does not bubble.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('iceconnectionstatechange', (event) => { });
+addEventListener('icegatheringstatechange', (event) => { });
 
-oniceconnectionstatechange = (event) => { };
+onicegatheringstatechange = (event) => { };
 ```
 
 ## Event type


### PR DESCRIPTION
### Description

The first example is using `iceconnectionstatechange` instead of  `icegatheringstatechange`. This commit fixes it.

### Motivation

Make it correct.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
