### PR TITLE
Update documentation for {HTML,SVG}Element.style

### DIFF
--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -7,7 +7,7 @@ browser-compat: api.HTMLElement.style
 
 {{APIRef("CSSOM")}}
 
-The read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
+The read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned only for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
 
 This property is read-only, meaning it is not possible to assign a {{domxref("CSSStyleDeclaration")}} object to it. Nevertheless, it is possible to set an inline style by assigning a _string_ directly to the `style` property. In this case the string is forwarded to {{domxref("CSSStyleDeclaration.cssText")}}. Using `style` in this manner will completely overwrite all inline styles on the element.
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -15,7 +15,13 @@ Therefore, to add specific styles to an element without altering other style val
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 
-> **Note:** See the [CSS Properties Reference](/en-US/docs/Web/CSS/CSS_Properties_Reference) for a list of the CSS properties accessible via `style`. The `style` property has the same priority in the CSS cascade as an inline style declaration set via the `style` attribute.
+> **Note:** Properties name are converted to JavaScript identifier with these rules:
+>
+> - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
+> - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.
+> - The property `float`, being a reserved JavaScript keyword, is converted to `cssFloat`.
+>
+> The `style` property has the same priority in the CSS cascade as an inline style declaration set via the `style` attribute.
 
 ## Value
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -9,6 +9,8 @@ browser-compat: api.HTMLElement.style
 
 The read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned only for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
 
+Shorthand properties are expanded. If you set `style="border-top: 1px solid black"`, the longhand properties ({{cssxref("border-top-color")}}), {{cssxref("border-top-style")}}, and {{cssxref("border-top-width")}} are set instead.
+
 This property is read-only, meaning it is not possible to assign a {{domxref("CSSStyleDeclaration")}} object to it. Nevertheless, it is possible to set an inline style by assigning a _string_ directly to the `style` property. In this case the string is forwarded to {{domxref("CSSStyleDeclaration.cssText")}}. Using `style` in this manner will completely overwrite all inline styles on the element.
 
 Therefore, to add specific styles to an element without altering other style values, it is generally preferable to set individual properties on the {{domxref("CSSStyleDeclaration")}} object. For example, `element.style.backgroundColor = "red"`.
@@ -31,48 +33,38 @@ A live {{domxref("CSSStyleDeclaration")}} object.
 
 ### Getting style information
 
-The `style` property is not useful for completely learning about the styles applied on the element, since it represents only the CSS declarations set in the element's inline `style` attribute, not those that come from style rules elsewhere, such as style rules in the {{HTMLElement("head")}} section, or external style sheets. To get the values of all CSS properties for an element you should use {{domxref("Window.getComputedStyle()")}} instead.
-
-The following code snippet demonstrates the difference between the values obtained using the element's `style` property and that obtained using the `getComputedStyle()` method:
+The following code snippet demonstrates how the values obtained using the element's `style` property relates to the style set on the HTML attribute:
 
 ```html
 <!DOCTYPE html>
 <html lang="en-US">
   <body style="font-weight:bold">
-    <div style="color:red" id="elt">…</div>
+    <div style="border-top: 1px solid blue; color:red" id="elt">
+      An example div
+    </div>
+    <pre id="out"></pre>
   </body>
 </html>
 ```
 
 ```js
 const element = document.getElementById("elt");
-let out = "";
+const out = document.getElementById("out");
 const elementStyle = element.style;
-const computedStyle = window.getComputedStyle(element, null);
 
-// We loop all styles (for…of doesn't work with CSStyleDeclaration)
-for (const prop in computedStyle) {
-  if (Object.hasOwn(computedStyle, prop)) {
-    out += `${computedStyle[prop]} = '${elementStyle.getPropertyValue(
-      computedStyle[prop]
-    )}' > '${computedStyle[computedStyle[prop]]}'\n`;
+// We loop through all styles (for…of doesn't work with CSStyleDeclaration)
+for (const prop in elementStyle) {
+  if (Object.hasOwn(elementStyle, prop)) {
+    out.textContent += `${
+      elementStyle[prop]
+    } = '${elementStyle.getPropertyValue(elementStyle[prop])}'\n`;
   }
 }
