### PR TITLE
HTTP Status: Remove tags/add status where necessary

### DIFF
--- a/files/en-us/mozilla/add-ons/contact_us/index.md
+++ b/files/en-us/mozilla/add-ons/contact_us/index.md
@@ -2,12 +2,6 @@
 title: Contact us
 slug: Mozilla/Add-ons/Contact_us
 page-type: guide
-tags:
-  - Add-ons
-  - Extension
-  - Extensions
-  - Landing
-  - Mozilla
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/index.md
+++ b/files/en-us/mozilla/add-ons/index.md
@@ -1,12 +1,6 @@
 ---
 title: Add-ons
 slug: Mozilla/Add-ons
-tags:
-  - Add-ons
-  - Extension
-  - Extensions
-  - Landing
-  - Mozilla
 ---
 
 {{AddonSidebarMain}}

--- a/files/en-us/web/http/status/100/index.md
+++ b/files/en-us/web/http/status/100/index.md
@@ -1,10 +1,6 @@
 ---
 title: 100 Continue
 slug: Web/HTTP/Status/100
-tags:
-  - HTTP
-  - Informational
-  - Status code
 browser-compat: http.status.100
 ---
 

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -1,12 +1,6 @@
 ---
 title: 101 Switching Protocols
 slug: Web/HTTP/Status/101
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Informational
-  - Reference
-  - WebSockets
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.101
 ---
 

--- a/files/en-us/web/http/status/102/index.md
+++ b/files/en-us/web/http/status/102/index.md
@@ -1,10 +1,6 @@
 ---
 title: 102 Processing
 slug: Web/HTTP/Status/102
-tags:
-  - HTTP
-  - Informational
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2518.html#section-10.1
 ---
 

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -1,14 +1,8 @@
 ---
 title: 103 Early Hints
 slug: Web/HTTP/Status/103
-tags:
-  - Draft
-  - HTTP
-  - Informational
-  - NeedsCompatTable
-  - NeedsContent
-  - Status code
-  - Experimental
+status:
+  - experimental
 browser-compat: http.status.103
 ---
 

--- a/files/en-us/web/http/status/200/index.md
+++ b/files/en-us/web/http/status/200/index.md
@@ -1,10 +1,6 @@
 ---
 title: 200 OK
 slug: Web/HTTP/Status/200
-tags:
-  - HTTP
-  - Status code
-  - Success
 browser-compat: http.status.200
 ---
 

--- a/files/en-us/web/http/status/201/index.md
+++ b/files/en-us/web/http/status/201/index.md
@@ -1,11 +1,6 @@
 ---
 title: 201 Created
 slug: Web/HTTP/Status/201
-tags:
-  - HTTP
-  - Reference
-  - Status code
-  - Success
 browser-compat: http.status.201
 ---
 

--- a/files/en-us/web/http/status/202/index.md
+++ b/files/en-us/web/http/status/202/index.md
@@ -1,11 +1,6 @@
 ---
 title: 202 Accepted
 slug: Web/HTTP/Status/202
-tags:
-  - HTTP
-  - Reference
-  - Status code
-  - Success response
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.202
 ---
 

--- a/files/en-us/web/http/status/203/index.md
+++ b/files/en-us/web/http/status/203/index.md
@@ -1,12 +1,6 @@
 ---
 title: 203 Non-Authoritative Information
 slug: Web/HTTP/Status/203
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
-  - Successful response
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.203
 ---
 

--- a/files/en-us/web/http/status/204/index.md
+++ b/files/en-us/web/http/status/204/index.md
@@ -1,11 +1,6 @@
 ---
 title: 204 No Content
 slug: Web/HTTP/Status/204
-tags:
-  - HTTP
-  - Reference
-  - Status code
-  - Success
 browser-compat: http.status.204
 ---
 

--- a/files/en-us/web/http/status/205/index.md
+++ b/files/en-us/web/http/status/205/index.md
@@ -1,11 +1,6 @@
 ---
 title: 205 Reset Content
 slug: Web/HTTP/Status/205
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.205
 ---
 

