### PR TITLE
Fix formnovalidate attribute on button inside Dialog element

### DIFF
--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -35,7 +35,7 @@ From there you can click the _X_ button to close the dialog (via the {{domxref("
 <!-- Simple pop-up dialog box, containing a form -->
 <dialog id="favDialog">
   <form method="dialog">
-    <button id="close" aria-label="close" novalidate>X</button>
+    <button id="close" aria-label="close" formnovalidate>X</button>
     <section>
       <p>
         <label for="favAnimal">Favorite animal:</label>


### PR DESCRIPTION
### Description
Apologies if I'm wrong, but from the docs of the Button element, there is no `novalidate` attribute, but a `formnovalidate` attribute instead. The `novalidate` attribute exists on a form.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#formnovalidate

(I'm not actually sure if the attribute is needed here at all, on second thoughts, since the form is not submitted so no validation will take place regardless of this. Also see the following docs to see where there is correct usage of submission and `formnovalidate`: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue)

### Motivation

To use the correct attribute in usage examples so we don't use non-existent attributes.
