### PR TITLE
Add MutationEvent.* members docs

### DIFF
--- a/files/en-us/web/api/mutationevent/attrchange/index.md
+++ b/files/en-us/web/api/mutationevent/attrchange/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MutationEvent.attrChange
 
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 
-The **`attrChange`** read-only property of the {{domxref("MutationEvent")}} interface returns a number indicating what kind of change triggered the `DOMAttrModified` event. The three possible values are `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then the set to `0`.
+The **`attrChange`** read-only property of the {{domxref("MutationEvent")}} interface returns a number indicating what kind of change triggered the `DOMAttrModified` event. The three possible values are `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then set to `0`.
 
 ## Value
 

--- a/files/en-us/web/api/mutationevent/attrchange/index.md
+++ b/files/en-us/web/api/mutationevent/attrchange/index.md
@@ -1,0 +1,36 @@
+---
+title: MutationEvent.attrChange
+slug: Web/API/MutationEvent/attrChange
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.MutationEvent.attrChange
+---
+
+{{APIRef("UI Events")}}{{Deprecated_Header}}
+
+The **`attrChange`** read-only property of the {{domxref("MutationEvent")}} interface returns a number indicating what kind of change triggered the `DOMAttrModified` event. The three possible values are `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then the set to `0`.
+
+## Value
+
+An integer: `0`, `1` (`MODIFICATION`), `2` (`ADDITION`), or `3` (`REMOVAL`).
+
+## Examples
+
+```js
+element.addEventListener(
+  "DOMAttrModified",
+  (event) => {
+    console.log(event.attrChange);
+  },
+  false
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mutationevent/attrname/index.md
+++ b/files/en-us/web/api/mutationevent/attrname/index.md
@@ -1,0 +1,36 @@
+---
+title: MutationEvent.attrName
+slug: Web/API/MutationEvent/attrName
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.MutationEvent.attrName
+---
+
+{{APIRef("UI Events")}}{{Deprecated_Header}}
+
+The **`attrName`** read-only property of the {{domxref("MutationEvent")}} interface returns a string with the name of the node affected by the `DOMAttrModified` event. It has no meaning for other events and is then set to the empty string (`""`).
+
+## Value
+
+A string.
+
+## Examples
+
+```js
+element.addEventListener(
+  "DOMAttrModified",
+  (event) => {
+    console.log(event.attrName);
+  },
+  false
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/index.md
@@ -39,7 +39,7 @@ _This interface also inherits properties from its parent {{domxref("UIEvent")}},
 ## Instance methods
 
 - {{domxref("MutationEvent.initMutationEvent()")}}
-  - : Constructor methods that returns a new `MutationEvent` configured with the parameters given.
+  - : Constructor method that returns a new `MutationEvent` configured with the parameters given.
 
 ## Mutation events list
 

--- a/files/en-us/web/api/mutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/index.md
@@ -26,7 +26,7 @@ The **`MutationEvent`** interface provides event properties that are specific to
 _This interface also inherits properties from its parent {{domxref("UIEvent")}}, and indirectly from {{domxref("Event")}}._
 
 - {{domxref("MutationEvent.attrChange")}} {{ReadOnlyInline}}
-  - : Indicates what kind of change triggered the `DOMAttrModified` event. It can be `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then the set to `0`.
+  - : Indicates what kind of change triggered the `DOMAttrModified` event. It can be `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then set to `0`.
 - {{domxref("MutationEvent.attrName")}} {{ReadOnlyInline}}
   - : Indicates the name of the node affected by the `DOMAttrModified` event. It has no meaning for other events and is then set to the empty string (`""`).
 - {{domxref("MutationEvent.newValue")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/mutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/index.md
@@ -9,51 +9,53 @@ browser-compat: api.MutationEvent
 
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 
-> **Note:** [Mutation Events](https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents) (W3C DOM Level 3 Events) have been deprecated in favor of [Mutation Observers](/en-US/docs/Web/API/MutationObserver) (W3C DOM4).
-
 The **`MutationEvent`** interface provides event properties that are specific to modifications to the Document Object Model (DOM) hierarchy and nodes.
+
+> **Note:** Using _mutation events_ is problematic:
+>
+> - Their design is [flawed](https://lists.w3.org/Archives/Public/public-webapps/2011JulSep/0779.html).
+> - Adding DOM mutation listeners to a document [profoundly degrades the performance](https://groups.google.com/d/topic/mozilla.dev.platform/L0Lx11u5Bvs?pli=1) of further DOM modifications to that document (making them 1.5 - 7 times slower!). Moreover, removing the listeners does not reverse the damage.
+> - They have poor cross-browser compatibility: Safari doesn't support `DOMAttrModified` (see [WebKit bug 8191](https://webkit.org/b/8191)) and Firefox doesn't support _mutation name events_ (like `DOMElementNameChanged` and `DOMAttributeNameChanged`).
+>
+> They have been deprecated in favor of [mutation observers](/en-US/docs/Web/API/MutationObserver). **Consider using these instead.**
 
 {{InheritanceDiagram}}
 
-## Preface
+## Instance properties
 
-The mutation events have been marked as deprecated in [the DOM Events specification](https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents), as the API's design is flawed (see details in the "DOM Mutation Events Replacement: The Story So Far / Existing Points of Consensus" post to [public-webapps](https://lists.w3.org/Archives/Public/public-webapps/2011JulSep/0779.html)).
+_This interface also inherits properties from its parent {{domxref("UIEvent")}}, and indirectly from {{domxref("Event")}}._
 
-[Mutation Observers](/en-US/docs/Web/API/MutationObserver) have replaced mutation events in DOM4. They have been supported in [most popular browsers for some years](/en-US/docs/Web/API/MutationObserver#browser_compatibility).
+- {{domxref("MutationEvent.attrChange")}} {{ReadOnlyInline}}
+  - : Indicates what kind of change triggered the `DOMAttrModified` event. It can be `MODIFICATION` (`1`), `ADDITION` (`2`) or `REMOVAL` (`3`). It has no meaning for other events and is then the set to `0`.
+- {{domxref("MutationEvent.attrName")}} {{ReadOnlyInline}}
+  - : Indicates the name of the node affected by the `DOMAttrModified` event. It has no meaning for other events and is then set to the empty string (`""`).
+- {{domxref("MutationEvent.newValue")}} {{ReadOnlyInline}}
+  - : In `DOMAttrModified` events, contains the new value of the modified {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains the new value of the modified {{domxref("CharacterData")}} node. In all other cases, returns the empty string (`""`).
+- {{domxref("MutationEvent.prevValue")}} {{ReadOnlyInline}}
+  - : In `DOMAttrModified` events, contains the previous value of the modified {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains previous new value of the modified{{domxref("CharacterData")}} node. In all other cases, returns the empty string (`""`).
+- {{domxref("MutationEvent.relatedNode")}} {{ReadOnlyInline}}
+  - : Indicates the node related to the event, like the changed node inside the subtree for `DOMSubtreeModified`.
 
-In addition, mutation events should be avoided because they have **performance issues** and **poor cross-browser support** (as described in the following sections).
+## Instance methods
 
-### Performance
-
-Adding DOM mutation listeners to a document [profoundly degrades the performance](https://groups.google.com/d/topic/mozilla.dev.platform/L0Lx11u5Bvs?pli=1) of further DOM modifications to that document (making them 1.5 - 7 times slower!). Moreover, removing the listeners does not reverse the damage.
-
-The performance effect is [limited to the documents that have the mutation event listeners](https://groups.google.com/forum/#!topic/mozilla.dev.platform/UH2VqFQRTDA).
-
-### Cross-browser support
-
-These events are not implemented consistently across different browsers, for example:
-
-- IE prior to version 9 didn't support the mutation events at all and does not implement some of them correctly in version 9 ([for example, DOMNodeInserted](http://help.dottoro.com/ljmcxjla.php))
-- WebKit doesn't support DOMAttrModified (see [webkit bug 8191](https://webkit.org/b/8191) and [the workaround](https://engineering.silk.co/post/31921750832/mutation-events-what-happens))
-- "mutation name events", i.e. DOMElementNameChanged and DOMAttributeNameChanged are not supported in Firefox (as of version 11), and probably in other browsers as well.
-
-Dottoro [documents browser support for mutation events](http://help.dottoro.com/ljfvvdnm.php#additionalEvents).
+- {{domxref("MutationEvent.initMutationEvent()")}}
+  - : Constructor methods that returns a new `MutationEvent` configured with the parameters given.
 
 ## Mutation events list
 
-The following is a list of all mutation events, as defined in [DOM Level 3 Events specification](https://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents):
+The following is a list of all mutation events:
 
-- `DOMAttrModified`
-- `DOMAttributeNameChanged`
+- `DOMAttrModified` (Not supported by Safari)
+- `DOMAttributeNameChanged` (Not supported by Firefox)
 - `DOMCharacterDataModified`
-- `DOMElementNameChanged`
+- `DOMElementNameChanged` (Not supported by Firefox)
 - `DOMNodeInserted`
 - `DOMNodeInsertedIntoDocument`
 - `DOMNodeRemoved`
 - `DOMNodeRemovedFromDocument`
 - `DOMSubtreeModified`
 
-## Usage
+## Examples
 
 You can register a listener for mutation events using {{DOMxRef("EventTarget.addEventListener()")}} as follows:
 
@@ -67,7 +69,9 @@ element.addEventListener(
 );
 ```
 
-The event object is passed to the listener in a `MutationEvent` (see [its definition in the specification](https://www.w3.org/TR/DOM-Level-3-Events/#events-MutationEvent)) for most events, and {{DOMxRef("MutationNameEvent")}} for `DOMAttributeNameChanged` and `DOMElementNameChanged`.
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 
@@ -75,4 +79,4 @@ The event object is passed to the listener in a `MutationEvent` (see [its defini
 
 ## See also
 
-- {{DOMxRef("MutationNameEvent")}}
+- {{DOMxRef("MutationObserver")}}

--- a/files/en-us/web/api/mutationevent/initmutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/initmutationevent/index.md
@@ -33,11 +33,11 @@ initMutationEvent(type, canBubble, cancelable, relatedNode,
 - `cancelable`
   - : A boolean indicating whether or not the event's default action can be prevented. Sets the value of {{domxref("Event.cancelable")}}.
 - `relatedNode`
-  - : A string the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.relatedNode")}}.
+  - : A string representing the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.relatedNode")}}.
 - `prevValue`
-  - : A string the previous value of the modified node, if any. Sets the value of {{domxref("MutationEvent.prevValue")}}.
+  - : A string representing the previous value of the modified node, if any. Sets the value of {{domxref("MutationEvent.prevValue")}}.
 - `newValue`
-  - : A string the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.newValue")}}.
+  - : A string representing the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.newValue")}}.
 - `attrName`
   - : A string representing the name of the {{domxref("Attr")}} node changed, if any. Sets the value of {{domxref("MutationEvent.attrName")}}.
 - `attrChange`

--- a/files/en-us/web/api/mutationevent/initmutationevent/index.md
+++ b/files/en-us/web/api/mutationevent/initmutationevent/index.md
@@ -1,0 +1,56 @@
+---
+title: MutationEvent.initMutationEvent()
+slug: Web/API/MutationEvent/initMutationEvent
+page-type: web-api-instance-method
+status:
+  - deprecated
+browser-compat: api.MutationEvent.initMutationEvent
+---
+
+{{APIRef("UI Events")}}{{deprecated_header}}
+
+The **`initMutationEvent()`** method of the {{domxref("MutationEvent")}} interface initializes the
+value of a mutation event once it's been created (normally using the {{domxref("Document.createEvent()")}} method).
+
+This method must be called to set the event before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.
+
+> **Note:** In general, you won't create these events yourself; they are created by the browser.
+
+## Syntax
+
+```js-nolint
+initMutationEvent(type, canBubble, cancelable, relatedNode,
+                  prevValue, newValue, attrName, attrChange)
+```
+
+### Parameters
+
+- `type`
+  - : A string to set the event's {{domxref("Event.type", "type")}} to. Browsers set the following values for {{domxref("MutationEvent")}}:
+    `DOMAttrModified`, `DOMAttributeNameChanged`, `DOMCharacterDataModified`, `DOMElementNameChanged`, `DOMNodeInserted`, `DOMNodeInsertedIntoDocument`, `DOMNodeRemoved`, `DOMNodeRemovedFromDocument`,`DOMSubtreeModified`.
+- `canBubble`
+  - : A boolean indicating whether or not the event can bubble. Sets the value of {{domxref("Event.bubbles")}}.
+- `cancelable`
+  - : A boolean indicating whether or not the event's default action can be prevented. Sets the value of {{domxref("Event.cancelable")}}.
+- `relatedNode`
+  - : A string the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.relatedNode")}}.
+- `prevValue`
+  - : A string the previous value of the modified node, if any. Sets the value of {{domxref("MutationEvent.prevValue")}}.
+- `newValue`
+  - : A string the new value of the modified node, if any. Sets the value of {{domxref("MutationEvent.newValue")}}.
+- `attrName`
+  - : A string representing the name of the {{domxref("Attr")}} node changed, if any. Sets the value of {{domxref("MutationEvent.attrName")}}.
+- `attrChange`
+  - : A integer representing the reason attribute node changed. Sets the value of {{domxref("MutationEvent.attrChange")}}.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mutationevent/newvalue/index.md
+++ b/files/en-us/web/api/mutationevent/newvalue/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MutationEvent.newValue
 
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 
-The **`newValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the new value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains the new value of the {{domxref("CharacterData")}}node. In all other cases, returns the empty string (`""`).
+The **`newValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the new value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, it contains the new value of the {{domxref("CharacterData")}} node. In all other cases, returns the empty string (`""`).
 
 ## Value
 

--- a/files/en-us/web/api/mutationevent/newvalue/index.md
+++ b/files/en-us/web/api/mutationevent/newvalue/index.md
@@ -1,0 +1,36 @@
+---
+title: MutationEvent.newValue
+slug: Web/API/MutationEvent/newValue
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.MutationEvent.newValue
+---
+
+{{APIRef("UI Events")}}{{Deprecated_Header}}
+
+The **`newValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the new value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains the new value of the {{domxref("CharacterData")}}node. In all other cases, returns the empty string (`""`).
+
+## Value
+
+A string.
+
+## Examples
+
+```js
+element.addEventListener(
+  "DOMAttrModified",
+  (event) => {
+    console.log(event.newValue);
+  },
+  false
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mutationevent/prevvalue/index.md
+++ b/files/en-us/web/api/mutationevent/prevvalue/index.md
@@ -1,0 +1,36 @@
+---
+title: MutationEvent.prevValue
+slug: Web/API/MutationEvent/prevValue
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.MutationEvent.prevValue
+---
+
+{{APIRef("UI Events")}}{{Deprecated_Header}}
+
+The **`prevValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the previous value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains the previous value of the {{domxref("CharacterData")}}node. In all other cases, returns the empty string (`""`).
+
+## Value
+
+A string.
+
+## Examples
+
+```js
+element.addEventListener(
+  "DOMAttrModified",
+  (event) => {
+    console.log(event.previousValue);
+  },
+  false
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mutationevent/prevvalue/index.md
+++ b/files/en-us/web/api/mutationevent/prevvalue/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MutationEvent.prevValue
 
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 
-The **`prevValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the previous value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, contains the previous value of the {{domxref("CharacterData")}}node. In all other cases, returns the empty string (`""`).
+The **`prevValue`** read-only property of the {{domxref("MutationEvent")}} interface returns a string. In `DOMAttrModified` events, it represents the previous value of the {{domxref("Attr")}} node. In `DOMCharacterDataModified` events, it contains the previous value of the {{domxref("CharacterData")}} node. In all other cases, returns the empty string (`""`).
 
 ## Value
 

--- a/files/en-us/web/api/mutationevent/relatednode/index.md
+++ b/files/en-us/web/api/mutationevent/relatednode/index.md
@@ -1,0 +1,36 @@
+---
+title: MutationEvent.relatedNode
+slug: Web/API/MutationEvent/relatedNode
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.MutationEvent.relatedNode
+---
+
+{{APIRef("UI Events")}}{{Deprecated_Header}}
+
+The **`relatedNode`** read-only property of the {{domxref("MutationEvent")}} interface returns a string indicating the node related to the event, like the changed node inside the subtree for `DOMSubtreeModified`.
+
+## Value
+
+A string.
+
+## Examples
+
+```js
+element.addEventListener(
+  "DOMSubtreeModified",
+  (event) => {
+    console.log(event.relatedNode);
+  },
+  false
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
Part of openwebdocs/project#152

As these methods/properties are deprecated I kept the examples very basic.

As `initMutationEvent`, in addition to the deprecation, is not called by user code (outside tests), I skipped the example section altogether.