### PR TITLE
Interval variable is not in scope of cancel method

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -108,6 +108,7 @@ When a button is pressed, the generation is stopped, the stream is closed using
 which reads the data back out of the stream.
 
 ```js
+let interval;
 const stream = new ReadableStream({
   start(controller) {
     interval = setInterval(() => {

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
@@ -48,6 +48,7 @@ When a button is pressed, the generation is stopped, the stream is closed using
 which reads the data back out of the stream.
 
 ```js
+let interval;
 const stream = new ReadableStream({
   start(controller) {
     interval = setInterval(() => {

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
@@ -45,6 +45,7 @@ When a button is pressed, the generation is stopped, the stream is closed using
 which reads the data back out of the stream.
 
 ```js
+let interval;
 const stream = new ReadableStream({
   start(controller) {
     interval = setInterval(() => {

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.md
@@ -36,6 +36,7 @@ Note that a {{domxref("ReadableStreamDefaultController")}} object is provided as
 When a button is pressed, the generation is stopped, the stream is closed using {{domxref("ReadableStreamDefaultController.close()")}}, and another function is run, which reads the data back out of the stream.
 
 ```js
+let interval;
 const stream = new ReadableStream({
   start(controller) {
     interval = setInterval(() => {

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -521,6 +521,7 @@ But a custom stream is still a `ReadableStream` instance, meaning you can attach
 The custom stream constructor has a `start()` method that uses a {{domxref("setInterval()")}} call to generate a random string every second. {{domxref("ReadableStreamDefaultController.enqueue()")}} is then used to enqueue it into the stream. When the button is pressed, the interval is cancelled, and a function called `readStream()` is invoked to read the data back out of the stream again. We also close the stream, as we've stopped enqueuing chunks to it.
 
 ```js
+let interval;
 const stream = new ReadableStream({
   start(controller) {
     interval = setInterval(() => {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The scope of the variable 'interval' is unclear. We cannot say whether the cancel function actually has access to it!
In your running example, the cancel function cannot.

### Motivation

Correctness of the doc

### What did you expect to see?

let interval;
const stream = new ReadableStream({
start(controller) {
...

### Additional details

.

### Related issues and pull requests
Issue :-  #25480 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
