### PR TITLE
Remove "immediately" and clarify when.

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that immediately resolves with `undefined`.
+A {{jsxref("Promise")}} that resolves with `undefined` after trying to actiavete the newly installed service worker.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with `undefined` after trying to actiavete the newly installed service worker.
+A {{jsxref("Promise")}} that resolves with `undefined` after trying to activate the newly installed service worker.
 
 ## Examples
 


### PR DESCRIPTION
According to https://www.w3.org/TR/service-workers/#service-worker-global-scope-skipwaiting, a promise is returned soon but it won't be resolved until Try Activate (https://www.w3.org/TR/service-workers/#try-activate) finishes.  Let me revise the explanation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated the `SkipWaiting()` return value explanation by removing "immediately", and clarifying when.

### Motivation

According to [the service worker specification](https://www.w3.org/TR/service-workers/#service-worker-global-scope-skipwaiting), the promise looks not resolved immediately.  It at least need to be resolved after [Try Activate](https://www.w3.org/TR/service-workers/#try-activate).  This change adjust the explanation to align with the specification.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
n/a

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
n/a

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
