### PR TITLE
Use new MathML sidebar

### DIFF
--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -1,11 +1,9 @@
 ---
-title: MathML attribute reference
+title: Attributes
 slug: Web/MathML/Attribute
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 This is an alphabetical list of MathML attributes. More details for each attribute are available on relevant [MathML element pages](/en-US/docs/Web/MathML/Element) and on the [global attributes page](/en-US/docs/Web/MathML/Global_attributes). The [values](/en-US/docs/Web/MathML/Attribute/Values) page also describes some notes on common values used by MathML attributes.
 

--- a/files/en-us/web/mathml/attribute/values/index.md
+++ b/files/en-us/web/mathml/attribute/values/index.md
@@ -4,9 +4,7 @@ slug: Web/MathML/Attribute/Values
 browser-compat: mathml.attribute_values
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 ## MathML-specific types
 

--- a/files/en-us/web/mathml/authoring/index.md
+++ b/files/en-us/web/mathml/authoring/index.md
@@ -3,9 +3,7 @@ title: Authoring MathML
 slug: Web/MathML/Authoring
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 This page explains how to write mathematics using the MathML language, which is described with tags and attributes in text format. Just like for HTML or SVG, this text can become very verbose for complex content and so requires [proper authoring tools](https://www.w3.org/wiki/Math_Tools#Authoring_tools) such as converters from a [lightweight markup language](https://en.wikipedia.org/wiki/Lightweight_markup_language) or [WYSIWYG](https://en.wikipedia.org/wiki/WYSIWYG) equation editors. Many such tools are available and it is impossible to provide an exhaustive list. Instead, this article focuses on common approaches and examples.
 

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -3,9 +3,7 @@ title: MathML element reference
 slug: Web/MathML/Element
 ---
 
-<section id="Quick_links">
-  {{MathMLRef}}
-</section>
+{{MathMLRef}}
 
 This is an alphabetical list of MathML elements. All of them implement the {{domxref("MathMLElement")}} class.
 

--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -1,9 +1,9 @@
 ---
-title: "MathML: Deriving the Quadratic Formula"
+title: "Deriving the Quadratic Formula"
 slug: Web/MathML/Examples/Deriving_the_Quadratic_Formula
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Examples")}}
+{{MathMLRef}}
 
 This page outlines the derivation of the [Quadratic Formula](https://en.wikipedia.org/wiki/Quadratic_formula).
 

--- a/files/en-us/web/mathml/examples/index.md
+++ b/files/en-us/web/mathml/examples/index.md
@@ -3,9 +3,7 @@ title: Examples
 slug: Web/MathML/Examples
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 Below you'll find some examples you can look at to help you to understand how to use MathML.
 

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -3,7 +3,7 @@ title: Proving the Pythagorean theorem
 slug: Web/MathML/Examples/MathML_Pythagorean_Theorem
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Examples")}}
+{{MathMLRef}}
 
 We will now prove the [Pythagorean theorem](https://en.wikipedia.org/wiki/Pythagorean_theorem):
 

--- a/files/en-us/web/mathml/fonts/index.md
+++ b/files/en-us/web/mathml/fonts/index.md
@@ -3,9 +3,7 @@ title: Fonts for MathML
 slug: Web/MathML/Fonts
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 Fonts with appropriate Unicode coverage and Open Font Format features are required for good math rendering.
 This page describes how users can install such math fonts to properly display MathML in browsers.

--- a/files/en-us/web/mathml/global_attributes/dir/index.md
+++ b/files/en-us/web/mathml/global_attributes/dir/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/dir
 browser-compat: mathml.global_attributes.dir
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
+{{MathMLRef}}
 
 The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that indicates the directionality of the MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/displaystyle/index.md
+++ b/files/en-us/web/mathml/global_attributes/displaystyle/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/displaystyle
 browser-compat: mathml.global_attributes.displaystyle
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
+{{MathMLRef}}
 
 The **`displaystyle`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is a boolean setting the [math-style](/en-US/docs/Web/CSS/math-style) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/href/index.md
+++ b/files/en-us/web/mathml/global_attributes/href/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/href
 browser-compat: mathml.global_attributes.href
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Non-standard_header}}
+{{MathMLRef}}{{Non-standard_header}}
 
 The **`href`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) creates a hyperlink on the MathML element pointing to the specified URL.
 

--- a/files/en-us/web/mathml/global_attributes/index.md
+++ b/files/en-us/web/mathml/global_attributes/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes
 browser-compat: mathml.global_attributes
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
+{{MathMLRef}}
 
 **Global attributes** are attributes common to all MathML elements; they can be used on all elements, though they may have no effect on some elements.
 

--- a/files/en-us/web/mathml/global_attributes/mathbackground/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathbackground/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/mathbackground
 browser-compat: mathml.global_attributes.mathbackground
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
+{{MathMLRef}}{{Deprecated_Header}}
 
 The **`mathbackground`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [background-color](/en-US/docs/Web/CSS/background-color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathcolor/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathcolor/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/mathcolor
 browser-compat: mathml.global_attributes.mathcolor
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
+{{MathMLRef}}{{Deprecated_Header}}
 
 The **`mathcolor`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [color](/en-US/docs/Web/CSS/color) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/mathsize
 browser-compat: mathml.global_attributes.mathsize
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}{{Deprecated_Header}}
+{{MathMLRef}}{{Deprecated_Header}}
 
 The **`mathsize`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [font-size](/en-US/docs/Web/CSS/font-size) of a MathML element.
 

--- a/files/en-us/web/mathml/global_attributes/mathvariant/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathvariant/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/mathvariant
 browser-compat: mathml.global_attributes.mathvariant
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
+{{MathMLRef}}
 
 The **`mathvariant`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets a logical class for textual elements, which is visually
 distinguished by using special [Mathematical Alphanumeric Symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols).

--- a/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
+++ b/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
@@ -4,7 +4,7 @@ slug: Web/MathML/Global_attributes/scriptlevel
 browser-compat: mathml.global_attributes.scriptlevel
 ---
 
-{{QuickLinksWithSubPages("/en-us/docs/Web/MathML/Global_attributes")}}
+{{MathMLRef}}
 
 The **`scriptlevel`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) sets the [math-depth](/en-US/docs/Web/CSS/math-depth) of a MathML element. It allows overriding rules from the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) that define automatic calculation of [font-size](/en-US/docs/Web/CSS/font-size) within MathML formulas.
 


### PR DESCRIPTION
Now we have a new [MathML sidebar](https://github.com/mdn/yari/pull/8309), let's use it in all pages.

Note I also reworded a couple of page titles:

- [MathML attribute reference](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute) -> "Attributes"
- [MathML: Deriving the Quadratic Formula](https://developer.mozilla.org/en-US/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula) -> "Deriving the Quadratic Formula"

I think these are better but can revert them if you wish :).