### PR TITLE
Updated line at which the max age for Access-Control-Max-Age is defined

### DIFF
--- a/files/en-us/web/http/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/headers/access-control-max-age/index.md
@@ -31,7 +31,7 @@ Access-Control-Max-Age: <delta-seconds>
 
 - \<delta-seconds>
   - : Maximum number of seconds the results can be cached, as an unsigned non-negative integer.
-    Firefox [caps this at 24 hours](https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1118) (86400 seconds).
+    Firefox [caps this at 24 hours](https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1207) (86400 seconds).
     Chromium (prior to v76) [caps at 10 minutes](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=52002151773d8cd9ffc5f557cd7cc880fddcae3e;l=36) (600 seconds).
     Chromium (starting in v76) [caps at 2 hours](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa;l=31) (7200 seconds).
     The default value is 5 seconds.


### PR DESCRIPTION
### Description
Relates to: [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age)
The line at which the max age for the Access-Control-Max-Age header was defined, had changed. This PR fixes that

### Motivation

Keeps the docs updated.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1207
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
