### PR TITLE
Only first listener is persisted fix release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -55,6 +55,8 @@ This article provides information about the changes in Firefox 113 that affect d
 
 ## Changes for add-on developers
 
+- When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up ([Firefox bug 1798655](https://bugzil.la/1798655)).
+
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -55,7 +55,7 @@ This article provides information about the changes in Firefox 113 that affect d
 
 ## Changes for add-on developers
 
-- When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up ([Firefox bug 1798655](https://bugzil.la/1798655)).
+- When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up, instead of only the first one ([Firefox bug 1798655](https://bugzil.la/1798655)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Add a release note to note that a fix has been implemented so that when an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up.

### Related issues and pull requests

Addresses the documentation quest on [Bug 1795801](https://bugzilla.mozilla.org/show_bug.cgi?id=1795801) Only the first listener is persisted; multiple listeners not triggered when event page awakes
