### PR TITLE
Add XMLSerializer() docs

### DIFF
--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -9,6 +9,11 @@ browser-compat: api.XMLSerializer
 
 The `XMLSerializer` interface provides the {{domxref("XMLSerializer.serializeToString", "serializeToString()")}} method to construct an XML string representing a {{Glossary("DOM")}} tree.
 
+## Constructor
+
+- {{domxref("XMLSerializer.XMLSerializer", "XMLSerializer()")}}
+  - : Creates a new `XMLSerializer` object.
+
 ## Instance methods
 
 - {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}
@@ -18,16 +23,15 @@ The `XMLSerializer` interface provides the {{domxref("XMLSerializer.serializeToS
 
 ### Serializing XML into a string
 
-The first, basic, example just serializes an entire document into a string containing XML.
+This example just serializes an entire document into a string containing XML.
 
 ```js
  const s = new XMLSerializer();
- const d = document;
- const str = s.serializeToString(d);
+ const str = s.serializeToString(document);
  saveXML(str);
 ```
 
-This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document.
+This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. The function `saveXML()` stands for the subsequent action on the serialized string.
 
 ### Inserting nodes into a DOM based on XML
 

--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -31,7 +31,7 @@ This example just serializes an entire document into a string containing XML.
  saveXML(str);
 ```
 
-This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. The function `saveXML()` stands for the subsequent action on the serialized string.
+This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. `saveXML()` represents a function that would then save the serialized string.
 
 ### Inserting nodes into a DOM based on XML
 

--- a/files/en-us/web/api/xmlserializer/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/xmlserializer/index.md
@@ -36,7 +36,7 @@ This example serializes an entire document into a string containing XML.
  saveXML(str);
 ```
 
-This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. The function `saveXML()` stands for the subsequent action on the serialized string.
+This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document.  `saveXML()` represents a function that would then save the serialized string.
 
 ## Specifications
 

--- a/files/en-us/web/api/xmlserializer/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/xmlserializer/index.md
@@ -1,0 +1,47 @@
+---
+title: XMLSerializer()
+slug: Web/API/XMLSerializer/XMLSerializer
+page-type: web-api-constructor
+browser-compat: api.XMLSerializer.XMLSerializer
+---
+
+{{APIRef('XMLSerializer')}}
+
+The **`XMLSerializer()`** constructor creates a new {{domxref("XMLSerializer")}}.
+
+## Syntax
+
+```js-nolint
+new XMLSerializer()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A new {{domxref("XMLSerializer")}} object.
+
+## Examples
+
+### Serializing XML into a string
+
+This example serializes an entire document into a string containing XML.
+
+```js
+ const s = new XMLSerializer();
+ const d = document;
+ const str = s.serializeToString(d);
+ saveXML(str);
+```
+
+This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. The function `saveXML()` stands for the subsequent action on the serialized string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/xmlserializer/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/xmlserializer/index.md
@@ -36,7 +36,7 @@ This example serializes an entire document into a string containing XML.
  saveXML(str);
 ```
 
-This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document.  `saveXML()` represents a function that would then save the serialized string.
+This involves creating a new `XMLSerializer` object, then passing the {{domxref("Document")}} to be serialized into {{domxref("XMLSerializer.serializeToString", "serializeToString()")}}, which returns the XML equivalent of the document. `saveXML()` represents a function that would then save the serialized string.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add documentation for:

- `XMLSerializer()`

### Motivation

openwebdocs/project#152

### Additional details

- Detected thanks to this fix in the mdn-gaps tool: dontcallmedom/mdn-gaps#2 

### Related issues and pull requests

- BCD PR to add the missing `mdn_url` entries: mdn/browser-compat-data#19230
