### PR TITLE
Correct descriptions on "Logical properties for margins, borders, and padding"

### DIFF
--- a/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -150,4 +150,4 @@ The specification has flow-relative equivalents for the {{cssxref("border-radius
 
 The specification makes a suggestion for the four-value shorthands such as the `margin` property, however the final decision on how this should be indicated is as yet unresolved, and is discussed in [this issue](https://github.com/w3c/csswg-drafts/issues/1282).
 
-Using any four-value shorthand such as margin, padding, or border will currently use the physical versions, so if following the flow of the document is important, use the longhand properties for the time being.
+Using any four-value shorthand such as `margin`, `padding`, or `border` will currently use the physical versions, so if following the flow of the document is important, use the longhand properties for the time being.

--- a/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -122,7 +122,7 @@ The demo below uses some longhands and three shorthand values. As with the other
 
 ### New border shorthands
 
-There are two-value shorthands to set the width, style and, color of the block or inline dimension, and two-value shorthands to set all three values in the block or inline dimension. The below code, in a horizontal writing mode, would give you a 2px green solid border on the top and bottom of the box, and a 4px dotted purple border on the left and right.
+There are two-value shorthands to set the width, style, and color of the block or inline dimension, and shorthands to set all three values in the block or inline dimension. The below code, in a horizontal writing mode, would give you a 2px green solid border on the top and bottom of the box, and a 4px dotted purple border on the left and right.
 
 ```css
 .box {
@@ -135,7 +135,7 @@ There are two-value shorthands to set the width, style and, color of the block o
 
 ### Flow relative border-radius properties
 
-The specification has fairly recently added flow-relative values for the {{cssxref("border-radius")}} longhands. These have not yet been implemented by any browser. The below example, in a horizontal `writing-mode`, would set the top-right border radius to 1em, the bottom-right to 0, the bottom-left to 20px and the top-left to 40px.
+The specification has flow-relative equivalents for the {{cssxref("border-radius")}} longhands. The below example, in a horizontal `writing-mode`, would set the top-right border radius to 1em, the bottom-right to 0, the bottom-left to 20px and the top-left to 40px.
 
 ```css
 .box {


### PR DESCRIPTION
### Description

This PR corrects the description of logical `border` shorthands, and removes outdated descriptions about logical `border-radius` longhands.

### Motivation

  1. `border-(block|inline)` have a three-value syntax instead of the written two-value.
  2. `border-(end|start)-(end|start)-radius` are no longer a recent addition to the spec, and have gained wide support by now.

### Additional details

The BCD table for `border-end-end-radius`:
https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius#browser_compatibility

### Related issues and pull requests

This blocks the l10n of this page.