### PR TITLE
Remove mention of PhotoCapabilities dictionary

### DIFF
--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -12,7 +12,7 @@ browser-compat: api.ImageCapture.getPhotoCapabilities
 
 The **`getPhotoCapabilities()`**
 method of the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}}
-that resolves with a {{domxref("PhotoCapabilities")}} object containing the ranges of
+that resolves with an object containing the ranges of
 available configuration options.
 
 ## Syntax


### PR DESCRIPTION
Our modern policy is not to use the dictionary name. Also, it was a link redirecting to this very same page.