### PR TITLE
WebExt - Fixtags from /api/runtime/o

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -2,16 +2,6 @@
 title: runtime.PlatformArch
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - PlatformArch
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.PlatformArch
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -2,16 +2,6 @@
 title: runtime.PlatformInfo
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - PlatformInfo
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.PlatformInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -2,16 +2,6 @@
 title: runtime.PlatformNaclArch
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - PlatformNaclArch
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.PlatformNaclArch
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -2,16 +2,6 @@
 title: runtime.PlatformOs
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - PlatformOs
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.PlatformOs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -2,16 +2,6 @@
 title: runtime.Port
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/Port
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - port
-  - runtime
 browser-compat: webextensions.api.runtime.Port
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -2,16 +2,6 @@
 title: runtime.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/reload
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - reload
-  - runtime
 browser-compat: webextensions.api.runtime.reload
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -2,16 +2,6 @@
 title: runtime.requestUpdateCheck()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/requestUpdateCheck
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - requestUpdateCheck
-  - runtime
 browser-compat: webextensions.api.runtime.requestUpdateCheck
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -2,16 +2,6 @@
 title: runtime.RequestUpdateCheckStatus
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/RequestUpdateCheckStatus
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - RequestUpdateCheckStatus
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.RequestUpdateCheckStatus
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -2,16 +2,6 @@
 title: runtime.sendMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - runtime
-  - sendMessage
 browser-compat: webextensions.api.runtime.sendMessage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -2,16 +2,6 @@
 title: runtime.sendNativeMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - runtime
-  - sendNativeMessage
 browser-compat: webextensions.api.runtime.sendNativeMessage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -2,16 +2,6 @@
 title: runtime.setUninstallURL()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - runtime
-  - setUninstallURL
 browser-compat: webextensions.api.runtime.setUninstallURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
@@ -2,15 +2,6 @@
 title: scripting.ContentScriptFilter
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/ContentScriptFilter
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ContentScriptFilter
-  - Reference
-  - Type
-  - WebExtensions
-  - scripting
 browser-compat: webextensions.api.scripting.ContentScriptFilter
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -2,15 +2,6 @@
 title: scripting.executeScript()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/executeScript
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - executeScript
-  - scripting
 browser-compat: webextensions.api.scripting.executeScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -1,15 +1,6 @@
 ---
 title: scripting.ExecutionWorld
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ExecutionWorld
-  - Reference
-  - Type
-  - WebExtensions
-  - scripting
 browser-compat: webextensions.api.scripting.ExecutionWorld
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
@@ -2,15 +2,6 @@
 title: scripting.getRegisteredContentScripts()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/getRegisteredContentScripts
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getRegisteredContentScripts
-  - scripting
 browser-compat: webextensions.api.scripting.getRegisteredContentScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -2,14 +2,6 @@
 title: scripting
 slug: Mozilla/Add-ons/WebExtensions/API/scripting
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Reference
-  - WebExtensions
-  - scripting
 browser-compat: webextensions.api.scripting
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
@@ -2,15 +2,6 @@
 title: scripting.InjectionTarget
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/InjectionTarget
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - InjectionTarget
-  - Reference
-  - Type
-  - WebExtensions
-  - scripting
 browser-compat: webextensions.api.scripting.InjectionTarget
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
@@ -2,15 +2,6 @@
 title: scripting.insertCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/insertCSS
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - insertCSS
-  - scripting
 browser-compat: webextensions.api.scripting.insertCSS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -2,15 +2,6 @@
 title: scripting.registerContentScripts()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/registerContentScripts
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - registerContentScripts
-  - scripting
 browser-compat: webextensions.api.scripting.registerContentScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -2,15 +2,6 @@
 title: scripting.RegisteredContentScript
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - RegisteredContentScript
-  - Reference
-  - Type
-  - WebExtensions
-  - scripting
 browser-compat: webextensions.api.scripting.RegisteredContentScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
@@ -2,15 +2,6 @@
 title: scripting.removeCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/removeCSS
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - removeCSS
-  - scripting
 browser-compat: webextensions.api.scripting.removeCSS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
