### PR TITLE
Use italics instead of capitalization for emphasis

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -24,7 +24,7 @@ parseInt(string, radix)
   - : A string starting with an integer. Leading {{glossary("whitespace")}} in this argument is ignored.
 - `radix` {{optional_inline}}
 
-  - : An integer between `2` and `36` that represents the _radix_ (the base in mathematical numeral systems) of the `string`. It is converted to a [32-bit integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#fixed-width_number_conversion); if it's nonzero and outside the range of \[2, 36] after conversion, the function will always return `NaN`. If `0` or not provided, the radix will be inferred based on `string`'s value. Be careful — this does NOT always default to `10`! The [description below](#description) explains in more detail what happens when `radix` is not provided.
+  - : An integer between `2` and `36` that represents the _radix_ (the base in mathematical numeral systems) of the `string`. It is converted to a [32-bit integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#fixed-width_number_conversion); if it's nonzero and outside the range of \[2, 36] after conversion, the function will always return `NaN`. If `0` or not provided, the radix will be inferred based on `string`'s value. Be careful — this does _not_ always default to `10`! The [description below](#description) explains in more detail what happens when `radix` is not provided.
 
 ### Return value
 


### PR DESCRIPTION
We try to avoid writing in all caps for emphasis. Using italics is more appropriate.