### PR TITLE
Basic container docs fixes as precursor to adding CSSContainerRule 

### DIFF
--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -25,7 +25,7 @@ _No specific methods; inherits methods from its ancestors {{domxref("CSSConditio
 ## Examples
 
 The CSS below includes a media query with one style rule.
-As this in the last stylesheet added to the document, it will be the first CSSRule returned by the last stylesheet in the document (`document.styleSheets[document.styleSheets.length-1].cssRules`).
+As this rule lives in the last stylesheet added to the document, it will be the first CSSRule returned by the last stylesheet in the document (`document.styleSheets[document.styleSheets.length-1].cssRules`).
 `myRules[0]` returns a {{domxref("CSSMediaRule")}} object, from which we can get the `mediaText`.
 
 ```html

--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -24,8 +24,13 @@ _No specific methods; inherits methods from its ancestors {{domxref("CSSConditio
 
 ## Examples
 
-The CSS includes a media query with one style rule. This will be the first CSSRule returned by `document.styleSheets[0].cssRules`.
-`myRules[0]` therefore returns a {{domxref("CSSMediaRule")}} object.
+The CSS below includes a media query with one style rule.
+As this in the last stylesheet added to the document, it will be the first CSSRule returned by the last stylesheet in the document (`document.styleSheets[document.styleSheets.length-1].cssRules`).
+`myRules[0]` returns a {{domxref("CSSMediaRule")}} object, from which we can get the `mediaText`.
+
+```html
+<p id="log"></p>
+```
 
 ```css
 @media (min-width: 500px) {
@@ -36,9 +41,13 @@ The CSS includes a media query with one style rule. This will be the first CSSRu
 ```
 
 ```js
-let myRules = document.styleSheets[0].cssRules;
-console.log(myRules[0]); // a CSSMediaRule representing the media query.
+const log = document.getElementById("log");
+const myRules = document.styleSheets[document.styleSheets.length - 1].cssRules;
+const mediaList = myRules[0]; // a CSSMediaRule representing the media query.
+log.textContent += ` ${mediaList.media.mediaText}`;
 ```
+
+{{EmbedLiveSample("Examples","100%","300px")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/container-name/index.md
+++ b/files/en-us/web/css/container-name/index.md
@@ -20,12 +20,15 @@ container-name: <container-name>;
 ### Values
 
 - `<container-name>`
+
   - : A case-sensitive string that is used to identify the container.
+
     The following conditions apply:
-  - The name can be any valid {{cssxref("custom-ident")}}, but must not equal `default`.
-  - The name value must not be in quotes.
-  - The dashed ident intended to denote author-defined identifiers (e.g., `--container-name`) is permitted.
-  - A list of multiple names separated by a space is allowed.
+
+    - The name can be any valid {{cssxref("custom-ident")}}, but must not equal `default`.
+    - The name value must not be in quotes.
+    - The dashed ident intended to denote author-defined identifiers (e.g., `--container-name`) is permitted.
+    - A list of multiple names separated by a space is allowed.
 
 ## Examples
 

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -17,13 +17,18 @@ container-type: <type>;
 
 ### Values
 
-- `size`: Establishes a query container for container size queries on both the inline and block axis in both the [inline and block](/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts#block_and_inline_dimensions) dimensions.
-  Applies layout containment, style containment, and size containment to the container.
+- `size`
 
-- `inline-size`: Establishes a query container for dimensional queries on the [inline axis](/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts#block_and_inline_dimensions) of the container.
-  Applies layout, style, and inline-size containment to the element.
+  - : Establishes a query container for container size queries on both the inline and block axis in both the [inline and block](/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts#block_and_inline_dimensions) dimensions.
+    Applies layout containment, style containment, and size containment to the container.
 
-- `normal`: The element is not a query container for any container size queries, but remains a query container for container style queries.
+- `inline-size`
+
+  - : Establishes a query container for dimensional queries on the [inline axis](/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts#block_and_inline_dimensions) of the container.
+    Applies layout, style, and inline-size containment to the element.
+
+- `normal`
+  - : The element is not a query container for any container size queries, but remains a query container for container style queries.
 
 > **Note:** to understand what happens when you apply layout, style, and size containment to a box, see the {{cssxref("contain")}} property.
 


### PR DESCRIPTION
This fixes a few things in CSSMediaRule and CSS container rule as a precursor to adding docs for CSSContainerRule.

Explanations inline. Contributes to #25398