### PR TITLE
Intl.NumberFormat(): narrowSymbol for currencyDisplay option doesn't work in any browser

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -62,7 +62,6 @@ Intl.NumberFormat(locales, options)
       - : How to display the currency in currency formatting. The default is `"symbol"`.
 
         - `"symbol"`: use a localized currency symbol such as €.
-        - `"narrowSymbol"`: use a narrow format symbol ("$100" rather than "US$100").
         - `"code"`: use the ISO currency code.
         - `"name"`: use a localized currency name such as `"dollar"`.
 


### PR DESCRIPTION
Removed the `narrowSymbol` option for `currencyDisplay` ("narrowSymbol": use a narrow format symbol ("$100" rather than "US$100"). It currently doesn't work, and the currency display falls back to `symbol`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed the `narrowSymbol` option for `currencyDisplay` ("narrowSymbol": use a narrow format symbol ("$100" rather than "US$100"). It currently doesn't work, and the currency display falls back to `symbol`.

### Motivation
It is misleading since the option does not work.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
