### PR TITLE
Add install/uninstall overview for Ubuntu PWA

### DIFF
--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -87,4 +87,3 @@ On Ubuntu Linux, for Brave, this can be done by opening the PWA, navigating into
 ## See also
 
 - [Install, manage, or uninstall apps in Microsoft Edge](https://support.microsoft.com/en-us/topic/install-manage-or-uninstall-apps-in-microsoft-edge-0c156575-a94a-45e4-a54f-3a84846f6113)
-

--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -19,6 +19,8 @@ Installation is supported by Chrome for Android and Android WebView version 31 a
 
 Safari on iOS is a little different. Some parts of the PWA ecosystem are supported, while others are not. iOS 13 introduced a much more comparable installation experience, which is also described here.
 
+PWA installation is also confirmed to work on Ubuntu Linux 22.04, for example in Brave 111 and Edge 111 or later.
+
 ## The installation user experience
 
 We've written a very simple example website ([see our demo live](https://mdn.github.io/pwa-examples/a2hs/), and also [see the source code](https://github.com/mdn/pwa-examples/tree/master/a2hs)) that doesn't do much, but was developed with the necessary code to allow it to be installed, as well as a service worker to enable it to be used offline.
@@ -77,3 +79,12 @@ Regardless of which browser and device you're using, when you choose to add the 
 ![Screenshot of an Android home screen with the "Foxes" app displayed](a2hs-on-home-screen.png)
 
 When you tap the web app's icon on the home screen, it opens up in a full screen web environment, without the browser's UI around it.
+
+### Uninstalling
+
+On Ubuntu Linux, for Brave, this can be done by opening the PWA, navigating into more details (right side of top bar > hamburger icon), and finding the `Uninstall <app name> ...`. Edge is a bit different, open a new tab, navigate to `edge://apps`, and use the `...` > `🗑️ Uninstall` menu on the app list.
+
+## See also
+
+- [Install, manage, or uninstall apps in Microsoft Edge](https://support.microsoft.com/en-us/topic/install-manage-or-uninstall-apps-in-microsoft-edge-0c156575-a94a-45e4-a54f-3a84846f6113)
+


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add install/uninstall overview confirmed to work for Ubuntu PWA.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Happy for others to see if it works in earlier browser versions than v111, or earlier operating systems, or is otherwise confirmed to be supported upstream by those systems/browser vendors. I just put down my test setup right now (Ubuntu 22.04.2 LTS, Brave 111/Edge 111) since I can verify it worked for me.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

I started looking as this is the route Microsoft Teams on Linux has gone down, so that's at least one major vendor now supporting the PWA experience: https://techcommunity.microsoft.com/t5/microsoft-teams-blog/microsoft-teams-progressive-web-app-now-available-on-linux/ba-p/3669846

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
