### PR TITLE
RemoveListener -> RemoveEventListener

### DIFF
--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -106,7 +106,7 @@ const updatePixelRatio = () => {
   let media = matchMedia(mqString);
   media.addEventListener("change", updatePixelRatio);
   remove = function () {
-    media.removeListener(updatePixelRatio);
+    media.removeEventListener("change", updatePixelRatio);
   };
 
   console.log("devicePixelRatio: " + window.devicePixelRatio);


### PR DESCRIPTION
Replaced `.removeListener()` with `.removeEventListener()` to match up with previous change of replacing `.addListener()` with `.addEventListener()`

### Description

I previously submitted a pull request (which was approved and merged) replacing `.addListener()` with `.addEventListener()` but after double-checking to make sure I got everything right I realized that I missed a later call to `.removeListener()` which is also deprecated, so now I'm submitting this to replace that as well.