### PR TITLE
Update example usage of NodeList.length to actually use .length in example instead of for-of loop

### DIFF
--- a/files/en-us/web/api/nodelist/length/index.md
+++ b/files/en-us/web/api/nodelist/length/index.md
@@ -27,8 +27,8 @@ const items = document.getElementsByTagName("p");
 // For each item in the list,
 // append the entire element as a string of HTML
 let gross = "";
-for (const item of items) {
-  gross += item.innerHTML;
+for (let i = 0; i < items.length; i++) {
+  gross += items[i].innerHTML;
 }
 
 // gross is now all the HTML for the paragraphs


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Previously the example usage of `NodeList.length` as an iterator in a for loop was not accurately displayed. Instead of using `.length` as the iterator in the loop, a for-of loop was used instead. Though the for-of loop may have been better in this case, it does not display the use of `.length`. This change fixes the example to do what it says it does and use `items.length` as the stop value in the for loop.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This will help the reader by providing them with an example of the thing they are searching for instead of an example of something unrelated
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Page with issue https://developer.mozilla.org/en-US/docs/Web/API/NodeList/length
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
