### PR TITLE
Remove broken link

### DIFF
--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -29,7 +29,7 @@ suspend(suspendTime)
 ### Parameters
 
 - `suspendTime`
-  - : A {{jsxref("double")}} specifying the suspend time, in seconds.
+  - : A floating-point number specifying the suspend time, in seconds.
 
 ### Return value
 


### PR DESCRIPTION
We never use a link for _double_.