### PR TITLE
Fix link to Document.copy_event

### DIFF
--- a/files/en-us/web/api/svggraphicselement/copy_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.md
@@ -91,5 +91,5 @@ document.querySelector("text").addEventListener("copy", (evt) => {
 
 - Related events: [`cut`](/en-US/docs/Web/API/SVGGraphicsElement/cut_event), [`paste`](/en-US/docs/Web/API/SVGGraphicsElement/paste_event)
 - This event on HTML {{domxref("Element")}} targets: [`copy`](/en-US/docs/Web/API/Element/copy_event)
-- This event on {{domxref("Document")}} targets: [`copy`](/en-US/docs/Web/API/Document/v_event)
+- This event on {{domxref("Document")}} targets: [`copy`](/en-US/docs/Web/API/Document/copy_event)
 - This event on {{domxref("Window")}} targets: [`copy`](/en-US/docs/Web/API/Window/copy_event)


### PR DESCRIPTION
It was called `v_event`, likely a CTRL-v that failed.