### PR TITLE
Adding missing section titles for `initial-letter` and `initial-letter-align`

### DIFF
--- a/files/en-us/web/css/initial-letter-align/index.md
+++ b/files/en-us/web/css/initial-letter-align/index.md
@@ -98,5 +98,7 @@ One of the keyword values listed below.
 
 {{Compat}}
 
+## See also
+
 - {{cssxref("initial-letter")}}
 - [Drop caps in CSS](https://www.oddbird.net/2017/01/03/initial-letter/)

--- a/files/en-us/web/css/initial-letter/index.md
+++ b/files/en-us/web/css/initial-letter/index.md
@@ -93,5 +93,7 @@ The keyword value `normal`, or a `<number>` optionally followed by an `<integer>
 
 {{Compat}}
 
+## See also
+
 - {{cssxref("initial-letter-align")}}
 - [Drop caps in CSS](https://www.oddbird.net/2017/01/03/initial-letter/)


### PR DESCRIPTION
### Description

This PR adds missing section titles “See also” for the `initial-letter` and `initial-letter-align` CSS properties.

### Motivation

Obviously cross references are not part of the browser compatibility sections, and comparing with other CSS property pages shows that a section title is missing there.