### PR TITLE
Specification tables - mentions spec_urls

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/specification_tables/index.md
@@ -9,23 +9,37 @@ browser-compat: css.properties.text-align
 
 Every reference page on MDN should provide information about the specification or specifications in which that API or technology was defined. This article demonstrates what these tables look like and explains how to add them.
 
-These tables are similar to the [compatibility tables](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) and usually both are part of a reference page.
+The specifications section definition is similar to the [compatibility table](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) definition, is commonly generated from the same data source, and typically appears immediately before it in a page.
 
 ## Standard specification tables
 
-The standard specification section looks like this:
+The standard specification section should look like this:
 
-```html
-<h2 id="Specifications">Specifications</h2>
+```md
+## Specifications
 
 \{{Specifications}}
 ```
 
-The `\{{Specifications}}` macro does all the work and generates a table containing the relevant and most current specifications.
-It checks the page's front matter for the `browser-compat` property to determine for which feature to load specifications.
+The `\{{Specifications}}` macro generates the specification table based on the value(s) in the page front-matter.
 
-If the page has a front-matter, like `browser-compat: css.property.text-align`,
-then the macro gets the specifications for {{cssxref("text-align")}} and renders them in a table:
+By default the value(s) in the `browser-compat` key are used.
+Each value references a particular feature and its associated compatibility and specification information in the [browser-compat-data](https://github.com/mdn/browser-compat-data) repository.
+For example, the {{cssxref("text-align")}} page has the following key, which it uses to fetch the associated specification information.
+
+```md
+browser-compat: css.property.text-align
+```
+
+Some features are not maintained in the above repository.
+In these cases, specification information can be added to the page front matter using the `spec-urls` key.
+For example, the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute has the front matter key:
+
+```
+spec-urls: https://w3c.github.io/aria/#aria-atomic
+```
+
+The specifications table for the `css.property.text-align` key above is rendered in a table as shown:
 
 ### Specifications
 
@@ -33,8 +47,7 @@ then the macro gets the specifications for {{cssxref("text-align")}} and renders
 
 ## Non-standard features
 
-When documenting a feature that doesn't have a specification (anymore),
-don't call the `\{{Specifications}}` macro.
+When documenting a non-standard feature, in particular one that has been removed from a standardization track, don't call the `\{{Specifications}}` macro.
 
 Instead, try to provide information about the standardization status and possible alternatives. Examples:
 


### PR DESCRIPTION
This follows on from #25008. It attempts to make it clear that data can come from browser compat or spec urls, and that it can have multiple values. Also updated the heading recommendation to markdown.

FWIW I think we probably should update the compatibility tables doc as well, and have a dedicated page introducing front matter. Job for another day.
