### PR TITLE
Remove PaintWorklet as subclass of Worklet

### DIFF
--- a/files/en-us/web/api/worklet/index.md
+++ b/files/en-us/web/api/worklet/index.md
@@ -62,7 +62,7 @@ Worklets are restricted to specific use cases; they cannot be used for arbitrary
   </tbody>
 </table>
 
-> **Note:** Paint worklets, defined by the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API), don't subclass {{domxref("Worklet")}}. They are used for programmatically generating an image where a CSS property expects a file. A paint worklet is accessed throught a regulare `Worklet` obtained using {{DOMxRef("CSS.paintWorklet")}}.
+> **Note:** Paint worklets, defined by the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API), don't subclass {{domxref("Worklet")}}. They are accessed through a regular `Worklet` object obtained using {{DOMxRef("CSS.paintWorklet")}}.
 
 For 3D rendering with [WebGL](/en-US/docs/Web/API/WebGL_API), you don't use worklets. Instead, you write vertex shaders and fragment shaders using GLSL code, and those shaders will then run on the graphics card.
 

--- a/files/en-us/web/api/worklet/index.md
+++ b/files/en-us/web/api/worklet/index.md
@@ -26,23 +26,6 @@ Worklets are restricted to specific use cases; they cannot be used for arbitrary
   </thead>
   <tbody>
     <tr>
-      <td>{{domxref("PaintWorklet")}}</td>
-      <td>
-        For programmatically generating an image where a CSS property expects a
-        file. Access this interface through
-        {{DOMxRef("CSS.paintWorklet")}}.
-      </td>
-      <td>
-        <strong>Chrome:</strong> Main thread, <strong>Gecko:</strong> Paint
-        thread
-      </td>
-      <td>
-        <a href="https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet"
-          >CSS Painting API</a
-        >
-      </td>
-    </tr>
-    <tr>
       <td>{{domxref("AudioWorklet")}}</td>
       <td>For audio processing with custom AudioNodes.</td>
       <td>Web Audio render thread</td>
@@ -79,7 +62,9 @@ Worklets are restricted to specific use cases; they cannot be used for arbitrary
   </tbody>
 </table>
 
-For 3D rendering with [WebGL](/en-US/docs/Web/API/WebGL_API), you don't use Worklets. Instead, you write Vertex Shaders and Fragment Shaders using GLSL code, and those shaders will then run on the graphics card.
+> **Note:** Paint worklets, defined by the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API), don't subclass {{domxref("Worklet")}}. They are used for programmatically generating an image where a CSS property expects a file. A paint worklet is accessed throught a regulare `Worklet` obtained using {{DOMxRef("CSS.paintWorklet")}}.
+
+For 3D rendering with [WebGL](/en-US/docs/Web/API/WebGL_API), you don't use worklets. Instead, you write vertex shaders and fragment shaders using GLSL code, and those shaders will then run on the graphics card.
 
 ## Instance properties
 


### PR DESCRIPTION
There is no interface `PaintWorklet`. Paint worklets directly use `Worklet` (with a specific global scope).