### PR TITLE
Add mention of then() promise adopting rejection state

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -41,7 +41,7 @@ One of the `onFulfilled` and `onRejected` handlers will be executed to handle th
 - throws an error: `p` gets rejected with the thrown error as its value.
 - returns an already fulfilled promise: `p` gets fulfilled with that promise's value as its value.
 - returns an already rejected promise: `p` gets rejected with that promise's value as its value.
-- returns another pending promise: `p` is pending and becomes fulfilled/rejected with that promise's value as its value when that promise becomes fulfilled/rejected.
+- returns another pending promise: `p` is pending and becomes fulfilled/rejected with that promise's value as its value immediately after that promise becomes fulfilled/rejected.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -41,7 +41,7 @@ One of the `onFulfilled` and `onRejected` handlers will be executed to handle th
 - throws an error: `p` gets rejected with the thrown error as its value.
 - returns an already fulfilled promise: `p` gets fulfilled with that promise's value as its value.
 - returns an already rejected promise: `p` gets rejected with that promise's value as its value.
-- returns another pending promise: the fulfillment/rejection of the promise returned by `then` will be subsequent to the resolution/rejection of the promise returned by the handler. Also, the resolved value of the promise returned by `then` will be the same as the resolved value of the promise returned by the handler.
+- returns another pending promise: the fulfillment/rejection of `p` will be subsequent to the fulfillment/rejection of that promise. Also, `p` will get fulfilled/rejected with that promise's value as its value.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -37,11 +37,11 @@ Returns a new {{jsxref("Promise")}} immediately. This new promise is always pend
 One of the `onFulfilled` and `onRejected` handlers will be executed to handle the current promise's fulfillment or rejection. The call always happens asynchronously, even when the current promise is already settled. The behavior of the returned promise (call it `p`) depends on the handler's execution result, following a specific set of rules. If the handler function:
 
 - returns a value: `p` gets fulfilled with the returned value as its value.
-- doesn't return anything: `p` gets fulfilled with `undefined`.
+- doesn't return anything: `p` gets fulfilled with `undefined` as its value.
 - throws an error: `p` gets rejected with the thrown error as its value.
 - returns an already fulfilled promise: `p` gets fulfilled with that promise's value as its value.
 - returns an already rejected promise: `p` gets rejected with that promise's value as its value.
-- returns another pending promise: the fulfillment/rejection of `p` will be subsequent to the fulfillment/rejection of that promise. Also, `p` will get fulfilled/rejected with that promise's value as its value.
+- returns another pending promise: `p` is pending and becomes fulfilled/rejected with that promise's value as its value when that promise becomes fulfilled/rejected.
 
 ## Description
 


### PR DESCRIPTION
As illustrated in the example using the `rejectLater` executor function in the subsequent [Example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then#examples) section.