### PR TITLE
Use proper sidebar in MathML main page

### DIFF
--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -5,9 +5,7 @@ page-type: landing-page
 browser-compat: mathml.elements.math
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/MathML")}}
-</section>
+{{MathMLRef}}
 
 **Mathematical Markup Language (MathML)** is an [XML](/en-US/docs/Web/XML)-based language for describing mathematical notation.
 


### PR DESCRIPTION
Noticed this looking at the page-type PR. The main MathML page isn't using the new sidebar.