### PR TITLE
Enter and Escape instead of Ctrl and Alt to avoid WM conflict.

### DIFF
--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -583,11 +583,12 @@ The code below adds [`keydown`](/en-US/docs/Web/API/Element/keydown_event) and [
 ```js-nolint
 const synthKeys = document.querySelectorAll(".key");
 const keyCodes = [
-  "ControlLeft", "AltLeft", "Space",
+  "Space",
   "ShiftLeft", "KeyZ", "KeyX", "KeyC", "KeyV", "KeyB", "KeyN", "KeyM", "Comma", "Period", "Slash", "ShiftRight",
-  "KeyA", "KeyS", "KeyD", "KeyF", "KeyG", "KeyH", "KeyJ", "KeyK", "KeyL", "Semicolon", "Quote",
+  "KeyA", "KeyS", "KeyD", "KeyF", "KeyG", "KeyH", "KeyJ", "KeyK", "KeyL", "Semicolon", "Quote", "Enter",
   "Tab", "KeyQ", "KeyW", "KeyE", "KeyR", "KeyT", "KeyY", "KeyU", "KeyI", "KeyO", "KeyP", "BracketLeft", "BracketRight",
   "Digit1", "Digit2", "Digit3", "Digit4", "Digit5", "Digit6", "Digit7", "Digit8", "Digit9", "Digit0", "Minus", "Equal", "Backspace",
+  "Escape",
 ];
 function keyNote(event) {
   const elKey = synthKeys[keyCodes.indexOf(event.code)];

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -602,6 +602,7 @@ function keyNote(event) {
       elKey.classList.remove("active");
       noteReleased({ buttons: 1, target: elKey });
     }
+    event.preventDefault();
   }
 }
 addEventListener("keydown", keyNote);


### PR DESCRIPTION
My PR merged yesterday from https://github.com/mdn/content/issues/23825 conflicts with Alt+Tab etc. https://stackoverflow.com/questions/40434142/javascript-event-preventdefault-is-useless-for-alttab-in-windows

I've replaced ControlLeft and AltLeft keybindings with Enter and Escape, respectively.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes bug introduced by #23825.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
