### PR TITLE
HTTP Headers: Remove tags/add status where necessary

### DIFF
--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept-CH
 slug: Web/HTTP/Headers/Accept-CH
-tags:
-  - Accept-CH
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Response header
 browser-compat: http.headers.Accept-CH
 ---
 

--- a/files/en-us/web/http/headers/accept-charset/index.md
+++ b/files/en-us/web/http/headers/accept-charset/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept-Charset
 slug: Web/HTTP/Headers/Accept-Charset
-tags:
-  - Content Negotiation
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/accept-encoding/index.md
+++ b/files/en-us/web/http/headers/accept-encoding/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept-Encoding
 slug: Web/HTTP/Headers/Accept-Encoding
-tags:
-  - Content Negotiation
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Accept-Encoding
 ---
 

--- a/files/en-us/web/http/headers/accept-language/index.md
+++ b/files/en-us/web/http/headers/accept-language/index.md
@@ -1,13 +1,6 @@
 ---
 title: Accept-Language
 slug: Web/HTTP/Headers/Accept-Language
-tags:
-  - Accept-Language
-  - Content Negotiation
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Accept-Language
 ---
 

--- a/files/en-us/web/http/headers/accept-patch/index.md
+++ b/files/en-us/web/http/headers/accept-patch/index.md
@@ -1,9 +1,6 @@
 ---
 title: Accept-Patch
 slug: Web/HTTP/Headers/Accept-Patch
-tags:
-  - HTTP
-  - Reference
 spec-urls: https://www.rfc-editor.org/rfc/rfc5789#section-3.1
 ---
 

--- a/files/en-us/web/http/headers/accept-post/index.md
+++ b/files/en-us/web/http/headers/accept-post/index.md
@@ -1,11 +1,6 @@
 ---
 title: Accept-Post
 slug: Web/HTTP/Headers/Accept-Post
-tags:
-  - Accept-Post
-  - HTTP
-  - HTTP Header
-  - Response Header
 spec-urls: https://www.w3.org/TR/ldp/#header-accept-post
 ---
 

--- a/files/en-us/web/http/headers/accept-ranges/index.md
+++ b/files/en-us/web/http/headers/accept-ranges/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept-Ranges
 slug: Web/HTTP/Headers/Accept-Ranges
-tags:
-  - HTTP
-  - HTTP Header
-  - Range Requests
-  - Reference
-  - Response Header
 browser-compat: http.headers.Accept-Ranges
 ---
 

--- a/files/en-us/web/http/headers/accept/index.md
+++ b/files/en-us/web/http/headers/accept/index.md
@@ -1,11 +1,6 @@
 ---
 title: Accept
 slug: Web/HTTP/Headers/Accept
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Accept
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.md
@@ -1,13 +1,6 @@
 ---
 title: Access-Control-Allow-Credentials
 slug: Web/HTTP/Headers/Access-Control-Allow-Credentials
-tags:
-  - Access-Control-Allow-Credentials
-  - CORS
-  - HTTP
-  - Reference
-  - credentials
-  - header
 browser-compat: http.headers.Access-Control-Allow-Credentials
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.md
@@ -1,12 +1,6 @@
 ---
 title: Access-Control-Allow-Headers
 slug: Web/HTTP/Headers/Access-Control-Allow-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.Access-Control-Allow-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Allow-Methods
 slug: Web/HTTP/Headers/Access-Control-Allow-Methods
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Access-Control-Allow-Methods
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-origin/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-origin/index.md
@@ -1,19 +1,6 @@
 ---
 title: Access-Control-Allow-Origin
 slug: Web/HTTP/Headers/Access-Control-Allow-Origin
-tags:
-  - Access Control
-  - Access-Control-Allow-Origin
-  - CORS
-  - Dealing with CORS
-  - HTTP
-  - HTTP Header
-  - How to Fix CORS
-  - Reference
-  - Security
-  - cross-origin issue
-  - header
-  - origin
 browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Expose-Headers
 slug: Web/HTTP/Headers/Access-Control-Expose-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Access-Control-Expose-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/headers/access-control-max-age/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Max-Age
 slug: Web/HTTP/Headers/Access-Control-Max-Age
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Access-Control-Max-Age
 ---
 

--- a/files/en-us/web/http/headers/access-control-request-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Request-Headers
 slug: Web/HTTP/Headers/Access-Control-Request-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Access-Control-Request-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-request-method/index.md
+++ b/files/en-us/web/http/headers/access-control-request-method/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Request-Method
 slug: Web/HTTP/Headers/Access-Control-Request-Method
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Access-Control-Request-Method
 ---
 

--- a/files/en-us/web/http/headers/age/index.md
+++ b/files/en-us/web/http/headers/age/index.md
@@ -1,11 +1,6 @@
 ---
 title: Age
 slug: Web/HTTP/Headers/Age
-tags:
-  - Caching
-  - HTTP
-  - Response
-  - header
 browser-compat: http.headers.Age
 ---
 

--- a/files/en-us/web/http/headers/allow/index.md
+++ b/files/en-us/web/http/headers/allow/index.md
@@ -1,11 +1,6 @@
 ---
 title: Allow
 slug: Web/HTTP/Headers/Allow
-tags:
-  - HTTP
-  - HTTP Header
-  - Response header
-  - Reference
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.allow
 ---
 

--- a/files/en-us/web/http/headers/alt-svc/index.md
+++ b/files/en-us/web/http/headers/alt-svc/index.md
@@ -1,11 +1,6 @@
 ---
 title: Alt-Svc
 slug: Web/HTTP/Headers/Alt-Svc
-tags:
-  - HTTP
-  - HTTP Header
-  - NeedsCompatTable
-  - Reference
 browser-compat: http.headers.Alt-Svc
 ---
 

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -1,14 +1,6 @@
 ---
 title: Authorization
 slug: Web/HTTP/Headers/Authorization
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Header
-  - Authorization
-  - Authentication
 browser-compat: http.headers.Authorization
 ---
 

--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -1,12 +1,6 @@
 ---
 title: Clear-Site-Data
 slug: Web/HTTP/Headers/Clear-Site-Data
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.Clear-Site-Data
 ---
 

