### PR TITLE
Update hasinstance example to show invocation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -56,6 +56,22 @@ const cat = new Animal();
 console.log(Animal[Symbol.hasInstance](cat)); // true
 ```
 
+### Calling the `@@hasInstance` method
+
+The default `@@hasInstance` method uses the `this` context as the constructor object to compare against. To invoke it you have to provide the `this` context, for example via binding:
+
+```js
+function MyArray() {}
+const originalHasInstance = MyArray[Symbol.hasInstance].bind(MyArray);
+Object.defineProperty(MyArray, Symbol.hasInstance, {
+  value(instance) {
+    return originalHasInstance(instance) || Array.isArray(instance);
+  },
+});
+console.log(new MyArray() instanceof MyArray); // true
+console.log([] instanceof MyArray); // true
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -53,23 +53,9 @@ class Animal {
 
 const cat = new Animal();
 
+console.log(cat instanceof Animal); // true
 console.log(Animal[Symbol.hasInstance](cat)); // true
-```
-
-### Calling the `@@hasInstance` method
-
-The default `@@hasInstance` method uses the `this` context as the constructor object to compare against. To invoke it you have to provide the `this` context, for example via binding:
-
-```js
-function MyArray() {}
-const originalHasInstance = MyArray[Symbol.hasInstance].bind(MyArray);
-Object.defineProperty(MyArray, Symbol.hasInstance, {
-  value(instance) {
-    return originalHasInstance(instance) || Array.isArray(instance);
-  },
-});
-console.log(new MyArray() instanceof MyArray); // true
-console.log([] instanceof MyArray); // true
+console.log(Animal[Symbol.hasInstance].call(Animal, cat)); // true
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Included an example of how to invoke the default hasinstance implementation. I expect it to be a common use case to augment existing behavior and thus it being useful to see how to invoke the existing method.

### Motivation

Found it difficult to invoke the original hasInstance symbol myself. I could not find clear documentation on the default value of the symbol to understand how to invoke the default function. 

I had to dive into the spec to see that the default implementation from the Function prototype operates on the `this` context as the class to compare against: https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype-@@hasinstance

I created an example that shows what I expect to be a common use-case. Modifying the instanceof behavior of an existing class to invoke the original behavior in addition to augmenting it with a custom capability.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
