### PR TITLE
Fix description of outerHTML behavior

### DIFF
--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -84,9 +84,8 @@ console.log(container.firstElementChild.nodeName); // logs "P"
 
 ## Notes
 
-If the element has no parent element, setting its `outerHTML` property will
-not change it or its descendants. Many browsers will also throw an exception. For
-example:
+If the element has no parent node, setting its `outerHTML` property will not change it
+or its descendants. For example:
 
 ```js
 const div = document.createElement("div");


### PR DESCRIPTION
### Description

I elaborate on browsers' behavior on setting the `outerHTML` property of an element without a parent element. The [DOM Parsing and Serialization standard](https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml) says that the operation does nothing with no parent node, and works correctly with a document fragment, but Chromium- and WebKit-based browsers throw an exception in both cases. 

### Motivation

The current note is contrary to both the standard and Firefox's behavior in the document-fragment case. So fully clarifying current browser behavior would probably be a good idea.

### Additional details

The document-fragment case is [Chromium bug 1403060](https://crbug.com/1403060) and [WebKit bug 249737](https://bugs.webkit.org/show_bug.cgi?id=249737).