--- a/files/en-us/web/http/headers/connection/index.md
+++ b/files/en-us/web/http/headers/connection/index.md
@@ -1,13 +1,6 @@
 ---
 title: Connection
 slug: Web/HTTP/Headers/Connection
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
-  - Web
 browser-compat: http.headers.Connection
 ---
 

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -1,12 +1,6 @@
 ---
 title: Content-Disposition
 slug: Web/HTTP/Headers/Content-Disposition
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
 browser-compat: http.headers.Content-Disposition
 ---
 

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -1,10 +1,6 @@
 ---
 title: Content-Encoding
 slug: Web/HTTP/Headers/Content-Encoding
-tags:
-  - HTTP
-  - Headers
-  - Reference
 browser-compat: http.headers.Content-Encoding
 ---
 

--- a/files/en-us/web/http/headers/content-language/index.md
+++ b/files/en-us/web/http/headers/content-language/index.md
@@ -1,10 +1,6 @@
 ---
 title: Content-Language
 slug: Web/HTTP/Headers/Content-Language
-tags:
-  - HTTP
-  - Headers
-  - Reference
 browser-compat: http.headers.Content-Language
 ---
 

--- a/files/en-us/web/http/headers/content-length/index.md
+++ b/files/en-us/web/http/headers/content-length/index.md
@@ -1,14 +1,6 @@
 ---
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
-tags:
-  - Content-Length
-  - HTTP
-  - HTTP header
-  - Request header
-  - Response header
-  - Reference
-  - Payload header
 browser-compat: http.headers.Content-Length
 ---
 

--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -1,10 +1,6 @@
 ---
 title: Content-Location
 slug: Web/HTTP/Headers/Content-Location
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Content-Location
 ---
 

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Range
 slug: Web/HTTP/Headers/Content-Range
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - Header
-  - Payload header
 browser-compat: http.headers.Content-Range
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Security-Policy-Report-Only
 slug: Web/HTTP/Headers/Content-Security-Policy-Report-Only
-tags:
-  - CSP
-  - HTTP
-  - HTTPS
-  - Reference
-  - Security
-  - header
 browser-compat: http.headers.Content-Security-Policy-Report-Only
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -1,12 +1,6 @@
 ---
 title: "CSP: base-uri"
 slug: Web/HTTP/Headers/Content-Security-Policy/base-uri
-tags:
-  - CSP
-  - Directive
-  - Document directive
-  - HTTP
-  - Security
 browser-compat: http.headers.Content-Security-Policy.base-uri
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: child-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/child-src
-tags:
-  - CSP
-  - Child
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - child-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.child-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -1,15 +1,6 @@
 ---
 title: "CSP: connect-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/connect-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - connect-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.connect-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: default-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/default-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - default
-  - default-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.default-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -1,15 +1,6 @@
 ---
 title: "CSP: font-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/font-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - font
-  - source
 browser-compat: http.headers.Content-Security-Policy.font-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -1,15 +1,6 @@
 ---
 title: "CSP: form-action"
 slug: Web/HTTP/Headers/Content-Security-Policy/form-action
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Security
-  - action
-  - form
-  - form-action
 browser-compat: http.headers.Content-Security-Policy.form-action
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -1,15 +1,6 @@
 ---
 title: "CSP: frame-ancestors"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-tags:
-  - Ancestors
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - Frame
-  - HTTP
-  - Security
-  - frame-ancestors
 browser-compat: http.headers.Content-Security-Policy.frame-ancestors
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: frame-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - Frame
-  - HTTP
-  - Reference
-  - Security
-  - frame-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.frame-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: img-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/img-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Image
-  - Reference
-  - Security
-  - img-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.img-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Security-Policy
 slug: Web/HTTP/Headers/Content-Security-Policy
-tags:
-  - CSP
-  - Content Security Policy
-  - HTTP
-  - Reference
-  - Security
-  - header
 browser-compat: http.headers.Content-Security-Policy
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: manifest-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/manifest-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Manifest
-  - Reference
-  - Security
-  - manifest-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.manifest-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: media-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/media-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Media
-  - Reference
-  - Security
-  - media-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.media-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: object-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/object-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Object
-  - Reference
-  - Security
-  - object-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.object-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
@@ -1,17 +1,9 @@
 ---
 title: "CSP: plugin-types"
 slug: Web/HTTP/Headers/Content-Security-Policy/plugin-types
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Java
-  - Plugin
-  - Plugins
-  - Security
-  - Deprecated
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.Content-Security-Policy.plugin-types
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -1,14 +1,8 @@
 ---
 title: "CSP: prefetch-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/prefetch-src
-tags:
-  - CSP
-  - Content Security Policy
-  - Directive
-  - HTTP
-  - Reference
-  - prefetch-src
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Content-Security-Policy.prefetch-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.md
@@ -1,16 +1,9 @@
 ---
 title: "CSP: referrer"
 slug: Web/HTTP/Headers/Content-Security-Policy/referrer
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Deprecated
-  - Reference
-  - Security
-  - referrer
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.Content-Security-Policy.referrer
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -1,14 +1,6 @@
 ---
 title: "CSP: report-to"
 slug: Web/HTTP/Headers/Content-Security-Policy/report-to
-tags:
-  - CSP
-  - Content Security Policy
-  - Content-Security-Policy
-  - HTTP
-  - Reporting
-  - Security
-  - report-to
 browser-compat: http.headers.Content-Security-Policy.report-to
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
@@ -1,13 +1,8 @@
 ---
 title: "CSP: report-uri"
 slug: Web/HTTP/Headers/Content-Security-Policy/report-uri
-tags:
-  - CSP
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Deprecated
+status:
+  - deprecated
 browser-compat: http.headers.Content-Security-Policy.report-uri
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -1,12 +1,8 @@
 ---
 title: "CSP: require-trusted-types-for"
 slug: Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
