### PR TITLE
Fix requestPort() exception type returned when user aborts

### DIFF
--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -41,7 +41,7 @@ A {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort"
 
 - `SecurityError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this error if a [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) blocks the use of this feature or a user permission prompt was denied.
-- `AbortError` {{domxref("DOMException")}}
+- `NotFoundError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this if the user does not select a port when prompted.
 
 ## Examples


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The exception returned by `requestPort()` when user aborts selecting a port should be `NotFoundError` instead of `AbortError`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Currently, the MDN don't followthe [spec](https://wicg.github.io/serial/#requestport-method).

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

The exception type was changed in the spec a while ago, see this [PR](https://github.com/WICG/serial/pull/138).

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

- [Current spec](https://wicg.github.io/serial/#requestport-method)
- [PR that updated the spec](https://github.com/WICG/serial/pull/138)

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
