### PR TITLE
Document WebGLContextEvent()

### DIFF
--- a/files/en-us/web/api/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/index.md
@@ -11,6 +11,11 @@ The **WebContextEvent** interface is part of the [WebGL API](/en-US/docs/Web/API
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- {{domxref("WebGLContextEvent.WebGLContextEvent", "WebGLContextEvent()")}}
+  - : Creates a new `WebGLContextEvent` object.
+
 ## Instance properties
 
 _This interface inherits properties from its parent interface, {{domxref("Event")}}._

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -21,7 +21,7 @@ new WebGLContextEvent(type, options)
 
 - `type`
   - : A string indicating the type of the event.
-    It is case-sensitive and browsers set it to `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
+    It is case-sensitive and should be one of `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
 - `options` {{Optional_inline}}
   - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `statusMessage` {{Optional_inline}}

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -1,0 +1,46 @@
+---
+title: WebGLContextEvent()
+slug: Web/API/WebGLContextEvent/WebGLContextEvent
+page-type: web-api-constructor
+browser-compat: api.WebGLContextEvent.WebGLContextEvent
+---
+
+{{APIRef("WebGL")}}
+
+The **`WebGLContextEvent()`** constructor creates a new {{domxref("WebGLContextEvent")}} object.
+
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+
+## Syntax
+
+```js-nolint
+new WebGLContextEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
+- `options` {{Optional_inline}}
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
+    - `status` {{Optional_inline}}
+      - : A string with some additional status information. It defaults to the empty string (`""`).
+
+### Return value
+
+A new {{domxref("WebGLContextEvent")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)
+- [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event)
+- [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.WebGLContextEvent.WebGLContextEvent
 
 The **`WebGLContextEvent()`** constructor creates a new {{domxref("WebGLContextEvent")}} object.
 
-> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+> **Note:** You typically don't need to call this constructor; the browser creates these objects automatically when WebGL context events get fired. To manually trigger a `webglcontextlost` event, use {{domxref("WEBGL_lose_context.loseContext()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -20,7 +20,7 @@ new WebGLContextEvent(type, options)
 ### Parameters
 
 - `type`
-  - : A string with the name of the event.
+  - : A string indicating the type of the event.
     It is case-sensitive and browsers set it to `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
 - `options` {{Optional_inline}}
   - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -24,7 +24,7 @@ new WebGLContextEvent(type, options)
     It is case-sensitive and browsers set it to `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
 - `options` {{Optional_inline}}
   - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
-    - `status` {{Optional_inline}}
+    - `statusMessage` {{Optional_inline}}
       - : A string with some additional status information. It defaults to the empty string (`""`).
 
 ### Return value

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -25,7 +25,7 @@ new WebGLContextEvent(type, options)
 - `options` {{Optional_inline}}
   - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `statusMessage` {{Optional_inline}}
-      - : A string with some additional status information. It defaults to the empty string (`""`).
+      - : A string with additional status information. It defaults to the empty string (`""`).
 
 ### Return value
 

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -23,7 +23,7 @@ new WebGLContextEvent(type, options)
   - : A string with the name of the event.
     It is case-sensitive and browsers set it to `webglcontextcreationerror`, `webglcontextlost`, or `weblcontextrestored`.
 - `options` {{Optional_inline}}
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `status` {{Optional_inline}}
       - : A string with some additional status information. It defaults to the empty string (`""`).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add documentation for:

- `WebGLContextEvent()`

### Motivation

openwebdocs/project#152

### Additional details

- Detected thanks to this fix in the mdn-gaps tool: dontcallmedom/mdn-gaps#2 
- I didn't add any examples, except in edge cases, as the browser calls these constructors. They would have been very artificial, and we don't want web developers to cut & paste them. In 99.99% of cases, they don't need to call these constructors themselves.

### Related issues and pull requests

- BCD PR to add the missing `mdn_url` entry: mdn/browser-compat-data#TBD
