### PR TITLE
Add missing 'instant' scroll behavior option value

### DIFF
--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -36,7 +36,10 @@ scroll(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+          - `smooth`: scrolling should animate smoothly
+          - `instant`: scrolling should happen instantly in a single jump
+          - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -37,9 +37,9 @@ scroll(options)
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
       - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
-          - `smooth`: scrolling should animate smoothly
-          - `instant`: scrolling should happen instantly in a single jump
-          - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -36,7 +36,7 @@ scroll(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`) or happen instantly in a single jump (`auto`, default).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -41,7 +41,7 @@ scrollIntoView(scrollIntoViewOptions)
 
     - `behavior` {{optional_inline}}
       - : Defines the transition animation.
-        One of `auto` or `smooth`. Defaults to `auto`.
+        One of `auto`, `smooth` or `instant`. Defaults to `auto`.
     - `block` {{optional_inline}}
       - : Defines vertical alignment.
         One of `start`, `center`, `end`, or

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -40,8 +40,10 @@ scrollIntoView(scrollIntoViewOptions)
   - : An Object with the following properties:
 
     - `behavior` {{optional_inline}}
-      - : Defines the transition animation.
-        One of `auto`, `smooth` or `instant`. Defaults to `auto`.
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
     - `block` {{optional_inline}}
       - : Defines vertical alignment.
         One of `start`, `center`, `end`, or

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -33,7 +33,10 @@ scrollTo(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -33,10 +33,10 @@ scroll(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Browsers scrolling an element to a position can have one of the following scroll behaviors:
-        - `auto` (default): The scrolling behavior is controlled by the [`scroll-behavior`](/en-US/docs/Web/CSS/scroll-behavior) CSS style, which is set on or inherited by the scrolling element.
-        - `smooth`: The scrolling animates smoothly.
-        - `instant`: The scrolling happens instantly in a single jump.
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -36,6 +36,7 @@ scroll(options)
       - : Browsers scrolling an element to a position can have one of the following scroll behaviors:
         - `auto` (default): The scrolling behavior is controlled by the [`scroll-behavior`](/en-US/docs/Web/CSS/scroll-behavior) CSS style, which is set on or inherited by the scrolling element.
         - `smooth`: The scrolling animates smoothly.
+        - `instant`: The scrolling happens instantly in a single jump.
 
 ### Return value
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -33,7 +33,10 @@ scrollTo(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -33,7 +33,7 @@ scrollTo(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), or happen instantly in a single jump (`auto`, the default value).
+      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
ScrollBehavior has three possible values ("auto", "instant" and "smooth"), but only two are presented ("auto", and "smooth"), this commit adds the third one.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Make all allowed values presented.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Page that already has the same info: [Element.scrollTo](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo)

https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
