### PR TITLE
Fix return value of Window.showDirectoryPicker()

### DIFF
--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -38,7 +38,7 @@ showDirectoryPicker()
 
 ### Return value
 
-A {{domxref('FileSystemDirectoryHandle')}}.
+A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSystemDirectoryHandle')}} object.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fix return value of `Window.showDirectoryPicker()`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This method should return a `Promise`, not raw `FileSystemDirectoryHandle`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The specification: [File System Access](https://wicg.github.io/file-system-access/#api-showdirectorypicker)

> 3.5. The showDirectoryPicker() method
> 
> (omit)
> 
> The showDirectoryPicker(options) method, when invoked, must run these steps:
> 
> (omit)
> 
> 5\. Let p be a new promise.
> 
> (omit)
> 
> 7\. Return p.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
