### PR TITLE
Remove onperiodicsync in GroupData.json

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1012,8 +1012,7 @@
       "interfaces": ["PeriodicSyncEvent", "PeriodicSyncManager"],
       "methods": [],
       "properties": [
-        "ServiceWorkerRegistration.periodicSync",
-        "ServiceWorkerGlobalScope.onperiodicsync"
+        "ServiceWorkerRegistration.periodicSync"
       ],
       "events": ["ServiceWorkerGlobalScope: periodicsync"]
     },

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1011,9 +1011,7 @@
       "overview": ["Web Periodic Background Synchronization API"],
       "interfaces": ["PeriodicSyncEvent", "PeriodicSyncManager"],
       "methods": [],
-      "properties": [
-        "ServiceWorkerRegistration.periodicSync"
-      ],
+      "properties": ["ServiceWorkerRegistration.periodicSync"],
       "events": ["ServiceWorkerGlobalScope: periodicsync"]
     },
     "Permissions API": {


### PR DESCRIPTION
We don't document `onXYZ` properties and the corresponding event is already listed.