### PR TITLE
Document CSSFontFeatureValuesRule

### DIFF
--- a/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
@@ -17,7 +17,7 @@ A string.
 
 ### Read font family
 
-In this example, we declared two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
+In this example, we declare two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
 
 ```html
 <pre id="log"></pre>

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
@@ -17,7 +17,7 @@ A string.
 
 ### Read font family
 
-In this example, we declared to {{cssxref("@font-feature-values")}} one fo the _Font One_ font family, and the other for _Font Two_. We then uses the CSSOm to read these font families, displaying them into the log.
+In this example, we declared two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
 
 ```html
 <pre id="log"></pre>

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
@@ -2,7 +2,7 @@
 title: CSSFontFeatureValuesRule.fontFamily
 slug: Web/API/CSSFontFeatureValuesRule/fontFamily
 page-type: web-api-instance-property
-browser-compat: api.CSSCFontFeatureValuesRule.fontFamily
+browser-compat: api.CSSFontFeatureValuesRule.fontFamily
 ---
 
 {{ APIRef("CSSOM") }}

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSFontFeatureValuesRule.fontFamily
 
 {{ APIRef("CSSOM") }}
 
-The **`fontFamily`** property of the {{domxref("CSSConditionRule")}} interface represent the name of the font family it applies to.
+The **`fontFamily`** property of the {{domxref("CSSConditionRule")}} interface represents the name of the font family it applies to.
 
 ## Value
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/fontfamily/index.md
@@ -1,0 +1,74 @@
+---
+title: CSSFontFeatureValuesRule.fontFamily
+slug: Web/API/CSSFontFeatureValuesRule/fontFamily
+page-type: web-api-instance-property
+browser-compat: api.CSSCFontFeatureValuesRule.fontFamily
+---
+
+{{ APIRef("CSSOM") }}
+
+The **`fontFamily`** property of the {{domxref("CSSConditionRule")}} interface represent the name of the font family it applies to.
+
+## Value
+
+A string.
+
+## Examples
+
+### Read font family
+
+In this example, we declared to {{cssxref("@font-feature-values")}} one fo the _Font One_ font family, and the other for _Font Two_. We then uses the CSSOm to read these font families, displaying them into the log.
+
+```html
+<pre id="log"></pre>
+```
+
+#### CSS
+
+```css
+/* At-rule for "nice-style" in Font One */
+@font-feature-values Font One {
+  @styleset {
+    nice-style: 12;
+  }
+}
+
+/* At-rule for "nice-style" in Font Two */
+@font-feature-values Font Two {
+  @styleset {
+    nice-style: 4;
+  }
+}
+
+/* Apply the at-rules with a single declaration */
+.nice-look {
+  font-variant-alternates: styleset(nice-style);
+}
+```
+
+#### JavaScript
+
+```js
+const log = document.getElementById("log");
+const rules = document.styleSheets[document.styleSheets.length - 1].cssRules;
+
+const fontOne = rules[0]; // A CSSFontFeatureValuesRule
+log.textContent = `The 1st '@font-feature-values' family: "${fontOne.fontFamily}".\n`;
+
+const fontTwo = rules[1]; // Another CSSFontFeatureValuesRule
+log.textContent += `The 2nd '@font-feature-values' family: "${fontTwo.fontFamily}".`;
+```
+
+{{EmbedLiveSample("read_font_family", "100%", "75px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+-

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSFontFeatureValuesRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feature-values")}} [at-rule](/en-US/docs/Web/CSS/At-rule), letting developpers assign for each font face a common name to specify features indices to be used in {{cssxref("font-variant-alternates")}}.
+The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feature-values")}} [at-rule](/en-US/docs/Web/CSS/At-rule), letting developers assign for each font face a common name to specify features indices to be used in {{cssxref("font-variant-alternates")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -26,7 +26,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 ### Read font family
 
-In this example, we declared two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
+In this example, we declare two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
 
 #### HTML
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -16,7 +16,7 @@ The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feat
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSFontFeatureValuesRule.fontFamily")}}
-  - : A string that identifies the font-family this rule applies to.
+  - : A string that identifies the font family this rule applies to.
 
 ## Instance methods
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -1,0 +1,85 @@
+---
+title: CSSFontFeatureValuesRule
+slug: Web/API/CSSFontFeatureValuesRule
+page-type: web-api-interface
+browser-compat: api.CSSFontFeatureValuesRule
+---
+
+{{APIRef("CSSOM")}}
+
+The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feature-values")}} [at-rule](/en-US/docs/Web/CSS/At-rule), letting developpers assign for each font face a common name to specify features indices to be used in {{cssxref("font-variant-alternates")}}.
+
+{{InheritanceDiagram}}
+
+## Instance properties
+
+_Inherits properties from its ancestor {{domxref("CSSRule")}}._
+
+- {{domxref("CSSFontFeatureValuesRule.fontFamily")}}
+  - : A string identify the font-family this rule applies to.
+
+## Instance methods
+
+_Inherits methods from its ancestor {{domxref("CSSRule")}}._
+
+## Examples
+
+### Read font family
+
+In this example, we declared to {{cssxref("@font-feature-values")}} one fo the _Font One_ font family, and the other for _Font Two_. We then uses the CSSOm to read these font families, displaying them into the log.
+
+#### HTML
+
+```html
+<pre id="log"></pre>
+```
+
+#### CSS
+
+```css
+/* At-rule for "nice-style" in Font One */
+@font-feature-values Font One {
+  @styleset {
+    nice-style: 12;
+  }
+}
+
+/* At-rule for "nice-style" in Font Two */
+@font-feature-values Font Two {
+  @styleset {
+    nice-style: 4;
+  }
+}
+
+/* Apply the at-rules with a single declaration */
+.nice-look {
+  font-variant-alternates: styleset(nice-style);
+}
+```
+
+#### JavaScript
+
+```js
+const log = document.getElementById("log");
+const rules = document.styleSheets[document.styleSheets.length - 1].cssRules;
+
+const fontOne = rules[0]; // A CSSFontFeatureValuesRule
+log.textContent = `The 1st '@font-feature-values' family: "${fontOne.fontFamily}".\n`;
+
+const fontTwo = rules[1]; // Another CSSFontFeatureValuesRule
+log.textContent += `The 2nd '@font-feature-values' family: "${fontTwo.fontFamily}".`;
+```
+
+{{EmbedLiveSample("read_font_family", "100%", "75px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("@font-feature-values")}}

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -16,7 +16,7 @@ The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feat
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSFontFeatureValuesRule.fontFamily")}}
-  - : A string identify the font-family this rule applies to.
+  - : A string that identifies the font-family this rule applies to.
 
 ## Instance methods
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -26,7 +26,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 ### Read font family
 
-In this example, we declared to {{cssxref("@font-feature-values")}} one fo the _Font One_ font family, and the other for _Font Two_. We then uses the CSSOm to read these font families, displaying them into the log.
+In this example, we declared two {{cssxref("@font-feature-values")}} one for the _Font One_ font family, and the other for _Font Two_. We then use the CSSOM to read these font families, displaying them into the log.
 
 #### HTML
 


### PR DESCRIPTION
### Description

Document `CSSFontFeatureValuesRule`.
Document `CSSFontFeatureValuesRule.fontFamily`

### Motivation

openwebdocs/project#152

### Additional details

This interface has additional properties. They are experimental and a recent addition to Chrome only (not even Edge and Opera). I didn't want to fall into this rabbit hole, as the current project goal is to document _interoperable_ features. 

### Related issues and pull requests

Some `mdn_url` entries are missing in BCD. I will create a PR over there soon.