### PR TITLE
Clarify relationship between readystate=interactive and DOMContentLoaded

### DIFF
--- a/files/en-us/web/api/document/readystate/index.md
+++ b/files/en-us/web/api/document/readystate/index.md
@@ -18,7 +18,8 @@ The `readyState` of a document can be one of following:
   - : The {{domxref("document")}} is still loading.
 - `interactive`
   - : The document has finished loading and the document has been parsed but sub-resources
-    such as scripts, images, stylesheets and frames are still loading.
+    such as scripts, images, stylesheets and frames are still loading. The state indicates that
+    the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event is about to fire.
 - `complete`
   - : The document and all sub-resources have finished loading. The state indicates that
     the {{domxref("Window/load_event", "load")}} event is about to fire.


### PR DESCRIPTION
### Description

Clarify relationship between `readystate=interactive` and `DOMContentLoaded`

### Motivation

`complete` bullet point mentions "the {{domxref("Window/load_event", "load")}} event is about to fire", but `interactive` bullet point neglects to mention its relationship to `DOMContentLoaded`

### Additional details

N/A

### Related issues and pull requests

N/A