### PR TITLE
DataTransferItem -> DataTransfer

### DIFF
--- a/files/en-us/web/api/htmlinputelement/files/index.md
+++ b/files/en-us/web/api/htmlinputelement/files/index.md
@@ -56,4 +56,4 @@ for (const file of fileInput.files) {
 
 ## See also
 
-- {{domxref("DataTransferItem.files")}}
+- {{domxref("DataTransfer.files")}}


### PR DESCRIPTION
The `files` property is on `DataTransfer` and not on `DataTransferItem`.