### PR TITLE
Fix info about Windows High Contrast Mode

### DIFF
--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -61,9 +61,7 @@ With this implementation, the hint content is available even if information is e
 
 ### Windows High Contrast Mode
 
-Placeholder text will appear with the same styling as user-entered text content when rendered in [Windows High Contrast Mode](/en-US/docs/Web/CSS/@media/-ms-high-contrast). This will make it difficult for some people to determine which content has been entered, and which content is placeholder text.
-
-- [Greg Whitworth — How to use -ms-high-contrast](https://www.gwhitworth.com/posts/2017/how-to-use-ms-high-contrast/)
+Placeholder text will appear with the same styling as user-entered text content when rendered in [Windows High Contrast Mode](https://www.smashingmagazine.com/2022/06/guide-windows-high-contrast-mode/)). This will make it difficult for some people to determine which content has been entered, and which content is placeholder text.
 
 ### Labels
 


### PR DESCRIPTION
Tthe MS-only property is long gone, so linking to a modern (2022) article instead of the red link.