### PR TITLE
Sync the contents of logical `padding` properties with other logical properties

### DIFF
--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -31,16 +31,11 @@ padding-block-end: unset;
 
 ### Values
 
-- {{cssxref("&lt;length&gt;")}}
-  - : The size of the padding as a fixed value. Must be nonnegative.
-- {{cssxref("&lt;percentage&gt;")}}
-  - : The size of the padding as a percentage, relative to the inline size (_width_ in a horizontal language, defined by {{cssxref("writing-mode")}}) of the [containing block](/en-US/docs/Web/CSS/Containing_block). Must be nonnegative.
+The `padding-block-end` property takes the same values as the {{CSSXref("padding-left")}} property.
 
 ## Description
 
-The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
-
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+This property corresponds to the {{CSSXref("padding-top")}}, {{CSSXref("padding-right")}}, {{CSSXref("padding-bottom")}}, or {{CSSXref("padding-left")}} property depending on the values defined for {{CSSXref("writing-mode")}}, {{CSSXref("direction")}}, and {{CSSXref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -31,16 +31,11 @@ padding-block-start: unset;
 
 ### Values
 
-- {{cssxref("&lt;length&gt;")}}
-  - : The size of the padding as a fixed value. Must be nonnegative.
-- {{cssxref("&lt;percentage&gt;")}}
-  - : The size of the padding as a percentage, relative to the [inline-size](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow) (_width_ in a horizontal language) of the [containing block](/en-US/docs/Web/CSS/Containing_block). Must be nonnegative.
+The `padding-block-start` property takes the same values as the {{CSSXref("padding-left")}} property.
 
 ## Description
 
-The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
-
-It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+This property corresponds to the {{CSSXref("padding-top")}}, {{CSSXref("padding-right")}}, {{CSSXref("padding-bottom")}}, or {{CSSXref("padding-left")}} property depending on the values defined for {{CSSXref("writing-mode")}}, {{CSSXref("direction")}}, and {{CSSXref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -31,16 +31,11 @@ padding-inline-end: unset;
 
 ### Values
 
-- {{cssxref("&lt;length&gt;")}}
-  - : The size of the padding as a fixed value. Must be nonnegative.
-- {{cssxref("&lt;percentage&gt;")}}
-  - : The size of the padding as a percentage, relative to the [inline-size](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow) (_width_ in a horizontal language) of the [containing block](/en-US/docs/Web/CSS/Containing_block). Must be nonnegative.
+The `padding-inline-end` property takes the same values as the {{CSSXref("padding-left")}} property.
 
 ## Description
 
-The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
-
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other paddings of the element.
+This property corresponds to the {{CSSXref("padding-top")}}, {{CSSXref("padding-right")}}, {{CSSXref("padding-bottom")}}, or {{CSSXref("padding-left")}} property depending on the values defined for {{CSSXref("writing-mode")}}, {{CSSXref("direction")}}, and {{CSSXref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -31,16 +31,11 @@ padding-inline-start: unset;
 
 ### Values
 
-- {{cssxref("&lt;length&gt;")}}
-  - : The size of the padding as a fixed value. Must be nonnegative.
-- {{cssxref("&lt;percentage&gt;")}}
-  - : The size of the padding as a percentage, relative to the inline size (_width_ in a horizontal language, defined by {{cssxref("writing-mode")}}) of the [containing block](/en-US/docs/Web/CSS/Containing_block). Must be nonnegative.
+The `padding-inline-start` property takes the same values as the {{CSSXref("padding-left")}} property.
 
 ## Description
 
-The `padding-inline-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
-
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+This property corresponds to the {{CSSXref("padding-top")}}, {{CSSXref("padding-right")}}, {{CSSXref("padding-bottom")}}, or {{CSSXref("padding-left")}} property depending on the values defined for {{CSSXref("writing-mode")}}, {{CSSXref("direction")}}, and {{CSSXref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -15,8 +15,8 @@ The **`padding-inline`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/
 
 This property is a shorthand for the following CSS properties:
 
-- [`padding-inline-end`](/en-US/docs/Web/CSS/padding-inline-end)
-- [`padding-inline-start`](/en-US/docs/Web/CSS/padding-inline-start)
+- {{CSSXref("padding-inline-end")}}
+- {{CSSXref("padding-inline-start")}}
 
 ## Syntax
 
@@ -40,10 +40,7 @@ The `padding-inline` property may be specified with one or two values. If one va
 
 ### Values
 
-- {{cssxref("&lt;length&gt;")}}
-  - : The size of the padding as a fixed value. Must be nonnegative.
-- {{cssxref("&lt;percentage&gt;")}}
-  - : The size of the padding as a percentage, relative to the inline size (_width_ in a horizontal language, defined by {{cssxref("writing-mode")}}) of the [containing block](/en-US/docs/Web/CSS/Containing_block). Must be nonnegative.
+The `padding-inline` property takes the same values as the {{cssxref("padding-left")}} property.
 
 ## Description
 


### PR DESCRIPTION
### Description

This PR syncs the "Values" and "Description" sections of `padding-block-*` and `padding-inline*` with those of `inset-*`, `margin-*` (logical) and `padding-block`.

### Motivation

For consistency among the contents of logical property pages. Also, the existing "Values" and "Description" sections of the mentioned properties don't seem to do a better work than the simple ones of other logical properties.

### Additional details

### Related issues and pull requests