--- a/files/en-us/web/http/status/206/index.md
+++ b/files/en-us/web/http/status/206/index.md
@@ -1,11 +1,6 @@
 ---
 title: 206 Partial Content
 slug: Web/HTTP/Status/206
-tags:
-  - HTTP
-  - HTTP Status
-  - Range Requests
-  - Success
 browser-compat: http.status.206
 ---
 

--- a/files/en-us/web/http/status/207/index.md
+++ b/files/en-us/web/http/status/207/index.md
@@ -1,10 +1,6 @@
 ---
 title: 207 Multi-Status
 slug: Web/HTTP/Status/207
-tags:
-  - HTTP
-  - Status code
-  - Partial Success
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.1
 ---
 

--- a/files/en-us/web/http/status/208/index.md
+++ b/files/en-us/web/http/status/208/index.md
@@ -1,10 +1,6 @@
 ---
 title: 208 Already Reported
 slug: Web/HTTP/Status/208
-tags:
-  - HTTP
-  - Status code
-  - Reported
 spec-urls: https://www.rfc-editor.org/rfc/rfc5842.html#section-7.1
 ---
 

--- a/files/en-us/web/http/status/226/index.md
+++ b/files/en-us/web/http/status/226/index.md
@@ -1,10 +1,6 @@
 ---
 title: 226 IM Used
 slug: Web/HTTP/Status/226
-tags:
-  - HTTP
-  - Status code
-  - Used
 spec-urls: https://www.rfc-editor.org/rfc/rfc3229.html#section-10.4.1
 ---
 

--- a/files/en-us/web/http/status/300/index.md
+++ b/files/en-us/web/http/status/300/index.md
@@ -1,11 +1,6 @@
 ---
 title: 300 Multiple Choices
 slug: Web/HTTP/Status/300
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.300
 ---
 

--- a/files/en-us/web/http/status/301/index.md
+++ b/files/en-us/web/http/status/301/index.md
@@ -1,11 +1,6 @@
 ---
 title: 301 Moved Permanently
 slug: Web/HTTP/Status/301
-tags:
-  - HTTP
-  - Redirect
-  - Reference
-  - Status code
 browser-compat: http.status.301
 ---
 

--- a/files/en-us/web/http/status/302/index.md
+++ b/files/en-us/web/http/status/302/index.md
@@ -1,11 +1,6 @@
 ---
 title: 302 Found
 slug: Web/HTTP/Status/302
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
 browser-compat: http.status.302
 ---
 

--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -1,11 +1,6 @@
 ---
 title: 303 See Other
 slug: Web/HTTP/Status/303
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
 browser-compat: http.status.303
 ---
 

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -1,11 +1,6 @@
 ---
 title: 304 Not Modified
 slug: Web/HTTP/Status/304
-tags:
-  - HTTP
-  - Redirection
-  - Reference
-  - Status code
 browser-compat: http.status.304
 ---
 

--- a/files/en-us/web/http/status/307/index.md
+++ b/files/en-us/web/http/status/307/index.md
@@ -1,11 +1,6 @@
 ---
 title: 307 Temporary Redirect
 slug: Web/HTTP/Status/307
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
 browser-compat: http.status.307
 ---
 

--- a/files/en-us/web/http/status/308/index.md
+++ b/files/en-us/web/http/status/308/index.md
@@ -1,11 +1,6 @@
 ---
 title: 308 Permanent Redirect
 slug: Web/HTTP/Status/308
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
 browser-compat: http.status.308
 ---
 

--- a/files/en-us/web/http/status/400/index.md
+++ b/files/en-us/web/http/status/400/index.md
@@ -1,12 +1,6 @@
 ---
 title: 400 Bad Request
 slug: Web/HTTP/Status/400
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.400
 ---
 

--- a/files/en-us/web/http/status/401/index.md
+++ b/files/en-us/web/http/status/401/index.md
@@ -1,11 +1,6 @@
 ---
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.401
 ---
 

