### PR TITLE
Updated article example text

### DIFF
--- a/files/en-us/web/css/animation-fill-mode/index.md
+++ b/files/en-us/web/css/animation-fill-mode/index.md
@@ -77,7 +77,7 @@ animation-fill-mode: unset;
 
 ### Setting fill mode
 
-You can see the effect of `animation-fill-mode` in the following example. It demonstrates how, for an animation that runs for specified time, you can cause it to remain in its final state rather than reverting to the original state (which is the default).
+You can see the effect of `animation-fill-mode` in the following example. It demonstrates how you can make the animation remain in its final state rather than reverting to the original state (which is the default).
 
 #### HTML
 

--- a/files/en-us/web/css/animation-fill-mode/index.md
+++ b/files/en-us/web/css/animation-fill-mode/index.md
@@ -77,7 +77,7 @@ animation-fill-mode: unset;
 
 ### Setting fill mode
 
-You can see the effect of `animation-fill-mode` in the following example. It demonstrates how, for an animation that runs for an infinite time, you can cause it to remain in its final state rather than reverting to the original state (which is the default).
+You can see the effect of `animation-fill-mode` in the following example. It demonstrates how, for an animation that runs for specified time, you can cause it to remain in its final state rather than reverting to the original state (which is the default).
 
 #### HTML
 


### PR DESCRIPTION


### Description
Second sentence in the example text "It demonstrates how, for an animation that runs for an infinite time, you can cause it to remain in its final state rather than reverting to the original state (which is the default)" was changed to "It demonstrates how, for an animation that runs for specified time, you can cause it to remain in its final state rather than reverting to the original state (which is the default)" because example crearly shows that animation time is set for 3s and not for infinite time.

### Motivation
Just wanted to help creators and users of the website.
