### PR TITLE
Fix inconsistent use of `rotate`

### DIFF
--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -71,7 +71,7 @@ This example performs a four-second font size transition with a two-second delay
 <body>
   <p>
     The box below combines transitions for: width, height, background-color,
-    transform. Hover over the box to see these properties animated.
+    rotate. Hover over the box to see these properties animated.
   </p>
   <div class="box">Sample</div>
 </body>
@@ -87,7 +87,7 @@ This example performs a four-second font size transition with a two-second delay
   width: 100px;
   height: 100px;
   background-color: #0000ff;
-  transition: width 2s, height 2s, background-color 2s, transform 2s;
+  transition: width 2s, height 2s, background-color 2s, rotate 2s;
 }
 
 .box:hover {


### PR DESCRIPTION
### Description

This PR unifies the property used in the transition example, i.e. `transform` and `rotate`.

### Motivation

### Additional details

### Related issues and pull requests

Fixes #25809.
Relates to #21698.