### PR TITLE
Remove {{deprecated_header}} call from kitchensink

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -372,5 +372,4 @@ The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macr
   - : Information about a particular alarm.
 
 {{Non-standard_Header}}
-{{Deprecated_Header}}
 [![Iceberg pic](iceberg.jpg)](iceberg.jpg)


### PR DESCRIPTION
This PR removes the `{{Deprecated_Header}}` call from the kitchensink, following its removal in https://github.com/mdn/yari/pull/8199.
