### PR TITLE
Add scripting.executeScript.InjectionResult.documentId

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -58,6 +58,8 @@ Each `InjectionResult` object has these properties:
   - : `number`. The frame ID associated with the injection.
 - `result` {{optional_inline}}
   - : `any`. The result of the script execution.
+- `documentId` {{optional_inline}}
+  - : `string`. The document associated with the injection.
 - `error` {{optional_inline}}
   - : `any`. If an error occurs, contains the value the script threw or rejected with. Typically this is an error object with a message property but it could be any value (including primitives and undefined).
 


### PR DESCRIPTION
### Description

Add documentation for chrome only property `documentId` to the return value of `InjectionResult` in `scripting.executeScript`.

### Motivation

To provide more complete documentation.

### Additional details

Omission identified while completing  Adds compatibility data for scripting.executeScript.InjectionResult [#19247](https://github.com/mdn/browser-compat-data/pull/19247) 