### PR TITLE
[PWA] Document parameters for BackgroundFetchManager.fetch()

### DIFF
--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -65,7 +65,7 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistrat
 
 ## Examples
 
-The following examples shows how to use `fetch()` to initiate a background fetch operation. With an active
+The following example shows how to use `fetch()` to initiate a background fetch operation. With an active
 {{domxref('ServiceWorker', 'service worker', "", "nocode")}}, use the
 {{domxref('ServiceWorkerRegistration.backgroundFetch')}} property to access the
 `BackgroundFetchManager` object and call its `fetch()`

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -43,7 +43,7 @@ fetch(id, requests, options)
         - `type`
           - : A string representing the {{Glossary("MIME")}} type of the icon. {{optional_inline}}
         - `label`
-          - : A string representing the accessible name of the icon.
+          - : A string representing the accessible name of the icon. {{optional_inline}}
     - `downloadTotal`
 
       - : A number representing the estimated total download size, in bytes, for the fetch operation. This is used to show the user how big the download is and to show the user download progress.
@@ -83,6 +83,7 @@ navigator.serviceWorker.ready.then(async (swReg) => {
           sizes: "300x300",
           src: "/ep-5-icon.png",
           type: "image/png",
+          label: "Downloading a show",
         },
       ],
       downloadTotal: 60 * 1024 * 1024,

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -9,7 +9,7 @@ browser-compat: api.BackgroundFetchManager.fetch
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
-The **`fetch()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
+The **`fetch()`** method of the {{domxref("BackgroundFetchManager")}} interface initiates a background fetch operation, given one or more URLs or {{domxref("Request")}} objects.
 
 ## Syntax
 
@@ -21,11 +21,34 @@ fetch(id, requests, options)
 ### Parameters
 
 - `id`
-  - : A developer-defined identifier that can be passed to the other methods to retrieve a {{domxref("backgroundFetchRegistration")}}.
+  - : A developer-defined identifier that can be passed to the other methods to retrieve the {{domxref("BackgroundFetchRegistration")}} for this operation.
 - `requests`
-  - : A {{domxref("RequestInfo")}} object or an array of such objects.
+
+  - : A `RequestInfo` object or an array of `RequestInfo` objects.
+
+    Each `RequestInfo` object is a {{domxref("Request")}} object or a string that will be given as the `input` argument to the {{domxref("Request.Request()", "Request()")}} constructor.
+
 - `options` {{optional_inline}}
-  - : A {{domxref("BackgroundFetchOptions")}} object.
+
+  - : An object which will be used to customize the fetch progress dialog that the browser shows to the user. It has the following properties:
+
+    - `title`
+      - : A string that will be used as the title for the progress dialog.
+    - `icons`
+      - : An array of objects, each representing an icon that the browser may use for the progress dialog. Each object has the following properties:
+        - `src`
+          - : A string representing a URL to the icon file.
+        - `sizes`
+          - : A string representing the sizes of the image, expressed using the same syntax as the [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute of the [`<link>`](/en-US/docs/Web/HTML/Element/link) element. {{optional_inline}}
+        - `type`
+          - : A string representing the {{Glossary("MIME")}} type of the icon. {{optional_inline}}
+        - `label`
+          - : A string representing the accessible name of the icon.
+    - `downloadTotal`
+
+      - : A number representing the estimated total download size, in bytes, for the fetch operation. This is used to show the user how big the download is and to show the user download progress.
+
+        As soon as the total download size exceeds `downloadTotal`, then the fetch is aborted.
 
 ### Return value
 
@@ -42,9 +65,8 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistrat
 
 ## Examples
 
-The following examples shows how to use `fetch()` to create a
-{{domxref("BackgroundFetchRegistration")}}. With an active
-{{domxref('ServiceWorker', 'service worker')}}, use the
+The following examples shows how to use `fetch()` to initiate a background fetch operation. With an active
+{{domxref('ServiceWorker', 'service worker', "", "nocode")}}, use the
 {{domxref('ServiceWorkerRegistration.backgroundFetch')}} property to access the
 `BackgroundFetchManager` object and call its `fetch()`
 method.

--- a/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ServiceWorkerRegistration.backgroundFetch
 
 The **`backgroundFetch`** property of the
 {{domxref("ServiceWorkerRegistration")}} interface returns a reference to a
-{{domxref("BackgroundFetchManager")}} object, which can be used to initiate background fetch operations
+{{domxref("BackgroundFetchManager")}} object, which can be used to initiate background fetch operations.
 
 ## Value
 

--- a/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
@@ -34,6 +34,7 @@ async function requestBackgroundFetch(movieData) {
       icons: movieIcons,
       title: "Downloading my movie",
       downloadTotal: 60 * 1024 * 1024,
+      label: "Downloading a show",
     }
   );
   //...

--- a/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/backgroundfetch/index.md
@@ -1,0 +1,49 @@
+---
+title: ServiceWorkerRegistration.backgroundFetch
+slug: Web/API/ServiceWorkerRegistration/backgroundFetch
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.ServiceWorkerRegistration.backgroundFetch
+---
+
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+
+The **`backgroundFetch`** property of the
+{{domxref("ServiceWorkerRegistration")}} interface returns a reference to a
+{{domxref("BackgroundFetchManager")}} object, which can be used to initiate background fetch operations
+
+## Value
+
+A {{domxref("BackgroundFetchManager")}} object.
+
+## Examples
+
+### Initiating a background fetch
+
+The following code accesses the `backgroundFetch` property and uses it to initiate a background fetch operation.
+
+```js
+// main.js
+async function requestBackgroundFetch(movieData) {
+  const swRegistration = await navigator.serviceWorker.ready;
+  const fetchRegistration = await swRegistration.backgroundFetch.fetch(
+    "download-movie",
+    ["/my-movie-part-1.webm", "/my-movie-part-2.webm"],
+    {
+      icons: movieIcons,
+      title: "Downloading my movie",
+      downloadTotal: 60 * 1024 * 1024,
+    }
+  );
+  //...
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -21,6 +21,8 @@ _Also implements properties from its parent interface,_ {{domxref("EventTarget")
 
 - {{domxref("ServiceWorkerRegistration.active")}} {{ReadOnlyInline}}
   - : Returns a service worker whose state is `activating` or `activated`. This is initially set to `null`. An active worker will control a {{domxref("Client")}} if the client's URL falls within the scope of the registration (the `scope` option set when {{domxref("ServiceWorkerContainer.register")}} is first called.)
+- {{domxref("ServiceWorkerRegistration.backgroundFetch")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns a reference to a {{domxref("BackgroundFetchManager")}} object, which manages background fetch operations.
 - {{domxref("ServiceWorkerRegistration.index")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a reference to the {{domxref("ContentIndex")}} interface, for managing indexed content for offline viewing.
 - {{domxref("ServiceWorkerRegistration.installing")}} {{ReadOnlyInline}}


### PR DESCRIPTION
As part of https://github.com/mdn/mdn/issues/280 I'm writing some stuff about the Background Fetch API and noticed that we don't document the parameters to [BackgroundFetchManager.fetch()](https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchManager/fetch).

In case it helps reviewers, I pushed my guide in background operations. It's WIP, but the section on background fetch is more or less done: https://pr25305.content.dev.mdn.mozit.cloud/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation#background_fetch .