### PR TITLE
cleanup: Explicitly clarify that HTTP 303 is a temporary redirect

### DIFF
--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -7,7 +7,7 @@ browser-compat: http.status.303
 {{HTTPSidebar}}
 
 The HyperText Transfer Protocol (HTTP) **`303 See Other`**
-redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object — see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14) — or an upload-progress page). This response code is often sent back as a result of
+temporary redirect status response code indicates that the redirects don't link to the requested resource itself, but to another page (such as a confirmation page, a representation of a real-world object — see [HTTP range-14](https://en.wikipedia.org/wiki/HTTPRange-14) — or an upload-progress page). This response code is often sent back as a result of
 {{HTTPMethod("PUT")}} or {{HTTPMethod("POST")}}. The method used to display this
 redirected page is always {{HTTPMethod("GET")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

It's not explicitly clear that 303 is a temporary redirect. Add clarification in HTTP 303 description to specify that it is a temporary redirect.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Multiple status codes often perform the same function, with the only difference between them being that one is temporary and one is permanent. This is often the most important item that people wonder about with redirect status codes; which ones are temporary and which ones are permanent.

This should be information explicitly provided on all redirect status descriptions.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
