### PR TITLE
Removed whitespace between 'p' and 'special'

### DIFF
--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -266,7 +266,7 @@ h1 + ul + p {
 You can combine multiple types together, too. Try adding the following into your code:
 
 ```css
-body h1 + p .special {
+body h1 + p.special {
   color: yellow;
   background-color: black;
   padding: 5px;


### PR DESCRIPTION
### Description

Removed whitespace in CSS snippet example that caused unintended behavior.

### Motivation

Teaches a correct example of combining selector types.

### Additional details
```

  body h1 + p .special {
    color: yellow;
    background-color: black;
    padding: 5px;
  } 
```

According to the exercise description:

> 'This will style any element with a class of special, which is inside a paragraph...' 

There shouldn't be any whitespace between 'p' and '.special'.  If there is, then the CSS selector may not match the desired elements.