@@ -2,15 +2,6 @@
 title: scripting.unregisterContentScripts()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/unregisterContentScripts
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - unregisterContentScripts
-  - tabs
 browser-compat: webextensions.api.scripting.unregisterContentScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -2,15 +2,6 @@
 title: scripting.updateContentScripts()
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/updateContentScripts
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - updateContentScripts
-  - scripting
 browser-compat: webextensions.api.scripting.updateContentScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -2,15 +2,6 @@
 title: search.get()
 slug: Mozilla/Add-ons/WebExtensions/API/search/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Search
-  - WebExtensions
-  - get
 browser-compat: webextensions.api.search.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
@@ -2,14 +2,6 @@
 title: search
 slug: Mozilla/Add-ons/WebExtensions/API/search
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Search
-  - Search Engines
-  - WebExtensions
 browser-compat: webextensions.api.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
@@ -1,14 +1,6 @@
 ---
 title: search.query()
 slug: Mozilla/Add-ons/WebExtensions/API/search/query
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Search
-  - Search Engines
-  - WebExtensions
 browser-compat: webextensions.api.search.query
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -2,14 +2,6 @@
 title: search.search()
 slug: Mozilla/Add-ons/WebExtensions/API/search/search
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Search
-  - Search Engines
-  - WebExtensions
 browser-compat: webextensions.api.search.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -2,16 +2,6 @@
 title: sessions.Filter
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/Filter
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - filter
-  - sessions
 browser-compat: webextensions.api.sessions.Filter
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -2,15 +2,6 @@
 title: sessions.forgetClosedTab()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedTab
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - forgetClosedTab
-  - sessions
 browser-compat: webextensions.api.sessions.forgetClosedTab
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -2,15 +2,6 @@
 title: sessions.forgetClosedWindow()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedWindow
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - forgetClosedWindow
-  - sessions
 browser-compat: webextensions.api.sessions.forgetClosedWindow
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -2,16 +2,6 @@
 title: sessions.getRecentlyClosed()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getRecentlyClosed
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getRecentlyClosed
-  - sessions
 browser-compat: webextensions.api.sessions.getRecentlyClosed
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.getTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getTabValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getTabValue
-  - sessions
 browser-compat: webextensions.api.sessions.getTabValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.getWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getWindowValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getWindowValue
-  - sessions
 browser-compat: webextensions.api.sessions.getWindowValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -2,14 +2,6 @@
 title: sessions
 slug: Mozilla/Add-ons/WebExtensions/API/sessions
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - sessions
 browser-compat: webextensions.api.sessions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
@@ -2,16 +2,6 @@
 title: sessions.MAX_SESSION_RESULTS
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MAX_SESSION_RESULTS
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - sessions
 browser-compat: webextensions.api.sessions.MAX_SESSION_RESULTS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -2,16 +2,6 @@
 title: sessions.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChanged
-  - sessions
 browser-compat: webextensions.api.sessions.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.removeTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/removeTabValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - removeTabValue
-  - sessions
 browser-compat: webextensions.api.sessions.removeTabValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.removeWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/removeWindowValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - removeWindowValue
-  - sessions
 browser-compat: webextensions.api.sessions.removeWindowValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -2,15 +2,6 @@
 title: sessions.restore()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/restore
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - WebExtensions
-  - restore
-  - sessions
 browser-compat: webextensions.api.sessions.restore
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -2,16 +2,6 @@
 title: sessions.Session
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/Session
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Session
-  - Type
-  - WebExtensions
-  - sessions
 browser-compat: webextensions.api.sessions.Session
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.setTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/setTabValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - sessions
-  - setTabValue
 browser-compat: webextensions.api.sessions.setTabValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -2,15 +2,6 @@
 title: sessions.setWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/setWindowValue
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - sessions
-  - setWindowValue
 browser-compat: webextensions.api.sessions.setWindowValue
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.close()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/close
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - close
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.close
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.getPanel()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/getPanel
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getPanel
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.getPanel
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/getTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getTitle
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.getTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/ImageDataType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDataType
-  - Reference
-  - Type
-  - WebExtensions
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.ImageDataType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -2,14 +2,6 @@
 title: sidebarAction
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction
 page-type: webextension-api
-tags:
-  - API
-  - Extensions
-  - Non-standard
-  - Reference
-  - Sidebar
-  - WebExtensions
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.isOpen()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/isOpen
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - isOpen
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.isOpen
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -2,14 +2,6 @@
 title: sidebarAction.open()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/open
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - open
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.open
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setIcon
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - setIcon
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.setIcon
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.setPanel()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setPanel
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - setPanel
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.setPanel
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - setTitle
-  - sidebarAction
 browser-compat: webextensions.api.sidebarAction.setTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
