### PR TITLE
Fix comment to match what Prettier does

### DIFF
--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -22,7 +22,7 @@ src: url(path/to/svgFont.svg#example); /* Fragment identifying font */
 src: local(font); /* Unquoted name */
 src: local(some font); /* Name containing space */
 src: local("font"); /* Quoted name */
-src: local("some font"); /* Single-quoted name containing a space */
+src: local("some font"); /* Quoted name containing a space */
 
 /* <tech(<font-tech>)> values */
 src: url(path/to/fontCOLRv1.otf) tech(color-COLRv1);


### PR DESCRIPTION
This is a follow-up of PR mdn/content#25040

Both single quotes and double quotes are valid. As Prettier (opinionately) chooses double quotes, but single quotes are valid too, let's say "quotes" instead of trying to impose a specific version.
