### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/serviceworker/postmessage/index.md
+++ b/files/en-us/web/api/serviceworker/postmessage/index.md
@@ -64,7 +64,7 @@ navigator.serviceWorker.ready.then((registration) => {
 In order to receive the message, the service worker, in `service-worker.js` has to listen to the {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event on its global scope.
 
 ```js
-// This must be in `service-worker.s``
+// This must be in `service-worker.js`
 addEventListener("message", (event) => 
   console.log(`Message received: ${event.data}`);
 );


### PR DESCRIPTION
### Description

Fixes a typo in a code snippet on the `ServiceWorker.postMessage()` page.