@@ -2,15 +2,6 @@
 title: sidebarAction.toggle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/toggle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - sidebarAction
-  - toggle
 browser-compat: webextensions.api.sidebarAction.toggle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
@@ -2,15 +2,6 @@
 title: storage
 slug: Mozilla/Add-ons/WebExtensions/API/storage
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - Storage
-  - WebExtensions
 browser-compat: webextensions.api.storage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -2,16 +2,6 @@
 title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - Storage
-  - WebExtensions
-  - local
 browser-compat: webextensions.api.storage.local
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -2,16 +2,6 @@
 title: storage.managed
 slug: Mozilla/Add-ons/WebExtensions/API/storage/managed
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - Storage
-  - WebExtensions
-  - managed
 browser-compat: webextensions.api.storage.managed
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -2,16 +2,6 @@
 title: storage.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/storage/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - Storage
-  - WebExtensions
-  - onChanged
 browser-compat: webextensions.api.storage.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
@@ -2,16 +2,6 @@
 title: storage.session
 slug: Mozilla/Add-ons/WebExtensions/API/storage/session
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - Storage
-  - WebExtensions
-  - session
 browser-compat: webextensions.api.storage.session
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -2,17 +2,6 @@
 title: StorageArea.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - remove
 browser-compat: webextensions.api.storage.StorageArea.clear
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -2,19 +2,6 @@
 title: StorageArea.get()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - JavaScript
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - Web
-  - WebExtensions
-  - get
 browser-compat: webextensions.api.storage.StorageArea.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -2,17 +2,6 @@
 title: StorageArea.getBytesInUse()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - getBytesInUse
 browser-compat: webextensions.api.storage.StorageArea.getBytesInUse
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -2,16 +2,6 @@
 title: storage.StorageArea
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.storage.StorageArea
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -2,16 +2,6 @@
 title: storage.StorageArea.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - Storage
-  - WebExtensions
-  - onChanged
 browser-compat: webextensions.api.storage.StorageArea.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -2,17 +2,6 @@
 title: StorageArea.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - remove
 browser-compat: webextensions.api.storage.StorageArea.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -2,17 +2,6 @@
 title: StorageArea.set()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - set
 browser-compat: webextensions.api.storage.StorageArea.set
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -2,16 +2,6 @@
 title: storage.StorageChange
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageChange
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageChange
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.storage.StorageChange
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -2,16 +2,6 @@
 title: storage.sync
 slug: Mozilla/Add-ons/WebExtensions/API/storage/sync
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - Storage
-  - Sync
-  - WebExtensions
 browser-compat: webextensions.api.storage.sync
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -2,15 +2,6 @@
 title: tabs.captureTab()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/captureTab
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - captureTab
-  - tabs
 browser-compat: webextensions.api.tabs.captureTab
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -2,16 +2,6 @@
 title: tabs.captureVisibleTab()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captureVisibleTab
-  - tabs
 browser-compat: webextensions.api.tabs.captureVisibleTab
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -2,16 +2,6 @@
 title: tabs.connect()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/connect
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - connect
-  - tabs
 browser-compat: webextensions.api.tabs.connect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -2,16 +2,6 @@
 title: tabs.create()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -2,16 +2,6 @@
 title: tabs.detectLanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - detectLanguage
-  - tabs
 browser-compat: webextensions.api.tabs.detectLanguage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -2,14 +2,6 @@
 title: tabs.discard()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/discard
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - WebExtensions
-  - discard
-  - tabs
 browser-compat: webextensions.api.tabs.discard
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -2,16 +2,6 @@
 title: tabs.duplicate()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Duplicate
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.duplicate
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -2,16 +2,6 @@
 title: tabs.executeScript()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - executeScript
-  - tabs
 browser-compat: webextensions.api.tabs.executeScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -2,16 +2,6 @@
 title: tabs.get()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - get
-  - tabs
 browser-compat: webextensions.api.tabs.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -2,17 +2,8 @@
 title: tabs.getAllInWindow()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getAllInWindow
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAllInWindow
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.getAllInWindow
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
@@ -2,16 +2,6 @@
 title: tabs.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getCurrent
