### PR TITLE
Remove "implemented from elsewhere" sections of global scopes

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -20,16 +20,28 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 
 ### Instance properties inherited from WorkerGlobalScope
 
-- {{domxref("WorkerGlobalScope.self")}}
-  - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
-- {{domxref("WorkerGlobalScope.console")}} {{ReadOnlyInline}}
+- {{domxref("caches", "DedicatedWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
+- {{domxref("WorkerGlobalScope.console", "DedicatedWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("console")}} associated with the worker.
-- {{domxref("WorkerGlobalScope.location")}} {{ReadOnlyInline}}
+- {{domxref("WorkerGlobalScope.fonts", "DedicatedWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
+- {{domxref("indexedDB", "DedicatedWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
+  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
+- {{domxref("isSecureContext", "DedicatedWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
+  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
+- {{domxref("WorkerGlobalScope.location", "DedicatedWorkerGlobalScope.location")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
+- {{domxref("WorkerGlobalScope.navigator", "DedicatedWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
+- {{domxref("origin", "DedicatedWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
+  - : Returns the global object's origin, serialized as a string.
+- {{domxref("performance_property", "DedicatedWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
+- {{domxref("Window.scheduler", "DedicatedWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
+- {{domxref("WorkerGlobalScope.self", "DedicatedWorkerGlobalScope.self")}}
+  - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
 
 ## Instance methods
 
@@ -42,29 +54,26 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ### Inherited from WorkerGlobalScope
 
-- {{domxref("WorkerGlobalScope.dump()")}} {{non-standard_inline}}
-  - : Writes a message to the console.
-- {{domxref("WorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-
-### Implemented from other places
-
-- {{domxref("atob", "atob()")}}
+- {{domxref("atob", "DedicatedWorkerGlobalScope.atob()")}}
   - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "btoa")}}
+- {{domxref("btoa", "DedicatedWorkerGlobalScope.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
-- {{domxref("clearTimeout")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
-- {{domxref("setInterval")}}
-  - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout")}}
-  - : Sets a delay for executing a function.
-- {{domxref("Window/requestAnimationFrame", "requestAnimationFrame")}}
-  - : Requests the browser to execute a callback function before painting the next frame.
-- {{domxref("Window/cancelAnimationFrame", "cancelAnimationFrame")}}
+- {{domxref("Window.cancelAnimationFrame", "DedicatedWorkerGlobalScope.cancelAnimationFrame()")}}
   - : Cancels a callback scheduled by requestAnimationFrame.
+- {{domxref("clearInterval", "DedicatedWorkerGlobalScope.clearInterval()")}}
+  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
+- {{domxref("clearTimeout", "DedicatedWorkerGlobalScope.clearTimeout()")}}
+  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+- {{domxref("WorkerGlobalScope.dump", "DedicatedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
+  - : Writes a message to the console.
+- {{domxref("WorkerGlobalScope.importScripts", "DedicatedWorkerGlobalScope.importScripts()")}}
+  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
+- {{domxref("Window.requestAnimationFrame", "DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
+  - : Requests the browser to execute a callback function before painting the next frame.
+- {{domxref("setInterval", "DedicatedWorkerGlobalScope.setInterval()")}}
+  - : Schedules the execution of a function every X milliseconds.
+- {{domxref("setTimeout", "DedicatedWorkerGlobalScope.setTimeout()")}}
+  - : Sets a delay for executing a function.
 
 ## Events
 

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -21,12 +21,67 @@ This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and
 
 ## Instance properties
 
-- {{domxref("caches")}} {{ReadOnlyInline}}
-  - : Contains the {{domxref("CacheStorage")}} object associated with the service worker.
+_This interface inherits properties from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
+
 - {{domxref("ServiceWorkerGlobalScope.clients")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("Clients")}} object associated with the service worker.
 - {{domxref("ServiceWorkerGlobalScope.registration")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("ServiceWorkerRegistration")}} object that represents the service worker's registration.
+
+### Instance properties inherited from WorkerGlobalScope
+
+- {{domxref("caches", "ServiceWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
+- {{domxref("WorkerGlobalScope.console", "ServiceWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
+  - : Returns the {{domxref("console")}} associated with the worker.
+- {{domxref("WorkerGlobalScope.fonts", "ServiceWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
+- {{domxref("indexedDB", "ServiceWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
+  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
+- {{domxref("isSecureContext", "ServiceWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
+  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
+- {{domxref("WorkerGlobalScope.location", "ServiceWorkerGlobalScope.location")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
+- {{domxref("WorkerGlobalScope.navigator", "ServiceWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
+- {{domxref("origin", "ServiceWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
+  - : Returns the global object's origin, serialized as a string.
+- {{domxref("performance_property", "ServiceWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
+- {{domxref("Window.scheduler", "ServiceWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
+- {{domxref("WorkerGlobalScope.self", "ServiceWorkerGlobalScope.self")}}
+  - : Returns an object reference to the `ServiceWorkerGlobalScope` object itself.
+
+## Instance methods
+
+_This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
+
+- {{domxref("ServiceWorkerGlobalScope.skipWaiting()")}}
+  - : Allows the current service worker registration to progress from waiting to active state while service worker clients are using it.
+
+### Inherited from WorkerGlobalScope
+
+- {{domxref("atob", "ServiceWorkerGlobalScope.atob()")}}
+  - : Decodes a string of data which has been encoded using base-64 encoding.
+- {{domxref("btoa", "ServiceWorkerGlobalScope.btoa()")}}
+  - : Creates a base-64 encoded ASCII string from a string of binary data.
+- {{domxref("Window.cancelAnimationFrame", "ServiceWorkerGlobalScope.cancelAnimationFrame()")}}
+  - : Cancels a callback scheduled by requestAnimationFrame.
+- {{domxref("clearInterval", "ServiceWorkerGlobalScope.clearInterval()")}}
+  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
+- {{domxref("clearTimeout", "ServiceWorkerGlobalScope.clearTimeout()")}}
+  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+- {{domxref("WorkerGlobalScope.dump", "ServiceWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
+  - : Writes a message to the console.
+- {{domxref("WorkerGlobalScope.importScripts", "ServiceWorkerGlobalScope.importScripts()")}}
+  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
+- {{domxref("Window.requestAnimationFrame", "ServiceWorkerGlobalScope.requestAnimationFrame()")}}
+  - : Requests the browser to execute a callback function before painting the next frame.
+- {{domxref("setInterval", "ServiceWorkerGlobalScope.setInterval()")}}
+  - : Schedules the execution of a function every X milliseconds.
+- {{domxref("setTimeout", "ServiceWorkerGlobalScope.setTimeout()")}}
+  - : Sets a delay for executing a function.
 
 ## Events
 
@@ -64,16 +119,6 @@ This interface inherits from the {{domxref("WorkerGlobalScope")}} interface, and
   - : Occurs when a server push notification is received.
 - {{domxref("ServiceWorkerGlobalScope/pushsubscriptionchange_event", "pushsubscriptionchange")}}
   - : Occurs when a push subscription has been invalidated, or is about to be invalidated (e.g. when a push service sets an expiration time).
-
-## Instance methods
-
-- {{domxref("ServiceWorkerGlobalScope.skipWaiting()")}}
-  - : Allows the current service worker registration to progress from waiting to active state while service worker clients are using it.
-
-`ServiceWorkerGlobalScope` implements {{domxref("WorkerGlobalScope")}}. Therefore it also has the following property available to it:
-
-- {{domxref("fetch()")}}
-  - : Starts the process of fetching a resource. This returns a promise that resolves to the {{domxref("Response")}} object representing the response to your request. This algorithm is the entry point for the fetch handling handed to the service worker context.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -20,16 +20,28 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 
 ### Instance properties inherited from WorkerGlobalScope
 
-- {{domxref("WorkerGlobalScope.self")}}
-  - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
-- {{domxref("WorkerGlobalScope.console")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("console")}} object associated with the worker.
-- {{domxref("WorkerGlobalScope.location")}} {{ReadOnlyInline}}
+- {{domxref("caches", "SharedWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
+- {{domxref("WorkerGlobalScope.console", "SharedWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
+  - : Returns the {{domxref("console")}} associated with the worker.
+- {{domxref("WorkerGlobalScope.fonts", "SharedWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
+- {{domxref("indexedDB", "SharedWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
+  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
+- {{domxref("isSecureContext", "SharedWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
+  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
+- {{domxref("WorkerGlobalScope.location", "SharedWorkerGlobalScope.location")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
+- {{domxref("WorkerGlobalScope.navigator", "SharedWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
+- {{domxref("origin", "SharedWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
+  - : Returns the global object's origin, serialized as a string.
+- {{domxref("performance_property", "SharedWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
+- {{domxref("Window.scheduler", "SharedWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
+- {{domxref("WorkerGlobalScope.self", "SharedWorkerGlobalScope.self")}}
+  - : Returns an object reference to the `SharedWorkerGlobalScope` object itself.
 
 ## Instance methods
 
@@ -40,24 +52,25 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ### Inherited from WorkerGlobalScope
 
-- {{domxref("WorkerGlobalScope.dump()")}} {{Non-standard_Inline}}
-  - : Allows you to write a message to stdout — i.e. in your terminal. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.
-- {{domxref("WorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-
-### Implemented from other places
-
-- {{domxref("atob", "atob()")}}
+- {{domxref("atob", "SharedWorkerGlobalScope.atob()")}}
   - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "btoa()")}}
+- {{domxref("btoa", "SharedWorkerGlobalScope.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
-- {{domxref("clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
-- {{domxref("setInterval()")}}
+- {{domxref("Window.cancelAnimationFrame", "SharedWorkerGlobalScope.cancelAnimationFrame()")}}
+  - : Cancels a callback scheduled by requestAnimationFrame.
+- {{domxref("clearInterval", "SharedWorkerGlobalScope.clearInterval()")}}
+  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
+- {{domxref("clearTimeout", "SharedWorkerGlobalScope.clearTimeout()")}}
+  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+- {{domxref("WorkerGlobalScope.dump", "SharedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
+  - : Writes a message to the console.
+- {{domxref("WorkerGlobalScope.importScripts", "SharedWorkerGlobalScope.importScripts()")}}
+  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
+- {{domxref("Window.requestAnimationFrame", "SharedWorkerGlobalScope.requestAnimationFrame()")}}
+  - : Requests the browser to execute a callback function before painting the next frame.
+- {{domxref("setInterval", "SharedWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout()")}}
+- {{domxref("setTimeout", "SharedWorkerGlobalScope.setTimeout()")}}
   - : Sets a delay for executing a function.
 
 ## Events

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -25,6 +25,8 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
 
 Note that properties which are objects (e.g., for overriding the prototype of built-in elements) are listed in a separate section below.
 
+- {{domxref("caches", "Window.caches")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
 - {{domxref("Window.navigator", "Window.clientInformation")}} {{ReadOnlyInline}}
   - : An alias for {{domxref("Window.navigator")}}.
 - {{domxref("Window.closed")}} {{ReadOnlyInline}}
@@ -33,10 +35,10 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : Returns a reference to the console object which provides access to the browser's debugging console.
 - {{domxref("Window.credentialless")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Returns a boolean that indicates whether the current document was loaded inside a credentialless {{htmlelement("iframe")}}. See [IFrame credentialless](/en-US/docs/Web/Security/IFrame_credentialless) for more details.
-- {{domxref("Window.customElements")}} {{ReadOnlyInline}}
-  - : Returns a reference to the {{domxref("CustomElementRegistry")}} object, which can be used to register new [custom elements](/en-US/docs/Web/Web_Components/Using_custom_elements) and get information about previously registered custom elements.
 - {{domxref("crypto_property", "Window.crypto")}} {{ReadOnlyInline}}
   - : Returns the browser crypto object.
+- {{domxref("Window.customElements")}} {{ReadOnlyInline}}
+  - : Returns a reference to the {{domxref("CustomElementRegistry")}} object, which can be used to register new [custom elements](/en-US/docs/Web/Web_Components/Using_custom_elements) and get information about previously registered custom elements.
 - {{domxref("Window.devicePixelRatio")}} {{ReadOnlyInline}}
   - : Returns the ratio between physical pixels and device independent pixels in the current display.
 - {{domxref("Window.document")}} {{ReadOnlyInline}}
@@ -49,11 +51,13 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : This property indicates whether the window is displayed in full screen or not.
 - {{domxref("Window.history")}} {{ReadOnlyInline}}
   - : Returns a reference to the history object.
+- {{domxref("indexedDB", "Window.indexedDB")}} {{ReadOnlyInline}}
+  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
 - {{domxref("Window.innerHeight")}} {{ReadOnlyInline}}
   - : Gets the height of the content area of the browser window including, if rendered, the horizontal scrollbar.
 - {{domxref("Window.innerWidth")}} {{ReadOnlyInline}}
   - : Gets the width of the content area of the browser window including, if rendered, the vertical scrollbar.
-- {{domxref("isSecureContext")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+- {{domxref("isSecureContext", "Window.isSecureContext")}} {{ReadOnlyInline}}
   - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
 - {{domxref("Window.launchQueue")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : When a [progressive web app](/en-US/docs/Web/Progressive_web_apps) (PWA) is launched with a [`launch_handler`](/en-US/docs/Web/Manifest/launch_handler) `client_mode` value of `focus-existing`, `navigate-new`, or `navigate-existing`, the `launchQueue` provides access to the {{domxref("LaunchQueue")}} class, which allows custom launch navigation handling to be implemented for the PWA.
@@ -79,6 +83,8 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : Returns a reference to the navigator object.
 - {{domxref("Window.opener")}}
   - : Returns a reference to the window that opened this current window.
+- {{domxref("origin", "Window.origin")}} {{ReadOnlyInline}}
+  - : Returns the global object's origin, serialized as a string.
 - {{domxref("Window.outerHeight")}} {{ReadOnlyInline}}
   - : Gets the height of the outside of the browser window.
 - {{domxref("Window.outerWidth")}} {{ReadOnlyInline}}
@@ -93,6 +99,8 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : Returns a {{domxref("Performance")}} object, which includes the {{domxref("Performance.timing", "timing")}} and {{domxref("Performance.navigation", "navigation")}} attributes, each of which is an object providing [performance-related](/en-US/docs/Web/API/Navigation_timing_API) data. See also [Using Navigation Timing](/en-US/docs/Web/API/Navigation_timing_API/Using_Navigation_Timing) for additional information and examples.
 - {{domxref("Window.personalbar")}} {{ReadOnlyInline}}
   - : Returns the personalbar object.
+- {{domxref("Window.scheduler")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
 - {{domxref("Window.screen")}} {{ReadOnlyInline}}
   - : Returns a reference to the screen object associated with the window.
 - {{domxref("Window.screenX")}} and {{domxref("Window.screenLeft")}} {{ReadOnlyInline}}
@@ -128,18 +136,6 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
 - `window[0]`, `window[1]`, etc.
   - : Returns a reference to the `window` object in the frames. See {{domxref("Window.frames")}} for more details.
 
-### Instance properties implemented from elsewhere
-
-- {{domxref("caches")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
-- {{domxref("indexedDB")}} {{ReadOnlyInline}}
-  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
-- {{domxref("origin")}} {{ReadOnlyInline}}
-  - : Returns the global object's origin, serialized as a string.
-- {{domxref("Window.scheduler")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Scheduler")}} object associated with the current context.
-    This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
-
 ### Deprecated properties
 
 - {{domxref("Window.content")}} and `Window._content` {{Deprecated_Inline}} {{Non-standard_Inline}} {{ReadOnlyInline}}
@@ -161,24 +157,40 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
 
 ## Instance methods
 
-_This interface inherits methods from the {{domxref("EventTarget")}} interface and implements methods from `WindowOrWorkerGlobalScope` and {{domxref("EventTarget")}}._
+_This interface inherits methods from the {{domxref("EventTarget")}} interface._
 
+- {{domxref("EventTarget.addEventListener", "Window.addEventListener()")}}
+  - : Register an event handler to a specific event type on the window.
+- {{domxref("atob", "Window.atob()")}}
+  - : Decodes a string of data which has been encoded using base-64 encoding.
 - {{domxref("Window.alert()")}}
   - : Displays an alert dialog.
 - {{domxref("Window.blur()")}}
   - : Sets focus away from the window.
+- {{domxref("btoa", "Window.btoa()")}}
+  - : Creates a base-64 encoded ASCII string from a string of binary data.
 - {{domxref("Window.cancelAnimationFrame()")}}
   - : Enables you to cancel a callback previously scheduled with {{domxref("Window.requestAnimationFrame")}}.
 - {{domxref("Window.cancelIdleCallback()")}}
   - : Enables you to cancel a callback previously scheduled with {{domxref("Window.requestIdleCallback")}}.
 - {{domxref("Window.clearImmediate()")}}
   - : Cancels the repeated execution set using `setImmediate`.
+- {{domxref("clearInterval", "Window.clearInterval()")}}
+  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
+- {{domxref("clearTimeout()", "Window.clearTimeout()")}}
+  - : Cancels the delayed execution set using {{domxref("setTimeout()")}}.
 - {{domxref("Window.close()")}}
   - : Closes the current window.
 - {{domxref("Window.confirm()")}}
   - : Displays a dialog with a message that the user needs to respond to.
+- {{domxref("createImageBitmap", "Window.createImageBitmap()")}}
+  - : Accepts a variety of different image sources, and returns a {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}}. Optionally the source is cropped to the rectangle of pixels originating at _(sx, sy)_ with width sw, and height sh.
+- {{domxref("EventTarget.dispatchEvent", "Window.dispatchEvent()")}}
+  - : Used to trigger an event.
 - {{domxref("Window.dump()")}} {{Non-standard_Inline}}
   - : Writes a message to the console.
+- {{domxref("fetch", "Window.fetch()")}}
+  - : Starts the process of fetching a resource from the network.
 - {{domxref("Window.find()")}} {{Non-standard_Inline}}
   - : Searches for a given string in a window.
 - {{domxref("Window.focus()")}}
@@ -205,6 +217,10 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Returns the text entered by the user in a prompt dialog.
 - {{DOMxRef("Window.queryLocalFonts()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that fulfills with an array of {{domxref("FontData")}} objects representing the font faces available locally.
+- {{domxref("EventTarget.removeEventListener", "Window.removeEventListener()")}}
+  - : Removes an event listener from the window.
+- {{domxref("reportError", "Window.reportError()")}}
+  - : Reports an error in a script, emulating an unhandled exception.
 - {{domxref("Window.requestAnimationFrame()")}}
   - : Tells the browser that an animation is in progress, requesting that the browser schedule a repaint of the window for the next animation frame.
 - {{domxref("Window.requestIdleCallback()")}}
@@ -225,8 +241,12 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : Scrolls to a particular set of coordinates in the document.
 - {{domxref("Window.setImmediate()")}}
   - : Executes a function after the browser has finished other heavy tasks.
+- {{domxref("setInterval", "Window.setInterval()")}}
+  - : Schedules a function to execute every time a given number of milliseconds elapses.
 - {{domxref("Window.setResizable()")}} {{Non-standard_Inline}}
   - : Toggles a user's ability to resize a window.
+- {{domxref("setTimeout", "Window.setTimeout()")}}
+  - : Schedules a function to execute in a given amount of time.
 - {{domxref("Window.sizeToContent()")}} {{Non-standard_Inline}}
   - : Sizes the window according to its content.
 - {{domxref("Window.showOpenFilePicker()")}} {{Experimental_Inline}}
@@ -239,33 +259,6 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface a
   - : This method stops window loading.
 - {{domxref("Window.updateCommands()")}} {{Non-standard_Inline}}
   - : Updates the state of commands of the current chrome window (UI).
-
-### Instance methods implemented from elsewhere
-
-- {{domxref("EventTarget.addEventListener()")}}
-  - : Register an event handler to a specific event type on the window.
-- {{domxref("EventTarget.dispatchEvent()")}}
-  - : Used to trigger an event.
-- {{domxref("atob", "atob()")}}
-  - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "btoa()")}}
-  - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
-- {{domxref("clearTimeout()")}}
-  - : Cancels the delayed execution set using {{domxref("setTimeout()")}}.
-- {{domxref("createImageBitmap()")}}
-  - : Accepts a variety of different image sources, and returns a {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}}. Optionally the source is cropped to the rectangle of pixels originating at _(sx, sy)_ with width sw, and height sh.
-- {{domxref("fetch()")}}
-  - : Starts the process of fetching a resource from the network.
-- {{domxref("EventTarget.removeEventListener()")}}
-  - : Removes an event listener from the window.
-- {{domxref("setInterval()")}}
-  - : Schedules a function to execute every time a given number of milliseconds elapses.
-- {{domxref("setTimeout()")}}
-  - : Schedules a function to execute in a given amount of time.
-- {{domxref("reportError()")}}
-  - : Reports an error in a script, emulating an unhandled exception.
 
 ### Deprecated methods
 

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -19,35 +19,63 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
 
 ### Standard properties
 
-- {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. It is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.self")}} {{ReadOnlyInline}}
-  - : Returns a reference to the `WorkerGlobalScope` itself. Most of the time it is a specific scope like {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} or {{domxref("ServiceWorkerGlobalScope")}}.
-- {{domxref("WorkerGlobalScope.location")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. It is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
+- {{domxref("caches", "WorkerGlobalScope.caches")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
 - {{domxref("WorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
+- {{domxref("indexedDB", "WorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
+  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
+- {{domxref("isSecureContext", "WorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
+  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
+- {{domxref("WorkerGlobalScope.location")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. It is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.r.
+- {{domxref("WorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. It is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
+- {{domxref("origin", "WorkerGlobalScope.origin")}} {{ReadOnlyInline}}
+  - : Returns the global object's origin, serialized as a string.
+- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Performance")}} associated with the worker. It is a regular performance object, except that only a subset of its property and methods are available to workers.
+- {{domxref("Window.scheduler", "WorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
+- {{domxref("WorkerGlobalScope.self")}} {{ReadOnlyInline}}
+  - : Returns a reference to the `WorkerGlobalScope` itself. Most of the time it is a specific scope like {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} or {{domxref("ServiceWorkerGlobalScope")}}.
 
 ### Non-standard properties
 
-- {{domxref("performance_property", "WorkerGlobalScope.performance")}} {{ReadOnlyInline}} {{Non-standard_inline}}
-  - : Returns the {{domxref("Performance")}} associated with the worker. It is a regular performance object, except that only a subset of its property and methods are available to workers.
 - {{domxref("WorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
   - : Returns the {{domxref("console")}} associated with the worker.
 
-### Instance properties implemented from elsewhere
+## Instance methods
 
-- {{domxref("caches")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
-- {{domxref("indexedDB")}} {{ReadOnlyInline}}
-  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
-- {{domxref("isSecureContext")}} {{ReadOnlyInline}}
-  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
-- {{domxref("origin")}} {{ReadOnlyInline}}
-  - : Returns the global object's origin, serialized as a string.
-- [`scheduler`](/en-US/docs/Web/API/Window/scheduler) {{ReadOnlyInline}}
-  - : Returns the {{domxref("Scheduler")}} object associated with the current context.
-    This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
+_This interface inherits methods from the {{domxref("EventTarget")}} interface._
+
+### Standard methods
+
+- {{domxref("atob", "WorkerGlobalScope.atob()")}}
+  - : Decodes a string of data which has been encoded using base-64 encoding.
+- {{domxref("btoa", "WorkerGlobalScope.btoa()")}}
+  - : Creates a base-64 encoded ASCII string from a string of binary data.
+- {{domxref("clearInterval", "WorkerGlobalScope.clearInterval()")}}
+  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
+- {{domxref("clearTimeout", "WorkerGlobalScope.clearTimeout()")}}
+  - : Cancels the delayed execution set using {{domxref("setTimeout()")}}.
+- {{domxref("createImageBitmap", "WorkerGlobalScope.createImageBitmap()")}}
+  - : Accepts a variety of different image sources, and returns a {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}}. Optionally the source is cropped to the rectangle of pixels originating at _(sx, sy)_ with width sw, and height sh.
+- {{domxref("fetch", "WorkerGlobalScope.fetch()")}}
+  - : Starts the process of fetching a resource from the network.
+- {{domxref("WorkerGlobalScope.importScripts()")}}
+  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
+- {{domxref("setInterval", "WorkerGlobalScope.setInterval()")}}
+  - : Schedules a function to execute every time a given number of milliseconds elapses.
+- {{domxref("setTimeout", "WorkerGlobalScope.setTimeout()")}}
+  - : Schedules a function to execute in a given amount of time.
+- {{domxref("reportError", "WorkerGlobalScope.reportError()")}}
+  - : Reports an error in a script, emulating an unhandled exception.
+
+### Non-standard methods
+
+- {{domxref("WorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
+  - : Allows you to write a message to stdout — i.e. in your terminal. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.
 
 ## Events
 
@@ -63,41 +91,6 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
   - : Fires on handled [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) rejection events.
 - `unhandledrejection` {{non-standard_inline}}
   - : Fires on unhandled [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) rejection events.
-
-## Instance methods
-
-_This interface inherits methods from the {{domxref("EventTarget")}} interface._
-
-### Standard methods
-
-- {{domxref("WorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-
-### Non-standard methods
-
-- {{domxref("WorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
-  - : Allows you to write a message to stdout — i.e. in your terminal. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.
-
-### Instance methods implemented from elsewhere
-
-- {{domxref("atob", "atob()")}}
-  - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "btoa()")}}
-  - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
-- {{domxref("clearTimeout()")}}
-  - : Cancels the delayed execution set using {{domxref("setTimeout()")}}.
-- {{domxref("createImageBitmap()")}}
-  - : Accepts a variety of different image sources, and returns a {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}}. Optionally the source is cropped to the rectangle of pixels originating at _(sx, sy)_ with width sw, and height sh.
-- {{domxref("fetch()")}}
-  - : Starts the process of fetching a resource from the network.
-- {{domxref("setInterval()")}}
-  - : Schedules a function to execute every time a given number of milliseconds elapses.
-- {{domxref("setTimeout()")}}
-  - : Schedules a function to execute in a given amount of time.
-- {{domxref("reportError()")}}
-  - : Reports an error in a script, emulating an unhandled exception.
 
 ## Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes all "implemented from elsewhere" sections from:
- `Window`
- `WorkerGlobalScope`
- `DedicatedWorkerGlobalScope`
- `ServiceWorkerGlobalScope`
- `SharedWorkerGlobalScope`

And reorganizes worker global scope section orders to be properties-methods-events.

### Motivation

"Elsewhere" is unclear as there are no mixin docs now.

### Additional details

### Related issues and pull requests

Fixes #25699.