### PR TITLE
Changed all the occurrences of queue!

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -68,7 +68,7 @@ const p2 = Promise.all([1, 2, 3, Promise.resolve(444)]);
 // so the returned promise gets rejected
 const p3 = Promise.all([1, 2, 3, Promise.reject(555)]);
 
-// Using setTimeout, we can execute code after the queue is empty
+// Using setTimeout, we can execute code after the stack is empty
 setTimeout(() => {
   console.log(p);
   console.log(p2);
@@ -94,15 +94,15 @@ const p = Promise.all(resolvedPromisesArray);
 // Immediately logging the value of p
 console.log(p);
 
-// Using setTimeout, we can execute code after the queue is empty
+// Using setTimeout, we can execute code after the stack is empty
 setTimeout(() => {
-  console.log("the queue is now empty");
+  console.log("the stack is now empty");
   console.log(p);
 });
 
 // Logs, in order:
 // Promise { <state>: "pending" }
-// the queue is now empty
+// the stack is now empty
 // Promise { <state>: "fulfilled", <value>: Array[2] }
 ```
 
@@ -113,13 +113,13 @@ const mixedPromisesArray = [Promise.resolve(33), Promise.reject(44)];
 const p = Promise.all(mixedPromisesArray);
 console.log(p);
 setTimeout(() => {
-  console.log("the queue is now empty");
+  console.log("the stack is now empty");
   console.log(p);
 });
 
 // Logs:
 // Promise { <state>: "pending" }
-// the queue is now empty
+// the stack is now empty
 // Promise { <state>: "rejected", <reason>: 44 }
 ```
 
@@ -131,14 +131,14 @@ const p2 = Promise.all([1337, "hi"]); // Non-promise values are ignored, but the
 console.log(p);
 console.log(p2);
 setTimeout(() => {
-  console.log("the queue is now empty");
+  console.log("the stack is now empty");
   console.log(p2);
 });
 
 // Logs:
 // Promise { <state>: "fulfilled", <value>: Array[0] }
 // Promise { <state>: "pending" }
-// the queue is now empty
+// the stack is now empty
 // Promise { <state>: "fulfilled", <value>: Array[2] }
 ```
 


### PR DESCRIPTION
Since javascript calls are actually stored in a stack "call stack" rather than in a queue as that are mentioned in the existing docs, I changed all the places where the queue is used instead of the stack!

https://www.youtube.com/watch?v=8aGhZQkoFbQ&ab_channel=JSConf

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

changed all the queue string occurrences in the page

### Motivation

This helps users to get the accurate information, because the javascript call are stored in a stack rather than queue.

### Additional details

This JSconf video how event loop works and how the stack calls are stored in JS runtime
https://www.youtube.com/watch?v=8aGhZQkoFbQ&ab_channel=JSConf

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
