### PR TITLE
clarify no pseudos in :is()

### DIFF
--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -189,6 +189,14 @@ some-element:is(::before, ::after) {
 }
 ```
 
+or this:
+
+```css example-bad
+:is(some-element::before, some-element::after) {
+  display: block;
+}
+```
+
 instead do:
 
 ```css example-good


### PR DESCRIPTION
There are many pseudo-elements that are becoming popular that are supported as prefixed in some browsers. Using `:is()` is also becoming more popular. We need to make it more apparent that `:is()` is NOT the solution in these cases. 

Confirmation of accuracy of edit: https://codepen.io/estelle/pen/RwYexba