-tags:
-  - CSP
-  - Directive
-  - HTTP
-  - Security
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Content-Security-Policy.require-trusted-types-for
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -1,13 +1,6 @@
 ---
 title: "CSP: sandbox"
 slug: Web/HTTP/Headers/Content-Security-Policy/sandbox
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Sandbox
-  - Security
 browser-compat: http.headers.Content-Security-Policy.sandbox
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -1,17 +1,6 @@
 ---
 title: "CSP: script-src-attr"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src-attr
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Script
-  - Security
-  - script-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.script-src-attr
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -1,17 +1,6 @@
 ---
 title: "CSP: script-src-elem"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src-elem
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Script
-  - Security
-  - script-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.script-src-elem
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -1,17 +1,6 @@
 ---
 title: "CSP: script-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Script
-  - Security
-  - script-src
-  - source
 browser-compat: http.headers.Content-Security-Policy.script-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -1,14 +1,6 @@
 ---
 title: "CSP source values"
 slug: Web/HTTP/Headers/Content-Security-Policy/Sources
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - source
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -1,18 +1,6 @@
 ---
 title: "CSP: style-src-attr"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src-attr
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Style
-  - source
-  - style-src
-  - style-src-attr
 browser-compat: http.headers.Content-Security-Policy.style-src-attr
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -1,18 +1,6 @@
 ---
 title: "CSP: style-src-elem"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src-elem
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Style
-  - source
-  - style-src
-  - style-src-elem
 browser-compat: http.headers.Content-Security-Policy.style-src-elem
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -1,17 +1,6 @@
 ---
 title: "CSP: style-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Style
-  - source
-  - style-src
 browser-compat: http.headers.Content-Security-Policy.style-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -1,12 +1,8 @@
 ---
 title: "CSP: trusted-types"
 slug: Web/HTTP/Headers/Content-Security-Policy/trusted-types
-tags:
-  - CSP
-  - Directive
-  - HTTP
-  - Security
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Content-Security-Policy.trusted-types
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
@@ -1,16 +1,6 @@
 ---
 title: "CSP: upgrade-insecure-requests"
 slug: Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Requests
-  - Security
-  - Upgrade
-  - upgrade-insecure-requests
 browser-compat: http.headers.Content-Security-Policy.upgrade-insecure-requests
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -1,13 +1,6 @@
 ---
 title: "CSP: worker-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/worker-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
 browser-compat: http.headers.Content-Security-Policy.worker-src
 ---
 

--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -1,12 +1,6 @@
 ---
 title: Content-Type
 slug: Web/HTTP/Headers/Content-Type
-tags:
-  - Content-Type
-  - HTTP
-  - HTTP header
-  - Representation header
-  - Reference
 browser-compat: http.headers.Content-Type
 ---
 

--- a/files/en-us/web/http/headers/cookie/index.md
+++ b/files/en-us/web/http/headers/cookie/index.md
@@ -1,12 +1,6 @@
 ---
 title: Cookie
 slug: Web/HTTP/Headers/Cookie
-tags:
-  - Cookies
-  - HTTP
-  - Reference
-  - header
-  - request
 browser-compat: http.headers.Cookie
 ---
 

--- a/files/en-us/web/http/headers/critical-ch/index.md
+++ b/files/en-us/web/http/headers/critical-ch/index.md
@@ -1,14 +1,8 @@
 ---
 title: Critical-CH
 slug: Web/HTTP/Headers/Critical-CH
-tags:
-  - Critical-CH
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Critical-CH
 ---
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Cross-Origin-Embedder-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Embedder-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.Cross-Origin-Embedder-Policy
 ---
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Cross-Origin-Opener-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Opener-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.Cross-Origin-Opener-Policy
 ---
 

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Cross-Origin-Resource-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Resource-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 

--- a/files/en-us/web/http/headers/date/index.md
+++ b/files/en-us/web/http/headers/date/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date
 slug: Web/HTTP/Headers/Date
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
 browser-compat: http.headers.Date
 ---
 

--- a/files/en-us/web/http/headers/device-memory/index.md
+++ b/files/en-us/web/http/headers/device-memory/index.md
@@ -1,14 +1,8 @@
 ---
 title: Device-Memory
 slug: Web/HTTP/Headers/Device-Memory
-tags:
-  - Device-Memory
-  - Client hints
-  - Device Memory API
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Device-Memory
 ---
 

--- a/files/en-us/web/http/headers/digest/index.md
+++ b/files/en-us/web/http/headers/digest/index.md
@@ -1,10 +1,6 @@
 ---
 title: Digest
 slug: Web/HTTP/Headers/Digest
-tags:
-  - HTTP
-  - HTTP Header
-  - Digest
 browser-compat: http.headers.Digest
 ---
 

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -1,12 +1,8 @@
 ---
 title: DNT
 slug: Web/HTTP/Headers/DNT
-tags:
-  - DNT
-  - HTTP
-  - Reference
-  - header
-  - Deprecated
+status:
+  - deprecated
 browser-compat: http.headers.DNT
 ---
 

--- a/files/en-us/web/http/headers/downlink/index.md
+++ b/files/en-us/web/http/headers/downlink/index.md
@@ -1,14 +1,8 @@
 ---
 title: Downlink
 slug: Web/HTTP/Headers/Downlink
-tags:
-  - Downlink
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Client hints
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.downlink
 ---
 

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -1,14 +1,9 @@
 ---
 title: DPR
 slug: Web/HTTP/Headers/DPR
-tags:
-  - DPR
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Deprecated
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.DPR
 ---
 

--- a/files/en-us/web/http/headers/early-data/index.md
+++ b/files/en-us/web/http/headers/early-data/index.md
@@ -1,14 +1,8 @@
 ---
 title: Early-Data
 slug: Web/HTTP/Headers/Early-Data
-tags:
-  - Early-Data
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Early-Data
 ---
 

--- a/files/en-us/web/http/headers/ect/index.md
+++ b/files/en-us/web/http/headers/ect/index.md
@@ -1,14 +1,8 @@
 ---
 title: ECT
 slug: Web/HTTP/Headers/ECT
-tags:
-  - ect
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Client hints
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.ect
 ---
 

--- a/files/en-us/web/http/headers/etag/index.md
+++ b/files/en-us/web/http/headers/etag/index.md
@@ -1,11 +1,6 @@
 ---
 title: ETag
 slug: Web/HTTP/Headers/ETag
