### PR TITLE
fix WebSocket Source Schema

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -74,7 +74,7 @@ The following connections are blocked and won't load:
     xhr.open("GET", "https://not-example.com/");
     xhr.send();
 
-    const ws = new WebSocket("https://not-example.com/");
+    const ws = new WebSocket("wss://not-example.com/");
 
     const es = new EventSource("https://not-example.com/");
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

CSP: connect-src Example WebSocket Source Schema has a mistake.
Schema `https` shall be `wss`.

### Motivation

This will make readers think that the protocol can use https.

