### PR TITLE
Fix link capitalization

### DIFF
--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -76,7 +76,7 @@ new Request(input, options)
     - `keepalive`
       - : A boolean that indicates whether to make a persistent connection for multiple requests/responses.
     - `signal`
-      - : An [AbortSignal](/en-US/docs/Web/API/abortsignal) object which can be used to communicate with/abort a request.
+      - : An [AbortSignal](/en-US/docs/Web/API/AbortSignal) object which can be used to communicate with/abort a request.
     - `priority`
       - : Specifies the priority of the fetch request relative to other requests of the same type. Must be one of the following strings:
         - `high`: A high priority fetch request relative to other requests of the same type.


### PR DESCRIPTION
We use slugs and not file paths. This was a mix of both.