### PR TITLE
Refactor target identifier logic

### DIFF
--- a/files/en-us/web/api/view_transitions_api/index.md
+++ b/files/en-us/web/api/view_transitions_api/index.md
@@ -35,12 +35,7 @@ An SPA will include functionality to fetch new content and update the DOM in res
 ```js
 function updateView(event) {
   // Handle the difference in whether the event is fired on the <a> or the <img>
-  let targetIdentifier;
-  if (event.target.firstChild === null) {
-    targetIdentifier = event.target;
-  } else {
-    targetIdentifier = event.target.firstChild;
-  }
+  const targetIdentifier = event.target.firstChild || event.target;
 
   const displayNewImage = () => {
     const mainSrc = `${targetIdentifier.src.split("_th.jpg")[0]}.jpg`;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The previous implementation used an if statement to check whether the event target had a first child or not before assigning it to the `targetIdentifier` variable. This was replaced with a simplified implementation that uses a logical OR operator to assign the first child or the target itself to `targetIdentifier`.

### Motivation
- Simplify code logic and improve code readability for better understanding and maintainability.

### Additional details
- N/A

### Related issues and pull requests
- N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
