### PR TITLE
Fix capitalization of First_meaning_paint and Time_to_first_byte

### DIFF
--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -5554,7 +5554,7 @@
       "Anirban_Dutta"
     ]
   },
-  "Glossary/first_meaningful_paint": {
+  "Glossary/First_meaningful_paint": {
     "modified": "2019-05-14T16:39:56.381Z",
     "contributors": ["milsyobtaf", "estelle", "ehoops", "cfwilson"]
   },

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -5722,7 +5722,7 @@
     "modified": "2020-04-10T12:12:47.862Z",
     "contributors": ["mfuji09", "sideshowbarker", "hhimanshu", "estelle"]
   },
-  "Glossary/time_to_first_byte": {
+  "Glossary/Time_to_first_byte": {
     "modified": "2019-05-02T21:38:17.951Z",
     "contributors": ["estelle", "ehoops"]
   },

--- a/files/en-us/glossary/first_contentful_paint/index.md
+++ b/files/en-us/glossary/first_contentful_paint/index.md
@@ -13,5 +13,5 @@ _The First Contentful Paint_ timestamp is when the browser first rendered any te
 - [First paint](/en-US/docs/Glossary/First_paint)
 - [`PerformancePaintTiming`](/en-US/docs/Web/API/PerformancePaintTiming)
 - [Largest Contentful Paint](/en-US/docs/Glossary/Largest_contentful_paint)
-- [First meaningful paint](/en-US/docs/Glossary/first_meaningful_paint)
+- [First meaningful paint](/en-US/docs/Glossary/First_meaningful_paint)
 - [First Contentful Paint](https://web.dev/fcp/) at web.dev

--- a/files/en-us/glossary/first_paint/index.md
+++ b/files/en-us/glossary/first_paint/index.md
@@ -11,4 +11,4 @@ page-type: glossary-definition
 - [First contentful paint](/en-US/docs/Glossary/First_contentful_paint)
 - [`PerformancePaintTiming`](/en-US/docs/Web/API/PerformancePaintTiming)
 - [Largest Contentful Paint](/en-US/docs/Glossary/Largest_contentful_paint)
-- [First meaningful paint](/en-US/docs/Glossary/first_meaningful_paint)
+- [First meaningful paint](/en-US/docs/Glossary/First_meaningful_paint)

--- a/files/en-us/learn/performance/perceived_performance/index.md
+++ b/files/en-us/learn/performance/perceived_performance/index.md
@@ -49,7 +49,7 @@ There is no single metric or test that can be run on a site to evaluate how a us
   - : The time to start of first paint operation. Note that this change may not be visible; it can be a simple background color update or something even less noticeable.
 - [First Contentful Paint](/en-US/docs/Glossary/First_contentful_paint) (FCP)
   - : The time until first significant rendering (e.g. of text, foreground or background image, canvas or SVG, etc.). Note that this content is not necessarily useful or meaningful.
-- [First Meaningful Paint](/en-US/docs/Glossary/first_meaningful_paint) (FMP)
+- [First Meaningful Paint](/en-US/docs/Glossary/First_meaningful_paint) (FMP)
   - : The time at which useful content is rendered to the screen.
 - [Largest Contentful Paint](https://wicg.github.io/largest-contentful-paint/) (LCP)
   - : The render time of the largest content element visible in the viewport.

--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -176,7 +176,7 @@ The first time the size and position of nodes are determined is called _layout_.
 
 ### Paint
 
-The last step in the critical rendering path is painting the individual nodes to the screen, the first occurrence of which is called the [first meaningful paint](/en-US/docs/Glossary/first_meaningful_paint). In the painting or rasterization phase, the browser converts each box calculated in the layout phase to actual pixels on the screen. Painting involves drawing every visual part of an element to the screen, including text, colors, borders, shadows, and replaced elements like buttons and images. The browser needs to do this super quickly.
+The last step in the critical rendering path is painting the individual nodes to the screen, the first occurrence of which is called the [first meaningful paint](/en-US/docs/Glossary/First_meaningful_paint). In the painting or rasterization phase, the browser converts each box calculated in the layout phase to actual pixels on the screen. Painting involves drawing every visual part of an element to the screen, including text, colors, borders, shadows, and replaced elements like buttons and images. The browser needs to do this super quickly.
 
 To ensure smooth scrolling and animation, everything occupying the main thread, including calculating styles, along with reflow and paint, must take the browser less than 16.67ms to accomplish. At 2048 X 1536, the iPad has over 3,145,000 pixels to be painted to the screen. That is a lot of pixels that have to be painted very quickly. To ensure repainting can be done even faster than the initial paint, the drawing to the screen is generally broken down into several layers. If this occurs, then compositing is necessary.
 

--- a/files/en-us/web/performance/navigation_and_resource_timings/index.md
+++ b/files/en-us/web/performance/navigation_and_resource_timings/index.md
@@ -17,7 +17,7 @@ The performance timing API provided read only times, in milliseconds(ms), descri
 
 ![Navigation Timing event metrics](screen_shot_2019-05-03_at_1.06.27_pm.png)
 
-With the metrics above, and a bit of math, we can calculate many important metrics like [time to first byte](/en-US/docs/Glossary/time_to_first_byte), page load time, dns lookup, and whether the connection is secure.
+With the metrics above, and a bit of math, we can calculate many important metrics like [time to first byte](/en-US/docs/Glossary/Time_to_first_byte), page load time, dns lookup, and whether the connection is secure.
 
 To help measure the time it takes to complete all the steps, the Performance Timing API provides read only measurements of navigation timings. To view and capture our app's timing we enter:
 
@@ -302,7 +302,7 @@ const ssl = time.requestStart - time.secureConnectionStart;
 
 ### Time to first byte
 
-[Time to First Byte](/en-US/docs/Glossary/time_to_first_byte) is the time between the `navigationStart` (start of the navigation) and `responseStart`, (when the first byte of response data is received) available in the `performanceTiming` API:
+[Time to First Byte](/en-US/docs/Glossary/Time_to_first_byte) is the time between the `navigationStart` (start of the navigation) and `responseStart`, (when the first byte of response data is received) available in the `performanceTiming` API:
 
 ```js
 const ttfb = time.responseStart - time.navigationStart;


### PR DESCRIPTION
Fix capitalization of slugs pointing to two glossary entries.