### PR TITLE
selectstart event example logs "Selection changed" not "Selection started"

### DIFF
--- a/files/en-us/web/api/node/selectstart_event/index.md
+++ b/files/en-us/web/api/node/selectstart_event/index.md
@@ -35,7 +35,7 @@ document.addEventListener("selectstart", () => {
 
 // onselectstart version
 document.onselectstart = () => {
-  console.log("Selection changed.");
+  console.log("Selection started.");
 };
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

It is kind of trivial but `onselectstart` version of example should log "Selection started" as well.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The page and the example explains `selectstart` event handling which is clearly different from `selectionchange` event.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
