### PR TITLE
links in code broken

### DIFF
--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -22,7 +22,7 @@ color-mix(in hsl longer hue, hsl(120 100% 50%) 20%, white);
 
 ### Values
 
-- Functional notation: `color-mix( <color-interpolation-method> , [ [<color>](/en-US/docs/Web/CSS/color_value) && [<percentage [0,100]>](/en-US/docs/Web/CSS/percentage)? ]#{2} )`
+- Functional notation: <code>color-mix( &lt;color-interpolation-method> , [ [`<color>`](/en-US/docs/Web/CSS/color_value) && [`<percentage [0,100]>`](/en-US/docs/Web/CSS/percentage)? ]#{2} )</code>
 
   - `<color-interpolation-method>` is the keyword `in` (for interpolation) followed by either:
 


### PR DESCRIPTION
There were markdown links within \` marks, so the links were written out. this fixes that.