### PR TITLE
Avoid having text after interactive example section

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
@@ -8,11 +8,11 @@ page-type: guide
 
 **Unicode property escapes** [Regular Expressions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) allows for matching characters based on their Unicode properties. A character is described by several properties which are either binary ("boolean-like") or non-binary. For instance, unicode property escapes can be used to match emojis, punctuations, letters (even letters from specific languages or scripts), etc.
 
-{{EmbedInteractiveExample("pages/js/regexp-unicode-property-escapes.html", "taller")}}
-
 > **Note:** For Unicode property escapes to work, a regular expression must use [the `u` flag](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags) which indicates a string must be considered as a series of Unicode code points. See also [`RegExp.prototype.unicode`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode).
 
 > **Note:** Some Unicode properties encompasses many more characters than some [character classes](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes) (such as `\w` which matches only latin letters, `a` to `z`) but the latter is better supported among browsers (as of January 2020).
+
+{{EmbedInteractiveExample("pages/js/regexp-unicode-property-escapes.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -10,14 +10,14 @@ browser-compat: javascript.builtins.Array.find
 The **`find()`** method returns the first element in the provided array that satisfies the provided testing function.
 If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
-{{EmbedInteractiveExample("pages/js/array-find.html","shorter")}}
-
 - If you need the **index** of the found element in the array, use {{jsxref("Array/findIndex", "findIndex()")}}.
 - If you need to find the **index of a value**, use {{jsxref("Array/indexOf", "indexOf()")}}.
   (It's similar to {{jsxref("Array/findIndex", "findIndex()")}}, but checks each element for equality with the value instead of using a testing function.)
 - If you need to find if a value **exists** in an array, use {{jsxref("Array/includes", "includes()")}}.
   Again, it checks each element for equality with the value instead of using a testing function.
 - If you need to find if any element satisfies the provided testing function, use {{jsxref("Array/some", "some()")}}.
+
+{{EmbedInteractiveExample("pages/js/array-find.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -10,9 +10,9 @@ browser-compat: javascript.builtins.Array.findIndex
 The **`findIndex()`** method returns the index of the first element in an array that satisfies the provided testing function.
 If no elements satisfy the testing function, -1 is returned.
 
-{{EmbedInteractiveExample("pages/js/array-findindex.html","shorter")}}
-
 See also the {{jsxref("Array/find", "find()")}} method, which returns the first element that satisfies the testing function (rather than its index).
+
+{{EmbedInteractiveExample("pages/js/array-findindex.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -10,8 +10,6 @@ browser-compat: javascript.builtins.Array.findLast
 The **`findLast()`** method iterates the array in reverse order and returns the value of the first element that satisfies the provided testing function.
 If no elements satisfy the testing function, {{jsxref("undefined")}} is returned.
 
-{{EmbedInteractiveExample("pages/js/array-findlast.html","shorter")}}
-
 If you need to find:
 
 - the _first_ element that matches, use {{jsxref("Array/find", "find()")}}.
@@ -21,6 +19,8 @@ If you need to find:
 - whether a value _exists_ in an array, use {{jsxref("Array/includes", "includes()")}}.
   Again, it checks each element for equality with the value instead of using a testing function.
 - if any element satisfies the provided testing function, use {{jsxref("Array/some", "some()")}}.
+
+{{EmbedInteractiveExample("pages/js/array-findlast.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -10,9 +10,9 @@ browser-compat: javascript.builtins.Array.findLastIndex
 The **`findLastIndex()`** method iterates the array in reverse order and returns the index of the first element that satisfies the provided testing function.
 If no elements satisfy the testing function, -1 is returned.
 
-{{EmbedInteractiveExample("pages/js/array-findlastindex.html","shorter")}}
-
 See also the {{jsxref("Array/findLast", "findLast()")}} method, which returns the value of last element that satisfies the testing function (rather than its index).
+
+{{EmbedInteractiveExample("pages/js/array-findlastindex.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -11,9 +11,9 @@ The **`reduceRight()`** method applies a function against an
 accumulator and each value of the array (from right-to-left) to reduce it to a single
 value.
 
-{{EmbedInteractiveExample("pages/js/array-reduce-right.html","shorter")}}
-
 See also {{jsxref("Array.prototype.reduce()")}} for left-to-right.
+
+{{EmbedInteractiveExample("pages/js/array-reduce-right.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
@@ -11,8 +11,6 @@ The **`Intl.Collator()`** constructor creates {{jsxref("Intl.Collator")}} object
 
 {{EmbedInteractiveExample("pages/js/intl-collator.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
@@ -12,8 +12,6 @@ strings according to the sort order of this {{jsxref("Intl.Collator")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-compare.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/index.md
@@ -11,8 +11,6 @@ The **`Intl.Collator`** object enables language-sensitive string comparison.
 
 {{EmbedInteractiveExample("pages/js/intl-collator.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Constructor
 
 - {{jsxref("Intl/Collator/Collator", "Intl.Collator()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
@@ -13,8 +13,6 @@ computed during initialization of this {{jsxref("Intl.Collator")}} object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-resolvedoptions.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
@@ -13,8 +13,6 @@ having to fall back to the runtime's default locale.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-supportedlocalesof.html","shorter")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.DateTimeFormat()`** constructor creates {{jsxref("Intl.DateTimeForma
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -13,8 +13,6 @@ a date according to the locale and formatting options of this
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-format.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
@@ -12,10 +12,7 @@ date range in the most concise way based on the **`locale`** and
 **`options`** provided when instantiating
 {{jsxref("Intl.DateTimeFormat")}} object.
 
-{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrange.html",
-  "taller")}}
-
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
+{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrange.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
@@ -13,8 +13,6 @@ range produced by {{jsxref("Intl.DateTimeFormat")}} formatters.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrangetoparts.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.DateTimeFormat`** object enables language-sensitive date and time fo
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Constructor
 
 - {{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -14,8 +14,6 @@ object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-resolvedoptions.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
@@ -13,8 +13,6 @@ and time formatting without having to fall back to the runtime's default locale.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-supportedlocalesof.html","shorter")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
@@ -11,8 +11,6 @@ The **`Intl.DisplayNames()`** constructor creates {{jsxref("Intl.DisplayNames")}
 
 {{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/index.md
@@ -11,8 +11,6 @@ The **`Intl.DisplayNames`** object enables the consistent translation of languag
 
 {{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Constructor
 
 - {{jsxref("Intl/DisplayNames/DisplayNames", "Intl.DisplayNames()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -11,8 +11,6 @@ The **`Intl.DisplayNames.prototype.of()`** method receives a code and returns a 
 
 {{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -13,8 +13,6 @@ validated as structurally valid language tags.
 
 {{EmbedInteractiveExample("pages/js/intl-getcanonicallocales.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
@@ -12,8 +12,6 @@ language-specific representation of the list.
 
 {{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.ListFormat`** object enables language-sensitive list formatting.
 
 {{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Constructor
 
 - {{jsxref("Intl/ListFormat/ListFormat", "Intl.ListFormat()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.ListFormat()`** constructor creates {{jsxref("Intl.ListFormat")}} ob
 
 {{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
@@ -14,8 +14,6 @@ object.
 
 {{EmbedInteractiveExample("pages/js/intl-listformat-prototype-resolvedoptions.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
@@ -11,8 +11,6 @@ The **`Intl.Locale`** object is a standard built-in property of the Intl object 
 
 {{EmbedInteractiveExample("pages/js/intl-locale.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Description
 
 The **`Intl.Locale`** object was created to allow for easier manipulation of Unicode locales. Unicode represents locales with a string, called a _locale identifier_. The locale identifier consists of a _language identifier_ and _extension tags_. Language identifiers are the core of the locale, consisting of _language_, _script_, and _region subtags_. Additional information about the locale is stored in the optional _extension tags_. Extension tags hold information about locale aspects such as calendar type, clock type, and numbering system type.

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -11,8 +11,6 @@ The **`Intl.Locale()`** constructor creates {{jsxref("Intl.Locale")}} objects.
 
 {{EmbedInteractiveExample("pages/js/intl-locale.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
@@ -13,8 +13,6 @@ existing values.
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-maximize.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
@@ -13,8 +13,6 @@ remove information about the locale that would be added by calling
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -11,8 +11,6 @@ The **`Intl.Locale.prototype.toString()`** method returns the Locale's full [loc
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -11,8 +11,6 @@ The **`Intl.NumberFormat.prototype.format()`** method formats a number according
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-format.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.NumberFormat()`** constructor creates {{jsxref("Intl.NumberFormat")}
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -11,8 +11,6 @@ The **`Intl.NumberFormat.prototype.resolvedOptions()`** method returns a new obj
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-resolvedoptions.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
@@ -13,8 +13,6 @@ formatting without having to fall back to the runtime's default locale.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-supportedlocalesof.html","shorter")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -11,8 +11,6 @@ The **`Intl.RelativeTimeFormat.prototype.format()`** method formats a `value` an
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-format.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
@@ -11,8 +11,6 @@ The **`Intl.RelativeTimeFormat.prototype.formatToParts()`** method returns an {{
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-formattoparts.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
@@ -11,8 +11,6 @@ The **`Intl.RelativeTimeFormat`** object enables language-sensitive relative tim
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Constructor
 
 - {{jsxref("Intl/RelativeTimeFormat/RelativeTimeFormat", "Intl.RelativeTimeFormat()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -12,8 +12,6 @@ The **`Intl.RelativeTimeFormat.prototype.resolvedOptions()`** method returns a n
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-resolvedoptions.html")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
@@ -12,8 +12,6 @@ The **`Intl.RelativeTimeFormat.supportedLocalesOf()`** static method returns an 
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-supportedlocalesof.html","shorter")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -16,8 +16,6 @@ It can also be used to build UIs that allow users to select their preferred loca
 
 {{EmbedInteractiveExample("pages/js/intl-supportedvaluesof.html", "taller")}}
 
-<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -9,9 +9,9 @@ browser-compat: javascript.builtins.Math.random
 
 The **`Math.random()`** static method returns a floating-point, pseudo-random number that's greater than or equal to 0 and less than 1, with approximately uniform distribution over that range — which you can then scale to your desired range. The implementation selects the initial seed to the random number generation algorithm; it cannot be chosen or reset by the user.
 
-{{EmbedInteractiveExample("pages/js/math-random.html")}}
-
 > **Note:** `Math.random()` _does not_ provide cryptographically secure random numbers. Do not use them for anything related to security. Use the Web Crypto API instead, and more precisely the {{domxref("Crypto/getRandomValues", "window.crypto.getRandomValues()")}} method.
+
+{{EmbedInteractiveExample("pages/js/math-random.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -11,10 +11,10 @@ The **`hasOwnProperty()`** method returns a boolean indicating whether the
 object has the specified property as its own property (as opposed to inheriting
 it).
 
-{{EmbedInteractiveExample("pages/js/object-prototype-hasownproperty.html")}}
-
 > **Note:** {{jsxref("Object.hasOwn()")}} is recommended over
 > `hasOwnProperty()`, in browsers where it is supported.
+
+{{EmbedInteractiveExample("pages/js/object-prototype-hasownproperty.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.md
@@ -11,14 +11,14 @@ The **`charCodeAt()`** method returns
 an integer between `0` and `65535` representing the UTF-16 code
 unit at the given index.
 
-{{EmbedInteractiveExample("pages/js/string-charcodeat.html", "shorter")}}
-
 The UTF-16 code unit matches the Unicode code point for code points which can be
 represented in a single UTF-16 code unit. If the Unicode code point cannot be
 represented in a single UTF-16 code unit (because its value is greater than
 `0xFFFF`) then the code unit returned will be _the first part of a
 surrogate pair_ for the code point. If you want the entire code point value, use
-{{jsxref("Global_Objects/String/codePointAt", "codePointAt()")}}.
+{{jsxref("String/codePointAt", "codePointAt()")}}.
+
+{{EmbedInteractiveExample("pages/js/string-charcodeat.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
@@ -9,9 +9,9 @@ browser-compat: javascript.statements.async_generator_function
 
 The **`async function*`** declaration defines an _async generator function_, which returns an {{jsxref("Global_Objects/AsyncGenerator","AsyncGenerator")}} object.
 
-{{EmbedInteractiveExample("pages/js/expressions-async-function-asterisk.html", "taller")}}
-
 You can also define async generator functions using the {{jsxref("AsyncGeneratorFunction")}} constructor or the [`async function*` expression](/en-US/docs/Web/JavaScript/Reference/Operators/async_function*) syntax.
+
+{{EmbedInteractiveExample("pages/js/expressions-async-function-asterisk.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -10,10 +10,10 @@ browser-compat: javascript.statements.class
 The **`class`** declaration creates a new class
 with a given name using prototype-based inheritance.
 
-{{EmbedInteractiveExample("pages/js/statement-class.html")}}
-
 You can also define a class using a {{jsxref("Operators/class", "class expression",
     "", 1)}}, which allows redeclarations and omitting class names. Attempting to place **class declaration** in the same scope, under the same name, will throw a {{jsxref("SyntaxError")}}.
+
+{{EmbedInteractiveExample("pages/js/statement-class.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -11,8 +11,6 @@ The **`for await...of`** statement creates a loop iterating over [async iterable
 
 {{EmbedInteractiveExample("pages/js/statement-forawaitof.html", "taller")}}
 
-> **Note:** `for await...of` doesn't work with async iterators that are not async iterables.
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.md
@@ -11,10 +11,10 @@ The **`function*`** declaration (`function` keyword
 followed by an asterisk) defines a _generator function_, which returns a
 {{jsxref("Global_Objects/Generator","Generator")}} object.
 
-{{EmbedInteractiveExample("pages/js/statement-functionasterisk.html")}}
-
 You can also define generator functions using the {{jsxref("GeneratorFunction")}}
 constructor, or the function expression syntax.
+
+{{EmbedInteractiveExample("pages/js/statement-functionasterisk.html")}}
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`EmbedInteractiveExample` adds its own H2. Having description that should be in the intro section within this "Try it" section makes the structure more confusing. In addition, there are a lot of comments which are not necessary.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