--- a/files/en-us/web/http/status/402/index.md
+++ b/files/en-us/web/http/status/402/index.md
@@ -1,11 +1,6 @@
 ---
 title: 402 Payment Required
 slug: Web/HTTP/Status/402
-tags:
-  - Browser
-  - Client error
-  - HTTP
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.402
 ---
 

--- a/files/en-us/web/http/status/403/index.md
+++ b/files/en-us/web/http/status/403/index.md
@@ -1,11 +1,6 @@
 ---
 title: 403 Forbidden
 slug: Web/HTTP/Status/403
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.403
 ---
 

--- a/files/en-us/web/http/status/404/index.md
+++ b/files/en-us/web/http/status/404/index.md
@@ -1,11 +1,6 @@
 ---
 title: 404 Not Found
 slug: Web/HTTP/Status/404
-tags:
-  - Browser
-  - Client error
-  - HTTP
-  - Status code
 browser-compat: http.status.404
 ---
 

--- a/files/en-us/web/http/status/405/index.md
+++ b/files/en-us/web/http/status/405/index.md
@@ -1,12 +1,6 @@
 ---
 title: 405 Method Not Allowed
 slug: Web/HTTP/Status/405
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.405
 ---
 

--- a/files/en-us/web/http/status/406/index.md
+++ b/files/en-us/web/http/status/406/index.md
@@ -1,10 +1,6 @@
 ---
 title: 406 Not Acceptable
 slug: Web/HTTP/Status/406
-tags:
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.406
 ---
 

--- a/files/en-us/web/http/status/407/index.md
+++ b/files/en-us/web/http/status/407/index.md
@@ -1,11 +1,6 @@
 ---
 title: 407 Proxy Authentication Required
 slug: Web/HTTP/Status/407
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.407
 ---
 

--- a/files/en-us/web/http/status/408/index.md
+++ b/files/en-us/web/http/status/408/index.md
@@ -1,12 +1,6 @@
 ---
 title: 408 Request Timeout
 slug: Web/HTTP/Status/408
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.408
 ---
 

--- a/files/en-us/web/http/status/409/index.md
+++ b/files/en-us/web/http/status/409/index.md
@@ -1,11 +1,6 @@
 ---
 title: 409 Conflict
 slug: Web/HTTP/Status/409
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
 browser-compat: http.status.409
 ---
 

--- a/files/en-us/web/http/status/410/index.md
+++ b/files/en-us/web/http/status/410/index.md
@@ -1,11 +1,6 @@
 ---
 title: 410 Gone
 slug: Web/HTTP/Status/410
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.410
 ---
 

--- a/files/en-us/web/http/status/411/index.md
+++ b/files/en-us/web/http/status/411/index.md
@@ -1,12 +1,6 @@
 ---
 title: 411 Length Required
 slug: Web/HTTP/Status/411
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.411
 ---
 

--- a/files/en-us/web/http/status/412/index.md
+++ b/files/en-us/web/http/status/412/index.md
@@ -1,11 +1,6 @@
 ---
 title: 412 Precondition Failed
 slug: Web/HTTP/Status/412
-tags:
-  - Error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.412
 ---
 

--- a/files/en-us/web/http/status/413/index.md
+++ b/files/en-us/web/http/status/413/index.md
@@ -1,12 +1,6 @@
 ---
 title: 413 Content Too Large
 slug: Web/HTTP/Status/413
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.413
 ---
 

--- a/files/en-us/web/http/status/414/index.md
+++ b/files/en-us/web/http/status/414/index.md
@@ -1,11 +1,6 @@
 ---
 title: 414 URI Too Long
 slug: Web/HTTP/Status/414
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.414
 ---
 

--- a/files/en-us/web/http/status/415/index.md
+++ b/files/en-us/web/http/status/415/index.md
@@ -1,12 +1,6 @@
 ---
 title: 415 Unsupported Media Type
 slug: Web/HTTP/Status/415
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.415
 ---
 

