### PR TITLE
Replace .keyCode with .key

### DIFF
--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -268,13 +268,13 @@ window.addEventListener('load', () => {
     select.addEventListener('keyup', (event) => {
       let index = getIndex(select);
 
-      if (event.keyCode === 27) {
+      if (event.key === "Escape") {
         deactivateSelect(select);
       }
-      if (event.keyCode === 40 && index < optionList.length - 1) {
+      if (event.key === "ArrowDown" && index < optionList.length - 1) {
         index++;
       }
-      if (event.keyCode === 38 && index > 0) {
+      if (event.key === "ArrowUp" && index > 0) {
         index--;
       }
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaced deprecated .keyCode read-only property in favour of .key. Key values updated to string counterparts accordingly.

### Motivation

To improve consistency between the JavaScript code appearing in the article, and the JS provided within the example 4 source code link. 

### Additional details

### Related issues and pull requests
Fixes issue #25044


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
