### PR TITLE
WebExt - Fix tags from /api/dom/

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/index.md
@@ -1,12 +1,6 @@
 ---
 title: dom
 slug: Mozilla/Add-ons/WebExtensions/API/dom
-tags:
-  - API
-  - Add-ons
-  - DOM
-  - Extensions
-  - WebExtensions
 browser-compat: webextensions.api.dom
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
@@ -1,18 +1,6 @@
 ---
 title: dom.openOrClosedShadowRoot()
 slug: Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Mozilla
-  - Needs Privileges
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - openOrClosedShadowRoot
-  - shadow DOM
 browser-compat: webextensions.api.dom.openOrClosedShadowRoot
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -2,16 +2,6 @@
 title: downloads.acceptDanger()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/acceptDanger
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - acceptDanger
-  - downloads
 browser-compat: webextensions.api.downloads.acceptDanger
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -2,16 +2,6 @@
 title: downloads.BooleanDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/BooleanDelta
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BooleanDelta
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.BooleanDelta
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -2,16 +2,6 @@
 title: downloads.cancel()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/cancel
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - cancel
-  - downloads
 browser-compat: webextensions.api.downloads.cancel
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -2,16 +2,6 @@
 title: downloads.DangerType
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DangerType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DangerType
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.DangerType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -2,16 +2,6 @@
 title: downloads.DoubleDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DoubleDelta
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DoubleDelta
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.DoubleDelta
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -2,16 +2,6 @@
 title: downloads.download()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/download
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - download
-  - downloads
 browser-compat: webextensions.api.downloads.download
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -2,16 +2,6 @@
 title: downloads.DownloadItem
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadItem
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DownloadItem
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.DownloadItem
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -2,16 +2,6 @@
 title: downloads.DownloadQuery
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadQuery
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DownloadQuery
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.DownloadQuery
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -2,16 +2,6 @@
 title: downloads.DownloadTime
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadTime
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DownloadTime
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.DownloadTime
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.md
@@ -2,16 +2,6 @@
 title: downloads.drag()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/drag
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Drag
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.drag
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -2,16 +2,6 @@
 title: downloads.erase()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/erase
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - erase
 browser-compat: webextensions.api.downloads.erase
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -2,16 +2,6 @@
 title: downloads.FilenameConflictAction
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/FilenameConflictAction
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - FilenameConflictAction
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.FilenameConflictAction
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -2,16 +2,6 @@
 title: downloads.getFileIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/getFileIcon
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - getFileIcon
 browser-compat: webextensions.api.downloads.getFileIcon
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -2,15 +2,6 @@
 title: downloads
 slug: Mozilla/Add-ons/WebExtensions/API/downloads
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -2,16 +2,6 @@
 title: downloads.InterruptReason
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/InterruptReason
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - InterruptReason
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.InterruptReason
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -2,16 +2,6 @@
 title: downloads.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - onChanged
 browser-compat: webextensions.api.downloads.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -2,16 +2,6 @@
 title: downloads.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onCreated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - onCreated
 browser-compat: webextensions.api.downloads.onCreated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -2,16 +2,6 @@
 title: downloads.onErased
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onErased
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - onErased
 browser-compat: webextensions.api.downloads.onErased
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -2,16 +2,6 @@
 title: downloads.open()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/open
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - open
 browser-compat: webextensions.api.downloads.open
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -2,16 +2,6 @@
 title: downloads.pause()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/pause
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - pause
 browser-compat: webextensions.api.downloads.pause
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -2,16 +2,6 @@
 title: downloads.removeFile()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/removeFile
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - removeFile
 browser-compat: webextensions.api.downloads.removeFile
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -2,16 +2,6 @@
 title: downloads.resume()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/resume
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - resume
 browser-compat: webextensions.api.downloads.resume
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -2,16 +2,6 @@
 title: downloads.search()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/search
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Search
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -2,16 +2,6 @@
 title: downloads.setShelfEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/setShelfEnabled
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - setShelfEnabled
 browser-compat: webextensions.api.downloads.setShelfEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -2,16 +2,6 @@
 title: downloads.show()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/show
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - show
 browser-compat: webextensions.api.downloads.show
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -2,16 +2,6 @@
 title: downloads.showDefaultFolder()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/showDefaultFolder
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-  - showDefaultFolder
 browser-compat: webextensions.api.downloads.showDefaultFolder
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -2,16 +2,6 @@
 title: downloads.State
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/State
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - downloads
-  - state
 browser-compat: webextensions.api.downloads.State
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -2,16 +2,6 @@
 title: downloads.StringDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/StringDelta
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - StringDelta
-  - Type
-  - WebExtensions
-  - downloads
 browser-compat: webextensions.api.downloads.StringDelta
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -2,16 +2,6 @@
 title: events.Event
 slug: Mozilla/Add-ons/WebExtensions/API/events/Event
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - events
 browser-compat: webextensions.api.events.Event
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
@@ -2,15 +2,6 @@
 title: events
 slug: Mozilla/Add-ons/WebExtensions/API/events
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - events
 browser-compat: webextensions.api.events
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -2,16 +2,6 @@
 title: events.Rule
 slug: Mozilla/Add-ons/WebExtensions/API/events/Rule
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Rule
-  - Type
-  - WebExtensions
-  - events
 browser-compat: webextensions.api.events.Rule
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -2,16 +2,6 @@
 title: events.UrlFilter
 slug: Mozilla/Add-ons/WebExtensions/API/events/UrlFilter
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - UrlFilter
-  - WebExtensions
-  - events
 browser-compat: webextensions.api.events.UrlFilter
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -2,16 +2,6 @@
 title: extension.getBackgroundPage()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getBackgroundPage
 browser-compat: webextensions.api.extension.getBackgroundPage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -2,16 +2,6 @@
 title: extension.getExtensionTabs()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getExtensionTabs
 browser-compat: webextensions.api.extension.getExtensionTabs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -2,17 +2,8 @@
 title: extension.getURL()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getURL
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getURL
+status:
+  - deprecated
 browser-compat: webextensions.api.extension.getURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -2,16 +2,6 @@
 title: extension.getViews()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getViews
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getViews
 browser-compat: webextensions.api.extension.getViews
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -2,14 +2,6 @@
 title: extension
 slug: Mozilla/Add-ons/WebExtensions/API/extension
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Interface
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.extension
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -2,16 +2,6 @@
 title: extension.inIncognitoContext
 slug: Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - inIncognitoContext
 browser-compat: webextensions.api.extension.inIncognitoContext
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -2,16 +2,6 @@
 title: extension.isAllowedFileSchemeAccess()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - isAllowedFileSchemeAccess
 browser-compat: webextensions.api.extension.isAllowedFileSchemeAccess
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -2,16 +2,6 @@
 title: extension.isAllowedIncognitoAccess()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - isAllowedIncognitoAccess
 browser-compat: webextensions.api.extension.isAllowedIncognitoAccess
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -2,16 +2,6 @@
 title: extension.lastError
 slug: Mozilla/Add-ons/WebExtensions/API/extension/lastError
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - lastError
 browser-compat: webextensions.api.extension.lastError
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -2,16 +2,6 @@
 title: extension.onRequest
 slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequest
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extension
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRequest
 browser-compat: webextensions.api.extension.onRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -2,16 +2,6 @@
 title: extension.onRequestExternal
 slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequestExternal
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extension
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRequestExternal
 browser-compat: webextensions.api.extension.onRequestExternal
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -2,17 +2,8 @@
 title: extension.sendRequest()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/sendRequest
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - sendRequest
+status:
+  - deprecated
 browser-compat: webextensions.api.extension.sendRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -2,16 +2,6 @@
 title: extension.setUpdateUrlData()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/setUpdateUrlData
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - setUpdateUrlData
 browser-compat: webextensions.api.extension.setUpdateUrlData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -2,16 +2,6 @@
 title: extension.ViewType
 slug: Mozilla/Add-ons/WebExtensions/API/extension/ViewType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - ViewType
