### PR TITLE
Document WritableStreamDefaultController.signal

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.md
@@ -15,7 +15,8 @@ None. `WritableStreamDefaultController` instances are created automatically duri
 
 ## Instance properties
 
-None.
+- {{domxref("WritableStreamDefaultController.signal")}} {{ReadOnlyInline}}
+  - Returns the {{domxref("AbortSignal")}} associated with the controller.
 
 ## Instance methods
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.md
@@ -16,7 +16,7 @@ None. `WritableStreamDefaultController` instances are created automatically duri
 ## Instance properties
 
 - {{domxref("WritableStreamDefaultController.signal")}} {{ReadOnlyInline}}
-  - Returns the {{domxref("AbortSignal")}} associated with the controller.
+  - : Returns the {{domxref("AbortSignal")}} associated with the controller.
 
 ## Instance methods
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -15,7 +15,7 @@ An {{domxref("AbortSignal")}} object.
 
 ## Examples
 
-## Aborting a long write operation
+### Aborting a long write operation
 
 In this example, we simulate a slow operation using a local sink: We do nothing when somedata is written but to wait for a second. This gives us enough time to call the `writer.abort()` method and to immediately reject the promise.
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -1,5 +1,5 @@
 ---
-title: WritableStreamDefaultWriterController.signal
+title: WritableStreamDefaultController.signal
 slug: Web/API/WritableStreamDefaultWriterController/signal
 page-type: web-api-instance-property
 browser-compat: api.WritableStreamDefaultWriterController.signal

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -44,7 +44,7 @@ await writer.abort("Manual abort!");
 
 ## Transferring the `AbortSignal` to the underlying layer
 
-In this example, we will use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to actually send the message to a server. The Fetch API also support {{domxref("AbortSignal")}}: It is possible to use the same object for both the `fetch` methode and the {{domxref("WritableStreamDefaultController")}}.
+In this example, we use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to actually send the message to a server. The Fetch API also support {{domxref("AbortSignal")}}: It is possible to use the same object for both the `fetch` method and the {{domxref("WritableStreamDefaultController")}}.
 
 ```js
 const endpoint = "https://www.example.com/api"; // Fake URL for example purpose

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -1,0 +1,77 @@
+---
+title: WritableStreamDefaultWriterController.signal
+slug: Web/API/WritableStreamDefaultWriterController/signal
+page-type: web-api-instance-property
+browser-compat: api.WritableStreamDefaultWriterController.signal
+---
+
+{{APIRef("Streams")}}
+
+The read-only **`signal`** property of the {{domxref("WritableStreamDefaultWriterController")}} interface returns the {{domxref("AbortSignal")}} associated with the controller.
+
+## Value
+
+An {{domxref("AbortSignal")}}
+
+## Examples
+
+## Aborting a long write operation
+
+In this example, we simulate a slow operation using a local sink: we do nothing when data is written but to wait for a second. This gives enough time to call the `writer.abort()` method and to immediately reject the promise.
+
+```js
+const writingStream = new WritableStream({
+  // Define the slow local sink to simulate a long operation
+  write(controller) {
+    return new Promise((resolve, reject) => {
+      controller.signal.addEventListener("abort", () =>
+        reject(controller.signal.reason)
+      );
+
+      // Do nothing but wait with the data: it is a local sink
+      setTimeout(resolve, 1000); // Timeout to simulate a slow operation
+    });
+  },
+});
+
+// Perform the write
+const writer = writingStream.getWriter();
+writer.write("Lorem ipsum test data");
+
+// Abort the write manually
+await writer.abort("Manual abort!");
+```
+
+## Transferring the `AbortSignal` to the underlying layer
+
+In this example, we will use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to actually send the message to a server. The Fetch API also support {{domxref("AbortSignal")}}: It is possible to use the same object for both the `fetch` methode and the {{domxref("WritableStreamDefaultController")}}.
+
+```js
+const endpoint = "https://www.example.com/api"; // Fake URL for example purpose
+const writingStream = new WritableStream({
+  async write(controller, chunk) {
+    // Write to the server using the Fetch API
+    const response = await fetch(endpoint, {
+      signal: controller.signal, // We use the same object for both fetch and controller
+      method: "POST",
+      body: chunk,
+    });
+    await response.text();
+  },
+});
+
+// Perform the write
+const writer = writingStream.getWriter();
+writer.write("Lorem ipsum test data");
+
+// Abort the write manually
+await writer.abort("Manual abort!");
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -17,7 +17,7 @@ An {{domxref("AbortSignal")}} object.
 
 ## Aborting a long write operation
 
-In this example, we simulate a slow operation using a local sink: we do nothing when data is written but to wait for a second. This gives enough time to call the `writer.abort()` method and to immediately reject the promise.
+In this example, we simulate a slow operation using a local sink: We do nothing when somedata is written but to wait for a second. This gives us enough time to call the `writer.abort()` method and to immediately reject the promise.
 
 ```js
 const writingStream = new WritableStream({

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -7,7 +7,7 @@ browser-compat: api.WritableStreamDefaultWriterController.signal
 
 {{APIRef("Streams")}}
 
-The read-only **`signal`** property of the {{domxref("WritableStreamDefaultWriterController")}} interface returns the {{domxref("AbortSignal")}} associated with the controller.
+The read-only **`signal`** property of the {{domxref("WritableStreamDefaultController")}} interface returns the {{domxref("AbortSignal")}} associated with the controller.
 
 ## Value
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -42,7 +42,7 @@ writer.write("Lorem ipsum test data");
 await writer.abort("Manual abort!");
 ```
 
-## Transferring the `AbortSignal` to the underlying layer
+### Transferring the `AbortSignal` to the underlying layer
 
 In this example, we use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to actually send the message to a server. The Fetch API also support {{domxref("AbortSignal")}}: It is possible to use the same object for both the `fetch` method and the {{domxref("WritableStreamDefaultController")}}.
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -1,6 +1,6 @@
 ---
 title: WritableStreamDefaultController.signal
-slug: Web/API/WritableStreamDefaultWriterController/signal
+slug: Web/API/WritableStreamDefaultController/signal
 page-type: web-api-instance-property
 browser-compat: api.WritableStreamDefaultWriterController.signal
 ---

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -11,7 +11,7 @@ The read-only **`signal`** property of the {{domxref("WritableStreamDefaultContr
 
 ## Value
 
-An {{domxref("AbortSignal")}}
+An {{domxref("AbortSignal")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -2,7 +2,7 @@
 title: WritableStreamDefaultController.signal
 slug: Web/API/WritableStreamDefaultController/signal
 page-type: web-api-instance-property
-browser-compat: api.WritableStreamDefaultWriterController.signal
+browser-compat: api.WritableStreamDefaultController.signal
 ---
 
 {{APIRef("Streams")}}


### PR DESCRIPTION
### Description

This adds a page for `WritableStreamDefaultController.signal"

### Motivation

This is part of openwebdocs/project#152

### Additional details

(Not this was not part of the original list but reached interoperability for all three engines in Q1 2023, so a kind of bonus)