### PR TITLE
Removing prefixed CSS properties from the example

### DIFF
--- a/files/en-us/web/css/shape-outside/index.md
+++ b/files/en-us/web/css/shape-outside/index.md
@@ -121,18 +121,14 @@ When animating between one `<basic-shape>` and a second, the rules below are app
 }
 
 .left {
-  -webkit-shape-outside: polygon(0 0, 100% 100%, 0 100%);
   shape-outside: polygon(0 0, 100% 100%, 0 100%);
   float: left;
-  -webkit-clip-path: polygon(0 0, 100% 100%, 0 100%);
   clip-path: polygon(0 0, 100% 100%, 0 100%);
 }
 
 .right {
-  -webkit-shape-outside: polygon(100% 0, 100% 100%, 0 100%);
   shape-outside: polygon(100% 0, 100% 100%, 0 100%);
   float: right;
-  -webkit-clip-path: polygon(100% 0, 100% 100%, 0 100%);
   clip-path: polygon(100% 0, 100% 100%, 0 100%);
 }
 


### PR DESCRIPTION
### Description

This PR removes the `-webkit-clip-path` and `-webkit-shape-outside` CSS properties from the example codes.

### Motivation

The unprefixed `clip-version` and `shape-outside` have been supported by Chrome and Safari for at least 6 years by now, and leaving the prefixed properties in the example may cause miconception on the support statuses.

### Additional details

BCD table for `clip-path`: https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path#browser_compatibility
BCD table for `shape-outside`: https://developer.mozilla.org/en-US/docs/Web/CSS/shape-outside#browser_compatibility