### PR TITLE
Remove last auto links of MDN

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -40,7 +40,7 @@ Perform the following steps:
 
 ## Provisioning PKCS #11 modules
 
-> **Note:** Starting with Firefox 58, extensions can use the [pkcs11](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11) API to enumerate PKCS #11 modules and make them accessible to the browser as sources of keys and certificates.
+> **Note:** Starting with Firefox 58, extensions can use this API to enumerate PKCS #11 modules and make them accessible to the browser as sources of keys and certificates.
 
 There are two environmental prerequisites for using this **API**:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -31,7 +31,7 @@ This means that if extension X tries to change a setting:
 
 An extension can find out which of these scenarios applies by examining the "`levelOfControl`" property returned from a call to [`BrowserSetting.get()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get).
 
-The [`BrowserSetting.set()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set) method returns a Promise that resolves to a boolean: if an attempt to change a setting actually results in the setting being changed (scenarios 2 and 3 above) the boolean is `true`: otherwise it is `false`.
+The `BrowserSetting.set()` method returns a Promise that resolves to a boolean: if an attempt to change a setting actually results in the setting being changed (scenarios 2 and 3 above) the boolean is `true`: otherwise it is `false`.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
@@ -43,7 +43,7 @@ browser-compat: webextensions.manifest.user_scripts
 
 Instructs the browser to load a script packaged in the extension, known as the API script, this script is used to export a set of custom API methods for use in user scripts. The API script path, relative to the manifest.json file, is defined as a `string` in `"api_script"`.
 
-> **Note:** The [`user_script`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) key is required for the {{WebExtAPIRef("userScripts")}} API to function, even if no API script is specified. For example. `user_scripts: {}`.
+> **Note:** The `user_script` key is required for the {{WebExtAPIRef("userScripts")}} API to function, even if no API script is specified. For example. `user_scripts: {}`.
 
 The API script:
 

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -119,9 +119,9 @@ _No change._
 
 #### Highlights
 
