### PR TITLE
Add Safari's "autocapitalize" to list of non-standard attributes

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -608,6 +608,12 @@ The following non-standard attributes are also available on some browsers. As a 
   </thead>
   <tbody>
     <tr>
+      <td><a href="#autocapitalize"><code>autocapitalize</code></a></td>
+      <td>
+        A string indicating how auto-capitalization should be applied to the contet of text elements. <strong>Safari only.</strong>
+      </td>
+    </tr>
+    <tr>
       <td><a href="#autocorrect"><code>autocorrect</code></a></td>
       <td>
         A string indicating whether autocorrect is <code>on</code> or <code>off</code>. <strong>Safari only.</strong>
@@ -653,6 +659,19 @@ The following non-standard attributes are also available on some browsers. As a 
     </tr>
   </tbody>
 </table>
+
+- `autocapitalize` {{non-standard_inline}}
+
+  - : (Safari only). A string which indicates how auto-capitalization should be applied while the user is editing this field. Permitted values are:
+
+    - `none`
+      - : Do not automatically capitalize any text
+    - `sentences`
+      - : Automatically capitalize the first character of each sentence.
+    - `words`
+      - : Automatically capitalize the first character of each word.
+    - `characters`
+      - : Automatically capitalize every character.
 
 - `autocorrect` {{non-standard_inline}}
 

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -610,7 +610,7 @@ The following non-standard attributes are also available on some browsers. As a 
     <tr>
       <td><a href="#autocapitalize"><code>autocapitalize</code></a></td>
       <td>
-        A string indicating how auto-capitalization should be applied to the contet of text elements. <strong>Safari only.</strong>
+        A string indicating how auto-capitalization should be applied to the content of text elements. <strong>Safari only.</strong>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add the Safari-specific "autocapitalize" attribute to the existing list of non-standard attributes.

### Motivation

It is useful for web developers to easily discover that an attribute they are trying to use is non-standard.

### Additional details

This Safari-specific attribute is documented here:

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize

### Related issues and pull requests

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
