### PR TITLE
Unlink BCD from menuitem element

### DIFF
--- a/files/en-us/web/api/htmlmenuitemelement/index.md
+++ b/files/en-us/web/api/htmlmenuitemelement/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 status:
   - deprecated
   - non-standard
-browser-compat: api.HTMLMenuItemElement
 ---
 
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
@@ -20,7 +19,7 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+No longer supported in any browser. Firefox, the only browser that supported this element, removed support in 85.
 
 ## See also
 

--- a/files/en-us/web/html/element/menuitem/index.md
+++ b/files/en-us/web/html/element/menuitem/index.md
@@ -5,7 +5,6 @@ page-type: html-element
 status:
   - deprecated
   - non-standard
-browser-compat: html.elements.menuitem
 ---
 
 {{HTMLSidebar}}{{Deprecated_Header}}{{Non-standard_header}}
@@ -131,7 +130,7 @@ Not part of any current specifications.
 
 ## Browser compatibility
 
-{{Compat}}
+No longer supported in any browser. Firefox, the only browser that supported this element, removed support in 85.
 
 ## See also
 


### PR DESCRIPTION
Per the MDN weekly meeting, we discussed this would be better over #24886.  Correlates with https://github.com/mdn/browser-compat-data/pull/18983.
