### PR TITLE
Remove stray markup

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_regex_rules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/max_number_of_regex_rules/index.md
@@ -16,7 +16,6 @@ browser-compat: webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_REGEX_RULE
 
 {{AddonSidebar()}}
 
-```suggestion
 The maximum number of regular expression rules that an extension can add.
 
 In Chrome, its value is 1000, and this limit is evaluated separately for the set of dynamic and session rules, and those specified in the rule resources file.


### PR DESCRIPTION
### Description

Removed accidentally included "```suggestion" from the declarativeNetRequest.MAX_NUMBER_OF_REGEX_RULES page that was causing formatting issues.