### PR TITLE
Fix link to animation-composition

### DIFF
--- a/files/en-us/glossary/composite_operation/index.md
+++ b/files/en-us/glossary/composite_operation/index.md
@@ -16,5 +16,5 @@ The _composite operation_ is the specific operation that is used to combine an e
 
 ## See also
 
-- [`animation-composition`](/en-US/web/css/animation-composition)
+- [`animation-composition`](/en-US/docs/Web/CSS/animation-composition)
 - [`KeyframeEffect.composite`](/en-US/docs/Web/API/KeyframeEffect/composite)


### PR DESCRIPTION
Docs was missing and capitalization didn't match the slug.