-  - WebExtensions
 browser-compat: webextensions.api.extension.ViewType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -2,16 +2,6 @@
 title: extensionTypes.ImageDetails
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDetails
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - extensionTypes
 browser-compat: webextensions.api.extensionTypes.ImageDetails
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -2,16 +2,6 @@
 title: extensionTypes.ImageFormat
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageFormat
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageFormat
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - extensionTypes
 browser-compat: webextensions.api.extensionTypes.ImageFormat
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -2,15 +2,6 @@
 title: extensionTypes
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - extensionTypes
 browser-compat: webextensions.api.extensionTypes
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/injectdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/injectdetails/index.md
@@ -2,16 +2,6 @@
 title: extensionTypes.InjectDetails
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/InjectDetails
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - InjectDetails
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - extensionTypes
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -2,16 +2,6 @@
 title: extensionTypes.RunAt
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - RunAt
-  - Type
-  - WebExtensions
-  - extensionTypes
 browser-compat: webextensions.api.extensionTypes.RunAt
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -2,14 +2,6 @@
 title: find.find()
 slug: Mozilla/Add-ons/WebExtensions/API/find/find
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - find
 browser-compat: webextensions.api.find.find
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
@@ -2,15 +2,6 @@
 title: find.highlightResults()
 slug: Mozilla/Add-ons/WebExtensions/API/find/highlightResults
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - find
-  - highlightResults
 browser-compat: webextensions.api.find.highlightResults
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
@@ -2,13 +2,6 @@
 title: find
 slug: Mozilla/Add-ons/WebExtensions/API/find
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - find
 browser-compat: webextensions.api.find
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
@@ -2,15 +2,6 @@
 title: find.removeHighlighting()
 slug: Mozilla/Add-ons/WebExtensions/API/find/removeHighlighting
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - find
-  - removeHighlighting
 browser-compat: webextensions.api.find.removeHighlighting
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -2,16 +2,6 @@
 title: history.addUrl()
 slug: Mozilla/Add-ons/WebExtensions/API/history/addUrl
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - addUrl
 browser-compat: webextensions.api.history.addUrl
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -2,16 +2,6 @@
 title: history.deleteAll()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - deleteAll
 browser-compat: webextensions.api.history.deleteAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -2,16 +2,6 @@
 title: history.deleteRange()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteRange
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - deleteRange
 browser-compat: webextensions.api.history.deleteRange
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -2,16 +2,6 @@
 title: history.deleteUrl()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteUrl
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - deleteUrl
 browser-compat: webextensions.api.history.deleteUrl
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -2,16 +2,6 @@
 title: history.getVisits()
 slug: Mozilla/Add-ons/WebExtensions/API/history/getVisits
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getVisits
 browser-compat: webextensions.api.history.getVisits
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -2,16 +2,6 @@
 title: history.HistoryItem
 slug: Mozilla/Add-ons/WebExtensions/API/history/HistoryItem
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - HistoryItem
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.history.HistoryItem
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
@@ -2,15 +2,6 @@
 title: history
 slug: Mozilla/Add-ons/WebExtensions/API/history
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.history
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -2,14 +2,6 @@
 title: history.onTitleChanged
 slug: Mozilla/Add-ons/WebExtensions/API/history/onTitleChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - History
