### PR TITLE
Update image-set() to have informal and formal syntax sections

### DIFF
--- a/files/en-us/web/css/image/image-set/index.md
+++ b/files/en-us/web/css/image/image-set/index.md
@@ -30,7 +30,7 @@ image-set(
 /* Select gradient based on resolution */
 image-set(
   linear-gradient(blue, white) 1x,
-  linear-gradient(blue, green) 2x);
+  linear-gradient(blue, green) 2x
 );
 
 /* Select image based on supported formats */

--- a/files/en-us/web/css/image/image-set/index.md
+++ b/files/en-us/web/css/image/image-set/index.md
@@ -15,10 +15,29 @@ Resolution and bandwidth differ by device and network access. The `image-set()` 
 
 ## Syntax
 
-```css
-image-set() = image-set( <image-set-option># )
-where <image-set-option> = [ <image> | <string> ] <resolution> and
-      <string> is an <url>
+```css-nolint
+/* Select image based on resolution */
+image-set(
+  "image1.jpg" 1x,
+  "image2.jpg" 2x
+);
+
+image-set(
+  url("image1.jpg") 1x,
+  url("image2.jpg") 2x
+);
+
+/* Select gradient based on resolution */
+image-set(
+  linear-gradient(blue, white) 1x,
+  linear-gradient(blue, green) 2x);
+);
+
+/* Select image based on supported formats */
+image-set(
+  url("image1.avif") type("image/avif"),
+  url("image2.jpg") type("image/jpeg")
+);
 ```
 
 ### Values
@@ -31,6 +50,10 @@ where <image-set-option> = [ <image> | <string> ] <resolution> and
   - : [`<resolution>`](/en-US/docs/Web/CSS/resolution) units include `x` or `dppx`, for dots per pixel unit, `dpi`, for dots per inch, and `dpcm` for dots per centimeter. Every image within an `image-set()` must have a unique resolution.
 - `type(<string>)` {{optional_inline}}
   - : A valid MIME type string, for example "image/jpeg".
+
+### Formal syntax
+
+{{csssyntax}}
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/25080.

We don't have a definitive structure for CSS functions, but I've copied the most common one, in which we have "Formal syntax" as an H3 under "Syntax" (like, say, https://developer.mozilla.org/en-US/docs/Web/CSS/counters).