-tags:
-  - HTTP
-  - Reference
-  - Response
-  - header
 browser-compat: http.headers.ETag
 ---
 

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -1,10 +1,6 @@
 ---
 title: Expect-CT
 slug: Web/HTTP/Headers/Expect-CT
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Expect-CT
 ---
 

--- a/files/en-us/web/http/headers/expect/index.md
+++ b/files/en-us/web/http/headers/expect/index.md
@@ -1,11 +1,6 @@
 ---
 title: Expect
 slug: Web/HTTP/Headers/Expect
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Expect
 ---
 

--- a/files/en-us/web/http/headers/expires/index.md
+++ b/files/en-us/web/http/headers/expires/index.md
@@ -1,11 +1,6 @@
 ---
 title: Expires
 slug: Web/HTTP/Headers/Expires
-tags:
-  - Caching
-  - HTTP
-  - Response
-  - header
 browser-compat: http.headers.Expires
 ---
 

--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -1,12 +1,6 @@
 ---
 title: Forwarded
 slug: Web/HTTP/Headers/Forwarded
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - header
 browser-compat: http.headers.Forwarded
 ---
 

--- a/files/en-us/web/http/headers/from/index.md
+++ b/files/en-us/web/http/headers/from/index.md
@@ -1,10 +1,6 @@
 ---
 title: From
 slug: Web/HTTP/Headers/From
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.From
 ---
 

--- a/files/en-us/web/http/headers/host/index.md
+++ b/files/en-us/web/http/headers/host/index.md
@@ -1,10 +1,6 @@
 ---
 title: Host
 slug: Web/HTTP/Headers/Host
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Host
 ---
 

--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -1,12 +1,6 @@
 ---
 title: If-Match
 slug: Web/HTTP/Headers/If-Match
-tags:
-  - Conditional Requests
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.If-Match
 ---
 

--- a/files/en-us/web/http/headers/if-modified-since/index.md
+++ b/files/en-us/web/http/headers/if-modified-since/index.md
@@ -1,12 +1,6 @@
 ---
 title: If-Modified-Since
 slug: Web/HTTP/Headers/If-Modified-Since
-tags:
-  - Conditional Requests
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.If-Modified-Since
 ---
 

--- a/files/en-us/web/http/headers/if-none-match/index.md
+++ b/files/en-us/web/http/headers/if-none-match/index.md
@@ -1,12 +1,6 @@
 ---
 title: If-None-Match
 slug: Web/HTTP/Headers/If-None-Match
-tags:
-  - Conditional Requests
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.If-None-Match
 ---
 

--- a/files/en-us/web/http/headers/if-range/index.md
+++ b/files/en-us/web/http/headers/if-range/index.md
@@ -1,13 +1,6 @@
 ---
 title: If-Range
 slug: Web/HTTP/Headers/If-Range
-tags:
-  - Conditional Requests
-  - HTTP
-  - HTTP Header
-  - Range Requests
-  - Reference
-  - Request header
 browser-compat: http.headers.If-Range
 ---
 

--- a/files/en-us/web/http/headers/if-unmodified-since/index.md
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.md
@@ -1,11 +1,6 @@
 ---
 title: If-Unmodified-Since
 slug: Web/HTTP/Headers/If-Unmodified-Since
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.If-Unmodified-Since
 ---
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTTP headers
 slug: Web/HTTP/Headers
-tags:
-  - HTTP
-  - HTTP Header
-  - Headers
-  - Networking
-  - Overview
-  - Reference
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/keep-alive/index.md
+++ b/files/en-us/web/http/headers/keep-alive/index.md
@@ -1,12 +1,6 @@
 ---
 title: Keep-Alive
 slug: Web/HTTP/Headers/Keep-Alive
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
 browser-compat: http.headers.Keep-Alive
 ---
 

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -1,14 +1,9 @@
 ---
 title: Large-Allocation
 slug: Web/HTTP/Headers/Large-Allocation
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
-  - Deprecated
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.Large-Allocation
 ---
 

--- a/files/en-us/web/http/headers/last-modified/index.md
+++ b/files/en-us/web/http/headers/last-modified/index.md
@@ -1,11 +1,6 @@
 ---
 title: Last-Modified
 slug: Web/HTTP/Headers/Last-Modified
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
 browser-compat: http.headers.Last-Modified
 ---
 

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -1,15 +1,6 @@
 ---
 title: Link
 slug: Web/HTTP/Headers/Link
-tags:
-  - Draft
-  - HTTP
-  - HTTP Header
-  - Link
-  - NeedsCompatTable
-  - NeedsContent
-  - NeedsSyntax
-  - Reference
 browser-compat: http.headers.Link
 ---
 

--- a/files/en-us/web/http/headers/location/index.md
+++ b/files/en-us/web/http/headers/location/index.md
@@ -1,11 +1,6 @@
 ---
 title: Location
 slug: Web/HTTP/Headers/Location
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
 browser-compat: http.headers.Location
 ---
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -1,11 +1,6 @@
 ---
 title: Max-Forwards
 slug: Web/HTTP/Headers/Max-Forwards
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.max-forwards
 ---
 

--- a/files/en-us/web/http/headers/nel/index.md
+++ b/files/en-us/web/http/headers/nel/index.md
@@ -1,14 +1,8 @@
 ---
 title: NEL
 slug: Web/HTTP/Headers/NEL
-tags:
-  - HTTP
-  - HTTP Header
-  - Network Error Logging
-  - Reference
-  - Response Header
-  - header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.NEL
 ---
 

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -1,12 +1,6 @@
 ---
 title: Origin
 slug: Web/HTTP/Headers/Origin
-tags:
-  - HTTP
-  - Reference
-  - Request header
-  - header
-  - origin
 browser-compat: http.headers.Origin
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/accelerometer/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/accelerometer/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: accelerometer"
 slug: Web/HTTP/Headers/Permissions-Policy/accelerometer
-tags:
-  - Accelerometer
-  - Directive
-  - Permissions Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.accelerometer
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/ambient-light-sensor/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/ambient-light-sensor/index.md
@@ -1,11 +1,8 @@
 ---
 title: "Permissions-Policy: ambient-light-sensor"
 slug: Web/HTTP/Headers/Permissions-Policy/ambient-light-sensor
