### PR TITLE
Remove note about nested workers not supported in Safari

### DIFF
--- a/files/en-us/web/api/worker/index.md
+++ b/files/en-us/web/api/worker/index.md
@@ -11,7 +11,7 @@ The **`Worker`** interface of the [Web Workers API](/en-US/docs/Web/API/Web_Work
 
 Creating a worker is done by calling the `Worker("path/to/worker/script")` constructor.
 
-Workers may themselves spawn new workers, as long as those workers are hosted at the same [origin](/en-US/docs/Web/Security/Same-origin_policy) as the parent page. (Note: [nested workers are not yet implemented in WebKit](https://webkit.org/b/22723)).
+Workers may themselves spawn new workers, as long as those workers are hosted at the same [origin](/en-US/docs/Web/Security/Same-origin_policy) as the parent page.
 
 [Not all interfaces and functions are available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) to scripts inside a `Worker`. Workers may use {{domxref("XMLHttpRequest")}} for network communication, but its `responseXML` and `channel` attributes are always `null`. ([`fetch`](/en-US/docs/Web/API/Fetch_API) is also available, with no such restrictions.)
 


### PR DESCRIPTION
This removes a note about webkit support for nested workers. This support is now in Safari and the compat information was added here: https://github.com/mdn/browser-compat-data/pull/19045

This fell out of work for #24402