### PR TITLE
Document (Count|ByteLength)QueuingStrategy.highWaterMark

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
@@ -1,0 +1,50 @@
+---
+title: ByteLengthQueuingStrategy.highWaterMark
+slug: Web/API/ByteLengthQueuingStrategy/highWaterMark
+page-type: web-api-instance-property
+browser-compat: api.ByteLengthQueuingStrategy.highWaterMark
+---
+
+{{APIRef("Streams")}}
+
+The read-only **`ByteLengthQueuingStrategy.highWaterMark`** property returns the total number of bytes that can be contained in the internal queue before [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is applied.
+
+> **Note:** Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` property specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
+
+## Values
+
+An integer.
+
+## Examples
+
+```js
+const queuingStrategy = new ByteLengthQueuingStrategy({
+  highWaterMark: 1 * 1024,
+});
+
+const readableStream = new ReadableStream(
+  {
+    start(controller) {
+      // …
+    },
+    pull(controller) {
+      // …
+    },
+    cancel(err) {
+      console.log("stream error:", err);
+    },
+  },
+  queuingStrategy
+);
+
+const size = queuingStrategy.size(chunk);
+console.log(`highWaterMark value: ${queuingStrategy.highWaterMark}$`);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.md
@@ -16,7 +16,8 @@ The **`ByteLengthQueuingStrategy`** interface of the [Streams API](/en-US/docs/W
 
 ## Instance properties
 
-None.
+- {{domxref("ByteLengthQueuingStrategy.highWaterMark")}} {{ReadOnlyInline}}
+  - : The total number of bytes that can be contained in the internal queue before [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is applied.
 
 ## Instance methods
 
@@ -26,7 +27,7 @@ None.
 ## Examples
 
 ```js
-const queueingStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1 });
+const queueingStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1024 });
 
 const readableStream = new ReadableStream(
   {

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.md
@@ -54,3 +54,7 @@ const size = queueingStrategy.size(chunk);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("ByteLengthQueuingStrategy.ByteLengthQueuingStrategy", "ByteLengthQueuingStrategy()")}} constructor

--- a/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
@@ -1,0 +1,46 @@
+---
+title: CountQueuingStrategy.highWaterMark
+slug: Web/API/CountStrategy/highWaterMark
+page-type: web-api-instance-property
+browser-compat: api.CountQueuingStrategy.highWaterMark
+---
+
+{{APIRef("Streams")}}
+
+The read-only **`CountQueuingStrategy.highWaterMark`** property returns the total number of chunks that can be contained in the internal queue before backpressure is applied.
+
+## Values
+
+An integer representing a number of chunks.
+
+## Examples
+
+```js
+const queueingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
+
+const readableStream = new ReadableStream(
+  {
+    start(controller) {
+      // …
+    },
+    pull(controller) {
+      // …
+    },
+    cancel(err) {
+      console.log("stream error:", err);
+    },
+  },
+  queuingStrategy
+);
+
+const size = queuingStrategy.size(chunk);
+console.log(`highWaterMark value: ${queuingStrategy.highWaterMark}$`);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
@@ -44,3 +44,7 @@ console.log(`highWaterMark value: ${queuingStrategy.highWaterMark}$`);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CountQueuingStrategy.CountQueuingStrategy", "CountQueuingStrategy()")}} constructor

--- a/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/highwatermark/index.md
@@ -1,6 +1,6 @@
 ---
 title: CountQueuingStrategy.highWaterMark
-slug: Web/API/CountStrategy/highWaterMark
+slug: Web/API/CountQueuingStrategy/highWaterMark
 page-type: web-api-instance-property
 browser-compat: api.CountQueuingStrategy.highWaterMark
 ---

--- a/files/en-us/web/api/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/index.md
@@ -16,12 +16,13 @@ The **`CountQueuingStrategy`** interface of the [Streams API](/en-US/docs/Web/AP
 
 ## Instance properties
 
-None.
+- {{domxref("highWaterMark")}} {{ReadOnlyInline}}
+  - : The total number of chunks that can be contained in the internal queue before [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is applied.
 
 ## Instance methods
 
 - {{domxref("CountQueuingStrategy.size()")}}
-  - : Returns `1`.
+  - : Always returns `1`.
 
 ## Examples
 

--- a/files/en-us/web/api/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/index.md
@@ -16,7 +16,7 @@ The **`CountQueuingStrategy`** interface of the [Streams API](/en-US/docs/Web/AP
 
 ## Instance properties
 
-- {{domxref("highWaterMark")}} {{ReadOnlyInline}}
+- {{domxref("CountQueuingStrategy.highWaterMark")}} {{ReadOnlyInline}}
   - : The total number of chunks that can be contained in the internal queue before [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is applied.
 
 ## Instance methods


### PR DESCRIPTION
### Description

Adding documentation for 

- `CountQueuingStrategy.highWaterMark`
- `ByteLengthQueuingStrategy.highWaterMark`

### Motivation

openwebdocs/project#152

### Additional details

These properties read the corresponding value set by the constructor.

### Related issues and pull requests
A PR to add `mdn_url` in mdn/browser-compat-data will follow