### PR TITLE
clarify characters allowed in name and value of cookie

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -57,10 +57,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
   - : Defines the cookie name and its value.
     A cookie definition begins with a name-value pair.
 
-    A `<cookie-name>` can contain any US-ASCII characters except for: the control character, space, or a tab.
-    It also must not contain separator characters like the following: `( ) < > @ , ; : \ " / [ ] ? = { }`.
+    A `<cookie-name>` can contain any US-ASCII characters except for: controll characters (ASCII characters 0 upto 31 and ASCII character 127) or seperator characters (space, tab and the characters: `( ) < > @ , ; : \ " / [ ] ? = { }`) 
 
-    A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding a control character, {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
+    A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding controll characters (ASCII characters 0 upto 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
 
     **Encoding**: Many implementations perform [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) on cookie values.
     However, this is not required by the RFC specification.

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -59,7 +59,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     A `<cookie-name>` can contain any US-ASCII characters except for: control characters (ASCII characters 0 upto 31 and ASCII character 127) or separator characters (space, tab and the characters: `( ) < > @ , ; : \ " / [ ] ? = { }`)
 
-    A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding controll characters (ASCII characters 0 upto 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
+    A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding control characters (ASCII characters 0 up to 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, commas, semicolons, and backslashes.
 
     **Encoding**: Many implementations perform [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) on cookie values.
     However, this is not required by the RFC specification.

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -57,7 +57,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
   - : Defines the cookie name and its value.
     A cookie definition begins with a name-value pair.
 
-    A `<cookie-name>` can contain any US-ASCII characters except for: controll characters (ASCII characters 0 upto 31 and ASCII character 127) or seperator characters (space, tab and the characters: `( ) < > @ , ; : \ " / [ ] ? = { }`) 
+    A `<cookie-name>` can contain any US-ASCII characters except for: control characters (ASCII characters 0 upto 31 and ASCII character 127) or separator characters (space, tab and the characters: `( ) < > @ , ; : \ " / [ ] ? = { }`)
 
     A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding controll characters (ASCII characters 0 upto 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
What characters are allowed in the name and value of a cookie in a Set-cookie header were vague. I looked at the spec and updated it to these precise definitions.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
To make the docs clearer.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
[https://httpwg.org/specs/rfc6265.html#sane-set-cookie]()
[https://www.rfc-editor.org/rfc/rfc2616.html#section-2.2]()
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
n/a
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
