### PR TITLE
Remove paragraph about calling {{Specifications}} with a parameter

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
@@ -2,7 +2,7 @@
 title: Specification tables
 slug: MDN/Writing_guidelines/Page_structures/Specification_tables
 page-type: mdn-writing-guide
-browser-urls: css.properties.text-align
+browser-compat: css.properties.text-align
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
@@ -2,6 +2,7 @@
 title: Specification tables
 slug: MDN/Writing_guidelines/Page_structures/Specification_tables
 page-type: mdn-writing-guide
+browser-urls: css.properties.text-align
 ---
 
 {{MDNSidebar}}
@@ -28,7 +29,7 @@ then the macro gets the specifications for {{cssxref("text-align")}} and renders
 
 ### Specifications
 
-{{Specifications("css.properties.text-align")}}
+{{Specifications}}
 
 ## Non-standard features
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
@@ -30,11 +30,6 @@ then the macro gets the specifications for {{cssxref("text-align")}} and renders
 
 {{Specifications("css.properties.text-align")}}
 
-## Specification tables without front-matter
-
-In case you want to display a specification section on a page that doesn't provide a front-matter,
-you can pass the browser-compat query directly to the macro: `\{{Specifications("css.properties.text-align")}}`
-
 ## Non-standard features
 
 When documenting a feature that doesn't have a specification (anymore),


### PR DESCRIPTION
This is deprecated, let's not document this as a legit way to use the macro.