### PR TITLE
Rename PaintWorklet to PaintWorkletGlobalScope

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9193,8 +9193,11 @@
 /en-US/docs/Web/API/OscillatorNode/stop	/en-US/docs/Web/API/AudioScheduledSourceNode/stop
 /en-US/docs/Web/API/OverconstrainedError/message	/en-US/docs/Web/API/DOMException/message
 /en-US/docs/Web/API/OverconstrainedError/name	/en-US/docs/Web/API/DOMException/name
-/en-US/docs/Web/API/PaintWorklet/PaintWorklet.devicePixelRatio	/en-US/docs/Web/API/PaintWorklet/devicePixelRatio
-/en-US/docs/Web/API/PaintWorklet/devicePizelRatio	/en-US/docs/Web/API/PaintWorklet/devicePixelRatio
+/en-US/docs/Web/API/PaintWorklet	/en-US/docs/Web/API/PaintWorkletGlobalScope
+/en-US/docs/Web/API/PaintWorklet/PaintWorklet.devicePixelRatio	/en-US/docs/Web/API/PaintWorkletGlobalScope/devicePixelRatio
+/en-US/docs/Web/API/PaintWorklet/devicePixelRatio	/en-US/docs/Web/API/PaintWorkletGlobalScope/devicePixelRatio
+/en-US/docs/Web/API/PaintWorklet/devicePizelRatio	/en-US/docs/Web/API/PaintWorkletGlobalScope/devicePixelRatio
+/en-US/docs/Web/API/PaintWorklet/registerPaint	/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint
 /en-US/docs/Web/API/Paint_Timing_API	/en-US/docs/Web/API/PerformancePaintTiming
 /en-US/docs/Web/API/PannerNode.coneInnerAngle	/en-US/docs/Web/API/PannerNode/coneInnerAngle
 /en-US/docs/Web/API/PannerNode.coneOuterAngle	/en-US/docs/Web/API/PannerNode/coneOuterAngle

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -51123,7 +51123,7 @@
       "ernestd"
     ]
   },
