### PR TITLE
Document missing AudioWorkletGlobalScope.* pages

### DIFF
--- a/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
@@ -1,0 +1,72 @@
+---
+title: AudioWorkletGlobalScope.currentFrame
+slug: Web/API/AudioWorkletGlobalScope/currentFrame
+page-type: web-api-instance-property
+browser-compat: api.AudioWorkletGlobalScope.currentFrame
+---
+
+{{APIRef("Web Audio API")}}
+
+The read-only **`currentFrame`** property of the {{domxref("AudioWorkletGlobalScope")}} interface returns an integer that represents the ever-increasing current sample-frame of the audio block being processed. It is incremented by 128 (the size of a render quantum) after the processing of each audio block.
+
+## Value
+
+An integer number.
+
+## Examples
+
+The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+
+```js
+// AudioWorkletProcessor defined in : test-processor.js
+class TestProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Logs the current sample-frame and time at the moment of instantiation.
+    // They are accessible from the AudioWorkletGlobalScope.
+    console.log(currentFrame);
+    console.log(currentTime);
+  }
+
+  // The process method is required - output silence,
+  // which the outputs are already filled with.
+  process(inputs, outputs, parameters) {
+    return true;
+  }
+}
+
+// Logs the sample rate, that is not going to change ever,
+// because it's a read-only property of a BaseAudioContext
+// and is set only during its instantiation.
+console.log(sampleRate);
+
+// You can declare any variables and use them in your processors
+// for example it may be an ArrayBuffer with a wavetable.
+const usefulVariable = 42;
+console.log(usefulVariable);
+
+registerProcessor("test-processor", TestProcessor);
+```
+
+The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+
+```js
+const audioContext = new AudioContext();
+await audioContext.audioWorklet.addModule("test-processor.js");
+const testNode = new AudioWorkletNode(audioContext, "test-processor");
+testNode.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)

--- a/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
@@ -15,7 +15,7 @@ An integer number.
 
 ## Examples
 
-The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+The {{domxref("AudioWorkletProcessor")}} has access to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
 
 ```js
 // AudioWorkletProcessor defined in : test-processor.js

--- a/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
@@ -49,7 +49,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
@@ -15,7 +15,7 @@ A floating-point number representing the time.
 
 ## Examples
 
-The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+The {{domxref("AudioWorkletProcessor")}} has access to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
 
 ```js
 // AudioWorkletProcessor defined in : test-processor.js

--- a/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
@@ -1,0 +1,72 @@
+---
+title: AudioWorkletGlobalScope.currentTime
+slug: Web/API/AudioWorkletGlobalScope/currentTime
+page-type: web-api-instance-property
+browser-compat: api.AudioWorkletGlobalScope.currentTime
+---
+
+{{APIRef("Web Audio API")}}
+
+The read-only **`currentTime`** property of the {{domxref("AudioWorkletGlobalScope")}} interface returns a double that represents the ever-increasing context time of the audio block being processed. It is equal to the {{domxref("BaseAudioContext.currentTime", "currentTime")}} property of the {{domxref("BaseAudioContext")}} the worklet belongs to.
+
+## Value
+
+A floating-point number representing the time.
+
+## Examples
+
+The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+
+```js
+// AudioWorkletProcessor defined in : test-processor.js
+class TestProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Logs the current sample-frame and time at the moment of instantiation.
+    // They are accessible from the AudioWorkletGlobalScope.
+    console.log(currentFrame);
+    console.log(currentTime);
+  }
+
+  // The process method is required - output silence,
+  // which the outputs are already filled with.
+  process(inputs, outputs, parameters) {
+    return true;
+  }
+}
+
+// Logs the sample rate, that is not going to change ever,
+// because it's a read-only property of a BaseAudioContext
+// and is set only during its instantiation.
+console.log(sampleRate);
+
+// You can declare any variables and use them in your processors
+// for example it may be an ArrayBuffer with a wavetable.
+const usefulVariable = 42;
+console.log(usefulVariable);
+
+registerProcessor("test-processor", TestProcessor);
+```
+
+The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+
+```js
+const audioContext = new AudioContext();
+await audioContext.audioWorklet.addModule("test-processor.js");
+const testNode = new AudioWorkletNode(audioContext, "test-processor");
+testNode.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)

