### PR TITLE
Link to eTLD glossary entry

### DIFF
--- a/files/en-us/mozilla/firefox/releases/92/index.md
+++ b/files/en-us/mozilla/firefox/releases/92/index.md
@@ -26,7 +26,7 @@ No changes
 ### JavaScript
 
 - {{jsxref("Object.hasOwn()")}} can be used to test whether a property was defined on an object or inherited ([Firefox bug 1721149](https://bugzil.la/1721149)).
-- The default 5MB storage quota is now available to each origin. The quota previously applied to an entire domain group (also known as eTLD+1 domain; e.g., `*.wikipedia.org`). ([Firefox bug 1064466](https://bugzil.la/1064466)).
+- The default 5MB storage quota is now available to each origin. The quota previously applied to an entire domain group (also known as {{Glossary("eTLD", "eTLD+1")}} domain; e.g., `*.wikipedia.org`). ([Firefox bug 1064466](https://bugzil.la/1064466)).
 - Storage quotas for {{domxref("Window.localStorage")}} are now shared with [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) and {{domxref("Cache", "Cache API")}} ([Firefox bug 742822](https://bugzil.la/742822)).
 
 ### HTTP

--- a/files/en-us/web/privacy/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/partitioned_cookies/index.md
@@ -35,7 +35,7 @@ Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 
 > **Note:** Partitioned cookies must be set with `Secure` and `Path=/`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
 
-With `Partitioned` set, the cookie is stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and [eTLD+1](https://web.dev/same-site-same-origin/#site) of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
+With `Partitioned` set, the cookie is stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 
 Revisiting the example we described in the previous section:
 

--- a/files/en-us/web/privacy/redirect_tracking_protection/index.md
+++ b/files/en-us/web/privacy/redirect_tracking_protection/index.md
@@ -25,7 +25,7 @@ An origin will be cleared if it fulfills the following conditions:
 
 1. It has stored cookies or accessed other site storage (e.g. [localStorage](/en-US/docs/Web/API/Web_Storage_API), [IndexedDB](/en-US/docs/Web/API/IndexedDB_API), or the [Cache API](/en-US/docs/Web/API/CacheStorage)) within the last 72 hours. Since cookies are per-host, we will clear both the `http` and `https` origin variants of a cookie host.
 2. The origin is [classified as a tracker](/en-US/docs/Web/Privacy/Storage_Access_Policy#tracking_protection_explained) in our Tracking Protection list.
-3. No origin with the same base domain (eTLD+1) has a user-interaction permission.
+3. No origin with the same base domain ({{Glossary("eTLD", "eTLD+1")}}) has a user-interaction permission.
 
    - This permission is granted to an origin for 45 days once a user interacts with a top-level document from that origin. "Interacting" includes scrolling.
    - Although this permission is stored on a per-origin level, we will check whether any origin with the same base domain has it, to avoid breaking sites with subdomains and a corresponding cookie setup.

--- a/files/en-us/web/privacy/state_partitioning/index.md
+++ b/files/en-us/web/privacy/state_partitioning/index.md
@@ -55,7 +55,7 @@ all client-side state by the
 _[origin](https://html.spec.whatwg.org/#origin)_
 of the resource being loaded and by the _top-level
 [site](https://html.spec.whatwg.org/multipage/origin.html#site)_.
-In most instances, the top-level site is the scheme and eTLD+1 of the top-level
+In most instances, the top-level site is the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level
 page being visited by the user.
 
 In the example below `example.com` is embedded in

--- a/files/en-us/web/privacy/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/index.md
@@ -81,7 +81,7 @@ HTTP Referrers
 1. This policy does not currently restrict third-party storage access for resources that are not classified as tracking resources. We may choose to apply additional restrictions to third-party storage access in the future.
 2. The restrictions applied by the policy will not prevent third-party scripts classified as tracking resources from accessing storage in the main context of the page. These scripts can continue to use storage scoped to the top-level origin.
 3. Origins classified as trackers will have access to their own storage when they are loaded in a first-party context.
-4. Cross-origin resources loaded from the same eTLD+1 as the top-level context will still have access to their storage.
+4. Cross-origin resources loaded from the same {{Glossary("eTLD", "eTLD+1")}} as the top-level context will still have access to their storage.
 5. Origins normally classified as trackers will [not be blocked if the top-level page origin is determined to be from the same organization as them](https://github.com/mozilla-services/shavar-prod-lists#entity-list).
 
 ## Storage access grants


### PR DESCRIPTION
Now we have a glossary entry for eTLD, this PR updates all our references to be links to it.

I didn't update https://github.com/mdn/content/blob/main/files/en-us/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.md because Patrick is working on it in https://github.com/mdn/content/pull/25019 and I didn't want to introduce a conflict.