### PR TITLE
added clear message of the data encoded by using float32array

### DIFF
--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
@@ -7,7 +7,7 @@ browser-compat: api.AnalyserNode.getFloatFrequencyData
 
 {{ APIRef("Web Audio API") }}
 
-The **`getFloatFrequencyData()`** method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{jsxref("Float32Array")}} array passed into it.
+The **`getFloatFrequencyData()`** method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{jsxref("Float32Array")}} (the time-domain data is encoded in f32 format with the amplitude of samples in [-1:1]) array passed into it.
 
 Each item in the array represents the decibel value for a specific frequency. The frequencies are spread linearly from 0 to 1/2 of the sample rate. For example, for a `48000` Hz sample rate, the last item of the array will represent the decibel value for `24000` Hz.
 

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
@@ -7,7 +7,7 @@ browser-compat: api.AnalyserNode.getFloatFrequencyData
 
 {{ APIRef("Web Audio API") }}
 
-The **`getFloatFrequencyData()`** method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{jsxref("Float32Array")}} (the time-domain data is encoded in f32 format with the amplitude of samples in [-1:1]) array passed into it.
+The **`getFloatFrequencyData()`** method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{jsxref("Float32Array")}} array passed into it. Each array value is a _sample_, the magnitude of the signal at a particular time.
 
 Each item in the array represents the decibel value for a specific frequency. The frequencies are spread linearly from 0 to 1/2 of the sample rate. For example, for a `48000` Hz sample rate, the last item of the array will represent the decibel value for `24000` Hz.
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -7,7 +7,7 @@ browser-compat: api.AnalyserNode.getFloatTimeDomainData
 
 {{ APIRef("Web Audio API") }}
 
-The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it.
+The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} (the time-domain data is encoded in `f32` format with the amplitude of samples in [-1:1]) array passed into it.
 
 ## Syntax
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -7,7 +7,7 @@ browser-compat: api.AnalyserNode.getFloatTimeDomainData
 
 {{ APIRef("Web Audio API") }}
 
-The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} (the time-domain data is encoded in `f32` format with the amplitude of samples in [-1:1]) array passed into it.
+The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it. Each array value is a _sample_, the magnitude of the signal at a particular time.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Missing encoding of the waveform. Because the parameter is a Float32Array, one can reasonably assume that the encoding is f32 (that is, PCM data amplitude in [-1:1]). However it would be better to confirm this in writing instead of leaving developers to their guess. There's also no mention of planar/non-planar encoding, which is necessary to do anything with the data retrieved (unless the signal has a single channel).

Added text - "The time-domain data is encoded in `f32` format with the amplitude of samples in [-1:1]" for the following urls for clarity :

- https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatFrequencyData
- https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatTimeDomainData

### Motivation

Better clarity for users going through the docs


### Related issues and pull requests

Issue :- #25571 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
