### PR TITLE
Update index.md :: Corrected mistyped description for `indexEnd` in slice method.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -24,7 +24,7 @@ slice(indexStart, indexEnd)
 - `indexStart`
   - : The index of the first character to include in the returned substring.
 - `indexEnd` {{optional_inline}}
-  - : The index of the first character to exclude from the returned substring.
+  - : The index of the last character to exclude from the returned substring.
 
 ### Return value
 


### PR DESCRIPTION
Mistyped description for `indexEnd` fixed.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
