### PR TITLE
Update Document.applets

### DIFF
--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -9,22 +9,14 @@ browser-compat: api.Document.applets
 
 {{APIRef("DOM")}} {{Deprecated_Header}}
 
-The **`applets`** property of the {{domxref("Document")}}
-interface returns a list of the applets within a document.
+The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it would return a list of the applets within a document.
 
-> **Note:** The {{htmlelement("applet")}} element was removed in [Gecko 56](https://bugzil.la/1279218) and [Chrome in late 2015](https://crbug.com/470301). Since then, calling `document.applets` in those browsers always
-> returns an empty {{domxref("HTMLCollection")}}. Removal is being considered in [WebKit](https://webkit.org/b/157926).
+> **Note:** Support for the {{htmlelement("applet")}} element has been removed by all browsers. Therefore, calling `document.applets` always
+> returns no results.
 
 ## Value
 
-An {{domxref("HTMLCollection")}}.
-
-## Examples
-
-```js
-// When you know the second applet is the one you want
-my_java_app = document.applets[1];
-```
+An empty {{domxref("HTMLCollection")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Document.applets
 
 {{APIRef("DOM")}} {{Deprecated_Header}}
 
-The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it would return a list of the applets within a document.
+The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it returned a list of the applets within a document.
 
 > **Note:** Support for the {{htmlelement("applet")}} element has been removed by all browsers. Therefore, calling `document.applets` always
 > returns no results.

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Document.applets
 The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it returned a list of the applets within a document.
 
 > **Note:** Support for the {{htmlelement("applet")}} element has been removed by all browsers. Therefore, calling `document.applets` always
-> returns no results.
+> returns an empty collection.
 
 ## Value
 


### PR DESCRIPTION
### Description

This updates the `Document.applets` page to reflect the removal of applet functionality in all browsers. 

* WebKit removed HTMLAppletElement support in 2020, so remove the provisos about the `<applet>` element for each browser (which duplicates that element's compat data anyway), and just say it has been removed.
* Remove the example, as it won't work with any current browsers.
* Rewrite prose along the lines of other deprecated properties such as [`Navigator.appName`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appName) etc.

### Motivation

The current documentation is out of date and could be misleading to new web developers.

### Additional details

* [WebKit Bugzilla issue](https://bugs.webkit.org/show_bug.cgi?id=218677)