### PR TITLE
Replacing `ƒ` with `function` in code sections

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -341,15 +341,15 @@ As seen above, `doSomething()` has a default `prototype` property, as demonstrat
 
 ```
 {
-  constructor: ƒ doSomething(),
+  constructor: function doSomething(),
   [[Prototype]]: {
-    constructor: ƒ Object(),
-    hasOwnProperty: ƒ hasOwnProperty(),
-    isPrototypeOf: ƒ isPrototypeOf(),
-    propertyIsEnumerable: ƒ propertyIsEnumerable(),
-    toLocaleString: ƒ toLocaleString(),
-    toString: ƒ toString(),
-    valueOf: ƒ valueOf()
+    constructor: function Object(),
+    hasOwnProperty: function hasOwnProperty(),
+    isPrototypeOf: function isPrototypeOf(),
+    propertyIsEnumerable: function propertyIsEnumerable(),
+    toLocaleString: function toLocaleString(),
+    toString: function toString(),
+    valueOf: function valueOf()
   }
 }
 ```
@@ -369,15 +369,15 @@ This results in:
 ```
 {
   foo: "bar",
-  constructor: ƒ doSomething(),
+  constructor: function doSomething(),
   [[Prototype]]: {
-    constructor: ƒ Object(),
-    hasOwnProperty: ƒ hasOwnProperty(),
-    isPrototypeOf: ƒ isPrototypeOf(),
-    propertyIsEnumerable: ƒ propertyIsEnumerable(),
-    toLocaleString: ƒ toLocaleString(),
-    toString: ƒ toString(),
-    valueOf: ƒ valueOf()
+    constructor: function Object(),
+    hasOwnProperty: function hasOwnProperty(),
+    isPrototypeOf: function isPrototypeOf(),
+    propertyIsEnumerable: function propertyIsEnumerable(),
+    toLocaleString: function toLocaleString(),
+    toString: function toString(),
+    valueOf: function valueOf()
   }
 }
 ```
@@ -401,15 +401,15 @@ This results in an output similar to the following:
   prop: "some value",
   [[Prototype]]: {
     foo: "bar",
-    constructor: ƒ doSomething(),
+    constructor: function doSomething(),
     [[Prototype]]: {
-      constructor: ƒ Object(),
-      hasOwnProperty: ƒ hasOwnProperty(),
-      isPrototypeOf: ƒ isPrototypeOf(),
-      propertyIsEnumerable: ƒ propertyIsEnumerable(),
-      toLocaleString: ƒ toLocaleString(),
-      toString: ƒ toString(),
-      valueOf: ƒ valueOf()
+      constructor: function Object(),
+      hasOwnProperty: function hasOwnProperty(),
+      isPrototypeOf: function isPrototypeOf(),
+      propertyIsEnumerable: function propertyIsEnumerable(),
+      toLocaleString: function toLocaleString(),
+      toString: function toString(),
+      valueOf: function valueOf()
     }
   }
 }

--- a/files/en-us/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/name/index.md
@@ -244,7 +244,7 @@ With a `static name()` method `Foo.name` no longer holds the actual class name b
 
 ```js
 const fooInstance = new Foo();
-console.log(fooInstance.constructor.name); // ƒ name() {}
+console.log(fooInstance.constructor.name); // function name() {}
 ```
 
 Due to the existence of static fields, `name` may not be a function either.

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -131,10 +131,10 @@ console.log([][Symbol.iterator]());
 
 Array Iterator {}
   [[Prototype]]: Array Iterator     ==> This is the prototype shared by all array iterators
-    next: ƒ next()
+    next: function next()
     Symbol(Symbol.toStringTag): "Array Iterator"
     [[Prototype]]: Object           ==> This is the prototype shared by all built-in iterators
-      Symbol(Symbol.iterator): ƒ [Symbol.iterator]()
+      Symbol(Symbol.iterator): function [Symbol.iterator]()
       [[Prototype]]: Object         ==> This is Object.prototype
 ```
 

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -585,7 +585,7 @@ Object destructuring is almost equivalent to [property accessing](/en-US/docs/We
 
 ```js
 const { a, toFixed } = 1;
-console.log(a, toFixed); // undefined ƒ toFixed() { [native code] }
+console.log(a, toFixed); // undefined function toFixed() { [native code] }
 ```
 
 Same as accessing properties, destructuring `null` or `undefined` throws a {{jsxref("TypeError")}}.


### PR DESCRIPTION
### Description

This PR replaces all (~30) occurrences of `ƒ` in code sections with `function`.

### Motivation

`function` is more intuitive than `ƒ` for learners, and the vast majority of code sections on MDN pages also use `function` instead of `ƒ`.