### PR TITLE
Change macro to actually link to TypedArray

### DIFF
--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -36,7 +36,7 @@ controlTransferOut(setup, data)
       - : The interface number of the recipient.
 
 - `data`
-  - : A {{domxref("TypedArray")}} containing the data that will be transferred to the device.
+  - : A {{jsxref("TypedArray")}} containing the data that will be transferred to the device.
     Not all commands require data; some commands can send data just through the value parameter.
     Check with your device to see what the specific request requires.
 

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
@@ -24,7 +24,7 @@ isochronousTransferOut(endpointNumber, data, packetLengths)
 - `endpointNumber`
   - : The number of a device-specific endpoint (buffer).
 - `data`
-  - : A {{domxref("TypedArray")}} containing the data to send to the device.
+  - : A {{jsxxref("TypedArray")}} containing the data to send to the device.
 - `packetLengths`
   - : An array of lengths for the packets being transferred.
 


### PR DESCRIPTION
We must use `jsxref` and not `domxref` to link to `TypedArray`.