### PR TITLE
Add HashChangeEvent()

### DIFF
--- a/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
+++ b/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
@@ -23,7 +23,7 @@ new HashChangeEvent(type, options)
   - : A string with the name of the event.
     It is case-sensitive and browsers set it to `hashchange`.
 - `options` {{optional_inline}}
-  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following property:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `oldURL` {{optional_inline}}
       - : A string containing the old URL. Its default value is the empty string (`""`).
     - `newURL`{{optional_inline}}

--- a/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
+++ b/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.HashChangeEvent.HashChangeEvent
 
 {{APIRef("HTML DOM")}}
 
-The **`HashChangeEvent()`** constructor creates a new {{domxref("HashChangeEvent")}} object, that is used by the {{domxref("Window/hashchange_event", "hashchange")}} event fired at the {{domxref("hashchange")}} when the fragment of the URL change.
+The **`HashChangeEvent()`** constructor creates a new {{domxref("HashChangeEvent")}} object, that is used by the {{domxref("Window/hashchange_event", "hashchange")}} event fired at the {{domxref("window")}} object when the fragment of the URL change.
 
 > **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/hashchange_event", "hashchange")}} events.
 

--- a/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
+++ b/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.HashChangeEvent.HashChangeEvent
 
 {{APIRef("HTML DOM")}}
 
-The **`HashChangeEvent()`** constructor creates a new {{domxref("HashChangeEvent")}} object, that is used by the {{domxref("Window/hashchange_event", "hashchange")}} event fired at the {{domxref("window")}} object when the fragment of the URL change.
+The **`HashChangeEvent()`** constructor creates a new {{domxref("HashChangeEvent")}} object, that is used by the {{domxref("Window/hashchange_event", "hashchange")}} event fired at the {{domxref("window")}} object when the fragment of the URL changes.
 
 > **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/hashchange_event", "hashchange")}} events.
 

--- a/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
+++ b/files/en-us/web/api/hashchangeevent/hashchangeevent/index.md
@@ -1,0 +1,46 @@
+---
+title: HashChangeEvent()
+slug: Web/API/HashChangeEvent/HashChangeEvent
+page-type: web-api-constructor
+browser-compat: api.HashChangeEvent.HashChangeEvent
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`HashChangeEvent()`** constructor creates a new {{domxref("HashChangeEvent")}} object, that is used by the {{domxref("Window/hashchange_event", "hashchange")}} event fired at the {{domxref("hashchange")}} when the fragment of the URL change.
+
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/hashchange_event", "hashchange")}} events.
+
+## Syntax
+
+```js-nolint
+new HashChangeEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `hashchange`.
+- `options` {{optional_inline}}
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following property:
+    - `oldURL` {{optional_inline}}
+      - : A string containing the old URL. Its default value is the empty string (`""`).
+    - `newURL`{{optional_inline}}
+      - : A string containing the new URL. Its default value is the empty string (`""`).
+
+### Return value
+
+A new {{domxref("HashChangeEvent")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Window/hashchange_event", "hashchange")}} event

--- a/files/en-us/web/api/hashchangeevent/index.md
+++ b/files/en-us/web/api/hashchangeevent/index.md
@@ -13,6 +13,11 @@ The fragment identifier is the part of the URL that follows (and includes) the `
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- {{domxref("HashChangeEvent.HashChangeEvent", "HashChangeEvent()")}}
+  - : Creates a new `HashChangeEvent` object.
+
 ## Instance properties
 
 _This interface also inherits the properties of its parent, {{domxref("Event")}}._


### PR DESCRIPTION
### Description

This PR adds the missing documentation for the following:

- `HashChangeEvent()`

### Motivation

openwebdocs/project#153

### Additional details

- I didn't add an example to `PopStateEvent()` as the web developer usually does not call this constructor.

### Related pull request

- BCD update: mdn/browser-compat-data#19268