### PR TITLE
FF110 Using ReadableStream with async iteration

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -206,9 +206,37 @@ async function readData(url) {
 }
 ```
 
-If you want to cancel the operation, you can use an [`AbortController`](/en-US/docs/Web/API/AbortController), passing its associated [`AbortSignal`](/en-US/docs/Web/API/AbortSignal) to the `fetch()` function.
-Alternatively, you can use the `AbortSignal` within the `for await...of` loop to call `break`, which will exit the loop.
-Note however that code in the loop is only run when there is new data to process, so there may be some delay between the signal being triggered and the `break` being called.
+If you want to stop iterating the stream you can cancel the `fetch()` operation using an [`AbortController`](/en-US/docs/Web/API/AbortController) and its associated [`AbortSignal`](/en-US/docs/Web/API/AbortSignal):
+
+```js
+const aborter = new AbortController();
+button.addEventListener("click", () => aborter.abort());
+logChunks("http://example.com/somefile.txt", { signal: aborter.signal });
+
+async function logChunks(url, { signal }) {
+  const response = await fetch(url, signal);
+  for await (const chunk of response.body) {
+    // Do something with the chunk
+  }
+}
+```
+
+Alternatively, you can exit the loop using `break`, as shown in the code below.
+Note that code in the loop is only run when the stream has new data to process, so there may be some delay between the signal being aborted and `break` being called.
+
+```js
+const aborter = new AbortController();
+button.addEventListener("click", () => aborter.abort());
+logChunks("http://example.com/somefile.txt", { signal: aborter.signal });
+
+async function logChunks(url, { signal }) {
+  const response = await fetch(url);
+  for await (const chunk of response.body) {
+    if (signal.aborted) break; //just break out of loop
+    // Do something with the chunk
+  }
+}
+```
 
 ### Example async reader
 

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -191,8 +191,8 @@ async function readData(url) {
 
 ## Consuming a fetch() using asynchronous iteration
 
-There is another even simpler way to consume a `fetch()`, which is to iterate the returned `response.body` using the [for await...of](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax.
-This works because the `response.body` returns a `ReadableStream`, which is an [async iterator](/en-US/docs/Web/API/ReadableStream#async_iteration).
+There is another even simpler way to consume a `fetch()`, which is to iterate the returned `response.body` using the [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) syntax.
+This works because the `response.body` returns a `ReadableStream`, which is an [async iterable](/en-US/docs/Web/API/ReadableStream#async_iteration).
 
 Using this approach, the example code in the previous section can be rewritten as shown:
 
@@ -200,13 +200,13 @@ Using this approach, the example code in the previous section can be rewritten a
 async function readData(url) {
   const response = await fetch(url);
   for await (const chunk of response.body) {
-    // Do something with each 'chunk'
+    // Do something with each "chunk"
   }
-  //Exit when done
+  // Exit when done
 }
 ```
 
-If you want to cancel the operation you can use an [`AbortController`](/en-US/docs/Web/API/AbortController), passing its associated [`AbortSignal`](/en-US/docs/Web/API/AbortSignal) to the `fetch()` function.
+If you want to cancel the operation, you can use an [`AbortController`](/en-US/docs/Web/API/AbortController), passing its associated [`AbortSignal`](/en-US/docs/Web/API/AbortSignal) to the `fetch()` function.
 Alternatively, you can use the `AbortSignal` within the `for await...of` loop to call `break`, which will exit the loop.
 Note however that code in the loop is only run when there is new data to process, so there may be some delay between the signal being triggered and the `break` being called.
 


### PR DESCRIPTION
This does an update of [Using readable streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams) to include a section on how to use the `for await...of` syntax with `fetch()`. It is intended to be a bit more of a real world example to complement the section added in [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#async_iteration).

I've put a couple of notes inline about what I'm trying to achieve, so that you can help me decide if it is reasonable approach.

This is concluding work for #23678

