### PR TITLE
Add some clarity to description of only-if-cached Cache-Control directive

### DIFF
--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -343,7 +343,7 @@ Same meaning that `no-transform` has for a response, but for a request instead.
 
 #### `only-if-cached`
 
-The client indicates an already-cached response should be returned. If a cache has a stored response, even a stale one, it will be returned. If no cached response is available, a [504 Gateway timeout](/en-US/docs/Web/HTTP/Status/504) response will be returned.
+The client indicates that an already-cached response should be returned. If a cache has a stored response, even a stale one, it will be returned. If no cached response is available, a [504 Gateway timeout](/en-US/docs/Web/HTTP/Status/504) response will be returned.
 
 ## Use Cases
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -343,7 +343,7 @@ Same meaning that `no-transform` has for a response, but for a request instead.
 
 #### `only-if-cached`
 
-The client indicates that cache should obtain an already-cached response. If a cache has stored a response, it's reused.
+The client indicates an already-cached response should be returned. If a cache has a stored response, even a stale one, it will be returned. If no cached response is available, a [504 Gateway timeout](/en-US/docs/Web/HTTP/Status/504) response will be returned.
 
 ## Use Cases
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -343,7 +343,7 @@ Same meaning that `no-transform` has for a response, but for a request instead.
 
 #### `only-if-cached`
 
-The client indicates that an already-cached response should be returned. If a cache has a stored response, even a stale one, it will be returned. If no cached response is available, a [504 Gateway timeout](/en-US/docs/Web/HTTP/Status/504) response will be returned.
+The client indicates that an already-cached response should be returned. If a cache has a stored response, even a stale one, it will be returned. If no cached response is available, a [504 Gateway Timeout](/en-US/docs/Web/HTTP/Status/504) response will be returned.
 
 ## Use Cases
 


### PR DESCRIPTION
### Description

Adds a little more clarity to the description of the `only-if-cached` Cache-Control directive, including an explanation of what happens if no cached response is available.

Here is how my proposed change looks in the browser on [this page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control):

![image](https://user-images.githubusercontent.com/4397296/224868416-2194c195-4801-42a1-8a0a-d91e04e4caab.png)

### Motivation

I felt that the description here is incomplete without an explanation of what happens if no cached response is available. I discovered what happens via experimentation and then found [this page on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) which also has that detail.


