### PR TITLE
InjectionResult.error is not supported by Chrome

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -61,7 +61,7 @@ Each `InjectionResult` object has these properties:
 - `error` {{optional_inline}}
   - : `any`. If an error occurs, contains the value the script threw or rejected with. Typically this is an error object with a message property but it could be any value (including primitives and undefined).
 
-    Unsupported by Chrome, it just sets `result` to `null` hiding any details of an exception thrown by a function or a script file. Alternatevely exception is thrown or `runtime.lastError` is passed to the callback when a script file is not found.
+    Chrome does not support the `error` property yet (see [Issue 1271527: Propagate errors from scripting.executeScript to InjectionResult](https://crbug.com/1271527)). As an alternative, runtime errors can be caught by wrapping the code to execute in a try-catch statement. Uncaught errors are also reported to the console of the target tab.
 
 The result of the script is the last evaluated statement, which is similar to the results seen if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) (not any `console.log()` output). For example, consider a script like this:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -61,6 +61,8 @@ Each `InjectionResult` object has these properties:
 - `error` {{optional_inline}}
   - : `any`. If an error occurs, contains the value the script threw or rejected with. Typically this is an error object with a message property but it could be any value (including primitives and undefined).
 
+    Unsupported by Chrome, it just sets `result` to `null` hiding any details of an exception thrown by a function or a script file. Alternatevely exception is thrown or `runtime.lastError` is passed to the callback when a script file is not found.
+
 The result of the script is the last evaluated statement, which is similar to the results seen if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) (not any `console.log()` output). For example, consider a script like this:
 
 ```js


### PR DESCRIPTION
Clarify `scripting.executeScript()` (WebExtensions) error handling in Chrome that differs from Firefox.

### Motivation

Avoid confusion of developers of cross-browser extensions.