### PR TITLE
Fix link to interface

### DIFF
--- a/files/en-us/web/svg/element/femergenode/index.md
+++ b/files/en-us/web/svg/element/femergenode/index.md
@@ -61,7 +61,7 @@ The `feMergeNode` takes the result of another filter to be processed by its pare
 
 ## DOM Interface
 
-This element implements the [`SVGFEMergeNodeElement`](/en-US/docs/DOM/SVGFEMergeNodeElement) interface.
+This element implements the [`SVGFEMergeNodeElement`](/en-US/docs/Web/API/SVGFEMergeNodeElement) interface.
 
 ## Specifications
 


### PR DESCRIPTION
The extremely old: `/en-US/docs/DOM/` is now `/en-US/docs/Web/API`