### PR TITLE
Correct <input type="month"> min attribute docs

### DIFF
--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -81,7 +81,7 @@ This value must specify a year-month pairing later than or equal to the one spec
 
 ### min
 
-The latest year and month to accept, in the same "`yyyy-MM`" format described above.
+The earliest year and month to accept, in the same "`yyyy-MM`" format described above.
 If the {{htmlattrxref("value", "input")}} of the element is less than this, the element fails [constraint validation](/en-US/docs/Web/HTML/Constraint_validation).
 If a value is specified for `min` that isn't a valid year and month string, the input has no minimum value.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->


<!-- ❓ Why are you making these changes and how do they help readers? -->

### Description
Fix `min` attribute language of the `<input type="month">` documentation - replace `latest` with `earliest`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Clarify the intent of the `min` attribute of the `<input type="month">` element

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
A simple language change that corrects the documentation- as it is, the `max` and `min` attributes of `<input type="month">` both stay `The latest year and month to accept`

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
