### PR TITLE
Remove extraneous / in internal MDN links

### DIFF
--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -430,8 +430,8 @@ This article has by no means covered all that's available in WAI-ARIA, but it sh
 
 ## See also
 
-- [Definition of Roles](/en-US/docs/Web/Accessibility/ARIA/Roles/) — ARIA roles reference.
-- [Definitions of States and Properties (all aria-\* attributes)](/en-US/docs/Web/Accessibility/ARIA/Attributes/) — properties and states reference.
+- [Definition of Roles](/en-US/docs/Web/Accessibility/ARIA/Roles) — ARIA roles reference.
+- [Definitions of States and Properties (all aria-\* attributes)](/en-US/docs/Web/Accessibility/ARIA/Attributes) — properties and states reference.
 - [Deque university code library](https://dequeuniversity.com/library/) — a library of really useful practical examples showing complex UI controls made accessible using WAI-ARIA features.
 - [WAI-ARIA Authoring Practices](https://w3c.github.io/aria-practices/) — very detailed design patterns from the W3C, explaining how to implement different types of complex UI control whilst making them accessible using WAI-ARIA features.
 - [ARIA in HTML](https://www.w3.org/TR/html-aria/) — A W3C spec that defines, for each HTML feature, what accessibility (ARIA) semantics that feature implicitly has set on it by the browser, and what WAI-ARIA features you may set on it if extra semantics are required.


### PR DESCRIPTION
We are using slugs for internal links, and they don't end with a `/`.