### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -104,7 +104,7 @@ const updatePixelRatio = () => {
   }
   let mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
   let media = matchMedia(mqString);
-  media.addListener(updatePixelRatio);
+  media.addEventListener("change", updatePixelRatio);
   remove = function () {
     media.removeListener(updatePixelRatio);
   };


### PR DESCRIPTION
Replaced `.addListener()` with `.addEventListener("change")` to match up with modern best practices. `.addListener()` is deprecated according to https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener

### Description

Replaced `.addListener()` with `.addEventListener("change")` to match up with modern best practices. `.addListener()` is deprecated according to https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener