### PR TITLE
min-content is not a valid property - only value

### DIFF
--- a/files/en-us/web/css/min-content/index.md
+++ b/files/en-us/web/css/min-content/index.md
@@ -20,13 +20,6 @@ block-size: min-content;
 
 /* used in grid tracks */
 grid-template-columns: 200px 1fr min-content;
-
-/* Global values */
-min-content: inherit;
-min-content: initial;
-min-content: revert;
-min-content: revert-layer;
-min-content: unset;
 ```
 
 ## Examples


### PR DESCRIPTION
AFAICT, `min-content` is only valid as a value, not as a property name.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
