### PR TITLE
Remove bcd key from old IE features

### DIFF
--- a/files/en-us/web/api/element/msgesturechange_event/index.md
+++ b/files/en-us/web/api/element/msgesturechange_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSGestureChange_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSGestureChange_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -40,7 +39,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/element/msgestureend_event/index.md
+++ b/files/en-us/web/api/element/msgestureend_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSGestureEnd_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSGestureEnd_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -40,7 +39,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/element/msgesturehold_event/index.md
+++ b/files/en-us/web/api/element/msgesturehold_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSGestureHold_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSGestureHold_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -49,7 +48,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/element/msgesturestart_event/index.md
+++ b/files/en-us/web/api/element/msgesturestart_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSGestureStart_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSGestureStart_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -40,7 +39,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/element/msgesturetap_event/index.md
+++ b/files/en-us/web/api/element/msgesturetap_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSGestureTap_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSGestureTap_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -40,7 +39,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/element/msinertiastart_event/index.md
+++ b/files/en-us/web/api/element/msinertiastart_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Element/MSInertiaStart_event
 page-type: web-api-event
 status:
   - non-standard
-browser-compat: api.Element.MSInertiaStart_event
 ---
 
 {{APIRef}}{{Non-standard_header}}
@@ -40,7 +39,7 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 

--- a/files/en-us/web/api/msgestureevent/index.md
+++ b/files/en-us/web/api/msgestureevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/MSGestureEvent
 page-type: web-api-interface
 status:
   - non-standard
-browser-compat: api.MSGestureEvent
 ---
 
 {{APIRef("UI Events")}}
@@ -13,43 +12,43 @@ browser-compat: api.MSGestureEvent
 
 The **`MSGestureEvent`** is a proprietary interface specific to Internet Explorer and Microsoft Edge which represents events that occur due to touch gestures. Events using this interface include {{domxref("Element/MSGestureStart_event", "MSGestureStart")}}, {{domxref("Element/MSGestureEnd_event", "MSGestureEnd")}}, {{domxref("Element/MSGestureTap_event", "MSGestureTap")}}, {{domxref("Element/MSGestureHold_event", "MSGestureHold")}}, {{domxref("Element/MSGestureChange_event", "MSGestureChange")}}, and {{domxref("Element/MSInertiaStart_event", "MSInertiaStart")}}.
 
-`MSGestureEvent` derives from {{domxref("UIEvent")}}, which in turn derives from {{domxref("Event")}}. Though the {{domxref("MSGestureEvent.initGestureEvent()")}} method is kept for backward compatibility, the creation of an `MSGestureEvent` object should be done using the {{domxref("MSGestureEvent.MSGestureEvent", "MSGestureEvent()")}} constructor.
+`MSGestureEvent` derives from {{domxref("UIEvent")}}, which in turn derives from {{domxref("Event")}}. Though the `MSGestureEvent.initGestureEvent()` method is kept for backward compatibility, the creation of an `MSGestureEvent` object should be done using the `MSGestureEvent()` constructor.
 
 ## Constructor
 
-- {{domxref("MSGestureEvent.MSGestureEvent", "MSGestureEvent()")}}
+- `MSGestureEvent()`
   - : Creates an `MSGestureEvent` object.
 
 ## Instance properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 
-- {{domxref("MSGestureEvent.expansion")}} {{ReadOnlyInline}}
+- `MSGestureEvent.expansion`")}}` {{ReadOnlyInline}}
   - : The diameter of the gesture area. For example, the distance between fingers.
-- {{domxref("MSGestureEvent.gestureObject")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("MSGesture")}} object for this gesture event.
-- {{domxref("MSGestureEvent.rotation")}} {{ReadOnlyInline}}
-  - : Amount of rotation (in radians) since the previous {{domxref("MSGestureEvent")}} of the current gesture. Positive values indicate clockwise rotation; negative values indicate counterclockwise rotation.
-- {{domxref("MSGestureEvent.scale")}} {{ReadOnlyInline}}
-  - : The difference in scale (for zoom gestures) from the previous {{domxref("MSGestureEvent")}} of the current gesture.
-- {{domxref("MSGestureEvent.translationX")}} {{ReadOnlyInline}}
-  - : Distance traversed along the X-axis since the previous {{domxref("MSGestureEvent")}} of the current gesture
-- {{domxref("MSGestureEvent.translationY")}} {{ReadOnlyInline}}
-  - : Distance traversed along the Y-axis since the previous {{domxref("MSGestureEvent")}} of the current gesture
-- {{domxref("MSGestureEvent.velocityAngular")}} {{ReadOnlyInline}}
+- `MSGestureEvent.gestureObject`")}}` {{ReadOnlyInline}}
+  - : Returns the `MSGesture"`)}}` object for this gesture event.
+- `MSGestureEvent.rotation")}} {{ReadOnlyInline}}
+  - : Amount of rotation (in radians) since the previous `MSGestureEvent` of the current gesture. Positive values indicate clockwise rotation; negative values indicate counterclockwise rotation.
+- `MSGestureEvent.scale`)}}` {{ReadOnlyInline}}
+  - : The difference in scale (for zoom gestures) from the previous `MSGestureEvent` of the current gesture.
+- `MSGestureEvent.translationX` {{ReadOnlyInline}}
+  - : Distance traversed along the X-axis since the previous `MSGestureEvent` of the current gesture
+- `MSGestureEvent.translationY` {{ReadOnlyInline}}
+  - : Distance traversed along the Y-axis since the previous `MSGestureEvent` of the current gesture
+- `MSGestureEvent.velocityAngular` {{ReadOnlyInline}}
   - : Angular velocity. Expressed in radians.
-- {{domxref("MSGestureEvent.velocityExpansion")}} {{ReadOnlyInline}}
+- `MSGestureEvent.velocityExpansion` {{ReadOnlyInline}}
   - : The velocity of the expansion of the gesture area.
-- {{domxref("MSGestureEvent.velocityX")}} {{ReadOnlyInline}}
+- `MSGestureEvent.velocityX` {{ReadOnlyInline}}
   - : Velocity along the direction of the X-axis.
-- {{domxref("MSGestureEvent.velocityY")}} {{ReadOnlyInline}}
+- `MSGestureEvent.velocityY` {{ReadOnlyInline}}
   - : Velocity along the direction of the Y-axis.
 
 ## Instance methods
 
 _This interface also inherits methods of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._
 
-- {{domxref("MSGestureEvent.initGestureEvent()")}} {{deprecated_inline}}
+- `MSGestureEvent.initGestureEvent()` {{deprecated_inline}}
   - : Initializes the value of an `MSGestureEvent`. If the event has already been dispatched, this method does nothing. This method is deprecated as of Microsoft Edge.
 
 ## Gesture event types
@@ -67,7 +66,7 @@ _Not part of any specification._ Microsoft has [a description on MSDN](<https://
 
 ## Browser compatibility
 
-{{Compat}}
+This was an IE-only feature. No modern browser supports it.
 
 ## See also
 


### PR DESCRIPTION
The bcd data has been removed from mdn/browser-compat-data

For the moment, we still keep these kinds of pages (= IE feature documented in their own page), while we remove IE notes/links from the other pages.

But no need to have an error message in them. Let's explain it to the reader.