-  - tabs
 browser-compat: webextensions.api.tabs.getCurrent
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -2,17 +2,8 @@
 title: tabs.getSelected()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getSelected
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.getSelected
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -2,16 +2,6 @@
 title: tabs.getZoom()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getZoom
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getZoom
-  - tabs
 browser-compat: webextensions.api.tabs.getZoom
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -2,16 +2,6 @@
 title: tabs.getZoomSettings()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getZoomSettings
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getZoomSettings
-  - tabs
 browser-compat: webextensions.api.tabs.getZoomSettings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -2,15 +2,6 @@
 title: tabs.goBack()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/goBack
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - goBack
 browser-compat: webextensions.api.tabs.goBack
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -2,15 +2,6 @@
 title: tabs.goForward()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/goForward
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - goForward
 browser-compat: webextensions.api.tabs.goForward
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.md
@@ -2,15 +2,6 @@
 title: tabs.hide()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/hide
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - hide
-  - tabs
 browser-compat: webextensions.api.tabs.hide
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -2,16 +2,6 @@
 title: tabs.highlight()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/highlight
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - highlight
-  - tabs
 browser-compat: webextensions.api.tabs.highlight
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -2,15 +2,6 @@
 title: tabs
 slug: Mozilla/Add-ons/WebExtensions/API/tabs
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -2,16 +2,6 @@
 title: tabs.insertCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - insertCSS
-  - tabs
 browser-compat: webextensions.api.tabs.insertCSS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -2,16 +2,6 @@
 title: tabs.move()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/move
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - move
-  - tabs
 browser-compat: webextensions.api.tabs.move
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
@@ -2,14 +2,6 @@
 title: tabs.moveInSuccession()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/moveInSuccession
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.moveInSuccession
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -2,16 +2,6 @@
 title: tabs.MutedInfo
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MutedInfo
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.MutedInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -2,16 +2,6 @@
 title: tabs.MutedInfoReason
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MutedInfoReason
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.MutedInfoReason
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -2,16 +2,6 @@
 title: tabs.onActivated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onActivated
-  - tabs
 browser-compat: webextensions.api.tabs.onActivated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
@@ -2,17 +2,8 @@
 title: tabs.onActiveChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onActiveChanged
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.onActiveChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -2,16 +2,6 @@
 title: tabs.onAttached
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onAttached
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onAttached
-  - tabs
 browser-compat: webextensions.api.tabs.onAttached
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -2,16 +2,6 @@
 title: tabs.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCreated
-  - tabs
 browser-compat: webextensions.api.tabs.onCreated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -2,16 +2,6 @@
 title: tabs.onDetached
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onDetached
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onDetached
-  - tabs
 browser-compat: webextensions.api.tabs.onDetached
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
@@ -2,17 +2,8 @@
 title: tabs.onHighlightChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onHighlightChanged
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.onHighlightChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -2,16 +2,6 @@
 title: tabs.onHighlighted
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onHighlighted
-  - tabs
 browser-compat: webextensions.api.tabs.onHighlighted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -2,16 +2,6 @@
 title: tabs.onMoved
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onMoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onMoved
-  - tabs
 browser-compat: webextensions.api.tabs.onMoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -2,16 +2,6 @@
 title: tabs.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRemoved
-  - tabs
 browser-compat: webextensions.api.tabs.onRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -2,16 +2,6 @@
 title: tabs.onReplaced
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onReplaced
-  - tabs
 browser-compat: webextensions.api.tabs.onReplaced
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -2,17 +2,8 @@
 title: tabs.onSelectionChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onSelectionChanged
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.onSelectionChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -2,16 +2,6 @@
 title: tabs.onUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onUpdated
-  - tabs
 browser-compat: webextensions.api.tabs.onUpdated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -2,16 +2,6 @@
 title: tabs.onZoomChange
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onZoomChange
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onZoomChange
-  - tabs
 browser-compat: webextensions.api.tabs.onZoomChange
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
@@ -2,15 +2,6 @@
 title: tabs.PageSettings
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/PageSettings
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - PageSettings
-  - Reference
-  - Type
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.PageSettings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/print/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/print/index.md
@@ -2,15 +2,6 @@
 title: tabs.print()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/print
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - print
-  - tabs
 browser-compat: webextensions.api.tabs.print
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -2,15 +2,6 @@
 title: tabs.printPreview()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/printPreview
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - printPreview
-  - tabs
 browser-compat: webextensions.api.tabs.printPreview
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -2,16 +2,6 @@
 title: tabs.query()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/query
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - query
-  - tabs
 browser-compat: webextensions.api.tabs.query
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -2,16 +2,6 @@
 title: tabs.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/reload
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - reload
-  - tabs
 browser-compat: webextensions.api.tabs.reload
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -2,16 +2,6 @@
 title: tabs.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - remove
