### PR TITLE
fix: typo on index.md

### DIFF
--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -1265,7 +1265,7 @@ As such, TIFF files are not useful within the context of web content, _but_ it's
 ### WebP image
 
 WebP supports lossy compression via predictive coding based on the VP8 video codec, and lossless compression that uses substitutions for repeating data.
-Lossy WebP images average 25–35% smaller than JPEG images of visually similar compression levels.
+Lossy WebP images are on average 25–35% smaller than JPEG images of visually similar compression levels.
 Lossless WebP images are typically 26% smaller than the same images in PNG format.
 
 WebP also supports animation: in a lossy WebP file, the image data is represented by a VP8 bitstream, which may contain multiple frames.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Proposed fix for a typo on the "WebP image" section, which describes the type of compression but lacks the proper verb to connect the sentence, making it confusing to read.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I have always used MDN docs as a reliable source and after I found a typo I thought "why not collaborate?". So I created this PR, which is also my first OSP related one! 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Typos are usually a common mistake that takes time out of more capable developers, so I think it is our responsibility to collaborate on whatever we can. This change makes the document more readable and agreeable to understand.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
