### PR TITLE
Document SpeechSynthesis*Event()

### DIFF
--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
@@ -12,7 +12,7 @@ The **`error`** property of the
 
 ## Value
 
-A string containing the reason of the error. Possible values are:
+A string containing the error reason. Possible values are:
 
 - `canceled`
   - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the

--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
@@ -12,7 +12,7 @@ The **`error`** property of the
 
 ## Value
 
-A string containing an error code. Possible codes are:
+A string containing the reason of the error. Possible values are:
 
 - `canceled`
   - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the
@@ -50,6 +50,8 @@ A string containing an error code. Possible codes are:
   - : The content of the {{domxref("SpeechSynthesisUtterance.rate")}},
     {{domxref("SpeechSynthesisUtterance.pitch")}} or
     {{domxref("SpeechSynthesisUtterance.volume")}} property was not valid.
+- `not-allowed`
+  - : The operation's start was not allowed.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.md
@@ -11,6 +11,11 @@ The **`SpeechSynthesisErrorEvent`** interface of the [Web Speech API](/en-US/doc
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- {{domxref("SpeechSynthesisErrorEvent.SpeechSynthesisErrorEvent", "SpeechSynthesisErrorEvent()")}}
+  - : Creates a new `SpeechSynthesisErrorEvent`.
+
 ## Instance properties
 
 _`SpeechSynthesisErrorEvent` extends the {{domxref("SpeechSynthesisEvent")}} interface, which inherits properties from its parent interface, {{domxref("Event")}}._

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -25,7 +25,7 @@ new SpeechSynthesisErrorEvent(type, options)
 - `options`
   - : An object that, _in addition to the properties defined in {{domxref("SpeechSynthesisEvent/SpeechSynthesisEvent", "SpeechSynthesisEvent()")}}_, has the following properties:
     - `error`
-      - : A string containing the reason of the error. Possible values are:
+      - : A string containing the error reason. Possible values are:
         - `canceled`
           - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before it had begun being spoken.
         - `interrupted`

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -29,7 +29,7 @@ new SpeechSynthesisErrorEvent(type, options)
         - `canceled`
           - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before speech started.
         - `interrupted`
-          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}}  to be interrupted after speech had started but before it completed.
+          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be interrupted after speech had started but before it completed.
         - `audio-busy`
           - : The operation couldn't be completed at this time because the user-agent couldn't access the audio output device (for example, the user may need to correct this by closing another application).
         - `audio-hardware`

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -31,7 +31,7 @@ new SpeechSynthesisErrorEvent(type, options)
         - `interrupted`
           - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}}  to be interrupted after speech had started but before it completed.
         - `audio-busy`
