### PR TITLE
Update the "Syntax" section of `overflow-clip-margin`

### DIFF
--- a/files/en-us/web/css/overflow-clip-margin/index.md
+++ b/files/en-us/web/css/overflow-clip-margin/index.md
@@ -12,8 +12,12 @@ The **`overflow-clip-margin`** [CSS](/en-US/docs/Web/CSS) property determines ho
 ## Syntax
 
 ```css
+/* <length> values */
 overflow-clip-margin: 20px;
 overflow-clip-margin: 1em;
+
+/* <visual-box> | <length> */
+overflow-clip-margin: content-box 5px;
 
 /* Global values */
 overflow-clip-margin: inherit;
@@ -23,7 +27,7 @@ overflow-clip-margin: revert-layer;
 overflow-clip-margin: unset;
 ```
 
-The `overflow-clip-margin` property is specified as a length, negative values are not allowed.
+The `<visual-box>` value, which defaults to `padding-box`, specifies the box edge to use as the overflow clip edge origin. The `<length>` value specified in `overflow-clip-margin` must be nonnegative.
 
 > **Note:** If the element does not have `overflow: clip` then this property will be ignored.
 


### PR DESCRIPTION
### Description

This PR adds a few examples in the "Syntax" section of the `overflow-clip-margin` property, and adds an explanation on the `<visual-box>` value.

### Motivation

The spec added `<visual-box>` as acceptable values after https://github.com/w3c/csswg-drafts/issues/5801, and this PR intends to reflect that change.

### Additional details

The spec:
https://w3c.github.io/csswg-drafts/css-overflow/#overflow-clip-margin

### Related issues and pull requests

Relates to #25906.