### PR TITLE
Number conversion to TypedArray: Fix, format examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -91,11 +91,19 @@ JavaScript has some lower-level functions that deal with the binary encoding of 
 
 ```js
 new Int32Array([1.1, 1.9, -1.1, -1.9]); // Int32Array(4) [ 1, 1, -1, -1 ]
+
 new Int8Array([257, -257]); // Int8Array(2) [ 1, -1 ]
-// 257 = 0001 0000 0001 = 0000 0001 (mod 2^8) = 1
-// -257 = 1110 1111 1111 = 1111 1111 (mod 2^8) = -1 (as signed integer)
+// 257 = 0001 0000 0001
+//     =      0000 0001 (mod 2^8)
+//     = 1
+// -257 = 1110 1111 1111
+//      =      1111 1111 (mod 2^8) 
+//      = -1 (as signed integer)
+
 new Uint8Array([257, -257]); // Uint8Array(2) [ 1, 255 ]
-// -257 = 1110 1111 1111 = 1111 1111 (mod 2^8) = 255 (as unsigned integer)
+// -257 = 1110 1111 1111 
+//      =      1111 1111 (mod 2^8)
+//      = 255 (as unsigned integer)
 ```
 
 ## Constructor

--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -91,10 +91,10 @@ JavaScript has some lower-level functions that deal with the binary encoding of 
 
 ```js
 new Int32Array([1.1, 1.9, -1.1, -1.9]); // Int32Array(4) [ 1, 1, -1, -1 ]
-new Int8Array([257, -257]); // Int8Array(1) [ 1, -1 ]
+new Int8Array([257, -257]); // Int8Array(2) [ 1, -1 ]
 // 257 = 0001 0000 0001 = 0000 0001 (mod 2^8) = 1
 // -257 = 1110 1111 1111 = 1111 1111 (mod 2^8) = -1 (as signed integer)
-new Uint8Array([257, -257]); // Uint8Array(1) [ 1, 255 ]
+new Uint8Array([257, -257]); // Uint8Array(2) [ 1, 255 ]
 // -257 = 1110 1111 1111 = 1111 1111 (mod 2^8) = 255 (as unsigned integer)
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Two separate commits:
1. Correct the array sizes shown in example code comments. (The length of a 2-element array is 2, not 1.)
2. Reformat the step-by-step sample conversions vertically, instead of horizontally, for readability.

### Motivation

Reporting wrong array sizes for example lines of code can only serve to confuse readers. (Worked on me!) In addition, when converting numbers from one form to another, showing the conversion progress vertically instead of horizontally makes it easier to compare the values step-by-step as they change.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