--- a/files/en-us/web/http/status/416/index.md
+++ b/files/en-us/web/http/status/416/index.md
@@ -1,10 +1,6 @@
 ---
 title: 416 Range Not Satisfiable
 slug: Web/HTTP/Status/416
-tags:
-  - Client error
-  - HTTP
-  - Status code
 browser-compat: http.status.416
 ---
 

--- a/files/en-us/web/http/status/417/index.md
+++ b/files/en-us/web/http/status/417/index.md
@@ -1,12 +1,6 @@
 ---
 title: 417 Expectation Failed
 slug: Web/HTTP/Status/417
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.417
 ---
 

--- a/files/en-us/web/http/status/418/index.md
+++ b/files/en-us/web/http/status/418/index.md
@@ -1,10 +1,6 @@
 ---
 title: 418 I'm a teapot
 slug: Web/HTTP/Status/418
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
 browser-compat: http.status.418
 ---
 

--- a/files/en-us/web/http/status/421/index.md
+++ b/files/en-us/web/http/status/421/index.md
@@ -1,10 +1,6 @@
 ---
 title: 421 Misdirected Request
 slug: Web/HTTP/Status/421
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
 spec-urls: https://www.rfc-editor.org/rfc/rfc9110#name-421-misdirected-request
 ---
 

--- a/files/en-us/web/http/status/422/index.md
+++ b/files/en-us/web/http/status/422/index.md
@@ -1,13 +1,6 @@
 ---
 title: 422 Unprocessable Content
 slug: Web/HTTP/Status/422
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
-  - WebDAV
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.422
 ---
 

--- a/files/en-us/web/http/status/423/index.md
+++ b/files/en-us/web/http/status/423/index.md
@@ -1,11 +1,6 @@
 ---
 title: 423 Locked
 slug: Web/HTTP/Status/423
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Client Error
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.3
 ---
 

--- a/files/en-us/web/http/status/424/index.md
+++ b/files/en-us/web/http/status/424/index.md
@@ -1,11 +1,6 @@
 ---
 title: 424 Failed Dependency
 slug: Web/HTTP/Status/424
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Client Error
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.4
 ---
 

--- a/files/en-us/web/http/status/425/index.md
+++ b/files/en-us/web/http/status/425/index.md
@@ -1,11 +1,6 @@
 ---
 title: 425 Too Early
 slug: Web/HTTP/Status/425
-tags:
-  - Browser
-  - Client error
-  - HTTP
-  - Status code
 browser-compat: http.status.425
 ---
 

--- a/files/en-us/web/http/status/426/index.md
+++ b/files/en-us/web/http/status/426/index.md
@@ -1,12 +1,6 @@
 ---
 title: 426 Upgrade Required
 slug: Web/HTTP/Status/426
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.426
 ---
 

--- a/files/en-us/web/http/status/428/index.md
+++ b/files/en-us/web/http/status/428/index.md
@@ -1,12 +1,6 @@
 ---
 title: 428 Precondition Required
 slug: Web/HTTP/Status/428
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-3
 ---
 

--- a/files/en-us/web/http/status/429/index.md
+++ b/files/en-us/web/http/status/429/index.md
@@ -1,12 +1,6 @@
 ---
 title: 429 Too Many Requests
 slug: Web/HTTP/Status/429
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-4
 ---
 

--- a/files/en-us/web/http/status/431/index.md
+++ b/files/en-us/web/http/status/431/index.md
@@ -1,12 +1,6 @@
 ---
 title: 431 Request Header Fields Too Large
 slug: Web/HTTP/Status/431
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-5
 ---
 

--- a/files/en-us/web/http/status/451/index.md
+++ b/files/en-us/web/http/status/451/index.md
@@ -1,11 +1,6 @@
 ---
 title: 451 Unavailable For Legal Reasons
 slug: Web/HTTP/Status/451
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
 browser-compat: http.status.451
 ---
 

