### PR TITLE
Add FileReaderSync() documentation

### DIFF
--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -20,7 +20,7 @@ File objects may be obtained from a {{domxref("FileList")}} object returned as a
 ## Constructor
 
 - {{domxref("FileReader.FileReader", "FileReader()")}}
-  - : Returns a newly constructed `FileReader`.
+  - : Returns a new `FileReader` object.
 
 See [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files_from_web_applications) for details and examples.
 

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -28,7 +28,7 @@ function readFile(blob) {
   const reader = new FileReaderSync();
   postMessage(reader.readAsDataURL(blob));
 }
-
+```
 > **Note:** This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
 
 ## Specifications

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -1,0 +1,44 @@
+---
+title: FileReaderSync()
+slug: Web/API/FileReaderSync/FileReaderSync
+page-type: web-api-constructor
+browser-compat: api.FileReaderSync.FileReaderSync
+---
+
+{{APIRef("File API")}}
+
+The **`FileReaderSync()`** constructor creates a new {{domxref("FileReaderSync")}}.
+
+## Syntax
+
+```js-nolint
+new FileReader()
+```
+
+### Parameters
+
+None.
+
+## Examples
+
+The following code snippet shows creation of a [`FileReaderSync`](/en-US/docs/Web/API/FileReaderSync) object using the `FileReaderSync()` constructor and subsequent usage of the object:
+
+```js
+function printFile(file) {
+  const reader = new FileReader();
+  reader.onload = (evt) => {
+    console.log(evt.target.result);
+  };
+  reader.readAsText(file);
+}
+```
+
+> **Note:** This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -24,14 +24,10 @@ None.
 The following code snippet shows creation of a [`FileReaderSync`](/en-US/docs/Web/API/FileReaderSync) object using the `FileReaderSync()` constructor and subsequent usage of the object:
 
 ```js
-function printFile(file) {
-  const reader = new FileReader();
-  reader.onload = (evt) => {
-    console.log(evt.target.result);
-  };
-  reader.readAsText(file);
+function readFile(blob) {
+  const reader = new FileReaderSync();
+  postMessage(reader.readAsDataURL(blob));
 }
-```
 
 > **Note:** This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
 

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -12,7 +12,7 @@ The **`FileReaderSync()`** constructor creates a new {{domxref("FileReaderSync")
 ## Syntax
 
 ```js-nolint
-new FileReader()
+new FileReaderSync()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -29,6 +29,7 @@ function readFile(blob) {
   postMessage(reader.readAsDataURL(blob));
 }
 ```
+
 > **Note:** This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
 
 ## Specifications

--- a/files/en-us/web/api/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/index.md
@@ -13,6 +13,11 @@ The `FileReaderSync` interface allows to read {{DOMxRef("File")}} or {{DOMxRef("
 
 > **Warning:** This interface is **only available** in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
+## Constructor
+
+- {{domxref("FileReaderSync.FileReaderSync", "FileReaderSync()")}}
+  - : Returns a new `FileReaderSync` object.
+
 ## Instance properties
 
 This interface does not have any properties.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add documentation for:

- `FileReaderSync()`

### Motivation

openwebdocs/project#152

### Additional details

- Detected thanks to this fix in the mdn-gaps tool: dontcallmedom/mdn-gaps#2 
- There is no spec_url in mdn/browser-compat-data, hence the spec table is broken. The BCD PR will fix this.

### Related issues and pull requests

- BCD PR to add the missing `mdn_url` and `spec_url`entries: mdn/browser-compat-data#19233
