### PR TITLE
Fixing incorrect syntax comments

### DIFF
--- a/files/en-us/webassembly/reference/numeric/negate/index.md
+++ b/files/en-us/webassembly/reference/numeric/negate/index.md
@@ -15,10 +15,10 @@ The **`neg`** instructions, short for _negate_, are used to negate a number. Tha
 ;; load a number onto the stack
 f32.const 2.7
 
-;; round down
+;; negate
 f32.neg
 
-;; the top item on the stack will now be 2
+;; the top item on the stack will now be -2.7
 ```
 
 | Instruction | Binary opcode |


### PR DESCRIPTION
The comments in the 'Syntax' code example were for a 'floor' instruction instead of for the described 'neg' instruction.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Minor change of the comments in the code example of the "Syntax" section to fit the 'neg' instruction.
Best seen in diff.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fixing incorrect info.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
