### PR TITLE
Refer to BCP 47, not to RFC 5646

### DIFF
--- a/files/en-us/web/http/headers/content-language/index.md
+++ b/files/en-us/web/http/headers/content-language/index.md
@@ -54,7 +54,7 @@ Content-Language: de-DE, en-CA
 - `language-tag`
   - : Multiple language tags are separated by a comma. Each language tag is a sequence of one or more case-insensitive subtags, each separated by a hyphen character ("`-`", `%x2D`). In most cases, a language tag consists of a primary language subtag that identifies a broad family of related languages (e.g., "`en`" = English) and is optionally followed by a series of subtags that refine or narrow that language's range (e.g., "`en-CA`" = the variety of English as communicated in Canada).
 
-> **Note:** Language tags are formally defined in [RFC 5646](https://datatracker.ietf.org/doc/html/rfc5646), which rely on the [ISO 639](https://en.wikipedia.org/wiki/ISO_639) standard (quite often the [ISO 639-1 code list](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) for [language codes](https://en.wikipedia.org/wiki/Language_code) to be used.
+> **Note:** Language tags are formally defined in [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt), which rely on the [ISO 639](https://en.wikipedia.org/wiki/ISO_639) standard (quite often the [ISO 639-1 code list](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) for [language codes](https://en.wikipedia.org/wiki/Language_code) to be used.
 
 ## Examples
 


### PR DESCRIPTION
This PR uses the recommended URL of the IETF language tag standard, so if the spec is updated, we don't need to update the URL. This is also the URL [recommended](https://www.w3.org/TR/international-specs/#lang_bcp_not_rfc) by W3C (for many years):

> The link to and name of BCP 47 was created specifically so that there is an unchanging reference to the definition of Tags for the Identification of Languages. RFCs 1766, 3066, 4646 were previous (superseded) versions and 5646 is the current version of BCP 47.

In terms of content, RFC 5646 is just the core of BCP 47, so it doesn't introduce or remove any language tags. (The language subtags are managed by the [IANA Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).)