### PR TITLE
X-Frame-Options: ALLOW-FROM does not use equal sign

### DIFF
--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -49,7 +49,7 @@ If you specify `DENY`, not only will the browser attempt to load the page in a f
   - : The page cannot be displayed in a frame, regardless of the site attempting to do so.
 - `SAMEORIGIN`
   - : The page can only be displayed if all ancestor frames are same origin to the page itself.
-- `ALLOW-FROM=url` {{deprecated_inline}}
+- `ALLOW-FROM origin` {{deprecated_inline}}
   - : This is an obsolete directive that no longer works in modern browsers. (Using it will give the same behavior as omitting the header.) Don't use it. The {{HTTPHeader("Content-Security-Policy")}} HTTP header has a {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive which you can use instead.
 
 ## Examples


### PR DESCRIPTION
Fix syntax of the (deprecated) variant of the X-Frame-Options header according to RFC 7034.

- no equal sign
- origin instead of URL

### Description

The original `ALLOW-FROM` variant of the `X-Frame-Options` header specified in RFC 7034 (but now deprecated) does not use an equal sign and does not use URL but origin (RFC 6454).

### Motivation

The description of the header value is wrong.

### Additional details

See RFC 7034, e.g. specifically https://www.rfc-editor.org/rfc/rfc7034#section-2.2.1

### Related issues and pull requests

* https://github.com/mdn/browser-compat-data/issues/16012 claims this deprecated functionality still works (or, worked in Apr 2022) in current versions of Chrome and Firefox which should mean the description text should be changed as well.