### PR TITLE
Remove broken outdated entry in See also

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -86,4 +86,3 @@ video.onloadedmetadata = (event) => {
 - {{domxref("HTMLVideoElement")}}
 - {{HTMLElement("audio")}}
 - {{HTMLElement("video")}}
-- This event is part of gecko's [Audio API extension](/en-US/docs/Introducing_the_Audio_API_Extension)


### PR DESCRIPTION
The link was implying that this is non-standard. This is part of HTML for more than a decade now.