### PR TITLE
Remove link to outdated document in See also (Promise-related)

### DIFF
--- a/files/en-us/web/api/promiserejectionevent/index.md
+++ b/files/en-us/web/api/promiserejectionevent/index.md
@@ -58,7 +58,6 @@ window.onunhandledrejection = (e) => {
 
 ## See also
 
-- [Promises](/en-US/docs/Archive/Add-ons/Techniques/Promises)
 - [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)
 - {{jsxref("Promise")}}
 - {{domxref("Window/rejectionhandled_event", "rejectionhandled")}}


### PR DESCRIPTION
This page was archived long ago and was from a time when _promises_ weren't part of JavaScript!