### PR TITLE
Fix possible L values for oklab() and oklch()

### DIFF
--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -33,10 +33,10 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
 ### Values
 
 - Functional notation: `oklab(L a b [/ A])`
-  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies perceived lightness where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white).
-  - `a` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`, specifying the distance along the `a` axis in the Oklab colorspace, that is how green/red the color is.
-  - `b` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`, specifying the distance along the `b` axis in the Oklab colorspace, that is how blue/yellow the color is.
-  - `A` is a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity), representing the transparency (or alpha channel) of the color.
+  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%`, where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white). `L` specifies the perceived lightness.
+  - `a` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`. It specifies the distance along the `a` axis in the Oklab colorspace, that is, how green or red the color is.
+  - `b` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`. It specifies the distance along the `b` axis in the Oklab colorspace, that is, how blue or yellow the color is.
+  - `A` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity). `A` represents the transparency (or alpha channel) of the color.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -33,7 +33,7 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
 ### Values
 
 - Functional notation: `oklab(L a b [/ A])`
-  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `100` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies perceived lightness where the number `0` corresponds to `0%` (black) and the number `100` corresponds to `100%` (white).
+  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies perceived lightness where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white).
   - `a` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`, specifying the distance along the `a` axis in the Oklab colorspace, that is how green/red the color is.
   - `b` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`, specifying the distance along the `b` axis in the Oklab colorspace, that is how blue/yellow the color is.
   - `A` is a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity), representing the transparency (or alpha channel) of the color.

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -38,9 +38,6 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
   - `b` is a {{cssxref("&lt;number&gt;")}} between `-0.4` and `0.4` or a {{cssxref("&lt;percentage&gt;")}} between `-100%` and `100%`, specifying the distance along the `b` axis in the Oklab colorspace, that is how blue/yellow the color is.
   - `A` is a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity), representing the transparency (or alpha channel) of the color.
 
-> **Note:** Usually when percentage values have a numeric equivalent in CSS, `100%` is equal to the number `1`.
-> This case is notable in that `100%` is equal to the number `100` for the `L` value and `0.4` for the `a` and `b` values.
-
 ### Formal syntax
 
 {{csssyntax}}

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -29,9 +29,6 @@ oklch(59.69% 0.156 49.77 / .5)
 
   - `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
 
-> **Note:** Usually when percentage values have a numeric equivalent in CSS, `100%` is equal to the number `1`.
-> This case is notable in that `100%` is equal to the number `100` for the `L` value and `0.4` for the `C` value.
-
 ### Formal syntax
 
 {{csssyntax}}

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -23,11 +23,11 @@ oklch(59.69% 0.156 49.77 / .5)
 
   - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%`, where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white). `L` specifies the perceived lightness.
 
-  - `C` is a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} where `0%` is `0` and `100%` is the number `0.4`. It is a measure of the chroma (roughly representing the "amount of color"). Its minimum useful value is `0`, while its maximum is theoretically unbounded (but in practice does not exceed `0.5`).
+  - `C` is a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}, where `0%` is `0` and `100%` is the number `0.4`. It is a measure of the chroma (roughly representing the "amount of color"). Its minimum useful value is `0`, while the maximum is theoretically unbounded (but in practice does not exceed `0.5`).
 
   - `H` is a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;angle&gt;")}} that specifies the hue angle along the positive "a" axis (toward purplish red), `90deg` points along the positive "b" axis (toward mustard yellow), `180deg` points along the negative "a" axis (toward greenish cyan), and `270deg` points along the negative "b" axis (toward sky blue).
 
-  - `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1`, or a {{cssxref("&lt;percentage&gt;")}}, where the number `1` corresponds to `100%` (full opacity).
+  - `A` (alpha) can be a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%`, where the number `1` corresponds to `100%` (full opacity).
 
 ### Formal syntax
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -21,7 +21,7 @@ oklch(59.69% 0.156 49.77 / .5)
 
 - Functional notation: `oklch(L C H [/ A])`
 
-  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `100` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies the CIE Lightness where the number `0` corresponds to `0%` (black) and the number `100` corresponds to `100%` (white).
+  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies the CIE Lightness where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white).
 
   - `C` is a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} where `0%` is `0` and `100%` is the number `0.4`. It is a measure of the chroma (roughly representing the "amount of color"). Its minimum useful value is `0`, while its maximum is theoretically unbounded (but in practice does not exceed `0.5`).
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -21,7 +21,7 @@ oklch(59.69% 0.156 49.77 / .5)
 
 - Functional notation: `oklch(L C H [/ A])`
 
-  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%` that specifies the CIE Lightness where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white).
+  - `L` is a {{cssxref("&lt;number&gt;")}} between `0` and `1` or a {{cssxref("&lt;percentage&gt;")}} between `0%` and `100%`, where the number `0` corresponds to `0%` (black) and the number `1` corresponds to `100%` (white). `L` specifies the perceived lightness.
 
   - `C` is a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} where `0%` is `0` and `100%` is the number `0.4`. It is a measure of the chroma (roughly representing the "amount of color"). Its minimum useful value is `0`, while its maximum is theoretically unbounded (but in practice does not exceed `0.5`).
 


### PR DESCRIPTION
Fix #25416

L values are between 0 and 1 not 0 and 100 (or a %-age).