### PR TITLE
Remove leftover tags

### DIFF
--- a/files/en-us/web/http/methods/delete/index.md
+++ b/files/en-us/web/http/methods/delete/index.md
@@ -1,10 +1,6 @@
 ---
 title: DELETE
 slug: Web/HTTP/Methods/DELETE
-tags:
-  - HTTP
-  - Reference
-  - Request method
 browser-compat: http.methods.DELETE
 ---
 

--- a/files/en-us/web/http/range_requests/index.md
+++ b/files/en-us/web/http/range_requests/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP range requests
 slug: Web/HTTP/Range_requests
-tags:
-  - Guide
-  - HTTP
-  - HTTP range requests
 ---
 
 {{HTTPSidebar}}


### PR DESCRIPTION
This removes a few tags that slipped through the sieve when we removed them.

After this PR, we only have tags left in the following documents:
- web/svg/* – We are waiting for the new sidebar to land to remove them
- mozilla/add-ons/* – We are waiting for the page-type/sidebar work to be done hew
- mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md – That will be updated when the new sidebar lands
- mdn/writing_guidelines/howto/tag/index.md – To delete when the last tags are removed (no need to try to update it to the current situation).

\o/ We are getting close to have removed all tags from MDN.