### PR TITLE
Fix method name (type() -> types())

### DIFF
--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -63,4 +63,4 @@ function drop_handler(ev) {
 ## See also
 
 - {{domxref("DataTransfer.types()")}}
-- [Incomplete list of MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+- [List of common MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -62,5 +62,5 @@ function drop_handler(ev) {
 
 ## See also
 
-- {{domxref("DataTransfer.type()")}}
+- {{domxref("DataTransfer.types()")}}
 - [Incomplete list of MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)


### PR DESCRIPTION
The method name on `DataTransfer` is `types()` and not `type()` like on each `DataTransferItem`