### PR TITLE
Typo in JavaScript Code Style Guide.

### DIFF
--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -754,7 +754,7 @@ When declaring variables and constants, use the [`let`](/en-US/docs/Web/JavaScri
 
   ```js example-bad
   let name = "Shilpa";
-  console.log(myName);
+  console.log(name);
   ```
 
 - The example below uses `const` for a variable that gets reassigned. The reassignment will throw an error.


### PR DESCRIPTION
### Description

One of the bad examples showed `name` being defined but had `myName` in the console.log.

### Motivation

Just came across it while reading it. Looked wrong.
