### PR TITLE
Document SVGMaskElement.* members

### DIFF
--- a/files/en-us/web/api/svganimatedlength/animval/index.md
+++ b/files/en-us/web/api/svganimatedlength/animval/index.md
@@ -1,0 +1,61 @@
+---
+title: SVGAnimatedLength.animVal
+slug: Web/API/SVGAnimatedLength/animVal
+page-type: web-api-instance-property
+browser-compat: api.SVGAnimatedLength.animVal
+---
+
+{{APIRef("SVG")}}
+
+The **`animVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the value as the {{domxref("SVGAnimatedLength.baseVal", "baseVal")}}.
+
+## Value
+
+An {{domxref("SVGLength")}} containing the current value of the enumeration.
+
+## Examples
+
+```html
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 100 100"
+  width="200"
+  height="200">
+  <circle cx="50" cy="50" r="20" fill="gold" id="circle">
+    <animate
+      attributeName="r"
+      values="20;25;10;20"
+      dur="8s"
+      repeatCount="indefinite" />
+  </circle>
+</svg>
+<pre id="log"></pre>
+```
+
+```js
+const circle = document.getElementById("circle");
+const log = document.getElementById("log");
+
+function displayLog() {
+  const animValue = circle.r.animVal.value;
+  const baseValue = circle.r.baseVal.value;
+  log.textContent = `The 'circle.r.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'circle.r.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample("Examples", "280", "260")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGAnimatedLength.baseVal")}}

--- a/files/en-us/web/api/svganimatedlength/animval/index.md
+++ b/files/en-us/web/api/svganimatedlength/animval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedLength.animVal
 
 {{APIRef("SVG")}}
 
-The **`animVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedLength.baseVal", "baseVal")}}.
+The **`animVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the current value of an SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedLength.baseVal", "baseVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedlength/animval/index.md
+++ b/files/en-us/web/api/svganimatedlength/animval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedLength.animVal
 
 {{APIRef("SVG")}}
 
-The **`animVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the value as the {{domxref("SVGAnimatedLength.baseVal", "baseVal")}}.
+The **`animVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the current value of a SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedLength.baseVal", "baseVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedlength/baseval/index.md
+++ b/files/en-us/web/api/svganimatedlength/baseval/index.md
@@ -7,7 +7,7 @@ browser-compat: api.SVGAnimatedEnumeration.baseVal
 
 {{APIRef("SVG")}}
 
-The **`baseVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the initial value of a SVG enumeration.
+The **`baseVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the initial value of an SVG enumeration.
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedlength/baseval/index.md
+++ b/files/en-us/web/api/svganimatedlength/baseval/index.md
@@ -1,0 +1,63 @@
+---
+title: SVGAnimatedLength.baseVal
+slug: Web/API/SVGAnimatedLength/baseVal
+page-type: web-api-instance-property
+browser-compat: api.SVGAnimatedEnumeration.baseVal
+---
+
+{{APIRef("SVG")}}
+
+The **`baseVal`** property of the {{domxref("SVGAnimatedLength")}} interface contains the initial value of a SVG enumeration.
+
+## Value
+
+A {{domxref("SVGLength")}} containing the initial value of the length.
+
+## Examples
+
+```html
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 100 100"
+  width="200"
+  height="200">
+  <circle cx="50" cy="50" r="20px" fill="gold" id="circle"></circle>
+</svg>
+<pre id="log"></pre>
+```
+
+```js
+const unit = [
+  "unknown",
+  "",
+  "%",
+  "em",
+  "ex",
+  "px",
+  "cm",
+  "mm",
+  "in",
+  "pt",
+  "pc",
+];
+const circle = document.getElementById("circle");
+const log = document.getElementById("log");
+const baseValue = circle.r.baseVal.value;
+const baseUnit = unit[circle.r.baseVal.unitType];
+
+log.textContent = `The 'circle.r.baseVal' is ${baseValue} (in ${baseUnit}).`;
+```
+
+{{EmbedLiveSample("Examples", "280", "260")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGAnimatedLength.animVal")}}

--- a/files/en-us/web/api/svganimatedlength/index.md
+++ b/files/en-us/web/api/svganimatedlength/index.md
@@ -7,17 +7,17 @@ browser-compat: api.SVGAnimatedLength
 
 {{APIRef("SVG")}}
 
-The `SVGAnimatedLength` interface represents attributes of type [\<length>](/en-US/docs/Web/SVG/Content_type#length) which can be animated.
+The **`SVGAnimatedLength`** interface represents attributes of type [\<length>](/en-US/docs/Web/SVG/Content_type#length) which can be animated.
 
 ## Instance properties
 
-- {{domxref("baseVal")}} {{ReadOnlyInline}}
+- {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} {{ReadOnlyInline}}
   - : A {{domxref("SVGLength")}} representing the base value of the given attribute before applying any animations.
-- {{domxref("animVal")}} {{ReadOnlyInline}}
+- {{domxref("SVGAnimatedLength.animVal", "animVal")}} {{ReadOnlyInline}}
   - : If the given attribute or property is being animated,
     a {{domxref("SVGLength")}} containing the current animated value of the attribute or property.
     If the given attribute or property is not currently being animated,
-    a {{domxref("SVGLength")}} containing the same value as <code>baseVal</code>.
+    a {{domxref("SVGLength")}} containing the same value as `baseVal`.
 
 ## Instance methods
 
@@ -30,3 +30,7 @@ _This interface does not implement any specific methods._
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("SVGLength")}}

--- a/files/en-us/web/api/svgmaskelement/height/index.md
+++ b/files/en-us/web/api/svgmaskelement/height/index.md
@@ -1,0 +1,76 @@
+---
+title: SVGMaskElement.height
+slug: Web/API/SVGMaskElement/height
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.height
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`height`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("height")}} attribute of the {{SVGElement("marker")}}.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `height` value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewBox="-10 -10 120 120" width="100" height="100">
+    <mask id="mask" x="0" maskUnits="objectBoundingBox">
+      <!-- Everything under a white pixel will be visible -->
+      <rect x="0" y="0" width="100" height="100" fill="white" />
+
+      <!-- Everything under a black pixel will be invisible -->
+      <path
+        d="M10,35 A20,20,0,0,1,50,35 A20,20,0,0,1,90,35 Q90,65,50,95 Q10,65,10,35 Z"
+        fill="black" />
+      <animate
+        attributeName="height"
+        values="144;0;144"
+        dur="5s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <polygon points="-10,110 110,110 110,-10" fill="orange" />
+
+    <!-- with this mask applied, we "punch" a heart shape hole into the circle -->
+    <circle cx="50" cy="50" r="50" mask="url(#mask)" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const mask = document.getElementById("mask");
+
+function displayLog() {
+  const animValue = mask.height.animVal.value;
+  const baseValue = mask.height.baseVal.value;
+  log.textContent = `The 'height.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'height.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample('Example', 100, 160)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
@@ -16,11 +16,11 @@ The read-only **`maskContentUnits`** property of the {{domxref("SVGMaskElement")
 An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
 
 - `0` (`SVG_UNIT_TYPE_UNKWOWN`)
-  - : The type is not one of the predefined type.
+  - : The type is not one of the predefined types.
 - `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
-  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("maskContentUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
+  - : Corresponds to a value of `userSpaceOnUse` for the {{SVGAttr("maskContentUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
 - `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
-  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+  - : Corresponds to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
 
 ## Examples
 

--- a/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
@@ -1,0 +1,104 @@
+---
+title: SVGMaskElement.maskContentUnits
+slug: Web/API/SVGMaskElement/maskContentUnits
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.maskContentUnits
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`maskContentUnits`** property of the {{domxref("SVGMaskElement")}} interface reflects the {{SVGAttr("maskContentUnits")}} attribute. It indicates which coordinate system to use for the contents of the {{SVGElement("mask")}} element.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
+
+- `0` (`SVG_UNIT_TYPE_UNKWOWN`)
+  - : The type is not one of the predefined type.
+- `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
+  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("maskContentUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
+- `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
+  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg
+    viewBox="0 0 100 100"
+    width="150"
+    height="150"
+    xmlns="http://www.w3.org/2000/svg">
+    <mask id="mask1" maskContentUnits="userSpaceOnUse">
+      <rect fill="black" x="0" y="0" width="100%" height="100%" />
+      <circle fill="white" cx="50" cy="50" r="35" />
+    </mask>
+
+    <mask id="mask2" maskContentUnits="objectBoundingBox">
+      <rect fill="black" x="0" y="0" width="100%" height="100%" />
+      <circle fill="white" cx=".5" cy=".5" r=".35" />
+      <animate
+        attributeName="maskContentUnits"
+        values="objectBoundingBox;userSpaceOnUse"
+        dur="1s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <!-- Some reference rect to materialized the mask -->
+    <rect id="r1" x="0" y="0" width="45" height="45" />
+    <rect id="r2" x="0" y="55" width="45" height="45" />
+    <rect id="r3" x="55" y="55" width="45" height="45" />
+    <rect id="r4" x="55" y="0" width="45" height="45" />
+
+    <!-- The first 3 rect are masked with useSpaceOnUse units -->
+    <use mask="url(#mask1)" xlink:href="#r1" fill="blue" />
+    <use mask="url(#mask1)" xlink:href="#r2" fill="yellow" />
+    <use mask="url(#mask1)" xlink:href="#r3" fill="green" />
+
+    <!-- The last rect is masked with objectBoundingBox units -->
+    <use mask="url(#mask2)" xlink:href="#r4" fill="lightblue" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const unitType = ["unknown", "userSpaceOnUse", "objectBoundingBox"];
+
+const mask = document.getElementById("mask2");
+const log = document.getElementById("log");
+
+function displayLog() {
+  const baseValue = unitType[mask.maskContentUnits.baseVal];
+  const animValue = unitType[mask.maskContentUnits.animVal];
+  log.textContent = `The top-right 'maskContentUnits.baseVal' coord system : ${baseValue}\n`;
+  log.textContent += `The top-right 'maskContentUnits.animVal' coord system : ${animValue}`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample("Examples", "280", "220")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{SVGAttr("maskContentUnits")}}
+- {{SVGElement("mask")}}

--- a/files/en-us/web/api/svgmaskelement/maskunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskunits/index.md
@@ -1,0 +1,116 @@
+---
+title: SVGMaskElement.maskUnits
+slug: Web/API/SVGMaskElement/maskUnits
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.maskUnits
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`maskUnits`** property of the {{domxref("SVGMaskElement")}} interface reflects the {{SVGAttr("maskUnits")}} attribute of a {{SVGElement("mask")}} element which defines the coordinate system to use for the mask of the element.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
+
+- `0` (`SVG_UNIT_TYPE_UNKWOWN`)
+  - : The type is not one of the predefined type.
+- `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
+  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("maskUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
+- `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
+  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg
+    viewBox="0 0 100 100"
+    height="200"
+    width="200"
+    xmlns="http://www.w3.org/2000/svg">
+    <mask
+      id="mask1"
+      maskUnits="userSpaceOnUse"
+      x="20%"
+      y="20%"
+      width="60%"
+      height="60%">
+      <rect fill="black" x="0" y="0" width="100%" height="100%" />
+      <circle fill="white" cx="50" cy="50" r="35" />
+    </mask>
+
+    <mask
+      id="mask2"
+      maskUnits="objectBoundingBox"
+      x="20%"
+      y="20%"
+      width="60%"
+      height="60%">
+      <rect fill="black" x="0" y="0" width="100%" height="100%" />
+      <circle fill="white" cx="50" cy="50" r="35" />
+      <animate
+        attributeName="maskUnits"
+        values="objectBoundingBox;userSpaceOnUse"
+        dur="1s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <!-- Some reference rect to materialized the mask -->
+    <rect id="r1" x="0" y="0" width="45" height="45" />
+    <rect id="r2" x="0" y="55" width="45" height="45" />
+    <rect id="r3" x="55" y="55" width="45" height="45" />
+    <rect id="r4" x="55" y="0" width="45" height="45" />
+
+    <!-- The first 3 rect are masked with useSpaceOnUse units -->
+    <use mask="url(#mask1)" xlink:href="#r1" fill="blue" />
+    <use mask="url(#mask1)" xlink:href="#r2" fill="green" />
+    <use mask="url(#mask1)" xlink:href="#r3" fill="yellow" />
+
+    <!-- The last rect is masked with objectBoundingBox units -->
+    <use mask="url(#mask2)" xlink:href="#r4" fill="lightblue" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const unitType = ["unknown", "userSpaceOnUse", "objectBoundingBox"];
+
+const mask = document.getElementById("mask2");
+const log = document.getElementById("log");
+
+function displayLog() {
+  const baseValue = unitType[mask.maskUnits.baseVal];
+  const animValue = unitType[mask.maskUnits.animVal];
+  log.textContent = `The top-right 'maskUnits.baseVal' coord system : ${baseValue}\n`;
+  log.textContent += `The top-right 'maskUnits.animVal' coord system : ${animValue}`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample("Examples", "280", "260")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{SVGAttr("maskUnits")}}
+- {{SVGElement("mask")}}

--- a/files/en-us/web/api/svgmaskelement/maskunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskunits/index.md
@@ -16,11 +16,11 @@ The read-only **`maskUnits`** property of the {{domxref("SVGMaskElement")}} inte
 An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
 
 - `0` (`SVG_UNIT_TYPE_UNKWOWN`)
-  - : The type is not one of the predefined type.
+  - : The type is not one of the predefined types.
 - `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
-  - : Corresponding to a value of `userSpaceOnUse` for the {{SVGAttr("maskUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
+  - : Corresponds to a value of `userSpaceOnUse` for the {{SVGAttr("maskUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the mask was created. It is the default value.
 - `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)
-  - : Corresponding to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
+  - : Corresponds to a value of `objectBoundingBox` for the attribute and means that all coordinates inside the element are relative to the bounding box of the element the mask is applied to. It means that the origin of the coordinate system is the top left corner of the object bounding box and the width and height of the object bounding box are considered to have a length of 1 unit value.
 
 ## Examples
 

--- a/files/en-us/web/api/svgmaskelement/width/index.md
+++ b/files/en-us/web/api/svgmaskelement/width/index.md
@@ -1,0 +1,76 @@
+---
+title: SVGMaskElement.width
+slug: Web/API/SVGMaskElement/width
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.width
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`width`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("width")}} attribute of the {{SVGElement("marker")}}.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `width` value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewBox="-10 -10 120 120" width="100" height="100">
+    <mask id="mask" x="0" maskUnits="objectBoundingBox">
+      <!-- Everything under a white pixel will be visible -->
+      <rect x="0" y="0" width="100" height="100" fill="white" />
+
+      <!-- Everything under a black pixel will be invisible -->
+      <path
+        d="M10,35 A20,20,0,0,1,50,35 A20,20,0,0,1,90,35 Q90,65,50,95 Q10,65,10,35 Z"
+        fill="black" />
+      <animate
+        attributeName="width"
+        values="144;0;144"
+        dur="5s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <polygon points="-10,110 110,110 110,-10" fill="orange" />
+
+    <!-- with this mask applied, we "punch" a heart shape hole into the circle -->
+    <circle cx="50" cy="50" r="50" mask="url(#mask)" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const mask = document.getElementById("mask");
+
+function displayLog() {
+  const animValue = mask.width.animVal.value;
+  const baseValue = mask.width.baseVal.value;
+  log.textContent = `The 'width.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'width.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample('Example', 100, 160)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgmaskelement/x/index.md
+++ b/files/en-us/web/api/svgmaskelement/x/index.md
@@ -1,0 +1,76 @@
+---
+title: SVGMaskElement.x
+slug: Web/API/SVGMaskElement/x
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.x
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`x`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("x")}} attribute of the {{SVGElement("mask")}}. It represents the x-axis coordinate of the _top-left_ corner of the masking area.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedLength")}} object in the coordinate system defined by {{domxref("SVGMaskElement.maskUnits")}}. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the initial `x` value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewBox="-10 -10 120 120" width="100" height="100">
+    <mask id="mask" x="0" maskUnits="userSpaceOnUse">
+      <!-- Everything under a white pixel will be visible -->
+      <rect x="0" y="0" width="100" height="100" fill="white" />
+
+      <!-- Everything under a black pixel will be invisible -->
+      <path
+        d="M10,35 A20,20,0,0,1,50,35 A20,20,0,0,1,90,35 Q90,65,50,95 Q10,65,10,35 Z"
+        fill="black" />
+      <animate
+        attributeName="x"
+        values="0;80;0"
+        dur="5s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <polygon points="-10,110 110,110 110,-10" fill="orange" />
+
+    <!-- with this mask applied, we "punch" a heart shape hole into the circle -->
+    <circle cx="50" cy="50" r="50" mask="url(#mask)" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const mask = document.getElementById("mask");
+
+function displayLog() {
+  const animValue = mask.x.animVal.value;
+  const baseValue = mask.x.baseVal.value;
+  log.textContent = `The 'x.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'x.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample('Example', 100, 160)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgmaskelement/y/index.md
+++ b/files/en-us/web/api/svgmaskelement/y/index.md
@@ -1,0 +1,76 @@
+---
+title: SVGMaskElement.y
+slug: Web/API/SVGMaskElement/y
+page-type: web-api-instance-property
+browser-compat: api.SVGMaskElement.y
+---
+
+{{APIRef("SVG")}}
+
+The read-only **`y`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("y")}} attribute of the {{SVGElement("marker")}}. It represents the y-axis coordinate of the _top-left_ corner of the masking area.
+
+> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+
+## Value
+
+An {{domxref("SVGAnimatedLength")}} object. The `baseVal` property of this object returns an {{domxref("SVGLength")}}, the value of which returns the `y` value.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<div>
+  <svg viewBox="-10 -10 120 120" width="100" height="100">
+    <mask id="mask" x="0" maskUnits="userSpaceOnUse">
+      <!-- Everything under a white pixel will be visible -->
+      <rect x="0" y="0" width="100" height="100" fill="white" />
+
+      <!-- Everything under a black pixel will be invisible -->
+      <path
+        d="M10,35 A20,20,0,0,1,50,35 A20,20,0,0,1,90,35 Q90,65,50,95 Q10,65,10,35 Z"
+        fill="black" />
+      <animate
+        attributeName="y"
+        values="0;80;0"
+        dur="5s"
+        repeatCount="indefinite" />
+    </mask>
+
+    <polygon points="-10,110 110,110 110,-10" fill="orange" />
+
+    <!-- with this mask applied, we "punch" a heart shape hole into the circle -->
+    <circle cx="50" cy="50" r="50" mask="url(#mask)" />
+  </svg>
+</div>
+<pre id="log"></pre>
+```
+
+```js
+const mask = document.getElementById("mask");
+
+function displayLog() {
+  const animValue = mask.y.animVal.value;
+  const baseValue = mask.y.baseVal.value;
+  log.textContent = `The 'y.animVal' is ${animValue}.\n`;
+  log.textContent += `The 'y.baseVal' is ${baseValue}.`;
+  requestAnimationFrame(displayLog);
+}
+displayLog();
+```
+
+{{EmbedLiveSample('Example', 100, 160)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
### Description

Document the members of `SVGMaskElement`

### Motivation

This part of openwebdocs/project#152

### Additional details

To prevent the creation of new flaws:
- I documented `SVGAnimatedLength.animVal`
- I documented `SVGAnimatedLength.baseVal`
- I updated `SVGAnimatedLength` to match the modern structure

### Related issues and pull requests

There are 2 times 2 flaws left, but they will be fixed when #25340 is merged.