### PR TITLE
Remove remnants of animateColor

### DIFF
--- a/files/en-us/web/api/svganimatecolorelement/index.md
+++ b/files/en-us/web/api/svganimatecolorelement/index.md
@@ -9,7 +9,7 @@ browser-compat: api.SVGAnimateColorElement
 
 {{APIRef("SVG")}}{{deprecated_header}}
 
-The **`SVGAnimateColorElement`** interface corresponds to the {{SVGElement("animateColor")}} element.
+The **`SVGAnimateColorElement`** interface corresponds to the `<animateColor>` element.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/svg/attribute/accumulate/index.md
+++ b/files/en-us/web/svg/attribute/accumulate/index.md
@@ -14,7 +14,6 @@ It is frequently useful for repeated animations to build upon the previous resul
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/additive/index.md
+++ b/files/en-us/web/svg/attribute/additive/index.md
@@ -14,7 +14,6 @@ It is frequently useful to define animation as an offset or delta to an attribut
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/attributename/index.md
+++ b/files/en-us/web/svg/attribute/attributename/index.md
@@ -12,7 +12,6 @@ The **`attributeName`** attribute indicates the name of the CSS property or attr
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}
 

--- a/files/en-us/web/svg/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/attribute/attributetype/index.md
@@ -14,7 +14,6 @@ The **`attributeType`** attribute specifies the namespace in which the target at
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}
 

--- a/files/en-us/web/svg/attribute/begin/index.md
+++ b/files/en-us/web/svg/attribute/begin/index.md
@@ -16,15 +16,14 @@ The attribute value is a semicolon separated list of values. The interpretation 
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("discard")}}
 - {{SVGElement("set")}}
 
-## animate, animateColor, animateMotion, animateTransform, set
+## animate, animateMotion, animateTransform, set
 
