### PR TITLE
Rephrase to avoid the non-existant PaintWorklet interface

### DIFF
--- a/files/en-us/web/api/request/destination/index.md
+++ b/files/en-us/web/api/request/destination/index.md
@@ -27,7 +27,7 @@ where the received data is stored for processing later. Others are script-based,
 which case the received data is delivered to a script by calling it and passing the data
 along. Script-based destinations include {{HTMLElement("script")}} elements, as well as
 any of the {{domxref("Worklet")}}-based destinations
-(including {{domxref("AudioWorklet")}} and {{domxref("PaintWorklet")}}), and the
+(including subclasses like {{domxref("AudioWorklet")}}), and the
 {{domxref("Worker")}}-based destinations, including {{domxref("ServiceWorker")}}
 and {{domxref("SharedWorker")}}.
 


### PR DESCRIPTION
A paint worklet is a `Worklet` and has no dedicated subclasses (unlike audio worklets that are `AudioWorklet`).