### PR TITLE
Create AudioProcessingEvent.* docs

### DIFF
--- a/files/en-us/web/api/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/index.md
@@ -9,7 +9,7 @@ browser-compat: api.AudioBuffer
 
 The **`AudioBuffer`** interface represents a short audio asset residing in memory, created from an audio file using the {{ domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()") }} method, or from raw data using {{ domxref("BaseAudioContext/createBuffer", "AudioContext.createBuffer()") }}. Once put into an AudioBuffer, the audio can then be played by being passed into an {{ domxref("AudioBufferSourceNode") }}.
 
-Objects of these types are designed to hold small audio snippets, typically less than 45 s. For longer sounds, objects implementing the {{domxref("MediaElementAudioSourceNode")}} are more suitable. The buffer contains data in the following format: non-interleaved IEEE754 32-bit linear PCM with a nominal range between `-1` and `+1`, that is, a 32-bit floating point buffer, with each sample between -1.0 and 1.0. If the {{domxref("AudioBuffer")}} has multiple channels, they are stored in separate buffers.
+Objects of these types are designed to hold small audio snippets, typically less than 45 s. For longer sounds, objects implementing the {{domxref("MediaElementAudioSourceNode")}} are more suitable. The buffer contains the audio signal waveform encoded as a series of amplitudes in the following format: non-interleaved IEEE754 32-bit linear PCM with a nominal range between `-1` and `+1`, that is, a 32-bit floating point buffer, with each sample between -1.0 and 1.0. If the {{domxref("AudioBuffer")}} has multiple channels, they are stored in separate buffers.
 
 ## Constructor
 

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -1,0 +1,51 @@
+---
+title: AudioProcessingEvent()
+slug: Web/API/AudioProcessingEvent/AudioProcessingEvent
+page-type: web-api-constructor
+status:
+  - deprecated
+browser-compat: api.AudioProcessingEvent.AudioProcessingEvent
+---
+
+{{APIRef}}{{Deprecated_header}}
+
+The **`AudioProcessingEvent()`** constructor creates a new {{domxref("AudioProcessingEvent")}} object.
+
+> **Note:** Usually, this constructor is not directly called by your code, as the browser creates these objects itself and provides them to the event handler.
+
+## Syntax
+
+```js-nolint
+new AudioProcessingEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers always set it to `audioprocess`.
+- `options`
+  - : An object that has the following properties:
+    - `playbackTime`
+      - : A number representing the time when the audio will be played.
+    - `inputBuffer`
+      - : An {{domxref("AudioBuffer")}} containing the input audio data.
+    - `outputBuffer`
+      - : An {{domxref("AudioBuffer")}} where the output audio data will be written.
+
+## Return Value
+
+A new {{domxref("AudioProcessingEvent")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioProcessingEvent")}}
+- {{domxref("ScriptProcessorNode")}}

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -33,7 +33,7 @@ new AudioProcessingEvent(type, options)
     - `outputBuffer`
       - : An {{domxref("AudioBuffer")}} where the output audio data will be written.
 
-## Return Value
+### Return value
 
 A new {{domxref("AudioProcessingEvent")}}.
 

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -40,7 +40,7 @@ _Also implements the properties inherited from its parent, {{domxref("Event")}}_
     of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
     Note that the returned <code>AudioBuffer</code> is only valid in the scope of the event handler.
 
-## Example
+## Examples
 
 The following example shows how to use of a `ScriptProcessorNode` to take a
 track loaded via {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}, process it, adding a bit

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -11,6 +11,8 @@ browser-compat: api.AudioProcessingEvent
 
 The `AudioProcessingEvent` interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.
 
+An `audioprocess` event with this interface is thrown to a {{domxref("ScriptProcessorNode")}} when audio processing is required. During audio processing, the input buffer is read and processed to produce output audio data, which is then written to the output buffer.
+
 > **Warning:** This feature has been deprecated and should be replaced by an [`AudioWorklet`](/en-US/docs/Web/API/AudioWorklet).
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -11,7 +11,7 @@ browser-compat: api.AudioProcessingEvent
 
 The `AudioProcessingEvent` interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.
 
-An `audioprocess` event with this interface is thrown to a {{domxref("ScriptProcessorNode")}} when audio processing is required. During audio processing, the input buffer is read and processed to produce output audio data, which is then written to the output buffer.
+An `audioprocess` event with this interface is fired on a {{domxref("ScriptProcessorNode")}} when audio processing is required. During audio processing, the input buffer is read and processed to produce output audio data, which is then written to the output buffer.
 
 > **Warning:** This feature has been deprecated and should be replaced by an [`AudioWorklet`](/en-US/docs/Web/API/AudioWorklet).
 

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -42,7 +42,7 @@ _Also implements the properties inherited from its parent, {{domxref("Event")}}_
 
 ## Example
 
-The following example shows basic usage of a `ScriptProcessorNode` to take a
+The following example shows how to use of a `ScriptProcessorNode` to take a
 track loaded via {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}, process it, adding a bit
 of white noise to each audio sample of the input track (buffer) and play it through the
 {{domxref("AudioDestinationNode")}}. For each channel and each sample frame, the

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -9,30 +9,30 @@ browser-compat: api.AudioProcessingEvent
 
 {{APIRef("Web Audio API")}}{{deprecated_header}}
 
-The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.
+The `AudioProcessingEvent` interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.
 
-> **Note:** As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by [AudioWorklet](https://webaudio.github.io/web-audio-api/#audioworklet).
+> **Warning:** This feature has been deprecated and should be replaced by an [`AudioWorklet`](/en-US/docs/Web/API/AudioWorklet).
 
 {{InheritanceDiagram}}
 
 ## Constructor
 
-- `AudioProcessingEvent()` {{Deprecated_Inline}}
+- {{domxref("AudioProcessingEvent.AudioProcessingEvent", "AudioProcessingEvent()")}} {{Deprecated_Inline}}
   - : Creates a new `AudioProcessingEvent` object.
 
 ## Instance properties
 
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 
-- `playbackTime` {{ReadOnlyInline}} {{Deprecated_Inline}}
+- {{domxref("AudioProcessingEvent.playbackTime", "playbackTime")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : A double representing the time when the audio will be played,
     as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
-- `inputBuffer` {{ReadOnlyInline}} {{Deprecated_Inline}}
+- {{domxref("AudioProcessingEvent.inputBuffer", "inputBuffer")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer containing the input audio data to be processed.
     The number of channels is defined as a parameter `numberOfInputChannels`,
     of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
     Note that the returned <code>AudioBuffer</code> is only valid in the scope of the event handler.
-- `outputBuffer` {{ReadOnlyInline}} {{Deprecated_Inline}}
+- {{domxref("AudioProcessingEvent.outputBuffer", "outputBuffer")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer where the output audio data should be written.
     The number of channels is defined as a parameter, <code>numberOfOutputChannels</code>,
     of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
@@ -40,7 +40,91 @@ _Also implements the properties inherited from its parent, {{domxref("Event")}}_
 
 ## Example
 
-See [`BaseAudioContext.createScriptProcessor()`](/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example) for example code that uses an `AudioProcessingEvent`.
+The following example shows basic usage of a `ScriptProcessorNode` to take a
+track loaded via {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}, process it, adding a bit
+of white noise to each audio sample of the input track (buffer) and play it through the
+{{domxref("AudioDestinationNode")}}. For each channel and each sample frame, the
+`scriptNode.onaudioprocess` function takes the associated
+`audioProcessingEvent` and uses it to loop through each channel of the input
+buffer, and each sample in each channel, and add a small amount of white noise, before
+setting that result to be the output sample in each case.
+
+> **Note:** For a full working example, see our [script-processor-node](https://mdn.github.io/webaudio-examples/script-processor-node/)
+> GitHub repo. (You can also access the [source code](https://github.com/mdn/webaudio-examples/blob/master/script-processor-node/index.html).)
+
+```js
+const myScript = document.querySelector("script");
+const myPre = document.querySelector("pre");
+const playButton = document.querySelector("button");
+
+// Create AudioContext and buffer source
+const audioCtx = new AudioContext();
+const source = audioCtx.createBufferSource();
+
+// Create a ScriptProcessorNode with a bufferSize of 4096 and a single input and output channel
+const scriptNode = audioCtx.createScriptProcessor(4096, 1, 1);
+console.log(scriptNode.bufferSize);
+
+// load in an audio track via XHR and decodeAudioData
+
+function getData() {
+  request = new XMLHttpRequest();
+  request.open("GET", "viper.ogg", true);
+  request.responseType = "arraybuffer";
+  request.onload = () => {
+    const audioData = request.response;
+
+    audioCtx.decodeAudioData(
+      audioData,
+      (buffer) => {
+        myBuffer = buffer;
+        source.buffer = myBuffer;
+      },
+      (e) => console.error(`Error with decoding audio data: ${e.err}`)
+    );
+  };
+  request.send();
+}
+
+// Give the node a function to process audio events
+scriptNode.onaudioprocess = (audioProcessingEvent) => {
+  // The input buffer is the song we loaded earlier
+  const inputBuffer = audioProcessingEvent.inputBuffer;
+
+  // The output buffer contains the samples that will be modified and played
+  const outputBuffer = audioProcessingEvent.outputBuffer;
+
+  // Loop through the output channels (in this case there is only one)
+  for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+    const inputData = inputBuffer.getChannelData(channel);
+    const outputData = outputBuffer.getChannelData(channel);
+
+    // Loop through the 4096 samples
+    for (let sample = 0; sample < inputBuffer.length; sample++) {
+      // make output equal to the same as the input
+      outputData[sample] = inputData[sample];
+
+      // add noise to each output sample
+      outputData[sample] += (Math.random() * 2 - 1) * 0.2;
+    }
+  }
+};
+
+getData();
+
+// Wire up the play button
+playButton.onclick = () => {
+  source.connect(scriptNode);
+  scriptNode.connect(audioCtx.destination);
+  source.start();
+};
+
+// When the buffer source stops playing, disconnect everything
+source.onended = () => {
+  source.disconnect(scriptNode);
+  scriptNode.disconnect(audioCtx.destination);
+};
+```
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
@@ -1,0 +1,56 @@
+---
+title: AudioProcessingEvent.inputBuffer
+slug: Web/API/AudioProcessingEvent/inputBuffer
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.AudioProcessingEvent.inputBuffer
+---
+
+{{APIRef}}{{Deprecated_header}}
+The **`inputBuffer`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the input buffer of an audio processing event.
+
+The input buffer is represented by an {{domxref("AudioBuffer")}} object, which contains a collection of audio channels, each of which is an array of floating-point values representing the audio signal waveform encoded as a series of amplitudes. The number of channels and the length of each channel are determined by the channel count and buffer size properties of the `AudioBuffer`.
+
+## Value
+
+An {{domxref("AudioBuffer")}} object.
+
+## Example
+
+In this example, a {{domxref("ScriptProcessorNode")}} is created with a buffer size of 256 samples, 2 input channels, and 2 output channels. When an {{domxref("ScriptProcessorNode/audioprocess_event", "audioprocess")}} event is fired, the input and output buffers are retrieved from the event object. The audio data in the input buffer is processed, and the result is written to the output buffer. In this case, the audio data is scaled down by a factor of 0.5.
+
+```js
+const audioContext = new AudioContext();
+const processor = audioContext.createScriptProcessor(256, 2, 2);
+
+processor.addEventListener("audioprocess", (event) => {
+  const inputBuffer = event.inputBuffer;
+  const outputBuffer = event.outputBuffer;
+
+  for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+    const inputData = inputBuffer.getChannelData(channel);
+    const outputData = outputBuffer.getChannelData(channel);
+
+    // Process the audio data here
+    for (let i = 0; i < outputBuffer.length; i++) {
+      outputData[i] = inputData[i] * 0.5;
+    }
+  }
+});
+
+processor.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioProcessingEvent.outputBuffer")}}
+- {{domxref("ScriptProcessorNode")}}

