### PR TITLE
Fix link to aria-selected

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -159,7 +159,7 @@ Inherited into roles:
 - HTML {{HTMLElement('option')}} element
 - HTML {{HTMLElement('input')}} element
 - {{htmlattrxref("multiple")}} attribute
-- [`aria-selected`](/en-US/docs/Web/Accessibility/Attributes/aria-selected)
+- [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)
 
 <section id="Quick_links">
 <strong><a href="/en-US/docs/Web/Accessibility/ARIA/Attributes">WAI-ARIA states and properties</a></strong>


### PR DESCRIPTION
There was an _ARIA_ directory missing, leading to a flaw.