### PR TITLE
Remove `<datalist>` from list of "inline" elements

### DIFF
--- a/files/en-us/web/html/inline_elements/index.md
+++ b/files/en-us/web/html/inline_elements/index.md
@@ -117,7 +117,6 @@ The following elements are inline by default (although block and inline elements
 - {{ HTMLElement("cite") }}
 - {{ HTMLElement("code") }}
 - {{ HTMLElement("data") }}
-- {{ HTMLElement("datalist") }}
 - {{ HTMLElement("del") }}
 - {{ HTMLElement("dfn") }}
 - {{ HTMLElement("em") }}


### PR DESCRIPTION
`<datalist>` elements are technically `display: none` by default. While it is true that their content may be used by other elements, such as an `<input>` via the `list` attribute, I do not believe this is sufficient for classifying `<datalist>` as an "inline" element.