### PR TITLE
Remove links to webextension-only methods from Element

### DIFF
--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -61,8 +61,6 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
   - : An {{DOMxRef("Element")}}, the element immediately following the given one in the tree, or `null` if there's no sibling node.
 - {{DOMxRef("Element.outerHTML")}}
   - : A string representing the markup of the element including its content. When used as a setter, replaces the element with nodes parsed from the given string.
-- {{DOMxRef("Element.openOrClosedShadowRoot")}} {{Non-standard_Inline}} {{ReadOnlyInline}}
-  - : Returns the shadow root that is hosted by the element, regardless if its open or closed. **Only available to [WebExtensions](/en-US/docs/Mozilla/Add-ons/WebExtensions).**
 - {{DOMxRef("Element.part")}}
   - : Represents the part identifier(s) of the element (i.e. set using the `part` attribute), returned as a {{domxref("DOMTokenList")}}.
 - {{DOMxRef("Element.prefix")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/element/shadowroot/index.md
+++ b/files/en-us/web/api/element/shadowroot/index.md
@@ -75,7 +75,3 @@ function updateStyle(elem) {
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- {{DOMxRef("Element.openOrClosedShadowRoot")}} {{non-standard_inline}}


### PR DESCRIPTION
The links were originally inside Web/API/Element but moved to a better place.

We don't need to link to it from this page.