### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/learn/css/building_blocks/organizing/index.md
+++ b/files/en-us/learn/css/building_blocks/organizing/index.md
@@ -370,7 +370,7 @@ Once compiled to CSS, you would end up with the following CSS in the final style
 
 I mentioned above that one way to organize CSS is to break down stylesheets into smaller stylesheets. When using Sass you can take this to another level and have lots of very small stylesheets — even going as far as having a separate stylesheet for each component. By using the included functionality in Sass (partials), these can all be compiled together into one or a small number of stylesheets to actually link into your website.
 
-So, for example, with [partials](https://sass-lang.com/documentation/at-rules/use#partials), you could have several style files inside a directory, say `foundation/_code.scss`, `foundation/_lists.scss`, `foundation/_footer.scss`, `foundation/_links.scss`, etc. You could then use the Sass `@use` role to load them into other stylesheets:
+So, for example, with [partials](https://sass-lang.com/documentation/at-rules/use#partials), you could have several style files inside a directory, say `foundation/_code.scss`, `foundation/_lists.scss`, `foundation/_footer.scss`, `foundation/_links.scss`, etc. You could then use the Sass `@use` rule to load them into other stylesheets:
 
 ```scss
 // foundation/_index.scss


### PR DESCRIPTION
Fixed typo role in Compiling component stylesheets section.

### Description

Fixed the typing error in the the second paragraph of the section Compiling component stylesheets.
