### PR TITLE
Remove link to long deleted page from See also

### DIFF
--- a/files/en-us/web/api/document/enablestylesheetsforset/index.md
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.md
@@ -62,4 +62,3 @@ document.enableStyleSheetsForSet("Some style sheet set name");
 - {{domxref("document.preferredStyleSheetSet")}}
 - {{domxref("document.selectedStyleSheetSet")}}
 - {{domxref("document.enableStyleSheetsForSet()")}}
-- [Correctly Using Titles With External Stylesheets](/en-US/docs/Archive/Web_Standards/Correctly_Using_Titles_With_External_Stylesheets)


### PR DESCRIPTION
This was moved to `Archive/` years ago, then deleted.