### PR TITLE
Remove HTMLAttrXRef macro

### DIFF
--- a/files/en-us/glossary/ltr/index.md
+++ b/files/en-us/glossary/ltr/index.md
@@ -21,8 +21,8 @@ The opposite of LTR, {{Glossary("RTL")}} (Right To Left) is used in other common
 
 - [HTML global attributes](/en-US/docs/Web/HTML/Global_attributes)
 
-  - {{htmlattrxref("dir")}}
-  - {{htmlattrxref("lang")}}
+  - [dir](/en-US/docs/Web/HTML/Global_attributes#dir)
+  - [lang](/en-US/docs/Web/HTML/Global_attributes#lang)
 
 - [CSS](/en-US/docs/Web/CSS)
 

--- a/files/en-us/learn/accessibility/html/index.md
+++ b/files/en-us/learn/accessibility/html/index.md
@@ -592,7 +592,7 @@ People experiencing low vision conditions, who are navigating with the aid of sc
 >
 ```
 
-If an icon is used in place of text to signify this kind of links behavior, make sure it includes an {{HTMLAttrxRef("alt", "img", "alternate description", "true")}}.
+If an icon is used in place of text to signify this kind of links behavior, make sure it includes an [`alternate description`](/en-US/docs/Web/HTML/Element/img#alt).
 
 - [WebAIM: Links and Hypertext - Hypertext Links](https://webaim.org/techniques/hypertext/hypertext_links)
 - [MDN Understanding WCAG, Guideline 3.2 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.2_—_predictable_make_web_pages_appear_and_operate_in_predictable_ways)

--- a/files/en-us/learn/accessibility/html/index.md
+++ b/files/en-us/learn/accessibility/html/index.md
@@ -592,7 +592,7 @@ People experiencing low vision conditions, who are navigating with the aid of sc
 >
 ```
 
-If an icon is used in place of text to signify this kind of links behavior, make sure it includes an [`alternate description`](/en-US/docs/Web/HTML/Element/img#alt).
+If an icon is used in place of text to signify this kind of links behavior, make sure it includes an [alternate description](/en-US/docs/Web/HTML/Element/img#alt).
 
 - [WebAIM: Links and Hypertext - Hypertext Links](https://webaim.org/techniques/hypertext/hypertext_links)
 - [MDN Understanding WCAG, Guideline 3.2 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.2_—_predictable_make_web_pages_appear_and_operate_in_predictable_ways)

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -361,8 +361,8 @@ The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macr
 
 - {{SVGElement("feGaussianBlur")}}
 - {{SVGAttr("keySplines")}} SVG attribute
-- {{htmlattrxref("dir")}}
-- {{htmlattrxref("lang")}}
+- [dir](/en-US/docs/Web/HTML/Global_attributes#dir)
+- [lang](/en-US/docs/Web/HTML/Global_attributes#lang)
 - {{cssxref(":dir")}}
 - {{cssxref("direction")}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -170,4 +170,4 @@ Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
 - [Permissions API](/en-US/docs/Web/API/Permissions_API)
 - [Making content editable](/en-US/docs/Web/Guide/HTML/Editable_content)
-- {{htmlattrxref("contenteditable")}}
+- [contenteditable](/en-US/docs/Web/HTML/Global_attributes#contenteditable)

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -159,7 +159,7 @@ document.querySelector("#paste").addEventListener("click", paste);
 
 ### Browser-specific considerations
 
-Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) from version 54 but only supports pasting into elements in [content editable mode](/en-US/docs/Web/Guide/HTML/Editable_content), which for content scripts only works with a {{HTMLElement("textarea")}}. For background scripts, any element can be set to content editable mode.
+Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) from version 54 but only supports pasting into elements in [content editable mode](/en-US/docs/Web/HTML/Global_attributes/contenteditable), which for content scripts only works with a {{HTMLElement("textarea")}}. For background scripts, any element can be set to content editable mode.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -169,4 +169,4 @@ Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
 - [Permissions API](/en-US/docs/Web/API/Permissions_API)
-- [Making content editable](/en-US/docs/Web/HTML/Global_attributes#contenteditable)
+- [Make content editable](/en-US/docs/Web/HTML/Global_attributes#contenteditable)

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -169,5 +169,4 @@ Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
 - [Permissions API](/en-US/docs/Web/API/Permissions_API)
-- [Making content editable](/en-US/docs/Web/Guide/HTML/Editable_content)
-- [contenteditable](/en-US/docs/Web/HTML/Global_attributes#contenteditable)
+- [Making content editable](/en-US/docs/Web/HTML/Global_attributes#contenteditable)

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -149,7 +149,7 @@ Inherits into roles:
 
 - [Making disabled buttons more inclusive](https://css-tricks.com/making-disabled-buttons-more-inclusive/) by Sandrina Pereira
 - [Styling for Windows high contrast with new standards for forced colors](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/)
-- {{htmlattrxref('disabled')}}
+- [disabled](/en-US/docs/Web/HTML/Attributes/disabled)
 - {{domxref("Element.ariaDisabled")}}
 - {{domxref("ElementInternals.ariaDisabled")}}
 - [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -158,7 +158,7 @@ Inherited into roles:
 - HTML {{HTMLElement('select')}} element
 - HTML {{HTMLElement('option')}} element
 - HTML {{HTMLElement('input')}} element
-- {{htmlattrxref("multiple")}} attribute
+- [multiple](/en-US/docs/Web/HTML/Attributes/multiple) attribute
 - [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)
 
 <section id="Quick_links">

--- a/files/en-us/web/accessibility/aria/roles/tab_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tab_role/index.md
@@ -50,7 +50,7 @@ From the assistive technology user's perspective, the heading does not exist sin
   - : boolean
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
   - : `id` of element with `tabpanel` role
-- {{htmlattrxref("id")}}
+- [id](/en-US/docs/Web/HTML/Global_attributes#id)
   - : content
 
 ### Keyboard interaction

--- a/files/en-us/web/api/element/part/index.md
+++ b/files/en-us/web/api/element/part/index.md
@@ -56,4 +56,4 @@ tabs.forEach((tab) => {
 ## See also
 
 - {{cssxref("::part")}}
-- {{htmlattrxref("part")}}
+- [part](/en-US/docs/Web/HTML/Global_attributes#part)

--- a/files/en-us/web/api/htmlelement/hidden/index.md
+++ b/files/en-us/web/api/htmlelement/hidden/index.md
@@ -24,7 +24,7 @@ For details on the usage of this attribute, see the page for the [`hidden`](/en-
 
 ## Examples
 
-Here's an example where a hidden block is used to contain a thank you message that is
+Here's an example where a hidden block is used to contain a 'thank you' message that is
 displayed after a user agrees to an unusual request.
 
 ### HTML
@@ -97,5 +97,5 @@ document.getElementById("okButton").addEventListener(
 
 ## See also
 
-- {{htmlattrxref("hidden")}} attribute
+- [hidden](/en-US/docs/Web/HTML/Global_attributes#hidden) attribute
 - {{cssxref("display")}}

--- a/files/en-us/web/api/htmlelement/inputmode/index.md
+++ b/files/en-us/web/api/htmlelement/inputmode/index.md
@@ -52,4 +52,4 @@ For details on the usage of this attribute, see the page for the [`inputmode`](/
 
 ## See also
 
-- {{htmlattrxref("inputmode")}} attribute
+- [inputmode](/en-US/docs/Web/HTML/Global_attributes#inputmode) attribute

--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -330,7 +330,7 @@ People experiencing low vision conditions, navigating with the aid of screen rea
 <a href="2017-annual-report.ppt"> 2017 Annual Report (PowerPoint) </a>
 ```
 
-If an icon is used to signify link behavior, make sure it has [`alt text`](/en-US/docs/Web/HTML/Element/img#alt):
+If an icon is used to signify link behavior, make sure it has an [_alt text_](/en-US/docs/Web/HTML/Element/img#alt):
 
 ```html
 <a target="_blank" href="https://www.wikipedia.org">

--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -330,7 +330,7 @@ People experiencing low vision conditions, navigating with the aid of screen rea
 <a href="2017-annual-report.ppt"> 2017 Annual Report (PowerPoint) </a>
 ```
 
-If an icon is used to signify link behavior, make sure it has {{HTMLAttrxRef("alt", "img", "alt text", "true")}}:
+If an icon is used to signify link behavior, make sure it has [`alt text`](/en-US/docs/Web/HTML/Element/img#alt):
 
 ```html
 <a target="_blank" href="https://www.wikipedia.org">

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -136,7 +136,7 @@ function updateFirst(event) {
 }
 ```
 
-When the color picker is dismissed, indicating that the value will not be changing again (unless the user re-opens the color picker), a `change` event is sent to the element. We handle that event using the `updateAll()` function, using {{htmlattrxref("value", "input", "Event.target.value")}} to obtain the final selected color:
+When the color picker is dismissed, indicating that the value will not be changing again (unless the user re-opens the color picker), a `change` event is sent to the element. We handle that event using the `updateAll()` function, using [Event.target.value](/en-US/docs/Web/HTML/Element/input#value) to obtain the final selected color:
 
 ```js
 function updateAll(event) {

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -136,7 +136,7 @@ function updateFirst(event) {
 }
 ```
 
-When the color picker is dismissed, indicating that the value will not be changing again (unless the user re-opens the color picker), a `change` event is sent to the element. We handle that event using the `updateAll()` function, using [Event.target.value](/en-US/docs/Web/HTML/Element/input#value) to obtain the final selected color:
+When the color picker is dismissed, indicating that the value will not change again (unless the user re-opens the color picker), a `change` event is sent to the element. We handle that event using the `updateAll()` function, using [`Event.target.value`](/en-US/docs/Web/HTML/Element/input#value) to obtain the final selected color:
 
 ```js
 function updateAll(event) {

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -400,7 +400,7 @@ These properties are own properties of each `String` instance.
 > They are of limited use, as they are based on a very old HTML standard and provide only a subset of the currently available HTML tags and attributes. Many of them create deprecated or non-standard markup today. In addition, they do simple string concatenation without any validation or sanitation, which makes them a potential security threat when directly inserted using [`innerHTML`](/en-US/docs/Web/API/Element/innerHTML). Use [DOM APIs](/en-US/docs/Web/API/Document_Object_Model) such as [`document.createElement()`](/en-US/docs/Web/API/Document/createElement) instead.
 
 - {{jsxref("String.prototype.anchor()")}} {{Deprecated_Inline}}
-  - : [&lt;a name=\"name\"&gt;](/en-US/docs/Web/HTML/Element/a#name) (hypertext target)
+  - : [`<a name="name">`](/en-US/docs/Web/HTML/Element/a#name) (hypertext target)
 - {{jsxref("String.prototype.big()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("big")}}
 - {{jsxref("String.prototype.blink()")}} {{Deprecated_Inline}}
@@ -410,13 +410,13 @@ These properties are own properties of each `String` instance.
 - {{jsxref("String.prototype.fixed()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("tt")}}
 - {{jsxref("String.prototype.fontcolor()")}} {{Deprecated_Inline}}
-  - : [&lt;font color=\"color\"&gt;](/en-US/docs/Web/HTML/Element/font#color)
+  - : [`<font color="color">`](/en-US/docs/Web/HTML/Element/font#color)
 - {{jsxref("String.prototype.fontsize()")}} {{Deprecated_Inline}}
-  - : [&lt;font size=\"size\"&gt;](/en-US/docs/Web/HTML/Element/font#size)
+  - : [`<font size="size">`](/en-US/docs/Web/HTML/Element/font#size)
 - {{jsxref("String.prototype.italics()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("i")}}
 - {{jsxref("String.prototype.link()")}} {{Deprecated_Inline}}
-  - : [&lt;a href=\"url\"&gt;](/en-US/docs/Web/HTML/Element/a#href) (link to URL)
+  - : [`<a href="url">`](/en-US/docs/Web/HTML/Element/a#href) (link to URL)
 - {{jsxref("String.prototype.small()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("small")}}
 - {{jsxref("String.prototype.strike()")}} {{Deprecated_Inline}}

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -400,7 +400,7 @@ These properties are own properties of each `String` instance.
 > They are of limited use, as they are based on a very old HTML standard and provide only a subset of the currently available HTML tags and attributes. Many of them create deprecated or non-standard markup today. In addition, they do simple string concatenation without any validation or sanitation, which makes them a potential security threat when directly inserted using [`innerHTML`](/en-US/docs/Web/API/Element/innerHTML). Use [DOM APIs](/en-US/docs/Web/API/Document_Object_Model) such as [`document.createElement()`](/en-US/docs/Web/API/Document/createElement) instead.
 
 - {{jsxref("String.prototype.anchor()")}} {{Deprecated_Inline}}
-  - : {{htmlattrxref("name", "a", "&lt;a name=\"name\"&gt;")}} (hypertext target)
+  - : [&lt;a name=\"name\"&gt;](/en-US/docs/Web/HTML/Element/a#name) (hypertext target)
 - {{jsxref("String.prototype.big()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("big")}}
 - {{jsxref("String.prototype.blink()")}} {{Deprecated_Inline}}
@@ -410,13 +410,13 @@ These properties are own properties of each `String` instance.
 - {{jsxref("String.prototype.fixed()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("tt")}}
 - {{jsxref("String.prototype.fontcolor()")}} {{Deprecated_Inline}}
-  - : {{htmlattrxref("color", "font", "&lt;font color=\"color\"&gt;")}}
+  - : [&lt;font color=\"color\"&gt;](/en-US/docs/Web/HTML/Element/font#color)
 - {{jsxref("String.prototype.fontsize()")}} {{Deprecated_Inline}}
-  - : {{htmlattrxref("size", "font", "&lt;font size=\"size\"&gt;")}}
+  - : [&lt;font size=\"size\"&gt;](/en-US/docs/Web/HTML/Element/font#size)
 - {{jsxref("String.prototype.italics()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("i")}}
 - {{jsxref("String.prototype.link()")}} {{Deprecated_Inline}}
-  - : {{htmlattrxref("href", "a", "&lt;a href=\"url\"&gt;")}} (link to URL)
+  - : [&lt;a href=\"url\"&gt;](/en-US/docs/Web/HTML/Element/a#href) (link to URL)
 - {{jsxref("String.prototype.small()")}} {{Deprecated_Inline}}
   - : {{HTMLElement("small")}}
 - {{jsxref("String.prototype.strike()")}} {{Deprecated_Inline}}


### PR DESCRIPTION
Addresses https://github.com/mdn/content/pull/24289#issuecomment-1423807630

The macro is no longer needed because def lists auto generate ids now.\
We've completely removed `HTMLAttrDef` from content, and now it is time to remove `HTMLAttrXRef` macro.

