### PR TITLE
Small change proposal

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Window.requestAnimationFrame
 
 The **`window.requestAnimationFrame()`** method tells the
 browser that you wish to perform an animation and requests that the browser calls a
-specified function to update an animation before the next repaint. The method takes a
+specified function to update an animation right before the next repaint. The method takes a
 callback as an argument to be invoked before the repaint.
 
 > **Note:** Your callback routine must itself call


### PR DESCRIPTION
### Description

I propose saying the function will be called "RIGHT before the next repaint" instead of just "before the nest repaint".

### Motivation

I believe it's important for the reader to understand that Window.requestAnimationFrame() will wait 1 / [browser fps] seconds before executing the callback, and that's why it must be used recursively.