-  - Reference
-  - WebExtensions
-  - onTitleChanged
 browser-compat: webextensions.api.history.onTitleChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -2,16 +2,6 @@
 title: history.onVisited
 slug: Mozilla/Add-ons/WebExtensions/API/history/onVisited
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - History
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onVisited
 browser-compat: webextensions.api.history.onVisited
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -2,16 +2,6 @@
 title: history.onVisitRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/history/onVisitRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - History
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onVisitRemoved
 browser-compat: webextensions.api.history.onVisitRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -2,16 +2,6 @@
 title: history.search()
 slug: Mozilla/Add-ons/WebExtensions/API/history/search
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Method
-  - Non-standard
-  - Reference
-  - Search
-  - WebExtensions
 browser-compat: webextensions.api.history.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -2,16 +2,6 @@
 title: history.TransitionType
 slug: Mozilla/Add-ons/WebExtensions/API/history/TransitionType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Non-standard
-  - Reference
-  - TransitionType
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.history.TransitionType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -2,16 +2,6 @@
 title: history.VisitItem
 slug: Mozilla/Add-ons/WebExtensions/API/history/VisitItem
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Non-standard
-  - Reference
-  - Type
-  - VisitItem
-  - WebExtensions
 browser-compat: webextensions.api.history.VisitItem
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -2,16 +2,6 @@
 title: i18n.detectLanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - detectLanguage
-  - i18n
 browser-compat: webextensions.api.i18n.detectLanguage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -2,16 +2,6 @@
 title: i18n.getAcceptLanguages()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAcceptLanguages
-  - i18n
 browser-compat: webextensions.api.i18n.getAcceptLanguages
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -2,16 +2,6 @@
 title: i18n.getMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getMessage
-  - i18n
 browser-compat: webextensions.api.i18n.getMessage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -2,16 +2,6 @@
 title: i18n.getUILanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getUILanguage
-  - i18n
 browser-compat: webextensions.api.i18n.getUILanguage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -2,15 +2,6 @@
 title: i18n
 slug: Mozilla/Add-ons/WebExtensions/API/i18n
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - i18n
 browser-compat: webextensions.api.i18n
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -2,16 +2,6 @@
 title: i18n.LanguageCode
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - LanguageCode
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - i18n
 browser-compat: webextensions.api.i18n.LanguageCode
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
@@ -2,16 +2,6 @@
 title: Locale-specific message reference
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference
 page-type: guide
