### PR TITLE
Change `crisp-edges` to `pixelated` for Games' example

### DIFF
--- a/files/en-us/games/techniques/crisp_pixel_art_look/index.md
+++ b/files/en-us/games/techniques/crisp_pixel_art_look/index.md
@@ -39,11 +39,11 @@ Retro [pixel art](https://en.wikipedia.org/wiki/Pixel_art) aesthetics are gettin
 
 The good news is that you can use CSS to automatically do the up-scaling, which not only solves the blur problem, but also allows you to use the images in their original, smaller size, thus saving download time. Also, some game techniques require algorithms that analyze images, which also benefit from working with smaller images.
 
-The CSS property to achieve this scaling is {{cssxref("image-rendering")}}. It is still experimental, but there is partial support in most browsers. The steps to achieve this effect are:
+The CSS property to achieve this scaling is {{cssxref("image-rendering")}}. The steps to achieve this effect are:
 
 - Create a {{htmlelement("canvas")}} element and set its `width` and `height` attributes to the original, smaller resolution.
 - Set its CSS {{cssxref("width")}} and {{cssxref("height")}} properties to be 2x or 4x the value of the HTML `width` and `height`. If the canvas was created with a 128 pixel width, for example, we would set the CSS `width` to `512px` if we wanted a 4x scale.
-- Set the {{htmlelement("canvas")}} element's `image-rendering` CSS property to some value that does not make the image blurry. Either `crisp-edges` or `pixelated` will work. Check out the {{cssxref("image-rendering")}} article for more information on the differences between these values, and which prefixes to use depending on the browser.
+- Set the {{htmlelement("canvas")}} element's `image-rendering` CSS property to `pixelated`, which does not make the image blurry. There are also the `crisp-edges` and `-webkit-optimize-contrast` values that work on some browsers. Check out the {{cssxref("image-rendering")}} article for more information on the differences between these values, and which values to use depending on the browser.
 
 ## An example
 
@@ -63,7 +63,7 @@ CSS to size the canvas and render a crisp image:
 canvas {
   width: 512px;
   height: 512px;
-  image-rendering: crisp-edges;
+  image-rendering: pixelated;
 }
 ```
 


### PR DESCRIPTION
### Description

This PR changes the `crisp-edges` value of the `image-rendering` CSS property used in the exmaple on [Crisp pixel art look with image-rendering](https://developer.mozilla.org/en-US/docs/Games/Techniques/Crisp_pixel_art_look) to `pixelated`. Also, the outdated note on the experimental status of `image-rendering` is removed.

### Motivation

`pixelated` has much wider support than `crisp-edges` now, so changing to this value enables the example to work on more browsers.

### Additional details

Mozilla bug for implementing `image-rendering: pixelated`:
https://bugzilla.mozilla.org/show_bug.cgi?id=856337#c57

### Related issues and pull requests

Fixes #25770.