### PR TITLE
chore: remove deprecated {{htmlattrxref}} macro

### DIFF
--- a/files/en-us/glossary/submit_button/index.md
+++ b/files/en-us/glossary/submit_button/index.md
@@ -16,11 +16,11 @@ In addition to submitting a form, a submit button can affect the form's behavior
 
 Submit buttons can override the form's submission behavior through various attributes:
 
-- `{{HtmlElement("button#attr-formaction", "formaction")}}`: Override the {{htmlattrxref("action","form")}} attribute of the form.
-- `{{HtmlElement("button#attr-formenctype", "formenctype")}}`: Override the {{htmlattrxref("enctype","form")}} attribute of the form.
-- `{{HtmlElement("button#attr-formmethod", "formmethod")}}`: Override the {{htmlattrxref("method","form")}} attribute of the form.
-- `{{HtmlElement("button#attr-formnovalidate", "formnovalidate")}}`: Override the {{htmlattrxref("novalidate","form")}} attribute of the form.
-- `{{HtmlElement("button#attr-formtarget", "formtarget")}}`: Override the {{htmlattrxref("target","form")}} attribute of the form.
+- `{{HtmlElement("button#attr-formaction", "formaction")}}`: Override the [`action`](/en-US/docs/Web/HTML/Element/form#action) attribute of the form.
+- `{{HtmlElement("button#attr-formenctype", "formenctype")}}`: Override the [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) attribute of the form.
+- `{{HtmlElement("button#attr-formmethod", "formmethod")}}`: Override the [`method`](/en-US/docs/Web/HTML/Element/form#method) attribute of the form.
+- `{{HtmlElement("button#attr-formnovalidate", "formnovalidate")}}`: Override the [`novalidate`](/en-US/docs/Web/HTML/Element/form#novalidate) attribute of the form.
+- `{{HtmlElement("button#attr-formtarget", "formtarget")}}`: Override the [`target`](/en-US/docs/Web/HTML/Element/form#target) attribute of the form.
 
 ## Form data entries
 

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -32,7 +32,7 @@ new FormData(form, submitter)
   - : Thrown if the specified `submitter` is not a {{Glossary("submit button")}}.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if the specified `submitter` isn't a member of the `form`. The `submitter` must be either a
-    descendant of the form element or must have a {{htmlattrxref("form", "input")}}
+    descendant of the form element or must have a [`form`](/en-US/docs/Web/HTML/Element/input#form)
     attribute referring to the form.
 
 ## Examples

--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -124,7 +124,7 @@ p {
 
 ### Applying brightness using the url() SVG brightness filter
 
-The SVG {{SVGElement("filter")}} element is used to define custom filter effects that can then be referenced by {{htmlattrxref("id")}}. The `<filter>` element's {{SVGElement("feComponentTransfer")}} primitive enables pixel-level color remapping.
+The SVG {{SVGElement("filter")}} element is used to define custom filter effects that can then be referenced by [`id`](/en-US/docs/Web/HTML/Global_attributes#id). The `<filter>` element's {{SVGElement("feComponentTransfer")}} primitive enables pixel-level color remapping.
 
 In this example, to create a filter that darkens the content on which it is applied by 25% (i.e., 75% of the original brightness), the `slope` attribute is set to `0.75`. We can then reference the filter by `id`.
 


### PR DESCRIPTION
### Description

chore: remove deprecated {{htmlattrxref}} macro

### Related issues and pull requests

https://github.com/orgs/mdn/discussions/347
