### PR TITLE
RTCPeerConnection.addTransceiver() add additional exceptions from spec

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -48,8 +48,16 @@ The {{domxref("RTCRtpTransceiver")}} object which will be used to exchange the m
 
   - : Thrown if `trackOrKind` was not either `"audio"` or `"video"`.
 
+    If the `sendEncodings` argument is used, this error may also be thrown if there is badly formatted `rid` member, some but all encodings contain a `rid` member, or different encodings have the same `rid` value.
+
 - {{jsxref("RangeError")}}
-  - : Thrown if any of the `sendEncodings` encodings have a {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} value less than 0.0.
+  - : Thrown if any of the `sendEncodings` encodings have a {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} value less than 0.0, or a {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} value of less than 1.0.
+
+- {{jsxref("InvalidStateError")}}
+  - : Thrown if the the method is called when the associated connection is closed.
+
+- {{jsxref("InvalidAccessError")}}
+  - : Thrown if the `sendEncodings` argument is used, and contains a read-only parameter other than `rid`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -48,7 +48,7 @@ The {{domxref("RTCRtpTransceiver")}} object which will be used to exchange the m
 
   - : Thrown if `trackOrKind` was not either `"audio"` or `"video"`.
 
-    If the `sendEncodings` argument is used, this error may also be thrown if there is badly formatted `rid` member, some but all encodings contain a `rid` member, or different encodings have the same `rid` value.
+    If the `sendEncodings` argument is used, this error may also be thrown if there is a badly formatted `rid` member, some but not all encodings contain a `rid` member, or different encodings have the same `rid` value.
 
 - {{jsxref("RangeError")}}
   - : Thrown if any of the `sendEncodings` encodings have a {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} value less than 0.0, or a {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} value of less than 1.0.


### PR DESCRIPTION
This just adds a few extra exceptions listed in the spec for `RTCPeerConnection.addTransceiver()` here: https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver

This is related to other docs worktracked in #23677