### PR TITLE
Move the constant section of <SVGFEGaussianBlurElement> inside property's description

### DIFF
--- a/files/en-us/web/api/svgfegaussianblurelement/index.md
+++ b/files/en-us/web/api/svgfegaussianblurelement/index.md
@@ -11,48 +11,20 @@ The **`SVGFEGaussianBlurElement`** interface corresponds to the {{SVGElement("fe
 
 {{InheritanceDiagram}}
 
-## Constants
-
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th>Name</th>
-      <th>Value</th>
-      <th>Description</th>
-    </tr>
-    <tr>
-      <td><code>SVG_EDGEMODE_UNKNOWN</code></td>
-      <td>0</td>
-      <td>
-        The type is not one of predefined types. It is invalid to attempt to
-        define a new value of this type or to attempt to switch an existing
-        value to this type.
-      </td>
-    </tr>
-    <tr>
-      <td><code>SVG_EDGEMODE_DUPLICATE</code></td>
-      <td>1</td>
-      <td>Corresponds to the <code>duplicate</code> value.</td>
-    </tr>
-    <tr>
-      <td><code>SVG_EDGEMODE_WRAP</code></td>
-      <td>2</td>
-      <td>Corresponds to the <code>wrap</code> value.</td>
-    </tr>
-    <tr>
-      <td><code>SVG_EDGEMODE_NONE</code></td>
-      <td>3</td>
-      <td>Corresponds to <code>none</code> value.</td>
-    </tr>
-  </tbody>
-</table>
-
 ## Instance properties
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGFEGaussianBlurElement.edgeMode")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("edgeMode")}} attribute of the given element. Takes one of the `SVG_EDGEMODE_*` constants defined on this interface.
+  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("edgeMode")}} attribute of the given element. Returns two identical values that are one of the following values:
+    - `SVG_EDGEMODE_UNKNOWN` (0)
+      - :  The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+    - `SVG_EDGEMODE_DUPLICATE` (1)
+      - : Corresponds to the `duplicate` value.
+    - `SVG_EDGEMODE_WRAP` (2)
+      - : Corresponds to the `wrap` value.
+    - `SVG_EDGEMODE_NONE` (3)
+      - : Corresponds to `none` value.
 - {{domxref("SVGFEGaussianBlurElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given element.
 - {{domxref("SVGFEGaussianBlurElement.in1")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgfegaussianblurelement/index.md
+++ b/files/en-us/web/api/svgfegaussianblurelement/index.md
@@ -18,7 +18,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEGaussianBlurElement.edgeMode")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("edgeMode")}} attribute of the given element. Returns two identical values that are one of the following values:
     - `SVG_EDGEMODE_UNKNOWN` (0)
-      - :  The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+      - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
     - `SVG_EDGEMODE_DUPLICATE` (1)
       - : Corresponds to the `duplicate` value.
     - `SVG_EDGEMODE_WRAP` (2)


### PR DESCRIPTION
The constants on these interfaces are only used by one property.

This PR moves them inside this property's short description and uses a definition list instead of a table.