### PR TITLE
Correct summary table

### DIFF
--- a/files/en-us/web/http/methods/patch/index.md
+++ b/files/en-us/web/http/methods/patch/index.md
@@ -28,7 +28,7 @@ Another (implicit) indication that `PATCH` is allowed, is the presence of the {{
     </tr>
     <tr>
       <th scope="row">Successful response has body</th>
-      <td>Yes</td>
+      <td>May</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>


### PR DESCRIPTION
### Description
Summary table has `Successful response has body: Yes`, when it's actually `Successful response has body: May`. 

This same document has an example and explanation of a a PATCH request with an HTTP 204 response without body.

### Motivation
Current information doesn't seem accurate

### Additional details
The example and corresponding explanation is taken from the PATCH RFC 5789 https://www.rfc-editor.org/rfc/rfc5789#section-2.1, where response may be an HTTP 200 with body or an HTTP 204 without body, among others.