### PR TITLE
Prettify inline code

### DIFF
--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -25,7 +25,7 @@ In the following snippet, we aim to download a video using the [Fetch API](/en-U
 
 We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
 
-When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{ signal }` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 ```js
 const controller = new AbortController();


### PR DESCRIPTION
The inline code didn't match the actual code (that got prettified). Adding the extra spaces to help readers to match both occurrences.