### PR TITLE
Some fetch guide refactorings

### DIFF
--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -13,9 +13,7 @@ The Fetch API provides an interface for fetching resources (including across the
 
 ## Concepts and usage
 
-Fetch provides a definition of {{DOMxRef("Request")}} and {{DOMxRef("Response")}} objects (and other things involved with network requests). This will allow them to be used wherever they are needed in the future, whether it's for service workers, Cache API, and other similar things that handle or modify requests and responses, or any kind of use case that might require you to generate your responses programmatically.
-
-It also defines related concepts such as CORS and the HTTP Origin header semantics, supplanting their separate definitions elsewhere.
+The Fetch API uses {{DOMxRef("Request")}} and {{DOMxRef("Response")}} objects (and other things involved with network requests), as well as related concepts such as CORS and the HTTP Origin header semantics.
 
 For making a request and fetching a resource, use the {{DOMxRef("fetch()")}} method. It is a global method in both {{DOMxRef("Window")}} and {{DOMxRef("WorkerGlobalScope", "Worker")}} contexts. This makes it available in pretty much any context you might want to fetch resources in.
 

--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -7,17 +7,17 @@ browser-compat: api.fetch
 
 {{DefaultAPISidebar("Fetch API")}}
 
-The Fetch API provides an interface for fetching resources (including across the network). It will seem familiar to anyone who has used {{DOMxRef("XMLHttpRequest")}}, but the new API provides a more powerful and flexible feature set.
+The Fetch API provides an interface for fetching resources (including across the network). It is a more powerful and flexible replacement for {{DOMxRef("XMLHttpRequest")}}.
 
 {{AvailableInWorkers}}
 
 ## Concepts and usage
 
-Fetch provides a generic definition of {{DOMxRef("Request")}} and {{DOMxRef("Response")}} objects (and other things involved with network requests). This will allow them to be used wherever they are needed in the future, whether it's for service workers, Cache API, and other similar things that handle or modify requests and responses, or any kind of use case that might require you to generate your responses programmatically (that is, the use of computer program or personal programming instructions).
+Fetch provides a definition of {{DOMxRef("Request")}} and {{DOMxRef("Response")}} objects (and other things involved with network requests). This will allow them to be used wherever they are needed in the future, whether it's for service workers, Cache API, and other similar things that handle or modify requests and responses, or any kind of use case that might require you to generate your responses programmatically.
 
 It also defines related concepts such as CORS and the HTTP Origin header semantics, supplanting their separate definitions elsewhere.
 
-For making a request and fetching a resource, use the {{DOMxRef("fetch()")}} method. It is implemented in multiple interfaces, specifically {{DOMxRef("Window")}} and {{DOMxRef("WorkerGlobalScope")}}. This makes it available in pretty much any context you might want to fetch resources in.
+For making a request and fetching a resource, use the {{DOMxRef("fetch()")}} method. It is a global method in both {{DOMxRef("Window")}} and {{DOMxRef("WorkerGlobalScope", "Worker")}} contexts. This makes it available in pretty much any context you might want to fetch resources in.
 
 The `fetch()` method takes one mandatory argument, the path to the resource you want to fetch. It returns a {{JSxRef("Promise")}} that resolves to the {{DOMxRef("Response")}} to that request — as soon as the server responds with headers — **even if the server response is an HTTP error status**. You can also optionally pass in an `init` options object as the second argument (see {{DOMxRef("Request")}}).
 
@@ -25,21 +25,7 @@ Once a {{DOMxRef("Response")}} is retrieved, there are a number of methods avail
 
 You can create a request and response directly using the {{DOMxRef("Request.Request", "Request()")}} and {{DOMxRef("Response.Response", "Response()")}} constructors, but it's uncommon to do this directly. Instead, these are more likely to be created as results of other API actions (for example, {{DOMxRef("FetchEvent.respondWith()")}} from service workers).
 
-### Differences from jQuery
-
-The `fetch` specification differs from `jQuery.ajax()` in three main ways:
-
-- The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP `404` or `500`. Instead, it will resolve normally (with `ok` status set to `false`), and it will only reject on network failure or if anything prevented the request from completing.
-- `fetch()` **won't send cross-origin cookies** unless you set the _credentials_ [init option](/en-US/docs/Web/API/fetch#parameters) (to `include`).
-
-  - In [April 2018](https://github.com/whatwg/fetch/pull/585), the spec changed the default credentials policy to `'same-origin'`. The following browsers shipped an outdated native fetch, and were updated in these versions: Firefox 61.0b13, Safari 12, Chrome 68.
-  - If you are targeting older versions of these browsers, be sure to include `credentials: 'same-origin'` [init option](/en-US/docs/Web/API/fetch#parameters) on all API requests that may be affected by cookies/user login state.
-
-> **Note:** Find out more about using the Fetch API features in [Using Fetch](/en-US/docs/Web/API/Fetch_API/Using_Fetch), and study concepts in [Fetch basic concepts](/en-US/docs/Web/API/Fetch_API/Basic_concepts).
-
-### Aborting a fetch
-
-To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
+Find out more about using the Fetch API features in [Using Fetch](/en-US/docs/Web/API/Fetch_API/Using_Fetch), and study concepts in [Fetch basic concepts](/en-US/docs/Web/API/Fetch_API/Basic_concepts).
 
 ## Fetch Interfaces
 
@@ -63,7 +49,7 @@ To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{
 ## See also
 
 - [Using Fetch](/en-US/docs/Web/API/Fetch_API/Using_Fetch)
-- [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API)
+- [Service Worker API](/en-US/docs/Web/API/Service_Worker_API)
 - [HTTP access control (CORS)](/en-US/docs/Web/HTTP/CORS)
 - [HTTP](/en-US/docs/Web/HTTP)
 - [Fetch polyfill](https://github.com/github/fetch)

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -477,7 +477,7 @@ if (window.fetch) {
 
 The `fetch` specification differs from `jQuery.ajax()` in the following significant ways:
 
-- The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the {{domxref("Response/ok", "ok")}} property of the response set to false if the response isn't in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.
+- The promise returned from `fetch()` won't reject on HTTP errors even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the promise will resolve (with the {{domxref("Response/ok", "ok")}} property of the response set to `false` if the response isn't in the range 200–299). The promise will only reject on network failure or if anything prevented the request from completing.
 - Unless `fetch()` is called with the [`credentials`](/en-US/docs/Web/API/fetch#credentials) option set to `include`, `fetch()`:
   - won't send cookies in cross-origin requests
   - won't set any cookies sent back in cross-origin responses

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -2,29 +2,22 @@
 title: Using the Fetch API
 slug: Web/API/Fetch_API/Using_Fetch
 page-type: guide
-browser-compat: api.fetch
 ---
 
 {{DefaultAPISidebar("Fetch API")}}
 
 The [Fetch API](/en-US/docs/Web/API/Fetch_API) provides a JavaScript interface for accessing and manipulating parts of the [protocol](/en-US/docs/Glossary/Protocol), such as requests and responses. It also provides a global {{domxref("fetch()")}} method that provides an easy, logical way to fetch resources asynchronously across the network.
 
-This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as {{domxref("Service_Worker_API", "Service Workers")}}. Fetch also provides a single logical place to define other HTTP-related concepts such as [CORS](/en-US/docs/Web/HTTP/CORS) and extensions to HTTP.
+This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as [service workers](/en-US/docs/Web/API/Service_Worker_API). Fetch also provides a single logical place to define other HTTP-related concepts such as [CORS](/en-US/docs/Web/HTTP/CORS) and extensions to HTTP.
 
-The `fetch` specification differs from `jQuery.ajax()` in the following significant ways:
-
-- The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the {{domxref("Response/ok", "ok")}} property of the response set to false if the response isn't in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.
-- Unless `fetch()` is called with the [`credentials`](/en-US/docs/Web/API/fetch#credentials) option set to `include`, `fetch()`:
-  - won't send cookies in cross-origin requests
-  - won't set any cookies sent back in cross-origin responses
-  - As of August 2018, the default credentials policy changed to same-origin. Firefox was also modified in version 61.0b13)
-
-A basic fetch request is really simple to set up. Have a look at the following code:
+A basic fetch request looks like this:
 
 ```js
-fetch("http://example.com/movies.json")
-  .then((response) => response.json())
-  .then((data) => console.log(data));
+async function logJSONData() {
+  const response = await fetch("http://example.com/movies.json");
+  const jsonData = await response.json();
+  console.log(data);
+}
 ```
 
 Here we are fetching a JSON file across the network and printing it to the console. The simplest use of `fetch()` takes one argument — the path to the resource you want to fetch — and does not directly return the JSON response body but instead returns a promise that resolves with a {{domxref("Response")}} object.
@@ -73,6 +66,10 @@ Note that `mode: "no-cors"` only allows a limited set of headers in the request:
 - `Content-Language`
 - `Content-Type` with a value of `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`
 
+### Aborting a fetch
+
+To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
+
 ## Sending a request with credentials included
 
 To cause browsers to send a request with credentials included on both same-origin and cross-origin calls, add `credentials: 'include'` to the `init` object you pass to the `fetch()` method.
@@ -110,22 +107,25 @@ fetch("https://example.com", {
 Use {{domxref("fetch()")}} to POST JSON-encoded data.
 
 ```js
-const data = { username: "example" };
+async function postJSON(data) {
+  try {
+    const response = await fetch("https://example.com/profile", {
+      method: "POST", // or 'PUT'
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
 
-fetch("https://example.com/profile", {
-  method: "POST", // or 'PUT'
-  headers: {
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify(data),
-})
-  .then((response) => response.json())
-  .then((data) => {
-    console.log("Success:", data);
-  })
-  .catch((error) => {
+    const result = await response.json();
+    console.log("Success:", result);
+  } catch (error) {
     console.error("Error:", error);
-  });
+  }
+}
+
+const data = { username: "example" };
+postJSON(data);
 ```
 
 ## Uploading a file
@@ -133,23 +133,26 @@ fetch("https://example.com/profile", {
 Files can be uploaded using an HTML `<input type="file" />` input element, {{domxref("FormData.FormData","FormData()")}} and {{domxref("fetch()")}}.
 
 ```js
+async function upload(formData) {
+  try {
+    const response = await fetch("https://example.com/profile/avatar", {
+      method: "PUT",
+      body: formData,
+    });
+    const result = await response.json();
+    console.log("Success:", result);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
 const formData = new FormData();
 const fileField = document.querySelector('input[type="file"]');
 
 formData.append("username", "abc123");
 formData.append("avatar", fileField.files[0]);
 
-fetch("https://example.com/profile/avatar", {
-  method: "PUT",
-  body: formData,
-})
-  .then((response) => response.json())
-  .then((result) => {
-    console.log("Success:", result);
-  })
-  .catch((error) => {
-    console.error("Error:", error);
-  });
+upload(formData);
 ```
 
 ## Uploading multiple files
@@ -157,8 +160,21 @@ fetch("https://example.com/profile/avatar", {
 Files can be uploaded using an HTML `<input type="file" multiple />` input element, {{domxref("FormData.FormData","FormData()")}} and {{domxref("fetch()")}}.
 
 ```js
-const formData = new FormData();
+async function uploadMultiple(formData) {
+  try {
+    const response = await fetch("https://example.com/posts", {
+      method: "POST",
+      body: formData,
+    });
+    const result = await response.json();
+    console.log("Success:", result);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
 const photos = document.querySelector('input[type="file"][multiple]');
+const formData = new FormData();
 
 formData.append("title", "My Vegas Vacation");
 let i = 0;
@@ -167,17 +183,7 @@ for (const photo of photos.files) {
   i++;
 }
 
-fetch("https://example.com/posts", {
-  method: "POST",
-  body: formData,
-})
-  .then((response) => response.json())
-  .then((result) => {
-    console.log("Success:", result);
-  })
-  .catch((error) => {
-    console.error("Error:", error);
-  });
+uploadMultiple(formData);
 ```
 
 ## Processing a text file line by line
@@ -230,19 +236,18 @@ run();
 A {{domxref("fetch()")}} promise will reject with a {{jsxref("TypeError")}} when a network error is encountered or CORS is misconfigured on the server-side, although this usually means permission issues or similar — a 404 does not constitute a network error, for example. An accurate check for a successful `fetch()` would include checking that the promise resolved, then checking that the {{domxref("Response.ok")}} property has a value of true. The code would look something like this:
 
 ```js
-fetch("flowers.jpg")
-  .then((response) => {
+async function fetchImage() {
+  try {
+    const response = await fetch("flowers.jpg");
     if (!response.ok) {
       throw new Error("Network response was not OK");
     }
-    return response.blob();
-  })
-  .then((myBlob) => {
+    const myBlob = await response.blob();
     myImage.src = URL.createObjectURL(myBlob);
-  })
-  .catch((error) => {
+  } catch (error) {
     console.error("There has been a problem with your fetch operation:", error);
-  });
+  }
+}
 ```
 
 ## Supplying your own request object
@@ -250,6 +255,19 @@ fetch("flowers.jpg")
 Instead of passing a path to the resource you want to request into the `fetch()` call, you can create a request object using the {{domxref("Request.Request","Request()")}} constructor, and pass that in as a `fetch()` method argument:
 
 ```js
+async function fetchImage(request) {
+  try {
+    const response = await fetch(request);
+    if (!response.ok) {
+      throw new Error("Network response was not OK");
+    }
+    const myBlob = await response.blob();
+    myImage.src = URL.createObjectURL(myBlob);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
 const myHeaders = new Headers();
 
 const myRequest = new Request("flowers.jpg", {
@@ -259,11 +277,7 @@ const myRequest = new Request("flowers.jpg", {
   cache: "default",
 });
 
-fetch(myRequest)
-  .then((response) => response.blob())
-  .then((myBlob) => {
-    myImage.src = URL.createObjectURL(myBlob);
-  });
+fetchImage(myRequest);
 ```
 
 `Request()` accepts exactly the same parameters as the `fetch()` method. You can even pass in an existing request object to create a copy of it:
@@ -331,18 +345,19 @@ try {
 A good use case for headers is checking whether the content type is correct before you process it further. For example:
 
 ```js
-fetch(myRequest)
-  .then((response) => {
+async function fetchJSON(request) {
+  try {
+    const response = await fetch(request);
     const contentType = response.headers.get("content-type");
     if (!contentType || !contentType.includes("application/json")) {
       throw new TypeError("Oops, we haven't got JSON!");
     }
-    return response.json();
-  })
-  .then((data) => {
-    /* process your data further */
-  })
-  .catch((error) => console.error(error));
+    const jsonData = await response.json();
+    // process your data further
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
 ```
 
 ### Guard
@@ -435,13 +450,15 @@ if (window.fetch) {
 }
 ```
 
-## Specifications
+## Differences from `jQuery.ajax()`
 
-{{Specifications}}
+The `fetch` specification differs from `jQuery.ajax()` in the following significant ways:
 
-## Browser compatibility
-
-{{Compat}}
+- The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the {{domxref("Response/ok", "ok")}} property of the response set to false if the response isn't in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.
+- Unless `fetch()` is called with the [`credentials`](/en-US/docs/Web/API/fetch#credentials) option set to `include`, `fetch()`:
+  - won't send cookies in cross-origin requests
+  - won't set any cookies sent back in cross-origin responses
+  - As of August 2018, the default credentials policy changed to same-origin.
 
 ## See also
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -200,10 +200,9 @@ const photos = document.querySelector('input[type="file"][multiple]');
 const formData = new FormData();
 
 formData.append("title", "My Vegas Vacation");
-let i = 0;
-for (const photo of photos.files) {
+
+for (const [i, photo] of photos.files.entries()) {
   formData.append(`photos_${i}`, photo);
-  i++;
 }
 
 uploadMultiple(formData);

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -66,9 +66,32 @@ Note that `mode: "no-cors"` only allows a limited set of headers in the request:
 - `Content-Language`
 - `Content-Type` with a value of `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`
 
-### Aborting a fetch
+## Aborting a fetch
 
 To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
+
+```js
+const controller = new AbortController();
+const signal = controller.signal;
+const url = "video.mp4";
+
+const downloadBtn = document.querySelector(".download");
+const abortBtn = document.querySelector(".abort");
+
+downloadBtn.addEventListener("click", async () => {
+  try {
+    const response = await fetch(url, { signal });
+    console.log("Download complete", response);
+  } catch (error) {
+    console.error(`Download error: ${error.message}`);
+  }
+});
+
+abortBtn.addEventListener("click", () => {
+  controller.abort();
+  console.log("Download aborted");
+});
+```
 
 ## Sending a request with credentials included
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 The [Fetch API](/en-US/docs/Web/API/Fetch_API) provides a JavaScript interface for accessing and manipulating parts of the [protocol](/en-US/docs/Glossary/Protocol), such as requests and responses. It also provides a global {{domxref("fetch()")}} method that provides an easy, logical way to fetch resources asynchronously across the network.
 
-This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as [service workers](/en-US/docs/Web/API/Service_Worker_API). Fetch also provides a single logical place to define other HTTP-related concepts such as [CORS](/en-US/docs/Web/HTTP/CORS) and extensions to HTTP.
+Unlike {{domxref("XMLHttpRequest")}} that is a callback-based API, Fetch is promise-based and provides a better alternative that can be easily used in [service workers](/en-US/docs/Web/API/Service_Worker_API). Fetch also integrates advanced HTTP concepts such as [CORS](/en-US/docs/Web/HTTP/CORS) and other extensions to HTTP.
 
 A basic fetch request looks like this:
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -201,7 +201,7 @@ const formData = new FormData();
 
 formData.append("title", "My Vegas Vacation");
 
-for (const [i, photo] of photos.files.entries()) {
+for (const [i, photo] of Array.from(photos.files).entries()) {
   formData.append(`photos_${i}`, photo);
 }
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -75,8 +75,8 @@ const controller = new AbortController();
 const signal = controller.signal;
 const url = "video.mp4";
 
-const downloadBtn = document.querySelector(".download");
-const abortBtn = document.querySelector(".abort");
+const downloadBtn = document.querySelector("#download");
+const abortBtn = document.querySelector("#abort");
 
 downloadBtn.addEventListener("click", async () => {
   try {

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -68,7 +68,7 @@ Note that `mode: "no-cors"` only allows a limited set of headers in the request:
 
 ## Aborting a fetch
 
-To abort incomplete `fetch()`, and even `XMLHttpRequest`, operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
+To abort incomplete `fetch()` operations, use the {{DOMxRef("AbortController")}} and {{DOMxRef("AbortSignal")}} interfaces.
 
 ```js
 const controller = new AbortController();


### PR DESCRIPTION
I wanted to add something to the fetch docs about reading responses more than once (for https://github.com/mdn/content/issues/13208#issuecomment-1492638882) but when I got there, there were a few other things that seemed worth doing.

So this PR just does the other things, and I will add the stuff about reading response later.

Specifically:
- a very little light copy editing
- the bit about jQuery.ajax() was duplicated in both pages: I killed one and moved the other to the end of the guide page.
- I moved the bit about aborting fetched into the guide page, and added an example
- I converted pretty much all the examples to use `async`/`await`
