### PR TITLE
privacy.reduceTimerPrecision: fix typo.

### DIFF
--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -34,7 +34,7 @@ animation.currentTime =
 ## Reduced time precision
 
 To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20ms in Firefox 59; in 60 it will be 2ms.
+In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 microseconds in Firefox 59; in 60 it will be 2 milliseconds.
 
 ```js
 // reduced time precision (2ms) in Firefox 60

--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -34,7 +34,7 @@ animation.currentTime =
 ## Reduced time precision
 
 To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20us in Firefox 59; in 60 it will be 2ms.
+In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20ms in Firefox 59; in 60 it will be 2ms.
 
 ```js
 // reduced time precision (2ms) in Firefox 60


### PR DESCRIPTION
changed 20us to 20ms.
The document stated earlier that the current time will be in milliseconds.