### PR TITLE
Remove duplicate from See also section

### DIFF
--- a/files/en-us/web/api/htmlelement/contenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.md
@@ -35,6 +35,5 @@ A string.
 
 ## See also
 
-- [Making content editable](/en-US/docs/Web/Guide/HTML/Editable_content)
 - {{domxref("HTMLElement.isContentEditable")}}
 - The [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes#contenteditable) global attribute.


### PR DESCRIPTION
The original page was removed and is now redirecting to the `contenteditable` attribute that is already listed in the _See also_ section.