### PR TITLE
Move MathML 'Values' guide page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -5625,7 +5625,7 @@
 /en-US/docs/Manipulating_video_using_canvas	/en-US/docs/Web/API/Canvas_API/Manipulating_video_using_canvas
 /en-US/docs/MathML	/en-US/docs/Web/MathML
 /en-US/docs/MathML/Attributes	/en-US/docs/Web/MathML/Attribute
-/en-US/docs/MathML/Attributes/Values	/en-US/docs/Web/MathML/Attribute/Values
+/en-US/docs/MathML/Attributes/Values	/en-US/docs/Web/MathML/Values
 /en-US/docs/MathML/Element	/en-US/docs/Web/MathML/Element
 /en-US/docs/MathML/Element/maction	/en-US/docs/Web/MathML/Element/maction
 /en-US/docs/MathML/Element/math	/en-US/docs/Web/MathML/Element/math
@@ -12511,6 +12511,7 @@
 /en-US/docs/Web/Manifest/dir	/en-US/docs/Web/Manifest
 /en-US/docs/Web/Manifest/iarc_rating_id	/en-US/docs/Web/Manifest
 /en-US/docs/Web/Manifest/lang	/en-US/docs/Web/Manifest
+/en-US/docs/Web/MathML/Attribute/Values	/en-US/docs/Web/MathML/Values
 /en-US/docs/Web/MathML/Element/annotation	/en-US/docs/Web/MathML/Element/semantics
 /en-US/docs/Web/MathML/Element/annotation-xml	/en-US/docs/Web/MathML/Element/semantics
 /en-US/docs/Web/MathML/Element/menclosed	/en-US/docs/Web/MathML/Element/menclose

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -124209,10 +124209,6 @@
       "Sheppy"
     ]
   },
-  "Web/MathML/Attribute/Values": {
-    "modified": "2019-10-25T11:46:38.660Z",
-    "contributors": ["fscholz", "maryannetpdx", "Sheppy"]
-  },
   "Web/MathML/Authoring": {
     "modified": "2020-11-28T13:32:39.862Z",
     "contributors": [
@@ -124590,6 +124586,10 @@
       "Paul_Mollomo",
       "ethertank"
     ]
+  },
+  "Web/MathML/Values": {
+    "modified": "2019-10-25T11:46:38.660Z",
+    "contributors": ["fscholz", "maryannetpdx", "Sheppy"]
   },
   "Web/Media": {
     "modified": "2020-05-29T11:42:14.330Z",

--- a/files/en-us/web/mathml/values/index.md
+++ b/files/en-us/web/mathml/values/index.md
@@ -1,6 +1,6 @@
 ---
 title: MathML Attribute Values
-slug: Web/MathML/Attribute/Values
+slug: Web/MathML/Values
 page-type: guide
 browser-compat: mathml.attribute_values
 ---


### PR DESCRIPTION
This came up looking at the page-types PR for MathML.

The page at https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values is not discoverable in the nav. It should probably live under "Guides", but it should then probably live in the same location as the other guide pages, which is at the top level.

Arguably all the guides should live together under /Guides, [like we now do for PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides), and maybe we should work towards a common divio-driven sidebar organization.

There will also need to be an update to the MathMLSidebar macro to expose this page. Note that if we kept guides together under /Guides, and implemented [weight](https://github.com/orgs/mdn/discussions/124), then we would not need a macro update for changes like this 🤷 .