-          - : The operation couldn't be completed at this time because the user-agent couldn't access the audio output device (for example, the user may need to correct this by closing another application.)
+          - : The operation couldn't be completed at this time because the user-agent couldn't access the audio output device (for example, the user may need to correct this by closing another application).
         - `audio-hardware`
           - : The operation couldn't be completed at this time because the user-agent couldn't identify an audio output device (for example, the user may need to connect a speaker or configure system settings.)
         - `network`

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -1,0 +1,68 @@
+---
+title: SpeechSynthesisErrorEvent()
+slug: Web/API/SpeechSynthesisErrorEvent/SpeechSynthesisErrorEvent
+page-type: web-api-constructor
+browser-compat: api.SpeechSynthesisErrorEvent.SpeechSynthesisErrorEvent
+---
+
+{{APIRef("Web Speech API")}}
+
+The **`SpeechSynthesisErrorEvent()`** constructor creates a new {{domxref("SpeechSynthesisErrorEvent")}} object.
+
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+
+## Syntax
+
+```js-nolint
+new SpeechSynthesisErrorEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `error`.
+- `options`
+  - : An object that, _in addition of the properties defined in {{domxref("SpeechSynthesisEvent/SpeechSynthesisEvent", "SpeechSynthesisEvent()")}}_, has the following properties:
+    - `error`
+      - : A string containing the reason of the error. Possible values are:
+        - `canceled`
+          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before it had begun being spoken.
+        - `interrupted`
+          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be interrupted after it had begun being spoken and before it completed.
+        - `audio-busy`
+          - : The operation couldn't be completed at this time because the user-agent couldn't access the audio output device (for example, the user may need to correct this by closing another application.)
+        - `audio-hardware`
+          - : The operation couldn't be completed at this time because the user-agent couldn't identify an audio output device (for example, the user may need to connect a speaker or configure system settings.)
+        - `network`
+          - : The operation couldn't be completed at this time because some required network communication failed.
+        - `synthesis-unavailable`
+          - : The operation couldn't be completed at this time because no synthesis engine was available (For example, the user may need to install or configure a synthesis engine.)
+        - `synthesis-failed`
+          - : The operation failed because the synthesis engine raised an error.
+        - `language-unavailable`
+          - : No appropriate voice was available for the language set in {{domxref("SpeechSynthesisUtterance.lang")}}. You can use the [`window.speechSynthesis.getVoices()`](/en-US/docs/Web/API/SpeechSynthesis/getVoices) method to determine which voices and languages are supported in the user's browser.
+        - `voice-unavailable`
+          - : The voice set in {{domxref("SpeechSynthesisUtterance.voice")}} was not available.
+        - `text-too-long`
+          - : The contents of the {{domxref("SpeechSynthesisUtterance.text")}} attribute was too long to synthesize.
+        - `invalid-argument`
+          - : The content of the {{domxref("SpeechSynthesisUtterance.rate")}}, {{domxref("SpeechSynthesisUtterance.pitch")}} or {{domxref("SpeechSynthesisUtterance.volume")}} property was not valid.
+        - `not-allowed`
+          - : The operation's start was not allowed.
+
+### Return value
+
+A new {{domxref("SpeechSynthesisErrorEvent")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SpeechSynthesisEvent")}}

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -23,7 +23,7 @@ new SpeechSynthesisErrorEvent(type, options)
   - : A string with the name of the event.
     It is case-sensitive and browsers set it to `error`.
 - `options`
-  - : An object that, _in addition of the properties defined in {{domxref("SpeechSynthesisEvent/SpeechSynthesisEvent", "SpeechSynthesisEvent()")}}_, has the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("SpeechSynthesisEvent/SpeechSynthesisEvent", "SpeechSynthesisEvent()")}}_, has the following properties:
     - `error`
       - : A string containing the reason of the error. Possible values are:
         - `canceled`

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -37,7 +37,7 @@ new SpeechSynthesisErrorEvent(type, options)
         - `network`
           - : The operation couldn't be completed at this time because some required network communication failed.
         - `synthesis-unavailable`
-          - : The operation couldn't be completed at this time because no synthesis engine was available (For example, the user may need to install or configure a synthesis engine.)
+          - : The operation couldn't be completed at this time because no synthesis engine was available (for example, the user may need to install or configure a synthesis engine).
         - `synthesis-failed`
           - : The operation failed because the synthesis engine raised an error.
         - `language-unavailable`

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -27,9 +27,9 @@ new SpeechSynthesisErrorEvent(type, options)
     - `error`
       - : A string containing the error reason. Possible values are:
         - `canceled`
-          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before it had begun being spoken.
+          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be removed from the queue before speech started.
         - `interrupted`
-          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}} to be interrupted after it had begun being spoken and before it completed.
+          - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the {{domxref("SpeechSynthesisUtterance")}}  to be interrupted after speech had started but before it completed.
         - `audio-busy`
           - : The operation couldn't be completed at this time because the user-agent couldn't access the audio output device (for example, the user may need to correct this by closing another application.)
         - `audio-hardware`

--- a/files/en-us/web/api/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/index.md
@@ -11,6 +11,11 @@ The **`SpeechSynthesisEvent`** interface of the [Web Speech API](/en-US/docs/Web
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- {{domxref("SpeechSynthesisEvent.SpeechSynthesisEvent", "SpeechSynthesisEvent()")}}
+  - : Creates a new `SpeechSynthesisEvent`.
+
 ## Instance properties
 
 _The {{domxref("SpeechSynthesisEvent")}} interface also inherits properties from its parent interface, {{domxref("Event")}}._

--- a/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
@@ -23,7 +23,7 @@ new SpeechSynthesisEvent(type, options)
   - : A string with the name of the event.
     It is case-sensitive and browsers set it to `start`, `end`, `error`, `pause`, `resume`, `mark`, or `boundary`.
 - `options`
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `utterance`
       - : A {{domxref("SpeechSynthesisUtterance")}} object, that is the speech request the event was triggered on.
     - `charIndex` {{Optional_inline}}

--- a/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
@@ -31,7 +31,7 @@ new SpeechSynthesisEvent(type, options)
     - `charLength` {{Optional_inline}}
       - : The number of characters left to be spoken after the character at the {{DOMxRef("SpeechSynthesisEvent.charIndex", "charIndex")}} position. Its default value is `0`.
     - `elapsedTime` {{Optional_inline}}
-      - : The elapsed time in seconds, after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken, at which the event was triggered.Its default value is `0`.
+      - : The elapsed time in seconds, after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken, at which the event was triggered. Its default value is `0`.
     - `name` {{Optional_inline}}
       - : The name associated with certain types of events: the name of the [SSML](https://www.w3.org/TR/speech-synthesis/#S3.3.2) marker reached in the case of a {{domxref("SpeechSynthesisUtterance.mark_event", "mark")}} event, or the type of boundary reached in the case of a {{domxref("SpeechSynthesisUtterance.boundary_event", "boundary")}} event. It defaults to the empty string (`""`).
 

--- a/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
@@ -1,0 +1,52 @@
+---
+title: SpeechSynthesisEvent()
+slug: Web/API/SpeechSynthesisEvent/SpeechSynthesisEvent
+page-type: web-api-constructor
+browser-compat: api.SpeechSynthesisEvent.SpeechSynthesisEvent
+---
+
+{{APIRef("Web Speech API")}}
+
+The **`SpeechSynthesisEvent()`** constructor creates a new {{domxref("SpeechSynthesisEvent")}} object.
+
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+
+## Syntax
+
+```js-nolint
+new SpeechSynthesisEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `start`, `end`, `error`, `pause`, `resume`, `mark`, or `boundary`.
+- `options`
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
+    - `utterance`
+      - : A {{domxref("SpeechSynthesisUtterance")}} object, that is the speech request the event was triggered on.
+    - `charIndex` {{Optional_inline}}
+      - : The index position of the character in {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered. Its default value is `0`.
+    - `charLength` {{Optional_inline}}
+      - : The number of characters left to be spoken after the character at the {{DOMxRef("SpeechSynthesisEvent.charIndex", "charIndex")}} position. Its default value is `0`.
+    - `elapsedTime` {{Optional_inline}}
+      - : The elapsed time in seconds, after the {{domxref("SpeechSynthesisUtterance.text")}} started being spoken, at which the event was triggered.Its default value is `0`.
+    - `name` {{Optional_inline}}
+      - : The name associated with certain types of events: the name of the [SSML](https://www.w3.org/TR/speech-synthesis/#S3.3.2) marker reached in the case of a {{domxref("SpeechSynthesisUtterance.mark_event", "mark")}} event, or the type of boundary reached in the case of a {{domxref("SpeechSynthesisUtterance.boundary_event", "boundary")}} event. It defaults to the empty string (`""`).
+
+### Return value
+
+A new {{domxref("SpeechSynthesisEvent")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SpeechSynthesisErrorEvent")}}

--- a/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
@@ -25,7 +25,7 @@ new SpeechSynthesisEvent(type, options)
 - `options`
   - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `utterance`
-      - : A {{domxref("SpeechSynthesisUtterance")}} object, that is the speech request the event was triggered on.
+      - : A {{domxref("SpeechSynthesisUtterance")}} object, which is the speech request the event was triggered on.
     - `charIndex` {{Optional_inline}}
       - : The index position of the character in {{domxref("SpeechSynthesisUtterance.text")}} that was being spoken when the event was triggered. Its default value is `0`.
     - `charLength` {{Optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add constructors:
- `SpeechSynthesisEvent()`
- `SpeechSynthesisErrorEvent()`

### Motivation

openwebdocs/project#152

### Additional details

- Detected thanks to this fix in the mdn-gaps tool: dontcallmedom/mdn-gaps#2 
- I didn't add any examples, except in edge cases, as the browser calls these constructors. They would have been very artificial, and we don't want web developers to cut & paste them. In 99.99% of cases, they don't need to call these constructors themselves.

### Related issues and pull requests

- BCD PR to add the missing `mdn_url` entries: mdn/browser-compat-data#19229