### PR TITLE
One `in` is not one inch

### DIFF
--- a/files/en-us/glossary/css_pixel/index.md
+++ b/files/en-us/glossary/css_pixel/index.md
@@ -4,7 +4,7 @@ slug: Glossary/CSS_pixel
 page-type: glossary-definition
 ---
 
-The term **CSS pixel** is synonymous with the CSS unit of absolute length _px_ — which is [normatively defined](https://drafts.csswg.org/css-values/#absolute-lengths) as being exactly 1/96th of 1 inch.
+The term **CSS pixel** is synonymous with the CSS unit of absolute length _px_ — which is [normatively defined](https://drafts.csswg.org/css-values/#absolute-lengths) as being exactly 1/96th of 1 CSS inch (_in_).
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changes the use of "inch"  to rather talk about the CSS unit *in*.

### Motivation

As is correctly explained in the link in that same page (https://hacks.mozilla.org/2013/09/css-length-explained/)
> On a computer screen, a CSS inch has nothing to do with the physical inch.

That this article states that `1px` is one 96th of one inch is very misleading.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
