### PR TITLE
Clarify FontFaceSet check() method

### DIFF
--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -7,8 +7,7 @@ browser-compat: api.FontFaceSet.check
 
 {{APIRef("CSS Font Loading API")}}
 
-The `check()` method of the {{domxref("FontFaceSet")}} returns whether all
-fonts in the given font list have been loaded and are available.
+The `check()` method of the {{domxref("FontFaceSet")}} returns `true` if you can render some text using the given font specification without attempting to use any fonts in this `FontFaceSet` that are not yet fully loaded. This means you can use the font specification without causing a [font swap](/en-US/docs/Web/CSS/@font-face/font-display#the_font_display_timeline).
 
 ## Syntax
 
@@ -20,31 +19,104 @@ check(font, text)
 ### Parameters
 
 - `font`
-  - : a font specification using the CSS value syntax, for example `"italic bold 16px Roboto"`
+  - : a font specification using the syntax for the CSS [`font`](/en-US/docs/Web/CSS/font) property, for example `"italic bold 16px Roboto"`
 - `text`
   - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
 
 ### Return value
 
-A {{jsxref("Boolean")}} value that is `true` if the font list is available.
+A {{jsxref("Boolean")}} value that is `true` if rendering text with the given font specification will not attempt to use any fonts in this `FontFaceSet` that are not yet fully loaded.
 
-The method returns `true` if the font list contains system or nonexistent fonts. This prevents websites from identifying users by the fonts they have installed.
+This means that all fonts in this `FontFaceSet` that are matched by the given font specification have a [`status`](/en-US/docs/Web/API/FontFace/status) property set to `"loaded"`.
+
+Otherwise, this function returns `false`.
 
 ## Examples
 
-In the following example, the first line will print `true` if the Courier font is available at `12px`. The second line will print `true` if the font `MyFont` contains the "ß" character.
+In the following example, we create a new `FontFace` and add it to the `FontFaceSet`:
 
 ```js
-console.log(document.fonts.check("12px courier"));
+const font = new FontFace(
+  "molot",
+  "url(https://interactive-examples.mdn.mozilla.net/media/fonts/molot.woff2)",
+  {
+    style: "normal",
+    weight: "400",
+    stretch: "condensed",
+  }
+);
 
-console.log(document.fonts.check("12px MyFont", "ß"));
+document.fonts.add(font);
 ```
 
-If the font given in the font specification does not exist, this function returns `false`:
+### Unloaded fonts
+
+The font is not yet loaded, so `check("12px molot")` returns `false`, indicating that if we try to use the given font specification, we will trigger a font load:
 
 ```js
-console.log(document.fonts.check("12px NonExistingFont"));
-// false
+console.log(document.fonts.check("12px molot"));
+// false: the matching font is in the set, but is not yet loaded
+```
+
+### System fonts
+
+If we specify only a system font in the argument to `check()`, it returns `true`, because we can use the system font without loading any fonts from the set:
+
+```js
+console.log(document.fonts.check("12px Courier"));
+// true: the matching font is a system font
+```
+
+### Nonexistent fonts
+
+If we specify a font that is not in the `FontFaceSet` and is not a system font, `check()` returns `true`, because in this situation we will not rely on any fonts from the set:
+
+```js
+console.log(document.fonts.check("12px i-dont-exist"));
+// true: the matching font is a nonexistent font
+```
+
+> **Note:** In this situation Chrome incorrectly returns `false`. This can make [fingerprinting](/en-US/docs/Glossary/Fingerprinting) easier, because an attacker can easily test which system fonts the browser has.
+
+### System and unloaded fonts
+
+If we specify both a system font and a font in the set that is not yet loaded, then `check()` returns `false`:
+
+```js
+console.log(document.fonts.check("12px molot, Courier"));
+// false: `molot` is in the set but not yet loaded
+```
+
+### Fonts that are loading
+
+If we specify a font from the set that is still loading, `check()` returns `false`:
+
+```js
+function check() {
+  font.load();
+  console.log(document.fonts.check("12px molot"));
+  // false: font is still loading
+  console.log(font.status);
+  // "loading"
+}
+
+check();
+```
+
+### Fonts that have loaded
+
+If we specify a font from the set that has loaded, `check()` returns `true`:
+
+```js
+async function check() {
+  await font.load();
+  console.log(document.fonts.check("12px molot"));
+  // true: font has finished loading
+  console.log(font.status);
+  // "loaded"
+}
+
+check();
 ```
 
 ## Specifications


### PR DESCRIPTION
This came out of and obsoletes https://github.com/mdn/content/pull/24488. The current page talks about this function telling you whether a font is "available" which doesn't match up with the spec text. The spec says it tells you whether using the given font specification will make the browser use a font from the set that is not yet loaded, potentially causing a font swap.

In that context, returning `true` for fonts that are neither system fonts nor fonts in the set makes more sense.

So I have had a go at rewriting things, as well as noting Chrome's divergence from the specced behavior. I know, I know, we should only document compat in BCD, but given the number of times people have tried to "fix" the page to match Chrome, it seems like we need to be more obvious.

(there's a potential systemic issue here, where it might be good to have a way to indicate somehow that certain compat issues are important enough that they should be more visible on the page than buried in a note. That way we could still maintain compat only in BCD, while solving this usability issue.)

