### PR TITLE
FF110 Relnote and Element: blur focus fixup

### DIFF
--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -42,6 +42,11 @@ No notable changes.
 
 - {{domxref("CSSContainerRule")}} is supported, allowing JavaScript to access the name and query used in an {{cssxref("@container")}} at-rule definition ([Firefox bug 1787173](https://bugzil.la/1787173)).
 
+- Elements now lose focus if a style is applied that makes them ineligible to hold focus, such as `hidden`, and the [`blur` event](/en-US/docs/Web/API/Element/blur_event) is fired.
+  Focus then moves to the viewport.
+  Previously focus would remain with the element.
+  (See [Firefox bug 1810077](https://bugzil.la/1810077) for more details.)
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi

--- a/files/en-us/web/api/element/blur_event/index.md
+++ b/files/en-us/web/api/element/blur_event/index.md
@@ -9,6 +9,12 @@ browser-compat: api.Element.blur_event
 
 The **`blur`** event fires when an element has lost focus. The event does not bubble, but the related {{domxref("Element/focusout_event", "focusout")}} event that follows does bubble.
 
+An element will lose focus if another element is selected.
+An element will also lose focus if a style that does not allow focus is applied, such as `hidden`, or if the element is removed from the document — in both of these cases focus moves to the `body` element (viewport).
+Note however that `blur` is not fired when a focused element is is removed from the document.
+
+<!-- Prior to FF110 elements did not lose focus if the style changed to hidden (say) -->
+
 The opposite of `blur` is the {{domxref("Element/focus_event", "focus")}} event, which fires when the element has _received_ focus.
 
 The `blur` event is not cancelable.

--- a/files/en-us/web/api/element/blur_event/index.md
+++ b/files/en-us/web/api/element/blur_event/index.md
@@ -11,7 +11,7 @@ The **`blur`** event fires when an element has lost focus. The event does not bu
 
 An element will lose focus if another element is selected.
 An element will also lose focus if a style that does not allow focus is applied, such as `hidden`, or if the element is removed from the document — in both of these cases focus moves to the `body` element (viewport).
-Note however that `blur` is not fired when a focused element is is removed from the document.
+Note however that `blur` is not fired when a focused element is removed from the document.
 
 <!-- Prior to FF110 elements did not lose focus if the style changed to hidden (say) -->
 


### PR DESCRIPTION
FF110 implements the "focus fixup rule" on elements in https://bugzilla.mozilla.org/show_bug.cgi?id=1810077.

This was basically a spec clarification to state what happened to the focus and blur/focus events if focus was lost on an element because:
- A style like `hidden` was applied to the element, which cannot accept focus. 
- The element was removed.

The spec changes says that the first case focus should be lost by the element and blur event should fire. This is what happened in FF110, which previously held the focus on the ineligible element. 
For removal of element from document the focus should move to the `body`, but `blur` should not fire. 

To fix this I have 
- explained the FF change in the release notes. 
- In the `blur` element docs I added a note explaining what the spec requires. I think that is a good place because you'll probably only wonder about this in the context of "why didn't I see the blur element in this case".

Other docs work can be tracked in https://github.com/mdn/content/issues/25496