### PR TITLE
Add a missing subsection title

### DIFF
--- a/files/en-us/web/css/inset-block-start/index.md
+++ b/files/en-us/web/css/inset-block-start/index.md
@@ -73,6 +73,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample("Setting_block_start_offset", 140, 140)}}
 
 ## Specifications


### PR DESCRIPTION
### Description

This PR adds the missing title for the "Result" subsection for the `inset-block-start` CSS property.

### Motivation

For consistency with other CSS properties.

### Additional details

### Related issues and pull requests