### PR TITLE
added a pair of missing quotation marks

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -3,7 +3,7 @@ title: Home page
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Home_page
 ---
 
-The first page we'll create will be the website home page, which is accessible from either the site (`'/'`) or catalog (`catalog/`) root. This will display some static text describing the site, along with dynamically calculated "counts" of different record types in the database.
+The first page we'll create will be the website home page, which is accessible from either the site (`'/'`) or catalog (`'catalog/'`) root. This will display some static text describing the site, along with dynamically calculated "counts" of different record types in the database.
 
 We've already created a route for the home page. In order to complete the page we need to update our controller function to fetch "counts" of records from the database, and create a view (template) that we can use to render the page.
 

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -3,7 +3,7 @@ title: Home page
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Home_page
 ---
 
-The first page we'll create will be the website home page, which is accessible from either the site (`'/'`) or catalog (`'catalog/'`) root. This will display some static text describing the site, along with dynamically calculated "counts" of different record types in the database.
+The first page we'll create will be the website home page, which is accessible from either the site (`/`) or catalog (`catalog/`) root. This will display some static text describing the site, along with dynamically calculated "counts" of different record types in the database.
 
 We've already created a route for the home page. In order to complete the page we need to update our controller function to fetch "counts" of records from the database, and create a view (template) that we can use to render the page.
 


### PR DESCRIPTION
I'm wondering if it should be `('/catalog/')` or `('catalog/')`
i.e. with or without the preceding forward slash.

PS: Should it not preceed with a forward slash instead of forward slash following it?
i.e. `('/catalog')` instead of `('catalog/')` ?

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Home_page
This is the link of the document.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
