### PR TITLE
docs(fx112-relnote): Update release note for 'overlay' support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -17,6 +17,8 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ### CSS
 
+- The `overlay` keyword value for the {{cssxref("overflow")}} property is now supported as a legacy alias of the keyword value `auto` ([Firefox bug 1817189](https://bugzil.la/1817189)).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

From Fx112, `overlay` will be recognized as a value for `overflow`.

### Related issues and pull requests

Related content update: https://github.com/mdn/content/pull/25749
Related BCD update: https://github.com/mdn/browser-compat-data/pull/19283
Doc issue tracker: https://github.com/mdn/content/issues/25355
Spec: https://w3c.github.io/csswg-drafts/css-overflow/#overflow-control
