### PR TITLE
Fixes to Background Sync API

### DIFF
--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -36,7 +36,7 @@ As this API relies on service workers, functionality provided by this API is onl
 The following additions to the {{domxref('Service Worker API', "", "", "nocode")}} are specified in the Background Synchronization specification to provide an entry point for using background sync.
 
 - {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}}
-  - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run nce the device has network connectivity.
+  - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run once the device has network connectivity.
 - [`ServiceWorkerGlobalScope: sync` event](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event)
   - : An event handler fired whenever a {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}} event occurs. This happens as soon as the network becomes available.
 

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SyncManager
 
 {{DefaultAPISidebar("Background Sync")}}{{Securecontext_Header}}{{SeeCompatTable}}
 
-The Background Synchronization API enables a web app to defer tasks, so that they can be run in a {{domxref('Service Worker API','service worker', "", "nocode")}} once the user has a stable network connection.
+The **Background Synchronization API** enables a web app to defer tasks so that they can be run in a [service worker](/en-US/docs/Web/API/Service_Worker_API) once the user has a stable network connection.
 
 ## Concepts and usage
 
@@ -29,15 +29,15 @@ As this API relies on service workers, functionality provided by this API is onl
 - {{domxref('SyncManager')}} {{Experimental_Inline}}
   - : Registers tasks to be run in a service worker at a later time with network connectivity. These tasks are referred to as _background sync requests_.
 - {{domxref('SyncEvent')}} {{Experimental_Inline}}
-  - : Represents a synchronization event, sent to the {{domxref('ServiceWorkerGlobalScope', 'global scope', "", "nocode")}} of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker once the device has network connectivity.
+  - : Represents a synchronization event, sent to the [global scope](/en-US/docs/Web/API/ServiceWorkerGlobalScope) of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker once the device has network connectivity.
 
 ### Extensions to other interfaces
 
-The following additions to the {{domxref('Service Worker API', "", "", "nocode")}} are specified in the Background Synchronization specification to provide an entry point for using background sync.
+The following additions to the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) provide an entry point for setting up background synchronization.
 
 - {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}}
   - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run once the device has network connectivity.
-- [`ServiceWorkerGlobalScope: sync` event](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event)
+- [`ServiceWorkerGlobalScope: sync`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event)  event
   - : An event handler fired whenever a {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}} event occurs. This happens as soon as the network becomes available.
 
 ## Examples

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -4,16 +4,17 @@ slug: Web/API/Background_Synchronization_API
 page-type: web-api-overview
 status:
   - experimental
+spec-urls: https://wicg.github.io/background-sync/spec/
 browser-compat: api.SyncManager
 ---
 
 {{DefaultAPISidebar("Background Sync")}}{{Securecontext_Header}}{{SeeCompatTable}}
 
-The Background Synchronization API provides a way to defer tasks to be run in a {{domxref('Service Worker API','service worker')}} until the user has a stable network connection.
+The Background Synchronization API enables a web app to defer tasks, so that they can be run in a {{domxref('Service Worker API','service worker', "", "nocode")}} once the user has a stable network connection.
 
-## Background Synchronization Concepts and Usage
+## Concepts and usage
 
-The Background Sync API allows web applications to defer server synchronization work to their service worker to handle at a later time, if the device is offline. Uses may include sending requests in the background if they couldn't be sent while the application was being used.
+The Background Synchronization API allows web applications to defer server synchronization work to their service worker to handle at a later time, if the device is offline. Uses may include sending requests in the background if they couldn't be sent while the application was being used.
 
 For example, an email client application could let its users compose and send messages at any time, even when the device has no network connection. The application frontend just registers a sync request and the service worker gets alerted when the network is present again and handles the sync.
 
@@ -21,23 +22,23 @@ The {{domxref('SyncManager')}} interface is available through {{domxref('Service
 
 As this API relies on service workers, functionality provided by this API is only available in a secure context.
 
-> **Note:** At the time of writing, the Background Synchronization API is only available through an installed [Progressive Web App](/en-US/docs/Web/Progressive_web_apps)
+> **Note:** At the time of writing, the Background Synchronization API is only available through an installed [Progressive Web App](/en-US/docs/Web/Progressive_web_apps).
 
-## Background Synchronization Interfaces
+## Interfaces
 
 - {{domxref('SyncManager')}} {{Experimental_Inline}}
   - : Registers tasks to be run in a service worker at a later time with network connectivity. These tasks are referred to as _background sync requests_.
-- {{domxref('SyncEvent')}}
-  - : Represents a synchronization event, sent to the {{domxref('ServiceWorkerGlobalScope', 'global scope')}} of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker with network connectivity.
+- {{domxref('SyncEvent')}} {{Experimental_Inline}}
+  - : Represents a synchronization event, sent to the {{domxref('ServiceWorkerGlobalScope', 'global scope', "", "nocode")}} of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker once the device has network connectivity.
 
-## Service Worker Additions
+### Extensions to other interfaces
 
-The following additions to the {{domxref('Service Worker API')}} are specified in the Background Sync specification to provide an entry point for using Background Sync.
+The following additions to the {{domxref('Service Worker API', "", "", "nocode")}} are specified in the Background Synchronization specification to provide an entry point for using background sync.
 
 - {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}}
-  - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run with network connectivity.
-- {{domxref("ServiceWorkerGlobalScope.sync_event", "onsync")}}
-  - : An event handler fired whenever a {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}} event occurs. This happens either immediately if the network is available or as soon as the network becomes available.
+  - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run nce the device has network connectivity.
+- [`ServiceWorkerGlobalScope: sync` event](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event)
+  - : An event handler fired whenever a {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}} event occurs. This happens as soon as the network becomes available.
 
 ## Examples
 

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -37,7 +37,7 @@ The following additions to the [Service Worker API](/en-US/docs/Web/API/Service_
 
 - {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}}
   - : Returns a reference to the {{domxref("SyncManager")}} interface for registering tasks to run once the device has network connectivity.
