### PR TITLE
Replace the spec links for two MathML elements

### DIFF
--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -53,7 +53,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Specifications
 
-The `<menclose>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_menclose).
+The `<menclose>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://www.w3.org/TR/mathml4/#presm_menclose).
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -68,7 +68,7 @@ Rendering in your browser:
 
 ## Specifications
 
-The `<mfenced>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://w3c.github.io/mathml/#presm_mfenced).
+The `<mfenced>` element is not defined in any browser-oriented specification but you can find a description in [MathML 4](https://www.w3.org/TR/mathml4/#presm_mfenced).
 
 ## Browser compatibility
 


### PR DESCRIPTION
### Description

This PR replaces the spec links for the `<menclose>` and `<mfenced>` elements.

### Motivation

Current links point to the editor's draft, which doesn't have readable definitions for these two elements.

### Additional details

The spec link for `<menclose>` and `<mfenced>`:
https://www.w3.org/TR/mathml4/#presm_menclose
https://www.w3.org/TR/mathml4/#presm_mfenced

### Related issues and pull requests