### PR TITLE
Fix 11494: promise handling in WritableStreamDefaultWriter example

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -59,7 +59,7 @@ async function sendMessage(message, writableStream) {
     await defaultWriter.close();
     console.log("All chunks written");
   } catch (err) {
-    console.log("Chunk error:", err);
+    console.log("Error:", err);
   }
 }
 
@@ -88,7 +88,7 @@ const writableStream = new WritableStream(
       list.appendChild(listItem);
     },
     abort(err) {
-      console.log(`Sink error: ${err}`);
+      console.log("Sink error:", err);
     },
   },
   queuingStrategy

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -41,33 +41,26 @@ The following example shows the creation of a `WritableStream` with a custom sin
 ```js
 const list = document.querySelector("ul");
 
-function sendMessage(message, writableStream) {
+async function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
-  encoded.forEach((chunk) => {
-    defaultWriter.ready
-      .then(() => defaultWriter.write(chunk))
-      .then(() => {
-        console.log("Chunk written to sink.");
-      })
-      .catch((err) => {
-        console.log("Chunk error:", err);
-      });
-  });
-  // Call ready again to ensure that all chunks are written
-  //   before closing the writer.
-  defaultWriter.ready
-    .then(() => {
-      defaultWriter.close();
-    })
-    .then(() => {
-      console.log("All chunks written");
-    })
-    .catch((err) => {
-      console.log("Stream error:", err);
-    });
+  const encoded = encoder.encode(message);
+
+  try {
+    for (const chunk of encoded) {
+      await defaultWriter.ready;
+      await defaultWriter.write(chunk);
+      console.log("Chunk written to sink.");
+    }
+    // Call ready again to ensure that all chunks are written
+    // before closing the writer.
+    await defaultWriter.ready;
+    await defaultWriter.close();
+    console.log("All chunks written");
+  } catch (err) {
+    console.log("Chunk error:", err);
+  }
 }
 
 const decoder = new TextDecoder("utf-8");
@@ -95,7 +88,7 @@ const writableStream = new WritableStream(
       list.appendChild(listItem);
     },
     abort(err) {
-      console.log("Sink error:", err);
+      console.log(`Sink error: ${err}`);
     },
   },
   queuingStrategy


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11494, I hope.

This PR rewrites the example to use `await`.

In the issue report I was a bit puzzled by this bit:

> defaultWriter.ready.then is called multiple times.

As far as I can see you have to call `ready` after each time you write to the stream, so you know you can write to it again. However it is true that:
- if any chunk write throws an error, then the writer keeps writing (and keeps getting errors), when it should presumably give up
- `defaultWriter.close();` should presumably return its promise, or any error is unhandled

 One change I have made here is no longer distinguishing between a chunk write failing and `defaultWriter.close();` failing: they're all in the same `try` block. That is simpler and seemed OK?

Anyway if you like this I'll update all the other places it's used, as well as the working copy in mdn/dom-examples.

I've tested this and it seems to work fine. I've also tested it with `write` throwing an error: in the old version the output was like:

************

<img width="636" alt="Screen Shot 2023-03-23 at 10 20 31 PM" src="https://user-images.githubusercontent.com/432915/227431577-36098d79-1bc9-4a5d-b286-f741ee332ed4.png">

************
...and in this version it is like:

************

<img width="636" alt="Screen Shot 2023-03-23 at 10 20 54 PM" src="https://user-images.githubusercontent.com/432915/227431632-fc7e5c7a-8847-4a53-abbc-9bb254877e41.png">



