### PR TITLE
Add the missing "Formal syntax" section

### DIFF
--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -42,6 +42,10 @@ content-visibility: unset;
 
 {{cssinfo}}
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Accessibility concerns
 
 Off-screen content within a `content-visibility: auto` property remains in the document object model and the accessibility tree. This allows improving page performance with `content-visibility: auto` without negatively impacting accessibility.


### PR DESCRIPTION
### Description

This PR adds the missing "Formal syntax" section for the `content-visibility` CSS property.

### Motivation

For consistency with other CSS property pages.

### Additional details

### Related issues and pull requests

https://github.com/mdn/data/pull/652