### PR TITLE
 docs(relnote): Update Fx111 release note to current

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/111
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 111 that affect developers. Firefox 111 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [March 14, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 111 that affect developers. Firefox 111 was released on March 14, 2023.
 
 ## Changes for web developers
 


### PR DESCRIPTION
This is a follow up for https://github.com/mdn/content/pull/25299 to update the description in the `/en-us/mozilla/firefox/releases/111/index.md` file.