### PR TITLE
Add more detail to storage.session docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
@@ -17,9 +17,10 @@ browser-compat: webextensions.api.storage.session
 
 {{AddonSidebar()}}
 
-Represents the `session` storage area. Items in `session` storage are stored in memory and are not persisted to disk.
+Represents the `session` storage area. Items in `session` storage are stored in memory for the duration of the browser session and are not persisted to disk.
+By default, it's not exposed to content scripts, but this behavior can be changed through {{WebExtAPIRef("storage.StorageArea.setAccessLevel", "storage.session.setAccessLevel()")}}.
 
-The browser may restrict the amount of data that an extension can store in the session storage area. For example, in Chrome 112, an extension is limited to storing 10MB of data in this storage area.
+The amount of data that an extension can store in the session storage area is limited to 10 MB, unless stated otherwise in the [browser compatibility table](#browser_compatibility).
 
 When the browser stops, all session storage is cleared. When the extension is uninstalled, its associated session storage is cleared.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Clarify quota, duration and availability of the storage.session data.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
In https://github.com/w3c/webextensions/issues/350, browsers (Chrome, Firefox, Safari) agreed to bumping the quota limit from 1 MB to 10 MB. This was reflected in the documentation in #24853, but conditional on "Chrome 122". Since the quota is universal, I updated the phrasing of the article accordingly.

During review of the content, I found some missing details, which I added (on the duration and the access level).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- https://github.com/w3c/webextensions/issues/350
- The newly added `setAccessLevel` is supported by Chrome but does not have an article on MDN yet. It will be added later as a part of https://bugzilla.mozilla.org/show_bug.cgi?id=1724754 and/or https://bugzilla.mozilla.org/show_bug.cgi?id=1687778
- Chrome's documentation on the `session` storage area: https://developer.chrome.com/docs/extensions/reference/storage/#storage-areas

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- BCD change for storage.session: https://github.com/mdn/browser-compat-data/pull/18997
- Previous mdn/content update: https://github.com/mdn/content/pull/24853

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
