### PR TITLE
More updates to fullscreenchange example

### DIFF
--- a/files/en-us/web/api/document/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.md
@@ -31,6 +31,8 @@ A generic {{domxref("Event")}}.
 
 ## Examples
 
+### Logging `fullscreenchange` events
+
 In this example, a handler for the `fullscreenchange` event is added to the {{domxref("Document")}}.
 
 If the user clicks on the "Toggle Fullscreen Mode" button, the `click` handler will toggle fullscreen mode for the `div`. If `document.fullscreenElement` has a value it will exit fullscreen mode. If not, the div will be placed into fullscreen mode.
@@ -39,49 +41,72 @@ Remember that by the time the `fullscreenchange` event is handled, the status of
 
 What that means to the example code is that, if an element is currently in fullscreen mode, the `fullscreenchange` handler logs the `id` of the fullscreen element to the console. If `document.fullscreenElement` is null, the code logs a message that the change is to leave fullscreen mode.
 
-### HTML
+#### HTML
 
 ```html
 <h1>fullscreenchange event example</h1>
 <div id="fullscreen-div">
   <button id="toggle-fullscreen">Toggle Fullscreen Mode</button>
+  <pre id="logger"></pre>
 </div>
 ```
 
-### JavaScript
+#### CSS
+
+```css
+* {
+  box-sizing: border-box;
+}
+
+#fullscreen-div {
+  height: 150px;
+  padding: 1rem;
+  background-color: pink;
+}
+
+#logger {
+  height: 80px;
+  padding: 0 0.5rem;
+  background-color: white;
+  overflow: scroll;
+}
+```
+
+#### JavaScript
 
 ```js
+const logger = document.querySelector("#logger");
+const fullScreenElement = document.querySelector("#fullscreen-div");
+
+function log(message) {
+  logger.textContent = `${logger.textContent}\n${message}`;
+}
+
 function fullscreenchanged(event) {
   // document.fullscreenElement will point to the element that
   // is in fullscreen mode if there is one. If there isn't one,
   // the value of the property is null.
   if (document.fullscreenElement) {
-    console.log(
-      `Element: ${document.fullscreenElement.id} entered fullscreen mode.`
-    );
+    log(`Element: ${document.fullscreenElement.id} entered fullscreen mode.`);
   } else {
-    console.log("Leaving fullscreen mode.");
+    log("Leaving fullscreen mode.");
   }
 }
 
 document.addEventListener("fullscreenchange", fullscreenchanged);
-// or
-document.onfullscreenchange = fullscreenchanged;
 
 // When the toggle button is clicked, enter/exit fullscreen
-document
-  .getElementById("toggle-fullscreen")
-  .addEventListener("click", function () {
-    if (document.fullscreenElement) {
-      // exitFullscreen is only available on the Document object.
-      document.exitFullscreen();
-    } else {
-      this.requestFullscreen();
-    }
-  });
+document.getElementById("toggle-fullscreen").addEventListener("click", () => {
+  if (document.fullscreenElement) {
+    // exitFullscreen is only available on the Document object.
+    document.exitFullscreen();
+  } else {
+    fullScreenElement.requestFullscreen();
+  }
+});
 ```
 
-{{EmbedLiveSample("Examples", 640, 800, "", "", "", "display-capture")}}
+{{EmbedLiveSample("Logging fullscreenchange events", 640, 250, "", "", "", "display-capture")}}
 
 ## Specifications
 


### PR DESCRIPTION
Some follow-ups to https://github.com/mdn/content/pull/25409.

- the example fullscreened the button, while the intention I think was to fullscreen the containing div
- the example was much taller than it needed to be
- the example added listeners twice

While I was there I made some other changes:
- using an in-page console so it could be seen without opening the devtools
- some styling changes to make things more obvious
