### PR TITLE
Add `await` to example

### DIFF
--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -37,7 +37,7 @@ If an error occurs, the promise will resolve with one of the following exception
 The following example flushes the `AudioDecoder`.
 
 ```js
-AudioDecoder.flush();
+await audioDecoder.flush();
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

Add `await` to the example.

### Motivation

`flush()` returns a promise, and awaiting it brings the example in line with the expected usage.