### PR TITLE
fix function name

### DIFF
--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -136,7 +136,7 @@ function pointerupHandler(ev) {
   log(ev.type, ev);
   // Remove this pointer from the cache and reset the target's
   // background and border
-  remove_event(ev);
+  removeEvent(ev);
   ev.target.style.background = "white";
   ev.target.style.border = "1px solid black";
 


### PR DESCRIPTION
The function `removeEvent`, defined at the end of the page, was called above, but using snake_case `remove_event` ...

### Description

I've fixed the snake_case function name `remove_event` to  camelCase `removeEvent`.

### Motivation

1. Function name should use camelCase
2. The function was defined further down the page using camelCase

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Pinch_zoom_gestures#miscellaneous_functions

### Related issues and pull requests

None