### PR TITLE
Update docs for performance.now/DOMHighResTimeStamp

### DIFF
--- a/files/en-us/web/api/domhighrestimestamp/index.md
+++ b/files/en-us/web/api/domhighrestimestamp/index.md
@@ -8,87 +8,33 @@ browser-compat: api.DOMHighResTimestamp
 
 The **`DOMHighResTimeStamp`** type is a `double` and is used to store a time value in milliseconds.
 
-This type can be used to describe a discrete point in time or a time interval (the difference in time between two discrete points in time).
+This type can be used to describe a discrete point in time or a time interval (the difference in time between two discrete points in time). The starting time can be either a specific time determined by the script for a site or app, or the [time origin](/en-US/docs/Web/API/Performance/timeOrigin).
 
 The time, given in milliseconds, should be accurate to 5 µs (microseconds), with the fractional part of the number indicating fractions of a millisecond. However, if the browser is unable to provide a time value accurate to 5 µs (due, for example, to hardware or software constraints), the browser can represent the value as a time in milliseconds accurate to a millisecond. Also note the section below on reduced time precision controlled by browser preferences to avoid timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting).
 
 Further, if the device or operating system the user agent is running on doesn't have a clock accurate to the microsecond level, they may only be accurate to the millisecond.
 
-## Reduced time precision
+## Security requirements
 
-To offer protection against timing attacks and fingerprinting, the precision of timestamps might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 µs in Firefox 59; in 60 it will be 2ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), `DOMHighResTimeStamp` types are coarsened based on site isolation status.
 
