### PR TITLE
chore(CI): limit locking of old PRs to run only on first day of the month

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,7 +1,7 @@
 name: "Lock old issues and pull requests"
 on:
   schedule:
-    - cron: "49 11,23 * * *"
+    - cron: "0 9 1 * *"
 
 jobs:
   lock:


### PR DESCRIPTION
__background:__
Currently the "lock PRs" workflow is running daily at [49 11,23 * * *](https://crontab.guru/#49_11,23_*_*_*)

This causes year-old PRs to be bumped as 'updated recently' every day.

This PR changes the schedule to run at 9am on the first day of the month ([0 9 1 * *](https://crontab.guru/#0_9_1_*_*))

__cc__ @OnkarRuikar:

>can we defer locking conversations to weekends or month ends?
Every day the bot puts year old PRs at the top of the merged PRs list. It becomes hard to figure out what got merged yesterday or recently.