### PR TITLE
Fixed typo in CSS filter reference

### DIFF
--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -210,7 +210,7 @@ Filter functions are applied in order of appearance. The same filter function ca
 
 {{EmbedLiveSample('Repeating_filter_functions','100%','229px')}}
 
-The filters are applied in order. This is why the drop shadows are not the same color: the first drop shadow's hue is altered by the `hue-rotation()` function but the second one is not.
+The filters are applied in order. This is why the drop shadows are not the same color: the first drop shadow's hue is altered by the `hue-rotate()` function but the second one is not.
 
 ## Specifications
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

'hue-rotation()' should be 'hue-rotate()'

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