-```js
-// reduced time precision (2ms) in Firefox 60
-event.timeStamp;
-// 1519211809934
-// 1519211810362
-// 1519211811670
-// …
+- Resolution in isolated contexts: 5 microseconds
+- Resolution in non-isolated contexts: 100 microseconds
 
-// reduced time precision with `privacy.resistFingerprinting` enabled
-event.timeStamp;
-// 1519129853500
-// 1519129858900
-// 1519129864400
-// …
+Cross-origin isolate your site using the {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
+{{HTTPHeader("Cross-Origin-Embedder-Policy")}} headers:
+
+```http
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
 ```
 
-In Firefox, you can also enable `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
-
-## Instance properties
-
-_This type has no properties. It is a double-precision floating-point value._
-
-### Value
-
-The value of a `DOMHighResTimeStamp` is a double-precision floating-point number which describes the number of milliseconds (accurate to within 5 microseconds if the device supports it) elapsed between two points in time. The starting time can be either a specific time determined by the script for a site or app, or the **time origin**.
-
-#### The time origin
-
-The **time origin** is a standard time which is considered to be the beginning of the current document's lifetime. It's calculated like this:
-
-- If the script's {{Glossary("global object")}} is a {{domxref("Window")}}, the time origin is determined as follows:
-
-  - If the current {{domxref("Document")}} is the first one loaded in the `Window`, the time origin is the time at which the browser context was created.
-  - If during the process of unloading the previous document which was loaded in the window, a confirmation dialog was displayed to let the user confirm whether or not to leave the previous page, the time origin is the time at which the user confirmed that navigating to the new page was acceptable.
-  - If neither of the above determines the time origin, then the time origin is the time at which the navigation responsible for creating the window's current `Document` took place.
-
-- If the script's global object is a {{domxref("WorkerGlobalScope")}} (that is, the script is running as a web worker), the time origin is the moment at which the worker was created.
-- In all other cases, the time origin is undefined.
-
-## Instance methods
-
-_This type has no methods._
-
-## Usage notes
-
-You can get the current timestamp value—the time that has elapsed since the context was created—by calling the {{domxref("performance")}} method {{domxref("performance.now", "now()")}}. This method is available in both {{domxref("Window")}} and {{domxref("Worker")}} contexts.
-
-## Example
-
-To determine how much time has elapsed since a particular point in your code, you can do something like this:
-
-```js
-let startTime = performance.now();
-
-/* do things for a while */
-
-let elapsedTime = performance.now() - startTime;
-```
-
-Upon completion, the value of `elapsedTime` is the number of milliseconds that have elapsed since you recorded the starting time in line 1.
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
+These headers ensure a top-level document does not share a browsing context group with
+cross-origin documents. COOP process-isolates your document and potential attackers
+can't access to your global object if they were opening it in a popup, preventing a set
+of cross-origin attacks dubbed [XS-Leaks](https://github.com/xsleaks/xsleaks).
 
 ## See also
 
-- [Navigation Timing API](/en-US/docs/Web/API/Navigation_timing_API)
-- {{domxref("Performance")}}
 - [`performance.now()`](/en-US/docs/Web/API/Performance/now)
+- [`performance.timeOrigin`](/en-US/docs/Web/API/Performance/timeOrigin)

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -7,29 +7,7 @@ browser-compat: api.Performance.now
 
 {{APIRef("Performance API")}}
 
-The **`performance.now()`** method
-returns a {{domxref("DOMHighResTimeStamp")}}, measured in milliseconds.
-
-{{AvailableInWorkers}}
-
-The returned value represents the time elapsed since the [time origin](/en-US/docs/Web/API/DOMHighResTimeStamp#the_time_origin).
-
-Bear in mind the following points:
-
-- In dedicated workers created from a {{domxref("Window")}} context, the value in the
-  worker will be lower than `performance.now()` in the window who spawned
-  that worker. It used to be the same as `t0` of the main context, but this
-  was changed.
-- In shared or service workers, the value in the worker might be higher than that of
-  the main context because that window can be created after those workers.
-
-It's important to keep in mind that to mitigate potential security threats such as [Spectre](https://spectreattack.com/), browsers typically round the returned
-value by some amount in order to be less predictable. This inherently introduces a
-degree of inaccuracy by limiting the resolution or precision of the timer. For example,
-Firefox rounds the returned time to 1 millisecond increments.
-
-The precision of the returned value is subject to change if/when the security concerns
-are alleviated through other means.
+The **`performance.now()`** method returns a high resolution timestamp in milliseconds. It represents the time elapsed since {{domxref("Performance.timeOrigin")}} (the time when navigation has started in window contexts, or the time when the worker is run in {{domxref("Worker")}} and {{domxref("ServiceWorker")}} contexts).
 
 ## Syntax
 
@@ -45,7 +23,49 @@ None.
 
 Returns a {{domxref("DOMHighResTimeStamp")}} measured in milliseconds.
 
+## Description
+
+### `Performance.now` vs. `Date.now`
+
+Unlike [`Date.now`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now), the timestamps returned by `performance.now()` are not limited to one-millisecond resolution. Instead, they represent times as floating-point numbers with bup to microsecond precision.
+
+Also, `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. as it is relative to the Unix epoch (1970-01-01T00:00:00Z) and dependent on the system clock.
+The `performance.now()` method on the other hand is relative to the `timeOrigin` property which is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock): its current time never decreases and isn't subject to adjustments.
+
+### `performance.now` specification changes
+
+The semantics of the `performance.now()` method changed between High Resolution Time Level 1 and Level 2.
+
+| Changes               | Level 1                                                                                       | Level 2                                                                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Relative to           | [`performance.timing.navigationStart`](/en-US/docs/Web/API/PerformanceTiming/navigationStart) | {{domxref("Performance.timeOrigin")}}                                                                                                                       |
+| Triggering conditions | Document fetch or unload prompt (if any).                                                     | Creation of the browsing context (if no prior document), unload prompt (if any), or start of the navigation (as defined in HTML, a few steps before fetch). |
+
+The `performance.now()` method used to be relative to [`performance.timing.navigationStart`](/en-US/docs/Web/API/PerformanceTiming/navigationStart) property from the Navigation Timing specification. This changed and `performance.now()` is now relative to {{domxref("Performance.timeOrigin")}} which avoids clock change risks when comparing timestamps across webpages.
+
+```js
+// Level 1 (clock change risks)
+currentTime = performance.timing.navigationStart + performance.now();
+
+// Level 2 (no clock change risks)
+currentTime = performance.timeOrigin + performance.now();
+```
+
+### Ticking during sleep
+
+The specification (Level 2) requires that `performance.now()` should tick during sleep. It appears that only Firefox on Windows, and Chromiums on Windows keep ticking during sleep. Relevant browser bugs for other operating systems:
+
+- Chrome/Chromium ([bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1206450))
+- Firefox ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1709767))
+- Safari/WebKit ([bug](https://bugs.webkit.org/show_bug.cgi?id=225610))
+
+More details can also be found in the specification issue [hr-time#115](https://github.com/w3c/hr-time/issues/115).
+
 ## Examples
+
+### Using `performance.now()`
+
+To determine how much time has elapsed since a particular point in your code, you can do something like this:
 
 ```js
 const t0 = performance.now();
@@ -54,47 +74,14 @@ const t1 = performance.now();
 console.log(`Call to doSomething took ${t1 - t0} milliseconds.`);
 ```
 
-Unlike other timing data available to JavaScript (for example [`Date.now`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)),
-the timestamps returned by `performance.now()` are not limited to
-one-millisecond resolution. Instead, they represent times as floating-point numbers with
-up to microsecond precision.
+## Security requirements
 
-Also unlike `Date.now()`, the values returned by
-`performance.now()` always increase at a constant rate, independent of the
-system clock (which might be adjusted manually or skewed by software like NTP).
-Otherwise, `performance.timing.navigationStart + performance.now()` will be
-approximately equal to `Date.now()`.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), `performance.now()` is coarsened based on site isolation status.
 
-## Reduced time precision
+- Resolution in isolated contexts: 5 microseconds
+- Resolution in non-isolated contexts: 100 microseconds
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of
-`performance.now()` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by
-default and defaults to 1ms.
-
-```js
-// reduced time precision (1ms) in Firefox 60
-performance.now();
-// 8781416
-// 8781815
-// 8782206
-// …
-
-// reduced time precision with `privacy.resistFingerprinting` enabled
-performance.now();
-// 8865400
-// 8866200
-// 8866700
-// …
-```
-
-In Firefox, you can also enable `privacy.resistFingerprinting` — this
-changes the precision to 100ms or the value of
-`privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever
-is larger.
-
-Starting with Firefox 79, high resolution timers can be used if you cross-origin
-isolate your document using the {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
+Cross-origin isolate your site using the {{HTTPHeader("Cross-Origin-Opener-Policy")}} and
 {{HTTPHeader("Cross-Origin-Embedder-Policy")}} headers:
 
 ```http
@@ -117,4 +104,4 @@ of cross-origin attacks dubbed [XS-Leaks](https://github.com/xsleaks/xsleaks).
 
 ## See also
 
-- [When milliseconds are not enough: performance.now()](https://developer.chrome.com/blog/when-milliseconds-are-not-enough-performance-now/)
+- {{domxref("Performance.timeOrigin")}}

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -11,11 +11,20 @@ The **`timeOrigin`** read-only property of the {{domxref("Performance")}} interf
 
 In Window contexts, this value represents the time when navigation has started. In {{domxref("Worker")}} and {{domxref("ServiceWorker")}} contexts, this value represents the time when the worker is run. You can use this property to synchronize the time origins between the contexts (see example below).
 
-> **Note:** The value of `performance.timeOrigin` may differ from the value returned by {{jsxref("Date.now()")}} executed at the time origin, because `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. The `timeOrigin` property is a [monotonic clock](https://w3c.github.io/hr-time/#sec-monotonic-clock) which current time never decreases and which isn't subject to these adjustments.
+> **Note:** The value of `performance.timeOrigin` may differ from the value returned by {{jsxref("Date.now()")}} executed at the time origin, because `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. The `timeOrigin` property is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock) which current time never decreases and which isn't subject to these adjustments.
 
 ## Value
 
-A high resolution timestamp.
+A high resolution timestamp which considered to be the beginning of the current document's lifetime. It's calculated like this:
+
+- If the script's {{Glossary("global object")}} is a {{domxref("Window")}}, the time origin is determined as follows:
+
+  - If the current {{domxref("Document")}} is the first one loaded in the `Window`, the time origin is the time at which the browser context was created.
+  - If during the process of unloading the previous document which was loaded in the window, a confirmation dialog was displayed to let the user confirm whether or not to leave the previous page, the time origin is the time at which the user confirmed that navigating to the new page was acceptable.
+  - If neither of the above determines the time origin, then the time origin is the time at which the navigation responsible for creating the window's current `Document` took place.
+
+- If the script's global object is a {{domxref("WorkerGlobalScope")}} (that is, the script is running as a web worker), the time origin is the moment at which the worker was created.
+- In all other cases, the time origin is undefined.
 
 ## Examples
 


### PR DESCRIPTION
### Description

I've made some updates to performance.now, performance.timeOrigin, and DOMHighResTimeStamp.

- DOMHighResTimeStamp is a typedef so reduce the page to be that. (no compat data etc)
- Outline spec changes from level 1 vs level 2.
- Talk about coarsening which happens if you don't meet the security requirements (cross site isolation)
- Remove Firefox-centric info about reduced time precision preference settings 

### Motivation

https://github.com/openwebdocs/project/issues/62

### Additional details

I'm happy to go more in-depth here if anyone (a subject matter expert) feels like helping me out to get this stuff right. 

### Related issues and pull requests

I'm not sure if this PR fully addresses https://github.com/mdn/content/issues/4713 but it should help at least.
