### PR TITLE
Remove element from attribute (attribute list)

### DIFF
--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -706,8 +706,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         <code><a href="/en-US/docs/Web/HTML/Attributes/hreflang">hreflang</a></code>
       </td>
       <td>
-        {{ HTMLElement("a") }}, {{ HTMLElement("area") }},
-        {{ HTMLElement("link") }}
+        {{ HTMLElement("a") }}, {{ HTMLElement("link") }}
       </td>
       <td>Specifies the language of the linked resource.</td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `area` element is listed under the `hreflang` attribute, even though the attribute is deprecated for this element.

### Motivation

The element listing should be correct and up to date.

### Additional details

The [reference for the area element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area) says that the `hreflang` attribute is deprecated.
The attribute is also not listed in the [HTML standard specification](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element).

### Related issues and pull requests

/


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
