### PR TITLE
Fix typo creating a red broken link

### DIFF
--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -30,7 +30,7 @@ SVG makes use of a number of data types. This article lists these types along wi
 
     The unit identifiers in such \<angle> values must be in lower case.
 
-    In the SVG DOM, \<angle> values are represented using {{domxref("SVGAngle")}} or {{domxref("SVGAnimatedAngle objects")}}.
+    In the SVG DOM, \<angle> values are represented using {{domxref("SVGAngle")}} or {{domxref("SVGAnimatedAngle")}} objects.
 
 ## Anything
 


### PR DESCRIPTION
Just saw this one in a list of flaws. Let's get rid of this error.