### PR TITLE
Fix last occurrences of internal anchors not lowercase

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -40,7 +40,7 @@ In the beginning, the Web was just text, and it was really quite boring. Fortuna
 
 In order to put a simple image on a web page, we use the {{htmlelement("img")}} element. This is a {{Glossary("void element")}} (meaning, it cannot have any child content and cannot have an end tag) that requires two attributes to be useful: `src` and `alt`. The `src` attribute contains a URL pointing to the image you want to embed in the page. As with the `href` attribute for {{htmlelement("a")}} elements, the `src` attribute can be a relative URL or an absolute URL. Without a `src` attribute, an `img` element has no image to load.
 
-The [`alt` attribute is described below](#Alternative_text).
+The [`alt` attribute is described below](#alternative_text).
 
 > **Note:** You should read [A quick primer on URLs and paths](/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#a_quick_primer_on_urls_and_paths) to refresh your memory on relative and absolute URLs before continuing.
 

--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -49,7 +49,7 @@ For example:
 - A video is played, paused, or ends.
 - An error occurs.
 
-You can gather from this (and from glancing at the MDN [event reference](/en-US/docs/Web/Events) that there are **a lot** of events that can be fired.
+You can gather from this (and from glancing at the MDN [event reference](/en-US/docs/Web/Events)) that there are **a lot** of events that can be fired.
 
 To react to an event, you attach an **event handler** to it. This is a block of code (usually a JavaScript function that you as a programmer create) that runs when the event fires.
 When such a block of code is defined to run in response to an event, we say we are **registering an event handler**.

--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -49,7 +49,7 @@ For example:
 - A video is played, paused, or ends.
 - An error occurs.
 
-You can gather from this (and from glancing at the MDN [event reference](/en-US/docs/Web/Events)) that there are **a lot** of events that can be fired.
+You can gather from this (and from glancing at the MDN [event reference](/en-US/docs/Web/Events) that there are **a lot** of events that can be fired.
 
 To react to an event, you attach an **event handler** to it. This is a block of code (usually a JavaScript function that you as a programmer create) that runs when the event fires.
 When such a block of code is defined to run in response to an event, we say we are **registering an event handler**.
@@ -651,7 +651,7 @@ An alternative form of event propagation is _event capture_. This is like event 
 
 Event capture is disabled by default. To enable it you have to pass the `capture` option in `addEventListener()`.
 
-This example is just like the [bubbling example](#Bubbling_example) we saw earlier, except that we have used the `capture` option:
+This example is just like the [bubbling example](#bubbling_example) we saw earlier, except that we have used the `capture` option:
 
 ```html
 <body>

--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -6,7 +6,7 @@ page-type: mdn-community-guide
 
 {{MDNSidebar}}
 
-As a contributor, you can [report](#Guidelines_for_reporting_an_issue) and [work](#guidelines_for_working_on_an_issue) on issues.
+As a contributor, you can [report](#guidelines_for_reporting_an_issue) and [work](#guidelines_for_working_on_an_issue) on issues.
 
 After you report an issue, the issue gets triaged. Issue [triaging](#guidelines_for_triaging_issues) is typically done by people assigned the role of a maintainer or an owner.
 
@@ -98,7 +98,7 @@ Remember that if you take on an issue, the expectation is for the work to be com
 
 These are the general steps for working on an issue:
 
-1. **Find an issue:** If you're looking to contribute, search for issues with [`good first issue`, `help wanted`](#Set_other_labels) or [`p3`](#Set_a_priority_label) label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set. Another useful place to look for issues to work on is the [MDN Contributors Task Board](https://github.com/orgs/mdn/projects/25). This project view lists open issues from multiple repositories. You can filter the list based on the topics (`Labels` column) you're interested in. See the description of some of the [labels](#Set_other_labels) that get applied during the issue triage process.
+1. **Find an issue:** If you're looking to contribute, search for issues with [`good first issue`, `help wanted`](#set_other_labels) or [`p3`](#set_a_priority_label) label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set. Another useful place to look for issues to work on is the [MDN Contributors Task Board](https://github.com/orgs/mdn/projects/25). This project view lists open issues from multiple repositories. You can filter the list based on the topics (`Labels` column) you're interested in. See the description of some of the [labels](#set_other_labels) that get applied during the issue triage process.
 
    > **Note:** An issue with the `needs triage` label indicates that the MDN Web Docs core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
@@ -128,7 +128,7 @@ Wait for the issue to be triaged, so that the MDN Web Docs team can verify that 
 > **Note:** If you open a pull request before the issue has been triaged, your time and effort might go waste if the linked issue is deemed invalid or the solution does not match the one expected by the MDN Web Docs team.
 > After the issue is triaged, assign the issue to yourself.
 
-Using the [guidelines on working on an issue](#Guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:
+Using the [guidelines on working on an issue](#guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:
 
 - The MDN Web Docs content (in English) in the [content](https://github.com/mdn/content) repository
 - The MDN Web Docs translated content in the [translated-content](https://github.com/mdn/translated-content) repository

--- a/files/en-us/web/text_fragments/index.md
+++ b/files/en-us/web/text_fragments/index.md
@@ -20,7 +20,7 @@ browser-compat:
   - css.selectors.target-text
 ---
 
-Text Fragments allow you to link directly to a specific portion of text in a web document, without requiring the author to annotate it with an ID, using particular syntax in the URL fragment. Supporting browsers are free to choose how to draw attention to the linked text, e.g. with a color highlight and/or scrolling to the content on the page. This is useful because it allows web content authors to deep-link to other content they don't control, without relying on the presence of IDs to make that possible. Building on top of that, it could be used to generate more effective content-sharing links for users to pass to one another.
+**Text fragments** allow you linking directly to a specific portion of text in a web document, without requiring the author to annotate it with an ID, using particular syntax in the URL fragment. Supporting browsers are free to choose how to draw attention to the linked text, e.g. with a color highlight and/or scrolling to the content on the page. This is useful because it allows web content authors to deep-link to other content they don't control, without relying on the presence of IDs to make that possible. Building on top of that, it could be used to generate more effective content-sharing links for users to pass to one another.
 
 ## Concepts and usage
 
@@ -72,7 +72,7 @@ Supporting browsers will scroll to and highlight the first text fragment in the 
 
 - Text strings used for the `textStart`, `textEnd`, `prefix-`, and `-suffix` values need to be [percent-encoded](/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 - Matches are case-insensitive.
-- Individual `textStart`, `textEnd`, `prefix-`, and `-suffix` strings need to reside wholly inside the same [block-level element](/en-US/docs/Web/HTML/Block-level_elements#Elements), but complete matches can span across multiple element boundaries.
+- Individual `textStart`, `textEnd`, `prefix-`, and `-suffix` strings need to reside wholly inside the same [block-level element](/en-US/docs/Web/HTML/Block-level_elements#elements), but complete matches can span across multiple element boundaries.
 - For security reasons, the feature requires links to be opened in a noopener context — you need to add `rel="noopener"` to your {{htmlelement("a")}} elements, and add `noopener` to your {{domxref("window.open()")}} calls when using this feature.
 - Text fragments are invoked only on full (non-same-page), user-initiated navigations.
 - Text fragments are only applied to the main frame; text will not be searched inside {{htmlelement("iframe")}}s, and `iframe` navigation will not invoke a text fragment.


### PR DESCRIPTION
Yari generates anchors in lowercase. It detects internal anchors that aren't and raises a flaw, which is helpful to detect them.

This PR fixes the last valid such flaws 🎉 

Two more flaws are left but are invalid as they are [text fragments](https://developer.mozilla.org/en-US/docs/Web/Text_fragments). I filed mdn/yari#8313 so that no flaw is raised in such cases.
