### PR TITLE
Add case of 0 elements for functions accepting any number of arguments and give length limit

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -159,6 +159,7 @@ filter(function (currentValue, index, array) {
 For methods that accept an arbitrary number of parameters, the syntax block is written like this:
 
 ```js
+unshift();
 unshift(element0);
 unshift(element0, element1);
 unshift(element0, element1, /* … ,*/ elementN);

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -13,14 +13,16 @@ The **`Array()`** constructor is used to create {{jsxref("Array")}} objects.
 
 ```js-nolint
 new Array()
-new Array(element0OrLength)
+new Array(element0)
 new Array(element0, element1)
 new Array(element0, element1, /* … ,*/ elementN)
+new Array(arrayLength)
 
 Array()
-Array(element0OrLength)
+Array(element0)
 Array(element0, element1)
 Array(element0, element1, /* … ,*/ elementN)
+Array(arrayLength)
 ```
 
 > **Note:** `Array()` can be called with or without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Both create a new `Array` instance.
@@ -43,7 +45,7 @@ Array(element0, element1, /* … ,*/ elementN)
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : Thrown if there's only one argument (`arrayLength`) and its value is not between 0 and 2<sup>32</sup> - 1 (inclusive).
+  - : Thrown if there's only one argument (`arrayLength`) that is an integer with a value not between 0 and 2<sup>32</sup> - 1 (inclusive).
 
 ## Examples
 
@@ -61,15 +63,27 @@ console.log(fruits[0]); // "Apple"
 
 ### Array constructor with a single parameter
 
-Arrays can be created using a constructor with a single number parameter. An array with
-its `length` property set to that number and the array elements are empty
+Arrays can be created using a constructor with a single number parameter. An array is created with
+its `length` property set to that number, and the array elements are empty
 slots.
 
 ```js
-const fruits = new Array(2);
+const arrayEmpty = new Array(2);
 
-console.log(fruits.length); // 2
-console.log(fruits[0]); // undefined
+console.log(arrayEmpty.length); // 2
+console.log(arrayEmpty[0]); // undefined
+                            // undefined displayed, but actually an empty slot
+console.log(0 in arrayEmpty); // false
+console.log(1 in arrayEmpty); // false
+```
+
+```js
+const arrayOfOne = new Array("2"); // Not the number 2 but the string "2"
+
+console.log(arrayOfOne.length); // 1
+console.log(arrayOfOne[0]); // "2" or 2 depending on where it is run
+                            // However, the actual value is the string "2" 
+console.log(arrayOfOne[0] === "2"); // true
 ```
 
 ### Array constructor with multiple parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -12,11 +12,15 @@ The **`Array()`** constructor is used to create {{jsxref("Array")}} objects.
 ## Syntax
 
 ```js-nolint
+new Array()
+new Array(element0OrLength)
+new Array(element0, element1)
 new Array(element0, element1, /* … ,*/ elementN)
-new Array(arrayLength)
 
+Array()
+Array(element0OrLength)
+Array(element0, element1)
 Array(element0, element1, /* … ,*/ elementN)
-Array(arrayLength)
 ```
 
 > **Note:** `Array()` can be called with or without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Both create a new `Array` instance.

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -45,7 +45,7 @@ Array(arrayLength)
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : Thrown if there's only one argument (`arrayLength`) that is an integer with a value not between 0 and 2<sup>32</sup> - 1 (inclusive).
+  - : Thrown if there's only one argument (`arrayLength`) that is a number, but its value is not an integer or not between 0 and 2<sup>32</sup> - 1 (inclusive).
 
 ## Examples
 
@@ -71,8 +71,7 @@ slots.
 const arrayEmpty = new Array(2);
 
 console.log(arrayEmpty.length); // 2
-console.log(arrayEmpty[0]); // undefined
-                            // undefined displayed, but actually an empty slot
+console.log(arrayEmpty[0]); // undefined; actually, it is an empty slot
 console.log(0 in arrayEmpty); // false
 console.log(1 in arrayEmpty); // false
 ```
@@ -81,9 +80,7 @@ console.log(1 in arrayEmpty); // false
 const arrayOfOne = new Array("2"); // Not the number 2 but the string "2"
 
 console.log(arrayOfOne.length); // 1
-console.log(arrayOfOne[0]); // "2" or 2 depending on where it is run
-                            // However, the actual value is the string "2" 
-console.log(arrayOfOne[0] === "2"); // true
+console.log(arrayOfOne[0]); // "2"
 ```
 
 ### Array constructor with multiple parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -220,6 +220,8 @@ console.log(Array.prototype.join.call(arrayLike, "+")); // 'a+b'
 
 The `length` property is [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion) and then clamped to the range between 0 and 2<sup>53</sup> - 1. `NaN` becomes `0`, so even when `length` is not present or is `undefined`, it behaves as if it has value `0`.
 
+The language avoids setting `length` to an [unsafe integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). All built-in methods will throw a {{jsxref("TypeError")}} if `length` will be set to a number greater than 2<sup>53</sup> - 1. However, because the {{jsxref("Array/length", "length")}} property of arrays throws an error if it's set to greater than 2<sup>32</sup>, the safe integer threshold is usually not reached unless the method is called on a non-array object.
+
 ```js
 Array.prototype.flat.call({}); // []
 ```

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -16,6 +16,7 @@ arguments.
 ## Syntax
 
 ```js-nolint
+Array.of()
 Array.of(element0)
 Array.of(element0, element1)
 Array.of(element0, element1, /* … ,*/ elementN)

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.push
 
 {{JSRef}}
 
-The **`push()`** method adds zero or more elements to the end of
+The **`push()`** method adds the specified elements to the end of
 an array and returns the new length of the array.
 
 {{EmbedInteractiveExample("pages/js/array-push.html")}}
@@ -39,8 +39,6 @@ The `push()` method appends values to an array.
 The `push()` method is a mutating method. It changes the length and the content of `this`. In case you want the value of `this` to be the same, but return a new array with elements appended to the end, you can use [`arr.concat([element0, element1, /* ... ,*/ elementN])`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat) instead. Notice that the elements are wrapped in an extra array — otherwise, if the element is an array itself, it would be spread instead of pushed as a single element due to the behavior of `concat()`.
 
 The `push()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties. Although strings are also array-like, this method is not suitable to be applied on them, as strings are immutable.
-
-If there would be more than 2<sup>53</sup> - 1 elements after `push()` completes, a TypeError exception is thrown.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.push
 
 {{JSRef}}
 
-The **`push()`** method adds one or more elements to the end of
+The **`push()`** method adds zero or more elements to the end of
 an array and returns the new length of the array.
 
 {{EmbedInteractiveExample("pages/js/array-push.html")}}
@@ -15,6 +15,7 @@ an array and returns the new length of the array.
 ## Syntax
 
 ```js-nolint
+push()
 push(element0)
 push(element0, element1)
 push(element0, element1, /* … ,*/ elementN)
@@ -38,6 +39,8 @@ The `push()` method appends values to an array.
 The `push()` method is a mutating method. It changes the length and the content of `this`. In case you want the value of `this` to be the same, but return a new array with elements appended to the end, you can use [`arr.concat([element0, element1, /* ... ,*/ elementN])`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat) instead. Notice that the elements are wrapped in an extra array — otherwise, if the element is an array itself, it would be spread instead of pushed as a single element due to the behavior of `concat()`.
 
 The `push()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties. Although strings are also array-like, this method is not suitable to be applied on them, as strings are immutable.
+
+If there would be more than 2<sup>53</sup> - 1 elements after `push()` completes, a TypeError exception is thrown.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.unshift
 
 {{JSRef}}
 
-The **`unshift()`** method adds one or more elements to the
+The **`unshift()`** method adds the specified elements to the
 beginning of an array and returns the new length of the array.
 
 {{EmbedInteractiveExample("pages/js/array-unshift.html")}}
@@ -15,6 +15,7 @@ beginning of an array and returns the new length of the array.
 ## Syntax
 
 ```js-nolint
+unshift()
 unshift(element0)
 unshift(element0, element1)
 unshift(element0, element1, /* … ,*/ elementN)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -16,9 +16,10 @@ The **`TypedArray.of()`** static method creates a new
 ## Syntax
 
 ```js-nolint
+TypedArray.of()
 TypedArray.of(element0)
 TypedArray.of(element0, element1)
-TypedArray.of(element0, element1, /* ... ,*/ elementN)
+TypedArray.of(element0, element1, /* … ,*/ elementN)
 ```
 
 Where `TypedArray` is one of:


### PR DESCRIPTION
push() can validly be called with any number of arguments including zero, provided that the total number of elements after the push operation completes does not exceed (2**53) - 1.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
