### PR TITLE
Styling_links readability

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -92,7 +92,7 @@ p {
 
 {{ EmbedLiveSample('Default_styles', '100%', 130) }}
 
-> **Note:** All the links in the examples on this page are fake links — a `#` (hash/pound sign) is put in place of the real URL. This is because if the real links were included, clicking on them would break the examples (you'd end up with an error or a page loaded in the embedded example that you couldn't get back from). `#` just links to the current page.
+> **Note:** All the link examples on this page link to the top of their window. The empty fragment (`href="#"`) is used to create simple examples and ensure the live examples, which are each contained in an {{HTMLElement("iframe")}}, don't break.
 
 Interestingly enough, these default styles are nearly the same as they were back in the early days of browsers in the mid-1990s. This is because users know and have come to expect this behavior — if links were styled differently, it would confuse a lot of people. This doesn't mean that you shouldn't style links at all. It just means that you shouldn't stray too far from the expected behavior. You should at least:
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -53,7 +53,7 @@ The first thing to understand is the concept of link states — different states
 
 ### Default styles
 
-The example below illustrates what a link will behave like by default (the CSS is enlarging and centering the text to make it stand out more). You can compare the behavior of the default stylings in the example with the behavior of other links on this page (which have some CSS stylings applied to them). Default links have the following properties:
+The example below illustrates what a link will look and behave like by default; though the CSS is enlarging and centering the text to make it stand out more. You can compare the look and behavior of the default stylings in the example with the look and behavior of other links on this page which have more CSS styles applied. Default links have the following properties:
 
 - Links are underlined.
 - Unvisited links are blue.

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -53,24 +53,7 @@ The first thing to understand is the concept of link states — different states
 
 ### Default styles
 
-The following example illustrates what a link will behave like by default (the CSS is enlarging and centering the text to make it stand out more).
-
-```html
-<p><a href="#">A simple link</a></p>
-```
-
-```css
-p {
-  font-size: 2rem;
-  text-align: center;
-}
-```
-
-{{ EmbedLiveSample('Default_styles', '100%', 130) }}
-
-> **Note:** All the links in the examples on this page are fake links — a `#` (hash/pound sign) is put in place of the real URL. This is because if the real links were included, clicking on them would break the examples (you'd end up with an error or a page loaded in the embedded example that you couldn't get back from). `#` just links to the current page.
-
-You'll notice a few things as you explore the default styles:
+The example below illustrates what a link will behave like by default (the CSS is enlarging and centering the text to make it stand out more). You can compare the behavior of the default stylings in the example with the behavior of other links on this page (which have some CSS stylings applied to them). Default links have the following properties:
 
 - Links are underlined.
 - Unvisited links are blue.
@@ -95,6 +78,22 @@ You'll notice a few things as you explore the default styles:
   .)
 
 - Active links are red. Try holding down the mouse button on the link as you click it.
+
+
+```html
+<p><a href="#">A simple link</a></p>
+```
+
+```css
+p {
+  font-size: 2rem;
+  text-align: center;
+}
+```
+
+{{ EmbedLiveSample('Default_styles', '100%', 130) }}
+
+> **Note:** All the links in the examples on this page are fake links — a `#` (hash/pound sign) is put in place of the real URL. This is because if the real links were included, clicking on them would break the examples (you'd end up with an error or a page loaded in the embedded example that you couldn't get back from). `#` just links to the current page.
 
 Interestingly enough, these default styles are nearly the same as they were back in the early days of browsers in the mid-1990s. This is because users know and have come to expect this behavior — if links were styled differently, it would confuse a lot of people. This doesn't mean that you shouldn't style links at all. It just means that you shouldn't stray too far from the expected behavior. You should at least:
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -79,7 +79,6 @@ The example below illustrates what a link will behave like by default (the CSS i
 
 - Active links are red. Try holding down the mouse button on the link as you click it.
 
-
 ```html
 <p><a href="#">A simple link</a></p>
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

I got confused by the way the information was presented while exploring the page (

<!-- ✍️ Summarize your changes in one or two sentences -->

Made some changes to make the references more obvious to what links they are describing on the page. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

I spent about a minute trying to figure out why the link directly above the line about "Active links turn red..." wasn't turning red. The changes make it a little more obvious what links they refer to. 

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