-
-console.log(out);
 ```
 
-The output is a long list of properties. The two interesting properties have the following values:
+{{EmbedLiveSample("Getting_style_information", "100", "115")}}
 
-```
-…
-color = 'red' > 'rgb(255, 0, 0)'
-…
-font-weight = '' > '700'
-…
-```
-
-Note the absence of a value `font-weight` for `elementStyle` as it is not defined `style` attribute of the element, but on its parent. Nevertheless, it is taken into account for the calculation of the computed style, though (`computedStyle["font-weight"])` returns `700` which means bold).
+Note the absence of a value `font-weight` for `elementStyle` as it is not defined `style` attribute of the element, but on its parent. The shorthand {{cssxref("border-top")}} property, although set on the `style` attribute is not listed; it is replaced by the three corresponding longhand properties ({{cssxref("border-top-color")}}), {{cssxref("border-top-style")}}, and {{cssxref("border-top-width")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -64,7 +64,7 @@ for (const prop in elementStyle) {
 
 {{EmbedLiveSample("Getting_style_information", "100", "115")}}
 
-Note the absence of a value `font-weight` for `elementStyle` as it is not defined `style` attribute of the element, but on its parent. The shorthand {{cssxref("border-top")}} property, although set on the `style` attribute is not listed; it is replaced by the three corresponding longhand properties ({{cssxref("border-top-color")}}), {{cssxref("border-top-style")}}, and {{cssxref("border-top-width")}}.
+Note `font-weight` is not listed as a value for `elementStyle` as it is not defined within the `style` attribute of the element itself. Rather, it is inherited from the definition on its parent. Also note that the shorthand {{cssxref("border-top")}} property, defined in the `style` attribute, is not listed directly. Rather, it is replaced by the three corresponding longhand properties ({{cssxref("border-top-color")}}), {{cssxref("border-top-style")}}, and {{cssxref("border-top-width")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -15,7 +15,7 @@ Therefore, to add specific styles to an element without altering other style val
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 
-> **Note:** Properties name are converted to JavaScript identifier with these rules:
+> **Note:** CSS property names are converted to JavaScript identifier with these rules:
 >
 > - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
 > - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -13,7 +13,7 @@ Shorthand properties are expanded. If you set `style="border-top: 1px solid blac
 
 This property is read-only, meaning it is not possible to assign a {{domxref("CSSStyleDeclaration")}} object to it. Nevertheless, it is possible to set an inline style by assigning a _string_ directly to the `style` property. In this case the string is forwarded to {{domxref("CSSStyleDeclaration.cssText")}}. Using `style` in this manner will completely overwrite all inline styles on the element.
 
-Therefore, to add specific styles to an element without altering other style values, it is generally preferable to set individual properties on the {{domxref("CSSStyleDeclaration")}} object. For example, `element.style.backgroundColor = "red"`.
+Therefore, to add specific styles to an element without altering other style values, it is generally preferable to set individual properties on the {{domxref("CSSStyleDeclaration")}} object. For example, you can write `element.style.backgroundColor = "red"`.
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -17,7 +17,7 @@ A style declaration is reset by setting it to `null` or an empty string, e.g., `
 
 > **Note:** CSS property names are converted to JavaScript identifier with these rules:
 >
-> - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
+> - If the property is made of one word, it remains as it is: `height` stays as is (in lowercase).
 > - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.
 > - The property `float`, being a reserved JavaScript keyword, is converted to `cssFloat`.
 >

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -31,12 +31,12 @@ A live {{domxref("CSSStyleDeclaration")}} object.
 
 ### Getting style information
 
-The `style` property is not useful for completely learning about the styles applied on the element, since it represents only the CSS declarations set in the element's inline `style` attribute, not those that come from style rules elsewhere, such as style rules in the {{HTMLElement("head")}} section, or external style sheets. To get the values of all CSS properties for an element you should use {{domxref("Window.getComputedStyle()")}} instead.
-
-The following code snippet demonstrates the difference between the values obtained using the element's `style` property and that obtained using the `getComputedStyle()` method:
+The following code snippet show how the `style` attribute is translated into a list of entries in {{domxref("CSSStyleDeclaration")}} :
 
 ```html
 <svg
+  width="50"
+  height="50"
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 250 250"
   width="250"
@@ -48,37 +48,25 @@ The following code snippet demonstrates the difference between the values obtain
     id="circle"
     style="fill: red; stroke: black; stroke-width: 2px;" />
 </svg>
+<pre id="out"></pre>
 ```
 
 ```js
 const element = document.querySelector("circle");
-let out = "";
+const out = document.getElementById("out");
 const elementStyle = element.style;
-const computedStyle = window.getComputedStyle(element, null);
 
