### PR TITLE
Fix internal link to url()

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -33,7 +33,7 @@ Values of this type are objects. They contain the following properties:
 - `method`
   - : `string`. Standard HTTP method: for example, "GET" or "POST".
 - `originUrl`
-  - : `string`. URL of the resource that triggered the request. Note that this may not be the same as the URL of the page into which the requested resource will be loaded. For example, if a document triggers a load in a different window through the [target attribute of a link](/en-US/docs/Web/HTML/Element/a#target), or a CSS document includes an image using the [`url()` functional notation](</en-US/docs/Web/CSS/url()#the_url()_functional_notation>), then this is the URL of the original document or of the CSS document, respectively.
+  - : `string`. URL of the resource that triggered the request. Note that this may not be the same as the URL of the page into which the requested resource will be loaded. For example, if a document triggers a load in a different window through the [target attribute of a link](/en-US/docs/Web/HTML/Element/a#target), or a CSS document includes an image using the [`url()` functional notation](/en-US/docs/Web/CSS/url), then this is the URL of the original document or of the CSS document, respectively.
 - `parentFrameId`
   - : `integer`. ID of the frame that contains the frame that sent the request. Set to -1 if no parent frame exists.
 - `requestId`


### PR DESCRIPTION
This link initially linked to an anchor inside the page; now there is a single page about it.