### PR TITLE
Capitalize the Word 'arial'

### DIFF
--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -98,7 +98,7 @@ To set a different font for your text, you use the {{cssxref("font-family")}} pr
 
 ```css
 p {
-  font-family: arial;
+  font-family: Arial;
 }
 ```
 


### PR DESCRIPTION
Capitalized the letter 'a' in the word 'arial' for better consistency with other examples found on the page labelled 'Fundamental Text and Font Styling'.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Added a minor capitalization.

#### Original Version:

![image](https://user-images.githubusercontent.com/77248542/226161507-fa77f10a-627a-4084-98f9-9720b0eeb8ac.png)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To maintain consistency for better readability as other examples throughout the page which exemplify the usage of the Arial font style show it capitalized. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The example can be found in the sub-section labelled [Font families](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#font_families). 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
