### PR TITLE
Fix bug in collision detection

### DIFF
--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -76,8 +76,8 @@ Another simple shape for collision detection is between two circles. This algori
 ```js
 Crafty.init(200, 200);
 
-const dim1 = { x: 5, y: 5 };
-const dim2 = { x: 20, y: 20 };
+const dim1 = { x: 20, y: 20 };
+const dim2 = { x: 40, y: 40 };
 
 Crafty.c("Circle", {
   circle(radius, color) {
@@ -95,8 +95,8 @@ Crafty.c("Circle", {
     ctx.fillStyle = this.color;
     ctx.beginPath();
     ctx.arc(
-      this.x + this.radius,
-      this.y + this.radius,
+      this.x,
+      this.y,
       this.radius,
       0,
       Math.PI * 2

--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -95,8 +95,8 @@ Crafty.c("Circle", {
     ctx.fillStyle = this.color;
     ctx.beginPath();
     ctx.arc(
-      this.x,
-      this.y,
+      this.x + this.radius,
+      this.y + this.radius,
       this.radius,
       0,
       Math.PI * 2
@@ -104,6 +104,10 @@ Crafty.c("Circle", {
     ctx.closePath();
     ctx.fill();
     ctx.restore();
+  },
+  
+  get center() {
+    return { x: this.x + this.radius, y: this.y + this.radius };
   },
 });
 
@@ -115,8 +119,8 @@ const circle2 = Crafty.e("2D, Canvas, Circle, Fourway")
   .circle(20, "blue");
 
 circle2.bind("EnterFrame", function () {
-  const dx = circle1.x - circle2.x;
-  const dy = circle1.y - circle2.y;
+  const dx = circle1.center.x - circle2.center.x;
+  const dy = circle1.center.y - circle2.center.y;
   const distance = Math.sqrt(dx * dx + dy * dy);
 
   const colliding = distance < circle1.radius + circle2.radius;


### PR DESCRIPTION
### Description

I changed the position of the drawn circles in the "circle collision detection" example so that they correspond to the positions used in the detection of collisions. 

### Motivation

Circle collision detection did not work because position of a drawn circle and position of that circle in the collision calculation were two different positions. And distance between visible circles was different from distance used in collision detection.