### PR TITLE
Fix broken event timing information example

### DIFF
--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -173,7 +173,7 @@ const observer = new PerformanceObserver((list) => {
     const eventHandlerTime = entry.processingEnd - entry.processingStart;
     console.log(`Total duration: ${duration}`);
     console.log(`Event delay: ${delay}`);
-    console.log(`Event handler duration: ${time}`);
+    console.log(`Event handler duration: ${eventHandlerTime}`);
   });
 });
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This commit fixes a broken example due to missing variable name `time` from the "event timing information" section.
I've updated the example to use the calculated `eventHandlerTime` variable.


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
