### PR TITLE
replace "lines of text" with "inline elements"

### DIFF
--- a/files/en-us/web/css/writing-mode/index.md
+++ b/files/en-us/web/css/writing-mode/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.writing-mode
 
 {{CSSRef}}
 
-The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which blocks progress. When set for an entire document, it should be set on the root element (`html` element for HTML documents).
+The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether [inline elements](/en-US/docs/Web/HTML/Inline_elements) are laid out horizontally or vertically, as well as the direction in which [block-level elements](/en-US/docs/Web/HTML/Block-level_elements) progress. When set for an entire document, it should be set on the root element (`html` element for HTML documents).
 
 {{EmbedInteractiveExample("pages/css/writing-mode.html")}}
 


### PR DESCRIPTION
Correct me if I'm wrong but I'm pretty sure that the CSS property "writing-mode" sets whether inline elements (such as text and images) are laid out horizontally or vertically, not just the lines of text.
