### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -29,7 +29,7 @@ The following parameters are passed to the `construct()` method. `this` is bound
 - `argumentsList`
   - : The list of arguments for the constructor.
 - `newTarget`
-  - : The constructor that was originally called, `p` above.
+  - : The constructor that was originally called.
 
 ### Return value
 


### PR DESCRIPTION
Removed typo on the `handler.construct()` page.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Removes a typo on the `handler.construct()` page. It describes the `newTarget` parameter as `p` above which is incorrect.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I noticed a small error, so I figured I should correct it.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