-tags:
-  - Ambient Light Sensor
-  - Permissions Policy
-  - HTTP
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.ambient-light-sensor
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/autoplay/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/autoplay/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: autoplay"
 slug: Web/HTTP/Headers/Permissions-Policy/autoplay
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - autoplay
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.autoplay
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/battery/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/battery/index.md
@@ -1,11 +1,8 @@
 ---
 title: "Permissions-Policy: battery"
 slug: Web/HTTP/Headers/Permissions-Policy/battery
-tags:
-  - Battery
-  - Permissions Policy
-  - HTTP
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.battery
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/camera/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/camera/index.md
@@ -1,13 +1,6 @@
 ---
 title: "Permissions-Policy: camera"
 slug: Web/HTTP/Headers/Permissions-Policy/camera
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - camera
 browser-compat: http.headers.Permissions-Policy.camera
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/display-capture/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/display-capture/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Permissions-Policy: display-capture"
 slug: Web/HTTP/Headers/Permissions-Policy/display-capture
-tags:
-  - Directive
-  - Permissions Policy
-  - HTTP
-  - Reference
-  - display-capture
 browser-compat: http.headers.Permissions-Policy.display-capture
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/document-domain/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/document-domain/index.md
@@ -1,15 +1,8 @@
 ---
 title: "Permissions-Policy: document-domain"
 slug: Web/HTTP/Headers/Permissions-Policy/document-domain
-tags:
-  - Directive
-  - Experimental
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - document-domain
-  - Header
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.document-domain
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/encrypted-media/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/encrypted-media/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: encrypted-media"
 slug: Web/HTTP/Headers/Permissions-Policy/encrypted-media
-tags:
-  - Directive
-  - EME
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.encrypted-media
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/execution-while-not-rendered/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/execution-while-not-rendered/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: execution-while-not-rendered"
 slug: Web/HTTP/Headers/Permissions-Policy/execution-while-not-rendered
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.execution-while-not-rendered
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/execution-while-out-of-viewport/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/execution-while-out-of-viewport/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: execution-while-out-of-viewport"
 slug: Web/HTTP/Headers/Permissions-Policy/execution-while-out-of-viewport
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.execution-while-out-of-viewport
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/fullscreen/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/fullscreen/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Permissions-Policy: fullscreen"
 slug: Web/HTTP/Headers/Permissions-Policy/fullscreen
-tags:
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - fullscreen
-  - header
 browser-compat: http.headers.Permissions-Policy.fullscreen
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/gamepad/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/gamepad/index.md
@@ -1,12 +1,8 @@
 ---
 title: "Permissions-Policy: gamepad"
 slug: Web/HTTP/Headers/Permissions-Policy/gamepad
-tags:
-  - Permissions Policy
-  - Gamepad
-  - HTTP
-  - header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.gamepad
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/geolocation/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/geolocation/index.md
@@ -1,11 +1,6 @@
 ---
 title: "Permissions-Policy: geolocation"
 slug: Web/HTTP/Headers/Permissions-Policy/geolocation
-tags:
-  - Permissions Policy
-  - Geolocation
-  - HTTP
-  - header
 browser-compat: http.headers.Permissions-Policy.geolocation
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/gyroscope/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/gyroscope/index.md
@@ -1,12 +1,8 @@
 ---
 title: "Permissions-Policy: gyroscope"
 slug: Web/HTTP/Headers/Permissions-Policy/gyroscope
-tags:
-  - Permissions Policy
-  - gyroscope
-  - HTTP
-  - header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.gyroscope
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/hid/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/hid/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: hid"
 slug: Web/HTTP/Headers/Permissions-Policy/hid
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.hid
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/idle-detection/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/idle-detection/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: idle-detection"
 slug: Web/HTTP/Headers/Permissions-Policy/idle-detection
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.idle-detection
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -1,15 +1,6 @@
 ---
 title: Permissions-Policy
 slug: Web/HTTP/Headers/Permissions-Policy
-tags:
-  - Authorization
-  - Permissions-Policy
-  - HTTP
-  - Permissions
-  - Reference
-  - Security
-  - Web
-  - header
 browser-compat: http.headers.Permissions-Policy
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/local-fonts/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/local-fonts/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: local-fonts"
 slug: Web/HTTP/Headers/Permissions-Policy/local-fonts
-tags:
-  - Directive
-  - Permissions-Policy
-  - HTTP
-  - local-fonts
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.local-fonts
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/magnetometer/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/magnetometer/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: magnetometer"
 slug: Web/HTTP/Headers/Permissions-Policy/magnetometer
-tags:
-  - Directive
-  - Permissions-Policy
-  - HTTP
-  - Magnetometer
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.magnetometer
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/microphone/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/microphone/index.md
@@ -1,12 +1,6 @@
 ---
 title: "Permissions-Policy: microphone"
 slug: Web/HTTP/Headers/Permissions-Policy/microphone
-tags:
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - header
-  - microphone
 browser-compat: http.headers.Permissions-Policy.microphone
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/midi/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/midi/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: midi"
 slug: Web/HTTP/Headers/Permissions-Policy/midi
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - MIDI
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.midi
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/payment/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/payment/index.md
@@ -1,15 +1,8 @@
 ---
 title: "Permissions-Policy: payment"
 slug: Web/HTTP/Headers/Permissions-Policy/payment
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Payment Request API
-  - Payments API
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.payment
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/picture-in-picture/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/picture-in-picture/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: picture-in-picture"
 slug: Web/HTTP/Headers/Permissions-Policy/picture-in-picture
-tags:
-  - Directive
-  - Permissions-Policy
-  - HTTP
-  - Picture in picture
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.picture-in-picture
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: publickey-credentials-get"
 slug: Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get
