### PR TITLE
Remove stray comma

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -145,7 +145,7 @@ Now that all the data the shaders need is available to them, we need to update t
 
 ### The vertex shader
 
-The first thing to do i,s update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
+The first thing to do is update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
 
 > **Note:** Update the `vsSource` declaration in your `main()` function like this:
 


### PR DESCRIPTION
### Description

Remove stray comma in "is"

### Motivation

There should not be a stray comma in "is"

### Additional details

https://www.merriam-webster.com/dictionary/is
