### PR TITLE
Add redirects to keep old links to configuring_build_options working

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1128,6 +1128,7 @@
 /en-US/docs/Class_Elements	/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
 /en-US/docs/Common_CSS_Questions	/en-US/docs/Learn/CSS/Howto/CSS_FAQ
 /en-US/docs/Common_XSLT_Errors	/en-US/docs/Web/XSLT/Common_errors
+/en-US/docs/Configuring_Build_Options	https://firefox-source-docs.mozilla.org/setup/configuring_build_options.html
 /en-US/docs/Configuring_servers_for_Ogg_media	/en-US/docs/Web/HTTP/Configuring_servers_for_Ogg_media
 /en-US/docs/Consistent_List_Indentation	/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Consistent_list_indentation
 /en-US/docs/Const_statement	/en-US/docs/Web/JavaScript/Reference/Statements/const
@@ -5783,6 +5784,7 @@
 /en-US/docs/Mozilla/Command_Line_Options	https://wiki.mozilla.org/Firefox/CommandLineOptions
 /en-US/docs/Mozilla/Debugging/HTTP_logging	https://firefox-source-docs.mozilla.org/networking/http/logging.html
 /en-US/docs/Mozilla/Developer_guide/Build_Instructions/Build_Instructions	https://firefox-source-docs.mozilla.org/setup/index.html
+/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options	https://firefox-source-docs.mozilla.org/setup/configuring_build_options.html
 /en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation	https://firefox-source-docs.mozilla.org/setup/linux_build.html
 /en-US/docs/Mozilla/Developer_guide/ESLint	https://firefox-source-docs.mozilla.org/code-quality/lint/index.html
 /en-US/docs/Mozilla/Developer_guide/Source_Code/Directory_structure	https://firefox-source-docs.mozilla.org/contributing/directory_structure.html


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add redirect to keep old links working:
* https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/5
* https://github.com/ahal/mozconfigwrapper

### Motivation

Old links in other locations will start to redirect to the correct location again. ["Cool URIs don't change"](https://www.w3.org/Provider/Style/URI)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
