### PR TITLE
Remove unnecessary parenthesis

### DIFF
--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -57,7 +57,7 @@ Below are examples to clarify the syntax.
 
 ### Named import
 
-Given a value named `myExport` which has been exported from the module `my-module` either implicitly as `export * from 'another.js'` or explicitly using the {{JSxRef("Statements/export", "export")}} statement, this inserts `myExport` into the current scope.
+Given a value named `myExport` which has been exported from the module `my-module` either implicitly as `export * from "another.js"` or explicitly using the {{jsxref("Statements/export", "export")}} statement, this inserts `myExport` into the current scope.
 
 ```js
 import { myExport } from "/modules/my-module.js";

--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -57,7 +57,7 @@ Below are examples to clarify the syntax.
 
 ### Named import
 
-Given a value named `myExport` which has been exported from the module `my-module` either implicitly as `export * from 'another.js'`) or explicitly using the {{JSxRef("Statements/export", "export")}} statement, this inserts `myExport` into the current scope.
+Given a value named `myExport` which has been exported from the module `my-module` either implicitly as `export * from 'another.js'` or explicitly using the {{JSxRef("Statements/export", "export")}} statement, this inserts `myExport` into the current scope.
 
 ```js
 import { myExport } from "/modules/my-module.js";


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Get rid of unnecessary parenthesis in the middle of a sentence.

### Motivation

This helps readers so they don't get distracted finding a typo during their reading. This helps give readers a more sound experience reading documentation.

### Additional details

N/A

### Related issues and pull requests
N/A


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
