### PR TITLE
Unlinkify link to localhost

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -799,7 +799,7 @@ If you don't want to use a service like Sauce Labs or BrowserStack, you can alwa
 
    (update the `.jar` filename) so it matches exactly what file you've got.
 
-4. The server will run on [`http://localhost:4444/wd/hub`](http://localhost:4444/wd/hub) — try going there now to see what you get.
+4. The server will run on `http://localhost:4444/wd/hub` — try going there now to see what you get.
 
 Now we've got the server running, let's create a demo test that will run on the remote selenium server.
 


### PR DESCRIPTION
We don't want links to localhost: most of the time they don't work, and they can be unpredictable. 

We had one such links.

This blocks #25761.