-// We loop all styles (for…of doesn't work with CSStyleDeclaration)
-for (const prop in computedStyle) {
-  if (Object.hasOwn(computedStyle, prop)) {
-    out += `${computedStyle[prop]} = '${elementStyle.getPropertyValue(
-      computedStyle[prop]
-    )}' > '${computedStyle[computedStyle[prop]]}'\n`;
+// We loop through all styles (for…of doesn't work with CSStyleDeclaration)
+for (const prop in elementStyle) {
+  if (Object.hasOwn(elementStyle, prop)) {
+    out.textContent += `${
+      elementStyle[prop]
+    } = '${elementStyle.getPropertyValue(elementStyle[prop])}'\n`;
   }
 }
-
-console.log(out);
 ```
 
-The output is a long list of properties. The three interesting properties have the following values:
-
-```
-…
-fill = 'red' > 'rgb(255, 0, 0)'
-…
-stroke = 'black' > 'rgb(0, 0, 0)'
-…
-stroke-width = '2px' > '2px'
-…
-```
+{{EmbedLiveSample("Getting_style_information", "100", "130")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -15,7 +15,13 @@ Therefore, to add specific styles to an element without altering other style val
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 
-> **Note:** See the [CSS Properties Reference](/en-US/docs/Web/CSS/CSS_Properties_Reference) for a list of the CSS properties accessible via `style`. The `style` property has the same priority in the CSS cascade as an inline style declaration set via the `style` attribute.
+> **Note:** Properties name are converted to JavaScript identifier with these rules:
+>
+> - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
+> - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.
+> - The property `float`, being a reserved JavaScript keyword, is converted to `cssFloat`.
+>
+> The `style` property has the same priority in the CSS cascade as an inline style declaration set via the `style` attribute.
 
 ## Value
 

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGElement.style
 
 {{APIRef("CSSOM")}}
 
-he read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
+The read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
 
 This property is read-only, meaning it is not possible to assign a {{domxref("CSSStyleDeclaration")}} object to it. Nevertheless, it is possible to set an inline style by assigning a _string_ directly to the `style` property. In this case the string is forwarded to {{domxref("CSSStyleDeclaration.cssText")}}. Using `style` in this manner will completely overwrite all inline styles on the element.
 

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -15,7 +15,7 @@ Therefore, to add specific styles to an element without altering other style val
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 
-> **Note:** Properties name are converted to JavaScript identifier with these rules:
+> **Note:** CSS property names are converted to JavaScript identifier with these rules:
 >
 > - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
 > - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -1,13 +1,13 @@
 ---
-title: HTMLElement.style
-slug: Web/API/HTMLElement/style
+title: SVGlement.style
+slug: Web/API/SVGElement/style
 page-type: web-api-instance-property
-browser-compat: api.HTMLElement.style
+browser-compat: api.SVGElement.style
 ---
 
 {{APIRef("CSSOM")}}
 
-The read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
+he read-only **`style`** property of the {{domxref("HTMLElement")}} returns the _inline_ style of an element in the form of a live {{domxref("CSSStyleDeclaration")}} object that contains a list of all styles properties for that element with values assigned for the attributes that are defined in the element's inline [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
 
 This property is read-only, meaning it is not possible to assign a {{domxref("CSSStyleDeclaration")}} object to it. Nevertheless, it is possible to set an inline style by assigning a _string_ directly to the `style` property. In this case the string is forwarded to {{domxref("CSSStyleDeclaration.cssText")}}. Using `style` in this manner will completely overwrite all inline styles on the element.
 
@@ -30,16 +30,22 @@ The `style` property is not useful for completely learning about the styles appl
 The following code snippet demonstrates the difference between the values obtained using the element's `style` property and that obtained using the `getComputedStyle()` method:
 
 ```html
-<!DOCTYPE html>
-<html lang="en-US">
-  <body style="font-weight:bold">
-    <div style="color:red" id="elt">…</div>
-  </body>
-</html>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 250 250"
+  width="250"
+  height="250">
+  <circle
+    cx="100"
+    cy="100"
+    r="50"
+    id="circle"
+    style="fill: red; stroke: black; stroke-width: 2px;" />
+</svg>
 ```
 
 ```js
-const element = document.getElementById("elt");
+const element = document.querySelector("circle");
 let out = "";
 const elementStyle = element.style;
 const computedStyle = window.getComputedStyle(element, null);
@@ -56,17 +62,17 @@ for (const prop in computedStyle) {
 console.log(out);
 ```
 
-The output is a long list of properties. The two interesting properties have the following values:
+The output is a long list of properties. The three interesting properties have the following values:
 
 ```
 …
-color = 'red' > 'rgb(255, 0, 0)'
+fill = 'red' > 'rgb(255, 0, 0)'
 …
-font-weight = '' > '700'
+stroke = 'black' > 'rgb(0, 0, 0)'
+…
+stroke-width = '2px' > '2px'
 …
 ```
-
-Note the absence of a value `font-weight` for `elementStyle` as it is not defined `style` attribute of the element, but on its parent. Nevertheless, it is taken into account for the calculation of the computed style, though (`computedStyle["font-weight"])` returns `700` which means bold).
 
 ## Specifications
 
@@ -79,4 +85,4 @@ Note the absence of a value `font-weight` for `elementStyle` as it is not define
 ## See also
 
 - [Using dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information)
-- {{domxref("SVGElement.style")}}
+- {{domxref("HTMLElement.style")}}

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -17,7 +17,7 @@ A style declaration is reset by setting it to `null` or an empty string, e.g., `
 
 > **Note:** CSS property names are converted to JavaScript identifier with these rules:
 >
-> - If the property is made of one work, it remains as it is: `height` stays as is (in lowercase).
+> - If the property is made of one word, it remains as it is: `height` stays as is (in lowercase).
 > - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to _camelCase_: `background-attachment` becomes `backgroundAttachement`.
 > - The property `float`, being a reserved JavaScript keyword, is converted to `cssFloat`.
 >


### PR DESCRIPTION
Part of openwebdocs/project#152

1. `HTMLElement.style` did not match the page's modern style, and the example was wrong.
2. `SVGElement.style` was missing. Added.
3. The page linked to _CSS Properties Reference_ was removed. The new page doesn't have the information to convert a CSS property name into a JS identifier, so I added it. (in both pages)

I tested both examples via a temporary `{{EmbedLiveSample}}` macro. I didn't keep it: the interesting part is on the console anyway (and very long).

In the future, there may be a `MathMLElement.style`.