### PR TITLE
Fix `FileSystemDirectoryHandle.resolve()`

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -20,7 +20,7 @@ resolve(possibleDescendant)
 
 ### Parameters
 
-- possibleDescendant
+- `possibleDescendant`
   - : The {{domxref('FileSystemHandle')}} from which to return the relative path.
 
 ### Return value

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -53,7 +53,6 @@ async function returnPathDirectories(directoryHandle) {
     // Not inside directory handle
   } else {
     // relativePath is an array of names, giving the relative path
-
     for (const name of relativePaths) {
       // log each entry
       console.log(name);

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -21,8 +21,7 @@ resolve(possibleDescendant)
 ### Parameters
 
 - possibleDescendant
-  - : The {{domxref('FileSystemHandle.name')}} of the {{domxref('FileSystemHandle')}} from
-    which to return the relative path.
+  - : The {{domxref('FileSystemHandle')}} from which to return the relative path.
 
 ### Return value
 
@@ -41,14 +40,14 @@ chosen file, relative to a specified directory handle.
 ```js
 async function returnPathDirectories(directoryHandle) {
   // Get a file handle by showing a file picker:
-  const handle = await self.showOpenFilePicker();
+  const [handle] = await self.showOpenFilePicker();
   if (!handle) {
     // User cancelled, or otherwise failed to open a file.
     return;
   }
 
   // Check if handle exists inside our directory handle
-  const relativePaths = await directoryHandle.resolve(handle[0]);
+  const relativePaths = await directoryHandle.resolve(handle);
 
   if (relativePaths === null) {
     // Not inside directory handle


### PR DESCRIPTION
### Description

- `resolve()` takes a handle as its argument, not a name ([spec](https://fs.spec.whatwg.org/#ref-for-dom-filesystemdirectoryhandle-resolve)).
- Improve code sample.

### Motivation

The docs were wrong.

### Additional details

https://fs.spec.whatwg.org/#ref-for-dom-filesystemdirectoryhandle-resolve
