### PR TITLE
Remove deprecated parameters to an {{EmbedLiveSample}} macros

### DIFF
--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -562,7 +562,7 @@ svg text.em {
 }
 ```
 
-{{EmbedLiveSample("Comparison_of_HTML_and_SVG", "100%", 800, "", "", "example-outcome-frame")}}
+{{EmbedLiveSample("Comparison_of_HTML_and_SVG", "100%", "800px")}}
 
 ### Complete example
 


### PR DESCRIPTION
The last three parameters had no effect. They are useless and deprecated. Removing them.