### PR TITLE
Remove unnecessary defer tag from WebGL tutorial

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -28,7 +28,7 @@ This project uses the [glMatrix](https://glmatrix.net/) library to perform its m
       integrity="sha512-zhHQR0/H5SEBL3Wn6yYSaTTZej12z0hVZKOv3TwCUXT1z5qeqGcXJLLrbERYRScEDDpYIJhPC1fk31gqR783iQ=="
       crossorigin="anonymous"
       defer></script>
-    <script src="webgl-demo.js" type="module" defer></script>
+    <script src="webgl-demo.js" type="module"></script>
   </head>
 
   <body>

--- a/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -31,7 +31,7 @@ The "index.html" file should contain the following:
   <head>
     <meta charset="utf-8" />
     <title>WebGL Demo</title>
-    <script src="webgl-demo.js" type="module" defer></script>
+    <script src="webgl-demo.js" type="module"></script>
   </head>
 
   <body>


### PR DESCRIPTION
The <script> tag in index.html example has the "defer" attribute. This is not needed since the script webgl-demo.js is being used as a module and the execution of scripts is deferred by default.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
