### PR TITLE
FileSystemWritableFileStream not experimental after FF111

### DIFF
--- a/files/en-us/web/api/filesystemwritablefilestream/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.md
@@ -2,12 +2,10 @@
 title: FileSystemWritableFileStream
 slug: Web/API/FileSystemWritableFileStream
 page-type: web-api-interface
-status:
-  - experimental
 browser-compat: api.FileSystemWritableFileStream
 ---
 
-{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("File System Access API")}}
 
 The **`FileSystemWritableFileStream`** interface of the {{domxref('File System Access API')}} is a {{domxref('WritableStream')}} object with additional convenience methods, which operates on a single file on disk. The interface is accessed through the {{domxref('FileSystemFileHandle.createWritable()')}} method.
 
@@ -21,11 +19,11 @@ _Inherits properties from its parent, {{DOMxRef("WritableStream")}}._
 
 _Inherits methods from its parent, {{DOMxRef("WritableStream")}}._
 
-- {{domxref('FileSystemWritableFileStream.write')}} {{Experimental_Inline}}
+- {{domxref('FileSystemWritableFileStream.write')}}
   - : Writes content into the file the method is called on, at the current file cursor offset.
-- {{domxref('FileSystemWritableFileStream.seek')}} {{Experimental_Inline}}
+- {{domxref('FileSystemWritableFileStream.seek')}}
   - : Updates the current file cursor offset to the position (in bytes) specified.
-- {{domxref('FileSystemWritableFileStream.truncate')}} {{Experimental_Inline}}
+- {{domxref('FileSystemWritableFileStream.truncate')}}
   - : Resizes the file associated with the stream to be the specified size in bytes.
 
 ## Examples

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -2,16 +2,12 @@
 title: FileSystemWritableFileStream.seek()
 slug: Web/API/FileSystemWritableFileStream/seek
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.FileSystemWritableFileStream.seek
 ---
 
-{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("File System Access API")}}
 
-The **`seek()`** method of the
-{{domxref("FileSystemWritableFileStream")}} interface updates the current file cursor
-offset to the position (in bytes) specified when calling the method.
+The **`seek()`** method of the {{domxref("FileSystemWritableFileStream")}} interface updates the current file cursor offset to the position (in bytes) specified when calling the method.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -2,23 +2,19 @@
 title: FileSystemWritableFileStream.truncate()
 slug: Web/API/FileSystemWritableFileStream/truncate
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.FileSystemWritableFileStream.truncate
 ---
 
-{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("File System Access API")}}
 
-The **`truncate()`** method of the
-{{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with
-the stream to be the specified size in bytes.
+The **`truncate()`** method of the {{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with the stream to be the specified size in bytes.
 
-If the size specified is larger than the current file size this pads the file with
-`null` bytes, otherwise it truncates the file.
+If the size specified is larger than the current file size this pads the file with `null` bytes, otherwise it truncates the file.
 
-The file cursor is also updated when `truncate()` is called. If the offset
-is smaller than the size, it remains unchanged. If the offset is larger than size, the
-offset is set to that size. This ensures that subsequent writes do not error.
+The file cursor is also updated when `truncate()` is called.
+If the offset is smaller than the size, it remains unchanged.
+If the offset is larger than size, the offset is set to that size.
+This ensures that subsequent writes do not error.
 
 No changes are written to the actual file on disk until the stream has been closed.
 Changes are typically written to a temporary file instead.

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -2,21 +2,15 @@
 title: FileSystemWritableFileStream.write()
 slug: Web/API/FileSystemWritableFileStream/write
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.FileSystemWritableFileStream.write
 ---
 
-{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("File System Access API")}}
 
-The **`write()`** method of the
-{{domxref("FileSystemWritableFileStream")}} interface writes content into the file the
-method is called on, at the current file cursor offset.
+The **`write()`** method of the {{domxref("FileSystemWritableFileStream")}} interface writes content into the file the method is called on, at the current file cursor offset.
 
 No changes are written to the actual file on disk until the stream has been closed.
-Changes are typically written to a temporary file instead. This method can also be used
-to seek to a byte point within the stream and truncate to modify the total bytes the
-file contains.
+Changes are typically written to a temporary file instead. This method can also be used to seek to a byte point within the stream and truncate to modify the total bytes the file contains.
 
 ## Syntax
 
@@ -60,13 +54,10 @@ write(data)
 
 ## Examples
 
-This asynchronous function opens the 'Save File' picker, which returns a
-{{domxref('FileSystemFileHandle')}} once a file is selected. From which a writable
-stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}}
-method.
+This asynchronous function opens the 'Save File' picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected.
+From which a writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.
 
-A user defined {{domxref('Blob')}} is then written to the stream which is subsequently
-closed.
+A user defined {{domxref('Blob')}} is then written to the stream which is subsequently closed.
 
 ```js
 async function saveFile() {
@@ -84,8 +75,7 @@ async function saveFile() {
 }
 ```
 
-The following show different examples of options that can be passed into the
-`write()` method.
+The following show different examples of options that can be passed into the `write()` method.
 
 ```js
 // just pass in the data (no options)


### PR DESCRIPTION
This follows on from https://github.com/mdn/browser-compat-data/pull/19056 . Note that a number of APIs are now supported, but only FileSystemWritableFileStream changes from experimental to supported on 2 browser engines.

This is part of #24388