### PR TITLE
Remove usage of {{unimplemented_inline}}

### DIFF
--- a/files/en-us/web/html/element/td/index.md
+++ b/files/en-us/web/html/element/td/index.md
@@ -38,7 +38,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `center`: The content is centered in the cell.
     - `right`: The content is aligned to the right of the cell.
     - `justify` (with text only): The content is stretched out inside the cell so that it covers its entire width.
-    - `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the {{htmlattrxref("char", "td")}} and {{htmlattrxref("charoff", "td")}} attributes {{unimplemented_inline(2212)}}.
+    - `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the {{htmlattrxref("char", "td")}} and {{htmlattrxref("charoff", "td")}} attributes.
 
     The default value when this attribute is not specified is `left`.
 

--- a/files/en-us/web/html/element/td/index.md
+++ b/files/en-us/web/html/element/td/index.md
@@ -45,7 +45,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     > **Note:**
     >
     > - To achieve the same effect as the `left`, `center`, `right` or `justify` values, apply the CSS {{cssxref("text-align")}} property to the element.
-    > - To achieve the same effect as the `char` value, give the {{cssxref("text-align")}} property the same value you would use for the {{htmlattrxref("char", "td")}}. {{unimplemented_inline}} in CSS.
+    > - To achieve the same effect as the `char` value, give the {{cssxref("text-align")}} property the same value you would use for the {{htmlattrxref("char", "td")}}.
 
 - `axis` {{deprecated_inline}}
   - : This attribute contains a list of space-separated strings. Each string is the `id` of a group of cells that this header applies to.

--- a/files/en-us/web/html/element/tfoot/index.md
+++ b/files/en-us/web/html/element/tfoot/index.md
@@ -34,7 +34,7 @@ The following attributes are deprecated and should not be used. They are documen
     > **Note:**
     >
     > - To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS {{cssxref("text-align")}} property on it.
-    > - To achieve the same effect as the `char` value, in CSS, you can use the value of the {{htmlattrxref("char", "tfoot")}} as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > - To achieve the same effect as the `char` value, in CSS, you can use the value of the {{htmlattrxref("char", "tfoot")}} as the value of the {{cssxref("text-align")}} property.
 
 - `bgcolor` {{Deprecated_inline}}
 


### PR DESCRIPTION
This macro is deprecated and should have been removed.

I removed the info, as it is already in the browser compatibility section below.