### PR TITLE
Update `navigator.doNotTrack` possible values as per spec

### DIFF
--- a/files/en-us/web/api/navigator/donottrack/index.md
+++ b/files/en-us/web/api/navigator/donottrack/index.md
@@ -11,17 +11,17 @@ browser-compat: api.Navigator.doNotTrack
 
 The **`Navigator.doNotTrack`** property returns the user's Do Not Track setting, which indicates whether the user is requesting web sites and advertisers to not track them.
 
-The value of the property reflects that of the {{httpheader("DNT")}} HTTP header, i.e. values of `"1"`, `"0"`, or `"unspecified"`.
+The value of the property reflects that of the {{httpheader("DNT")}} HTTP header, i.e. values of `"1"`, `"0"`, or `null`.
 
 ## Value
 
-A number.
+A string or `null`.
 
 ## Examples
 
 ```js
 console.log(navigator.doNotTrack);
-// prints "1" if DNT is enabled; "0" if the user opted-in for tracking; otherwise this is "unspecified"
+// prints "1" if DNT is enabled; "0" if the user opted-in for tracking; otherwise null
 ```
 
 ## Specifications

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -50,7 +50,7 @@ The user's DNT preference can also be read from JavaScript using the
 {{domxref("Navigator.doNotTrack")}} property:
 
 ```js
-navigator.doNotTrack; // "0" or "1"
+navigator.doNotTrack; // "0", "1" or null
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

This PR updates the possible return values of `navigator.doNotTrack` as per specification.

### Motivation

See https://github.com/mdn/content/pull/25310#discussion_r1136345176

### Related issues and pull requests

See previous superseded PR: https://github.com/mdn/content/pull/25310

See related PR in `mdn/browser-compat-data` specifying the out-of-spec Firefox behavior: https://github.com/mdn/browser-compat-data/pull/19167