### PR TITLE
WebExt - Fixtags for apis to /dns

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -2,8 +2,6 @@
 title: Add a button to the toolbar
 slug: Mozilla/Add-ons/WebExtensions/Add_a_button_to_the_toolbar
 page-type: guide
-tags:
-  - WebExtensions
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -2,8 +2,6 @@
 title: Anatomy of an extension
 slug: Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
 page-type: guide
-tags:
-  - WebExtensions
 ---
 
 {{AddonSidebar}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
@@ -2,16 +2,6 @@
 title: action.ColorArray
 slug: Mozilla/Add-ons/WebExtensions/API/action/ColorArray
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - ColorArray
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - action
 browser-compat: webextensions.api.action.ColorArray
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
@@ -2,16 +2,6 @@
 title: action.disable()
 slug: Mozilla/Add-ons/WebExtensions/API/action/disable
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - disable
 browser-compat: webextensions.api.action.disable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
@@ -2,16 +2,6 @@
 title: action.enable()
 slug: Mozilla/Add-ons/WebExtensions/API/action/enable
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Enable
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
 browser-compat: webextensions.api.action.enable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
@@ -2,16 +2,6 @@
 title: action.getBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeBackgroundColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - getBadgeBackgroundColor
 browser-compat: webextensions.api.action.getBadgeBackgroundColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
@@ -2,16 +2,6 @@
 title: action.getBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeText
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - getBadgeText
 browser-compat: webextensions.api.action.getBadgeText
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
@@ -2,15 +2,6 @@
 title: action.getBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeTextColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - action
-  - getBadgeTextColor
 browser-compat: webextensions.api.action.getBadgeTextColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
@@ -2,16 +2,6 @@
 title: action.getPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/action/getPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - getPopup
 browser-compat: webextensions.api.action.getPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
@@ -2,16 +2,6 @@
 title: action.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/action/getTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - getTitle
 browser-compat: webextensions.api.action.getTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
@@ -2,16 +2,6 @@
 title: action.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/action/ImageDataType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDataType
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - action
 browser-compat: webextensions.api.action.ImageDataType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -2,15 +2,6 @@
 title: action
 slug: Mozilla/Add-ons/WebExtensions/API/action
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
 browser-compat: webextensions.api.action
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
@@ -2,15 +2,6 @@
 title: action.isEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/action/isEnabled
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - action
-  - isEnabled
 browser-compat: webextensions.api.action.isEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
@@ -2,16 +2,6 @@
 title: action.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/action/onClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - onClicked
 browser-compat: webextensions.api.action.onClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/openpopup/index.md
@@ -2,16 +2,6 @@
 title: action.openPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/action/openPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - openPopup
 browser-compat: webextensions.api.action.openPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -2,16 +2,6 @@
 title: action.setBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeBackgroundColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - setBadgeBackgroundColor
 browser-compat: webextensions.api.action.setBadgeBackgroundColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -2,16 +2,6 @@
 title: action.setBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeText
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - setBadgeText
 browser-compat: webextensions.api.action.setBadgeText
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
@@ -2,15 +2,6 @@
 title: action.setBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - action
-  - setBadgeTextColor
 browser-compat: webextensions.api.action.setBadgeTextColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -2,16 +2,6 @@
 title: action.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setIcon
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - setIcon
 browser-compat: webextensions.api.action.setIcon
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
@@ -2,16 +2,6 @@
 title: action.setPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - action
-  - setPopup
 browser-compat: webextensions.api.action.setPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
@@ -2,15 +2,6 @@
 title: action.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/action/setTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - action
-  - setTitle
 browser-compat: webextensions.api.action.setTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -2,16 +2,6 @@
 title: alarms.Alarm
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/Alarm
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - alarm
-  - alarms
 browser-compat: webextensions.api.alarms.Alarm
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -2,16 +2,6 @@
 title: alarms.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/clear
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - clear
 browser-compat: webextensions.api.alarms.clear
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -2,16 +2,6 @@
 title: alarms.clearAll()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - clearAll
 browser-compat: webextensions.api.alarms.clearAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -2,16 +2,6 @@
 title: alarms.create()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
 browser-compat: webextensions.api.alarms.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -2,16 +2,6 @@
 title: alarms.get()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - get
 browser-compat: webextensions.api.alarms.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -2,16 +2,6 @@
 title: alarms.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - getAll
 browser-compat: webextensions.api.alarms.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.md
@@ -2,14 +2,6 @@
 title: alarms
 slug: Mozilla/Add-ons/WebExtensions/API/alarms
 page-type: webextension-api
-tags:
-  - API
-  - Extensions
-  - Interface
-  - Needs Privileges
-  - Reference
-  - WebExtensions
-  - alarms
 browser-compat: webextensions.api.alarms
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
@@ -2,16 +2,6 @@
 title: alarms.onAlarm
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - onAlarm
 browser-compat: webextensions.api.alarms.onAlarm
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.BookmarkTreeNode
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNode
-  - Bookmarks
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.BookmarkTreeNode
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -2,15 +2,6 @@
 title: bookmarks.BookmarkTreeNodeType
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNodeType
-  - Bookmarks
-  - Extensions
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.BookmarkTreeNodeUnmodifiable
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNodeUnmodifiable
-  - Bookmarks
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.create()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.CreateDetails
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - CreateDetails
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.CreateDetails
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.get()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - get
 browser-compat: webextensions.api.bookmarks.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.getChildren()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getChildren
 browser-compat: webextensions.api.bookmarks.getChildren
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.getRecent()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getRecent
 browser-compat: webextensions.api.bookmarks.getRecent
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.getSubTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getSubTree
 browser-compat: webextensions.api.bookmarks.getSubTree
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.getTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getTree
 browser-compat: webextensions.api.bookmarks.getTree
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -2,15 +2,6 @@
 title: bookmarks
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.move()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/move
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - move
 browser-compat: webextensions.api.bookmarks.move
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChanged
 browser-compat: webextensions.api.bookmarks.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onChildrenReordered
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChildrenReordered
 browser-compat: webextensions.api.bookmarks.onChildrenReordered
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCreated
 browser-compat: webextensions.api.bookmarks.onCreated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onImportBegan
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onImportBegan
 browser-compat: webextensions.api.bookmarks.onImportBegan
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onImportEnded
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onImportEnded
 browser-compat: webextensions.api.bookmarks.onImportEnded
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onMoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onMoved
 browser-compat: webextensions.api.bookmarks.onMoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRemoved
 browser-compat: webextensions.api.bookmarks.onRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - remove
 browser-compat: webextensions.api.bookmarks.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.removeTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - removeTree
 browser-compat: webextensions.api.bookmarks.removeTree
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.search()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/search
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Search
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.search
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -2,16 +2,6 @@
 title: bookmarks.update()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Update
-  - WebExtensions
 browser-compat: webextensions.api.bookmarks.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -2,16 +2,6 @@
 title: browserAction.ColorArray
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - ColorArray
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - browserAction
 browser-compat: webextensions.api.browserAction.ColorArray
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -2,16 +2,6 @@
 title: browserAction.disable()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/disable
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - disable
 browser-compat: webextensions.api.browserAction.disable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -2,16 +2,6 @@
 title: browserAction.enable()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/enable
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Enable
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
 browser-compat: webextensions.api.browserAction.enable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -2,16 +2,6 @@
 title: browserAction.getBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeBackgroundColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - getBadgeBackgroundColor
 browser-compat: webextensions.api.browserAction.getBadgeBackgroundColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -2,16 +2,6 @@
 title: browserAction.getBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - getBadgeText
 browser-compat: webextensions.api.browserAction.getBadgeText
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -2,15 +2,6 @@
 title: browserAction.getBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeTextColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browserAction
-  - getBadgeTextColor
 browser-compat: webextensions.api.browserAction.getBadgeTextColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -2,16 +2,6 @@
 title: browserAction.getPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - getPopup
 browser-compat: webextensions.api.browserAction.getPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -2,16 +2,6 @@
 title: browserAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - getTitle
 browser-compat: webextensions.api.browserAction.getTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -2,16 +2,6 @@
 title: browserAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/ImageDataType
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDataType
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - browserAction
 browser-compat: webextensions.api.browserAction.ImageDataType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -2,15 +2,6 @@
 title: browserAction
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
 browser-compat: webextensions.api.browserAction
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
@@ -2,15 +2,6 @@
 title: browserAction.isEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/isEnabled
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browserAction
-  - isEnabled
 browser-compat: webextensions.api.browserAction.isEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -2,16 +2,6 @@
 title: browserAction.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - onClicked
 browser-compat: webextensions.api.browserAction.onClicked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
@@ -2,16 +2,6 @@
 title: browserAction.openPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - openPopup
 browser-compat: webextensions.api.browserAction.openPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -2,16 +2,6 @@
 title: browserAction.setBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setBadgeBackgroundColor
 browser-compat: webextensions.api.browserAction.setBadgeBackgroundColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -2,16 +2,6 @@
 title: browserAction.setBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setBadgeText
 browser-compat: webextensions.api.browserAction.setBadgeText
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -2,15 +2,6 @@
 title: browserAction.setBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeTextColor
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setBadgeTextColor
 browser-compat: webextensions.api.browserAction.setBadgeTextColor
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -2,16 +2,6 @@
 title: browserAction.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setIcon
 browser-compat: webextensions.api.browserAction.setIcon
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -2,16 +2,6 @@
 title: browserAction.setPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setPopup
 browser-compat: webextensions.api.browserAction.setPopup
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -2,15 +2,6 @@
 title: browserAction.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setTitle
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browserAction
-  - setTitle
 browser-compat: webextensions.api.browserAction.setTitle
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
@@ -2,14 +2,6 @@
 title: browserSettings.allowPopupsForUserEvents
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/allowPopupsForUserEvents
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - WebExtensions
-  - allowPopupsForUserEvents
-  - browserSettings
 browser-compat: webextensions.api.browserSettings.allowPopupsForUserEvents
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.cacheEnabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/cacheEnabled
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - cacheEnabled
 browser-compat: webextensions.api.browserSettings.cacheEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.closeTabsByDoubleClick
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/closeTabsByDoubleClick
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - closeTabsByDoubleClick
 browser-compat: webextensions.api.browserSettings.closeTabsByDoubleClick
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/colormanagement/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/colormanagement/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.colorManagement
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/colorManagement
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - colorManagement
 browser-compat: webextensions.api.browserSettings.colorManagement
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.contextMenuShowEvent
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/contextMenuShowEvent
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - contextMenuShowEvent
 browser-compat: webextensions.api.browserSettings.contextMenuShowEvent
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
@@ -2,16 +2,6 @@
 title: browserSettings.ftpProtocolEnabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - contextMenuShowEvent
-  - ftpProtocolEnabled
 browser-compat: webextensions.api.browserSettings.ftpProtocolEnabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.homepageOverride
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/homepageOverride
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - homepageOverride
 browser-compat: webextensions.api.browserSettings.homepageOverride
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
@@ -2,14 +2,6 @@
 title: browserSettings.imageAnimationBehavior
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/imageAnimationBehavior
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - browserSettings
-  - imageAnimationBehavior
 browser-compat: webextensions.api.browserSettings.imageAnimationBehavior
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -2,14 +2,6 @@
 title: browserSettings
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserSettings
 browser-compat: webextensions.api.browserSettings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.newTabPageOverride
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - newTabPageOverride
 browser-compat: webextensions.api.browserSettings.newTabPageOverride
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.newTabPosition
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPosition
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - newTabPosition
 browser-compat: webextensions.api.browserSettings.newTabPosition
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.openBookmarksInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openBookmarksInNewTabs
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - openBookmarksInNewTabs
 browser-compat: webextensions.api.browserSettings.openBookmarksInNewTabs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.openSearchResultsInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openSearchResultsInNewTabs
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - openSearchResultsInNewTabs
 browser-compat: webextensions.api.browserSettings.openSearchResultsInNewTabs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.openUrlbarResultsInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openUrlbarResultsInNewTabs
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - openUrlbarResultsInNewTabs
 browser-compat: webextensions.api.browserSettings.openUrlbarResultsInNewTabs
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.overrideContentColorScheme
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideContentColorScheme
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - overrideContentColorScheme
 browser-compat: webextensions.api.browserSettings.overrideContentColorScheme
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.overrideDocumentColors
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideDocumentColors
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - overrideDocumentColors
 browser-compat: webextensions.api.browserSettings.overrideDocumentColors
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.tlsVersionRestrictionConfig
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/tlsVersionRestrictionConfig
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - tlsVersionRestrictionConfig
 browser-compat: webextensions.api.browserSettings.tlsVersionRestrictionConfig
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.useDocumentFonts
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/useDocumentFonts
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - useDocumentFonts
 browser-compat: webextensions.api.browserSettings.useDocumentFonts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.webNotificationsDisabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - webNotificationsDisabled
 browser-compat: webextensions.api.browserSettings.webNotificationsDisabled
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
@@ -2,15 +2,6 @@
 title: browserSettings.zoomFullPage
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomFullPage
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - browserSettings
-  - zoomFullPage
 browser-compat: webextensions.api.browserSettings.zoomFullPage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
@@ -2,14 +2,6 @@
 title: browserSettings.zoomSiteSpecific
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomSiteSpecific
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - WebExtensions
-  - browserSettings
-  - zoomSiteSpecific
 browser-compat: webextensions.api.browserSettings.zoomSiteSpecific
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -2,15 +2,6 @@
 title: browsingData.DataTypeSet
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DataTypeSet
-  - Extensions
-  - Reference
-  - Type
-  - WebExtensions
-  - browsingData
 browser-compat: webextensions.api.browsingData.DataTypeSet
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -2,14 +2,6 @@
 title: browsingData
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browsingData
 browser-compat: webextensions.api.browsingData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -2,15 +2,6 @@
 title: browsingData.RemovalOptions
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/RemovalOptions
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - RemovalOptions
-  - Type
-  - WebExtensions
-  - browsingData
 browser-compat: webextensions.api.browsingData.RemovalOptions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -2,15 +2,6 @@
 title: browsingData.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - remove
 browser-compat: webextensions.api.browsingData.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeCache()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeCache
 browser-compat: webextensions.api.browsingData.removeCache
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeCookies()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCookies
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeCookies
 browser-compat: webextensions.api.browsingData.removeCookies
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeDownloads()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeDownloads
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeDownloads
 browser-compat: webextensions.api.browsingData.removeDownloads
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeFormData()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeFormData
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeDownloads
 browser-compat: webextensions.api.browsingData.removeFormData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeHistory()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeHistory
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeHistory
 browser-compat: webextensions.api.browsingData.removeHistory
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removeLocalStorage()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeLocalStorage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeLocalStorage
 browser-compat: webextensions.api.browsingData.removeLocalStorage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removePasswords()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removePasswords
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removePasswords
 browser-compat: webextensions.api.browsingData.removePasswords
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -2,15 +2,6 @@
 title: browsingData.removePluginData()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removePluginData
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removePluginData
 browser-compat: webextensions.api.browsingData.removePluginData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -2,15 +2,6 @@
 title: browsingData.settings()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/settings
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Settings
-  - WebExtensions
-  - browsingData
 browser-compat: webextensions.api.browsingData.settings
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -2,13 +2,6 @@
 title: captivePortal.canonicalURL
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/canonicalURL
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - WebExtensions
-  - canonicalURL
-  - captivePortal
 browser-compat: webextensions.api.captivePortal.canonicalURL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
@@ -2,14 +2,6 @@
 title: getLastChecked
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/getLastChecked
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captivePortal
 browser-compat: webextensions.api.captivePortal.getLastChecked
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
@@ -2,14 +2,6 @@
 title: getState
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/getState
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captivePortal
 browser-compat: webextensions.api.captivePortal.getState
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.md
@@ -2,14 +2,6 @@
 title: captivePortal
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captivePortal
 browser-compat: webextensions.api.captivePortal
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
@@ -2,14 +2,6 @@
 title: onConnectivityAvailable
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/onConnectivityAvailable
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captivePortal
 browser-compat: webextensions.api.captivePortal.onConnectivityAvailable
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
@@ -2,14 +2,6 @@
 title: onStateChanged
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/onStateChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captivePortal
 browser-compat: webextensions.api.captivePortal.onStateChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -2,13 +2,6 @@
 title: clipboard
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Clipboard
-  - Extensions
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.clipboard
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -2,15 +2,6 @@
 title: clipboard.setImageData()
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Clipboard
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - setImageData
 browser-compat: webextensions.api.clipboard.setImageData
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -2,16 +2,6 @@
 title: Command
 slug: Mozilla/Add-ons/WebExtensions/API/commands/Command
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Command
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - commands
 browser-compat: webextensions.api.commands.Command
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -2,16 +2,6 @@
 title: getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - commands
-  - getAll
 browser-compat: webextensions.api.commands.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -2,14 +2,6 @@
 title: commands
 slug: Mozilla/Add-ons/WebExtensions/API/commands
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - commands
 browser-compat: webextensions.api.commands
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -2,16 +2,6 @@
 title: onCommand
 slug: Mozilla/Add-ons/WebExtensions/API/commands/onCommand
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - commands
-  - onCommand
 browser-compat: webextensions.api.commands.onCommand
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
@@ -2,15 +2,6 @@
 title: commands.reset()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/reset
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - commands
-  - reset
 browser-compat: webextensions.api.commands.reset
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -2,15 +2,6 @@
 title: commands.update()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Update
-  - WebExtensions
-  - commands
 browser-compat: webextensions.api.commands.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
@@ -2,13 +2,6 @@
 title: contentScripts
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - WebExtensions
-  - contentScripts
 browser-compat: webextensions.api.contentScripts
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -2,13 +2,6 @@
 title: contentScripts.register()
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/register
 page-type: webextension-api-function
-tags:
-  - API
-  - Extensions
-  - Method
-  - Reference
-  - contentScripts
-  - register
 browser-compat: webextensions.api.contentScripts.register
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -2,13 +2,6 @@
 title: contentScripts.RegisteredContentScript
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript
 page-type: webextension-api-type
-tags:
-  - API
-  - Extensions
-  - Reference
-  - RegisteredContentScript
-  - Type
-  - contentScripts
 browser-compat: webextensions.api.contentScripts.RegisteredContentScript
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -3,12 +3,6 @@ title: contentScripts.RegisteredContentScript.unregister()
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript/unregister
 page-type: webextension-api-function
-tags:
-  - API
-  - Extensions
-  - Reference
-  - RegisteredContentScript.unregister
-  - contentScripts
 browser-compat: webextensions.api.contentScripts.RegisteredContentScript.unregister
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.ContextualIdentity
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - ContextualIdentity
-  - Extensions
-  - Reference
-  - Type
-  - WebExtensions
-  - contextualIdentities
 browser-compat: webextensions.api.contextualIdentities.ContextualIdentity
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.create()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - contextualIdentities
 browser-compat: webextensions.api.contextualIdentities.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.get()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - contextualIdentities
-  - get
 browser-compat: webextensions.api.contextualIdentities.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
@@ -2,8 +2,6 @@
 title: contextualIdentities
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities
 page-type: webextension-api
-tags:
-  - WebExtensions
 browser-compat: webextensions.api.contextualIdentities
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onCreated
 page-type: webextension-api-event
-tags:
-  - API
-  - APIReference
-  - Add-ons
-  - Event
-  - Extensions
-  - WebExtensions
-  - contextualIdentities
-  - onCreated
 browser-compat: webextensions.api.contextualIdentities.onCreated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onRemoved
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - contextualIdentities
-  - onRemoved
 browser-compat: webextensions.api.contextualIdentities.onRemoved
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.onUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onUpdated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - contextualIdentities
-  - onUpdated
 browser-compat: webextensions.api.contextualIdentities.onUpdated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.query()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/query
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - contextualIdentities
-  - query
 browser-compat: webextensions.api.contextualIdentities.query
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - contextualIdentities
-  - remove
 browser-compat: webextensions.api.contextualIdentities.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -2,15 +2,6 @@
 title: contextualIdentities.update()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/update
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - Update
-  - WebExtensions
-  - contextualIdentities
 browser-compat: webextensions.api.contextualIdentities.update
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -2,16 +2,6 @@
 title: cookies.Cookie
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - cookie
 browser-compat: webextensions.api.cookies.Cookie
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -2,16 +2,6 @@
 title: cookies.CookieStore
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - CookieStore
-  - Cookies
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.cookies.CookieStore
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -2,16 +2,6 @@
 title: cookies.get()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/get
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - get
 browser-compat: webextensions.api.cookies.get
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -2,16 +2,6 @@
 title: cookies.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/getAll
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAll
 browser-compat: webextensions.api.cookies.getAll
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -2,16 +2,6 @@
 title: cookies.getAllCookieStores()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAllCookieStores
 browser-compat: webextensions.api.cookies.getAllCookieStores
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.md
@@ -2,15 +2,6 @@
 title: cookies
 slug: Mozilla/Add-ons/WebExtensions/API/cookies
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
 browser-compat: webextensions.api.cookies
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -2,16 +2,6 @@
 title: cookies.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/onChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChanged
 browser-compat: webextensions.api.cookies.onChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -2,16 +2,6 @@
 title: cookies.OnChangedCause
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/OnChangedCause
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Non-standard
-  - OnChangedCause
-  - Reference
-  - Type
-  - WebExtensions
 browser-compat: webextensions.api.cookies.OnChangedCause
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -2,16 +2,6 @@
 title: cookies.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/remove
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - remove
 browser-compat: webextensions.api.cookies.remove
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
@@ -2,16 +2,6 @@
 title: cookies.SameSiteStatus
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
 ---
 
 {{AddonSidebar()}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -2,16 +2,6 @@
 title: cookies.set()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/set
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - set
 browser-compat: webextensions.api.cookies.set
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/dynamic_ruleset_id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/dynamic_ruleset_id/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.DYNAMIC_RULESET_ID
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/DYNAMIC_RULESET_ID
-tags:
-  - DYNAMIC_RULESET_ID
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - DYNAMIC_RULESET_ID
 browser-compat: webextensions.api.declarativeNetRequest.DYNAMIC_RULESET_ID
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getavailablestaticrulecount/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getavailablestaticrulecount/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.getAvailableStaticRuleCount
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getAvailableStaticRuleCount
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - getAvailableStaticRuleCount
 browser-compat: webextensions.api.declarativeNetRequest.getAvailableStaticRuleCount
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.getAvailableStaticRuleCount
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getDynamicRules
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - getDynamicRules
 browser-compat: webextensions.api.declarativeNetRequest.getDynamicRules
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getenabledrulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getenabledrulesets/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.getEnabledRulesets
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getEnabledRulesets
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - getEnabledRulesets
 browser-compat: webextensions.api.declarativeNetRequest.getEnabledRulesets
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.getMatchedRules
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getMatchedRules
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - getMatchedRules
 browser-compat: webextensions.api.declarativeNetRequest.getMatchedRules
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules_quota_interval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules_quota_interval/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.GETMATCHEDRULES_QUOTA_INTERVAL
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/GETMATCHEDRULES_QUOTA_INTERVAL
-tags:
-  - GETMATCHEDRULES_QUOTA_INTERVAL
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - GETMATCHEDRULES_QUOTA_INTERVAL
 browser-compat: webextensions.api.declarativeNetRequest.GETMATCHEDRULES_QUOTA_INTERVAL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.getSessionRules
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getSessionRules
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - getSessionRules
 browser-compat: webextensions.api.declarativeNetRequest.getSessionRules
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/guaranteed_minimum_static_rules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/guaranteed_minimum_static_rules/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.GUARANTEED_MINIMUM_STATIC_RULES
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/GUARANTEED_MINIMUM_STATIC_RULES
-tags:
-  - GUARANTEED_MINIMUM_STATIC_RULES
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - GUARANTEED_MINIMUM_STATIC_RULES
 browser-compat: webextensions.api.declarativeNetRequest.GUARANTEED_MINIMUM_STATIC_RULES
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -1,14 +1,6 @@
 ---
 title: declarativeNetRequest
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Reference
-  - WebExtensions
-  - declarativeNetRequest
 browser-compat: webextensions.api.declarativeNetRequest
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/isregexsupported/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/isregexsupported/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.isRegexSupported
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/isRegexSupported
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - isRegexSupported
 browser-compat: webextensions.api.declarativeNetRequest.isRegexSupported
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/matchedrule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/matchedrule/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.MatchedRule
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MatchedRule
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - MatchedRule
 browser-compat: webextensions.api.declarativeNetRequest.MatchedRule
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_getmatchedrules_calls_per_interval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_getmatchedrules_calls_per_interval/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.MAX_GETMATCHEDRULES_CALLS_PER_INTERVAL
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_GETMATCHEDRULES_CALLS_PER_INTERVAL
-tags:
-  - MAX_GETMATCHEDRULES_CALLS_PER_INTERVAL
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - MAX_GETMATCHEDRULES_CALLS_PER_INTERVAL
 browser-compat: webextensions.api.declarativeNetRequest.MAX_GETMATCHEDRULES_CALLS_PER_INTERVAL
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_dynamic_and_session_rules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_dynamic_and_session_rules/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
-tags:
-  - MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
 browser-compat: webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_enabled_static_rulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_enabled_static_rulesets/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.MAX_NUMBER_OF_ENABLED_STATIC_RULESETS
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_ENABLED_STATIC_RULESETS
-tags:
-  - MAX_NUMBER_OF_ENABLED_STATIC_RULESETS
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - MAX_NUMBER_OF_ENABLED_STATIC_RULESETS
 browser-compat: webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_ENABLED_STATIC_RULESETS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_regex_rules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_regex_rules/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.MAX_NUMBER_OF_REGEX_RULES
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_REGEX_RULES
-tags:
-  - MAX_NUMBER_OF_REGEX_RULES
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - MAX_NUMBER_OF_REGEX_RULES
 browser-compat: webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_REGEX_RULES
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_static_rulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_static_rulesets/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.MAX_NUMBER_OF_STATIC_RULESETS
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_STATIC_RULESETS
-tags:
-  - MAX_NUMBER_OF_STATIC_RULESETS
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - MAX_NUMBER_OF_STATIC_RULESETS
 browser-compat: webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_STATIC_RULESETS
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/modifyheaderinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/modifyheaderinfo/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.ModifyHeaderInfo
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ModifyHeaderInfo
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - ModifyHeaderInfo
 browser-compat: 
   - webextensions.api.declarativeNetRequest.RuleAction.requestHeaders
   - webextensions.api.declarativeNetRequest.RuleAction.responseHeaders

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/onrulematcheddebug/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/onrulematcheddebug/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.onRuleMatchedDebug
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/onRuleMatchedDebug
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Event
-  - declarativeNetRequest
-  - onRuleMatchedDebug
 browser-compat: webextensions.api.declarativeNetRequest.onRuleMatchedDebug
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.Redirect
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Redirect
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - Redirect
 browser-compat: webextensions.api.declarativeNetRequest.Redirect
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/resourcetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/resourcetype/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.ResourceType
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ResourceType
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - ResourceType
 browser-compat: webextensions.api.declarativeNetRequest.ResourceType
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rule/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.Rule
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Rule
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - Rule
 browser-compat: webextensions.api.declarativeNetRequest.Rule
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/ruleaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/ruleaction/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.RuleAction
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleAction
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - RuleAction
 browser-compat: webextensions.api.declarativeNetRequest.RuleAction
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.RuleCondition
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - RuleCondition
 browser-compat: webextensions.api.declarativeNetRequest.RuleCondition
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/session_ruleset_id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/session_ruleset_id/index.md
@@ -1,16 +1,6 @@
 ---
 title: declarativeNetRequest.SESSION_RULESET_ID
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/SESSION_RULESET_ID
-tags:
-  - SESSION_RULESET_ID
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Property
-  - declarativeNetRequest
-  - SESSION_RULESET_ID
 browser-compat: webextensions.api.declarativeNetRequest.SESSION_RULESET_ID
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/setextensionactionoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/setextensionactionoptions/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.setExtensionActionOptions
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/setExtensionActionOptions
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - setExtensionActionOptions
 browser-compat: webextensions.api.declarativeNetRequest.setExtensionActionOptions
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/testmatchoutcome/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/testmatchoutcome/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.testMatchOutcome
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/testMatchOutcome
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - testMatchOutcome
 browser-compat: webextensions.api.declarativeNetRequest.testMatchOutcome
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatedynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatedynamicrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.updateDynamicRules
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateDynamicRules
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - updateDynamicRules
 browser-compat: webextensions.api.declarativeNetRequest.updateDynamicRules
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updateenabledrulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updateenabledrulesets/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.updateEnabledRulesets
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateEnabledRulesets
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - updateEnabledRulesets
 browser-compat: webextensions.api.declarativeNetRequest.updateEnabledRulesets
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatesessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatesessionrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.updateSessionRules
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateSessionRules
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Method
-  - declarativeNetRequest
-  - updateSessionRules
 browser-compat: webextensions.api.declarativeNetRequest.updateSessionRules
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/urltransform/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/urltransform/index.md
@@ -1,15 +1,6 @@
 ---
 title: declarativeNetRequest.URLTransform
 slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/URLTransform
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - Type
-  - declarativeNetRequest
-  - URLTransform
 browser-compat: webextensions.api.declarativeNetRequest.URLTransform
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.md
@@ -2,15 +2,6 @@
 title: devtools
 slug: Mozilla/Add-ons/WebExtensions/API/devtools
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.inspectedWindow
-  - devtools.network
-  - devtools.panels
 browser-compat: webextensions.api.devtools
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -2,15 +2,6 @@
 title: devtools.inspectedWindow.eval()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Method
-  - WebExtensions
-  - devtools.inspectedWindow
-  - eval
 browser-compat: webextensions.api.devtools.inspectedWindow.eval
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -2,14 +2,6 @@
 title: devtools.inspectedWindow
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - devtools.inspectedWindow
 browser-compat: webextensions.api.devtools.inspectedWindow
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -2,15 +2,6 @@
 title: devtools.inspectedWindow.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/reload
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Method
-  - WebExtensions
-  - devtools.inspectedWindow
-  - reload
 browser-compat: webextensions.api.devtools.inspectedWindow.reload
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -2,15 +2,6 @@
 title: devtools.inspectedWindow.tabId
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Property
-  - WebExtensions
-  - devtools.inspectedWindow
-  - tabId
 browser-compat: webextensions.api.devtools.inspectedWindow.tabId
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -2,13 +2,6 @@
 title: devtools.network.getHAR()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/getHAR
 page-type: webextension-api-function
-tags:
-  - Add-ons
-  - Extensions
-  - Method
-  - WebExtensions
-  - devtools.network
-  - getHAR
 browser-compat: webextensions.api.devtools.network.getHAR
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -2,14 +2,6 @@
 title: devtools.network
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - devtools.network
 browser-compat: webextensions.api.devtools.network
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -2,14 +2,6 @@
 title: devtools.network.onNavigated
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Event
-  - WebExtensions
-  - devtools.network
 browser-compat: webextensions.api.devtools.network.onNavigated
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -2,15 +2,6 @@
 title: devtools.network.onRequestFinished
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/onRequestFinished
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Event
-  - WebExtensions
-  - devtools.network
-  - onRequestFinished
 browser-compat: webextensions.api.devtools.network.onRequestFinished
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -2,15 +2,6 @@
 title: devtools.panels.create()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/create
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - devtools.panels
 browser-compat: webextensions.api.devtools.panels.create
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -2,15 +2,6 @@
 title: devtools.panels.elements
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/elements
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Elements
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - devtools.panels
 browser-compat: webextensions.api.devtools.panels.elements
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -3,16 +3,6 @@ title: devtools.panels.ElementsPanel.createSidebarPane()
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Method
-  - Extensions
-  - Reference
-  - WebExtensions
-  - createSidebarPane
-  - devtools.panels
 browser-compat: webextensions.api.devtools.panels.ElementsPanel.createSidebarPane
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -2,16 +2,6 @@
 title: devtools.panels.ElementsPanel
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Type
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - devtools.panels.ElementsPanel
 browser-compat: webextensions.api.devtools.panels.ElementsPanel
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -3,16 +3,6 @@ title: onSelectionChanged
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Event
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - devtools.panelsElementsPanel
 browser-compat: webextensions.api.devtools.panels.ElementsPanel.onSelectionChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -2,14 +2,6 @@
 title: devtools.panels.ExtensionPanel
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionPanel
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Type
-  - Reference
-  - WebExtensions
-  - devtools.panels
 browser-compat: webextensions.api.devtools.panels.ExtensionPanel
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
@@ -2,16 +2,6 @@
 title: devtools.panels.ExtensionSidebarPane
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane
 page-type: webextension-api-type
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Extensions
-  - Type
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - devtools.panels.ExtensionSidebarPane
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -3,16 +3,6 @@ title: devtools.panels.ExtensionSidebarPane.onHidden
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - ExtensionSidebarPane
-  - Extensions
-  - Event
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - onHidden
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.onHidden
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -2,16 +2,6 @@
 title: devtools.panels.ExtensionSidebarPane.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onShown
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - ExtensionSidebarPane
-  - Extensions
-  - Event
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - onShown
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.onShown
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -3,15 +3,6 @@ title: devtools.panels.ElementsPanel.setExpression()
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - setExpression
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setExpression
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -3,15 +3,6 @@ title: devtools.panels.ExtensionSidebarPane.setObject()
 slug: >-
   Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - devtools.panels
-  - setObject
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setObject
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
@@ -2,14 +2,6 @@
 title: devtools.panels.ExtensionSidebarPane.setPage()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setPage
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - setPage
 browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setPage
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -2,14 +2,6 @@
 title: devtools.panels
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-  - devtools.panels
 browser-compat: webextensions.api.devtools.panels
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -2,15 +2,6 @@
 title: devtools.panels.onThemeChanged
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged
 page-type: webextension-api-event
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Reference
-  - Event
-  - WebExtensions
-  - devtools.panels
-  - onThemeChanged
 browser-compat: webextensions.api.devtools.panels.onThemeChanged
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -2,15 +2,6 @@
 title: devtools.panels.themeName
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName
 page-type: webextension-api-property
-tags:
-  - API
-  - Add-ons
-  - DevTools
-  - Reference
-  - Property
-  - WebExtensions
-  - devtools.panels
-  - themeName
 browser-compat: webextensions.api.devtools.panels.themeName
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/index.md
@@ -2,12 +2,6 @@
 title: dns
 slug: Mozilla/Add-ons/WebExtensions/API/dns
 page-type: webextension-api
-tags:
-  - API
-  - Add-ons
-  - DNS
-  - Extensions
-  - WebExtensions
 browser-compat: webextensions.api.dns
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -2,15 +2,6 @@
 title: dns.resolve()
 slug: Mozilla/Add-ons/WebExtensions/API/dns/resolve
 page-type: webextension-api-function
-tags:
-  - API
-  - Add-ons
-  - DNS
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - resolve
 browser-compat: webextensions.api.dns.resolve
 ---
 


### PR DESCRIPTION
Fixes up all WebExtension tags left.
"non-standard" information in tags is discarded.

Part of https://github.com/mdn/mdn/issues/262