### PR TITLE
Correct the listing of possible mappings for `padding-*-start`

### DIFF
--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -38,7 +38,7 @@ padding-block-end: unset;
 
 ## Description
 
-The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
+The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -38,7 +38,7 @@ padding-block-start: unset;
 
 ## Description
 
-The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
+The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
 
 It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -38,7 +38,7 @@ padding-inline-end: unset;
 
 ## Description
 
-The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
+The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -38,7 +38,7 @@ padding-inline-start: unset;
 
 ## Description
 
-The `padding-inline-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}
+The `padding-inline-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 


### PR DESCRIPTION
### Description

This PR changes `padding-top` in the listed possible mappings for `padding-block-start` and `padding-inline-start` to `padding-bottom`. Also, missing periods are added for all logical `padding-*` longhands.

### Motivation

The paragraph where the list appears is trying to convey that any of the four physical properties can be mapped to by their logical equivalents, despite the fact that the latter ones are defined to take the same value as `padding-top`. So the remaining possibilities should exclude `padding-top`, which is correctly done the on the `padding-*-end` pages.

### Additional details

This inconsistency blocks the l10n of the logical padding properties.

### Related issues and pull requests