### PR TITLE
Fix link to aria-relevant

### DIFF
--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Element.ariaAtomic
 
 {{DefaultAPISidebar("DOM")}}
 
-The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the {{domxref("aria-relevant")}} attribute.
+The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 
 ## Value
 


### PR DESCRIPTION
`domxref` is not adequate to link to an ARIA attribute.