### PR TITLE
Well-known symbol related improvements

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.functions.arguments.@@iterator
 
 {{jsSidebar("Functions")}}
 
-The **`[@@iterator]()`** method of the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows `arguments` to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the `arguments` object.
+The **`[@@iterator]()`** method of {{jsxref("Functions/arguments", "arguments")}} objects implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows `arguments` objects to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the `arguments` object.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Array.prototype.values")}} property (and also the same as [`Array.prototype[@@iterator]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)).
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of an `Array` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows arrays to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the array.
+The **`[@@iterator]()`** method of {{jsxref("Array")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows arrays to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the array.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Array.prototype.values")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/@@iterator/index.md
@@ -8,7 +8,7 @@ browser-compat: javascript.builtins.Intl.Segments.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a `Segments` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows `Segments` objects to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns an [segments iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields data about each segment.
+The **`[@@iterator]()`** method of [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows `Segments` objects to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [segments iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields data about each segment.
 
 {{EmbedInteractiveExample("pages/js/intl-segments-prototype-@@iterator.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Iterator.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a `Iterator` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows built-in iterators to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this), which is the iterator object itself.
+The **`[@@iterator]()`** method of {{jsxref("Iterator")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows built-in iterators to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this), which is the iterator object itself.
 
 {{EmbedInteractiveExample("pages/js/map-prototype-@@iterator.html")}}
 
@@ -45,4 +45,4 @@ for (const value of arrIterator) {
 
 ## See also
 
-- [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
+- {{jsxref("Statements/for...of", "for...of")}}

--- a/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Map.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a `Map` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows maps to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns a [map iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the key-value pairs of the map.
+The **`[@@iterator]()`** method of {{jsxref("Map")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows maps to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns a [map iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the key-value pairs of the map.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Map.prototype.entries")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -124,8 +124,10 @@ console.log(result.group(3)); // 02
 
 - [Polyfill of `RegExp.prototype[@@match]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)
+- [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)
+- [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search)
+- [`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
+- {{jsxref("Symbol.match")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
@@ -119,4 +119,8 @@ console.log(result[1]);
 
 - [Polyfill of `RegExp.prototype[@@matchAll]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.matchAll()")}}
+- [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match)
+- [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)
+- [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search)
+- [`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)
 - {{jsxref("Symbol.matchAll")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -125,9 +125,10 @@ console.log(newstr); // ###34567
 - [Polyfill of `RegExp.prototype[@@replace]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("String.prototype.replaceAll()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match)
+- [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)
+- [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search)
+- [`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
-- [`Symbol.replace`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)
+- {{jsxref("Symbol.replace")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -99,8 +99,10 @@ console.log(result); // 3
 
 - [Polyfill of `RegExp.prototype[@@search]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.search()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match)
+- [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)
+- [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)
+- [`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
+- {{jsxref("Symbol.search")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -98,8 +98,10 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 - [Polyfill of `RegExp.prototype[@@split]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.split()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
+- [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match)
+- [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)
+- [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)
+- [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search)
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
+- {{jsxref("Symbol.split")}}

--- a/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Set.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a `Set` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set.
+The **`[@@iterator]()`** method of {{jsxref("Set")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Set.prototype.values")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.String.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a string implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows strings to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns a [string iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the Unicode code points of the string value as individual strings.
+The **`[@@iterator]()`** method of {{jsxref("String")}} values implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows strings to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns a [string iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the Unicode code points of the string value as individual strings.
 
 {{EmbedInteractiveExample("pages/js/string-iterator.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.asyncIterator
 
 {{JSRef}}
 
-The **`Symbol.asyncIterator`** static data property represents the well-known symbol specifying the method that returns the [async iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) for an object. If this property is set on an object, it is an async iterable and can be used in a [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop.
+The **`Symbol.asyncIterator`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@asyncIterator`. The [async iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) looks up this symbol for the method that returns the async iterator for an object. In order for an object to be async iterable, it must have an `@@asyncIterator` key.
 
 {{EmbedInteractiveExample("pages/js/symbol-asynciterator.html", "taller")}}
 
@@ -16,10 +16,6 @@ The **`Symbol.asyncIterator`** static data property represents the well-known sy
 The well-known symbol `@@asyncIterator`.
 
 {{js_property_attributes(0, 0, 0)}}
-
-## Description
-
-The `Symbol.asyncIterator` symbol is a builtin symbol that is used to access an object's `@@asyncIterator` method. In order for an object to be async iterable, it must have a `Symbol.asyncIterator` key.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.hasInstance
 
 {{JSRef}}
 
-The **`Symbol.hasInstance`** static data property represents the well-known symbol specifying the method used to determine if a constructor object recognizes an object as its instance. The {{jsxref("Operators/instanceof", "instanceof")}} operator's behavior can be customized by this symbol.
+The **`Symbol.hasInstance`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@hasInstance`. The {{jsxref("Operators/instanceof", "instanceof")}} operator looks up this symbol on its right-hand operand for the method used to determine if the constructor object recognizes an object as its instance.
 
 {{EmbedInteractiveExample("pages/js/symbol-hasinstance.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -66,6 +66,8 @@ All static properties of the `Symbol` constructor are Symbols themselves, whose 
 
 Prior to well-known Symbols, JavaScript used normal properties to implement certain built-in operations. For example, the [`JSON.stringify`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function will attempt to call each object's `toJSON()` method, and the [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String) function will call the object's `toString()` and `valueOf()` methods. However, as more operations are added to the language, designating each operation a "magic property" can break backward compatibility and make the language's behavior harder to reason with. Well-known Symbols allow the customizations to be "invisible" from normal code, which typically only read string properties.
 
+In MDN and other sources, well-known symbol values are stylized by prefixing `@@`. For example, {{jsxref("Symbol.hasInstance")}} is written as `@@hasInstance`. This is because symbols don't have actual literal formats, but using `Symbol.hasInstance` does not reflect the ability of using other aliases to refer to the same symbol. This is like the difference between `Function.name` and `"Function"`.
+
 Well-known symbols do not have the concept of garbage collectability, because they come in a fixed set and are unique throughout the lifetime of the program, similar to intrinsic objects such as `Array.prototype`, so they are also allowed in {{jsxref("WeakMap")}}, {{jsxref("WeakSet")}}, {{jsxref("WeakRef")}}, and {{jsxref("FinalizationRegistry")}} objects.
 
 ### Finding Symbol properties on objects

--- a/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.isConcatSpreadable
 
 {{JSRef}}
 
-The **`Symbol.isConcatSpreadable`** static data property represents the well-known symbol used to configure if an object should be flattened to its array elements when using the {{jsxref("Array.prototype.concat()")}} method.
+The **`Symbol.isConcatSpreadable`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@isConcatSpreadable`. The {{jsxref("Array.prototype.concat()")}} method looks up this symbol on each object being concatenated to determine if it should be treated as an array-like object and flattened to its array elements.
 
 {{EmbedInteractiveExample("pages/js/symbol-isconcatspreadable.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.iterator
 
 {{JSRef}}
 
-The **`Symbol.iterator`** static data property represents the well-known symbol specifying the method that returns the iterator for an object. If this property is set on an object, it is an iterable and can be used in a [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop and various other syntaxes.
+The **`Symbol.iterator`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@iterator`. The [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) looks up this symbol for the method that returns the iterator for an object. In order for an object to be iterable, it must have an `@@iterator` key.
 
 {{EmbedInteractiveExample("pages/js/symbol-iterator.html")}}
 
@@ -21,13 +21,13 @@ The well-known symbol `@@iterator`.
 
 Whenever an object needs to be iterated (such as at the beginning of a `for...of` loop), its `@@iterator` method is called with no arguments, and the returned **iterator** is used to obtain the values to be iterated.
 
-Some built-in types have a default iteration behavior, while other types (such as {{jsxref("Object")}}) do not. The built-in types with a `@@iterator` method are:
+Some built-in types have a default iteration behavior, while other types (such as {{jsxref("Object")}}) do not. Some built-in types with a `@@iterator` method are:
 
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}
+- [`Array.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+- [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
+- [`String.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator)
+- [`Map.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator)
+- [`Set.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator)
 
 See also [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) for more information.
 
@@ -91,8 +91,10 @@ nonWellFormedIterable[Symbol.iterator] = () => 1;
 
 - [Polyfill of `Symbol.iterator` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}
+- [`Array.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+- [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
+- [`String.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator)
+- [`Map.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator)
+- [`Set.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator)
+- [`arguments[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator)
+- [`Segments.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.match
 
 {{JSRef}}
 
-The **`Symbol.match`** static data property represents the well-known symbol specifying the method used to match an input string against the current object, making the object behave like a {{jsxref("RegExp")}}. This function is called by the {{jsxref("String.prototype.match()")}} method.
+The **`Symbol.match`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@match`. The {{jsxref("String.prototype.match()")}} method looks up this symbol on its first argument for the method used to match an input string against the current object. This symbol is also used to determine if an object should be [treated as a regex](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes).
 
-For more information, see {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]()")}} and {{jsxref("String.prototype.match()")}}.
+For more information, see [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match) and {{jsxref("String.prototype.match()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-match.html", "taller")}}
 
@@ -56,7 +56,9 @@ re[Symbol.match] = false;
 ## See also
 
 - [Polyfill of `Symbol.match` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- {{jsxref("Symbol.matchAll")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]()")}}
+- {{jsxref("String.prototype.match()")}}
+- [`RegExp.prototype[@@match]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.matchAll
 
 {{JSRef}}
 
-The **`Symbol.matchAll`** static data property represents the well-known symbol specifying the method that returns an iterator, that yields matches of the regular expression against a string. This function is called by the {{jsxref("String.prototype.matchAll()")}} method.
+The **`Symbol.matchAll`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@matchAll`. The {{jsxref("String.prototype.matchAll()")}} method looks up this symbol on its first argument for the method that returns an iterator, that yields matches of the current object against a string.
 
-For more information, see {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}} and {{jsxref("String.prototype.matchAll()")}}.
+For more information, see [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll) and {{jsxref("String.prototype.matchAll()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-matchall.html")}}
 
@@ -47,5 +47,9 @@ console.log(Array.from(str.matchAll(numbers)));
 ## See also
 
 - [Polyfill of `Symbol.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- {{jsxref("Symbol.match")}}
+- {{jsxref("Symbol.replace")}}
+- {{jsxref("Symbol.search")}}
+- {{jsxref("Symbol.split")}}
 - {{jsxref("String.prototype.matchAll()")}}
-- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}
+- [`RegExp.prototype[@@matchAll]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.replace
 
 {{JSRef}}
 
-The **`Symbol.replace`** static data property represents the well-known symbol specifying the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
+The **`Symbol.replace`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@replace`. The {{jsxref("String.prototype.replace()")}} method looks up this symbol on its first argument for the method that replaces substrings matched by the current object.
 
-For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}} and {{jsxref("String.prototype.replace()")}}.
+For more information, see [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace) and {{jsxref("String.prototype.replace()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}
 
@@ -48,6 +48,8 @@ console.log("football".replace(new CustomReplacer("foo"))); // "#!@?tball"
 
 - [Polyfill of `Symbol.replace` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
+- {{jsxref("Symbol.matchAll")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}}
+- {{jsxref("String.prototype.replace()")}}
+- [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.search
 
 {{JSRef}}
 
-The **`Symbol.search`** static data property represents the well-known symbol specifying the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
+The **`Symbol.search`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@search`. The {{jsxref("String.prototype.search()")}} method looks up this symbol on its first argument for the method that returns the index within a string that matches the current object.
 
-For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}} and {{jsxref("String.prototype.search()")}}.
+For more information, see [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search) and {{jsxref("String.prototype.search()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-search.html")}}
 
@@ -48,6 +48,8 @@ console.log("foobar".search(new caseInsensitiveSearch("BaR"))); // 3
 
 - [Polyfill of `Symbol.search` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
+- {{jsxref("Symbol.matchAll")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}}
+- {{jsxref("String.prototype.search()")}}
+- [`RegExp.prototype[@@search]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/species/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.species
 
 {{JSRef}}
 
-The **`Symbol.species`** static data property represents the well-known symbol specifying the method that a constructor function uses to create derived objects.
+The **`Symbol.species`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@species`. Methods that create copies of an object may look up this symbol on the object for the constructor function to use when creating the copy.
 
 > **Warning:** The existence of `@@species` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.split
 
 {{JSRef}}
 
-The **`Symbol.split`** static data property represents the well-known symbol specifying the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
+The **`Symbol.split`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@split`. The {{jsxref("String.prototype.split()")}} method looks up this symbol on its first argument for the method that splits a string at the indices that match the current object.
 
-For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}} and {{jsxref("String.prototype.split()")}}.
+For more information, see[`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split) and {{jsxref("String.prototype.split()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-split.html")}}
 
@@ -47,6 +47,8 @@ console.log("Another one bites the dust".split(new ReverseSplit()));
 
 - [Polyfill of `Symbol.split` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.match")}}
+- {{jsxref("Symbol.matchAll")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
-- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}}
+- {{jsxref("String.prototype.split()")}}
+- [`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.toPrimitive
 
 {{JSRef}}
 
-The **`Symbol.toPrimitive`** static data property represents the well-known symbol specifying the method that accepts a preferred type and returns a primitive representation of an object. It is called in priority by all [type coercion](/en-US/docs/Web/JavaScript/Data_structures#type_coercion) algorithms.
+The **`Symbol.toPrimitive`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@toPrimitive`. All [type coercion](/en-US/docs/Web/JavaScript/Data_structures#type_coercion) algorithms look up this symbol on objects for the method that accepts a preferred type and returns a primitive representation of the object, before falling back to using the object's `valueOf()` and `toString()` methods.
 
 {{EmbedInteractiveExample("pages/js/symbol-toprimitive.html")}}
 
@@ -65,7 +65,8 @@ console.log(obj2 + ""); // "true"    — hint is "default"
 
 ## See also
 
-- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]()")}}
-- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]()")}}
+- [Polyfill of `Symbol.toPrimitive` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
+- [`Date.prototype[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive)
+- [`Symbol.prototype[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive)
 - {{jsxref("Object.prototype.toString()")}}
 - {{jsxref("Object.prototype.valueOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.toStringTag
 
 {{JSRef}}
 
-The **`Symbol.toStringTag`** static data property represents the well-known symbol used in the creation of the default string description of an object. It is accessed internally by the {{jsxref("Object.prototype.toString()")}} method.
+The **`Symbol.toStringTag`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@toStringTag`. {{jsxref("Object.prototype.toString()")}} looks up this symbol on the `this` value for the property containing a string that represents the type of the object.
 
 {{EmbedInteractiveExample("pages/js/symbol-tostringtag.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Symbol.unscopables
 
 {{JSRef}}
 
-The **`Symbol.unscopables`** static data property represents the well-known symbol used to specify properties of the associated object that should not become bindings within the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) environment.
+The **`Symbol.unscopables`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@unscopables`. The {{jsxref("Statements/with", "with")}} statement looks up this symbol on the scope object for a property containing a collection of properties that should not become bindings within the `with` environment.
 
 {{EmbedInteractiveExample("pages/js/symbol-unscopables.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.TypedArray.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of a `TypedArray` object implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows typed arrays to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the typed array.
+The **`[@@iterator]()`** method of {{jsxref("TypedArray")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows typed arrays to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the typed array.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("TypedArray.prototype.values")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -61,4 +61,4 @@ console.log(arrayEntries.next().value); // [4, 50]
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -60,6 +60,6 @@ console.log(arrKeys.next().value); // 4
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
 - [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -60,4 +60,4 @@ console.log(values.next().value); // 50
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR: did a minor update to the `@@iterator` intros (which is the new convention for instance methods), avoids using `JSxRef` macros for well-known symbol methods (because they create empty Markdown links if the renderer doesn't support KS), and fixes the long, unwieldy intros of well-known symbol pages.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
