### PR TITLE
Add note regarding SVG presentation attributes to CSS reference

### DIFF
--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -52,6 +52,8 @@ As the structure of at-rules varies widely, please see [At-rule](/en-US/docs/Web
 
 ## Index
 
+> **Note:** This index does not include SVG-exclusive [presentation attributes](/en-US/docs/Web/SVG/Attribute/Presentation), which can be used as CSS properties on [SVG](/en-US/docs/Web/SVG) elements.
+
 > **Note:** The property names in this index do **not** include the JavaScript names which do differ from the CSS standard names.
 
 {{CSS_Ref}}


### PR DESCRIPTION
### Description

Add a small note to the CSS reference pointing to the SVG presentation attributes, since they can be used in CSS but are not included in the reference.

### Motivation

The currently unexplained omission of SVG CSS properties is somewhat unintuitive. For example, someone new to web development may come across `fill` in a CSS file, and look for it in the CSS reference. This note would point them to the right place. 