### PR TITLE
ci(issue-regex-labeler): remove sync-labels option

### DIFF
--- a/.github/workflows/issue-regex-labeler.yml
+++ b/.github/workflows/issue-regex-labeler.yml
@@ -12,4 +12,3 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/issue-regex-labeler.yml
           enable-versioned-regex: 0
-          sync-labels: 1


### PR DESCRIPTION
### Description

Fixes https://github.com/mdn/content/issues/25373.

Removes the `sync-labels` option from the `github/issue-labeler` action in the `issue-regex-labeler` workflow.

### Motivation

github/issue-labeler v3 introduced the following breaking change: "Issue labels that do not match a regex will no longer be removed by default unless you set sync-labels: to 1"

So we added `sync-labels: 1` to keep the previous behavior.

However, we only label new issues, not existing issues, so the action does not need to sync or remove any labels.

### Additional details

See [this failing workflow run](https://github.com/mdn/content/actions/runs/4431085608/jobs/7773623770).

### Related issues and pull requests

See also:
- https://github.com/github/issue-labeler/issues/46