### PR TITLE
Add additional tip to "Usage notes"

### DIFF
--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -254,6 +254,7 @@ Other usage notes:
 - To allow precise control over your audio content, `HTMLMediaElement`s fire many different [events](/en-US/docs/Web/API/HTMLMediaElement#events). This also provides a way to monitor the audio's fetching process so you can watch for errors or detect when enough is available to begin to play or manipulate it.
 - You can also use the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) to directly generate and manipulate audio streams from JavaScript code rather than streaming pre-existing audio files.
 - `<audio>` elements can't have subtitles or captions associated with them in the same way that `<video>` elements can. See [WebVTT and Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/) by Ian Devlin for some useful information and workarounds.
+- To test the fallback content on browsers that support the element, you can replace `<audio>` with a non-existing element like `<notanaudio>`.
 
 A good general source of information on using HTML `<audio>` is the [Video and audio content](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content) beginner's tutorial.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add an info/tip for fallback testing like on the [video element reference page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#usage_notes)

### Motivation

I think this is a valuable tip for the reader.
I liked it on the video reference page, and it applies to the audio element as well.
It also unifies similar articles, making them easier to read.

### Additional details

/

### Related issues and pull requests

/


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
