### PR TITLE
Update comment in `navigator.doNotTrack` example

### DIFF
--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -50,7 +50,7 @@ The user's DNT preference can also be read from JavaScript using the
 {{domxref("Navigator.doNotTrack")}} property:
 
 ```js
-navigator.doNotTrack; // "0" or "1"
+navigator.doNotTrack; // "0", "1" or "unspecified"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The comment in the code example mentioned only `"1"` or `"0"` as possible return values, although `"unspecified"` is also possible.

### Motivation

The code example might trick readers into thinking that only those two values can be returned.
