### PR TITLE
Use the right permission name for fullscreen

### DIFF
--- a/files/en-us/web/api/document/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.md
@@ -106,7 +106,7 @@ document.getElementById("toggle-fullscreen").addEventListener("click", () => {
 });
 ```
 
-{{EmbedLiveSample("Logging fullscreenchange events", 640, 250, "", "", "", "display-capture")}}
+{{EmbedLiveSample("Logging fullscreenchange events", 640, 250, "", "", "", "allowfullscreen")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.md
@@ -106,7 +106,7 @@ document.getElementById("toggle-fullscreen").addEventListener("click", () => {
 });
 ```
 
-{{EmbedLiveSample("Logging fullscreenchange events", 640, 250, "", "", "", "allowfullscreen")}}
+{{EmbedLiveSample("Logging fullscreenchange events", 640, 250, "", "", "", "fullscreen")}}
 
 ## Specifications
 


### PR DESCRIPTION
See https://github.com/mdn/content/pull/25427 and in particular https://github.com/mdn/content/pull/25427#issuecomment-1474856919, and also https://fullscreen.spec.whatwg.org/#security-and-privacy-considerations.

I hope this will fix the problem. What I don't understand is why it works in the preview page:
https://pr25427.content.dev.mdn.mozit.cloud/en-US/docs/Web/API/Document/fullscreenchange_event
but not live:
https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenchange_event

I couldn't see any relevant difference in the response headers.
