### PR TITLE
Don't use domxref for a String object

### DIFF
--- a/files/en-us/web/api/overconstrainederror/constraint/index.md
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.md
@@ -14,7 +14,7 @@ in the constructor, meaning the constraint that was not satisfied.
 
 ## Value
 
-A {{domxref('String')}}
+A string.
 
 ## Specifications
 


### PR DESCRIPTION
It is a JavaScript primitive type… (Not even the JS wrapper object)