### PR TITLE
Typo in image file suffix within a code example

### DIFF
--- a/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
@@ -128,7 +128,7 @@ The following example shows code for a figure with a caption. The `alt` attribut
 ```html
 <figure>
   <img
-    src="milkweed.jgp"
+    src="milkweed.jpg"
     alt="Black and white close-up photo of milkweed flowers" />
   <figcaption>Asclepias verticillata</figcaption>
 </figure>


### PR DESCRIPTION
Changed milkweed.jgp to milkweed.jpg. Thank you.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the code example for 'Content with images must be labeled' the image had .jgp as a file suffix. I'm assuming it was meant to be .jpg

### Motivation

Just removing a typo to remove an error.

### Additional details

Not applicable.

### Related issues and pull requests

Not applicable.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
