### PR TITLE
remove old links to proposal and polyfill

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -90,5 +90,3 @@ console.log(Array.of.call({}, 1)); // [ 1 ]
 - [`Array()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array)
 - {{jsxref("Array.from()")}}
 - {{jsxref("TypedArray.of()")}}
-- [`Array.of()` & `Array.from()` proposal](https://gist.github.com/rwaldron/1074126)
-- [`Array.of()` polyfill](https://gist.github.com/rwaldron/3186576)


### PR DESCRIPTION
### Description

As there is a link to `core-js` polyfill which is a well known (and well enough) implementation, removing the polyfill link to another one.

And the proposal seems to not exists in other pages, removing this (we already have links to specifications).
