### PR TITLE
Fix event type for resize event

### DIFF
--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
@@ -23,9 +23,9 @@ onresize = (event) => {};
 
 ## Event type
 
-A {{domxref("PictureInPictureWindow")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("PictureInPictureEvent")}}. Inherits from {{domxref("Event")}}.
 
-{{InheritanceDiagram("PictureInPictureWindow")}}
+{{InheritanceDiagram("PictureInPictureEvent")}}
 
 ## Event properties
 


### PR DESCRIPTION
The original author mixed the notions of _event type_ and _event target_.