-For {{SVGElement("animate")}}, {{SVGElement("animateColor")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, and {{SVGElement("set")}}, `begin` defines when the element should begin, i.e. become active.
+For {{SVGElement("animate")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, and {{SVGElement("set")}}, `begin` defines when the element should begin, i.e. become active.
 
 <table class="properties">
   <tbody>
@@ -145,7 +144,7 @@ The `<discard>` element itself can be discarded prior to its activation, in whic
   </tbody>
 </table>
 
-The definition of `<begin-value-list>` is the [same as for the other animation elements](#animate_animatecolor_animatemotion_animatetransform_set).
+The definition of `<begin-value-list>` is the [same as for the other animation elements](#animate_animatemotion_animatetransform_set).
 
 ## Examples
 

--- a/files/en-us/web/svg/attribute/by/index.md
+++ b/files/en-us/web/svg/attribute/by/index.md
@@ -14,7 +14,6 @@ The starting value for the attribute is either indicated by specifying it as val
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/calcmode/index.md
+++ b/files/en-us/web/svg/attribute/calcmode/index.md
@@ -14,7 +14,6 @@ The default mode is `linear`, however if the attribute does not support linear i
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/color-interpolation/index.md
+++ b/files/en-us/web/svg/attribute/color-interpolation/index.md
@@ -21,7 +21,6 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("a")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("circle")}}
 - {{SVGElement("clipPath")}}
 - {{SVGElement("defs")}}

--- a/files/en-us/web/svg/attribute/dur/index.md
+++ b/files/en-us/web/svg/attribute/dur/index.md
@@ -12,7 +12,6 @@ The **`dur`** attribute indicates the simple duration of an animation.
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/end/index.md
+++ b/files/en-us/web/svg/attribute/end/index.md
@@ -12,7 +12,6 @@ The **`end`** attribute defines an end value for the animation that can constrai
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/fill/index.md
+++ b/files/en-us/web/svg/attribute/fill/index.md
@@ -23,7 +23,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement('tref')}}
 - {{SVGElement('tspan')}}
 
-For animation, these elements are using this attribute: {{SVGElement('animate')}}, {{SVGElement('animateColor')}}, {{SVGElement('animateMotion')}}, {{SVGElement('animateTransform')}}, and {{SVGElement('set')}}.
+For animation, these elements are using this attribute: {{SVGElement('animate')}}, {{SVGElement('animateMotion')}}, {{SVGElement('animateTransform')}}, and {{SVGElement('set')}}.
 
 ## Example
 
@@ -100,34 +100,6 @@ For {{SVGElement('altGlyph')}}, `fill` is a presentation attribute that defines 
 ## animate
 
 For {{SVGElement('animate')}}, `fill` defines the final state of the animation.
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td>
-        <code>freeze</code> (<em>Keep the state of the last animation frame</em
-        >) | <code>remove</code> (<em
-          >Keep the state of the first animation frame</em
-        >)
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><code>remove</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>No</td>
-    </tr>
-  </tbody>
-</table>
-
-## animateColor
-
-> **Warning:** As of SVG Animation 2 {{SVGElement('animateColor')}} is deprecated and shouldn't be used. Use {{SVGElement('animate')}} instead.
-
-For {{SVGElement('animateColor')}}, `fill` defines the final state of the animation.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/from/index.md
+++ b/files/en-us/web/svg/attribute/from/index.md
@@ -14,7 +14,6 @@ When used with the {{SVGAttr("to")}} attribute, the animation will change the mo
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/keypoints/index.md
+++ b/files/en-us/web/svg/attribute/keypoints/index.md
@@ -12,7 +12,6 @@ The **`keyPoints`** attribute indicates the simple duration of an animation.
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/keysplines/index.md
+++ b/files/en-us/web/svg/attribute/keysplines/index.md
@@ -16,7 +16,6 @@ If there are any errors in the keySplines specification (bad values, too many or
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/keytimes/index.md
+++ b/files/en-us/web/svg/attribute/keytimes/index.md
@@ -14,7 +14,6 @@ Each time in the list corresponds to a value in the {{SVGAttr("values")}} attrib
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 

--- a/files/en-us/web/svg/attribute/max/index.md
+++ b/files/en-us/web/svg/attribute/max/index.md
@@ -12,7 +12,6 @@ The **`max`** attribute specifies the maximum value of the active animation dura
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/min/index.md
+++ b/files/en-us/web/svg/attribute/min/index.md
@@ -12,7 +12,6 @@ The **`min`** attribute specifies the minimum value of the active animation dura
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/repeatcount/index.md
+++ b/files/en-us/web/svg/attribute/repeatcount/index.md
@@ -12,7 +12,6 @@ The **`repeatCount`** attribute indicates the number of times an animation will 
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/repeatdur/index.md
+++ b/files/en-us/web/svg/attribute/repeatdur/index.md
@@ -12,7 +12,6 @@ The **`repeatDur`** attribute specifies the total duration for repeating an anim
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/requiredfeatures/index.md
+++ b/files/en-us/web/svg/attribute/requiredfeatures/index.md
@@ -22,7 +22,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("circle")}}
@@ -242,7 +241,7 @@ The following are the feature strings for the `requiredFeatures` attribute. Thes
 - `http://www.w3.org/TR/SVG11/feature#Script`
   - : The browser supports the {{SVGElement("script")}} element
 - `http://www.w3.org/TR/SVG11/feature#Animation`
-  - : The browser supports the {{SVGElement("animate")}}, {{SVGElement("set")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, {{SVGElement("animateColor")}} and {{SVGElement("mpath")}} elements
+  - : The browser supports the {{SVGElement("animate")}}, {{SVGElement("set")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, and {{SVGElement("mpath")}} elements
 - `http://www.w3.org/TR/SVG11/feature#Font`
   - : The browser supports the {{SVGElement("font")}}, {{SVGElement("font-face")}}, {{SVGElement("glyph")}}, {{SVGElement("missing-glyph")}}, {{SVGElement("hkern")}}, {{SVGElement("vkern")}}, {{SVGElement("font-face-src")}}, {{SVGElement("font-face-uri")}}, {{SVGElement("font-face-format")}} and {{SVGElement("font-face-name")}} elements
 - `http://www.w3.org/TR/SVG11/feature#BasicFont`

--- a/files/en-us/web/svg/attribute/restart/index.md
+++ b/files/en-us/web/svg/attribute/restart/index.md
@@ -12,7 +12,6 @@ The **`restart`** attribute specifies whether or not an animation can restart.
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}

--- a/files/en-us/web/svg/attribute/systemlanguage/index.md
+++ b/files/en-us/web/svg/attribute/systemlanguage/index.md
@@ -14,7 +14,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("audio")}}

--- a/files/en-us/web/svg/attribute/to/index.md
+++ b/files/en-us/web/svg/attribute/to/index.md
@@ -16,7 +16,6 @@ The value of the attribute will change between the {{SVGAttr("from")}} attribute
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("set")}}
@@ -47,9 +46,9 @@ svg {
 
 {{EmbedLiveSample("Example", "200", "200")}}
 
-## animate, animateColor, animateMotion, animateTransform
+## animate, animateMotion, animateTransform
 
-For {{SVGElement("animate")}}, {{SVGElement("animateColor")}}, {{SVGElement("animateMotion")}}, and {{SVGElement("animateTransform")}}, `to` specifies the ending value of the animation.
+For {{SVGElement("animate")}}, {{SVGElement("animateMotion")}}, and {{SVGElement("animateTransform")}}, `to` specifies the ending value of the animation.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/values/index.md
+++ b/files/en-us/web/svg/attribute/values/index.md
@@ -14,14 +14,13 @@ The `values` attribute has different meanings, depending upon the context where 
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("feColorMatrix")}}
 