--- a/files/en-us/web/http/status/500/index.md
+++ b/files/en-us/web/http/status/500/index.md
@@ -1,10 +1,6 @@
 ---
 title: 500 Internal Server Error
 slug: Web/HTTP/Status/500
-tags:
-  - HTTP
-  - Server error
-  - Status code
 browser-compat: http.status.500
 ---
 

--- a/files/en-us/web/http/status/501/index.md
+++ b/files/en-us/web/http/status/501/index.md
@@ -1,10 +1,6 @@
 ---
 title: 501 Not Implemented
 slug: Web/HTTP/Status/501
-tags:
-  - HTTP
-  - Server error
-  - Status code
 browser-compat: http.status.501
 ---
 

--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -1,10 +1,6 @@
 ---
 title: 502 Bad Gateway
 slug: Web/HTTP/Status/502
-tags:
-  - HTTP
-  - Server error
-  - Status code
 browser-compat: http.status.502
 ---
 

--- a/files/en-us/web/http/status/503/index.md
+++ b/files/en-us/web/http/status/503/index.md
@@ -1,11 +1,6 @@
 ---
 title: 503 Service Unavailable
 slug: Web/HTTP/Status/503
-tags:
-  - 503 error
-  - HTTP
-  - Server error
-  - Status code
 browser-compat: http.status.503
 ---
 

--- a/files/en-us/web/http/status/504/index.md
+++ b/files/en-us/web/http/status/504/index.md
@@ -1,10 +1,6 @@
 ---
 title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
-tags:
-  - HTTP
-  - Server error
-  - Status code
 browser-compat: http.status.504
 ---
 

--- a/files/en-us/web/http/status/505/index.md
+++ b/files/en-us/web/http/status/505/index.md
@@ -1,11 +1,6 @@
 ---
 title: 505 HTTP Version Not Supported
 slug: Web/HTTP/Status/505
-tags:
-  - HTTP
-  - Reference
-  - Server error
-  - Status code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.505
 ---
 

--- a/files/en-us/web/http/status/506/index.md
+++ b/files/en-us/web/http/status/506/index.md
@@ -1,10 +1,6 @@
 ---
 title: 506 Variant Also Negotiates
 slug: Web/HTTP/Status/506
-tags:
-  - HTTP
-  - Server error
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2295#section-8.1
 ---
 

--- a/files/en-us/web/http/status/507/index.md
+++ b/files/en-us/web/http/status/507/index.md
@@ -1,10 +1,6 @@
 ---
 title: 507 Insufficient Storage
 slug: Web/HTTP/Status/507
-tags:
-  - HTTP
-  - Server error
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.5
 ---
 

--- a/files/en-us/web/http/status/508/index.md
+++ b/files/en-us/web/http/status/508/index.md
@@ -1,11 +1,6 @@
 ---
 title: 508 Loop Detected
 slug: Web/HTTP/Status/508
-tags:
-  - "508"
-  - HTTP
-  - Server error
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc5842#section-7.2
 ---
 

--- a/files/en-us/web/http/status/510/index.md
+++ b/files/en-us/web/http/status/510/index.md
@@ -1,10 +1,6 @@
 ---
 title: 510 Not Extended
 slug: Web/HTTP/Status/510
-tags:
-  - HTTP
-  - Server error
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2774#section-7
 ---
 

--- a/files/en-us/web/http/status/511/index.md
+++ b/files/en-us/web/http/status/511/index.md
@@ -1,12 +1,6 @@
 ---
 title: 511 Network Authentication Required
 slug: Web/HTTP/Status/511
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Server error
-  - Status code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-6
 ---
 

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTTP response status codes
 slug: Web/HTTP/Status
-tags:
-  - HTTP
-  - Landing
-  - Overview
-  - Reference
-  - Status code
-  - Web
 browser-compat: http.status
 ---
 


### PR DESCRIPTION
This removes tags/updates status on the HTTP status code pages.

It is part of https://github.com/mdn/mdn/issues/262