### PR TITLE
FF112 navigator.getAutoplayPolicy() enabled on release

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1600,49 +1600,6 @@ The {{domxref('HTML Sanitizer API')}} allow developers to take untrusted strings
   </tbody>
 </table>
 
-#### Navigator method: getAutoplayPolicy()
-
-The {{domxref("navigator.getAutoplayPolicy()")}} method returns a string value indicating how the browser handles requests to automatically play media for either media elements or audio contexts.
-The possible values are: `allowed` (autoplay is currently permitted), `allowed-muted` (autoplay is allowed but only with no—or muted—audio), and `disallowed` (autoplay is not allowed at this time).
-The value can change over time for all items of a particular type, or for a particular item, depending on what the user is doing, their preferences, and the state of the browser in general.
-See [Firefox bug 1773551](https://bugzil.la/1773551) for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>110</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>110</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>110</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>110</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.media.autoplay-policy-detection.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 #### GeometryUtils methods: convertPointFromNode(), convertRectFromNode(), and convertQuadFromNode()
 
 The `GeometryUtils` methods `convertPointFromNode()`, `convertRectFromNode()`, and `convertQuadFromNode()` map the given point, rectangle, or quadruple from the {{domxref("Node")}} on which they're called to another node. (See [Firefox bug 918189](https://bugzil.la/918189) for more details.)

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -37,6 +37,9 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ### APIs
 
+- {{domxref("navigator.getAutoplayPolicy()")}} is now supported, allowing developers to configure [autoplay](/en-US/docs/Web/Media/Autoplay_guide) of media elements and audio contexts based on whether autoplay is allowed, disallowed, or only allowed if the audio is muted.
+  See [Firefox bug 1773551](https://bugzil.la/1773551) for more details.
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/api/navigator/getautoplaypolicy/index.md
+++ b/files/en-us/web/api/navigator/getautoplaypolicy/index.md
@@ -9,8 +9,6 @@ browser-compat: api.Navigator.getAutoplayPolicy
 
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
-{{SeeCompatTable}}
-
 The **`getAutoplayPolicy()`** method of the _Autoplay Policy Detection API_ provides information about whether [autoplay](/en-US/docs/Web/Media/Autoplay_guide) of media elements and audio contexts is allowed, disallowed, or only allowed if the audio is muted.
 
 Applications can use this information to provide an appropriate user experience.


### PR DESCRIPTION
FF112 releases [`navigator.getAutoplayPolicy()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getAutoplayPolicy) support  in https://bugzilla.mozilla.org/show_bug.cgi?id=1812189

This just removes the experimental feature note and adds a release note. Also removes a duplicate compat header in the API doc

Other docs work can be tracked in #25362