-  - tabs
 browser-compat: webextensions.api.tabs.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -2,16 +2,6 @@
 title: tabs.removeCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - removeCSS
-  - tabs
 browser-compat: webextensions.api.tabs.removeCSS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
@@ -2,15 +2,6 @@
 title: tabs.saveAsPDF()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/saveAsPDF
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - saveAsPDF
-  - tabs
 browser-compat: webextensions.api.tabs.saveAsPDF
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
@@ -2,16 +2,6 @@
 title: tabs.sendMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - sendMessage
-  - tabs
 browser-compat: webextensions.api.tabs.sendMessage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -2,17 +2,8 @@
 title: tabs.sendRequest()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - sendRequest
-  - tabs
+status:
+  - deprecated
 browser-compat: webextensions.api.tabs.sendRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -2,16 +2,6 @@
 title: tabs.setZoom()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/setZoom
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - setZoom
-  - tabs
 browser-compat: webextensions.api.tabs.setZoom
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -2,16 +2,6 @@
 title: tabs.setZoomSettings()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/setZoomSettings
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - setZoomSettings
-  - tabs
 browser-compat: webextensions.api.tabs.setZoomSettings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.md
@@ -2,15 +2,6 @@
 title: tabs.show()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/show
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - show
-  - tabs
 browser-compat: webextensions.api.tabs.show
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -2,16 +2,6 @@
 title: tabs.Tab
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Tab
-  - Type
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.Tab
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -2,16 +2,6 @@
 title: tabs.TAB_ID_NONE
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - TAB_ID_NONE
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.TAB_ID_NONE
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -2,16 +2,6 @@
 title: tabs.TabStatus
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - TabStatus
-  - Type
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.TabStatus
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
@@ -2,15 +2,6 @@
 title: tabs.toggleReaderMode()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - tabs
-  - toggleReaderMode
 browser-compat: webextensions.api.tabs.toggleReaderMode
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -2,16 +2,6 @@
 title: tabs.update()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Update
-  - WebExtensions
-  - tabs
 browser-compat: webextensions.api.tabs.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
@@ -2,15 +2,6 @@
 title: tabs.warmup()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/warmup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - tabs
-  - warmup
 browser-compat: webextensions.api.tabs.warmup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -2,16 +2,6 @@
 title: tabs.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/WindowType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - WindowType
-  - tabs
 browser-compat: webextensions.api.tabs.WindowType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -2,16 +2,6 @@
 title: tabs.ZoomSettings
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - ZoomSettings
-  - tabs
 browser-compat: webextensions.api.tabs.ZoomSettings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -2,16 +2,6 @@
 title: tabs.ZoomSettingsMode
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsMode
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - ZoomSettingsMode
-  - tabs
 browser-compat: webextensions.api.tabs.ZoomSettingsMode
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -2,16 +2,6 @@
 title: tabs.ZoomSettingsScope
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsScope
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - ZoomSettingsScope
-  - tabs
 browser-compat: webextensions.api.tabs.ZoomSettingsScope
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -2,15 +2,6 @@
 title: theme.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/theme/getCurrent
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Theme
-  - WebExtensions
-  - getCurrent
 browser-compat: webextensions.api.theme.getCurrent
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
@@ -2,11 +2,6 @@
 title: theme
 slug: Mozilla/Add-ons/WebExtensions/API/theme
 page-type: webextension-api
-tags:
-  - Extensions
-  - Themes
-  - WebExtensions
-  - add-on
 browser-compat: webextensions.api.theme
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -2,12 +2,6 @@
 title: theme.onUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/theme/onUpdated
 page-type: webextension-api-event
-tags:
-  - Add-ons
-  - Event
-  - Extensions
-  - Theme
-  - WebExtensions
 browser-compat: webextensions.api.theme.onUpdated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
