### PR TITLE
FF112 Relnote: roundRect() supported in 2d canvasses

### DIFF
--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -39,6 +39,8 @@ This article provides information about the changes in Firefox 112 that affect d
 
 - {{domxref("navigator.getAutoplayPolicy()")}} is now supported, allowing developers to configure [autoplay](/en-US/docs/Web/Media/Autoplay_guide) of media elements and audio contexts based on whether autoplay is allowed, disallowed, or only allowed if the audio is muted.
   See [Firefox bug 1773551](https://bugzil.la/1773551) for more details.
+- Rounded rectangles can now be drawn in 2D canvases using {{domxref("CanvasRenderingContext2D.roundRect()")}}, [`Path2D.roundRect()`](/en-US/docs/Web/API/Path2D#path2d.roundrect) and [`OffscreenCanvasRenderingContext2D.roundRect()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.roundrect).
+  See [Firefox bug 1756175](https://bugzil.la/1756175) for more details.
 
 #### DOM
 


### PR DESCRIPTION
FF112 supports `roundRect()` in all the 2D canvas path drawing contexts (e.g. both offscreen and in main thread) in https://bugzilla.mozilla.org/show_bug.cgi?id=1756175

This adds a release note. 

Other docs work can be tracked in #25359