### PR TITLE
Document SVGClipPathElement.(clipPathUnits|transform)

### DIFF
--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedEnumeration.animVal
 
 {{APIRef("SVG")}}
 
-The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
+The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of an SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -1,0 +1,73 @@
+---
+title: SVGAnimatedEnumeration.animVal
+slug: Web/API/SVGAnimatedEnumeration/animVal
+page-type: web-api-instance-property
+browser-compat: api.SVGAnimatedEnumeration.animVal
+---
+
+{{APIRef("SVG")}}
+
+The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
+
+## Value
+
+An integer containing the current value of the enumeration
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewbox="0 0 100 100" width="200" height="200">
+    <clipPath id="clip1" clipPathUnits="userSpaceOnUse">
+      <animate
+        attributeName="clipPathUnits"
+        values="userSpaceOnUse;objectBoundingBox;userSpaceOnUse"
+        dur="2s"
+        repeatCount="indefinite" />
+      <circle cx="50" cy="50" r="25" />
+    </clipPath>
+
+    <rect id="r1" x="0" y="0" width="50" height="100" />
+
+    <use clip-path="url(#clip1)" xlink:href="#r1" fill="lightblue" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const clipPath1 = document.getElementById("clip1");
+const log = document.getElementById("log");
+
+function displayLog() {
+  const animValue = clipPath1.clipPathUnits.animVal;
+  const baseValue = clipPath1.clipPathUnits.baseVal;
+  log.textContent = `The 'clipPathUnits.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'clipPathUnits.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+
+displayLog();
+```
+
+{{EmbedLiveSample("Examples", "280", "260")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGAnimatedEnumeration.baseVal")}}

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedEnumeration.animVal
 
 {{APIRef("SVG")}}
 
-The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
+The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedenumeration/baseval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/baseval/index.md
@@ -1,0 +1,48 @@
+---
+title: SVGAnimatedEnumeration.baseVal
+slug: Web/API/SVGAnimatedEnumeration/baseVal
+page-type: web-api-instance-property
+browser-compat: api.SVGAnimatedEnumeration.baseVal
+---
+
+{{APIRef("SVG")}}
+
+The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the initial value of a SVG enumeration.
+
+## Value
+
+An integer containing the initial value of the enumeration
+
+## Examples
+
+Considering this snippet with a {{SVGElement("clipPath")}} element. Its {{SVGAttr("clipPathUnits")}} is associated with a {{domxref("SVGAnimatedEnumeration")}} object.
+
+```html
+<svg viewbox="0 0 100 100" width="200" height="200">
+  <clipPath id="clip1" clipPathUnits="userSpaceOnUse">
+    <circle cx="50" cy="50" r="35" />
+  </clipPath>
+
+  <!-- Some reference rect to materialized to clip path -->
+  <rect id="r1" x="0" y="0" width="45" height="45" />
+</svg>
+```
+
+This snippet gets the element, and logs the `baseVal`of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+
+```js
+const clipPathElt = document.getElementById("clip1");
+console.log(clipPathElt.clipPathUnits.baseVal); // Logs 1 that correspond to userSpaceOnUse
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGAnimatedEnumeration.animVal")}}

--- a/files/en-us/web/api/svganimatedenumeration/baseval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/baseval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedEnumeration.baseVal
 
 {{APIRef("SVG")}}
 
-The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the initial value of a SVG enumeration.
+The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the initial value of an SVG enumeration.
 
 ## Value
 
@@ -15,7 +15,7 @@ An integer containing the initial value of the enumeration
 
 ## Examples
 
-Considering this snippet with a {{SVGElement("clipPath")}} element. Its {{SVGAttr("clipPathUnits")}} is associated with a {{domxref("SVGAnimatedEnumeration")}} object.
+Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with a {{domxref("SVGAnimatedEnumeration")}} object.
 
 ```html
 <svg viewbox="0 0 100 100" width="200" height="200">

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedEnumeration
 
 {{APIRef("SVG")}}
 
-The **`SVGAnimatedEnumeration`** interface descrobes attributes value which are constants from a particular enumeration and which can be animated.
+The **`SVGAnimatedEnumeration`** interface describes attribute values which are constants from a particular enumeration and which can be animated.
 
 ## Instance properties
 
@@ -22,7 +22,7 @@ The `SVGAnimatedEnumeration` interface do not provide any specific methods.
 
 ## Examples
 
-Considering this snippet with a {{SVGElement("clipPath")}} element. Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
+Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
 
 ```html
 <svg viewbox="0 0 100 100" width="200" height="200">

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -14,7 +14,7 @@ The **`SVGAnimatedEnumeration`** interface descrobes attributes value which are 
 - {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}
   - : An integer that is the base value of the given attribute before applying any animations.
 - {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}
-  - : If the given attribute or property is being animated, contains thecurrent animated value of the attribute or property. If the given attribute or property is not currently being animated, contains the same value as `baseVal`.
+  - : If the given attribute or property is being animated, it contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, it contains the same value as `baseVal`.
 
 ## Instance methods
 

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -7,77 +7,45 @@ browser-compat: api.SVGAnimatedEnumeration
 
 {{APIRef("SVG")}}
 
-## SVG animated enumeration interface
-
-The `SVGAnimatedEnumeration` interface is used for attributes whose value must be a constant from a particular enumeration and which can be animated.
-
-### Interface overview
-
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="row">Also implement</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Methods</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Properties</th>
-      <td>
-        <ul>
-          <li>unsigned short <code>baseVal</code></li>
-          <li>readonly unsigned short <code>animVal</code></li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Normative document</th>
-      <td>
-        <a
-          href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedEnumeration"
-          >SVG 1.1 (2nd Edition)</a
-        >
-      </td>
-    </tr>
-  </tbody>
-</table>
+The **`SVGAnimatedEnumeration`** interface descrobes attributes value which are constants from a particular enumeration and which can be animated.
 
 ## Instance properties
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>baseVal</code></td>
-      <td>unsigned short</td>
-      <td>
-        The base value of the given attribute before applying any animations.
-      </td>
-    </tr>
-    <tr>
-      <td><code>animVal</code></td>
-      <td>unsigned short</td>
-      <td>
-        If the given attribute or property is being animated, contains the
-        current animated value of the attribute or property. If the given
-        attribute or property is not currently being animated, contains the same
-        value as <code>baseVal</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+- {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}
+  - : An integer that is the base value of the given attribute before applying any animations.
+- {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}
+  - : If the given attribute or property is being animated, contains thecurrent animated value of the attribute or property. If the given attribute or property is not currently being animated, contains the same value as `baseVal`.
 
 ## Instance methods
 
 The `SVGAnimatedEnumeration` interface do not provide any specific methods.
+
+## Examples
+
+Considering this snippet with a {{SVGElement("clipPath")}} element. Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
+
+```html
+<svg viewbox="0 0 100 100" width="200" height="200">
+  <clipPath id="clip1" clipPathUnits="userSpaceOnUse">
+    <circle cx="50" cy="50" r="35" />
+  </clipPath>
+
+  <!-- Some reference rect to materialized to clip path -->
+  <rect id="r1" x="0" y="0" width="45" height="45" />
+</svg>
+```
+
+This snippet gets the element, and logs the `baseVal` and `animVal`of the {{domxref("SVGClipPathElement.clipPathUnits")}} property. As no animation is happening, they have the same value.
+
+```js
+const clipPathElt = document.getElementById("clip1");
+console.log(clipPathElt.clipPathUnits.baseVal); // Logs 1 that correspond to userSpaceOnUse
+console.log(clipPathElt.clipPathUnits.animVal); // Logs 1 that correspond to userSpaceOnUse
+```
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -18,9 +18,9 @@ An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The
 - `0` (`SVG_UNIT_TYPE_UNKWOWN`)
   - : The type is not one of the predefined type.
 - `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
-  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
+  - : Corresponds to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
 - `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
-  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the clipping path is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+  - : Corresponds to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the clipping path is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
 
 ## Examples
 

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -18,7 +18,7 @@ An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The
 - `0` (`SVG_UNIT_TYPE_UNKWOWN`)
   - : The type is not one of the predefined type.
 - `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
-  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}}attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
+  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
 - `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
   - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the clipping path is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
 

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGClipPathElement.clipPathUnits
 
 {{APIRef("SVG")}}
 
-The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("clipPathUnits")}} attribute of a {{SVGElement("clipPath")}} element and by that defines the coordinate system to use for the content of the element.
+The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("clipPathUnits")}} attribute of a {{SVGElement("clipPath")}} element which defines the coordinate system to use for the content of the element.
 
 > **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
 

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -1,0 +1,87 @@
+---
+title: SVGClipPathElement.clipPathUnits
+slug: Web/API/SVGClipPathElement/clipPathUnits
+page-type: web-api-instance-property
+browser-compat: api.SVGClipPathElement.clipPathUnits
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("clipPathUnits")}} attribute of a {{SVGElement("clipPath")}} element and by that defines the coordinate system to use for the content of the element.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are the one defined in the {{domxref("SVGUnitTypes")}} interface:
+
+- `0` (`SVG_UNIT_TYPE_UNKWOWN`)
+  - : The type is not one of the predefined type.
+- `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
+  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}}attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
+- `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
+  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the clipping path is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewbox="0 0 100 100" width="200" height="200">
+    <clipPath id="clip1" clipPathUnits="userSpaceOnUse">
+      <circle cx="50" cy="50" r="35" />
+    </clipPath>
+
+    <clipPath id="clip2" clipPathUnits="objectBoundingBox">
+      <circle cx=".5" cy=".5" r=".35" />
+    </clipPath>
+
+    <!-- Some reference rect to materialized to clip path -->
+    <rect id="r1" x="0" y="0" width="45" height="45" />
+    <rect id="r2" x="0" y="55" width="45" height="45" />
+    <rect id="r3" x="55" y="55" width="45" height="45" />
+    <rect id="r4" x="55" y="0" width="45" height="45" />
+
+    <!-- The first 3 rect are clipped with userSpaceOnUse units -->
+    <use clip-path="url(#clip1)" xlink:href="#r1" fill="red" />
+    <use clip-path="url(#clip1)" xlink:href="#r2" fill="blue" />
+    <use clip-path="url(#clip1)" xlink:href="#r3" fill="yellow" />
+
+    <!-- The last rect is clipped with objectBoundingBox units -->
+    <use clip-path="url(#clip2)" xlink:href="#r4" fill="green" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const clipPath1 = document.getElementById("clip1");
+const clipPath2 = document.getElementById("clip2");
+
+const log = document.getElementById("log");
+
+log.textContent = `The clipPath used three times has a 'clipPathUnits' value of ${clipPath1.clipPathUnits.baseVal}
+The clipPath used three times has a 'clipPathUnits' value of ${clipPath2.clipPathUnits.baseVal}`;
+```
+
+{{EmbedLiveSample("Examples", "280", "260")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{SVGAttr("clipPathUnits")}}
+- {{SVGElement("clipPath")}}

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -13,7 +13,7 @@ The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement"
 
 ## Value
 
-An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are the one defined in the {{domxref("SVGUnitTypes")}} interface:
+An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
 
 - `0` (`SVG_UNIT_TYPE_UNKWOWN`)
   - : The type is not one of the predefined type.

--- a/files/en-us/web/api/svgclippathelement/index.md
+++ b/files/en-us/web/api/svgclippathelement/index.md
@@ -16,7 +16,9 @@ The **`SVGClipPathElement`** interface provides access to the properties of {{SV
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGClipPathElement.clipPathUnits")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("clipPathUnits")}} attribute of the given {{SVGElement("clipPath")}} element. Takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
+  - : Returns an {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("clipPathUnits")}} attribute of the associated {{SVGElement("clipPath")}} element. Takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
+- {{domxref("SVGClipPathElement.transform")}} {{ReadOnlyInline}}
+  - : Returns an {{domxref("SVGAnimatedTransformList")}} corresponding to the {{SVGAttr("transform")}} attribute of the associated {{SVGElement("clipPath")}} element.
 
 ## Instance methods
 

--- a/files/en-us/web/api/svgclippathelement/transform/index.md
+++ b/files/en-us/web/api/svgclippathelement/transform/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGClipPathElement.transform
 
 {{APIRef("SVG")}}
 
-The read-only **`transform`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("transform")}} attribute of a {{SVGElement("clipPath")}} element, that is a list of transformation applied to the element.
+The read-only **`transform`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("transform")}} attribute of a {{SVGElement("clipPath")}} element, that is a list of transformations applied to the element.
 
 ## Value
 

