### PR TITLE
Add a link for "references"

### DIFF
--- a/files/en-us/glossary/shallow_copy/index.md
+++ b/files/en-us/glossary/shallow_copy/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{MDNSidebar}}
 
-A **shallow copy** of an object is a copy whose properties share the same [references](https://en.wikipedia.org/wiki/Reference_(computer_science)) (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
+A **shallow copy** of an object is a copy whose properties share the same [references](<https://en.wikipedia.org/wiki/Reference_(computer_science)>) (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
 
 For shallow copies, it's important to understand that selectively changing the value of a shared property of an existing element in an object is different from assigning a completely new value to an existing element.
 

--- a/files/en-us/glossary/shallow_copy/index.md
+++ b/files/en-us/glossary/shallow_copy/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{MDNSidebar}}
 
-A **shallow copy** of an object is a copy whose properties share the same [references](<https://en.wikipedia.org/wiki/Reference_(computer_science)>) (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
+A **shallow copy** of an object is a copy whose properties share the same [references](/en-US/docs/Glossary/Object_reference) (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
 
 For shallow copies, it's important to understand that selectively changing the value of a shared property of an existing element in an object is different from assigning a completely new value to an existing element.
 

--- a/files/en-us/glossary/shallow_copy/index.md
+++ b/files/en-us/glossary/shallow_copy/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{MDNSidebar}}
 
-A **shallow copy** of an object is a copy whose properties share the same references (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
+A **shallow copy** of an object is a copy whose properties share the same [references](https://en.wikipedia.org/wiki/Reference_(computer_science)) (point to the same underlying values) as those of the source object from which the copy was made. As a result, when you change either the source or the copy, you may also cause the other object to change too — and so, you may end up unintentionally causing changes to the source or copy that you don't expect. That behavior contrasts with the behavior of a [deep copy](/en-US/docs/Glossary/Deep_copy), in which the source and copy are completely independent.
 
 For shallow copies, it's important to understand that selectively changing the value of a shared property of an existing element in an object is different from assigning a completely new value to an existing element.
 


### PR DESCRIPTION
###  Description
Added a link for the "references" word by using Wikipedia as a source : [References](https://en.wikipedia.org/wiki/Reference_(computer_science)).

The reason I'm adding this: "A shallow copy of an object is a copy whose properties share the same references". That's true. But only for object properties. If the field value is a reference to an object (e.g., a memory address) it copies the reference, hence referring to the same object.

For instance :
```js
const obj1 = { a: 0, b: { c: 0 } };
const obj2 = Object.assign({}, obj1);

console.log(obj1.b === obj2.b) // true
```` 

### Motivation
Just using the "whose properties share the same 'references'" wasn't a clear explanation. And generally, references refer to the objects, as in my provided example above. So that's why I have added a link to ensure brevity for the rest of the article.