-tags:
-  - Directive
-  - Permissions-Policy
-  - HTTP
-  - publickey-credentials-get
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.publickey-credentials-get
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/screen-wake-lock/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/screen-wake-lock/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: screen-wake-lock"
 slug: Web/HTTP/Headers/Permissions-Policy/screen-wake-lock
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - screen-wake-lock
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.screen-wake-lock
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/serial/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/serial/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: serial"
 slug: Web/HTTP/Headers/Permissions-Policy/serial
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.serial
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/speaker-selection/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/speaker-selection/index.md
@@ -1,13 +1,8 @@
 ---
 title: "Permissions-Policy: speaker-selection"
 slug: Web/HTTP/Headers/Permissions-Policy/speaker-selection
-tags:
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - header
-  - microphone
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.speaker-selection
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/usb/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/usb/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: usb"
 slug: Web/HTTP/Headers/Permissions-Policy/usb
-tags:
-  - Directive
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - Vibration API
-  - Web USB
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.usb
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/web-share/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/web-share/index.md
@@ -1,10 +1,6 @@
 ---
 title: "Permissions-Policy: web-share"
 slug: Web/HTTP/Headers/Permissions-Policy/web-share
-tags:
-  - Permissions-Policy
-  - HTTP
-  - Web Share
 browser-compat: http.headers.Permissions-Policy.web-share
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/xr-spatial-tracking/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/xr-spatial-tracking/index.md
@@ -1,14 +1,8 @@
 ---
 title: "Permissions-Policy: xr-spatial-tracking"
 slug: Web/HTTP/Headers/Permissions-Policy/xr-spatial-tracking
-tags:
-  - Directive
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Reference
-  - xr-spatial-tracking
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Permissions-Policy.xr-spatial-tracking
 ---
 

--- a/files/en-us/web/http/headers/pragma/index.md
+++ b/files/en-us/web/http/headers/pragma/index.md
@@ -1,13 +1,8 @@
 ---
 title: Pragma
 slug: Web/HTTP/Headers/Pragma
-tags:
-  - Caching
-  - Deprecated
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
+status:
+  - deprecated
 browser-compat: http.headers.Pragma
 ---
 

--- a/files/en-us/web/http/headers/proxy-authenticate/index.md
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.md
@@ -1,12 +1,6 @@
 ---
 title: Proxy-Authenticate
 slug: Web/HTTP/Headers/Proxy-Authenticate
-tags:
-  - HTTP
-  - HTTP Header
-  - Proxy
-  - Reference
-  - Response Header
 browser-compat: http.headers.Proxy-Authenticate
 ---
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -1,12 +1,6 @@
 ---
 title: Proxy-Authorization
 slug: Web/HTTP/Headers/Proxy-Authorization
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - header
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.proxy-authorization
 ---
 

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -1,12 +1,6 @@
 ---
 title: Range
 slug: Web/HTTP/Headers/Range
-tags:
-  - HTTP
-  - HTTP Header
-  - Range Requests
-  - Reference
-  - Request header
 browser-compat: http.headers.Range
 ---
 

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -1,12 +1,6 @@
 ---
 title: Referer
 slug: Web/HTTP/Headers/Referer
-tags:
-  - HTTP
-  - Reference
-  - header
-  - referer
-  - referrer
 browser-compat: http.headers.Referer
 ---
 

--- a/files/en-us/web/http/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/headers/referrer-policy/index.md
@@ -1,15 +1,6 @@
 ---
 title: Referrer-Policy
 slug: Web/HTTP/Headers/Referrer-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Privacy
-  - Reference
-  - Referrer-Policy
-  - Response
-  - Response Header
-  - referrer
 browser-compat: http.headers.Referrer-Policy
 ---
 

--- a/files/en-us/web/http/headers/retry-after/index.md
+++ b/files/en-us/web/http/headers/retry-after/index.md
@@ -1,12 +1,6 @@
 ---
 title: Retry-After
 slug: Web/HTTP/Headers/Retry-After
-tags:
-  - HTTP
-  - Reference
-  - Response
-  - Response Header
-  - header
 browser-compat: http.headers.Retry-After
 ---
 

--- a/files/en-us/web/http/headers/rtt/index.md
+++ b/files/en-us/web/http/headers/rtt/index.md
@@ -1,14 +1,8 @@
 ---
 title: RTT
 slug: Web/HTTP/Headers/RTT
-tags:
-  - RTT
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Client hints
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.rtt
 ---
 

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -1,14 +1,8 @@
 ---
 title: Save-Data
 slug: Web/HTTP/Headers/Save-Data
-tags:
-  - Save-Data
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Save-Data
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-Prefers-Reduced-Motion
 slug: Web/HTTP/Headers/Sec-CH-Prefers-Reduced-Motion
-tags:
-  - Sec-CH-Prefers-Reduced-Motion
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-Prefers-Reduced-Motion
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Arch
 slug: Web/HTTP/Headers/Sec-CH-UA-Arch
-tags:
-  - Sec-CH-UA-Arch
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Arch
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Bitness
 slug: Web/HTTP/Headers/Sec-CH-UA-Bitness
-tags:
-  - Sec-CH-UA-Bitness
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Bitness
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Full-Version-List
 slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version-List
-tags:
-  - Sec-CH-UA-Full-Version-List
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Full-Version-List
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Full-Version
 slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version
-tags:
-  - Sec-CH-UA-Full-Version
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Deprecated
+status:
+  - deprecated
 browser-compat: http.headers.Sec-CH-UA-Full-Version
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Mobile
 slug: Web/HTTP/Headers/Sec-CH-UA-Mobile
-tags:
-  - Sec-CH-UA-Mobile
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Mobile
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Model
 slug: Web/HTTP/Headers/Sec-CH-UA-Model
-tags:
-  - Sec-CH-UA-Model
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Model
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Platform-Version
 slug: Web/HTTP/Headers/Sec-CH-UA-Platform-Version
-tags:
-  - Sec-CH-UA-Platform-Version
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Platform-Version
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA-Platform
 slug: Web/HTTP/Headers/Sec-CH-UA-Platform
-tags:
-  - Sec-CH-UA-Platform
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA-Platform
 ---
 

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -1,14 +1,8 @@
 ---
 title: Sec-CH-UA
 slug: Web/HTTP/Headers/Sec-CH-UA
