### PR TITLE
Removed unneeded method parameter

### DIFF
--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -42,7 +42,7 @@ function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
+  const encoded = encoder.encode(message);
   encoded.forEach((chunk) => {
     defaultWriter.ready
       .then(() => defaultWriter.write(chunk))


### PR DESCRIPTION
### Description

Got rid of the second parameter in `TextEncoder.encode()` used in the example section in order not to be confused with `TextDecoder.decode()`