### PR TITLE
[PWA] Add background fetch events

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
@@ -1,0 +1,67 @@
+---
+title: "ServiceWorkerGlobalScope: backgroundfetchabort event"
+slug: Web/API/ServiceWorkerGlobalScope/backgroundfetchabort_event
+page-type: web-api-event
+browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchabort_event
+---
+
+{{APIRef("Background Fetch API")}}
+
+The **`backgroundfetchabort`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the user or the app itself cancels a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation.
+
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("backgroundfetchabort", (event) => {});
+
+onbackgroundfetchabort = (event) => {};
+```
+
+## Event type
+
+A {{domxref("BackgroundFetchEvent")}}.
+
+{{InheritanceDiagram("BackgroundFetchEvent")}}
+
+## Event properties
+
+_Inherits properties from its parent, {{domxref("ExtendableEvent")}}._
+
+- {{domxref("BackgroundFetchEvent.registration")}}
+  - : Returns the {{domxref("BackgroundFetchRegistration")}} for the aborted fetch.
+
+## Description
+
+In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. This element also enables the user to cancel the fetch. The app itself can also cancel the fetch by calling {{domxref("BackgroundFetchRegistration.abort()")}}.
+
+If fetch is canceled, the browser aborts the fetch, starts the service worker, if necessary, and fires the `backgroundfetchabort` event in the service worker's global scope.
+
+In the handler for this event, the service worker can clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+
+## Examples
+
+### Cleaning up
+
+This event handler might perform any cleanup of data associated with the aborted fetch.
+
+```js
+addEventListener("backgroundfetchabort", (event) => {
+  // clean up any related data
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Background Fetch API](/en-US/docs/Web/API/Background_Fetch_API)

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
@@ -38,7 +38,7 @@ _Inherits properties from its parent, {{domxref("ExtendableEvent")}}._
 
 In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. This element also enables the user to cancel the fetch. The app itself can also cancel the fetch by calling {{domxref("BackgroundFetchRegistration.abort()")}}.
 
-If fetch is canceled, the browser aborts the fetch, starts the service worker, if necessary, and fires the `backgroundfetchabort` event in the service worker's global scope.
+If the fetch is canceled, the browser aborts the fetch, starts the service worker, if necessary, and fires the `backgroundfetchabort` event in the service worker's global scope.
 
 In the handler for this event, the service worker can clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
@@ -40,7 +40,7 @@ In the background fetch API, the browser shows a UI element to the user to indic
 
 If the fetch is canceled, the browser aborts the fetch, starts the service worker, if necessary, and fires the `backgroundfetchabort` event in the service worker's global scope.
 
-In the handler for this event, the service worker can clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+In the handler for this event, the service worker can clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data, the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchclick_event/index.md
@@ -1,0 +1,71 @@
+---
+title: "ServiceWorkerGlobalScope: backgroundfetchclick event"
+slug: Web/API/ServiceWorkerGlobalScope/backgroundfetchclick_event
+page-type: web-api-event
+browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchclick_event
+---
+
+{{APIRef("Background Fetch API")}}
+
+The **`backgroundfetchclick`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the user clicks on the UI that the browser provides to show the user the progress of the [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation.
+
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("backgroundfetchclick", (event) => {});
+
+onbackgroundfetchclick = (event) => {};
+```
+
+## Event type
+
+A {{domxref("BackgroundFetchEvent")}}.
+
+{{InheritanceDiagram("BackgroundFetchEvent")}}
+
+## Event properties
+
+_Inherits properties from its parent, {{domxref("ExtendableEvent")}}._
+
+- {{domxref("BackgroundFetchEvent.registration")}}
+  - : Returns the {{domxref("BackgroundFetchRegistration")}} whose progress dialog the user clicked on.
+
+## Description
+
+When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation starts, the browser shows a UI element to the user to indicate the progress of the operation. If the user clicks this element, the browser starts the service worker, if necessary, and fires the `backgroundfetchclick` event in the service worker's global scope.
+
+A common task for the handler in this situation is to open a window giving the user more details about the fetch operation.
+
+## Examples
+
+### Opening a window with more details
+
+This event handler uses the global {{domxref("ServiceWorkerGlobalScope.clients", "clients")}} property to open a window giving the user more details about the fetch. It opens a different window depending on whether the fetch has completed or not.
+
+```js
+addEventListener("backgroundfetchclick", (event) => {
+  const registration = event.registration;
+
+  if (registration.result === "success") {
+    clients.openWindow("/play-movie");
+  } else {
+    clients.openWindow("/movie-download-progress");
+  }
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Background Fetch API](/en-US/docs/Web/API/Background_Fetch_API)

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
@@ -1,0 +1,67 @@
+---
+title: "ServiceWorkerGlobalScope: backgroundfetchfail event"
+slug: Web/API/ServiceWorkerGlobalScope/backgroundfetchfail_event
+page-type: web-api-event
+browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchfail_event
+---
+
+{{APIRef("Background Fetch API")}}
+
+The **`backgroundfetchfail`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has failed: that is, when at least one network request in the fetch has failed to complete successfully.
+
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("backgroundfetchfail", (event) => {});
+
+onbackgroundfetchfail = (event) => {};
+```
+
+## Event type
+
+A {{domxref("BackgroundFetchUpdateUIEvent")}}.
+
+{{InheritanceDiagram("BackgroundFetchUpdateUIEvent")}}
+
+## Event properties
+
+_Inherits properties from its parent, {{domxref("BackgroundFetchEvent")}}._
+
+- {{domxref("BackgroundFetchUpdateUIEvent.updateUI()")}}
+  - : Updates the UI of the element that the browser displays to show the progress of the fetch operation.
+
+## Description
+
+When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation fails (meaning that at least one of the individual network requests has not completed successfully), the browser starts the service worker, if necessary, and fires the `backgroundfetchfail` event in the service worker's global scope.
+
+In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchfail` handler, the service worker can update that UI to show that the operation has failed. To do this the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
+
+In the handler for this `backgroundfetchfail`, the service worker can also clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+
+## Examples
+
+### Updating UI
+
+This event handler updates the UI to let the user know that the operation failed.
+
+```js
+addEventListener("backgroundfetchfail", (event) => {
+  event.updateUI({ title: "Could not complete download" });
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Background Fetch API](/en-US/docs/Web/API/Background_Fetch_API)

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
@@ -40,7 +40,7 @@ When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation fa
 
 In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchfail` handler, the service worker can update that UI to show that the operation has failed. To do this, the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
 
-In the handler for this `backgroundfetchfail`, the service worker can also clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+In the handler for this `backgroundfetchfail`, the service worker can also clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data, the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
@@ -38,7 +38,7 @@ _Inherits properties from its parent, {{domxref("BackgroundFetchEvent")}}._
 
 When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation fails (meaning that at least one of the individual network requests has not completed successfully), the browser starts the service worker, if necessary, and fires the `backgroundfetchfail` event in the service worker's global scope.
 
-In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchfail` handler, the service worker can update that UI to show that the operation has failed. To do this the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
+In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchfail` handler, the service worker can update that UI to show that the operation has failed. To do this, the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
 
 In the handler for this `backgroundfetchfail`, the service worker can also clean up any related data for the operation. It can also retrieve and store any successful responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
@@ -38,7 +38,7 @@ _Inherits properties from its parent, {{domxref("BackgroundFetchEvent")}}._
 
 When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation completes successfully (meaning that all individual network requests have completed successfully), the browser starts the service worker, if necessary, and fires the `backgroundfetchsuccess` event in the service worker's global scope.
 
-In the handler for this event, the service worker can retrieve and store the responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+In the handler for this event, the service worker can retrieve and store the responses (for example, using the {{domxref("Cache")}} API). To access the response data, the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 
 In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchsuccess` handler, the service worker can update that UI to show that the operation has completed successfully. To do this the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
@@ -40,7 +40,7 @@ When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation co
 
 In the handler for this event, the service worker can retrieve and store the responses (for example, using the {{domxref("Cache")}} API). To access the response data, the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
 
-In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchsuccess` handler, the service worker can update that UI to show that the operation has completed successfully. To do this the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
+In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchsuccess` handler, the service worker can update that UI to show that the operation has completed successfully. To do this, the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
@@ -1,0 +1,85 @@
+---
+title: "ServiceWorkerGlobalScope: backgroundfetchsuccess event"
+slug: Web/API/ServiceWorkerGlobalScope/backgroundfetchsuccess_event
+page-type: web-api-event
+browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchsuccess_event
+---
+
+{{APIRef("Background Fetch API")}}
+
+The **`backgroundfetchsuccess`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has completed successfully: that is, when all network requests in the fetch have completed successfully.
+
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("backgroundfetchsuccess", (event) => {});
+
+onbackgroundfetchsuccess = (event) => {};
+```
+
+## Event type
+
+A {{domxref("BackgroundFetchUpdateUIEvent")}}.
+
+{{InheritanceDiagram("BackgroundFetchUpdateUIEvent")}}
+
+## Event properties
+
+_Inherits properties from its parent, {{domxref("BackgroundFetchEvent")}}._
+
+- {{domxref("BackgroundFetchUpdateUIEvent.updateUI()")}}
+  - : Updates the UI of the element that the browser displays to show the progress of the fetch operation.
+
+## Description
+
+When a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation completes successfully (meaning that all individual network requests have completed successfully), the browser starts the service worker, if necessary, and fires the `backgroundfetchsuccess` event in the service worker's global scope.
+
+In the handler for this event, the service worker can retrieve and store the responses (for example, using the {{domxref("Cache")}} API). To access the response data the service worker uses the event's {{domxref("BackgroundFetchEvent/registration", "registration")}} property.
+
+In the background fetch API, the browser shows a UI element to the user to indicate the progress of the operation. In the `backgroundfetchsuccess` handler, the service worker can update that UI to show that the operation has completed successfully. To do this the handler calls the event's {{domxref("BackgroundFetchUpdateUIEvent/updateUI", "updateUI()")}} method, passing in a new title and/or icons.
+
+## Examples
+
+### Storing responses and updating UI
+
+This event handler stores all responses in the cache, and updates the UI.
+
+```js
+addEventListener("backgroundfetchsuccess", (event) => {
+  const registration = event.registration;
+
+  event.waitUntil(async () => {
+    // Open a cache
+    const cache = await caches.open("movies");
+    // Get all the records
+    const records = await registration.matchAll();
+    // Cache all responses
+    const cachePromises = records.map(async (record) => {
+      const response = await record.responseReady;
+      await cache.put(record.request, response);
+    });
+
+    // Wait for caching to finish
+    await Promise.all(cachePromises);
+
+    // Update the browser's UI
+    event.updateUI({ title: "Move download complete" });
+  });
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Background Fetch API](/en-US/docs/Web/API/Background_Fetch_API)

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -32,6 +32,14 @@ This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and
 
 - {{domxref("ServiceWorkerGlobalScope/activate_event", "activate")}}
   - : Occurs when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active")}} worker.
+- {{domxref("ServiceWorkerGlobalScope/backgroundfetchabort_event", "backgroundfetchabort")}}
+  - : Fired when a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has been canceled by the user or the app.
+- {{domxref("ServiceWorkerGlobalScope/backgroundfetchclick_event", "backgroundfetchclick")}}
+  - : Fired when the user has clicked on the UI for a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation.
+- {{domxref("ServiceWorkerGlobalScope/backgroundfetchfail_event", "backgroundfetchfail")}}
+  - : Fired when at least one of the requests in a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has failed.
+- {{domxref("ServiceWorkerGlobalScope/backgroundfetchsuccess_event", "backgroundfetchsuccess")}}
+  - : Fired when all of the requests in a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation have succeeded.
 - {{domxref("ServiceWorkerGlobalScope.canmakepayment_event", "canmakepayment")}} {{Experimental_Inline}}
   - : Fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}.
 - {{domxref("ServiceWorkerGlobalScope/contentdelete_event", "contentdelete")}} {{Experimental_Inline}}


### PR DESCRIPTION
As part of https://github.com/mdn/mdn/issues/280 I'm writing some stuff about the Background Fetch API and noticed that these pages were missing.

Spec and MDN URLs are added in https://github.com/mdn/browser-compat-data/pull/19112.

In case it helps reviewers, I pushed my guide on "Offline and background operations". It's WIP, but the section on background fetch is more or less done: https://pr25305.content.dev.mdn.mozit.cloud/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation#background_fetch .