### PR TITLE
Fix 25697: clarify mandatory status of manifest members

### DIFF
--- a/files/en-us/web/manifest/background_color/index.md
+++ b/files/en-us/web/manifest/background_color/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.background_color
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.categories
       <th scope="row">Type</th>
       <td><code>Array</code> of <code>String</code>s</td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/description/index.md
+++ b/files/en-us/web/manifest/description/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.description
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.display
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.display_override
       <th scope="row">Type</th>
       <td><code>Array</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/file_handlers/index.md
+++ b/files/en-us/web/manifest/file_handlers/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.file_handlers
       <th scope="row">Type</th>
       <td><code>Array</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.icons
       <th scope="row">Type</th>
       <td><code>Array</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>Yes</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/id/index.md
+++ b/files/en-us/web/manifest/id/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.id
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -6,17 +6,17 @@ browser-compat: html.manifest
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-**Web app manifests** are part of a collection of web technologies that enable [progressive web apps](/en-US/docs/Web/Progressive_web_apps) (PWAs).
+A **web application manifest**, defined in the [Web Application Manifest](https://w3c.github.io/manifest/) specification, is a {{Glossary("JSON")}} text file that provides information about a web application.
 
-PWAs are web applications, written using web technologies, that can be installed on a device. Installed PWAs can work offline, use regular [Web APIs](/en-US/docs/Web/API), and be fully integrated into the operating system they're installed on.
+The most common use for a web application manifest is to provide information that the browser needs to install a [progressive web app](/en-US/docs/Web/Progressive_web_apps) (PWA) on a device, such as the app's name and icon.
 
-A web application manifest, as defined in the [Web Application Manifest](https://w3c.github.io/manifest/) specification, provides information about a web application in a {{Glossary("JSON")}} text file. A web application manifest is necessary for the web app to be installed on a device and behave like other OS-native apps.
-
-A PWA's manifest includes its [name](/en-US/docs/Web/Manifest/name), [icon(s)](/en-US/docs/Web/Manifest/icons), [description](/en-US/docs/Web/Manifest/description), and ways that the PWA appears and integrates into the operating system where it's installed.
+A web application manifest contains a single JSON object where the top-level keys are called _members_.
 
 ## Members
 
-A web application manifest contains a single JSON object where the top-level keys are called _members_. A web application manifest can contain the following members:
+This section lists the members that may appear in the manifest.
+
+All members are optional in the specification, but some applications require some members to be present. For example, [PWAs must provide certain manifest members](/en-US/docs/Web/Progressive_web_apps/guides/making_pwas_installable#required_manifest_members).
 
 {{ListSubpages("/en-US/docs/Web/Manifest")}}
 

--- a/files/en-us/web/manifest/launch_handler/index.md
+++ b/files/en-us/web/manifest/launch_handler/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.launch_handler
       <th scope="row">Type</th>
       <td><code>Object</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.name
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>Yes</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/orientation/index.md
+++ b/files/en-us/web/manifest/orientation/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.orientation
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.prefer_related_applications
       <th scope="row">Type</th>
       <td><code>Boolean</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/protocol_handlers/index.md
+++ b/files/en-us/web/manifest/protocol_handlers/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.protocol_handlers
       <th scope="row">Type</th>
       <td><code>Array</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.related_applications
       <th scope="row">Type</th>
       <td><code>Array</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.scope
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.screenshots
       <th scope="row">Type</th>
       <td><code>Object</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/serviceworker/index.md
+++ b/files/en-us/web/manifest/serviceworker/index.md
@@ -15,10 +15,6 @@ browser-compat: html.manifest.serviceworker
       <th scope="row">Type</th>
       <td><code>Object</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/share_target/index.md
+++ b/files/en-us/web/manifest/share_target/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.share_target
       <th scope="row">Type</th>
       <td><code>Object</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.short_name
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -14,10 +14,6 @@ browser-compat: html.manifest.shortcuts
       <th scope="row">Type</th>
       <td><code>Object</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.start_url
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -12,10 +12,6 @@ browser-compat: html.manifest.theme_color
       <th scope="row">Type</th>
       <td><code>String</code></td>
     </tr>
-    <tr>
-      <th scope="row">Mandatory</th>
-      <td>No</td>
-    </tr>
   </tbody>
 </table>
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -52,6 +52,8 @@ The manifest contains a single JSON object containing a collection of members, e
 }
 ```
 
+#### Required manifest members
+
 Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsoft Edge, require that the manifest includes the following members:
 
 - [`name`](/en-US/docs/Web/Manifest/name)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/25697 as outlined in https://github.com/mdn/content/issues/25697#issuecomment-1488929455.

The overview was very PWA-y, so I tried to clarify that manifest is not necessarily only for PWAs, although they are the most important use case.

I wasn't sure if it would be better to remove the tables entirely from the members, now they only have `Type`, or not. I do quite like the formal presentation you get with a table, compared to having types in prose, like: "The icons member is an `Array` of objects..."

However we do usually have types in prose (for properties or parameters, say). For example:

> The read-only body property of the [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) interface contains a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) with the body contents that have been added to the request. Note that a request using the GET or HEAD method cannot have a body and null is returned in these cases.