### PR TITLE
Add XPathEvaluator() documentation

### DIFF
--- a/files/en-us/web/api/xpathevaluator/index.md
+++ b/files/en-us/web/api/xpathevaluator/index.md
@@ -9,7 +9,10 @@ browser-compat: api.XPathEvaluator
 
 The `XPathEvaluator` interface allows to compile and evaluate {{Glossary("XPath")}} expressions.
 
-It is implemented by the {{domxref("Document")}} interface.
+## Constructor
+
+- {{domxref("XPathEvaluator.XPathEvaluator", "XPathEvaluator()")}}
+  - : Creates a new `XPathEvaluator` object.
 
 ## Instance methods
 
@@ -22,16 +25,18 @@ It is implemented by the {{domxref("Document")}} interface.
 
 ## Example
 
+### Count the number of `<div>` elements
+
 The following example shows the use of the `XPathEvaluator` interface.
 
-### HTML
+#### HTML
 
 ```html
 <div>XPath example</div>
-<div>Number of &lt;div&gt;s: <output></output></div>
+<div>Number of &lt;div&gt; elements: <output></output></div>
 ```
 
-### JavaScript
+#### JavaScript
 
 ```js
 const xpath = "//div";
@@ -41,9 +46,9 @@ const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_T
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample('Example', 400, 70)}}
+{{EmbedLiveSample("count_the_number_of_div_elements", "100%", "40")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/xpathevaluator/xpathevaluator/index.md
+++ b/files/en-us/web/api/xpathevaluator/xpathevaluator/index.md
@@ -48,7 +48,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 #### Result
 
-{{EmbedLiveSample("count_the_number_of_div_elements", "100%", "40")}}
+{{EmbedLiveSample("count_the_number_of_div_elements", "100%", "50")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/xpathevaluator/xpathevaluator/index.md
+++ b/files/en-us/web/api/xpathevaluator/xpathevaluator/index.md
@@ -1,0 +1,59 @@
+---
+title: XPathEvaluator()
+slug: Web/API/XPathEvaluator/XPathEvaluator
+page-type: web-api-constructor
+browser-compat: api.XPathEvaluator.XPathEvaluator
+---
+
+{{APIRef('DOM XPath')}}
+
+The **`XPathEvaluator()`** constructor creates a new {{domxref("XPathEvaluator")}}.
+
+## Syntax
+
+```js-nolint
+new XPathEvaluator()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A new {{domxref("XPathEvaluator")}} object.
+
+## Examples
+
+### Count the number of `<div>` elements
+
+The following example shows the use of the `XPathEvaluator` interface.
+
+#### HTML
+
+```html
+<div>XPath example</div>
+<div>Number of &lt;div&gt; elements: <output></output></div>
+```
+
+#### JavaScript
+
+```js
+const xpath = "//div";
+const evaluator = new XPathEvaluator();
+const expression = evaluator.createExpression(xpath);
+const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+document.querySelector("output").textContent = result.snapshotLength;
+```
+
+#### Result
+
+{{EmbedLiveSample("count_the_number_of_div_elements", "100%", "40")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add documentation for:

- `XPathEvaluator()`

### Motivation

openwebdocs/project#152

### Additional details

- Detected thanks to this fix in the mdn-gaps tool: dontcallmedom/mdn-gaps#2 

### Related issues and pull requests

- BCD PR to add the missing `mdn_url` entries: mdn/browser-compat-data#19232
