### PR TITLE
chore(ci): bump Python version in PR companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -66,7 +66,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11.0"
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -66,7 +66,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.0"
+          python-version: "3.10"
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local


### PR DESCRIPTION
There seems to be incompatibility with Python versions used in the Yari deployer and PR companion bot.  This PR bumps the Python version to ~~3.11.0~~ 3.10 for the companion workflow.

__failing workflows:__

https://github.com/mdn/content/actions/workflows/pr-review-companion.yml

* Example: https://github.com/mdn/content/actions/runs/4343545337/jobs/7585719894


__workflow errs:__


```bash
  cd yari/deployer
  poetry install --no-interaction --no-root
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.16/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.16/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.16/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.16/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.16/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.16/x64/lib
    VENV: .venv/bin/activate
The currently activated Python version 3.8.16 is not supported by the project (^3.10).
Trying to find and use a compatible version. 

[Errno 2] No such file or directory: 'python3.11'
```