### PR TITLE
Fix issue 24969: mangled AnimationEffect intro

### DIFF
--- a/files/en-us/web/api/animationeffect/index.md
+++ b/files/en-us/web/api/animationeffect/index.md
@@ -7,7 +7,9 @@ browser-compat: api.AnimationEffect
 
 {{ APIRef("Web Animations") }}
 
-The `AnimationEffect` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) defines current and future _animation effects_ like {{domxref("KeyframeEffect")}}, which can be passed to {{domxref("Animation")}} objects for playing, and {{domxref("KeyframeEffect")}} (which is used by [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions)).
+The `AnimationEffect` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) is an interface representing animation effects.
+
+`AnimationEffect` is an abstract interface and so isn't directly instantiable. However, concrete interfaces such as {{domxref("KeyframeEffect")}} inherit from it, and instances of these interfaces can be passed to {{domxref("Animation")}} objects for playing, and may also be used by [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions).
 
 ## Instance methods
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/24969.

Although there's currently only one concrete subtype of `AnimationEffect`, I've left it open here in case people add more.