### PR TITLE
Remove Duplicate Entry of FileReader in FileReaderSync Doc

### DIFF
--- a/files/en-us/web/api/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/index.md
@@ -41,4 +41,3 @@ This interface does not have any properties.
 - {{DOMxRef("FileReader")}}
 - {{DOMxRef("Blob")}}
 - {{DOMxRef("File")}}
-- {{DOMxRef("FileReader")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Two redundant entries were in the `See also` section of FileReaderSync.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Well, this redundancy has been triggering my OCD, so I thought why not correct it myself and let others like me have some relief as well?

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Web/API/FileReaderSync
This is the Link to the edited MDN Page.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
