### PR TITLE
Remove mention of PhotoSettings dictionary

### DIFF
--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -12,7 +12,7 @@ browser-compat: api.ImageCapture.getPhotoSettings
 
 The **`getPhotoSettings()`** method of
 the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}} that
-resolves with a {{domxref("PhotoSettings")}} object containing the current photo
+resolves with an object containing the current photo
 configuration settings.
 
 ## Syntax
@@ -27,17 +27,17 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with a {{domxref("PhotoSettings")}} object
+A {{jsxref("Promise")}} that resolves with an object
 containing the following properties:
 
-- `fillLightMode`: The flash setting of the capture device, one of
-  `"auto"`, `"off"`, or `"on"`.
-- `imageHeight`: The desired image height as an integer. The user agent
-  selects the closest width value to this setting if it only supports discrete heights.
-- `imageWidth`: The desired image width as an integer. The user agent
-  selects the closest width value to this setting if it only supports discrete widths.
-- `redEyeReduction`: A boolean indicating whether the red-eye reduction
-  should be used if it is available.
+- `fillLightMode`
+  - : The flash setting of the capture device, one of `"auto"`, `"off"`, or `"on"`.
+- `imageHeight`
+  - : The desired image height as an integer. The browser selects the closest width value to this setting if it only supports discrete heights.
+- `imageWidth`
+  - : The desired image width as an integer. The browser selects the closest width value to this setting if it only supports discrete widths.
+- `redEyeReduction`
+  - : A boolean indicating whether the red-eye reduction should be used if it is available.
 
 ## Examples
 


### PR DESCRIPTION
The dictionary properties are described just below, and there is no specific page (and it is not our policy to add more pages for dictionaries).