### PR TITLE
HTTP 410 docs: Dead link fix

### DIFF
--- a/files/en-us/web/http/status/410/index.md
+++ b/files/en-us/web/http/status/410/index.md
@@ -29,4 +29,4 @@ If you don't know whether this condition is temporary or permanent, a {{HTTPStat
 ## See also
 
 - {{HTTPStatus(404)}}
-- [410 gone](https://www.exai.com/blog/410-gone-client-error)
+- [410 gone](https://web.archive.org/web/20220705190318/https://www.exai.com/blog/410-gone-client-error)

--- a/files/en-us/web/http/status/410/index.md
+++ b/files/en-us/web/http/status/410/index.md
@@ -29,4 +29,4 @@ If you don't know whether this condition is temporary or permanent, a {{HTTPStat
 ## See also
 
 - {{HTTPStatus(404)}}
-- [410 gone](https://web.archive.org/web/20220705190318/https://www.exai.com/blog/410-gone-client-error)
+- [410 gone](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#410)


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The current link to https://www.exai.com/blog/410-gone-client-error seems dead.  It is currently unknown if it's permanent or not at this time.

This commit replaces the link with a web.archive.org link to the page instead.

### Motivation
Dead links are bad and anoying for any user. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
