### PR TITLE
Add missing global value for CSS properties

### DIFF
--- a/files/en-us/web/css/align-tracks/index.md
+++ b/files/en-us/web/css/align-tracks/index.md
@@ -24,6 +24,7 @@ align-tracks: start, center, end;
 align-tracks: inherit;
 align-tracks: initial;
 align-tracks: revert;
+align-tracks: revert-layer;
 align-tracks: unset;
 ```
 

--- a/files/en-us/web/css/contain-intrinsic-size/index.md
+++ b/files/en-us/web/css/contain-intrinsic-size/index.md
@@ -39,6 +39,7 @@ contain-intrinsic-size: auto 300px auto 4rem;
 contain-intrinsic-size: inherit;
 contain-intrinsic-size: initial;
 contain-intrinsic-size: revert;
+contain-intrinsic-size: revert-layer;
 contain-intrinsic-size: unset;
 ```
 

--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -38,6 +38,7 @@ offset-anchor: right 3em bottom 10px;
 offset-anchor: inherit;
 offset-anchor: initial;
 offset-anchor: revert;
+offset-anchor: revert-layer;
 offset-anchor: unset;
 ```
 

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -37,6 +37,7 @@ offset-path: stroke-box;
 offset-path: inherit;
 offset-path: initial;
 offset-path: revert;
+offset-path: revert-layer;
 offset-path: unset;
 ```
 

--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -33,6 +33,7 @@ padding-block: 5% 2%; /* relative to the nearest block container's width */
 padding-block: inherit;
 padding-block: initial;
 padding-block: revert;
+padding-block: revert-layer;
 padding-block: unset;
 ```
 

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -33,6 +33,7 @@ padding-inline: 5% 2%; /* relative to the nearest block container's width */
 padding-inline: inherit;
 padding-inline: initial;
 padding-inline: revert;
+padding-inline: revert-layer;
 padding-inline: unset;
 ```
 

--- a/files/en-us/web/css/paint-order/index.md
+++ b/files/en-us/web/css/paint-order/index.md
@@ -27,6 +27,7 @@ paint-order: markers stroke fill; /* draw markers, then stroke, then fill */
 paint-order: inherit;
 paint-order: initial;
 paint-order: revert;
+paint-order: revert-layer;
 paint-order: unset;
 ```
 


### PR DESCRIPTION
### Description

This PR adds the missing global value `revert-layer` for CSS properties not in deprecation.

### Motivation

### Additional details

### Related issues and pull requests