### PR TITLE
Fix issues in search API documentation

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
@@ -21,8 +21,8 @@ To use this API you need to have the `"search"` [permission](/en-US/docs/Mozilla
 
 When choosing between `search.query()` and `search.search()`, consider the following:
 
-- {{WebExtAPIRef("search.search()")}} is available on all the main browser engines and, therefore, is ideal for use in cross-browser extensions. However, it can only issue searches against the browser's default search engine.
-- {{WebExtAPIRef("search.query()")}} is available only on Firefox. However, it has the advantage of enabling you to issue a search against any search engines installed in the browser.
+- {{WebExtAPIRef("search.search()")}} is available in most major browsers, making it ideal for use in cross-browser extensions. However, it can only issue searches against the browser's default search engine.
+- {{WebExtAPIRef("search.query()")}} is available only in Firefox. However, it has the advantage of being able to issue a search against any search engines installed in the browser.
 
 ## Functions
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
@@ -21,8 +21,8 @@ To use this API you need to have the `"search"` [permission](/en-US/docs/Mozilla
 
 When choosing between `search.query()` and `search.search()`, consider the following:
 
-- {{WebExtAPIRef("search.search()")}} is available in most major browsers, making it ideal for use in cross-browser extensions. However, it can only issue searches against the browser's default search engine.
-- {{WebExtAPIRef("search.query()")}} is available only in Firefox. However, it has the advantage of being able to issue a search against any search engines installed in the browser.
+- {{WebExtAPIRef("search.query()")}} is available in most major browsers, making it ideal for use in cross-browser extensions. However, it can only issue searches against the browser's default search engine.
+- {{WebExtAPIRef("search.search()")}} is available only in Firefox. However, it has the advantage of being able to issue a search against any search engine installed in the browser.
 
 ## Functions
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
@@ -20,8 +20,6 @@ The results are displayed in the current tab, a new tab, or a new window accordi
 
 To use this function, your extension must have the `"search"` [manifest permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
-To get the installed search engines, use {{WebExtAPIRef("search.get()")}}.
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.search.query
 
 Perform a search using the browser's default search engine.
 
-The results are displayed in the current tab, a new tab, or a new window according to the `disposition` property or in the tab specified in the `tabId` property. If neither is specified, the results display in a new tab.
+The results are displayed in the current tab, a new tab, or a new window according to the `disposition` property or in the tab specified in the `tabId` property. If neither is specified, the results display in the current tab.
 
 To use this function, your extension must have the `"search"` [manifest permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
@@ -35,7 +35,7 @@ browser.search.query(
   - : `object`. An object with the following properties:
 
     - `disposition` {{optional_inline}}
-      - : `string`. The location where the search results are displayed. Valid values are `CURRENT_TAB`, `NEW_TAB`, and `NEW_WINDOW`. Defaults to `NEW_TAB`. Cannot be specified with `tabId`.
+      - : `string`. The location where the search results are displayed. Valid values are `CURRENT_TAB`, `NEW_TAB`, and `NEW_WINDOW`. Defaults to `CURRENT_TAB`. Cannot be specified with `tabId`.
     - `tabId` {{optional_inline}}
       - : `integer`. An optional identifier for the tab you want to execute the search in. If this property is omitted, the search results are displayed in a new tab. Cannot be specified with `disposition`.
     - `text`
@@ -72,7 +72,7 @@ function search() {
 browser.browserAction.onClicked.addListener(search);
 ```
 
-A search with the results shown in the current tab:
+A search with the results shown in a specific tab:
 
 ```js
 function search(tab) {


### PR DESCRIPTION

### Description

- Fix incorrect default disposition in search.query documentation.
- Remove reference to search.get() in search.query documentation, it is confusing.
- Improve phrasing in search index page.
- Fix incorrect example descriptions.

### Additional details
https://searchfox.org/mozilla-central/source/browser/components/extensions/schemas/search.json#84,112
