### PR TITLE
Fix link 404 gpc-spec (GitHub repo move)

### DIFF
--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -57,5 +57,5 @@ navigator.globalPrivacyControl; // "0" or "1"
 - {{HTTPHeader("DNT")}} header
 - {{HTTPHeader("Tk")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://globalprivacycontrol.github.io/gpc-spec/)
+- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)


### PR DESCRIPTION
The gpc-spec repository was moved from the organization globalprivacycontrol to privacycg (confirm via https://github.com/globalprivacycontrol/gpc-spec/), see https://github.com/privacycg/gpc-spec/issues/44.
