### PR TITLE
Fix double slash in redirect

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12676,7 +12676,7 @@
 /en-US/docs/Web/Reference/Functions_and classes_available_to_workers	/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
 /en-US/docs/Web/Reference/Functions_and_classes_available_to_workers	/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
 /en-US/docs/Web/SVG/Attribute/dataset	/en-US/docs/Web/API/HTMLElement/dataset
-/en-US/docs/Web/SVG/Compatibility_sources	/en-US/docs//Web/SVG
+/en-US/docs/Web/SVG/Compatibility_sources	/en-US/docs/Web/SVG
 /en-US/docs/Web/SVG/Element/animateColor	/en-US/docs/Web/SVG/Element/animate
 /en-US/docs/Web/SVG/Index	/en-US/docs/Web/SVG
 /en-US/docs/Web/SVG/Tutorial/Fill_Stroke_and_Gradients	/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Remove/fix a double slash in a redirect. I also searched the entire file but I did not find any other occurrences.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
There is currently an error when trying to redirect [`/en-US/docs/Web/SVG/Compatibility_sources`](https://developer.mozilla.org/en-US/docs/Web/SVG/Compatibility_sources) to the `Web/SVG` page due to the double slash.