@@ -2,15 +2,6 @@
 title: theme.reset()
 slug: Mozilla/Add-ons/WebExtensions/API/theme/reset
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Theme
-  - WebExtensions
-  - reset
 browser-compat: webextensions.api.theme.reset
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.md
@@ -2,12 +2,6 @@
 title: Theme
 slug: Mozilla/Add-ons/WebExtensions/API/theme/Theme
 page-type: webextension-api-type
-tags:
-  - Extension
-  - Theme
-  - Type
-  - WebExtensions
-  - add-on
 browser-compat: webextensions.api.theme.Theme
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -2,15 +2,6 @@
 title: theme.update()
 slug: Mozilla/Add-ons/WebExtensions/API/theme/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Theme
-  - Update
-  - WebExtensions
 browser-compat: webextensions.api.theme.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -2,16 +2,6 @@
 title: topSites.get()
 slug: Mozilla/Add-ons/WebExtensions/API/topSites/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - get
-  - topSites
 browser-compat: webextensions.api.topSites.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -2,15 +2,6 @@
 title: topSites
 slug: Mozilla/Add-ons/WebExtensions/API/topSites
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - topSites
 browser-compat: webextensions.api.topSites
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -2,16 +2,6 @@
 title: topSites.MostVisitedURL
 slug: Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MostVisitedURL
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - topSites
 browser-compat: webextensions.api.topSites.MostVisitedURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -2,15 +2,6 @@
 title: clear()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/clear
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Types
-  - WebExtensions
-  - clear
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -2,15 +2,6 @@
 title: get()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Types
