### PR TITLE
Remove useless parameter of EmbedLiveSample

### DIFF
--- a/files/en-us/web/api/dommatrixreadonly/translate/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.md
@@ -62,8 +62,7 @@ document
 ```
 
 {{ EmbedLiveSample('Examples', '250', '250',
-  'screen_shot_2019-02-19_at_11.20.40.png',
-  'Web/API/DOMMatrixReadOnly/translate') }}
+  'screen_shot_2019-02-19_at_11.20.40.png') }}
 
 ## Specifications
 


### PR DESCRIPTION
This parameter is deprecated and was pointing to the same page. It should do nothing.