### PR TITLE
Add clarification on frequencies

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -83,7 +83,10 @@ the result of a Fourier transform, where you get frequency domain values from ti
 domain value. Here, with `createPeriodicWave()`, you specify the
 frequencies, and the browser performs an inverse Fourier transform to get a time
 domain buffer for the frequency of the oscillator. Here, we only set one component at
-full volume (1.0) on the fundamental tone, so we get a sine wave.
+full volume (1.0) on the fundamental tone, so we get a sine wave. Bear in mind the
+fundamental tone is the oscillator's frequency (which, by default, is 440 Hz).
+Thus, by altering the oscillator's frequency we are in effect shifting the frequency
+of this periodic wave along with it.
 
 The coefficients of the Fourier transform should be given in _ascending_ order
 (i.e. <math>


### PR DESCRIPTION
### Description
After reading through the documentation it wasn't apparent (at least to me) that the fundamental frequency was that of the oscillator's. By adding these few lines we are explicitly stating that the fundamental frequency whose associated component are specified through the `real` and `imag` arrays is that of the oscillator (which, by default is 440 Hz).

### Motivation
I spent a while browsing other examples and tinkering with my code to try and verify if my intuition
was correct. Given this topic concerns concepts such as the [Fourier Series](https://en.wikipedia.org/wiki/Fourier_series) it can be a bit intimidating
to try different things out.

It goes without saying I would be more than happy to add a bit more information or to
alter its structure if you were to deem that appropriate.

Thanks for your time! 😼