-  - WebExtensions
-  - get
 ---
 
 {{AddonSidebar()}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -2,15 +2,6 @@
 title: BrowserSetting
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BrowserSetting
-  - Extensions
-  - Reference
-  - Type
-  - Types
-  - WebExtensions
 browser-compat: webextensions.api.types.BrowserSetting
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -2,16 +2,6 @@
 title: BrowserSetting.onChange
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - BrowserSetting
-  - Event
-  - Extensions
-  - Privacy
-  - Reference
-  - WebExtensions
-  - onchange
 browser-compat: webextensions.api.types.BrowserSetting.onChange
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -2,15 +2,6 @@
 title: set()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - BrowserSetting
-  - Extensions
-  - Privacy
-  - Reference
-  - WebExtensions
-  - set
 ---
 
 {{AddonSidebar()}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
@@ -2,13 +2,6 @@
 title: types
 slug: Mozilla/Add-ons/WebExtensions/API/types
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Types
-  - WebExtensions
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -2,15 +2,6 @@
 title: userScripts
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts
 page-type: webextension-api
-tags:
-  - Add-ons
-  - Customization
-  - Extensions
-  - Firefox
-  - Mozilla
-  - Reference
-  - WebExtensions
-  - userScripts
 browser-compat: webextensions.api.userScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
@@ -2,18 +2,6 @@
 title: userScripts.onBeforeScript
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript
 page-type: webextension-api-event
-tags:
-  - Add-ons
-  - Addons
-  - Customization
-  - Event
-  - Extensions
-  - Firefox
-  - Mozilla
-  - Reference
-  - User Scripts API
-  - WebExtensions
-  - userScripts
 browser-compat: webextensions.api.userScripts.onBeforeScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.md
@@ -2,14 +2,6 @@
 title: userScripts.register()
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/register
 page-type: webextension-api-function
-tags:
-  - Add-ons
-  - Extensions
-  - Method
-  - User Scripts API
-  - WebExtensions
-  - register
-  - userScripts
 browser-compat: webextensions.api.userScripts.register
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
@@ -2,13 +2,6 @@
 title: userScripts.RegisteredUserScript
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript
 page-type: webextension-api-type
-tags:
-  - API
-  - Extensions
-  - Reference
-  - RegisteredUserScript
-  - Type
-  - userScripts
 browser-compat: webextensions.api.userScripts.RegisteredUserScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
@@ -2,14 +2,6 @@
 title: RegisteredUserScript.unregister()
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister
 page-type: webextension-api-function
-tags:
-  - Add-ons
-  - Extensions
-  - Method
-  - User Scripts API
-  - WebExtensions
-  - unregister
-  - userScripts
 browser-compat: webextensions.api.userScripts.RegisteredUserScript.unregister
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/userscriptoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/userscriptoptions/index.md
@@ -2,16 +2,6 @@
 title: UserScripts.UserScriptOptions
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/UserScriptOptions
 page-type: webextension-api-type
-tags:
-  - Add-ons
-  - Extensions
-  - Firefox
-  - Guide
-  - Intermediate
-  - NeedsExample
-  - UserScriptOptions
-  - WebExtensions
-  - userScripts
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/working_with_userscripts/index.md
@@ -2,12 +2,6 @@
 title: Working with userScripts
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/Working_with_userScripts
 page-type: guide
-tags:
-  - API
-  - Extensions
-  - How-to
-  - Tutorial
-  - userScripts
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.getAllFrames()
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAllFrames
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.getAllFrames
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.getFrame()
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getFrame
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.getFrame
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -2,15 +2,6 @@
 title: webNavigation
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - webNavigation
 browser-compat: webextensions.api.webNavigation
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onBeforeNavigate
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onBeforeNavigate
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onBeforeNavigate
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onCommitted
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCommitted
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onCommitted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onCompleted
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCompleted
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onCompleted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onCreatedNavigationTarget
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCreatedNavigationTarget
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onCreatedNavigationTarget
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onDOMContentLoaded
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onDOMContentLoaded
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onDOMContentLoaded
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onErrorOccurred
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onErrorOccurred
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onErrorOccurred
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onHistoryStateUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onHistoryStateUpdated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onHistoryStateUpdated
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onHistoryStateUpdated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onReferenceFragmentUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onReferenceFragmentUpdated
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onReferenceFragmentUpdated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.onTabReplaced
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onTabReplaced
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onTabReplaced
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.onTabReplaced
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.TransitionQualifier
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionQualifier
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - TransitionQualifier
-  - Type
-  - WebExtensions
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.TransitionQualifier
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -2,16 +2,6 @@
 title: webNavigation.TransitionType
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - TransitionType
-  - Type
-  - WebExtensions
-  - webNavigation
 browser-compat: webextensions.api.webNavigation.TransitionType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -2,16 +2,6 @@
 title: webRequest.BlockingResponse
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BlockingResponse
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.BlockingResponse
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -2,15 +2,6 @@
 title: webRequest.CertificateInfo
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/CertificateInfo
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - CertificateInfo
-  - Extensions
-  - Reference
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.CertificateInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -2,15 +2,6 @@
 title: webRequest.filterResponseData()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/filterResponseData
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - filterResponseData
-  - webRequest
 browser-compat: webextensions.api.webRequest.filterResponseData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -2,15 +2,6 @@
 title: webRequest.getSecurityInfo()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/getSecurityInfo
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getSecurityInfo
-  - webRequest
 browser-compat: webextensions.api.webRequest.getSecurityInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -2,16 +2,6 @@
 title: webRequest.handlerBehaviorChanged()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/handlerBehaviorChanged
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - handlerBehaviorChanged
-  - webRequest
 browser-compat: webextensions.api.webRequest.handlerBehaviorChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -2,16 +2,6 @@
 title: webRequest.HttpHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/HttpHeaders
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - HttpHeaders
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.HttpHeaders
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -2,15 +2,6 @@
 title: webRequest
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -3,16 +3,6 @@ title: webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/webRequest/MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onAuthRequired
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onAuthRequired
-  - webRequest
 browser-compat: webextensions.api.webRequest.onAuthRequired
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onBeforeRedirect
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onBeforeRedirect
-  - webRequest
 browser-compat: webextensions.api.webRequest.onBeforeRedirect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onBeforeRequest
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onBeforeRequest
-  - webRequest
 browser-compat: webextensions.api.webRequest.onBeforeRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onBeforeSendHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onBeforeSendHeaders
-  - webRequest
 browser-compat: webextensions.api.webRequest.onBeforeSendHeaders
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onCompleted
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCompleted
-  - webRequest
 browser-compat: webextensions.api.webRequest.onCompleted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onErrorOccurred
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onErrorOccurred
-  - webRequest
 browser-compat: webextensions.api.webRequest.onErrorOccurred
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onHeadersReceived
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onHeadersReceived
-  - webRequest
 browser-compat: webextensions.api.webRequest.onHeadersReceived
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onResponseStarted
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onResponseStarted
-  - webRequest
 browser-compat: webextensions.api.webRequest.onResponseStarted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -2,16 +2,6 @@
 title: webRequest.onSendHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onSendHeaders
-  - webRequest
 browser-compat: webextensions.api.webRequest.onSendHeaders
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -2,16 +2,6 @@
 title: webRequest.RequestFilter
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - RequestFilter
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.RequestFilter
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -2,16 +2,6 @@
 title: webRequest.ResourceType
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - ResourceType
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.ResourceType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
@@ -2,14 +2,6 @@
 title: webRequest.SecurityInfo
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/SecurityInfo
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Reference
-  - SecurityInfo
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.SecurityInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -2,13 +2,6 @@
 title: webRequest.StreamFilter.close()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/close
 page-type: webextension-api-function
-tags:
-  - Add-ons
-  - Extensions
-  - Method
-  - StreamFilter.close
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.close
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -2,13 +2,6 @@
 title: webRequest.StreamFilter.disconnect()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/disconnect
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - StreamFilter.disconnect
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.disconnect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.error
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/error
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.error
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.error
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -2,15 +2,6 @@
 title: webRequest.StreamFilter
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter
-  - Type
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -2,16 +2,6 @@
 title: webRequest.StreamFilter.ondata
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/ondata
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.ondata
-  - TextDecoder
-  - TextEncoder
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.onerror
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onerror
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.onerror
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.onerror
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.onstart
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstart
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.onstart
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.onstart
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.onstop
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstop
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.onstop
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.onstop
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.resume()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/resume
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.resume()
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.resume
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.status
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/status
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.status
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.status
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.suspend()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/suspend
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.suspend()
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.suspend
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -2,14 +2,6 @@
 title: webRequest.StreamFilter.write()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/write
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - StreamFilter.write()
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.StreamFilter.write
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -2,16 +2,6 @@
 title: webRequest.UploadData
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/UploadData
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - UploadData
-  - WebExtensions
-  - webRequest
 browser-compat: webextensions.api.webRequest.UploadData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -2,16 +2,6 @@
 title: windows.create()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -2,16 +2,6 @@
 title: windows.CreateType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/CreateType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - CreateType
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows.CreateType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -2,16 +2,6 @@
 title: windows.get()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - get
 browser-compat: webextensions.api.windows.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -2,16 +2,6 @@
 title: windows.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - getAll
 browser-compat: webextensions.api.windows.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -2,16 +2,6 @@
 title: windows.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getCurrent
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - getCurrent
 browser-compat: webextensions.api.windows.getCurrent
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -2,16 +2,6 @@
 title: windows.getLastFocused()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - getLastFocused
 browser-compat: webextensions.api.windows.getLastFocused
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
@@ -2,15 +2,6 @@
 title: windows
 slug: Mozilla/Add-ons/WebExtensions/API/windows
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -2,16 +2,6 @@
 title: windows.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onCreated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - onCreated
 browser-compat: webextensions.api.windows.onCreated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -2,16 +2,6 @@
 title: windows.onFocusChanged
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - onFocusChanged
 browser-compat: webextensions.api.windows.onFocusChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -2,16 +2,6 @@
 title: windows.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - onRemoved
 browser-compat: webextensions.api.windows.onRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -2,17 +2,6 @@
 title: windows.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-  - close
-  - remove
 browser-compat: webextensions.api.windows.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -2,16 +2,6 @@
 title: windows.update()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Update
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -2,16 +2,6 @@
 title: windows.Window
 slug: Mozilla/Add-ons/WebExtensions/API/windows/Window
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - Window
-  - Windows
 browser-compat: webextensions.api.windows.Window
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -2,16 +2,6 @@
 title: windows.WINDOW_ID_CURRENT
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WINDOW_ID_CURRENT
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows.WINDOW_ID_CURRENT
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -2,16 +2,6 @@
 title: windows.WINDOW_ID_NONE
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WINDOW_ID_NONE
-  - WebExtensions
-  - Windows
 browser-compat: webextensions.api.windows.WINDOW_ID_NONE
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -2,16 +2,6 @@
 title: windows.WindowState
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowState
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - WindowState
-  - Windows
 browser-compat: webextensions.api.windows.WindowState
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -2,16 +2,6 @@
 title: windows.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - WindowType
-  - Windows
 browser-compat: webextensions.api.windows.WindowType
 ---
 


### PR DESCRIPTION
Fixes up all WebExtension tags with paths > /api/runtime/o
"non-standard" information in tags is discarded.

Part of https://github.com/mdn/mdn/issues/262