### PR TITLE
Fix 17274: JS execution not DOM loading

### DIFF
--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -200,7 +200,7 @@ In our example, maybe the image loaded quickly, but perhaps the `anotherscript.j
 
 ![The main thread is occupied by the downloading, parsing and execution of a JavaScript file - over a fast connection](visa_network.png)
 
-In this example, the DOM content load process took over 1.5 seconds, and the main thread was fully occupied that entire time, unresponsive to click events or screen taps.
+In this example, JavaScript execution took over 1.5 seconds, and the main thread was fully occupied that entire time, unresponsive to click events or screen taps.
 
 ## See also
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17274.

I think the report here is exactly right, and it the page should say "JS execution".