### PR TITLE
Fix glossary link

### DIFF
--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -64,7 +64,7 @@ The MDN [Web Performance Learning Area](/en-US/docs/Learn/Performance) contains 
 
 - {{glossary('Beacon')}}
 - {{glossary('Brotli compression')}}
-- {{glossary('Client hints')}}
+- [Client hints](/en-US/docs/Web/HTTP/Client_hints)
 - {{glossary('Code splitting')}}
 - {{glossary('CSSOM')}}
 - {{glossary('Domain sharding')}}


### PR DESCRIPTION
There is no glossary entry for this, but a whole page under HTTP/. Let's link to it.