-tags:
-  - Sec-CH-UA
-  - Client hint
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.Sec-CH-UA
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.md
@@ -1,13 +1,6 @@
 ---
 title: Sec-Fetch-Dest
 slug: Web/HTTP/Headers/Sec-Fetch-Dest
-tags:
-  - Sec-Fetch-Dest
-  - Fetch Metadata Request Headers
-  - HTTP
-  - HTTP Headers
-  - Reference
-  - Request header
 browser-compat: http.headers.Sec-Fetch-Dest
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-mode/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Sec-Fetch-Mode
 slug: Web/HTTP/Headers/Sec-Fetch-Mode
-tags:
-  - Sec-Fetch-Mode
-  - Fetch Metadata Request Headers
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Sec-Fetch-Mode
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-site/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-site/index.md
@@ -1,13 +1,6 @@
 ---
 title: Sec-Fetch-Site
 slug: Web/HTTP/Headers/Sec-Fetch-Site
-tags:
-  - Sec-Fetch-Site
-  - Fetch Metadata Request Headers
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Sec-Fetch-Site
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-user/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-user/index.md
@@ -1,13 +1,6 @@
 ---
 title: Sec-Fetch-User
 slug: Web/HTTP/Headers/Sec-Fetch-User
-tags:
-  - Sec-Fetch-User
-  - Fetch metadata request headers
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
 browser-compat: http.headers.Sec-Fetch-User
 ---
 

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -1,13 +1,9 @@
 ---
 title: Sec-GPC
 slug: Web/HTTP/Headers/Sec-GPC
-tags:
-  - GPC
-  - HTTP
-  - Reference
-  - header
-  - Experimental
-  - Non-standard
+status:
+  - experimental
+  - non-standard
 browser-compat: http.headers.Sec-GPC
 ---
 

--- a/files/en-us/web/http/headers/sec-websocket-accept/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.md
@@ -1,15 +1,6 @@
 ---
 title: Sec-WebSocket-Accept
 slug: Web/HTTP/Headers/Sec-WebSocket-Accept
-tags:
-  - Draft
-  - HTTP
-  - NeedsCompatTable
-  - NeedsContent
-  - Reference
-  - Sec-WebSocket-Accept
-  - WebSockets
-  - header
 browser-compat: http.headers.Sec-WebSocket-Accept
 ---
 

--- a/files/en-us/web/http/headers/server-timing/index.md
+++ b/files/en-us/web/http/headers/server-timing/index.md
@@ -1,11 +1,6 @@
 ---
 title: Server-Timing
 slug: Web/HTTP/Headers/Server-Timing
-tags:
-  - HTTP
-  - Performance
-  - Reference
-  - header
 browser-compat: http.headers.Server-Timing
 ---
 

--- a/files/en-us/web/http/headers/server/index.md
+++ b/files/en-us/web/http/headers/server/index.md
@@ -1,10 +1,6 @@
 ---
 title: Server
 slug: Web/HTTP/Headers/Server
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.Server
 ---
 

--- a/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
+++ b/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
@@ -1,12 +1,6 @@
 ---
 title: Service-Worker-Navigation-Preload
 slug: Web/HTTP/Headers/Service-Worker-Navigation-Preload
-tags:
-  - HTTP
-  - Reference
-  - Request header
-  - header
-  - NavigationPreloadManager
 browser-compat: http.headers.Service-Worker-Navigation-Preload
 ---
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -1,13 +1,6 @@
 ---
 title: Set-Cookie
 slug: Web/HTTP/Headers/Set-Cookie
-tags:
-  - Cookies
-  - HTTP
-  - Reference
-  - Response
-  - header
-  - samesite
 browser-compat: http.headers.Set-Cookie
 ---
 

--- a/files/en-us/web/http/headers/set-cookie/samesite/index.md
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.md
@@ -1,11 +1,6 @@
 ---
 title: SameSite cookies
 slug: Web/HTTP/Headers/Set-Cookie/SameSite
-tags:
-  - Cookies
-  - HTTP
-  - Reference
-  - samesite
 browser-compat: http.headers.Set-Cookie.SameSite
 ---
 

--- a/files/en-us/web/http/headers/sourcemap/index.md
+++ b/files/en-us/web/http/headers/sourcemap/index.md
@@ -1,12 +1,6 @@
 ---
 title: SourceMap
 slug: Web/HTTP/Headers/SourceMap
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
 browser-compat: http.headers.SourceMap
 ---
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -1,12 +1,6 @@
 ---
 title: Strict-Transport-Security
 slug: Web/HTTP/Headers/Strict-Transport-Security
-tags:
-  - HSTS
-  - HTTP
-  - HTTPS
-  - Security
-  - header
 browser-compat: http.headers.Strict-Transport-Security
 ---
 

--- a/files/en-us/web/http/headers/te/index.md
+++ b/files/en-us/web/http/headers/te/index.md
@@ -1,10 +1,6 @@
 ---
 title: TE
 slug: Web/HTTP/Headers/TE
-tags:
-  - HTTP
-  - Reference
-  - header
 browser-compat: http.headers.TE
 ---
 

--- a/files/en-us/web/http/headers/timing-allow-origin/index.md
+++ b/files/en-us/web/http/headers/timing-allow-origin/index.md
@@ -1,12 +1,6 @@
 ---
 title: Timing-Allow-Origin
 slug: Web/HTTP/Headers/Timing-Allow-Origin
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - Timing-Allow-Origin
-  - header
 browser-compat: http.headers.Timing-Allow-Origin
 ---
 

--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -1,14 +1,8 @@
 ---
 title: Tk
 slug: Web/HTTP/Headers/Tk
-tags:
-  - DNT
-  - HTTP
-  - Reference
-  - Response
-  - header
-  - tracking
-  - Deprecated
+status:
+  - deprecated
 browser-compat: http.headers.Tk
 ---
 

--- a/files/en-us/web/http/headers/trailer/index.md
+++ b/files/en-us/web/http/headers/trailer/index.md
@@ -1,12 +1,6 @@
 ---
 title: Trailer
 slug: Web/HTTP/Headers/Trailer
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Payload header
 browser-compat: http.headers.Trailer
 ---
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -1,13 +1,6 @@
 ---
 title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