--- a/files/en-us/web/api/svgclippathelement/transform/index.md
+++ b/files/en-us/web/api/svgclippathelement/transform/index.md
@@ -1,0 +1,80 @@
+---
+title: SVGClipPathElement.transform
+slug: Web/API/SVGClipPathElement/transform
+page-type: web-api-instance-property
+browser-compat: api.SVGClipPathElement.transform
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`transform`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("transform")}} attribute of a {{SVGElement("clipPath")}} element, that is a list of transformation applied to the element.
+
+## Value
+
+A {{domxref("SVGTransformList")}}.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewbox="0 0 100 100" width="200" height="200">
+    <clipPath
+      id="clip1"
+      clipPathUnits="objectBoundingBox"
+      transform="skewX(40) scale(1 0.5)">
+      <circle cx=".5" cy=".5" r=".35" />
+    </clipPath>
+
+    <rect id="r1" x="0" y="0" width="100" height="100" />
+
+    <use clip-path="url(#clip1)" xlink:href="#r1" fill="lightblue" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const translateType = [
+  "unknown",
+  "matrix()",
+  "translate()",
+  "scale()",
+  "rotate()",
+  "skewx()",
+  "skewy()",
+];
+
+const clipPath1 = document.getElementById("clip1");
+
+const log = document.getElementById("log");
+
+let result = "The following transformation have been applied:\n";
+for (const transform of clipPath1.transform.baseVal) {
+  result += `- A transform of type '${translateType[transform.type]}' found.\n`;
+}
+
+log.textContent = result;
+```
+
+{{EmbedLiveSample("Examples", "280", "280")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{SVGAttr("clipPathUnits")}}
+- {{SVGElement("clipPath")}}

--- a/files/en-us/web/api/svgunittypes/index.md
+++ b/files/en-us/web/api/svgunittypes/index.md
@@ -13,34 +13,12 @@ The **`SVGUnitTypes`** interface defines a commonly used set of constants used f
 
 ## Constants
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th>Name</th>
-      <th>Value</th>
-      <th>Description</th>
-    </tr>
-    <tr>
-      <td><code>SVG_UNIT_TYPE_UNKNOWN</code></td>
-      <td>0</td>
-      <td>
-        The type is not one of predefined types. It is invalid to attempt to
-        define a new value of this type or to attempt to switch an existing
-        value to this type.
-      </td>
-    </tr>
-    <tr>
-      <td><code>SVG_UNIT_TYPE_USERSPACEONUSE</code></td>
-      <td>1</td>
-      <td>Corresponds to the value <code>userSpaceOnUse</code>.</td>
-    </tr>
-    <tr>
-      <td><code>SVG_UNIT_TYPE_OBJECTBOUNDINGBOX</code></td>
-      <td>2</td>
-      <td>Corresponds to the value <code>objectBoundingBox</code>.</td>
-    </tr>
-  </tbody>
-</table>
+- `SVG_UNIT_TYPE_UNKNOWN` (0)
+  - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+- `SVG_UNIT_TYPE_USERSPACEONUSE` (1)
+  - : Corresponds to the value `userSpaceOnUse`.
+- `SVG_UNIT_TYPE_OBJECTBOUNDINGBOX` (2)
+  - : Corresponds to the value `objectBoundingBox`.
 
 ## Instance properties
 


### PR DESCRIPTION
### Description

Create docs for `SVGClipPathElement.clipPathUnits` and `SVGClipPathElement.transform`

### Motivation

This is part of openwebdocs/project#152

### Additional details

You fall into at least one rabbit hole when you touch the SVG docs. In this case, I had to:
- Fix `SVGClipPathElement` that was incomplete.
- Fix `SVGUnitTypes` that was old school.
- Fix `SVGAnimatedEnumeration` that was even older school.
- Add `SVGAnimatedEnumeration.baseVal` and `animVal`.

Having practical examples for the latest was not trivial (as animated enumeration is not very interesting to demonstrate).

I didn't fall further into the rabbit hole as I limited myself to what was needed to avoid flaws in these files.

### Related issues and pull requests

_None._
