### PR TITLE
Fix all links with wrong capitalization to an URL of the glossary

### DIFF
--- a/files/en-us/glossary/effective_connection_type/index.md
+++ b/files/en-us/glossary/effective_connection_type/index.md
@@ -8,12 +8,12 @@ page-type: glossary-definition
 
 The values of '`slow-2g`', '`2g`', '`3g`', and '`4g`' are determined using observed round-trip times and downlink values.
 
-| ECT       | Minimum [RTT](</en-US/docs/Glossary/Round_Trip_Time_(RTT)>) | Maximum downlink | Explanation                                                                                              |
-| --------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
-| `slow-2g` | 2000ms                                                      | 50 Kbps          | The network is suited for small transfers only such as text-only pages.                                  |
-| `2g`      | 1400ms                                                      | 70 Kbps          | The network is suited for transfers of small images.                                                     |
-| `3g`      | 270ms                                                       | 700 Kbps         | The network is suited for transfers of large assets such as high resolution images, audio, and SD video. |
-| `4g`      | 0ms                                                         | ∞                | The network is suited for HD video, real-time video, etc.                                                |
+| ECT       | Minimum [RTT](/en-US/docs/Glossary/Round_Trip_Time) | Maximum downlink | Explanation                                                                                              |
+| --------- | --------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `slow-2g` | 2000ms                                              | 50 Kbps          | The network is suited for small transfers only such as text-only pages.                                  |
+| `2g`      | 1400ms                                              | 70 Kbps          | The network is suited for transfers of small images.                                                     |
+| `3g`      | 270ms                                               | 700 Kbps         | The network is suited for transfers of large assets such as high resolution images, audio, and SD video. |
+| `4g`      | 0ms                                                 | ∞                | The network is suited for HD video, real-time video, etc.                                                |
 
 [effectiveType](/en-US/docs/Web/API/NetworkInformation/effectiveType) is a property of the [Network Information API](/en-US/docs/Web/API/Network_Information_API), exposed to JavaScript via the [navigator.connection](/en-US/docs/Web/API/Navigator/connection) object. To see your effective connection type, open the console of the developer tools of a supporting browser and enter the following:
 

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -8,7 +8,7 @@ Web technologies contain long lists of jargon and abbreviations that are used in
 
 Glossary terms can be selected from the sidebar.
 
-> **Note:** This glossary is a never-ending work in progress. You can help improve it by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_Glossary) or by making the existing ones better.
+> **Note:** This glossary is a never-ending work in progress. You can help improve it by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or by making the existing ones better.
 
 <section id="Quick_links">
  <ol>

--- a/files/en-us/glossary/page_prediction/index.md
+++ b/files/en-us/glossary/page_prediction/index.md
@@ -12,5 +12,5 @@ Although browser page prediction and prediction services enable faster page load
 
 ## See also
 
-- [prerender](/en-US/docs/Glossary/prerender)
+- [prerender](/en-US/docs/Glossary/Prerender)
 - [prefetch](/en-US/docs/Glossary/Prefetch)

--- a/files/en-us/glossary/real_user_monitoring/index.md
+++ b/files/en-us/glossary/real_user_monitoring/index.md
@@ -10,4 +10,4 @@ page-type: glossary-definition
 
 - [Real User Monitoring (RUM) versus Synthetic Monitoring](/en-US/docs/Web/Performance/Rum-vs-Synthetic)
 - [Synthetic Monitoring](/en-US/docs/Glossary/Synthetic_monitoring)
-- [Beacon](/en-US/docs/Glossary/beacon)
+- [Beacon](/en-US/docs/Glossary/Beacon)

--- a/files/en-us/glossary/synthetic_monitoring/index.md
+++ b/files/en-us/glossary/synthetic_monitoring/index.md
@@ -16,4 +16,4 @@ Unlike [RUM](/en-US/docs/Glossary/Real_User_Monitoring), synthetic monitoring pr
 
 - [Real User Monitoring (RUM)](/en-US/docs/Glossary/Real_User_Monitoring)
 - [Real User Monitoring (RUM) versus Synthetic Monitoring](/en-US/docs/Web/Performance/Rum-vs-Synthetic)
-- [Beacon](/en-US/docs/Glossary/beacon)
+- [Beacon](/en-US/docs/Glossary/Beacon)

--- a/files/en-us/mozilla/firefox/releases/65/index.md
+++ b/files/en-us/mozilla/firefox/releases/65/index.md
@@ -157,7 +157,7 @@ _No changes._
 
 ### Other
 
-- Support for [WebP](/en-US/docs/Glossary/webp) images has been added ([Firefox bug 1294490](https://bugzil.la/1294490)).
+- Support for [WebP](/en-US/docs/Glossary/WebP) images has been added ([Firefox bug 1294490](https://bugzil.la/1294490)).
 
   - In addition, to facilitate cross-browser compatibility in certain situations the WebP MIMEType (`image/webp`) has been added to the standard HTTP Request {{httpheader("Accept")}} header for HTML files ([Firefox bug 1507691](https://bugzil.la/1507691)).
 

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.md
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLFormElement.acceptCharset
 {{APIRef("HTML DOM")}}
 
 The **`HTMLFormElement.acceptCharset`** property represents a
-list of the supported [character encodings](/en-US/docs/Glossary/character_encoding) for the given {{htmlelement("form")}} element. This list can be
+list of the supported [character encodings](/en-US/docs/Glossary/Character_encoding) for the given {{htmlelement("form")}} element. This list can be
 comma-separated or space-separated.
 
 ## Value

--- a/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -19,7 +19,7 @@ If in doubt don't try doing it yourself, hire someone with experience and ensure
 
 This is the simplest useful thing you can do with the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API). It doesn't involve generating keys or certificates and has one single step.
 
-[Hashing](/en-US/docs/Glossary/hash) is a technique where you convert a large string of bytes into a smaller string, where small changes to the long string result in large changes in the smaller string. This technique is useful for identifying two identical files without checking every byte of both files. This is very useful as you have a simple string to compare. To be clear hashing is a **one way** operation. You cannot generate the original string of bytes from the hash.
+[Hashing](/en-US/docs/Glossary/Hash) is a technique where you convert a large string of bytes into a smaller string, where small changes to the long string result in large changes in the smaller string. This technique is useful for identifying two identical files without checking every byte of both files. This is very useful as you have a simple string to compare. To be clear hashing is a **one way** operation. You cannot generate the original string of bytes from the hash.
 
 If two generated hashes are the same, but the files that used to generate them are different, that is known as a _hash collision_ which is an extremely improbable thing to occur by accident and, for a secure hash function like SHA256, almost impossible to manufacture. So if the two strings are the same you can be reasonably sure the two original files are identical.
 

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -35,7 +35,7 @@ The XML file that describes a search engine follows the basic template below. Se
 - Description
   - : A brief description of the search engine. It must be **1024 or fewer characters** of plain text, with no HTML or other markup.
 - InputEncoding
-  - : The [character encoding](/en-US/docs/Glossary/character_encoding) to use when submitting input to the search engine.
+  - : The [character encoding](/en-US/docs/Glossary/Character_encoding) to use when submitting input to the search engine.
 - Image
 
   - : URL of an icon for the search engine. When possible, include a 16×16 image of type `image/x-icon` (such as `/favicon.ico`) and a 64×64 image of type `image/jpeg` or `image/png`.


### PR DESCRIPTION
I was reading the page for another reason and noticed the flaw…

So I fixed all cases for such flaws.