### PR TITLE
fix `const` to `let`

### DIFF
--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -40,7 +40,7 @@ Supporting a two-pointer gesture requires preserving a pointer's event state dur
 ```js
 // Global vars to cache event state
 const evCache = [];
-const prevDiff = -1;
+let prevDiff = -1;
 ```
 
 ### Register event handlers


### PR DESCRIPTION
### Description

I've changed the variable `prevDiff` definition to `let` instead of `const`.

### Motivation

The variable `prevDiff` was defined using `const`, but was reassigned later, hence it needs to be defined using `let`.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events/Pinch_zoom_gestures#global_state

### Related issues and pull requests

None