### PR TITLE
Fix a Minor Typo in the Responsive Design Page

### DIFF
--- a/files/en-us/learn/css/css_layout/responsive_design/index.md
+++ b/files/en-us/learn/css/css_layout/responsive_design/index.md
@@ -44,7 +44,7 @@ Responsive web design isn't a separate technology — it is an approach. It is a
 
 The term _responsive design_, [coined by Ethan Marcotte in 2010](https://alistapart.com/article/responsive-web-design/), described using fluid grids, fluid images, and media queries to create responsive content, as discussed in Zoe Mickley Gillenwater's book [Flexible Web Design](http://flexiblewebbook.com/).
 
-At the time, the recommendation was to use CSS `float` for layout and media queries to query the browser width, creating layouts for different breakpoints. Fluid images are set to not exceed the width of their container; they have their `max-width` property set to `100%`. Fluid images scale down when their containing column narrow but do not grow larger than their intrinsic size when the column grows. This enables an image to scale down to fit its content, rather than overflow it, but not grow larger and become pixelated if the container becomes wider than the image.
+At the time, the recommendation was to use CSS `float` for layout and media queries to query the browser width, creating layouts for different breakpoints. Fluid images are set to not exceed the width of their container; they have their `max-width` property set to `100%`. Fluid images scale down when their containing column narrows but do not grow larger than their intrinsic size when the column grows. This enables an image to scale down to fit its content, rather than overflow it, but not grow larger and become pixelated if the container becomes wider than the image.
 
 Modern CSS layout methods are inherently responsive, and, since the publication of Gillenwater's book and Marcotte's article, we have a multitude of features built into the web platform to make designing responsive sites easier.
 


### PR DESCRIPTION
Added a missing 's' to the word 'narrow'.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Original Sentence:
> Fluid images scale down when their containing column _narrow_ but do not grow larger than their intrinsic size when the column grows.

Updated Sentence:
> Fluid images scale down when their containing column _narrows_ but do not grow larger than their intrinsic size when the column grows.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To maintain grammatical consistency and correctness, preventing readers from being confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The sentence can be found three paragraphs above the subsection labelled [ _Media Queries_](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#media_queries).

A screenshot is provided for reference as well:

![image](https://user-images.githubusercontent.com/77248542/224969477-2df1d34d-a50e-47c3-930f-41d84f0a9106.png)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
