### PR TITLE
Fix capitalization of links to JS pages

### DIFF
--- a/files/en-us/mozilla/firefox/releases/78/index.md
+++ b/files/en-us/mozilla/firefox/releases/78/index.md
@@ -50,7 +50,7 @@ See also [New in Firefox 78: DevTools improvements, new regex engine, and abunda
   - [Lookbehind assertions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Assertions) ([Firefox bug 1225665](https://bugzil.la/1225665))
   - {{JSxRef("RegExp.prototype.dotAll")}} ([Firefox bug 1361856](https://bugzil.la/1361856))
   - [Unicode property escapes](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Unicode_property_escapes) ([Firefox bug 1361876](https://bugzil.la/1361876))
-  - [Named capture groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_ranges) ([Firefox bug 1362154](https://bugzil.la/1362154))
+  - [Named capture groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences) ([Firefox bug 1362154](https://bugzil.la/1362154))
 
 - Due to a [WebIDL spec change](https://github.com/whatwg/webidl/pull/357) in mid-2020, we've [added a `Symbol.toStringTag` property to all DOM prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#tostringtag_available_on_all_dom_prototype_objects) ([Firefox bug 1277799](https://bugzil.la/1277799)).
 - The garbage collection of {{jsxref("WeakMap")}} objects has been improved. `WeakMaps` are now marked incrementally ([Firefox bug 1167452](https://bugzil.la/1167452)).

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -24,7 +24,7 @@ As the examples above also illustrate, all complex expressions are joined by _op
 - [BigInt operators](#bigint_operators)
 - [String operators](#string_operators)
 - [Conditional (ternary) operator](#conditional_ternary_operator)
-- [Comma operator](#Comma_operator)
+- [Comma operator](#comma_operator)
 - [Unary operators](#unary_operators)
 - [Relational operators](#relational_operators)
 

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -319,7 +319,7 @@ eat(); // global object (in non-strict mode)
 
 ## See also
 
-- [Using classes](/en-US/docs/Web/JavaScript/Guide/Using_Classes)
+- [Using classes](/en-US/docs/Web/JavaScript/Guide/classes)
 - [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)
 - [`class` expression](/en-US/docs/Web/JavaScript/Reference/Operators/class)
 - [Functions](/en-US/docs/Web/JavaScript/Reference/Functions)

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -319,7 +319,7 @@ eat(); // global object (in non-strict mode)
 
 ## See also
 
-- [Using classes](/en-US/docs/Web/JavaScript/Guide/classes)
+- [Using classes](/en-US/docs/Web/JavaScript/Guide/Using_classes)
 - [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)
 - [`class` expression](/en-US/docs/Web/JavaScript/Reference/Operators/class)
 - [Functions](/en-US/docs/Web/JavaScript/Reference/Functions)

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -227,5 +227,5 @@ console.log(
 - {{jsxref("Object.defineProperty()")}}
 - [Object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
 - {{jsxref("Statements/class", "class")}}
-- [Property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors)
+- [Property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors)
 - [Incompatible ES5 change: literal getter and setter functions must now have exactly zero or one arguments](https://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/) by Jeff Walden (August 22, 2010)


### PR DESCRIPTION
This is a follow-up of #25915

It was easier to create a new PR as GitHub UI only allows comments close to other changes (and these fixes were far from other modifications).