-tags:
-  - Internationalization
-  - Localization
-  - Reference
-  - String
-  - WebExtensions
-  - i18n
-  - message
-  - messages.json
-  - placeholders
 ---
 
 {{AddonSidebar()}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -2,15 +2,6 @@
 title: identity.getRedirectURL()
 slug: Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Identity
-  - Method
-  - Reference
-  - WebExtensions
-  - getRedirectURL
 browser-compat: webextensions.api.identity.getRedirectURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
@@ -2,13 +2,6 @@
 title: identity
 slug: Mozilla/Add-ons/WebExtensions/API/identity
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Identity
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.identity
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -2,15 +2,6 @@
 title: identity.launchWebAuthFlow
 slug: Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Identity
-  - Method
-  - Reference
-  - WebExtensions
-  - launchWebAuthFlow
 browser-compat: webextensions.api.identity.launchWebAuthFlow
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -2,16 +2,6 @@
 title: idle.IdleState
 slug: Mozilla/Add-ons/WebExtensions/API/idle/IdleState
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Idle
-  - IdleState
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.idle.IdleState
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
@@ -2,15 +2,6 @@
 title: idle
 slug: Mozilla/Add-ons/WebExtensions/API/idle
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Idle
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.idle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -2,16 +2,6 @@
 title: idle.onStateChanged
 slug: Mozilla/Add-ons/WebExtensions/API/idle/onStateChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Idle
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onStateChanged
 browser-compat: webextensions.api.idle.onStateChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -2,16 +2,6 @@
 title: idle.queryState()
 slug: Mozilla/Add-ons/WebExtensions/API/idle/queryState
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Idle
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - queryState
 browser-compat: webextensions.api.idle.queryState
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -2,16 +2,6 @@
 title: idle.setDetectionInterval()
 slug: Mozilla/Add-ons/WebExtensions/API/idle/setDetectionInterval
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Idle
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - setDetectionInterval
 browser-compat: webextensions.api.idle.setDetectionInterval
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.md
@@ -2,8 +2,6 @@
 title: JavaScript APIs
 slug: Mozilla/Add-ons/WebExtensions/API
 page-type: landing-page
-tags:
-  - WebExtensions
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -2,15 +2,6 @@
 title: ExtensionInfo
 slug: Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - ExtensionInfo
-  - Extensions
-  - Reference
-  - Type
-  - WebExtensions
-  - management
 browser-compat: webextensions.api.management.ExtensionInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -2,14 +2,6 @@
 title: management.get()
 slug: Mozilla/Add-ons/WebExtensions/API/management/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - get
-  - management
 browser-compat: webextensions.api.management.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -2,14 +2,6 @@
 title: management.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - getAll
-  - management
 browser-compat: webextensions.api.management.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -2,14 +2,6 @@
 title: management.getPermissionWarningsById()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsById
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - getPermissionWarningsById
-  - management
 browser-compat: webextensions.api.management.getPermissionWarningsById
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -2,14 +2,6 @@
 title: management.getPermissionWarningsByManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsByManifest
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - getPermissionWarningsByManifest
-  - management
 browser-compat: webextensions.api.management.getPermissionWarningsByManifest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -2,14 +2,6 @@
 title: management.getSelf()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getSelf
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - getSelf
-  - management
 browser-compat: webextensions.api.management.getSelf
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
@@ -2,13 +2,6 @@
 title: management
 slug: Mozilla/Add-ons/WebExtensions/API/management
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - management
 browser-compat: webextensions.api.management
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
@@ -2,15 +2,6 @@
 title: management.install()
 slug: Mozilla/Add-ons/WebExtensions/API/management/install
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - Theme
-  - WebExtensions
-  - install
-  - management
 browser-compat: webextensions.api.management.install
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -2,14 +2,6 @@
 title: management.onDisabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onDisabled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Reference
-  - WebExtensions
-  - management
-  - onDisabled
 browser-compat: webextensions.api.management.onDisabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -2,14 +2,6 @@
 title: management.onEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onEnabled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Reference
-  - WebExtensions
-  - management
-  - onEnabled
 browser-compat: webextensions.api.management.onEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -2,14 +2,6 @@
 title: management.onInstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onInstalled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Reference
-  - WebExtensions
-  - management
-  - onInstalled
 browser-compat: webextensions.api.management.onInstalled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -2,14 +2,6 @@
 title: management.onUninstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onUninstalled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Reference
-  - WebExtensions
-  - management
-  - onUninstalled
 browser-compat: webextensions.api.management.onUninstalled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -2,14 +2,6 @@
 title: management.setEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/setEnabled
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - management
-  - setEnabled
 browser-compat: webextensions.api.management.setEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -2,14 +2,6 @@
 title: management.uninstall()
 slug: Mozilla/Add-ons/WebExtensions/API/management/uninstall
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - management
-  - uninstall
 browser-compat: webextensions.api.management.uninstall
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -2,14 +2,6 @@
 title: management.uninstallSelf()
 slug: Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Reference
-  - WebExtensions
-  - management
-  - uninstallSelf
 browser-compat: webextensions.api.management.uninstallSelf
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -2,16 +2,6 @@
 title: menus.ACTION_MENU_TOP_LEVEL_LIMIT
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ACTION_MENU_TOP_LEVEL_LIMIT
 page-type: webextension-api-property
-tags:
-  - ACTION_MENU_TOP_LEVEL_LIMIT
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - contextMenus
 browser-compat: webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -2,17 +2,6 @@
 title: menus.ContextType
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ContextType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - ContextType
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - contextMenus
-  - menus
 browser-compat: webextensions.api.menus.ContextType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -2,16 +2,6 @@
 title: menus.create()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
 browser-compat: webextensions.api.menus.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.md
@@ -2,13 +2,6 @@
 title: menus.getTargetElement()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/getTargetElement
 page-type: webextension-api-function
-tags:
-  - API
-  - Method
-  - Reference
-  - WebExtensions
-  - getTargetElement
-  - menus
 browser-compat: webextensions.api.menus.getTargetElement
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -2,16 +2,6 @@
 title: menus
 slug: Mozilla/Add-ons/WebExtensions/API/menus
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
-  - menus
 browser-compat: webextensions.api.menus
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -2,16 +2,6 @@
 title: menus.ItemType
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ItemType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - contextMenus
-  - itemtype
 browser-compat: webextensions.api.menus.ItemType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -2,16 +2,6 @@
 title: menus.OnClickData
 slug: Mozilla/Add-ons/WebExtensions/API/menus/OnClickData
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - OnClickData
-  - Reference
-  - Type
-  - WebExtensions
-  - contextMenus
 browser-compat: webextensions.api.menus.OnClickData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -2,16 +2,6 @@
 title: menus.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
-  - onClicked
 browser-compat: webextensions.api.menus.onClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
@@ -2,15 +2,6 @@
 title: menus.onHidden
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onHidden
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - menus
-  - onHidden
 browser-compat: webextensions.api.menus.onHidden
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -2,15 +2,6 @@
 title: menus.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onShown
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - menus
-  - onShown
 browser-compat: webextensions.api.menus.onShown
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
@@ -2,14 +2,6 @@
 title: menus.overrideContext()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/overrideContext
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - WebExtensions
-  - contextMenus
 browser-compat: webextensions.api.menus.overrideContext
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.md
@@ -2,15 +2,6 @@
 title: menus.refresh()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/refresh
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - menus
-  - refresh
 browser-compat: webextensions.api.menus.refresh
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -2,16 +2,6 @@
 title: menus.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
-  - remove
 browser-compat: webextensions.api.menus.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -2,17 +2,6 @@
 title: menus.removeAll()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/removeAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
-  - menus
-  - removeAll
 browser-compat: webextensions.api.menus.removeAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -2,16 +2,6 @@
 title: menus.update()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Update
-  - WebExtensions
-  - contextMenus
 browser-compat: webextensions.api.menus.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -2,16 +2,6 @@
 title: notifications.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/clear
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
-  - clear
 browser-compat: webextensions.api.notifications.clear
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -2,16 +2,6 @@
 title: notifications.create()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.notifications.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -2,16 +2,6 @@
 title: notifications.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
-  - getAll
 browser-compat: webextensions.api.notifications.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -2,12 +2,6 @@
 title: notifications
 slug: Mozilla/Add-ons/WebExtensions/API/notifications
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Notifications
-  - WebExtensions
 browser-compat: webextensions.api.notifications
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -2,16 +2,6 @@
 title: notifications.NotificationOptions
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - NotificationOptions
-  - Notifications
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.notifications.NotificationOptions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -2,16 +2,6 @@
 title: notifications.onButtonClicked
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
-  - onButtonClicked
 browser-compat: webextensions.api.notifications.onButtonClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -2,16 +2,6 @@
 title: notifications.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
-  - onClicked
 browser-compat: webextensions.api.notifications.onClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -2,16 +2,6 @@
 title: notifications.onClosed
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onClosed
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Notifications
-  - Reference
-  - WebExtensions
-  - onClosed
 browser-compat: webextensions.api.notifications.onClosed
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -2,16 +2,6 @@
 title: notifications.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onShown
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Notifications
-  - Reference
-  - WebExtensions
-  - events
-  - onShown
 browser-compat: webextensions.api.notifications.onShown
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -2,16 +2,6 @@
 title: notifications.TemplateType
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Notifications
-  - Reference
-  - TemplateType
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.notifications.TemplateType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -2,16 +2,6 @@
 title: notifications.update()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Notifications
-  - Reference
-  - Update
-  - WebExtensions
 browser-compat: webextensions.api.notifications.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.md
@@ -2,13 +2,6 @@
 title: omnibox
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
 browser-compat: webextensions.api.omnibox
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
@@ -1,15 +1,6 @@
 ---
 title: omnibox.onDeleteSuggestion
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onDeleteSuggestion
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-  - onDeleteSuggestion
 browser-compat: webextensions.api.omnibox.onDeleteSuggestion
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -2,15 +2,6 @@
 title: omnibox.onInputCancelled
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputCancelled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-  - onInputCancelled
 browser-compat: webextensions.api.omnibox.onInputCancelled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -2,15 +2,6 @@
 title: omnibox.onInputChanged
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-  - onInputChanged
 browser-compat: webextensions.api.omnibox.onInputChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -2,15 +2,6 @@
 title: omnibox.onInputEntered
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputEntered
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-  - onInputEntered
 browser-compat: webextensions.api.omnibox.onInputEntered
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
@@ -2,15 +2,6 @@
 title: omnibox.OnInputEnteredDisposition
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/OnInputEnteredDisposition
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - OnInputEnteredDisposition
-  - Reference
-  - Type
-  - WebExtensions
-  - omnibox
 browser-compat: webextensions.api.omnibox.OnInputEnteredDisposition
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -2,15 +2,6 @@
 title: omnibox.onInputStarted
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputStarted
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-  - onInputStarted
 browser-compat: webextensions.api.omnibox.onInputStarted
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -2,15 +2,6 @@
 title: omnibox.setDefaultSuggestion()
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/setDefaultSuggestion
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - omnibox
-  - setDefaultSuggestion
 browser-compat: webextensions.api.omnibox.setDefaultSuggestion
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
@@ -2,15 +2,6 @@
 title: omnibox.SuggestResult
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/SuggestResult
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - SuggestResult
-  - Type
-  - WebExtensions
-  - omnibox
 browser-compat: webextensions.api.omnibox.SuggestResult
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -2,16 +2,6 @@
 title: pageAction.getPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getPopup
-  - pageAction
 browser-compat: webextensions.api.pageAction.getPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -2,16 +2,6 @@
 title: pageAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getTitle
-  - pageAction
 browser-compat: webextensions.api.pageAction.getTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -2,16 +2,6 @@
 title: pageAction.hide()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/hide
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - hide
-  - pageAction
 browser-compat: webextensions.api.pageAction.hide
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -2,16 +2,6 @@
 title: pageAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDataType
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - pageAction
 browser-compat: webextensions.api.pageAction.ImageDataType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -2,15 +2,6 @@
 title: pageAction
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
 browser-compat: webextensions.api.pageAction
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
@@ -2,15 +2,6 @@
 title: pageAction.isShown()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/isShown
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - isShown
-  - pageAction
 browser-compat: webextensions.api.pageAction.isShown
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -2,16 +2,6 @@
 title: pageAction.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onClicked
-  - pageAction
 browser-compat: webextensions.api.pageAction.onClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -2,15 +2,6 @@
 title: pageAction.openPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/openPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - close
-  - sidebarAction
 browser-compat: webextensions.api.pageAction.openPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -2,16 +2,6 @@
 title: pageAction.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
-  - setIcon
 browser-compat: webextensions.api.pageAction.setIcon
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -2,16 +2,6 @@
 title: pageAction.setPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
-  - setPopup
 browser-compat: webextensions.api.pageAction.setPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -2,16 +2,6 @@
 title: pageAction.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
-  - setTitle
 browser-compat: webextensions.api.pageAction.setTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -2,16 +2,6 @@
 title: pageAction.show()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/show
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
-  - show
 browser-compat: webextensions.api.pageAction.show
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -2,14 +2,6 @@
 title: permissions.contains()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/contains
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Contains
-  - Method
-  - Permissions
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.permissions.contains
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -2,14 +2,6 @@
 title: permissions.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Permissions
-  - Reference
-  - WebExtensions
-  - getAll
 browser-compat: webextensions.api.permissions.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -2,13 +2,6 @@
 title: permissions
 slug: Mozilla/Add-ons/WebExtensions/API/permissions
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Permissions
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.permissions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -2,14 +2,6 @@
 title: permissions.onAdded
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/onAdded
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Permissions
-  - Reference
-  - WebExtensions
-  - onAdded
 browser-compat: webextensions.api.permissions.onAdded
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -2,14 +2,6 @@
 title: permissions.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Permissions
-  - Reference
-  - WebExtensions
-  - onRemoved
 browser-compat: webextensions.api.permissions.onRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -2,13 +2,6 @@
 title: Permissions
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/Permissions
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Permissions
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.permissions.Permissions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -2,14 +2,6 @@
 title: permissions.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Permissions
-  - Reference
-  - WebExtensions
-  - remove
 browser-compat: webextensions.api.permissions.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -2,14 +2,6 @@
 title: permissions.request()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/request
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Permissions
-  - Reference
-  - WebExtensions
-  - request
 browser-compat: webextensions.api.permissions.request
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
@@ -2,15 +2,6 @@
 title: pkcs11.getModuleSlots()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/getModuleSlots
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getModuleSlots
-  - pkcs11
 browser-compat: webextensions.api.pkcs11.getModuleSlots
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -2,16 +2,6 @@
 title: pkcs11
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11
 page-type: webextension-api
-tags:
-  - API
-  - API Extensions
-  - Add-ons
-  - Extensions
-  - Reference
-  - Web
-  - Web Development
-  - WebExtensions
-  - pkcs11
 browser-compat: webextensions.api.pkcs11
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -2,15 +2,6 @@
 title: pkcs11.installModule()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/installModule
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - installModule
-  - pkcs11
 browser-compat: webextensions.api.pkcs11.installModule
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
@@ -2,15 +2,6 @@
 title: pkcs11.isModuleInstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/isModuleInstalled
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - isModuleInstalled
-  - pkcs11
 browser-compat: webextensions.api.pkcs11.isModuleInstalled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
@@ -2,15 +2,6 @@
 title: pkcs11.uninstallModule()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/uninstallModule
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - pkcs11
-  - uninstallModule
 browser-compat: webextensions.api.pkcs11.uninstallModule
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -2,13 +2,6 @@
 title: privacy
 slug: Mozilla/Add-ons/WebExtensions/API/privacy
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Privacy
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.privacy
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -2,15 +2,6 @@
 title: privacy.network
 slug: Mozilla/Add-ons/WebExtensions/API/privacy/network
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Network
-  - Privacy
-  - Property
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.privacy.network
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -2,14 +2,6 @@
 title: privacy.services
 slug: Mozilla/Add-ons/WebExtensions/API/privacy/services
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Privacy
-  - Property
-  - Reference
-  - Services
 browser-compat: webextensions.api.privacy.services
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -2,15 +2,6 @@
 title: privacy.websites
 slug: Mozilla/Add-ons/WebExtensions/API/privacy/websites
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Privacy
-  - Property
-  - Reference
-  - WebExtensions
-  - websites
 browser-compat: webextensions.api.privacy.websites
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
@@ -2,11 +2,6 @@
 title: proxy
 slug: Mozilla/Add-ons/WebExtensions/API/proxy
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Proxy
-  - WebExtensions
 browser-compat: webextensions.api.proxy
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
@@ -2,14 +2,6 @@
 title: proxy.onError
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/onError
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Proxy
-  - Reference
-  - WebExtensions
-  - onProxyError
 browser-compat: webextensions.api.proxy.onError
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
@@ -2,15 +2,6 @@
 title: proxy.onRequest
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/onRequest
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Proxy
-  - Reference
-  - WebExtensions
-  - onRequest
 browser-compat: webextensions.api.proxy.onRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -2,13 +2,6 @@
 title: proxy.ProxyInfo
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo
 page-type: webextension-api-type
-tags:
-  - Add-ons
-  - Extensions
-  - Proxy
-  - ProxyInfo
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.proxy.ProxyInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
@@ -2,16 +2,6 @@
 title: proxy.register()
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/register
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Function
-  - Method
-  - Proxy
-  - Reference
-  - WebExtensions
-  - register
-  - registerProxyScript
 browser-compat: webextensions.api.proxy.register
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -2,13 +2,6 @@
 title: proxy.RequestDetails
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails
 page-type: webextension-api-type
-tags:
-  - Add-ons
-  - Extensions
-  - Proxy
-  - RequestDetails
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.proxy.RequestDetails
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -2,15 +2,6 @@
 title: proxy.settings
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/settings
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Proxy
-  - Reference
-  - Settings
-  - WebExtensions
 browser-compat: webextensions.api.proxy.settings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
@@ -2,15 +2,6 @@
 title: proxy.unregister()
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/unregister
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Proxy
-  - Reference
-  - WebExtensions
-  - unregister
 browser-compat: webextensions.api.proxy.unregister
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -2,16 +2,6 @@
 title: runtime.connect()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connect
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - connect
-  - runtime
 browser-compat: webextensions.api.runtime.connect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -2,16 +2,6 @@
 title: runtime.connectNative()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - connectNative
-  - runtime
 browser-compat: webextensions.api.runtime.connectNative
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -2,16 +2,6 @@
 title: runtime.getBackgroundPage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getBackgroundPage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getBackgroundPage
-  - runtime
 browser-compat: webextensions.api.runtime.getBackgroundPage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
@@ -2,15 +2,6 @@
 title: runtime.getBrowserInfo()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getBrowserInfo
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getBrowserInfo
-  - runtime
 browser-compat: webextensions.api.runtime.getBrowserInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -2,15 +2,6 @@
 title: runtime.getFrameId()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getFrameId
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - getBrowserInfo
-  - runtime
 browser-compat: webextensions.api.runtime.getFrameId
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -2,16 +2,6 @@
 title: runtime.getManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getManifest
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getManifest
-  - runtime
 browser-compat: webextensions.api.runtime.getManifest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -2,16 +2,6 @@
 title: runtime.getPackageDirectoryEntry()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getPackageDirectoryEntry
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getPackageDirectoryEntry
-  - runtime
 browser-compat: webextensions.api.runtime.getPackageDirectoryEntry
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -2,16 +2,6 @@
 title: runtime.getPlatformInfo()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getPlatformInfo
-  - runtime
 browser-compat: webextensions.api.runtime.getPlatformInfo
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -2,16 +2,6 @@
 title: runtime.getURL()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getURL
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getURL
-  - runtime
 browser-compat: webextensions.api.runtime.getURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -2,16 +2,6 @@
 title: runtime.id
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/id
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - id
-  - runtime
 browser-compat: webextensions.api.runtime.id
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -2,14 +2,6 @@
 title: runtime
 slug: Mozilla/Add-ons/WebExtensions/API/runtime
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Reference
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -2,16 +2,6 @@
 title: runtime.lastError
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/lastError
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - WebExtensions
-  - lastError
-  - runtime
 browser-compat: webextensions.api.runtime.lastError
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -2,16 +2,6 @@
 title: runtime.MessageSender
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MessageSender
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.MessageSender
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -2,17 +2,8 @@
 title: runtime.onBrowserUpdateAvailable
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onBrowserUpdateAvailable
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Deprecated
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onBrowserUpdateAvailable
-  - runtime
+status:
+  - deprecated
 browser-compat: webextensions.api.runtime.onBrowserUpdateAvailable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -2,16 +2,6 @@
 title: runtime.onConnect
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onConnect
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onconnect
-  - runtime
 browser-compat: webextensions.api.runtime.onConnect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -2,16 +2,6 @@
 title: runtime.onConnectExternal
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onConnectExternal
-  - runtime
 browser-compat: webextensions.api.runtime.onConnectExternal
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -2,16 +2,6 @@
 title: runtime.onInstalled
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onInstalled
-  - runtime
 browser-compat: webextensions.api.runtime.onInstalled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -2,16 +2,6 @@
 title: runtime.OnInstalledReason
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - OnInstalledReason
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.OnInstalledReason
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -2,16 +2,6 @@
 title: runtime.onMessage
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onmessage
-  - runtime
 browser-compat: webextensions.api.runtime.onMessage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -2,16 +2,6 @@
 title: runtime.onMessageExternal
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onMessageExternal
-  - runtime
 browser-compat: webextensions.api.runtime.onMessageExternal
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -2,16 +2,6 @@
 title: runtime.onRestartRequired
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onRestartRequired
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRestartRequired
-  - runtime
 browser-compat: webextensions.api.runtime.onRestartRequired
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -2,16 +2,6 @@
 title: runtime.OnRestartRequiredReason
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnRestartRequiredReason
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - OnRestartRequiredReason
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
 browser-compat: webextensions.api.runtime.OnRestartRequiredReason
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -2,16 +2,6 @@
 title: runtime.onStartup
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onStartup
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onStartup
-  - runtime
 browser-compat: webextensions.api.runtime.onStartup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -2,16 +2,6 @@
 title: runtime.onSuspend
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onSuspend
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onSuspend
-  - runtime
 browser-compat: webextensions.api.runtime.onSuspend
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -2,16 +2,6 @@
 title: runtime.onSuspendCanceled
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onSuspendCanceled
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onSuspendCanceled
-  - runtime
 browser-compat: webextensions.api.runtime.onSuspendCanceled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -2,16 +2,6 @@
 title: runtime.onUpdateAvailable
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onUpdateAvailable
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onUpdateAvailable
-  - runtime
 browser-compat: webextensions.api.runtime.onUpdateAvailable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -2,16 +2,6 @@
 title: runtime.openOptionsPage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - openOptionsPage
-  - runtime
 browser-compat: webextensions.api.runtime.openOptionsPage
 ---
 


### PR DESCRIPTION
Fixes up all WebExtension tags with paths > /api/dom and up
"non-standard" information in tags is discarded.

Part of https://github.com/mdn/mdn/issues/262