### PR TITLE
Fixed a small typo (Change "Mage" to "Image")

### DIFF
--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -174,7 +174,7 @@ img:nth-of-type(2) {
 
 ```html
 <img src="pencil.jpg" alt="Original image is sharp" />
-<img src="pencil.jpg" alt="The mage and border are blurred and muted" />
+<img src="pencil.jpg" alt="The image and border are blurred and muted" />
 ```
 
 {{EmbedLiveSample('Applying_filter_functions','100%','229px')}}


### PR DESCRIPTION
This just fixes a small typo (Changes "mage" to "**i**mage") on the CSS filter page.

Changes:
![Location of the typo](https://i.ibb.co/GMc8pQq/Screenshot-2023-03-16-123456.png)
to:
![Fixed typo](https://i.ibb.co/JB6VJrX/image.png)