--- a/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
@@ -49,7 +49,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/index.md
@@ -17,6 +17,8 @@ As the global execution context is shared across the current `BaseAudioContext`,
 
 ## Instance properties
 
+_This interface also inherits properties defined on its parent interface, {{domxref("WorkletGlobalScope")}}._
+
 - {{domxref("AudioWorkletGlobalScope.currentFrame", "currentFrame")}} {{ReadOnlyInline}}
   - : Returns an integer that represents the ever-increasing current sample-frame of the audio block being processed. It is incremented by 128 (the size of a render quantum) after the processing of each audio block.
 - {{domxref("AudioWorkletGlobalScope.currentTime", "currentTime")}} {{ReadOnlyInline}}
@@ -25,6 +27,8 @@ As the global execution context is shared across the current `BaseAudioContext`,
   - : Returns a float that represents the sample rate of the associated {{domxref("BaseAudioContext")}}.
 
 ## Instance methods
+
+_This interface also inherits methods defined on its parent interface, {{domxref("WorkletGlobalScope")}}._
 
 - {{domxref("AudioWorkletGlobalScope.registerProcessor", "registerProcessor()")}}
   - : Registers a class derived from the {{domxref('AudioWorkletProcessor')}} interface. The class can then be used by creating an {{domxref("AudioWorkletNode")}}, providing its registered name.
@@ -36,28 +40,30 @@ In this example we output all global properties into the console in the construc
 First we need to define the processor, and register it. Note that this should be done in a separate file.
 
 ```js
-// test-processor.js
+// AudioWorkletProcessor defined in : test-processor.js
 class TestProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
-    // current sample-frame and time at the moment of instantiation
-    // to see values change, you can put these two lines in process method
+
+    // Logs the current sample-frame and time at the moment of instantiation.
+    // They are accessible from the AudioWorkletGlobalScope.
     console.log(currentFrame);
     console.log(currentTime);
   }
-  // the process method is required - output silence,
-  // which the outputs are already filled with
+
+  // The process method is required - output silence,
+  // which the outputs are already filled with.
   process(inputs, outputs, parameters) {
     return true;
   }
 }
 
-// the sample rate is not going to change ever,
+// Logs the sample rate, that is not going to change ever,
 // because it's a read-only property of a BaseAudioContext
-// and is set only during its instantiation
+// and is set only during its instantiation.
 console.log(sampleRate);
 
-// you can declare any variables and use them in your processors
+// You can declare any variables and use them in your processors
 // for example it may be an ArrayBuffer with a wavetable
 const usefulVariable = 42;
 console.log(usefulVariable);
@@ -65,7 +71,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-Next, in our main scripts file we'll load the processor, create an instance of `AudioWorkletNode` — passing the name of the processor to it — and connect the node to an audio graph. We should see the output of `console.log` calls in the console:
+Next, in our main scripts file we'll load the processor, create an instance of {{domxref("AudioWorkletNode")}} — passing the name of the processor to it — and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
@@ -1,0 +1,72 @@
+---
+title: AudioWorkletGlobalScope.sampleRate
+slug: Web/API/AudioWorkletGlobalScope/sampleRate
+page-type: web-api-instance-property
+browser-compat: api.AudioWorkletGlobalScope.sampleRate
+---
+
+{{APIRef("Web Audio API")}}
+
+The read-only **`sampleRate`** property of the {{domxref("AudioWorkletGlobalScope")}} interface returns a float that represents the sample rate of the associated {{domxref("BaseAudioContext")}} the worklet belongs to.
+
+## Value
+
+A floating-point number representing the associated sample rate.
+
+## Examples
+
+The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+
+```js
+// AudioWorkletProcessor defined in : test-processor.js
+class TestProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Logs the current sample-frame and time at the moment of instantiation.
+    // They are accessible from the AudioWorkletGlobalScope.
+    console.log(currentFrame);
+    console.log(currentTime);
+  }
+
+  // The process method is required - output silence,
+  // which the outputs are already filled with.
+  process(inputs, outputs, parameters) {
+    return true;
+  }
+}
+
+// Logs the sample rate, that is not going to change ever,
+// because it's a read-only property of a BaseAudioContext
+// and is set only during its instantiation.
+console.log(sampleRate);
+
+// You can declare any variables and use them in your processors
+// for example it may be an ArrayBuffer with a wavetable.
+const usefulVariable = 42;
+console.log(usefulVariable);
+
+registerProcessor("test-processor", TestProcessor);
+```
+
+The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+
+```js
+const audioContext = new AudioContext();
+await audioContext.audioWorklet.addModule("test-processor.js");
+const testNode = new AudioWorkletNode(audioContext, "test-processor");
+testNode.connect(audioContext.destination);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)

