### PR TITLE
Remove non-existent `text-stroke` from `-webkit-text-stroke`

### DIFF
--- a/files/en-us/web/css/-webkit-text-stroke/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke/index.md
@@ -20,11 +20,6 @@ text-stroke: 4px navy;
 -webkit-text-stroke: revert;
 -webkit-text-stroke: revert-layer;
 -webkit-text-stroke: unset;
-text-stroke: inherit;
-text-stroke: initial;
-text-stroke: revert;
-text-stroke: revert-layer;
-text-stroke: unset;
 ```
 
 ## Constituent properties


### PR DESCRIPTION
### Description

This PR removes the non-existent the `text-stroke` property from the "Syntax" section of the `-webkit-text-stroke` page.

### Motivation

It's quite misleading and suggesting that `text-stroke` is the unprefixed version of `-webkit-text-stroke`. However, `text-stroke` is *not* defined in any CSS specs, and `-webkit-text-stroke` is only defined in the [Compatibility Standard](https://compat.spec.whatwg.org/#the-webkit-text-stroke).

### Additional details

The spec for `-webkit-text-stroke`:
https://compat.spec.whatwg.org/#the-webkit-text-stroke

### Related issues and pull requests

This blocks the l10n sync of this page.