### PR TITLE
Mathml fixtags

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -1,6 +1,8 @@
 ---
 title: <maction>
 slug: Web/MathML/Element/maction
+status:
+  - deprecated
 browser-compat: mathml.elements.maction
 ---
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -1,6 +1,8 @@
 ---
 title: <menclose>
 slug: Web/MathML/Element/menclose
+status:
+  - non-standard
 browser-compat: mathml.elements.menclose
 ---
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -1,6 +1,9 @@
 ---
 title: <mfenced>
 slug: Web/MathML/Element/mfenced
+status:
+  - deprecated
+  - non-standard
 browser-compat: mathml.elements.mfenced
 ---
 

--- a/files/en-us/web/mathml/global_attributes/href/index.md
+++ b/files/en-us/web/mathml/global_attributes/href/index.md
@@ -1,6 +1,8 @@
 ---
 title: href
 slug: Web/MathML/Global_attributes/href
+status:
+  - non-standard
 browser-compat: mathml.global_attributes.href
 ---
 

--- a/files/en-us/web/mathml/global_attributes/mathbackground/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathbackground/index.md
@@ -1,6 +1,8 @@
 ---
 title: mathbackground
 slug: Web/MathML/Global_attributes/mathbackground
+status:
+  - deprecated
 browser-compat: mathml.global_attributes.mathbackground
 ---
 

--- a/files/en-us/web/mathml/global_attributes/mathcolor/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathcolor/index.md
@@ -1,6 +1,8 @@
 ---
 title: mathcolor
 slug: Web/MathML/Global_attributes/mathcolor
+status:
+  - deprecated
 browser-compat: mathml.global_attributes.mathcolor
 ---
 

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -1,6 +1,8 @@
 ---
 title: mathsize
 slug: Web/MathML/Global_attributes/mathsize
+status:
+  - deprecated
 browser-compat: mathml.global_attributes.mathsize
 ---
 


### PR DESCRIPTION
Mathml tags had already been removed. This adds in status information based on the deprecated and non standard header macros and the BCD.

Part of https://github.com/mdn/mdn/issues/262