### PR TITLE
Use jsxref instead of domxref to link to Promise

### DIFF
--- a/files/en-us/web/api/paymentmanager/enabledelegations/index.md
+++ b/files/en-us/web/api/paymentmanager/enabledelegations/index.md
@@ -38,7 +38,7 @@ enableDelegations(delegations)
 
 ### Return value
 
-A {{domxref("Promise")}} that resolves with a value of `undefined`.
+A {{jsxref("Promise")}} that resolves with a value of `undefined`.
 
 ## Examples
 


### PR DESCRIPTION
The page has been moved to the JS area years ago. Time to update this internal link.