### PR TITLE
CSS subgrid add Safari support

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -643,11 +643,9 @@ In this case the nested grid has no relationship to the parent. As you can see i
 
 ### Subgrid
 
-In the working draft of the Level 2 Grid specification there is a feature called _subgrid_, which would let us create nested grids that use the track definition of the parent grid.
+In addition to regular grids, _subgrid_ let us create nested grids that use the track definition of the parent grid.
 
-> **Note:** This feature shipped in Firefox 71 and Safari 16, which are currently the only 2 browsers to implement subgrid.
-
-In the current specification, we would edit the above nested grid example to change the track definition of `grid-template-columns: repeat(3, 1fr)`, to `grid-template-columns: subgrid`. The nested grid will then use the parent grid tracks to layout items.
+To use them, we edit the above nested grid example to change the track definition of `grid-template-columns: repeat(3, 1fr)`, to `grid-template-columns: subgrid`. The nested grid then use the parent grid tracks to layout items.
 
 ```css
 .box1 {

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -645,7 +645,7 @@ In this case the nested grid has no relationship to the parent. As you can see i
 
 In the working draft of the Level 2 Grid specification there is a feature called _subgrid_, which would let us create nested grids that use the track definition of the parent grid.
 
-> **Note:** This feature shipped in Firefox 71, which is currently the only browser to implement subgrid.
+> **Note:** This feature shipped in Firefox 71 and Safari 16, which are currently the only 2 browsers to implement subgrid.
 
 In the current specification, we would edit the above nested grid example to change the track definition of `grid-template-columns: repeat(3, 1fr)`, to `grid-template-columns: subgrid`. The nested grid will then use the parent grid tracks to layout items.
 


### PR DESCRIPTION
Firefox is not the only browser to support CSS subgrid anymore.

Safari 16 shipped support for CSS subgrid: https://caniuse.com/css-subgrid