### PR TITLE
Add suggestion for IIFEs to avoid with statements

### DIFF
--- a/files/en-us/web/javascript/reference/statements/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/with/index.md
@@ -123,6 +123,18 @@ const r = 10;
 }
 ```
 
+### Avoiding the with statement by using an IIFE
+
+If you're producing an expression that must reuse a long-named reference multiple times, and your goal is to eliminate that lengthy name within your expression, you may prefer to provide the long-named reference as an argument to an [IIFE](/en-US/docs/Glossary/IIFE).
+
+```js
+const objectHavingAnEspeciallyLengthyName = { foo: true, bar: false };
+
+if ((o => o.foo && !o.bar)(objectHavingAnEspeciallyLengthyName)) {
+  // This branch runs.
+}
+```
+
 ### Creating dynamic namespaces using the with statement and a proxy
 
 `with` will transform every variable lookup to a property lookup, while [Proxies](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) allow trapping every property lookup call. You can create a dynamic namespace by combining them.

--- a/files/en-us/web/javascript/reference/statements/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/with/index.md
@@ -125,7 +125,7 @@ const r = 10;
 
 ### Avoiding the with statement by using an IIFE
 
-If you're producing an expression that must reuse a long-named reference multiple times, and your goal is to eliminate that lengthy name within your expression, you may prefer to provide the long-named reference as an argument to an [IIFE](/en-US/docs/Glossary/IIFE).
+If you're producing an expression that must reuse a long-named reference multiple times, and your goal is to eliminate that lengthy name within your expression, you can wrap the expression in an [IIFE](/en-US/docs/Glossary/IIFE) and provide the long name as an argument.
 
 ```js
 const objectHavingAnEspeciallyLengthyName = { foo: true, bar: false };


### PR DESCRIPTION
### Description

This change-set adds a suggestion for how people may avoid using the `with` statement by using an IIFE instead.

### Motivation

The documentation for the `with` statement wisely advises its avoidance, and does a good job of explaining why. Still, people who show up on this page may be seeking a `with`-like solution without its drawbacks. One such solution is already offered, and it's good: destructuring. This change-set introduces another, which is more appropriate to those who are producing an expression.

### Additional details

N/A

### Related issues and pull requests

N/A