### PR TITLE
Fix display issue with 'document' on line 37

### DIFF
--- a/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
@@ -34,7 +34,7 @@ When a web browser parses an HTML document, it builds a DOM tree and then uses i
 
 ## What does the Document API do?
 
-The Document API, also sometimes called the DOM API, allows you to modify a DOM tree in _any way you want_. It enables you to create any HTML or XML document from scratch or to change any contents of a given HTML or XML document. Web page authors can edit the DOM of a document using JavaScript to access the `document`")}} property of the global object. This `document` object implements the {{domxref("Document")}} interface.
+The Document API, also sometimes called the DOM API, allows you to modify a DOM tree in _any way you want_. It enables you to create any HTML or XML document from scratch or to change any contents of a given HTML or XML document. Web page authors can edit the DOM of a document using JavaScript to access the `document` property of the global object. This `document` object implements the {{domxref("Document")}} interface.
 
 ## A simple example
 


### PR DESCRIPTION
The document property is being displayed as 'document")}}' right now. I fixed it to display it properly with code formatting.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The current version looks weird and looks like a mistake in the markdown code.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Because I use the Mozilla guides often and I want them to remain perfect.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
