### PR TITLE
WindowProxy -> Window

### DIFF
--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
@@ -15,7 +15,7 @@ otherwise null.
 
 ## Value
 
-A {{domxref('WindowProxy')}}.
+A {{domxref('Window')}}, or `null` if there are none.
 
 ## Specifications
 


### PR DESCRIPTION
`WindowProxy` is an _exotic object_ (Yes, that's the spec use) that is transparent to the web developer. It isn't an interface and is the `Window` object. A technicality of no use for web developers.