### PR TITLE
Fix link to 'this' keyword

### DIFF
--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -26,7 +26,7 @@ forEach(callbackFn, thisArg)
     - `set`
       - : The `FontFaceSet` which `forEach()` was called on.
 - `thisArg`
-  - : Value to use as {{jsxref('this')}} when executing `callbackFn`.
+  - : Value to use as [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) when executing `callbackFn`.
 
 ### Return value
 


### PR DESCRIPTION
The link to the `this` keyword was broken, this fixes it.