-- The [`sdk/test/httpd`](/en-US/Add-ons/SDK/Low-Level_APIs/test_httpd) module was removed in [Firefox 36](/en-US/docs/Mozilla/Firefox/Releases/36), please use the [addon-httpd](https://www.npmjs.com/package/addon-httpd) npm module instead.
-- Add badges to [`sdk/ui`](/en-US/Add-ons/SDK/High-Level_APIs/ui) buttons ([Firefox bug 994280](https://bugzil.la/994280)).
-- Implemented global `require` function to access sdk modules anywhere ([Firefox bug 1070927](https://bugzil.la/1070927)), using:
+- The [`sdk/test/httpd`](/en-US/Add-ons/SDK/Low-Level_APIs/test_httpd) module was removed, use the [addon-httpd](https://www.npmjs.com/package/addon-httpd) npm module instead.
+- Add badges to [`sdk/ui`](/en-US/Add-ons/SDK/High-Level_APIs/ui) buttons ({{bug(994280)}}).
+- Implemented global `require` function to access sdk modules anywhere ({{bug(1070927)}}), using:
 
   ```js
   var { require } = Cu.import(

--- a/files/en-us/web/accessibility/aria/roles/article_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.md
@@ -82,7 +82,6 @@ This role corresponds to the {{HTMLElement('article')}} element in HTML, and tha
 
 ## See also
 
-- [ARIA: using the `article` role](/en-US/docs/Web/Accessibility/ARIA/Roles/article_role)
 - [`feed` role](/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role)
 - [`section` role](/en-US/docs/Web/Accessibility/ARIA/Roles/section_role)
 - The {{HTMLElement('article')}} element

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -60,8 +60,6 @@ When the listbox role is added to an element, or such an element becomes visible
 - [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription)
   - : A human-readable string value which more clearly identifies the role of the listbox. Screen readers will often read this value to the user after reading the label (if there is one), in place of saying "listbox".
 
-For further details and a full list of ARIA states and properties see the [`listbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role) role.
-
 ### Keyboard interactions
 
 - When a single-select listbox receives focus:

--- a/files/en-us/web/accessibility/aria/roles/log_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/log_role/index.md
@@ -38,7 +38,6 @@ With an area that has scrolling text, such as a stock ticker, the [`marquee`](/e
 
 ## See Also
 
-- [ARIA: using the `log` role](/en-US/docs/Web/Accessibility/ARIA/Roles/log_role)
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [ARIA: `marquee` role](/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role)
 - [ARIA: `status` role](/en-US/docs/Web/Accessibility/ARIA/Roles/status_role)

--- a/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
@@ -143,7 +143,6 @@ The first rule of ARIA is: if a native HTML element or attribute has the semanti
 
 ## See Also
 
-- [`menuitemradio` role](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role)
 - [`radio` role](/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role)
 - [`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)
 

--- a/files/en-us/web/api/element/mousewheel_event/index.md
+++ b/files/en-us/web/api/element/mousewheel_event/index.md
@@ -57,8 +57,6 @@ _This interface inherits properties from its ancestors, {{DOMxRef("MouseEvent")}
 - {{DOMxRef("WheelEvent.wheelDeltaY")}} {{ReadOnlyInline}} {{deprecated_inline}}
   - : Returns an integer representing the vertical scroll amount.
 
-> **Note:** [Element: mousewheel event](/en-US/docs/Web/API/Element/mousewheel_event) has additional documentation about the deprecated properties `wheelDelta`, `wheelDeltaX`, `wheelDeltaY`.
-
 ## The detail property
 
 The value of the {{domxref("UIEvent/detail", "detail")}} property is always zero, except in Opera, which uses `detail` similarly to the Firefox-only {{domxref("Element.DOMMouseScroll_event", "DOMMouseScroll")}} event's `detail` value, which indicates the scroll distance in terms of lines, with negative values indicating the scrolling movement is either toward the bottom or toward the right, and positive values indicating scrolling to the top or left.
@@ -115,5 +113,4 @@ Not part of any specification.
 
 ## See also
 
-- Gecko's legacy mouse wheel events: `DOMMouseScroll`, `MozMousePixelScroll`
-- Standardized wheel event: `wheel`
+- The standard {{domxref("Element/wheel_event", "wheel")}} event to listen to instead.

--- a/files/en-us/web/api/payment_request_api/concepts/index.md
+++ b/files/en-us/web/api/payment_request_api/concepts/index.md
@@ -58,7 +58,7 @@ A {{Glossary("user agent")}} may provide built-in support for certain types of p
 
 ## Merchant validation
 
-Some payment handlers use **merchant validation**, which is the process of validating the identity of a merchant in some way, usually using some form of cryptographic challenge. If the merchant doesn't successfully validate, it's not allowed to use the payment handler.
+Some payment handlers use _merchant validation_, which is the process of validating the identity of a merchant in some way, usually using some form of cryptographic challenge. If the merchant doesn't successfully validate, it's not allowed to use the payment handler.
 
 The exact validation technology depends on the payment handler, and merchant validation is entirely optional. In the end, the only thing that the web site or app is responsible for is fetching the merchant's validation key and passing it into the event's {{domxref("MerchantValidationEvent.complete", "complete()")}} method.
 
@@ -82,6 +82,5 @@ Thus, it's important to note that the {{Glossary("user agent")}} never sends a {
 
 - [Payment Request API](/en-US/docs/Web/API/Payment_Request_API)
 - [Using the Payment Request API](/en-US/docs/Web/API/Payment_Request_API/Using_the_Payment_Request_API)
-- [Payment processing concepts](/en-US/docs/Web/API/Payment_Request_API/Concepts)
 - [Introducing the Payment Request API for Apple Pay](https://webkit.org/blog/8182/introducing-the-payment-request-api-for-apple-pay/)
 - [Google Pay API PaymentRequest Tutorial](https://developers.google.com/pay/api/web/guides/paymentrequest/tutorial)

--- a/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.md
@@ -38,7 +38,7 @@ _In addition to the properties of {{domxref("Event")}}, this interface offers th
 
 ## Examples
 
-This example establishes a handler for the [`tonechange`](/en-US/docs/Web/API/RTCDTMFSender/tonechange_event) event which updates an element to display the currently playing tone in its content, or, if all tones have played, the string "\<none>".
+This example establishes a handler for the `tonechange` event which updates an element to display the currently playing tone in its content, or, if all tones have played, the string "\<none>".
 
 This can be done using {{domxref("EventTarget.addEventListener", "addEventListener()")}}:
 

--- a/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
+++ b/files/en-us/web/guide/ajax/wai_aria_live_regions_api_support/index.md
@@ -11,8 +11,6 @@ Firefox 3 contains important improvements to the way the Mozilla engine exposes 
 
 These features will help screen reader developers improve the quality and performance of live region support, both for pages that are marked up with ARIA live region markup, and for pages where the author did not add any additional markup.
 
-Please read the [ARIA spec](https://www.w3.org/TR/wai-aria/#dfn-live-region) or the [live region report](/en-US/docs/Web/Guide/AJAX/WAI_ARIA_Live_Regions_API_Support) to learn about ARIA live region markup.
-
 As always, we're open to questions and suggestions for changes in [community forums](https://support.mozilla.org/en-US/kb/get-community-support).
 
 ## Events fired for web page mutations

--- a/files/en-us/web/html/attributes/pattern/index.md
+++ b/files/en-us/web/html/attributes/pattern/index.md
@@ -71,7 +71,7 @@ Given the following:
 
 Here we have 3 sections for a north American phone number with an implicit label encompassing all three components of the phone number, expecting 3-digits, 3-digits and 4-digits respectively, as defined by the `pattern` attribute set on each.
 
-If the values are too long or too short, or contain characters that aren't digits, the patternMismatch will be true. When `true`, the element matches the {{cssxref(":invalid")}} CSS pseudo-classes.
+If the values are too long or too short, or contain characters that aren't digits, the `patternMismatch` will be true. When `true`, the element matches the {{cssxref(":invalid")}} CSS pseudo-classes.
 
 ```css
 input:invalid {

--- a/files/en-us/web/webdriver/commands/settimeouts/index.md
+++ b/files/en-us/web/webdriver/commands/settimeouts/index.md
@@ -46,5 +46,4 @@ The input is a [`Timeouts`](/en-US/docs/Web/WebDriver/Timeouts) object:
 ## See also
 
 - [`Timeouts`](/en-US/docs/Web/WebDriver/Timeouts) object
-- [Set Timeouts](/en-US/docs/Web/WebDriver/Commands/SetTimeouts) command
 - [List of WebDriver commands](/en-US/docs/Web/WebDriver/Commands)


### PR DESCRIPTION
After this PR, there is only one auto link left, in https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license. This last auto-link must stay as it is meta-documentation given a snippet of text that asks to link to this page.

This PR removes all other remaining auto-links of MDN. 🎉