-## animate, animateColor, animateMotion, animateTransform
+## animate, animateMotion, animateTransform
 
-For {{SVGElement("animate")}}, {{SVGElement("animateColor")}}, {{SVGElement("animateMotion")}}, and {{SVGElement("animateTransform")}}, `values` is a list of values defining the sequence of values over the course of the animation. If this attribute is specified, any {{SVGAttr("from")}}, {{SVGAttr("to")}}, and {{SVGAttr("by")}} attribute values set on the element are ignored.
+For {{SVGElement("animate")}}, {{SVGElement("animateMotion")}}, and {{SVGElement("animateTransform")}}, `values` is a list of values defining the sequence of values over the course of the animation. If this attribute is specified, any {{SVGAttr("from")}}, {{SVGAttr("to")}}, and {{SVGAttr("by")}} attribute values set on the element are ignored.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.md
@@ -18,7 +18,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("cursor")}}

--- a/files/en-us/web/svg/attribute/xlink_colon_href/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_href/index.md
@@ -18,7 +18,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("cursor")}}
@@ -111,9 +110,9 @@ If the reference is to an `<altGlyphDef>` element, then if an appropriate set of
   </tbody>
 </table>
 
-## animate, animateColor, animateMotion, animateTransform, set
+## animate, animateMotion, animateTransform, set
 