--- a/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
@@ -49,7 +49,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script load the processor, create an instance of {{domxref("AudioWorkletNode")}}, passing the name of the processor to it, and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
@@ -15,7 +15,7 @@ A floating-point number representing the associated sample rate.
 
 ## Examples
 
-The {{domxref("AudioWorkletProcessor")}} has accesses to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
+The {{domxref("AudioWorkletProcessor")}} has access to the specific {{domxref("AudioWorkletGlobalScope")}} properties:
 
 ```js
 // AudioWorkletProcessor defined in : test-processor.js

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.WorkletGlobalScope
 ---
 
-{{APIRef("HTM DOM")}}
+{{APIRef("HTM DOM")}}{{SecureContext_Header}}
 
 The **`WorkletGlobalScope`** interface is an abstract class that specific worklet scope classes inherit from. Each `WorkletGlobalScope` defines a new global environment.
 

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -10,7 +10,6 @@ browser-compat: api.WorkletGlobalScope
 The **`WorkletGlobalScope`** interface is an abstract class common to all global scope associated with worklets.
 
 > Note: You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
-
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -9,7 +9,7 @@ browser-compat: api.WorkletGlobalScope
 
 The **`WorkletGlobalScope`** interface is an abstract class that specific worklet scope classes inherit from. Each `WorkletGlobalScope` defines a new global environment.
 
-> **Note:** You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
+> **Note:** You don't normally need to interact with this interface. It is a base interface intended to be subclassed. You will encounter the subclasses {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -7,7 +7,7 @@ browser-compat: api.WorkletGlobalScope
 
 {{APIRef("HTM DOM")}}
 
-The **`WorkletGlobalScope`** interface is an abstract class common to all global scope associated with worklets.
+The **`WorkletGlobalScope`** interface is an abstract class that specific worklet scope classes inherit from. Each `WorkletGlobalScope` defines a new global environment.
 
 > **Note:** You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
 

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -9,7 +9,8 @@ browser-compat: api.WorkletGlobalScope
 
 The **`WorkletGlobalScope`** interface is an abstract class common to all global scope associated with worklets.
 
-> Note: You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
+> **Note:** You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
+
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -11,7 +11,6 @@ The **`WorkletGlobalScope`** interface is an abstract class that specific workle
 
 > **Note:** You don't normally need to interact with this interface. It is a base interface intended to be subclassed. You will encounter the subclasses {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
 
-{{InheritanceDiagram}}
 
 ## Instance properties
 

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -1,0 +1,35 @@
+---
+title: WorkletGlobalScope
+slug: Web/API/WorkletGlobalScope
+page-type: web-api-interface
+browser-compat: api.WorkletGlobalScope
+---
+
+{{APIRef("HTM DOM")}}
+
+The **`WorkletGlobalScope`** interface is an abstract class common to all global scope associated with worklets.
+
+> Note: You don't normally need to worry about this interface. It is a base interface intended to be subclassed. That is why you'll deal with {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
+
+{{InheritanceDiagram}}
+
+## Instance properties
+
+None.
+
+## Instance methods
+
+None.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioWorkletGlobalScope")}}
+- {{domxref("PaintWorkletGlobalScope")}}

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -11,7 +11,6 @@ The **`WorkletGlobalScope`** interface is an abstract class that specific workle
 
 > **Note:** You don't normally need to interact with this interface. It is a base interface intended to be subclassed. You will encounter the subclasses {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside {{domxref("PaintWorklet")}} objects.
 
-
 ## Instance properties
 
 None.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -641,7 +641,8 @@
         "RadioNodeList",
         "UserActivation",
         "ValidityState",
-        "Window"
+        "Window",
+        "WorkletGlobalScope"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
Part of openwebdocs/project#152

I needed to create the base interface page `WorkletGlobalScope` so we had no red links left in the `AudioWorkletGlobalScope`.

`PaintWorkletGlobalScope` is missing, but I didn't want to fall into this rabbit hole today.