### PR TITLE
Changed storage.session quota limit from 1MB to 10MB.

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
@@ -19,7 +19,7 @@ browser-compat: webextensions.api.storage.session
 
 Represents the `session` storage area. Items in `session` storage are stored in memory and are not persisted to disk.
 
-The browser may restrict the amount of data that an extension can store in the session storage area. For example, in Chrome, an extension is limited to storing 1MB of data in this storage area.
+The browser may restrict the amount of data that an extension can store in the session storage area. For example, in Chrome 112, an extension is limited to storing 10MB of data in this storage area.
 
 When the browser stops, all session storage is cleared. When the extension is uninstalled, its associated session storage is cleared.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the mention of a 1MB storage quota limit for sessions to a 10MB quota limit.

### Motivation

This change is based on a recommendation on a BCD PR.

### Additional details

Reference for Chrome bug that bumped the limit to 10 MB:
https://bugs.chromium.org/p/chromium/issues/detail?id=1385167

### Related issues and pull requests

Related to [#18997](https://github.com/mdn/browser-compat-data/pull/18997).
