### PR TITLE
Fix ChannelSplitterNode() constructor

### DIFF
--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
@@ -25,7 +25,7 @@ new ChannelSplitterNode(context, options)
 
   - : An object defining the properties you want the `ChannelSplitterNode` to have:
     - `numberOfOutputs` {{optional_inline}}
-      - : A number defining the number of inputs the {{domxref("ChannelSplitterNode")}} should have. If not specified, the default value used is 6.
+      - : A number defining the number of outputs the {{domxref("ChannelSplitterNode")}} should have. If not specified, the default value used is 6.
     - `channelCount` {{optional_inline}}
       - : An integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node.
         (See {{domxref("AudioNode.channelCount")}} for more information.)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The option `numberOfOutputs` is the number of **output**, not **input**.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[1.15.2.1. Dictionary ChannelSplitterOptions Members](https://webaudio.github.io/web-audio-api/#dictionary-channelsplitteroptions-members)

> numberOfOutputs, of type unsigned long, defaulting to 6
>
> The number outputs for the ChannelSplitterNode. See createChannelSplitter() for constraints on this value.

Specified as the number **outputs**.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
