### PR TITLE
Fix typo in index.md

### DIFF
--- a/files/en-us/web/api/cssstylesheet/rules/index.md
+++ b/files/en-us/web/api/cssstylesheet/rules/index.md
@@ -15,7 +15,7 @@ identical to the preferred {{domxref("CSSStyleSheet.cssRules", "cssRules")}} pro
 it provides access to a live-updating list of the CSS rules comprising the
 stylesheet.
 
-> **Note:** As a legacy property, you not use `rules` and
+> **Note:** As a legacy property, you should not use `rules` and
 > should instead use the preferred {{domxref("CSSStyleSheet.cssRules", "cssRules")}}.
 > While `rules` is unlikely to be removed soon, its availability is not as
 > widespread and using it will result in compatibility problems for your site or app.


### PR DESCRIPTION
The sentence:

> ...you not use `rules` 

Should read:

> ...you **should** not use `rules`