### PR TITLE
add missing space

### DIFF
--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -30,7 +30,7 @@ postMessage(message, transfer)
 
 - `transfer` {{optional_inline}}
 
-  - : An optional [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects)to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
+  - : An optional [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
 
     Transferable objects are instances of classes like {{jsxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. `null` is not an acceptable value for `transfer`.
 


### PR DESCRIPTION
### Description

I've added a space between a link and the next word

### Motivation

A space was missing between a link and the next word. It helps readability.

### Additional details

Page : https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage#parameters

### Related issues and pull requests

None
