### PR TITLE
Remove {{bug}} macro

### DIFF
--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -87,7 +87,7 @@ Great progress has been made to update IndexedDB to the latest draft specificati
 - The ESC key no longer incorrectly results in the {{ domxref("Element.keydown_event", "onkeydown") }} handler incorrectly getting called.
 - The `NameList` interface is no longer implemented; it previously had an implementation with no way to actually get access to one.
 - The {{ domxref("document.createProcessingInstruction()") }} method now works on HTML documents as well as XML documents. {{ domxref("ProcessingInstruction") }} nodes are still only supported on XML documents, but since nodes can be moved among documents, it's helpful to be able to create them on HTML documents as well.
-- The {{ domxref("XMLHttpRequest") }} `responseType` "`moz-json`" [introduced in Firefox 9](/en-US/docs/Mozilla/Firefox/Releases/9#dom) has been updated to the latest draft of the specification and has been unprefixed. See {{ bug("707142#c13") }}
+- The {{ domxref("XMLHttpRequest") }} `responseType` "`moz-json`" [introduced in Firefox 9](/en-US/docs/Mozilla/Firefox/Releases/9#dom) has been updated to the latest draft of the specification and has been unprefixed. See note in [Firefox bug 707142](https://bugzil.la/707142#c13).
 
 ### CSS
 

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -29,7 +29,7 @@ This article provides information about the changes in Firefox 111 that affect d
 ### SVG
 
 - The `context-stroke` and `context-fill` values are now supported inside `<marker>` elements.
-  For more information on using these values with `fill` and `stroke` properties, see the [`<marker>`](/en-US/docs/Web/SVG/Element/marker) documentation ({{bug(752638)}}).
+  For more information on using these values with `fill` and `stroke` properties, see the [`<marker>`](/en-US/docs/Web/SVG/Element/marker) documentation ([Firefox bug 752638](https://bugzil.la/752638)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -110,7 +110,7 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 - Support for microsummaries has been removed; these were never widely used, were not very discoverable, and continuing to support them was making improvements to the Places (bookmark and history) architecture difficult.
 - WebGL now supports the [`OES_texture_float`](https://www.khronos.org/registry/OpenGL/extensions/OES/OES_texture_float.txt) extension.
 - The new _Scratchpad_ tool provides a handy place to experiment with JavaScript code.
-- The `console.trace()` method has been added to the [Console API](/en-US/docs/Web/API/Console_API) (see {{ bug('585956') }}).
+- The `console.trace()` method has been added to the [Console API](/en-US/docs/Web/API/Console_API) ([Firefox bug 585956](https://bugzil.la/585956)).
 
 ## Changes for Mozilla and add-on developers
 


### PR DESCRIPTION
Thanks to the flaw dashboard, I found 3 `{{bug}}` macros we forgot to remove. This PR takes care of them.