--- a/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
@@ -16,7 +16,7 @@ The input buffer is represented by an {{domxref("AudioBuffer")}} object, which c
 
 An {{domxref("AudioBuffer")}} object.
 
-## Example
+## Examples
 
 In this example, a {{domxref("ScriptProcessorNode")}} is created with a buffer size of 256 samples, 2 input channels, and 2 output channels. When an {{domxref("ScriptProcessorNode/audioprocess_event", "audioprocess")}} event is fired, the input and output buffers are retrieved from the event object. The audio data in the input buffer is processed, and the result is written to the output buffer. In this case, the audio data is scaled down by a factor of 0.5.
 

--- a/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
@@ -1,0 +1,57 @@
+---
+title: AudioProcessingEvent.outputBuffer
+slug: Web/API/AudioProcessingEvent/outputBuffer
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.AudioProcessingEvent.outputBuffer
+---
+
+{{APIRef}}{{Deprecated_header}}
+
+The **`outputBuffer`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the output buffer of an audio processing event.
+
+The output buffer is represented by an {{domxref("AudioBuffer")}} object, which contains a collection of audio channels, each of which is an array of floating-point values representing the audio signal waveform encoded as a series of amplitudes. The number of channels and the length of each channel are determined by the channel count and buffer size properties of the `AudioBuffer`.
+
+## Value
+
+An {{domxref("AudioBuffer")}} object.
+
+## Example
+
+In this example, a {{domxref("ScriptProcessorNode")}} is created with a buffer size of 256 samples, 2 input channels, and 2 output channels. When an {{domxref("ScriptProcessorNode/audioprocess_event", "audioprocess")}} event is fired, the input and output buffers are retrieved from the event object. The audio data in the input buffer is processed, and the result is written to the output buffer. In this case, the audio data is scaled down by a factor of 0.5.
+
+```js
+const audioContext = new AudioContext();
+const processor = audioContext.createScriptProcessor(256, 2, 2);
+
+processor.addEventListener("audioprocess", (event) => {
+  const inputBuffer = event.inputBuffer;
+  const outputBuffer = event.outputBuffer;
+
+  for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+    const inputData = inputBuffer.getChannelData(channel);
+    const outputData = outputBuffer.getChannelData(channel);
+
+    // Process the audio data here
+    for (let i = 0; i < outputBuffer.length; i++) {
+      outputData[i] = inputData[i] * 0.5;
+    }
+  }
+});
+
+processor.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioProcessingEvent.inputBuffer")}}
+- {{domxref("ScriptProcessorNode")}}

--- a/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
@@ -17,7 +17,7 @@ The output buffer is represented by an {{domxref("AudioBuffer")}} object, which 
 
 An {{domxref("AudioBuffer")}} object.
 
-## Example
+## Examples
 
 In this example, a {{domxref("ScriptProcessorNode")}} is created with a buffer size of 256 samples, 2 input channels, and 2 output channels. When an {{domxref("ScriptProcessorNode/audioprocess_event", "audioprocess")}} event is fired, the input and output buffers are retrieved from the event object. The audio data in the input buffer is processed, and the result is written to the output buffer. In this case, the audio data is scaled down by a factor of 0.5.
 

--- a/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
+++ b/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
@@ -14,7 +14,7 @@ The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent
 
 A number that doesn't need to be an integer.
 
-## Example
+## Examples
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
+++ b/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
@@ -8,7 +8,7 @@ browser-compat: api.AudioProcessingEvent.playbackTime
 ---
 
 {{APIRef}}{{Deprecated_header}}
-The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the time when the audio will be played. It is in the same coordinate system than the time used by the {{domxref("AudioContext")}}.
+The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the time when the audio will be played. It is in the same coordinate system as the time used by the {{domxref("AudioContext")}}.
 
 ## Value
 

--- a/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
+++ b/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
@@ -1,0 +1,55 @@
+---
+title: AudioProcessingEvent.playbackTime
+slug: Web/API/AudioProcessingEvent/playbackTime
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.AudioProcessingEvent.playbackTime
+---
+
+{{APIRef}}{{Deprecated_header}}
+The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the time when the audio will be played. It is in the same coordinate system than the time used by the {{domxref("AudioContext")}}.
+
+## Value
+
+A number, that doesn't need to be an integer.
+
+## Example
+
+```js
+const audioContext = new AudioContext();
+const processor = audioContext.createScriptProcessor(256, 2, 2);
+
+processor.addEventListener("audioprocess", (event) => {
+  const inputBuffer = event.inputBuffer;
+  const outputBuffer = event.outputBuffer;
+
+  for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+    const inputData = inputBuffer.getChannelData(channel);
+    const outputData = outputBuffer.getChannelData(channel);
+
+    // Log the corresponding time for this audio buffer
+    console.log(`Received audio data to be played at ${event.playbackTime}`);
+
+    // Process the audio data here
+    for (let i = 0; i < outputBuffer.length; i++) {
+      outputData[i] = inputData[i] * 0.5;
+    }
+  }
+});
+
+processor.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioProcessingEvent")}}
+- {{domxref("ScriptProcessorNode")}}

--- a/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
+++ b/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
@@ -12,7 +12,7 @@ The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent
 
 ## Value
 
-A number, that doesn't need to be an integer.
+A number that doesn't need to be an integer.
 
 ## Example
 

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -128,7 +128,7 @@ scriptNode.onaudioprocess = (audioProcessingEvent) => {
 
 getData();
 
-// wire up play button
+// Wire up the play button
 playButton.onclick = () => {
   source.connect(scriptNode);
   scriptNode.connect(audioCtx.destination);


### PR DESCRIPTION
Associated BCD PR: mdn/browser-compat-data#19082

This is part of openwebdocs/project#152

I created all `AudioProcessingEvent.*` pages, including `AudioProcessingEvent()` even if not supported by Firefox (and strictly speaking outside the scope of the Q1 projects). As the interface is deprecated and, usually, the ctor is not called directly by the user code, I skipped writing an example for it. (It would have been cumbersome to test for next to no use).
