### PR TITLE
HTTP Leftovers: Remove tags/add status where necessary

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP authentication
 slug: Web/HTTP/Authentication
-tags:
-  - Access Control
-  - Authentication
-  - Guide
-  - HTTP
-  - Security
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -1,10 +1,6 @@
 ---
 title: Choosing between www and non-www URLs
 slug: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
-tags:
-  - Guide
-  - HTTP
-  - URL
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -1,12 +1,6 @@
 ---
 title: Data URLs
 slug: Web/HTTP/Basics_of_HTTP/Data_URLs
-tags:
-  - Base64
-  - Guide
-  - HTTP
-  - Intermediate
-  - URL
 browser-compat: http.data-url
 ---
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -1,11 +1,6 @@
 ---
 title: Evolution of HTTP
 slug: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
-tags:
-  - Guide
-  - HTTP
-  - NeedsUpdate
-  - NeedsUpdate(HTTP/3)
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -1,20 +1,6 @@
 ---
 title: Identifying resources on the Web
 slug: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
-tags:
-  - Domain
-  - HTTP
-  - Path
-  - Scheme
-  - Syntax
-  - URI
-  - URL
-  - URL Syntax
-  - Web
-  - fragment
-  - port
-  - query
-  - resources
 spec-urls: https://httpwg.org/specs/rfc9110.html#uri
 ---
 

--- a/files/en-us/web/http/basics_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/index.md
@@ -1,10 +1,6 @@
 ---
 title: Basics of HTTP
 slug: Web/HTTP/Basics_of_HTTP
-tags:
-  - Guide
-  - HTTP
-  - Overview
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/mime_types/common_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/common_types/index.md
@@ -1,18 +1,6 @@
 ---
 title: Common MIME types
 slug: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-tags:
-  - Audio
-  - File Types
-  - Files
-  - HTTP
-  - MIME
-  - MIME Types
-  - PHP
-  - Reference
-  - Text
-  - Types
-  - Video
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/mime_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.md
@@ -1,17 +1,6 @@
 ---
 title: MIME types (IANA media types)
 slug: Web/HTTP/Basics_of_HTTP/MIME_types
-tags:
-  - Content-Type
-  - Guide
-  - HTTP
-  - MIME Types
-  - Meta
-  - Request header
-  - Response Header
-  - application/javascript
-  - application/json
-  - application/xml
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/resource_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/resource_urls/index.md
@@ -1,11 +1,6 @@
 ---
 title: Resource URLs
 slug: Web/HTTP/Basics_of_HTTP/Resource_URLs
-tags:
-  - Guide
-  - HTTP
-  - Intermediate
-  - Resource
 ---
 
 {{HTTPSidebar}}{{non-standard_header}}

--- a/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
@@ -1,10 +1,6 @@
 ---
 title: Browser detection using the user agent
 slug: Web/HTTP/Browser_detection_using_the_user_agent
-tags:
-  - Compatibility
-  - HTTP
-  - Web Development
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP caching
 slug: Web/HTTP/Caching
-tags:
-  - Caching
-  - Guide
-  - HTTP
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP Client hints
 slug: Web/HTTP/Client_hints
-tags:
-  - Client hints
-  - Guide
-  - HTTP
-  - Performance
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/compression/index.md
+++ b/files/en-us/web/http/compression/index.md
@@ -1,10 +1,6 @@
 ---
 title: Compression in HTTP
 slug: Web/HTTP/Compression
-tags:
-  - Guide
-  - HTTP
-  - compression
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/conditional_requests/index.md
+++ b/files/en-us/web/http/conditional_requests/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP conditional requests
 slug: Web/HTTP/Conditional_requests
-tags:
-  - Conditional Requests
-  - Guide
-  - HTTP
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -1,12 +1,6 @@
 ---
 title: Configuring servers for Ogg media
 slug: Web/HTTP/Configuring_servers_for_Ogg_media
-tags:
-  - Audio
-  - HTTP
-  - Media
-  - Ogg
-  - Video
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/connection_management_in_http_1.x/index.md
+++ b/files/en-us/web/http/connection_management_in_http_1.x/index.md
@@ -1,13 +1,6 @@
 ---
 title: Connection management in HTTP/1.x
 slug: Web/HTTP/Connection_management_in_HTTP_1.x
-tags:
-  - Connection Management
-  - Guide
-  - HTTP
-  - Networking
-  - Performance
-  - WebMechanics
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/content_negotiation/index.md
+++ b/files/en-us/web/http/content_negotiation/index.md
@@ -1,11 +1,6 @@
 ---
 title: Content negotiation
 slug: Web/HTTP/Content_negotiation
-tags:
-  - Content Negotiation
-  - Content Negotiation Reference
-  - HTTP
-  - Reference
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -1,11 +1,6 @@
 ---
 title: List of default Accept values
 slug: Web/HTTP/Content_negotiation/List_of_default_Accept_values
-tags:
-  - Accept
-  - Content Negotiation
-  - HTTP
-  - Reference
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -1,23 +1,6 @@
 ---
 title: Using HTTP cookies
 slug: Web/HTTP/Cookies
-tags:
-  - Advertising
-  - Browser
-  - Cookies
-  - Cookies Article
-  - Guide
-  - HTTP
-  - History
-  - JavaScript
-  - Privacy
-  - Protocols
-  - Server
-  - Storage
-  - Web Development
-  - data
-  - request
-  - tracking
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS header 'Access-Control-Allow-Origin' does not match 'xyz'"
 slug: Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin
-tags:
-  - CORS
-  - CORSAllowOriginNotMatchingOrigin
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsdidnotsucceed/index.md
+++ b/files/en-us/web/http/cors/errors/corsdidnotsucceed/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS request did not succeed"
 slug: Web/HTTP/CORS/Errors/CORSDidNotSucceed
-tags:
-  - CORS
-  - CORSDidNotSucceed
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsdisabled/index.md
+++ b/files/en-us/web/http/cors/errors/corsdisabled/index.md
@@ -1,24 +1,6 @@
 ---
 title: "Reason: CORS disabled"
 slug: Web/HTTP/CORS/Errors/CORSDisabled
-tags:
-  - Authentication
-  - Authentication Article
-  - CORS
-  - Cross-Origin
-  - Disabled
-  - Errors
-  - HTTP
-  - HTTPS
-  - Messages
-  - Resource
-  - Same Origin
-  - Same-origin
-  - Security
-  - Sharing
-  - Validation
-  - secure
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsexternalredirectnotallowed/index.md
+++ b/files/en-us/web/http/cors/errors/corsexternalredirectnotallowed/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS request external redirect not allowed"
 slug: Web/HTTP/CORS/Errors/CORSExternalRedirectNotAllowed
-tags:
-  - CORS
-  - CORSOriginHeaderNotAdded
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsinvalidallowheader/index.md
+++ b/files/en-us/web/http/cors/errors/corsinvalidallowheader/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Headers'"
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowHeader
-tags:
-  - CORS
-  - CORSInvalidAllowHeader
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsinvalidallowmethod/index.md
+++ b/files/en-us/web/http/cors/errors/corsinvalidallowmethod/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Methods'"
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowMethod
-tags:
-  - CORS
-  - CORSInvalidAllowMethod
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
+++ b/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: Did not find method in CORS header 'Access-Control-Allow-Methods'"
 slug: Web/HTTP/CORS/Errors/CORSMethodNotFound
-tags:
-  - CORS
-  - CORSMethodNotFound
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: expected 'true' in CORS header 'Access-Control-Allow-Credentials'"
 slug: Web/HTTP/CORS/Errors/CORSMIssingAllowCredentials
-tags:
-  - CORS
-  - CORSMissingAllowCredentials
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -3,18 +3,6 @@ title: >-
   Reason: missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from
   CORS preflight channel
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
-tags:
-  - CORS
-  - CORSMissingAllowHeaderFromPreflight
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS header 'Access-Control-Allow-Origin' missing"
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
-tags:
-  - CORS
-  - CORSMissingAllowOrigin
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
+++ b/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: Multiple CORS header 'Access-Control-Allow-Origin' not allowed"
 slug: Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed
-tags:
-  - CORS
-  - CORSMultipleAllowOriginNotAllowed
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -3,18 +3,6 @@ title: >-
   Reason: Credential is not supported if the CORS header
   'Access-Control-Allow-Origin' is '*'
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
-tags:
-  - CORS
-  - CORSNotSupportingCredentials
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/en-us/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS header 'Origin' cannot be added"
 slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
-tags:
-  - CORS
-  - CORSOriginHeaderNotAdded
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corspreflightdidnotsucceed/index.md
+++ b/files/en-us/web/http/cors/errors/corspreflightdidnotsucceed/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS preflight channel did not succeed"
 slug: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
-tags:
-  - CORS
-  - CORSPreflightDidNotSucceed
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -1,18 +1,6 @@
 ---
 title: "Reason: CORS request not HTTP"
 slug: Web/HTTP/CORS/Errors/CORSRequestNotHttp
-tags:
-  - CORS
-  - CORSRequestNotHttp
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/index.md
+++ b/files/en-us/web/http/cors/errors/index.md
@@ -1,16 +1,6 @@
 ---
 title: CORS errors
 slug: Web/HTTP/CORS/Errors
-tags:
-  - CORS
-  - Errors
-  - HTTP
-  - HTTPS
-  - Messages
-  - Same-origin
-  - Security
-  - console
-  - troubleshooting
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -1,18 +1,6 @@
 ---
 title: Cross-Origin Resource Sharing (CORS)
 slug: Web/HTTP/CORS
-tags:
-  - AJAX
-  - CORS
-  - Cross-Origin Resource Sharing
-  - Fetch
-  - Fetch API
-  - HTTP
-  - HTTP Access Controls
-  - Same-origin policy
-  - Security
-  - XMLHttpRequest
-  - "l10n:priority"
 browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 

--- a/files/en-us/web/http/cross-origin_resource_policy/index.md
+++ b/files/en-us/web/http/cross-origin_resource_policy/index.md
@@ -1,10 +1,6 @@
 ---
 title: Cross-Origin Resource Policy (CORP)
 slug: Web/HTTP/Cross-Origin_Resource_Policy
-tags:
-  - HTTP
-  - Reference
-  - Security
 browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 

--- a/files/en-us/web/http/csp/errors/cspviolation/index.md
+++ b/files/en-us/web/http/csp/errors/cspviolation/index.md
@@ -3,18 +3,6 @@ title: >-
   Content Security Policy: The page's settings blocked the loading of a
   resource: xyz
 slug: Web/HTTP/CSP/Errors/CSPViolation
-tags:
-  - CSP
-  - CSPViolation
-  - Content Security Policy
-  - HTTP
-  - HTTPS
-  - NeedsContent
-  - Reference
-  - Security
-  - Warning
-  - Web security
-  - message
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/csp/errors/index.md
+++ b/files/en-us/web/http/csp/errors/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSP errors and warnings (Content Security Policy)
 slug: Web/HTTP/CSP/Errors
-tags:
-  - CSP
-  - Errors
-  - HTTP
-  - Landing
-  - Messages
-  - Warnings
-  - console
-  - log
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content Security Policy (CSP)
 slug: Web/HTTP/CSP
-tags:
-  - CSP
-  - Content Security Policy
-  - Example
-  - Guide
-  - Security
-  - access
 browser-compat: http.headers.Content-Security-Policy
 ---
 

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTTP
 slug: Web/HTTP
-tags:
-  - HTTP
-  - Hypertext
-  - Reference
-  - TCP/IP
-  - Web
-  - Web Development
-  - "l10n:priority"
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/link_prefetching_faq/index.md
+++ b/files/en-us/web/http/link_prefetching_faq/index.md
@@ -1,14 +1,6 @@
 ---
 title: Link prefetching FAQ
 slug: Web/HTTP/Link_prefetching_FAQ
-tags:
-  - HTML
-  - HTTP
-  - Link
-  - Necko
-  - Performance
-  - Prefetch
-  - Web Development
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP Messages
 slug: Web/HTTP/Messages
-tags:
-  - Guide
-  - HTTP
-  - WebMechanics
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/methods/connect/index.md
+++ b/files/en-us/web/http/methods/connect/index.md
@@ -1,10 +1,6 @@
 ---
 title: CONNECT
 slug: Web/HTTP/Methods/CONNECT
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.CONNECT
 ---
 

--- a/files/en-us/web/http/methods/get/index.md
+++ b/files/en-us/web/http/methods/get/index.md
@@ -1,10 +1,6 @@
 ---
 title: GET
 slug: Web/HTTP/Methods/GET
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.GET
 ---
 

--- a/files/en-us/web/http/methods/head/index.md
+++ b/files/en-us/web/http/methods/head/index.md
@@ -1,10 +1,6 @@
 ---
 title: HEAD
 slug: Web/HTTP/Methods/HEAD
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.HEAD
 ---
 

--- a/files/en-us/web/http/methods/index.md
+++ b/files/en-us/web/http/methods/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP request methods
 slug: Web/HTTP/Methods
-tags:
-  - HTTP
-  - Methods
-  - Reference
 browser-compat: http.methods
 ---
 

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -1,10 +1,6 @@
 ---
 title: OPTIONS
 slug: Web/HTTP/Methods/OPTIONS
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.OPTIONS
 ---
 

--- a/files/en-us/web/http/methods/patch/index.md
+++ b/files/en-us/web/http/methods/patch/index.md
@@ -1,10 +1,6 @@
 ---
 title: PATCH
 slug: Web/HTTP/Methods/PATCH
-tags:
-  - HTTP
-  - Reference
-  - Request method
 spec-urls: https://www.rfc-editor.org/rfc/rfc5789
 ---
 

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -1,10 +1,6 @@
 ---
 title: POST
 slug: Web/HTTP/Methods/POST
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.POST
 ---
 

--- a/files/en-us/web/http/methods/put/index.md
+++ b/files/en-us/web/http/methods/put/index.md
@@ -1,10 +1,6 @@
 ---
 title: PUT
 slug: Web/HTTP/Methods/PUT
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.PUT
 ---
 

--- a/files/en-us/web/http/methods/trace/index.md
+++ b/files/en-us/web/http/methods/trace/index.md
@@ -1,10 +1,6 @@
 ---
 title: TRACE
 slug: Web/HTTP/Methods/TRACE
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.TRACE
 ---
 

--- a/files/en-us/web/http/network_error_logging/index.md
+++ b/files/en-us/web/http/network_error_logging/index.md
@@ -1,12 +1,8 @@
 ---
 title: Network Error Logging
 slug: Web/HTTP/Network_Error_Logging
-tags:
-  - Guide
-  - HTTP
-  - Network Error Logging
-  - Reference
-  - Experimental
+status:
+  - experimental
 browser-compat: http.headers.NEL
 ---
 

--- a/files/en-us/web/http/overview/index.md
+++ b/files/en-us/web/http/overview/index.md
@@ -1,12 +1,6 @@
 ---
 title: An overview of HTTP
 slug: Web/HTTP/Overview
-tags:
-  - HTML
-  - HTTP
-  - Overview
-  - WebMechanics
-  - "l10n:priority"
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/permissions_policy/index.md
+++ b/files/en-us/web/http/permissions_policy/index.md
@@ -1,18 +1,6 @@
 ---
 title: Permissions Policy
 slug: Web/HTTP/Permissions_Policy
-tags:
-  - Permissions Policy
-  - Permissions-Policy
-  - HTTP
-  - Introduction
-  - Overview
-  - Reference
-  - Security
-  - access
-  - delegation
-  - header
-  - permission
 browser-compat: http.headers.Permissions-Policy
 ---
 

--- a/files/en-us/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/protocol_upgrade_mechanism/index.md
@@ -1,15 +1,6 @@
 ---
 title: Protocol upgrade mechanism
 slug: Web/HTTP/Protocol_upgrade_mechanism
-tags:
-  - Guide
-  - HTTP
-  - HTTP/2
-  - Networking
-  - Protocols
-  - Upgrade
-  - WebSocket
-  - WebSockets
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/proxy_servers_and_tunneling/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/index.md
@@ -1,11 +1,6 @@
 ---
 title: Proxy servers and tunneling
 slug: Web/HTTP/Proxy_servers_and_tunneling
-tags:
-  - HTTP
-  - HTTP Tunneling
-  - Proxies
-  - Proxy
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -1,11 +1,6 @@
 ---
 title: Proxy Auto-Configuration (PAC) file
 slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file
-tags:
-  - Necko
-  - Networking
-  - PAC
-  - Proxy
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/redirections/index.md
+++ b/files/en-us/web/http/redirections/index.md
@@ -1,10 +1,6 @@
 ---
 title: Redirections in HTTP
 slug: Web/HTTP/Redirections
-tags:
-  - Guide
-  - HTTP
-  - redirects
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/resources_and_specifications/index.md
+++ b/files/en-us/web/http/resources_and_specifications/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTTP resources and specifications
 slug: Web/HTTP/Resources_and_specifications
-tags:
-  - Guide
-  - HTTP
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/resources_and_uris/index.md
+++ b/files/en-us/web/http/resources_and_uris/index.md
@@ -1,16 +1,6 @@
 ---
 title: Resources and URIs
 slug: Web/HTTP/Resources_and_URIs
-tags:
-  - HTTP
-  - MIME
-  - MIME Type
-  - Overview
-  - Type
-  - URI
-  - URIs
-  - URL
-  - resources
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -1,8 +1,6 @@
 ---
 title: A typical HTTP session
 slug: Web/HTTP/Session
-tags:
-  - HTTP
 ---
 
 {{HTTPSidebar}}


### PR DESCRIPTION
This removes the remaining HTTP guide topics/leftovers after other PRs. It is part of https://github.com/mdn/mdn/issues/262