### PR TITLE
Remove useless parameter for {{EmbedLiveSample}}

### DIFF
--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -634,7 +634,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("Effect_of_different_mix-blend-mode_values", "100%", 1600, "", "", "example-outcome-frame")}}
+{{EmbedLiveSample("Effect_of_different_mix-blend-mode_values", "100%", "1600px")}}
 
 ### Using mix-blend-mode with HTML
 


### PR DESCRIPTION
The parameter is not used.

There is a slight difference: a white frame is now around the example; I think the difference is not something that was planned, as the previous keyword doesn't appear anywhere else anymore. And this difference is not so subtle that nobody will notice it and this simplification is worth it.