### PR TITLE
remove extra space in `console.log()`

### DIFF
--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -66,7 +66,7 @@ while (!result.done) {
   result = it.next();
 }
 
-console.log("Iterated over sequence of size: ", result.value); // [5 numbers returned, that took interval in between: 0 to 10]
+console.log("Iterated over sequence of size:", result.value); // [5 numbers returned, that took interval in between: 0 to 10]
 ```
 
 > **Note:** It is not possible to know reflectively whether a particular object is an iterator. If you need to do this, use [Iterables](#iterables).

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -278,11 +278,11 @@ for (let i = 0; i < a.length; i++) {
 let x = 0;
 let z = 0;
 labelCancelLoops: while (true) {
-  console.log("Outer loops: ", x);
+  console.log("Outer loops:", x);
   x += 1;
   z = 1;
   while (true) {
-    console.log("Inner loops: ", z);
+    console.log("Inner loops:", z);
     z += 1;
     if (z === 10 && x === 10) {
       break labelCancelLoops;
@@ -366,10 +366,10 @@ checkiandj: while (i < 4) {
     if (j % 2 === 0) {
       continue checkj;
     }
-    console.log(j, " is odd.");
+    console.log(j, "is odd.");
   }
-  console.log("i = ", i);
-  console.log("j = ", j);
+  console.log("i =", i);
+  console.log("j =", j);
 }
 ```
 

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -48,7 +48,7 @@ Alternatively, you can consider using a [template literal](/en-US/docs/Web/JavaS
 
 ```js example-good
 console.log(`PI: ${Math.PI}`);
-console.log("PI: ", Math.PI);
+console.log("PI:", Math.PI);
 ```
 
 ### Unterminated strings

--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -62,7 +62,7 @@ const global = this;
 
 const sillyFunction = function (recursed) {
   if (this !== global) {
-    console.log("This is: ", this);
+    console.log("This is:", this);
   } else {
     console.log("This is the global");
   }

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -135,7 +135,7 @@ console.log("Filtered Array\n", arrByID);
 // Filtered Array
 // [{ id: 15 }, { id: -1 }, { id: 3 }, { id: 12.2 }]
 
-console.log("Number of Invalid Entries = ", invalidEntries);
+console.log("Number of Invalid Entries =", invalidEntries);
 // Number of Invalid Entries = 5
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -139,7 +139,7 @@ const array = [0, 1, , , , 5, 6];
 
 // Shows all indexes, not just those with assigned values
 array.find((value, index) => {
-  console.log(`Visited index ${index} with value ${value}`);
+  console.log("Visited index", index, "with value", value);
 });
 // Visited index 0 with value 0
 // Visited index 1 with value 1
@@ -153,11 +153,11 @@ array.find((value, index) => {
 array.find((value, index) => {
   // Delete element 5 on first iteration
   if (index === 0) {
-    console.log(`Deleting array[5] with value ${array[5]}`);
+    console.log("Deleting array[5] with value", array[5]);
     delete array[5];
   }
   // Element 5 is still visited even though deleted
-  console.log(`Visited index ${index} with value ${value}`);
+  console.log("Visited index", index, "with value", value);
 });
 // Deleting array[5] with value 5
 // Visited index 0 with value 0

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -139,7 +139,7 @@ const array = [0, 1, , , , 5, 6];
 
 // Shows all indexes, not just those with assigned values
 array.find((value, index) => {
-  console.log("Visited index ", index, " with value ", value);
+  console.log(`Visited index ${index} with value ${value}`);
 });
 // Visited index 0 with value 0
 // Visited index 1 with value 1
@@ -153,11 +153,11 @@ array.find((value, index) => {
 array.find((value, index) => {
   // Delete element 5 on first iteration
   if (index === 0) {
-    console.log("Deleting array[5] with value ", array[5]);
+    console.log(`Deleting array[5] with value ${array[5]}`);
     delete array[5];
   }
   // Element 5 is still visited even though deleted
-  console.log("Visited index ", index, " with value ", value);
+  console.log(`Visited index ${index} with value ${value}`);
 });
 // Deleting array[5] with value 5
 // Visited index 0 with value 0

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -385,7 +385,7 @@ const str = `if (x === 5) {
   z = 0;
 }`;
 
-console.log("x is ", eval(str)); // z is 42  x is 420
+console.log("x is", eval(str)); // z is 42  x is 420
 ```
 
 ### eval() as a string defining function requires "(" and ")" as prefix and suffix

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -116,9 +116,9 @@ Intl.DateTimeFormat(locales, options)
     - `numberingSystem`
       - : Numbering System. Possible values include: `"arab"`,
         `"arabext"`, `"bali"`, `"beng"`,
-        `"deva"`, `"fullwide"`, " `gujr`",
-        `"guru"`, `"hanidec"`, `"khmr"`, "
-        `knda`", `"laoo"`, `"latn"`,
+        `"deva"`, `"fullwide"`, `"gujr"`,
+        `"guru"`, `"hanidec"`, `"khmr"`,
+        `"knda"`, `"laoo"`, `"latn"`,
         `"limb"`, `"mlym"`, `"mong"`,
         `"mymr"`, `"orya"`, `"tamldec"`, `"telu"`, `"thai"`, `"tibt"`.
     - `localeMatcher`

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -141,7 +141,7 @@ p2.then((value) => {
   console.log(value); // 1
   return value + 1;
 }).then((value) => {
-  console.log(value, " - A synchronous value works"); // 2 - A synchronous value works
+  console.log(value, "- A synchronous value works"); // 2 - A synchronous value works
 });
 
 p2.then((value) => {

--- a/files/en-us/web/javascript/reference/global_objects/reflect/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/index.md
@@ -23,7 +23,7 @@ const p = new Proxy(
   {
     deleteProperty(targetObject, property) {
       // Custom functionality: log the deletion
-      console.log("Deleting property: ", property);
+      console.log("Deleting property:", property);
 
       // Execute the default introspection behavior
       return Reflect.deleteProperty(targetObject, property);

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
@@ -76,7 +76,7 @@ Or you can use this to observe the copying process:
 ```js
 class MyRegExp extends RegExp {
   constructor(...args) {
-    console.log("Creating a new MyRegExp instance with args: ", args);
+    console.log("Creating a new MyRegExp instance with args:", args);
     super(...args);
   }
   static get [Symbol.species]() {
@@ -84,20 +84,20 @@ class MyRegExp extends RegExp {
     return this;
   }
   exec(value) {
-    console.log("Executing with lastIndex: ", this.lastIndex);
+    console.log("Executing with lastIndex:", this.lastIndex);
     return super.exec(value);
   }
 }
 
 Array.from("aabbccdd".matchAll(new MyRegExp("[ac]", "g")));
-// Creating a new MyRegExp instance with args:  [ '[ac]', 'g' ]
+// Creating a new MyRegExp instance with args: [ '[ac]', 'g' ]
 // Copying MyRegExp
-// Creating a new MyRegExp instance with args:  [ MyRegExp /[ac]/g, 'g' ]
-// Executing with lastIndex:  0
-// Executing with lastIndex:  1
-// Executing with lastIndex:  2
-// Executing with lastIndex:  5
-// Executing with lastIndex:  6
+// Creating a new MyRegExp instance with args: [ MyRegExp /[ac]/g, 'g' ]
+// Executing with lastIndex: 0
+// Executing with lastIndex: 1
+// Executing with lastIndex: 2
+// Executing with lastIndex: 5
+// Executing with lastIndex: 6
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -81,12 +81,12 @@ number of elements in the array, and the individual array elements.
 function splitString(stringToSplit, separator) {
   const arrayOfStrings = stringToSplit.split(separator);
 
-  console.log("The original string is: ", stringToSplit);
-  console.log("The separator is: ", separator);
+  console.log("The original string is:", stringToSplit);
+  console.log("The separator is:", separator);
   console.log(
-    "The array has ",
+    "The array has",
     arrayOfStrings.length,
-    " elements: ",
+    "elements:",
     arrayOfStrings.join(" / "),
   );
 }


### PR DESCRIPTION
### Description

remove extra space in `console.log()`. As the previous expression would have repeated spaces.
