### PR TITLE
Fix page-type of Webkit_extensions

### DIFF
--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebKit CSS extensions
 slug: Web/CSS/WebKit_Extensions
-page-type: css-property
+page-type: landing-page
 status:
   - non-standard
 ---


### PR DESCRIPTION
Fixes #25034

Uniformize the `page-type` with the one used in Mozilla_extensions.

@wbamberg Can you review this?