-For {{SVGElement("animate")}}, {{SVGElement("animateColor")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, and {{SVGElement("set")}}, `xlink:href` defines the reference to the element which is the target of this animation and which therefore will be modified over time.
+For {{SVGElement("animate")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, and {{SVGElement("set")}}, `xlink:href` defines the reference to the element which is the target of this animation and which therefore will be modified over time.
 
 The target element must be part of the current SVG document fragment.
 

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.md
@@ -20,7 +20,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("cursor")}}

--- a/files/en-us/web/svg/attribute/xlink_colon_type/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_type/index.md
@@ -16,7 +16,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("a")}}
 - {{SVGElement("altGlyph")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
 - {{SVGElement("cursor")}}

--- a/files/en-us/web/svg/element/feflood/index.md
+++ b/files/en-us/web/svg/element/feflood/index.md
@@ -70,7 +70,6 @@ This element implements the {{domxref("SVGFEFloodElement")}} interface.
 
 - {{SVGElement("filter")}}
 - {{SVGElement("animate")}}
-- {{SVGElement("animateColor")}}
 - {{SVGElement("set")}}
 - {{SVGElement("feBlend")}}
 - {{SVGElement("feColorMatrix")}}

--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -130,7 +130,7 @@ SVG drawings and images are created using a wide array of elements which are ded
 
 ### Animation elements
 
-{{SVGElement("animate")}}, {{SVGElement("animateColor")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, {{SVGElement("discard")}}, {{SVGElement("mpath")}}, {{SVGElement("set")}}
+{{SVGElement("animate")}}, {{SVGElement("animateMotion")}}, {{SVGElement("animateTransform")}}, {{SVGElement("discard")}}, {{SVGElement("mpath")}}, {{SVGElement("set")}}
 
 ### Basic shapes
 
@@ -208,7 +208,7 @@ SVG drawings and images are created using a wide array of elements which are ded
 
 ### A
 
-{{SVGElement("altGlyph")}}, {{SVGElement("altGlyphDef")}}, {{SVGElement("altGlyphItem")}}, {{SVGElement("animateColor")}}
+{{SVGElement("altGlyph")}}, {{SVGElement("altGlyphDef")}}, {{SVGElement("altGlyphItem")}}
 
 ### C
 

--- a/files/jsondata/SVGData.json
+++ b/files/jsondata/SVGData.json
@@ -123,28 +123,6 @@
       ],
       "interfaces": ["SVGAnimateElement"]
     },
-    "animateColor": {
-      "categories": ["basicShapeElement", "graphicsElement", "shapeElement"],
-      "content": {
-        "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["descriptiveElements"]
-      },
-      "attributes": [
-        "conditionalProcessingAttributes",
-        "coreAttributes",
-        "animationEventAttributes",
-        "xLinkAttributes",
-        "animationAttributeTargetAttributes",
-        "animationTimingAttributes",
-        "animationValueAttributes",
-        "animationAdditionAttributes",
-        "'externalResourcesRequired'",
-        "'by'",
-        "'from'",
-        "'to'"
-      ],
-      "interfaces": ["SVGAnimateColorElement"]
-    },
     "animateMotion": {
       "categories": ["animationElement"],
       "content": {
@@ -532,7 +510,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;animateColor&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -1534,7 +1512,7 @@
       "categories": ["gradientElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;animateColor&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -1720,7 +1698,6 @@
           "&lt;a&gt;",
           "&lt;altGlyph&gt;",
           "&lt;animate&gt;",
-          "&lt;animateColor&gt;",
           "&lt;set&gt;",
           "&lt;tref&gt;",
           "&lt;tspan&gt;"
@@ -1754,12 +1731,7 @@
       "categories": ["textContentElement", "textContentChildElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": [
-          "descriptiveElements",
-          "&lt;animate&gt;",
-          "&lt;animateColor&gt;",
-          "&lt;set&gt;"
-        ]
+        "elements": ["descriptiveElements", "&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "conditionalProcessingAttributes",
@@ -1783,7 +1755,6 @@
           "&lt;a&gt;",
           "&lt;altGlyph&gt;",
           "&lt;animate&gt;",
-          "&lt;animateColor&gt;",
           "&lt;set&gt;",
           "&lt;tref&gt;",
           "&lt;tspan&gt;"


### PR DESCRIPTION
`<animateColor>` got removed a decade ago; Gecko never implemented it and Chromium removed it.

Its feature overlaps with `<animate>`. 

Long long ago we removed `<animateColor>` and redirected it to `<animate>`. 

We let a trail of mentions. This PR removes all of them, instead of the one in `SVGAnimateColorElement` that is also deprecated, transformed in plaintext though.