### PR TITLE
Fix example using hsla of hsl page

### DIFF
--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -152,7 +152,7 @@ div.hsl {
 }
 
 div.hsla {
-  background-color: hsl(0 100% 50% / 50%);
+  background-color: hsla(0, 100%, 50%, 50%);
 }
 ```
 


### PR DESCRIPTION
The legacy example was using the same new syntax, instead of the actual legacy format.

from:
```css
div.hsla {
  background-color: hsl(0 100% 50% / 50%);
}
```

to: 
```css
div.hsla {
  background-color: hsla(0, 100%, 50%, 50%);
}
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
