### PR TITLE
Updating warning around -webkit-scroll

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -20,7 +20,7 @@ The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's s
 
 > **Note:** If `overflow:scroll;` is not set, no scrollbar is displayed.
 
-> **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}.
+> **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}, but is currently only supported in Firefox.
 
 ## CSS Scrollbar Selectors
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The warning on `-webkit-scrollbar` is currently a bit misleading - it makes it sound as if the `scrollbar-color` and `scrollbar-width` methods have *more* support, when in fact they have far less - only Firefox supports them. This edit attempts to make that clearer.

### Motivation

I think it's important that users don't mistakenly use the `scrollbar-width`, `scrollbar-color` methods thinking they have broader support, when in fact they have far less. I think it's also important that MDN appear impartial, and not appear to favor Firefox by implying that something only Firefox supports is standard.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
