### PR TITLE
Fix image links in rotate3d page

### DIFF
--- a/files/en-us/web/css/transform-function/rotate3d/index.md
+++ b/files/en-us/web/css/transform-function/rotate3d/index.md
@@ -63,7 +63,7 @@ rotate3d(x, y, z, a)
       <th scope="col">Cartesian coordinates on ℝ^3</th>
       <td>
         <a
-          href="/en-US/docs/Web/CSS/transform-function/rotate3d()/transform-functions-rotate3d_cart.png"
+          href="/en-US/docs/Web/CSS/transform-function/rotate3d/transform-functions-rotate3d_cart.png"
           ><img src="transform-functions-rotate3d_cart.png" /></a
         ><math>
           <mrow><mo>(</mo
@@ -247,7 +247,7 @@ rotate3d(x, y, z, a)
       <th scope="col">Homogeneous coordinates on ℝℙ^3</th>
       <td>
         <a
-          href="/en-US/docs/Web/CSS/transform-function/rotate3d()/transform-functions-rotate3d_hom4.png"
+          href="/en-US/docs/Web/CSS/transform-function/rotate3d/transform-functions-rotate3d_hom4.png"
           ><img src="transform-functions-rotate3d_hom4.png"
         /></a>
       </td>


### PR DESCRIPTION
Fixes the links on two matrix images on https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotate3d#values which currently lead to a 404.