### PR TITLE
Correct the spec link for `--webkit-line-clamp`

### DIFF
--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -15,7 +15,7 @@ In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, oth
 
 When applied to anchor elements, the truncating can happen in the middle of the text, not necessarily at the end.
 
-> **Note:** This property was originally implemented in WebKit and has some issues. It got standardized for legacy support. The [CSS Overflow Module Level 3](https://www.w3.org/TR/css-overflow-3/#propdef--webkit-line-clamp) specification also defines a {{cssxref("line-clamp")}} property, which is meant to replace this property and avoid its issues.
+> **Note:** This property was originally implemented in WebKit and has some issues. It got standardized in [CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef--webkit-line-clamp) for legacy support. The [CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef-line-clamp) specification also defines a {{cssxref("line-clamp")}} property, which is meant to replace this property and avoid its issues.
 
 ## Syntax
 

--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -35,6 +35,8 @@ When applied to anchor elements, the truncating can happen in the middle of the 
 -webkit-line-clamp: unset;
 ```
 
+### Values
+
 - `none`
   - : This value specifies that the content won't be clamped.
 - {{cssxref("integer")}}


### PR DESCRIPTION
### Description

This PR changes the spec links for `--webkit-line-clamp` and `line-clamp` from CSS Overflow Module Level 3 to Level 4. It also adds the missing "Values" subsection heading.

### Motivation

The definitions of these two properties have been moved to Level 4.

### Additional details

The spec links for there properties:
https://w3c.github.io/csswg-drafts/css-overflow-4/#webkit-line-clamp
https://w3c.github.io/csswg-drafts/css-overflow-4/#line-clamp

### Related issues and pull requests