### PR TITLE
Fix AudioContext.getOutputTimestamp()

### DIFF
--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -8,7 +8,7 @@ browser-compat: api.AudioContext.getOutputTimestamp
 {{APIRef("Web Audio API")}}
 
 The
-**`getOutputTimestamp()`** property of the
+**`getOutputTimestamp()`** method of the
 {{domxref("AudioContext")}} interface returns a new `AudioTimestamp` object
 containing two audio timestamp values relating to the current audio context.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
`AudioContext.getOutputTimestamp()` is a method, not property.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
