### PR TITLE
Improve example for bodyUsed

### DIFF
--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -32,7 +32,7 @@ When the user clicks "Use response", we check whether the response has been used
 <button id="reset">Reset</button>
 <br />
 <img id="my-image" src="" />
-<pre id="output"></pre>
+<pre id="log"></pre>
 ```
 
 #### JavaScript
@@ -41,7 +41,7 @@ When the user clicks "Use response", we check whether the response has been used
 const useResponse = document.querySelector("#use");
 const reset = document.querySelector("#reset");
 const myImage = document.querySelector("#my-image");
-const output = document.querySelector("#output");
+const log = document.querySelector("#log");
 
 const responsePromise = fetch(
   "https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg"
@@ -50,7 +50,7 @@ const responsePromise = fetch(
 useResponse.addEventListener("click", async () => {
   const response = await responsePromise;
   if (response.bodyUsed) {
-    output.textContent = "Body has already been used!";
+    log.textContent = "Body has already been used!";
   } else {
     const result = await response.blob();
     const objectURL = URL.createObjectURL(result);

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -15,40 +15,61 @@ A boolean value.
 
 ## Examples
 
-In our [fetch request example](https://github.com/mdn/dom-examples/tree/main/fetch/fetch-request) (run [fetch request live](https://mdn.github.io/dom-examples/fetch/fetch-request/)),
-we create a new request using the {{domxref("Request.Request","Request()")}} constructor,
-then use it to fetch a JPG. When the fetch is successful, we read a {{domxref("Blob")}} out of the response using `blob()`,
-put it into an object URL using {{domxref("URL.createObjectURL")}}, and then set that URL as the source of an {{htmlelement("img")}} element to display the image.
+### Checking `bodyUsed`
 
-Notice that we log `response.bodyUsed` to the console once before the `response.blob()` call and once after.
-This returns `false` before and `true` afterwards, as at that point the body has been read.
+This example illustrates that reading the body of a response changes the value of `bodyUsed` from `false` to `true`.
 
-### HTML Content
+The example contains an empty image.
+
+When the example's JavaScript runs, we fetch an image and assigns the returned promise to a variable `responsePromise`.
+
+When the user clicks "Use response", we check whether the response has been used already. If it has, we print a message. If it has not, we read the response body and used it to provide a value for the image's `src` attribute.
+
+#### HTML
 
 ```html
-<img
-  class="my-image"
-  src="https://wikipedia.org/static/images/project-logos/frwiki-1.5x.png" />
+<button id="use">Use response</button>
+<button id="reset">Reset</button>
+<br />
+<img id="my-image" src="" />
+<pre id="output"></pre>
 ```
 
-### JavaScript Content
+#### JavaScript
 
 ```js
-const myImage = document.querySelector(".my-image");
-fetch("https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg")
-  .then((response) => {
-    console.log(response.bodyUsed);
-    const res = response.blob();
-    console.log(response.bodyUsed);
-    return res;
-  })
-  .then((response) => {
-    const objectURL = URL.createObjectURL(response);
+const useResponse = document.querySelector("#use");
+const reset = document.querySelector("#reset");
+const myImage = document.querySelector("#my-image");
+const output = document.querySelector("#output");
+
+const responsePromise = fetch(
+  "https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg"
+);
+
+useResponse.addEventListener("click", async () => {
+  const response = await responsePromise;
+  if (response.bodyUsed) {
+    output.textContent = "Body has already been used!";
+  } else {
+    const result = await response.blob();
+    const objectURL = URL.createObjectURL(result);
     myImage.src = objectURL;
-  });
+  }
+});
+
+reset.addEventListener("click", () => {
+  document.location.reload();
+});
 ```
 
-{{ EmbedLiveSample('Examples', '100%', '250px') }}
+#### Result
+
+Initially there is no value for the image. If you click "Use response" once, then `bodyUsed` is `false`, so we read the response and set the image. If you then click "Use response" again, then `bodyUsed` is `true`, and we print the message.
+
+Click "Reset" to reload the example, so you can try again.
+
+{{ EmbedLiveSample('Examples', '100%', '300px') }}
 
 ## Specifications
 


### PR DESCRIPTION
The example for https://developer.mozilla.org/en-US/docs/Web/API/Response/bodyUsed uses the browser console, which isn't usually visible, and all runs on page load, so you can't interact with it.

This PR makes it interactive and uses in-example output.