### PR TITLE
Add PageTransitionEvent()

### DIFF
--- a/files/en-us/web/api/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/index.md
@@ -11,6 +11,11 @@ The **`PageTransitionEvent`** event object is available inside handler functions
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- {{domxref("PageTransitionEvent.PageTransitionEvent", "PageTransitionEvent()")}}
+  - : Creates a new `PageTransitionEvent` object.
+
 ## Instance properties
 
 _This interface also inherits properties from its parent, {{domxref("Event")}}._
@@ -51,5 +56,5 @@ window.addEventListener("pageshow", (event) => {
 
 ## See also
 
-- [`pageshow` event](/en-US/docs/Web/API/Window/pageshow_event)
-- [`pagehide` event](/en-US/docs/Web/API/Window/pagehide_event)
+- [`pageshow`](/en-US/docs/Web/API/Window/pageshow_event) event
+- [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event) event

--- a/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
@@ -1,0 +1,45 @@
+---
+title: PageTransitionEvent()
+slug: Web/API/PageTransitionEvent/PageTransitionEvent
+page-type: web-api-constructor
+browser-compat: api.PageTransitionEvent.PageTransitionEvent
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`PageTransitionEvent()`** constructor creates a new {{domxref("PageTransitionEvent")}} object, that is used by the {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events, fired at the {{domxref("window")}} object when a page is loaded or unloaded.
+
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/hashchange_event", "hashchange")}} events.
+
+## Syntax
+
+```js-nolint
+new PageTransitionEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `pageshow` or `pagehide`.
+- `options` {{optional_inline}}
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following property:
+    - `persisted` {{optional_inline}}
+      - : A boolean indicating if the document is loading from a cache.
+
+### Return value
+
+A new {{domxref("PageTransitionEvent")}} object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`pageshow`](/en-US/docs/Web/API/Window/pageshow_event) event
+- [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event) event

--- a/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.PageTransitionEvent.PageTransitionEvent
 
 The **`PageTransitionEvent()`** constructor creates a new {{domxref("PageTransitionEvent")}} object, that is used by the {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events, fired at the {{domxref("window")}} object when a page is loaded or unloaded.
 
-> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/hashchange_event", "hashchange")}} events.
+> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR adds the missing documentation for the following:

- `PageTransitionEvent()`

### Motivation

openwebdocs/project#153

### Additional details

- I didn't add an example to `PageTransitionEvent()` as the web developer usually does not call this constructor.

### Related pull request

- BCD update: mdn/browser-compat-data#TBD