### PR TITLE
`FileSystemDirectoryHandle.getDirectoryHandle()` is a way to obtain a `FileSystemDirectoryHandle`

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -9,7 +9,7 @@ browser-compat: api.FileSystemDirectoryHandle
 
 The **`FileSystemDirectoryHandle`** interface of the {{domxref('File System Access API')}} provides a handle to a file system directory.
 
-The interface can be accessed via the {{domxref('window.showDirectoryPicker()')}}, {{domxref('StorageManager.getDirectory()')}}, and {{domxref('DataTransferItem.getAsFileSystemHandle()')}} methods.
+The interface can be accessed via the {{domxref('window.showDirectoryPicker()')}}, {{domxref('StorageManager.getDirectory()')}}, {{domxref('DataTransferItem.getAsFileSystemHandle()')}}, and {{domxref('FileSystemDirectoryHandle.getDirectoryHandle()')}} methods.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
### Description

From a directory you can create another. 

### Motivation

This way was not documented.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle
