### PR TITLE
Remove tags in manifest, webdriver, webcomponents

### DIFF
--- a/files/en-us/web/manifest/background_color/index.md
+++ b/files/en-us/web/manifest/background_color/index.md
@@ -1,11 +1,8 @@
 ---
 title: background_color
 slug: Web/Manifest/background_color
-tags:
-  - Manifest
-  - Web
-  - background_color
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.background_color
 ---
 

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -1,11 +1,8 @@
 ---
 title: categories
 slug: Web/Manifest/categories
-tags:
-  - Manifest
-  - Web
-  - categories
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.categories
 ---
 

--- a/files/en-us/web/manifest/description/index.md
+++ b/files/en-us/web/manifest/description/index.md
@@ -1,10 +1,6 @@
 ---
 title: description
 slug: Web/Manifest/description
-tags:
-  - Manifest
-  - Web
-  - description
 browser-compat: html.manifest.description
 ---
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -1,10 +1,6 @@
 ---
 title: display
 slug: Web/Manifest/display
-tags:
-  - Manifest
-  - Web
-  - display
 browser-compat: html.manifest.display
 ---
 

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -1,12 +1,8 @@
 ---
 title: display_override
 slug: Web/Manifest/display_override
-tags:
-  - Manifest
-  - Web
-  - display
-  - display_override
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.display_override
 ---
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -1,10 +1,6 @@
 ---
 title: icons
 slug: Web/Manifest/icons
-tags:
-  - Icons
-  - Manifest
-  - Web
 browser-compat: html.manifest.icons
 ---
 

--- a/files/en-us/web/manifest/id/index.md
+++ b/files/en-us/web/manifest/id/index.md
@@ -1,10 +1,6 @@
 ---
 title: id
 slug: Web/Manifest/id
-tags:
-  - Manifest
-  - Web
-  - id
 browser-compat: html.manifest.id
 ---
 

--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -1,13 +1,6 @@
 ---
 title: Web app manifests
 slug: Web/Manifest
-tags:
-  - App
-  - Manifest
-  - PWA
-  - Progressive web apps
-  - Reference
-  - Web
 browser-compat: html.manifest
 ---
 

--- a/files/en-us/web/manifest/launch_handler/index.md
+++ b/files/en-us/web/manifest/launch_handler/index.md
@@ -1,11 +1,8 @@
 ---
 title: launch_handler
 slug: Web/Manifest/launch_handler
-tags:
-  - Manifest
-  - Web
-  - launch_handler
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.launch_handler
 ---
 

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -1,10 +1,6 @@
 ---
 title: name
 slug: Web/Manifest/name
-tags:
-  - Manifest
-  - Web
-  - name
 browser-compat: html.manifest.name
 ---
 

--- a/files/en-us/web/manifest/orientation/index.md
+++ b/files/en-us/web/manifest/orientation/index.md
@@ -1,11 +1,8 @@
 ---
 title: orientation
 slug: Web/Manifest/orientation
-tags:
-  - Manifest
-  - Orientation
-  - Web
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.orientation
 ---
 

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -1,11 +1,8 @@
 ---
 title: prefer_related_applications
 slug: Web/Manifest/prefer_related_applications
-tags:
-  - Manifest
-  - Web
-  - prefer_related_applications
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.prefer_related_applications
 ---
 

--- a/files/en-us/web/manifest/protocol_handlers/index.md
+++ b/files/en-us/web/manifest/protocol_handlers/index.md
@@ -1,11 +1,8 @@
 ---
 title: protocol_handlers
 slug: Web/Manifest/protocol_handlers
-tags:
-  - protocol_handlers
-  - Manifest
-  - Web
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.protocol_handlers
 ---
 

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -1,11 +1,8 @@
 ---
 title: related_applications
 slug: Web/Manifest/related_applications
-tags:
-  - Manifest
-  - Web
-  - related_applications
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.related_applications
 ---
 

--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -1,10 +1,6 @@
 ---
 title: scope
 slug: Web/Manifest/scope
-tags:
-  - Manifest
-  - Web
-  - scope
 browser-compat: html.manifest.scope
 ---
 

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -1,11 +1,8 @@
 ---
 title: screenshots
 slug: Web/Manifest/screenshots
-tags:
-  - Manifest
-  - Screenshots
-  - Web
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.screenshots
 ---
 

--- a/files/en-us/web/manifest/serviceworker/index.md
+++ b/files/en-us/web/manifest/serviceworker/index.md
@@ -1,12 +1,9 @@
 ---
 title: serviceworker
 slug: Web/Manifest/serviceworker
-tags:
-  - serviceworker
-  - Manifest
-  - Web
-  - Experimental
-  - Non-standard
+status:
+  - experimental
+  - non-standard
 browser-compat: html.manifest.serviceworker
 ---
 

--- a/files/en-us/web/manifest/share_target/index.md
+++ b/files/en-us/web/manifest/share_target/index.md
@@ -1,11 +1,8 @@
 ---
 title: share_target
 slug: Web/Manifest/share_target
-tags:
-  - Manifest
-  - Web
-  - share_target
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.share_target
 ---
 

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -1,10 +1,6 @@
 ---
 title: short_name
 slug: Web/Manifest/short_name
-tags:
-  - Manifest
-  - Web
-  - short_name
 browser-compat: html.manifest.short_name
 ---
 

--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -1,11 +1,8 @@
 ---
 title: shortcuts
 slug: Web/Manifest/shortcuts
-tags:
-  - Manifest
-  - Web
-  - shortcuts
-  - Experimental
+status:
+  - experimental
 browser-compat: html.manifest.shortcuts
 ---
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -1,10 +1,6 @@
 ---
 title: start_url
 slug: Web/Manifest/start_url
-tags:
-  - Manifest
-  - Web
-  - start_url
 browser-compat: html.manifest.start_url
 ---
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -1,10 +1,6 @@
 ---
 title: theme_color
 slug: Web/Manifest/theme_color
-tags:
-  - Manifest
-  - Web
-  - theme_color
 browser-compat: html.manifest.theme_color
 ---
 

--- a/files/en-us/web/web_components/index.md
+++ b/files/en-us/web/web_components/index.md
@@ -1,19 +1,6 @@
 ---
 title: Web Components
 slug: Web/Web_Components
-tags:
-  - Components
-  - HTML Imports
-  - JavaScript
-  - Landing
-  - Overview
-  - Template
-  - Web Article
-  - Web Components
-  - Web Development
-  - custom elements
-  - shadow dom
-  - slot
 browser-compat:
   - html.elements.template
   - api.ShadowRoot

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: Using custom elements
 slug: Web/Web_Components/Using_custom_elements
-tags:
-  - Classes
-  - Guide
-  - HTML
-  - Web Components
-  - autonomous
-  - custom elements
-  - customized
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/en-us/web/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/web_components/using_shadow_dom/index.md
@@ -1,12 +1,6 @@
 ---
 title: Using shadow DOM
 slug: Web/Web_Components/Using_shadow_DOM
-tags:
-  - API
-  - DOM
-  - Guide
-  - Web Components
-  - shadow dom
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/en-us/web/web_components/using_templates_and_slots/index.md
+++ b/files/en-us/web/web_components/using_templates_and_slots/index.md
@@ -1,12 +1,6 @@
 ---
 title: Using templates and slots
 slug: Web/Web_Components/Using_templates_and_slots
-tags:
-  - Template
-  - Web Components
-  - shadow dom
-  - slot
-  - slots
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
+++ b/files/en-us/web/webdriver/capabilities/acceptinsecurecerts/index.md
@@ -1,11 +1,6 @@
 ---
 title: acceptInsecureCerts
 slug: Web/WebDriver/Capabilities/acceptInsecureCerts
-tags:
-  - Reference
-  - WebDriver
-  - capabilities
-  - acceptInsecureCerts
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -1,12 +1,6 @@
 ---
 title: firefoxOptions
 slug: Web/WebDriver/Capabilities/firefoxOptions
-tags:
-  - Reference
-  - WebDriver
-  - capabilities
-  - Extension capabilities
-  - firefoxOptions
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}

--- a/files/en-us/web/webdriver/capabilities/index.md
+++ b/files/en-us/web/webdriver/capabilities/index.md
@@ -1,10 +1,6 @@
 ---
 title: Capabilities
 slug: Web/WebDriver/Capabilities
-tags:
-  - Reference
-  - WebDriver
-  - capabilities
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}

--- a/files/en-us/web/webdriver/capabilities/websocketurl/index.md
+++ b/files/en-us/web/webdriver/capabilities/websocketurl/index.md
@@ -1,11 +1,6 @@
 ---
 title: webSocketUrl
 slug: Web/WebDriver/Capabilities/webSocketUrl
-tags:
-  - Reference
-  - WebDriver
-  - capabilities
-  - webSocketUrl
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Capabilities")}}

--- a/files/en-us/web/webdriver/errors/index.md
+++ b/files/en-us/web/webdriver/errors/index.md
@@ -1,12 +1,6 @@
 ---
 title: WebDriver errors
 slug: Web/WebDriver/Errors
-tags:
-  - Automation
-  - Reference
-  - Testing
-  - Web
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/errors/insecurecertificate/index.md
+++ b/files/en-us/web/webdriver/errors/insecurecertificate/index.md
@@ -1,11 +1,6 @@
 ---
 title: Insecure certificate
 slug: Web/WebDriver/Errors/InsecureCertificate
-tags:
-  - Error
-  - Reference
-  - WebDriver
-  - insecure certificate
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/invalidargument/index.md
+++ b/files/en-us/web/webdriver/errors/invalidargument/index.md
@@ -1,11 +1,6 @@
 ---
 title: Invalid argument
 slug: Web/WebDriver/Errors/InvalidArgument
-tags:
-  - Error
-  - Reference
-  - WebDriver
-  - invalid argument
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/invalidcookiedomain/index.md
+++ b/files/en-us/web/webdriver/errors/invalidcookiedomain/index.md
@@ -1,11 +1,6 @@
 ---
 title: Invalid cookie domain
 slug: Web/WebDriver/Errors/InvalidCookieDomain
-tags:
-  - Error
-  - Reference
-  - WebDriver
-  - invalid cookie domain
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/invalidselector/index.md
+++ b/files/en-us/web/webdriver/errors/invalidselector/index.md
@@ -1,11 +1,6 @@
 ---
 title: Invalid selector
 slug: Web/WebDriver/Errors/InvalidSelector
-tags:
-  - Error
-  - Reference
-  - WebDriver
-  - invalid selector
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/invalidsessionid/index.md
+++ b/files/en-us/web/webdriver/errors/invalidsessionid/index.md
@@ -1,11 +1,6 @@
 ---
 title: Invalid session ID
 slug: Web/WebDriver/Errors/InvalidSessionID
-tags:
-  - Error
-  - Reference
-  - WebDriver
-  - invalid session id
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/javascripterror/index.md
+++ b/files/en-us/web/webdriver/errors/javascripterror/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScript error
 slug: Web/WebDriver/Errors/JavaScriptError
-tags:
-  - Error
-  - JavaScript error
-  - Reference
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/scripttimeout/index.md
+++ b/files/en-us/web/webdriver/errors/scripttimeout/index.md
@@ -1,11 +1,6 @@
 ---
 title: Script timeout
 slug: Web/WebDriver/Errors/ScriptTimeout
-tags:
-  - Error
-  - Reference
-  - Script timeout
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/staleelementreference/index.md
+++ b/files/en-us/web/webdriver/errors/staleelementreference/index.md
@@ -1,11 +1,6 @@
 ---
 title: Stale element reference
 slug: Web/WebDriver/Errors/StaleElementReference
-tags:
-  - Error
-  - Reference
-  - Stale element reference
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/unknowncommand/index.md
+++ b/files/en-us/web/webdriver/errors/unknowncommand/index.md
@@ -1,11 +1,6 @@
 ---
 title: Unknown command
 slug: Web/WebDriver/Errors/UnknownCommand
-tags:
-  - Error
-  - Reference
-  - Unknown command
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/unknownerror/index.md
+++ b/files/en-us/web/webdriver/errors/unknownerror/index.md
@@ -1,11 +1,6 @@
 ---
 title: Unknown error
 slug: Web/WebDriver/Errors/UnknownError
-tags:
-  - Error
-  - Reference
-  - Unknown error
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/errors/unknownmethod/index.md
+++ b/files/en-us/web/webdriver/errors/unknownmethod/index.md
@@ -1,11 +1,6 @@
 ---
 title: Unknown method
 slug: Web/WebDriver/Errors/UnknownMethod
-tags:
-  - Error
-  - Reference
-  - Unknown method
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Errors")}}

--- a/files/en-us/web/webdriver/index.md
+++ b/files/en-us/web/webdriver/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebDriver
 slug: Web/WebDriver
-tags:
-  - Automation
-  - Index
-  - Landing
-  - Reference
-  - Testing
-  - Web
-  - WebDriver
 ---
 
 {{QuickLinksWithSubpages}}

--- a/files/en-us/web/webdriver/timeouts/index.md
+++ b/files/en-us/web/webdriver/timeouts/index.md
@@ -1,9 +1,6 @@
 ---
 title: Timeouts
 slug: Web/WebDriver/Timeouts
-tags:
-  - WebDriver
-  - timeouts
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}


### PR DESCRIPTION
Remove tags in following, adding status metadata where relevant
```
/web/manifest/*
/web/web_components/**
/web/webdriver/*
```
This is part of https://github.com/mdn/mdn/issues/262