### PR TITLE
Add a page for WebGLObject

### DIFF
--- a/files/en-us/web/api/webglobject/index.md
+++ b/files/en-us/web/api/webglobject/index.md
@@ -26,13 +26,11 @@ WebGL 1:
 
 WebGL 2:
 
-- {{domxref("WebGLQuery")}}
+- {{domxref("WebGLQuery")}} (and `WebGLTimerQueryEXT`)
 - {{domxref("WebGLSampler")}}
 - {{domxref("WebGLSync")}}
-- {{domxref("WebGLTimerQueryEXT")}}
 - {{domxref("WebGLTransformFeedback")}}
-- {{domxref("WebGLVertexArrayObject")}}
-- {{domxref("WebGLVertexArrayObjectOES")}}
+- {{domxref("WebGLVertexArrayObject")}} (and `WebGLVertexArrayObjectOES`)
 
 ## See also
 

--- a/files/en-us/web/api/webglobject/index.md
+++ b/files/en-us/web/api/webglobject/index.md
@@ -1,0 +1,41 @@
+---
+title: WebGLObject
+slug: Web/API/WebGLObject
+page-type: web-api-interface
+browser-compat: api.WebGLObject
+---
+
+{{APIRef("WebGL")}}
+
+The **`WebGLObject`** is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and is the parent interface for all WebGL objects.
+
+This object has no public properties or methods on its own.
+
+If the WebGL context is lost, the internal _invalidated_ flag of all `WebGLObject` instances is set to `true`.
+
+## Objects inheriting from `WebGLObject`
+
+WebGL 1:
+
+- {{domxref("WebGLBuffer")}}
+- {{domxref("WebGLFramebuffer")}}
+- {{domxref("WebGLProgram")}}
+- {{domxref("WebGLRenderbuffer")}}
+- {{domxref("WebGLShader")}}
+- {{domxref("WebGLTexture")}}
+
+WebGL 2:
+
+- {{domxref("WebGLQuery")}}
+- {{domxref("WebGLSampler")}}
+- {{domxref("WebGLSync")}}
+- {{domxref("WebGLTimerQueryEXT")}}
+- {{domxref("WebGLTransformFeedback")}}
+- {{domxref("WebGLVertexArrayObject")}}
+- {{domxref("WebGLVertexArrayObjectOES")}}
+
+## See also
+
+- [`WebGLRenderingContext.isContextLost()`](/en-US/docs/Web/API/WebGLRenderingContext/isContextLost)
+- [`WEBGL_lose_context`](/en-US/docs/Web/API/WEBGL_lose_context)
+- [`webglcontextlost` event](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)


### PR DESCRIPTION
### Description

This PR documents WebGLObject, defined in https://registry.khronos.org/webgl/specs/latest/1.0/#5.3.

### Motivation

@teoli2003 tells me there are a lot of red links because this page doesn't exist.

See e.g. https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer where `WebGLObject` appears in the sidebar and in the inheritance diagram.

`WebGLObject` is added to MDN via https://github.com/mdn/content/blob/main/files/jsondata/InterfaceData.json which comes from the specification IDLs (webref).

### Additional details

It is not in BCD. I think it was there once but isn't anymore. I think this object might not be observable by web developers directly.

### Related issues and pull requests

None.
