### PR TITLE
Ff111 fetch authorization cross origin

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -47,6 +47,8 @@ This article provides information about the changes in Firefox 111 that affect d
   The data in this file system is origin-specific: permission prompts are not required to access files, and clearing data for the site/origin deletes the storage.
   The OPFS is accessed with the {{domxref("StorageManager.getDirectory()")}} method, by calling `navigator.storage.getDirectory()` in a worker or the main thread.
   See [Firefox bug 1785123](https://bugzil.la/1785123) for more details.
+- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from [`fetch()`](/en-US/docs/Web/API/fetch) requests that are redirected cross-origin (headers may be added by developers using the [`option.headers`](/en-US/docs/Web/API/fetch#headers) argument).
+  See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -35,6 +35,9 @@ This article provides information about the changes in Firefox 111 that affect d
 
 ### HTTP
 
+- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from cross origin redirects.
+  See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
+
 #### Removals
 
 ### Security
@@ -47,7 +50,7 @@ This article provides information about the changes in Firefox 111 that affect d
   The data in this file system is origin-specific: permission prompts are not required to access files, and clearing data for the site/origin deletes the storage.
   The OPFS is accessed with the {{domxref("StorageManager.getDirectory()")}} method, by calling `navigator.storage.getDirectory()` in a worker or the main thread.
   See [Firefox bug 1785123](https://bugzil.la/1785123) for more details.
-- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from [`fetch()`](/en-US/docs/Web/API/fetch) requests that are redirected cross-origin (headers may be added by developers using the [`option.headers`](/en-US/docs/Web/API/fetch#headers) argument).
+- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from [`fetch()`](/en-US/docs/Web/API/fetch) and [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) requests that are redirected cross-origin (`fetch()` headers may be added by developers using the [`option.headers`](/en-US/docs/Web/API/fetch#headers) argument).
   See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
 
 #### DOM

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -58,11 +58,14 @@ fetch(resource, options)
         {{httpheader("Origin")}} header is not set on Fetch requests with a method of
         {{HTTPMethod("HEAD")}} or {{HTTPMethod("GET")}}.
         (This behavior was corrected in Firefox 65 — see [Firefox bug 1508661](https://bugzil.la/1508661).)
-        Any string which is a case-insensitive match for one of the methods in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview ) will be uppercased automatically. If you want to use a custom method (like `PATCH`), you should uppercase it yourself.
+        Any string which is a case-insensitive match for one of the methods in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview) will be uppercased automatically. If you want to use a custom method (like `PATCH`), you should uppercase it yourself.
     - `headers`
-      - : Any headers you want to add to your request, contained within a
-        {{domxref("Headers")}} object or an object literal with {{jsxref("String")}}
-        values. Note that [some names are forbidden](/en-US/docs/Glossary/Forbidden_header_name).
+
+      - : Any headers you want to add to your request, contained within a {{domxref("Headers")}} object or an object literal with {{jsxref("String")}} values.
+        Note that [some names are forbidden](/en-US/docs/Glossary/Forbidden_header_name).
+
+        > **Note:** The `Authorization` header is sent with initial requests and same-origin redirects, but is removed from cross-origin redirects.
+
     - `body`
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -64,7 +64,7 @@ fetch(resource, options)
       - : Any headers you want to add to your request, contained within a {{domxref("Headers")}} object or an object literal with {{jsxref("String")}} values.
         Note that [some names are forbidden](/en-US/docs/Glossary/Forbidden_header_name).
 
-        > **Note:** The `Authorization` header is sent with initial requests and same-origin redirects, but is removed from cross-origin redirects.
+        > **Note:** The [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) HTTP header may be added to a request, but will be removed if the request is redirected cross-origin.
 
     - `body`
       - : Any body that you want to add to your request:

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -7,26 +7,20 @@ browser-compat: api.XMLHttpRequest.setRequestHeader
 
 {{APIRef('XMLHttpRequest')}}
 
-The {{domxref("XMLHttpRequest")}} method
-**`setRequestHeader()`** sets the value of an HTTP request
-header. When using `setRequestHeader()`, you must call it after calling
-{{domxref("XMLHttpRequest.open", "open()")}}, but before calling
-{{domxref("XMLHttpRequest.send", "send()")}}. If this method is called several times
-with the same header, the values are merged into one single request header.
+The {{domxref("XMLHttpRequest")}} method **`setRequestHeader()`** sets the value of an HTTP request header.
+When using `setRequestHeader()`, you must call it after calling {{domxref("XMLHttpRequest.open", "open()")}}, but before calling {{domxref("XMLHttpRequest.send", "send()")}}.
+If this method is called several times with the same header, the values are merged into one single request header.
 
-Each time you call `setRequestHeader()` after the first time you call it,
-the specified text is appended to the end of the existing header's content.
+Each time you call `setRequestHeader()` after the first time you call it, the specified text is appended to the end of the existing header's content.
 
-If no {{HTTPHeader("Accept")}} header has been set using this, an `Accept`
-header with the type `"*/*"` is sent with the request when
-{{domxref("XMLHttpRequest.send", "send()")}} is called.
+If no {{HTTPHeader("Accept")}} header has been set using this, an `Accept` header with the type `"*/*"` is sent with the request when {{domxref("XMLHttpRequest.send", "send()")}} is called.
 
 For security reasons, there are several {{Glossary("Forbidden_header_name", "forbidden header names")}} whose values are controlled by the user agent. Any attempt to set a value for one of those headers from frontend JavaScript code will be ignored without warning or error.
 
-> **Note:** For your custom fields, you may encounter a "**not
-> allowed by Access-Control-Allow-Headers in preflight response**" exception
-> when you send requests across domains. In this situation, you need to set up the
-> {{HTTPHeader("Access-Control-Allow-Headers")}} in your response header at server side.
+In addition, the [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) HTTP header may be added to a request, but will be removed if the request is redirected cross-origin.
+
+> **Note:** For your custom fields, you may encounter a "**not allowed by Access-Control-Allow-Headers in preflight response**" exception when you send requests across domains.
+> In this situation, you need to set up the {{HTTPHeader("Access-Control-Allow-Headers")}} in your response header at server side.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -13,6 +13,8 @@ The server responds with a {{HTTPStatus("401")}} `Unauthorized` message that inc
 This header indicates what authentication schemes can be used to access the resource (and any additional information needed by the client to use them).
 The user-agent should select the most secure authentication scheme that it supports from those offered, prompt the user for their credentials, and then re-request the resource (including the encoded credentials in the **`Authorization`** header).
 
+This header is stripped from cross-origin redirects.
+
 > **Note:** This header is part of the [General HTTP authentication framework](/en-US/docs/Web/HTTP/Authentication#the_general_http_authentication_framework).
 > It can be used with a number of [authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
 


### PR DESCRIPTION
From FF111 if a `fetch()` or `XMLHttpRequest`  request is redirected cross-origin, then a developer-added `Authorization` HTTP header will be removed from the request. The header is not stripped if the request is redirected to the same origin.

There isn't any particularly great place to record this information. What I have done is added it as a note to the `option.headers` value for `fetch()` and in the description for `XMLHttpRequest.setRequestHeader()` - I think that is the most likely place it will be seen.  This also gets a note in the `Authorization` header.

I've also added a release note.

Other docs work can be tracked in #22533