-  "Web/API/PaintWorklet": {
+  "Web/API/PaintWorkletGlobalScope": {
     "modified": "2020-10-15T22:17:26.607Z",
     "contributors": [
       "nakhodkiin",
@@ -51134,11 +51134,11 @@
       "jpmedley"
     ]
   },
-  "Web/API/PaintWorklet/devicePixelRatio": {
+  "Web/API/PaintWorkletGlobalScope/devicePixelRatio": {
     "modified": "2020-12-10T11:15:36.190Z",
     "contributors": ["bershanskiy", "estelle", "Puddingsan"]
   },
-  "Web/API/PaintWorklet/registerPaint": {
+  "Web/API/PaintWorkletGlobalScope/registerPaint": {
     "modified": "2020-12-10T11:13:09.249Z",
     "contributors": ["bershanskiy", "kspk", "estelle", "1valdis", "jpmedley"]
   },

--- a/files/en-us/web/api/css/paintworklet/index.md
+++ b/files/en-us/web/api/css/paintworklet/index.md
@@ -15,7 +15,7 @@ property expects a file.
 
 ## Value
 
-The {{DOMxRef('PaintWorklet')}} object.
+The associated {{DOMxRef('Worklet')}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -9,7 +9,7 @@ The [CSS Paint API](/en-US/docs/Web/API/CSS_Painting_API) is designed to enable 
 
 To programmatically create an image used by a CSS stylesheet we need to work through a few steps:
 
-1. Define a paint worklet using the [`registerPaint()`](/en-US/docs/Web/API/PaintWorklet/registerPaint) function
+1. Define a paint worklet using the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlob/registerPaint) function
 2. Register the worklet
 3. Include the `{{cssxref("image/paint","paint()")}}` CSS function
 
@@ -21,7 +21,7 @@ To elaborate over these steps, we're going to start by creating a half-highlight
 
 ## CSS paint worklet
 
-In an external script file, we employ the [`registerPaint()`](/en-US/docs/Web/API/PaintWorklet/registerPaint) function to name our [CSS Paint worklet](/en-US/docs/Web/API/PaintWorklet). It takes two parameters. The first is the name we give the worklet — this is the name we will use in our CSS as the parameter of the `paint()` function when we want to apply this styling to an element. The second parameter is the class that does all the magic, defining the context options and what to paint to the two-dimensional canvas that will be our image.
+In an external script file, we employ the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint) function to name our [CSS Paint worklet](/en-US/docs/Web/API/tWorklet). It takes two parameters. The first is the name we give the worklet — this is the name we will use in our CSS as the parameter of the `paint()` function when we want to apply this styling to an element. The second parameter is the class that does all the magic, defining the context options and what to paint to the two-dimensional canvas that will be our image.
 
 ```js
 registerPaint(

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -9,7 +9,7 @@ The [CSS Paint API](/en-US/docs/Web/API/CSS_Painting_API) is designed to enable 
 
 To programmatically create an image used by a CSS stylesheet we need to work through a few steps:
 
-1. Define a paint worklet using the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlob/registerPaint) function
+1. Define a paint worklet using the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint) function
 2. Register the worklet
 3. Include the `{{cssxref("image/paint","paint()")}}` CSS function
 
@@ -21,7 +21,7 @@ To elaborate over these steps, we're going to start by creating a half-highlight
 
 ## CSS paint worklet
 
-In an external script file, we employ the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint) function to name our [CSS Paint worklet](/en-US/docs/Web/API/tWorklet). It takes two parameters. The first is the name we give the worklet — this is the name we will use in our CSS as the parameter of the `paint()` function when we want to apply this styling to an element. The second parameter is the class that does all the magic, defining the context options and what to paint to the two-dimensional canvas that will be our image.
+In an external script file, we employ the [`registerPaint()`](/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint) function to name our [CSS Paint worklet](/en-US/docs/Web/API/Worklet). It takes two parameters. The first is the name we give the worklet — this is the name we will use in our CSS as the parameter of the `paint()` function when we want to apply this styling to an element. The second parameter is the class that does all the magic, defining the context options and what to paint to the two-dimensional canvas that will be our image.
 
 ```js
 registerPaint(
@@ -64,7 +64,7 @@ We tried to keep the example simple. For more options, look at the [canvas docum
 
 To use the paint worklet, we need to register it using [`addModule()`](/en-US/docs/Web/API/Worklet/addModule) and include it in our CSS, ensuring the CSS selector matches a DOM node in our HTML
 
-The setup and design of our paint worklet took place in the external script shown above. We need to register that [worklet](/en-US/docs/Web/API/PaintWorklet) from our main script.
+The setup and design of our paint worklet took place in the external script shown above. We need to register that [worklet](/en-US/docs/Web/API/Worklet) from our main script.
 
 ```js
 CSS.paintWorklet.addModule("nameOfPaintWorkletFile.js");

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -11,7 +11,7 @@ The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini
 
 ## Concepts and usage
 
-Essentially, the CSS Painting API contains functionality allowing developers to create custom values for {{cssxref('paint', 'paint()')}}, a CSS [`<image>`](/en-US/docs/Web/CSS/image) function. You can then apply these values to properties like {{cssxref("background-image")}} to set complex custom backgrounds on an element.
+Essentially, the CSS Painting API contains functionality allowing developers to create custom values for {{cssxref('image/paint', 'paint()')}}, a CSS [`<image>`](/en-US/docs/Web/CSS/image) function. You can then apply these values to properties like {{cssxref("background-image")}} to set complex custom backgrounds on an element.
 
 For example:
 
@@ -21,12 +21,10 @@ aside {
 }
 ```
 
-The API defines {{domxref('PaintWorklet')}}, a {{domxref('worklet')}} that can be used to programmatically generate an image that responds to computed style changes. To find out more about how this is used, consult [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide).
+The API defines a {{domxref('worklet')}} that can be used to programmatically generate an image that responds to computed style changes. To find out more about how this is used, consult [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide).
 
 ## Interfaces
 
-- {{domxref('PaintWorklet')}}
-  - : Programmatically generates an image where a CSS property expects a file. Access this interface through [`CSS.paintWorklet`](/en-US/docs/Web/API/CSS/paintWorklet).
 - {{domxref('PaintWorkletGlobalScope')}}
   - : The global execution context of the paint worklet.
 - {{domxref('PaintRenderingContext2D')}}

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -28,16 +28,11 @@ The API defines {{domxref('PaintWorklet')}}, a {{domxref('worklet')}} that can b
 - {{domxref('PaintWorklet')}}
   - : Programmatically generates an image where a CSS property expects a file. Access this interface through [`CSS.paintWorklet`](/en-US/docs/Web/API/CSS/paintWorklet).
 - {{domxref('PaintWorkletGlobalScope')}}
-  - : The global execution context of the `paintWorklet`.
+  - : The global execution context of the paint worklet.
 - {{domxref('PaintRenderingContext2D')}}
-  - : Implements a subset of the [CanvasRenderingContext2D API](/en-US/docs/Web/API/CanvasRenderingContext2D). It has an output bitmap that is the size of the object it is rendering to.
+  - : Implements a subset of the [`CanvasRenderingContext2D`](/en-US/docs/Web/API/CanvasRenderingContext2D) API. It has an output bitmap that is the size of the object it is rendering to.
 - {{domxref('PaintSize')}}
   - : Returns the read-only values of the output bitmap's width and height.
-
-## Dictionaries
-
-- {{domxref('PaintRenderingContext2DSettings')}}
-  - : A dictionary providing a subset of [CanvasRenderingContext2D](/en-US/docs/Web/API/CanvasRenderingContext2D) settings.
 
 ## Examples
 

--- a/files/en-us/web/api/paintworkletglobalscope/devicepixelratio/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/devicepixelratio/index.md
@@ -1,13 +1,15 @@
 ---
 title: PaintWorkletGlobalScope.devicePixelRatio
-slug: Web/API/PaintWorklet/devicePixelRatio
+slug: Web/API/PaintWorkletGlobalScope/devicePixelRatio
 page-type: web-api-instance-property
+status:
+  - Experimental
 browser-compat: api.PaintWorkletGlobalScope.devicePixelRatio
 ---
 
-{{APIRef("CSS Painting API")}}
+{{APIRef("CSS Painting API")}}{{SeeCompatTable}}
 
-The **`PaintWorkletGlobalScope.devicePixelRatio`** read-only property of the {{domxref("PaintWorklet")}} interface returns the current device's ratio of physical pixels to logical pixels.
+The read-only **`devicePixelRatio`** read-only property of the {{domxref("PaintWorkletGlobalScope")}} interface returns the current device's ratio of physical pixels to logical pixels.
 
 ## Value
 
@@ -23,7 +25,6 @@ A double-precision integer.
 
 ## See also
 
-- [PaintWorklet](/en-US/docs/Web/API/PaintWorklet)
 - [CSS.paintWorklet](/en-US/docs/Web/API/CSS/paintWorklet)
 - [Worklet](/en-US/docs/Web/API/Worklet)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)

--- a/files/en-us/web/api/paintworkletglobalscope/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/index.md
@@ -30,7 +30,7 @@ _This interface inherits methods from {{domxref('WorkletGlobalScope')}}._
 _This interface inherits methods from {{domxref('WorkletGlobalScope')}}._
 
 - {{domxref('PaintWorkletGlobalScope.registerPaint()')}}
-  - : Registers a class programmatically generate an image where a CSS property expects a file.
+  - : Registers a class to programmatically generate an image where a CSS property expects a file.
 
 ### Event
 

--- a/files/en-us/web/api/paintworkletglobalscope/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/index.md
@@ -1,13 +1,15 @@
 ---
-title: PaintWorklet
-slug: Web/API/PaintWorklet
+title: PaintWorkletGLobalScope
+slug: Web/API/PaintWorkletGlobalScope
 page-type: web-api-interface
+status:
+  - Experimental
 browser-compat: api.PaintWorkletGlobalScope
 ---
 
-{{APIRef("CSS Painting API")}}
+{{APIRef("CSS Painting API")}}{{SeeCompatTable}}
 
-The **`PaintWorklet`** interface of the {{domxref('CSS Painting API','','',' ')}} programmatically generates an image where a CSS property expects a file. Access this interface through {{DOMxRef("CSS.paintWorklet")}}.
+The **`PaintWorkletGLobalScope`** interface of the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API) represents the global object available inside a paint {{domxref("Worklet")}}.
 
 ## Privacy concerns
 
@@ -18,33 +20,38 @@ To avoid leaking visited links, this feature is currently disabled in Chrome-bas
 
 ## Instance properties
 
-- {{domxref('PaintWorklet.devicePixelRatio')}}
+_This interface inherits methods from {{domxref('WorkletGlobalScope')}}._
+
+- {{domxref('PaintWorkletGlobalScope.devicePixelRatio')}}
   - : Returns the current device's ratio of physical pixels to logical pixels.
-
-### Event handlers
-
-None.
 
 ## Instance methods
 
-_This interface inherits methods from {{domxref('Worklet')}}._
+_This interface inherits methods from {{domxref('WorkletGlobalScope')}}._
 
-- {{domxref('PaintWorklet.registerPaint()')}}
+- {{domxref('PaintWorkletGlobalScope.registerPaint()')}}
   - : Registers a class programmatically generate an image where a CSS property expects a file.
-- {{domxref('Worklet.addModule', 'PaintWorklet.addModule()')}}
-  - : The [`addModule()`](/en-US/docs/Web/API/Worklet/addModule) method, inherited from the _{{domxref('Worklet')}}_ interface loads the module in the given JavaScript file and adds it to the current PaintWorklet.
+
+### Event
+
+None.
 
 ## Examples
 
-The following three examples go together to show creating, loading, and using a `PaintWorklet`.
+The following three examples go together to show creating, loading, and using a paint `Worklet`.
 
-### Create a PaintWorklet
+### Create a paint worklet
 
-The following shows an example worklet module. This should be in a separate js file. Note that `registerPaint()` is called without a reference to `PaintWorklet`.
+The following shows an example worklet module. This should be in a separate js file. Note that `registerPaint()` is called without a reference to a paint `Worklet`.
 
 ```js
 class CheckerboardPainter {
   paint(ctx, geom, properties) {
+    // The global object here is a PaintWorkletGlobalScope
+    // Methods and properties can be accessed directly
+    // as global features or prefixed using self
+    const dpr = self.devicePixelRatio;
+
     // Use `ctx` as if it was a normal canvas
     const colors = ["red", "green", "blue"];
     const size = 32;
@@ -64,7 +71,7 @@ class CheckerboardPainter {
 registerPaint("checkerboard", CheckerboardPainter);
 ```
 
-### Load a PaintWorklet
+### Load a paint worklet
 
 The following example demonstrates loading the above worklet from its js file and does so by feature detection.
 
@@ -74,9 +81,9 @@ if ("paintWorklet" in CSS) {
 }
 ```
 
-### Use a PaintWorklet
+### Use a paint worklet
 
-This example shows how to use a `PaintWorklet` in a stylesheet, including the simplest way to provide a fallback if `PaintWorklet` isn't supported.
+This example shows how to use a paint `Worklet` in a stylesheet, including the simplest way to provide a fallback if `CSS.paintWorklet` isn't supported.
 
 ```html
 <style>

--- a/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PaintWorkletGlobalScope.registerPaint
 {{APIRef("CSS Painting API")}}{{SeeCompatTable}}
 
 The **`registerPaint()`** method of the
-{{domxref("PaintWorkletGlobalScope")}} interface registers a class programmatically generate an
+{{domxref("PaintWorkletGlobalScope")}} interface registers a class to programmatically generate an
 image where a CSS property expects a file.
 
 ## Syntax

--- a/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
@@ -1,15 +1,16 @@
 ---
 title: PaintWorkletGlobalScope.registerPaint()
-slug: Web/API/PaintWorklet/registerPaint
+slug: Web/API/PaintWorkletGlobalScope/registerPaint
 page-type: web-api-instance-method
+status:
+  - Experimental
 browser-compat: api.PaintWorkletGlobalScope.registerPaint
 ---
 
-{{APIRef("CSS Painting API")}}
+{{APIRef("CSS Painting API")}}{{SeeCompatTable}}
 
-The
-**`PaintWorkletGlobalScope.registerPaint()`** method of the
-{{domxref("PaintWorklet")}} interface registers a class programmatically generate an
+The **`registerPaint()`** method of the
+{{domxref("PaintWorkletGlobalScope")}} interface registers a class programmatically generate an
 image where a CSS property expects a file.
 
 ## Syntax

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -233,7 +233,6 @@
       "overview": ["CSS Painting API"],
       "guides": ["/docs/Web/API/CSS_Painting_API/Guide"],
       "interfaces": [
-        "PaintWorklet",
         "PaintWorkletGlobalScope",
         "PaintRenderingContext2D",
         "PaintSize"


### PR DESCRIPTION
Fix #25880

I have:
- Moved `PaintWorklet.*` to `PaintWorkletGlobalScope.*`
- Renamed the three pages and fixed their content to use the correct name
- Renamed "PaintWorklet" to "Worklet"  other pages (`CSS.paintWorklet`) as it is the only interface that exists
- Removed the bogus `PaintWorklet` from `GroupData.json`

I have not:
- Created the missing "PaintWorkletContext2D` and `PaintSize` interfaces (a rabbit hole…)

Related BCD PR: mdn/browser-compat-data#19313