### PR TITLE
Clarified description of arguments to setTimeout

### DIFF
--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -79,7 +79,7 @@ A downside of this model is that if a message takes too long to complete, the we
 
 In web browsers, messages are added anytime an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event.
 
-The function [`setTimeout`](/en-US/docs/Web/API/setTimeout) is called with 2 arguments: a message to add to the queue, and a time value (optional; defaults to `0`). The _time value_ represents the (minimum) delay after which the message will be pushed into the queue. If there is no other message in the queue, and the stack is empty, the message is processed right after the delay. However, if there are messages, the `setTimeout` message will have to wait for other messages to be processed. For this reason, the second argument indicates a _minimum_ time — not a _guaranteed_ time.
+The first two arguments to the function [`setTimeout`](/en-US/docs/Web/API/setTimeout) are a message to add to the queue and a time value (optional; defaults to `0`). The _time value_ represents the (minimum) delay after which the message will be pushed into the queue. If there is no other message in the queue, and the stack is empty, the message is processed right after the delay. However, if there are messages, the `setTimeout` message will have to wait for other messages to be processed. For this reason, the second argument indicates a _minimum_ time — not a _guaranteed_ time.
 
 Here is an example that demonstrates this concept (`setTimeout` does not run immediately after its timer expires):
 


### PR DESCRIPTION
setTimeout() takes more than two arguments when the callback function is given one or more arguments.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
