### PR TITLE
Fix description of start parameter

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -29,6 +29,7 @@ splice(start, deleteCount, item1, item2, itemN)
     - Negative index counts back from the end of the array — if `start < 0`, `start + array.length` is used.
     - If `start < -array.length`, `0` is used.
     - If `start >= array.length`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
+    - If `start` is omitted (and `splice()` is called with no arguments), nothing is deleted. This is different from passing `undefined`, which is converted to `0`.
 
 - `deleteCount` {{optional_inline}}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -27,7 +27,7 @@ splice(start, deleteCount, item1, item2, itemN)
 
   - : Zero-based index at which to start changing the array, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
     - Negative index counts back from the end of the array — if `start < 0`, `start + array.length` is used.
-    - If `start < -array.length` or `start` is omitted, `0` is used.
+    - If `start < -array.length`, `0` is used.
     - If `start >= array.length`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
 
 - `deleteCount` {{optional_inline}}


### PR DESCRIPTION
omitting `start` doesn't seem to delete anything
