### PR TITLE
Fix typos in Learn > Casacde layers

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -338,7 +338,7 @@ Inline styles are declared using the [`style` attribute](/en-US/docs/Web/HTML/Gl
 
 Animating styles have higher precedence than all normal styles, including inline normal styles.
 
-Important styles—property values that include the `!important` flag—take precedence over any styles previously mentioned on our list. They are sorted in reverse order of normal styles. Any important styles declared outside of a layer have less precedence than those declared within a layer. Important styles found within layers are also sorted in order of layer creation. For important styles, the last created layer has the lowest precedence, and the first created layer has the highest precedence among declared layers.
+Important styles, that is, property values that include the `!important` flag, take precedence over any styles previously mentioned in our list. They are sorted in reverse order of normal styles. Any important styles declared outside of a layer have less precedence than those declared within a layer. Important styles found within layers are also sorted in order of layer creation. For important styles, the last created layer has the lowest precedence, and the first created layer has the highest precedence among declared layers.
 
 Inline important styles again have higher precedence than important styles declared elsewhere.
 

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -362,7 +362,7 @@ We included that first line for two reasons: first, so you could easily edit the
 
 To summarize:
 
-- The order of layers is the order in which the layers are created.
+- The order of precedence of layers is the order in which the layers are created.
 - Once created, there is no way to change the layer order.
 - Layer precedence for normal styles is the order in which the layers are created.
 - Unlayered normal styles have precedence over normal layered styles.

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -338,7 +338,7 @@ Inline styles are declared using the [`style` attribute](/en-US/docs/Web/HTML/Gl
 
 Animating styles have higher precedence than all normal styles, including inline normal styles.
 
-Important styles—property values that include the `!important` flag—take precedence over any styles previously mentioned on our list. They are sorted in reverse order of normal styles. Any important styles declared outside of a layer have less precedence than those declared within a layer. Important styles found within layers are also sorted in order of layer creation. For important styles, the last created layer has the lowest precedence, and the first created layer has the highest precedence among declared. layers.
+Important styles—property values that include the `!important` flag—take precedence over any styles previously mentioned on our list. They are sorted in reverse order of normal styles. Any important styles declared outside of a layer have less precedence than those declared within a layer. Important styles found within layers are also sorted in order of layer creation. For important styles, the last created layer has the lowest precedence, and the first created layer has the highest precedence among declared layers.
 
 Inline important styles again have higher precedence than important styles declared elsewhere.
 
@@ -364,9 +364,9 @@ To summarize:
 
 - The order of layers is the order in which the layers are created.
 - Once created, there is no way to change the layer order.
-- Layer precedence or normal styles is the order in which the layers are created.
+- Layer precedence for normal styles is the order in which the layers are created.
 - Unlayered normal styles have precedence over normal layered styles.
-- Layer precedence or important styles is reversed, with earlier created layers having precedence.
+- Layer precedence for important styles is reversed, with earlier created layers having precedence.
 - All layered important styles have precedence over unlayered important (and normal) styles.
 - Normal inline styles take precedence over all normal styles, layered or not.
 - Important inline styles take precedence over all other styles, with the exception of styles being transitioned.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

While using the guide to learn web development, I noticed some typos. Here they are:

Line 341: declared. layers. REMOVED extra period
Line 367: "precedence or normal styles" CHANGED TO "precedence for important styles"
Line 369: "precedence or important styles" CHANGED TO "precedence for important styles"

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Submitting these changes to improve the readability of this article.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