-- [`ServiceWorkerGlobalScope: sync`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event)  event
+- [`ServiceWorkerGlobalScope: sync`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event) event
   - : An event handler fired whenever a {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}} event occurs. This happens as soon as the network becomes available.
 
 ## Examples

--- a/files/en-us/web/api/syncevent/syncevent/index.md
+++ b/files/en-us/web/api/syncevent/syncevent/index.md
@@ -23,7 +23,7 @@ new SyncEvent(type, options)
   - : A string with the name of the event.
     It is case-sensitive and browsers always set it to `sync`.
 - `options`
-  - : An object that, _in addition of the properties defined in {{domxref("ExtendableEvent/ExtendableEvent", "ExtendableEvent()")}}_, can have the following properties:
+  - : An object that, in addition to the properties defined in {{domxref("ExtendableEvent/ExtendableEvent", "ExtendableEvent()")}}, can have the following properties:
     - `tag`
       - : A developer-defined unique identifier for this `SyncEvent`.
     - `lastChance` {{optional_inline}}

--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -28,6 +28,10 @@ None.
 A {{jsxref("Promise")}} that resolves to an array of strings
 containing developer-defined identifiers for `SyncManager` registrations.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -41,6 +41,7 @@ async function syncMessagesLater() {
   }
 }
 ```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -27,6 +27,20 @@ register(tag)
 
 A {{jsxref("Promise")}} that resolves to {{jsxref("undefined")}}.
 
+### Examples
+
+The following asynchronous function registers a background sync from a browsing context:
+
+```js
+async function syncMessagesLater() {
+  const registration = await navigator.serviceWorker.ready;
+  try {
+    await registration.sync.register("sync-messages");
+  } catch {
+    console.log("Background Sync could not be registered!");
+  }
+}
+```
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -9,57 +9,27 @@ browser-compat: api.SyncManager.register
 
 {{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
-The **`SyncManager.register`** method of the
-{{domxref("SyncManager")}} interface returns a {{jsxref("Promise")}} that resolves to a
-{{domxref("SyncRegistration")}} instance.
+The **`SyncManager.register`** method of the {{domxref("SyncManager")}} interface registers a synchronization event, triggering a {{domxref("ServiceWorkerGlobalScope.sync_event", "sync")}} event inside the associated service worker as soon as network connectivity is available.
 
 ## Syntax
 
 ```js-nolint
-register()
-register(options)
+register(tag)
 ```
 
 ### Parameters
 
-- `options` {{optional_inline}}
+- `tag`
 
-  - : An object that sets options for an instance of {{domxref("SyncRegistration")}}. The
-    available options are:
-
-    - `allowOnBattery`
-      - : A boolean that determines whether synchronization
-        is allowed when the user agent is on a battery-powered device. The default
-        is `true`.
-    - `id`
-      - : The unique identifier of the specified
-        {{domxref("SyncRegistration")}} object.
-    - `idleRequired`
-      - : A boolean that determines whether synchronization is
-        allowed when the user agent's device is idle. The default is `false`.
-    - `maxDelay`
-      - : The maximum delay in milliseconds before the next
-        `sync` event (or the first `sync` event if it is periodic).
-        The default is `0`, meaning there is no maximum delay.
-    - `minDelay`
-      - : The minimum delay in milliseconds before the
-        next `sync` event (or the first sync event if it is periodic). The
-        default is `0`.
-    - `minPeriod`
-      - : The minimum time
-        in milliseconds between periodic sync events. The default is `0`,
-        meaning events are not periodic.
-    - `minRequiredNetwork`
-      - : The network condition under which background
-        synchronization will occur. Valid values are `'network-any'`,
-        `'network-offline'`, `'network-online'`,
-        `'network-non-mobile'`. The default value is
-        `'network-online'`.
+  - : An identifier for this synchronization event. This will be the value of the `tag` property of the {{domxref("SyncEvent")}} that gets passed into the service worker's {{domxref("ServiceWorkerGlobalScope.sync_event", "sync")}} event handler.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an instance of
-{{domxref("SyncRegistration")}}.
+A {{jsxref("Promise")}} that resolves to {{jsxref("undefined")}}.
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
The main thing here is that the signature of https://developer.mozilla.org/en-US/docs/Web/API/SyncManager/register is wrong, compared with the spec: https://wicg.github.io/background-sync/spec/#sync-manager-interface.

Apart from that just a  little cleanup and housekeeping.
