### PR TITLE
Update  Using Service Workers: remove unused field in object

### DIFF
--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -227,7 +227,7 @@ const putInCache = async (request, response) => {
   await cache.put(request, response);
 };
 
-const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
+const cacheFirst = async ({ request, fallbackUrl }) => {
   // First try to get the resource from the cache
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {


### PR DESCRIPTION

### Description
In "Using Service Workers" : 
in the "Recovering failed requests" paragraph, the preloadResponsePromise is not yet introduced or used : so the cacheFirst  should not expect it.

It is only on the "Service Worker navigation preload" paragraph that this promise is introduced and correctly sent to the cacheFirst function by the event handler


### Motivation

I think that the present version can't work correctly