-  - Payload header
 browser-compat: http.headers.Transfer-Encoding
 ---
 

--- a/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
@@ -1,11 +1,6 @@
 ---
 title: Upgrade-Insecure-Requests
 slug: Web/HTTP/Headers/Upgrade-Insecure-Requests
-tags:
-  - HTTP
-  - HTTPS
-  - Security
-  - header
 browser-compat: http.headers.Upgrade-Insecure-Requests
 ---
 

--- a/files/en-us/web/http/headers/upgrade/index.md
+++ b/files/en-us/web/http/headers/upgrade/index.md
@@ -1,12 +1,6 @@
 ---
 title: Upgrade
 slug: Web/HTTP/Headers/Upgrade
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Upgrade
 browser-compat: http.headers.Upgrade
 ---
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -1,13 +1,6 @@
 ---
 title: Firefox user agent string reference
 slug: Web/HTTP/Headers/User-Agent/Firefox
-tags:
-  - Compatibility
-  - Firefox
-  - Firefox 4
-  - Gecko
-  - Gecko 2.0
-  - Guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/user-agent/index.md
+++ b/files/en-us/web/http/headers/user-agent/index.md
@@ -1,11 +1,6 @@
 ---
 title: User-Agent
 slug: Web/HTTP/Headers/User-Agent
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - User-agent
 browser-compat: http.headers.User-Agent
 ---
 

--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -1,12 +1,6 @@
 ---
 title: Vary
 slug: Web/HTTP/Headers/Vary
-tags:
-  - HTTP
-  - Reference
-  - Response
-  - Response Header
-  - header
 browser-compat: http.headers.Vary
 ---
 

--- a/files/en-us/web/http/headers/via/index.md
+++ b/files/en-us/web/http/headers/via/index.md
@@ -1,12 +1,6 @@
 ---
 title: Via
 slug: Web/HTTP/Headers/Via
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Reference
 browser-compat: http.headers.Via
 ---
 

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -1,14 +1,9 @@
 ---
 title: Viewport-Width
 slug: Web/HTTP/Headers/Viewport-Width
-tags:
-  - Viewport-Width
-  - Client hints
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Deprecated
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.Viewport-Width
 ---
 

--- a/files/en-us/web/http/headers/want-digest/index.md
+++ b/files/en-us/web/http/headers/want-digest/index.md
@@ -1,11 +1,6 @@
 ---
 title: Want-Digest
 slug: Web/HTTP/Headers/Want-Digest
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
 browser-compat: http.headers.Want-Digest
 ---
 

--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -1,13 +1,8 @@
 ---
 title: Warning
 slug: Web/HTTP/Headers/Warning
-tags:
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Response header
-  - Deprecated
-  - Reference
+status:
+  - deprecated
 browser-compat: http.headers.Warning
 ---
 

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -1,15 +1,9 @@
 ---
 title: Width
 slug: Web/HTTP/Headers/Width
-tags:
-  - Width
-  - Client hints
-  - Device Memory API
-  - HTTP
-  - HTTP Header
-  - Request header
-  - Deprecated
-  - Non-standard
+status:
+  - deprecated
+  - non-standard
 browser-compat: http.headers.Width
 ---
 

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -1,14 +1,6 @@
 ---
 title: WWW-Authenticate
 slug: Web/HTTP/Headers/WWW-Authenticate
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - Header
-  - WWW-Authenticate
-  - Authentication
 browser-compat: http.headers.WWW-Authenticate
 ---
 

--- a/files/en-us/web/http/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/headers/x-content-type-options/index.md
@@ -1,11 +1,6 @@
 ---
 title: X-Content-Type-Options
 slug: Web/HTTP/Headers/X-Content-Type-Options
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
 browser-compat: http.headers.X-Content-Type-Options
 ---
 

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -1,12 +1,8 @@
 ---
 title: X-DNS-Prefetch-Control
 slug: Web/HTTP/Headers/X-DNS-Prefetch-Control
-tags:
-  - DNS
-  - HTTP
-  - X-DNS-Prefetch-Control
-  - header
-  - Non-standard
+status:
+  - non-standard
 browser-compat: http.headers.X-DNS-Prefetch-Control
 ---
 

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -1,13 +1,8 @@
 ---
 title: X-Forwarded-For
 slug: Web/HTTP/Headers/X-Forwarded-For
-tags:
-  - HTTP
-  - HTTP Header
-  - Non-standard
-  - Reference
-  - Request header
-  - header
+status:
+  - non-standard
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/x-forwarded-host/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.md
@@ -1,13 +1,8 @@
 ---
 title: X-Forwarded-Host
 slug: Web/HTTP/Headers/X-Forwarded-Host
-tags:
-  - HTTP
-  - HTTP Header
-  - Non-standard
-  - Reference
-  - Request header
-  - header
+status:
+  - non-standard
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/x-forwarded-proto/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-proto/index.md
@@ -1,13 +1,8 @@
 ---
 title: X-Forwarded-Proto
 slug: Web/HTTP/Headers/X-Forwarded-Proto
-tags:
-  - HTTP
-  - HTTP Header
-  - Non-standard
-  - Reference
-  - Request header
-  - header
+status:
+  - non-standard
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -1,13 +1,6 @@
 ---
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
-tags:
-  - Gecko
-  - HAProxy
-  - HTTP
-  - Response Header
-  - Security
-  - nginx
 browser-compat: http.headers.X-Frame-Options
 ---
 

--- a/files/en-us/web/http/headers/x-xss-protection/index.md
+++ b/files/en-us/web/http/headers/x-xss-protection/index.md
@@ -1,13 +1,8 @@
 ---
 title: X-XSS-Protection
 slug: Web/HTTP/Headers/X-XSS-Protection
-tags:
-  - HTTP
-  - Reference
-  - Security
-  - XSS
-  - header
-  - Non-standard
+status:
+  - non-standard
 browser-compat: http.headers.X-XSS-Protection
 ---
 


### PR DESCRIPTION
This removes tags on all the HTTP header docs. It is part of https://github.com/mdn/mdn/issues/262



