### PR TITLE
Correct the `<color>` links used on the logical `border` properties

### DIFF
--- a/files/en-us/web/css/border-block-color/index.md
+++ b/files/en-us/web/css/border-block-color/index.md
@@ -29,8 +29,8 @@ border-block-color: unset;
 
 ### Values
 
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-block-end-color/index.md
+++ b/files/en-us/web/css/border-block-end-color/index.md
@@ -29,8 +29,8 @@ Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("borde
 
 ### Values
 
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-block-end/index.md
+++ b/files/en-us/web/css/border-block-end/index.md
@@ -46,8 +46,8 @@ The `border-block-end` is specified with one or more of the following, in any or
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-block-start-color/index.md
+++ b/files/en-us/web/css/border-block-start-color/index.md
@@ -29,8 +29,8 @@ Related properties are {{cssxref("border-block-end-color")}}, {{cssxref("border-
 
 ### Values
 
-- `<'color'>`
-  - : See {{ cssxref("border-color") }}
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-block-start/index.md
+++ b/files/en-us/web/css/border-block-start/index.md
@@ -46,8 +46,8 @@ The `border-block-start` is specified with one or more of the following, in any 
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -46,8 +46,8 @@ The `border-block` is specified with one or more of the following, in any order:
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline-color/index.md
+++ b/files/en-us/web/css/border-inline-color/index.md
@@ -29,8 +29,8 @@ border-inline-color: unset;
 
 ### Values
 
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline-end-color/index.md
+++ b/files/en-us/web/css/border-inline-end-color/index.md
@@ -29,8 +29,8 @@ Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("borde
 
 ### Values
 
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -46,8 +46,8 @@ The `border-inline-end` is specified with one or more of the following, in any o
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline-start-color/index.md
+++ b/files/en-us/web/css/border-inline-start-color/index.md
@@ -29,8 +29,8 @@ Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("borde
 
 ### Values
 
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline-start/index.md
+++ b/files/en-us/web/css/border-inline-start/index.md
@@ -46,8 +46,8 @@ The `border-inline-start` is specified with one or more of the following, in any
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 

--- a/files/en-us/web/css/border-inline/index.md
+++ b/files/en-us/web/css/border-inline/index.md
@@ -46,8 +46,8 @@ The `border-inline` is specified with one or more of the following, in any order
   - : The width of the border. See {{cssxref("border-width")}}.
 - `<'border-style'>`
   - : The line style of the border. See {{cssxref("border-style")}}.
-- `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+- {{CSSXref("&lt;color&gt;")}}
+  - : The color of the border.
 
 ## Formal definition
 


### PR DESCRIPTION
### Description

This PR changes `<'color'>` and `{{CSSXref("color")}}` used on pages of the logical `border` properties, i.e. `border-(block|inline)(-(end|start))?(-color)?`, to `{{CSSXref("&lt;color&gt;")}}`.

### Motivation

Current links point to the `color` property, but in the "Syntax" subsection they're supposed to explain the value component instead.

### Additional details

### Related issues and pull requests