### PR TITLE
Fix private class fields example reentrancy

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -344,12 +344,13 @@ class PrivateConstructor {
     if (!PrivateConstructor.#isInternalConstructing) {
       throw new TypeError("PrivateConstructor is not constructable");
     }
+    PrivateConstructor.#isInternalConstructing = false;
+    // More initialization logic
   }
 
   static create() {
     PrivateConstructor.#isInternalConstructing = true;
     const instance = new PrivateConstructor();
-    PrivateConstructor.#isInternalConstructing = false;
     return instance;
   }
 }


### PR DESCRIPTION
### Description

Improve example to avoid reentrancy bugs.

### Motivation

The example shows a way of using private class fields to require that a constructor be called from a certain function. In its current form, strange things will happen if the constructor eventually calls itself (either directly or through another functions that calls it). This is called reentrancy, and it is a major source of bugs if not implemented correctly. Here, if another function is called by the constructor, it will be able to call the constructor when it's not supposed to be able to even though it's not the designated `static create()` function.

The fix is to unset the boolean right after checking it. In the timeline of statements executed, this brings the boolean gets and sets close together instead of spanning whatever logic the constructor does. By updating the example like this, readers will have a good example to base their work off of without inadvertently introducing reentrancy bugs.