### PR TITLE
Add page types for HTTP

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP authentication
 slug: Web/HTTP/Authentication
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Choosing between www and non-www URLs
 slug: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Data URLs
 slug: Web/HTTP/Basics_of_HTTP/Data_URLs
+page-type: guide
 browser-compat: http.data-url
 ---
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -1,6 +1,7 @@
 ---
 title: Evolution of HTTP
 slug: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -1,6 +1,7 @@
 ---
 title: Identifying resources on the Web
 slug: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
+page-type: guide
 spec-urls: https://httpwg.org/specs/rfc9110.html#uri
 ---
 

--- a/files/en-us/web/http/basics_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basics of HTTP
 slug: Web/HTTP/Basics_of_HTTP
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/mime_types/common_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/common_types/index.md
@@ -1,6 +1,7 @@
 ---
 title: Common MIME types
 slug: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/mime_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIME types (IANA media types)
 slug: Web/HTTP/Basics_of_HTTP/MIME_types
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/basics_of_http/resource_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/resource_urls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resource URLs
 slug: Web/HTTP/Basics_of_HTTP/Resource_URLs
+page-type: guide
 ---
 
 {{HTTPSidebar}}{{non-standard_header}}

--- a/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Browser detection using the user agent
 slug: Web/HTTP/Browser_detection_using_the_user_agent
+page-type: guide
 ---
 
 {{HTTPSidebar}}
@@ -43,7 +44,10 @@ if (navigator.userAgent.includes("Chrome")) {
   splitUpString = (str) => String(str).split(camelCaseExpression);
 } else {
   // This fallback code is much less performant, but works
-  splitUpString = (str) => String(str).split(/(.*?[A-Z])/).filter(Boolean);
+  splitUpString = (str) =>
+    String(str)
+      .split(/(.*?[A-Z])/)
+      .filter(Boolean);
 }
 
 console.log(splitUpString("fooBar")); // ["fooB", "ar"]
@@ -71,7 +75,10 @@ try {
 
 const splitUpString = isLookBehindSupported
   ? (str) => String(str).split(new RegExp("(?<=[A-Z])"))
-  : (str) => String(str).split(/(.*?[A-Z])/).filter(Boolean);
+  : (str) =>
+      String(str)
+        .split(/(.*?[A-Z])/)
+        .filter(Boolean);
 
 console.log(splitUpString("fooBar")); // ["fooB", "ar"]
 console.log(splitUpString("jQWhy")); // ["jQ", "W", "hy"]

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP caching
 slug: Web/HTTP/Caching
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP Client hints
 slug: Web/HTTP/Client_hints
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/compression/index.md
+++ b/files/en-us/web/http/compression/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compression in HTTP
 slug: Web/HTTP/Compression
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/conditional_requests/index.md
+++ b/files/en-us/web/http/conditional_requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP conditional requests
 slug: Web/HTTP/Conditional_requests
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -1,6 +1,7 @@
 ---
 title: Configuring servers for Ogg media
 slug: Web/HTTP/Configuring_servers_for_Ogg_media
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/connection_management_in_http_1.x/index.md
+++ b/files/en-us/web/http/connection_management_in_http_1.x/index.md
@@ -1,6 +1,7 @@
 ---
 title: Connection management in HTTP/1.x
 slug: Web/HTTP/Connection_management_in_HTTP_1.x
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/content_negotiation/index.md
+++ b/files/en-us/web/http/content_negotiation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content negotiation
 slug: Web/HTTP/Content_negotiation
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -1,6 +1,7 @@
 ---
 title: List of default Accept values
 slug: Web/HTTP/Content_negotiation/List_of_default_Accept_values
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using HTTP cookies
 slug: Web/HTTP/Cookies
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS header 'Access-Control-Allow-Origin' does not match 'xyz'"
 slug: Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsdidnotsucceed/index.md
+++ b/files/en-us/web/http/cors/errors/corsdidnotsucceed/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS request did not succeed"
 slug: Web/HTTP/CORS/Errors/CORSDidNotSucceed
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsdisabled/index.md
+++ b/files/en-us/web/http/cors/errors/corsdisabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS disabled"
 slug: Web/HTTP/CORS/Errors/CORSDisabled
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsexternalredirectnotallowed/index.md
+++ b/files/en-us/web/http/cors/errors/corsexternalredirectnotallowed/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS request external redirect not allowed"
 slug: Web/HTTP/CORS/Errors/CORSExternalRedirectNotAllowed
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsinvalidallowheader/index.md
+++ b/files/en-us/web/http/cors/errors/corsinvalidallowheader/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Headers'"
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowHeader
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsinvalidallowmethod/index.md
+++ b/files/en-us/web/http/cors/errors/corsinvalidallowmethod/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Methods'"
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowMethod
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
+++ b/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: Did not find method in CORS header 'Access-Control-Allow-Methods'"
 slug: Web/HTTP/CORS/Errors/CORSMethodNotFound
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: expected 'true' in CORS header 'Access-Control-Allow-Credentials'"
 slug: Web/HTTP/CORS/Errors/CORSMIssingAllowCredentials
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -1,6 +1,7 @@
 ---
 title: >-
   Reason: missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from
+page-type: http-cors-error
   CORS preflight channel
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
 ---

--- a/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -1,8 +1,8 @@
 ---
 title: >-
   Reason: missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from
-page-type: http-cors-error
   CORS preflight channel
+page-type: http-cors-error
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
 ---
 

--- a/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -2,8 +2,8 @@
 title: >-
   Reason: missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from
   CORS preflight channel
-page-type: http-cors-error
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS header 'Access-Control-Allow-Origin' missing"
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
+++ b/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: Multiple CORS header 'Access-Control-Allow-Origin' not allowed"
 slug: Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: >-
   Reason: Credential is not supported if the CORS header
+page-type: http-cors-error
   'Access-Control-Allow-Origin' is '*'
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---

--- a/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -2,8 +2,8 @@
 title: >-
   Reason: Credential is not supported if the CORS header
   'Access-Control-Allow-Origin' is '*'
-page-type: http-cors-error
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,8 +1,8 @@
 ---
 title: >-
   Reason: Credential is not supported if the CORS header
-page-type: http-cors-error
   'Access-Control-Allow-Origin' is '*'
+page-type: http-cors-error
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---
 

--- a/files/en-us/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/en-us/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS header 'Origin' cannot be added"
 slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corspreflightdidnotsucceed/index.md
+++ b/files/en-us/web/http/cors/errors/corspreflightdidnotsucceed/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS preflight channel did not succeed"
 slug: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reason: CORS request not HTTP"
 slug: Web/HTTP/CORS/Errors/CORSRequestNotHttp
+page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/errors/index.md
+++ b/files/en-us/web/http/cors/errors/index.md
@@ -1,6 +1,7 @@
 ---
 title: CORS errors
 slug: Web/HTTP/CORS/Errors
+page-type: landing-page
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-Origin Resource Sharing (CORS)
 slug: Web/HTTP/CORS
+page-type: guide
 browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 

--- a/files/en-us/web/http/cross-origin_resource_policy/index.md
+++ b/files/en-us/web/http/cross-origin_resource_policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-Origin Resource Policy (CORP)
 slug: Web/HTTP/Cross-Origin_Resource_Policy
+page-type: guide
 browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 

--- a/files/en-us/web/http/csp/errors/cspviolation/index.md
+++ b/files/en-us/web/http/csp/errors/cspviolation/index.md
@@ -1,6 +1,7 @@
 ---
 title: >-
   Content Security Policy: The page's settings blocked the loading of a
+page-type: guide
   resource: xyz
 slug: Web/HTTP/CSP/Errors/CSPViolation
 ---

--- a/files/en-us/web/http/csp/errors/cspviolation/index.md
+++ b/files/en-us/web/http/csp/errors/cspviolation/index.md
@@ -1,8 +1,8 @@
 ---
 title: >-
   Content Security Policy: The page's settings blocked the loading of a
-page-type: guide
   resource: xyz
+page-type: guide
 slug: Web/HTTP/CSP/Errors/CSPViolation
 ---
 

--- a/files/en-us/web/http/csp/errors/cspviolation/index.md
+++ b/files/en-us/web/http/csp/errors/cspviolation/index.md
@@ -2,8 +2,8 @@
 title: >-
   Content Security Policy: The page's settings blocked the loading of a
   resource: xyz
-page-type: guide
 slug: Web/HTTP/CSP/Errors/CSPViolation
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/csp/errors/index.md
+++ b/files/en-us/web/http/csp/errors/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSP errors and warnings (Content Security Policy)
 slug: Web/HTTP/CSP/Errors
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content Security Policy (CSP)
 slug: Web/HTTP/CSP
+page-type: guide
 browser-compat: http.headers.Content-Security-Policy
 ---
 

--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.md
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-CH-Lifetime
 slug: Web/HTTP/Headers/Accept-CH-Lifetime
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-CH
 slug: Web/HTTP/Headers/Accept-CH
+page-type: http-header
 browser-compat: http.headers.Accept-CH
 ---
 

--- a/files/en-us/web/http/headers/accept-charset/index.md
+++ b/files/en-us/web/http/headers/accept-charset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Charset
 slug: Web/HTTP/Headers/Accept-Charset
+page-type: http-header
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/accept-encoding/index.md
+++ b/files/en-us/web/http/headers/accept-encoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Encoding
 slug: Web/HTTP/Headers/Accept-Encoding
+page-type: http-header
 browser-compat: http.headers.Accept-Encoding
 ---
 

--- a/files/en-us/web/http/headers/accept-language/index.md
+++ b/files/en-us/web/http/headers/accept-language/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Language
 slug: Web/HTTP/Headers/Accept-Language
+page-type: http-header
 browser-compat: http.headers.Accept-Language
 ---
 

--- a/files/en-us/web/http/headers/accept-patch/index.md
+++ b/files/en-us/web/http/headers/accept-patch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Patch
 slug: Web/HTTP/Headers/Accept-Patch
+page-type: http-header
 spec-urls: https://www.rfc-editor.org/rfc/rfc5789#section-3.1
 ---
 

--- a/files/en-us/web/http/headers/accept-post/index.md
+++ b/files/en-us/web/http/headers/accept-post/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Post
 slug: Web/HTTP/Headers/Accept-Post
+page-type: http-header
 spec-urls: https://www.w3.org/TR/ldp/#header-accept-post
 ---
 

--- a/files/en-us/web/http/headers/accept-ranges/index.md
+++ b/files/en-us/web/http/headers/accept-ranges/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept-Ranges
 slug: Web/HTTP/Headers/Accept-Ranges
+page-type: http-header
 browser-compat: http.headers.Accept-Ranges
 ---
 

--- a/files/en-us/web/http/headers/accept/index.md
+++ b/files/en-us/web/http/headers/accept/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accept
 slug: Web/HTTP/Headers/Accept
+page-type: http-header
 browser-compat: http.headers.Accept
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Allow-Credentials
 slug: Web/HTTP/Headers/Access-Control-Allow-Credentials
+page-type: http-header
 browser-compat: http.headers.Access-Control-Allow-Credentials
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Allow-Headers
 slug: Web/HTTP/Headers/Access-Control-Allow-Headers
+page-type: http-header
 browser-compat: http.headers.Access-Control-Allow-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Allow-Methods
 slug: Web/HTTP/Headers/Access-Control-Allow-Methods
+page-type: http-header
 browser-compat: http.headers.Access-Control-Allow-Methods
 ---
 

--- a/files/en-us/web/http/headers/access-control-allow-origin/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Allow-Origin
 slug: Web/HTTP/Headers/Access-Control-Allow-Origin
+page-type: http-header
 browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Expose-Headers
 slug: Web/HTTP/Headers/Access-Control-Expose-Headers
+page-type: http-header
 browser-compat: http.headers.Access-Control-Expose-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/headers/access-control-max-age/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Max-Age
 slug: Web/HTTP/Headers/Access-Control-Max-Age
+page-type: http-header
 browser-compat: http.headers.Access-Control-Max-Age
 ---
 

--- a/files/en-us/web/http/headers/access-control-request-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Request-Headers
 slug: Web/HTTP/Headers/Access-Control-Request-Headers
+page-type: http-header
 browser-compat: http.headers.Access-Control-Request-Headers
 ---
 

--- a/files/en-us/web/http/headers/access-control-request-method/index.md
+++ b/files/en-us/web/http/headers/access-control-request-method/index.md
@@ -1,6 +1,7 @@
 ---
 title: Access-Control-Request-Method
 slug: Web/HTTP/Headers/Access-Control-Request-Method
+page-type: http-header
 browser-compat: http.headers.Access-Control-Request-Method
 ---
 

--- a/files/en-us/web/http/headers/age/index.md
+++ b/files/en-us/web/http/headers/age/index.md
@@ -1,6 +1,7 @@
 ---
 title: Age
 slug: Web/HTTP/Headers/Age
+page-type: http-header
 browser-compat: http.headers.Age
 ---
 

--- a/files/en-us/web/http/headers/allow/index.md
+++ b/files/en-us/web/http/headers/allow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Allow
 slug: Web/HTTP/Headers/Allow
+page-type: http-header
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.allow
 ---
 

--- a/files/en-us/web/http/headers/alt-svc/index.md
+++ b/files/en-us/web/http/headers/alt-svc/index.md
@@ -1,6 +1,7 @@
 ---
 title: Alt-Svc
 slug: Web/HTTP/Headers/Alt-Svc
+page-type: http-header
 browser-compat: http.headers.Alt-Svc
 ---
 

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 slug: Web/HTTP/Headers/Authorization
+page-type: http-header
 browser-compat: http.headers.Authorization
 ---
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache-Control
 slug: Web/HTTP/Headers/Cache-Control
+page-type: http-header
 browser-compat: http.headers.Cache-Control
 ---
 

--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clear-Site-Data
 slug: Web/HTTP/Headers/Clear-Site-Data
+page-type: http-header
 browser-compat: http.headers.Clear-Site-Data
 ---
 

--- a/files/en-us/web/http/headers/connection/index.md
+++ b/files/en-us/web/http/headers/connection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Connection
 slug: Web/HTTP/Headers/Connection
+page-type: http-header
 browser-compat: http.headers.Connection
 ---
 

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Disposition
 slug: Web/HTTP/Headers/Content-Disposition
+page-type: http-header
 browser-compat: http.headers.Content-Disposition
 ---
 

--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-DPR
 slug: Web/HTTP/Headers/Content-DPR
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Encoding
 slug: Web/HTTP/Headers/Content-Encoding
+page-type: http-header
 browser-compat: http.headers.Content-Encoding
 ---
 

--- a/files/en-us/web/http/headers/content-language/index.md
+++ b/files/en-us/web/http/headers/content-language/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Language
 slug: Web/HTTP/Headers/Content-Language
+page-type: http-header
 browser-compat: http.headers.Content-Language
 ---
 

--- a/files/en-us/web/http/headers/content-length/index.md
+++ b/files/en-us/web/http/headers/content-length/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
+page-type: http-header
 browser-compat: http.headers.Content-Length
 ---
 

--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Location
 slug: Web/HTTP/Headers/Content-Location
+page-type: http-header
 browser-compat: http.headers.Content-Location
 ---
 

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Range
 slug: Web/HTTP/Headers/Content-Range
+page-type: http-header
 browser-compat: http.headers.Content-Range
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Security-Policy-Report-Only
 slug: Web/HTTP/Headers/Content-Security-Policy-Report-Only
+page-type: http-header
 browser-compat: http.headers.Content-Security-Policy-Report-Only
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: base-uri"
 slug: Web/HTTP/Headers/Content-Security-Policy/base-uri
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.base-uri
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: block-all-mixed-content"
 slug: Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content
+page-type: http-csp-directive
 status:
   - deprecated
 browser-compat: http.headers.Content-Security-Policy.block-all-mixed-content

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: child-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/child-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.child-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: connect-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/connect-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.connect-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: default-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/default-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.default-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: font-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/font-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.font-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: form-action"
 slug: Web/HTTP/Headers/Content-Security-Policy/form-action
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.form-action
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: frame-ancestors"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.frame-ancestors
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: frame-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.frame-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: img-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/img-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.img-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Security-Policy
 slug: Web/HTTP/Headers/Content-Security-Policy
+page-type: http-header
 browser-compat: http.headers.Content-Security-Policy
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: manifest-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/manifest-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.manifest-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: media-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/media-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.media-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: object-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/object-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.object-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: plugin-types"
 slug: Web/HTTP/Headers/Content-Security-Policy/plugin-types
+page-type: http-csp-directive
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: prefetch-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/prefetch-src
+page-type: http-csp-directive
 status:
   - experimental
 browser-compat: http.headers.Content-Security-Policy.prefetch-src

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: referrer"
 slug: Web/HTTP/Headers/Content-Security-Policy/referrer
+page-type: http-csp-directive
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: report-to"
 slug: Web/HTTP/Headers/Content-Security-Policy/report-to
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.report-to
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: report-uri"
 slug: Web/HTTP/Headers/Content-Security-Policy/report-uri
+page-type: http-csp-directive
 status:
   - deprecated
 browser-compat: http.headers.Content-Security-Policy.report-uri

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: require-trusted-types-for"
 slug: Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
+page-type: http-csp-directive
 status:
   - experimental
 browser-compat: http.headers.Content-Security-Policy.require-trusted-types-for

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: sandbox"
 slug: Web/HTTP/Headers/Content-Security-Policy/sandbox
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.sandbox
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: script-src-attr"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src-attr
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.script-src-attr
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: script-src-elem"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src-elem
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.script-src-elem
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: script-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.script-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP source values"
 slug: Web/HTTP/Headers/Content-Security-Policy/Sources
+page-type: http-csp-directive
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: style-src-attr"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src-attr
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.style-src-attr
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: style-src-elem"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src-elem
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.style-src-elem
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: style-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.style-src
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: trusted-types"
 slug: Web/HTTP/Headers/Content-Security-Policy/trusted-types
+page-type: http-csp-directive
 status:
   - experimental
 browser-compat: http.headers.Content-Security-Policy.trusted-types

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: upgrade-insecure-requests"
 slug: Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.upgrade-insecure-requests
 ---
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -1,6 +1,7 @@
 ---
 title: "CSP: worker-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/worker-src
+page-type: http-csp-directive
 browser-compat: http.headers.Content-Security-Policy.worker-src
 ---
 

--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Type
 slug: Web/HTTP/Headers/Content-Type
+page-type: http-header
 browser-compat: http.headers.Content-Type
 ---
 

--- a/files/en-us/web/http/headers/cookie/index.md
+++ b/files/en-us/web/http/headers/cookie/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cookie
 slug: Web/HTTP/Headers/Cookie
+page-type: http-header
 browser-compat: http.headers.Cookie
 ---
 

--- a/files/en-us/web/http/headers/critical-ch/index.md
+++ b/files/en-us/web/http/headers/critical-ch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Critical-CH
 slug: Web/HTTP/Headers/Critical-CH
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Critical-CH

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-Origin-Embedder-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+page-type: http-header
 browser-compat: http.headers.Cross-Origin-Embedder-Policy
 ---
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-Origin-Opener-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Opener-Policy
+page-type: http-header
 browser-compat: http.headers.Cross-Origin-Opener-Policy
 ---
 

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-Origin-Resource-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Resource-Policy
+page-type: http-header
 browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 

--- a/files/en-us/web/http/headers/date/index.md
+++ b/files/en-us/web/http/headers/date/index.md
@@ -1,6 +1,7 @@
 ---
 title: Date
 slug: Web/HTTP/Headers/Date
+page-type: http-header
 browser-compat: http.headers.Date
 ---
 

--- a/files/en-us/web/http/headers/device-memory/index.md
+++ b/files/en-us/web/http/headers/device-memory/index.md
@@ -1,6 +1,7 @@
 ---
 title: Device-Memory
 slug: Web/HTTP/Headers/Device-Memory
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Device-Memory

--- a/files/en-us/web/http/headers/digest/index.md
+++ b/files/en-us/web/http/headers/digest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Digest
 slug: Web/HTTP/Headers/Digest
+page-type: http-header
 browser-compat: http.headers.Digest
 ---
 

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -1,6 +1,7 @@
 ---
 title: DNT
 slug: Web/HTTP/Headers/DNT
+page-type: http-header
 status:
   - deprecated
 browser-compat: http.headers.DNT

--- a/files/en-us/web/http/headers/downlink/index.md
+++ b/files/en-us/web/http/headers/downlink/index.md
@@ -1,6 +1,7 @@
 ---
 title: Downlink
 slug: Web/HTTP/Headers/Downlink
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.downlink

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -1,6 +1,7 @@
 ---
 title: DPR
 slug: Web/HTTP/Headers/DPR
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/early-data/index.md
+++ b/files/en-us/web/http/headers/early-data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Early-Data
 slug: Web/HTTP/Headers/Early-Data
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Early-Data

--- a/files/en-us/web/http/headers/ect/index.md
+++ b/files/en-us/web/http/headers/ect/index.md
@@ -1,6 +1,7 @@
 ---
 title: ECT
 slug: Web/HTTP/Headers/ECT
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.ect

--- a/files/en-us/web/http/headers/etag/index.md
+++ b/files/en-us/web/http/headers/etag/index.md
@@ -1,6 +1,7 @@
 ---
 title: ETag
 slug: Web/HTTP/Headers/ETag
+page-type: http-header
 browser-compat: http.headers.ETag
 ---
 

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -1,6 +1,7 @@
 ---
 title: Expect-CT
 slug: Web/HTTP/Headers/Expect-CT
+page-type: http-header
 browser-compat: http.headers.Expect-CT
 ---
 

--- a/files/en-us/web/http/headers/expect/index.md
+++ b/files/en-us/web/http/headers/expect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Expect
 slug: Web/HTTP/Headers/Expect
+page-type: http-header
 browser-compat: http.headers.Expect
 ---
 

--- a/files/en-us/web/http/headers/expires/index.md
+++ b/files/en-us/web/http/headers/expires/index.md
@@ -1,6 +1,7 @@
 ---
 title: Expires
 slug: Web/HTTP/Headers/Expires
+page-type: http-header
 browser-compat: http.headers.Expires
 ---
 

--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -1,6 +1,7 @@
 ---
 title: Forwarded
 slug: Web/HTTP/Headers/Forwarded
+page-type: http-header
 browser-compat: http.headers.Forwarded
 ---
 

--- a/files/en-us/web/http/headers/from/index.md
+++ b/files/en-us/web/http/headers/from/index.md
@@ -1,6 +1,7 @@
 ---
 title: From
 slug: Web/HTTP/Headers/From
+page-type: http-header
 browser-compat: http.headers.From
 ---
 

--- a/files/en-us/web/http/headers/host/index.md
+++ b/files/en-us/web/http/headers/host/index.md
@@ -1,6 +1,7 @@
 ---
 title: Host
 slug: Web/HTTP/Headers/Host
+page-type: http-header
 browser-compat: http.headers.Host
 ---
 

--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -1,6 +1,7 @@
 ---
 title: If-Match
 slug: Web/HTTP/Headers/If-Match
+page-type: http-header
 browser-compat: http.headers.If-Match
 ---
 

--- a/files/en-us/web/http/headers/if-modified-since/index.md
+++ b/files/en-us/web/http/headers/if-modified-since/index.md
@@ -1,6 +1,7 @@
 ---
 title: If-Modified-Since
 slug: Web/HTTP/Headers/If-Modified-Since
+page-type: http-header
 browser-compat: http.headers.If-Modified-Since
 ---
 

--- a/files/en-us/web/http/headers/if-none-match/index.md
+++ b/files/en-us/web/http/headers/if-none-match/index.md
@@ -1,6 +1,7 @@
 ---
 title: If-None-Match
 slug: Web/HTTP/Headers/If-None-Match
+page-type: http-header
 browser-compat: http.headers.If-None-Match
 ---
 

--- a/files/en-us/web/http/headers/if-range/index.md
+++ b/files/en-us/web/http/headers/if-range/index.md
@@ -1,6 +1,7 @@
 ---
 title: If-Range
 slug: Web/HTTP/Headers/If-Range
+page-type: http-header
 browser-compat: http.headers.If-Range
 ---
 

--- a/files/en-us/web/http/headers/if-unmodified-since/index.md
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.md
@@ -1,6 +1,7 @@
 ---
 title: If-Unmodified-Since
 slug: Web/HTTP/Headers/If-Unmodified-Since
+page-type: http-header
 browser-compat: http.headers.If-Unmodified-Since
 ---
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP headers
 slug: Web/HTTP/Headers
+page-type: landing-page
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/keep-alive/index.md
+++ b/files/en-us/web/http/headers/keep-alive/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keep-Alive
 slug: Web/HTTP/Headers/Keep-Alive
+page-type: http-header
 browser-compat: http.headers.Keep-Alive
 ---
 

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Large-Allocation
 slug: Web/HTTP/Headers/Large-Allocation
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/last-modified/index.md
+++ b/files/en-us/web/http/headers/last-modified/index.md
@@ -1,6 +1,7 @@
 ---
 title: Last-Modified
 slug: Web/HTTP/Headers/Last-Modified
+page-type: http-header
 browser-compat: http.headers.Last-Modified
 ---
 

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -1,6 +1,7 @@
 ---
 title: Link
 slug: Web/HTTP/Headers/Link
+page-type: http-header
 browser-compat: http.headers.Link
 ---
 

--- a/files/en-us/web/http/headers/location/index.md
+++ b/files/en-us/web/http/headers/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: Location
 slug: Web/HTTP/Headers/Location
+page-type: http-header
 browser-compat: http.headers.Location
 ---
 

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -1,6 +1,7 @@
 ---
 title: Max-Forwards
 slug: Web/HTTP/Headers/Max-Forwards
+page-type: http-header
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.max-forwards
 ---
 

--- a/files/en-us/web/http/headers/nel/index.md
+++ b/files/en-us/web/http/headers/nel/index.md
@@ -1,6 +1,7 @@
 ---
 title: NEL
 slug: Web/HTTP/Headers/NEL
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.NEL

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Origin
 slug: Web/HTTP/Headers/Origin
+page-type: http-header
 browser-compat: http.headers.Origin
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/accelerometer/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/accelerometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: accelerometer"
 slug: Web/HTTP/Headers/Permissions-Policy/accelerometer
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.accelerometer

--- a/files/en-us/web/http/headers/permissions-policy/ambient-light-sensor/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/ambient-light-sensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: ambient-light-sensor"
 slug: Web/HTTP/Headers/Permissions-Policy/ambient-light-sensor
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.ambient-light-sensor

--- a/files/en-us/web/http/headers/permissions-policy/autoplay/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/autoplay/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: autoplay"
 slug: Web/HTTP/Headers/Permissions-Policy/autoplay
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.autoplay

--- a/files/en-us/web/http/headers/permissions-policy/battery/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/battery/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: battery"
 slug: Web/HTTP/Headers/Permissions-Policy/battery
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.battery

--- a/files/en-us/web/http/headers/permissions-policy/camera/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/camera/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: camera"
 slug: Web/HTTP/Headers/Permissions-Policy/camera
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.camera
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/display-capture/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/display-capture/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: display-capture"
 slug: Web/HTTP/Headers/Permissions-Policy/display-capture
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.display-capture
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/document-domain/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/document-domain/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: document-domain"
 slug: Web/HTTP/Headers/Permissions-Policy/document-domain
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.document-domain

--- a/files/en-us/web/http/headers/permissions-policy/encrypted-media/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/encrypted-media/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: encrypted-media"
 slug: Web/HTTP/Headers/Permissions-Policy/encrypted-media
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.encrypted-media

--- a/files/en-us/web/http/headers/permissions-policy/execution-while-not-rendered/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/execution-while-not-rendered/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: execution-while-not-rendered"
 slug: Web/HTTP/Headers/Permissions-Policy/execution-while-not-rendered
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.execution-while-not-rendered

--- a/files/en-us/web/http/headers/permissions-policy/execution-while-out-of-viewport/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/execution-while-out-of-viewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: execution-while-out-of-viewport"
 slug: Web/HTTP/Headers/Permissions-Policy/execution-while-out-of-viewport
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.execution-while-out-of-viewport

--- a/files/en-us/web/http/headers/permissions-policy/fullscreen/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/fullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: fullscreen"
 slug: Web/HTTP/Headers/Permissions-Policy/fullscreen
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.fullscreen
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/gamepad/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/gamepad/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: gamepad"
 slug: Web/HTTP/Headers/Permissions-Policy/gamepad
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.gamepad

--- a/files/en-us/web/http/headers/permissions-policy/geolocation/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/geolocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: geolocation"
 slug: Web/HTTP/Headers/Permissions-Policy/geolocation
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.geolocation
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/gyroscope/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/gyroscope/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: gyroscope"
 slug: Web/HTTP/Headers/Permissions-Policy/gyroscope
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.gyroscope

--- a/files/en-us/web/http/headers/permissions-policy/hid/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/hid/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: hid"
 slug: Web/HTTP/Headers/Permissions-Policy/hid
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.hid

--- a/files/en-us/web/http/headers/permissions-policy/identity-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/identity-credentials-get/index.md
@@ -1,6 +1,7 @@
 ---
-title: 'Permissions-Policy: identity-credentials-get'
+title: "Permissions-Policy: identity-credentials-get"
 slug: Web/HTTP/Headers/Permissions-Policy/identity-credentials-get
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.identity-credentials-get

--- a/files/en-us/web/http/headers/permissions-policy/idle-detection/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/idle-detection/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: idle-detection"
 slug: Web/HTTP/Headers/Permissions-Policy/idle-detection
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.idle-detection

--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions-Policy
 slug: Web/HTTP/Headers/Permissions-Policy
+page-type: http-header
 browser-compat: http.headers.Permissions-Policy
 ---
 
@@ -125,6 +126,7 @@ You can specify
   - : Controls whether the current document is allowed to use the {{domxref("WebHID API", "WebHID API", "", "nocode")}} to connect to uncommon or exotic human interface devices such as alternative keyboards or gamepads.
 
 - {{httpheader('Permissions-Policy/identity-credentials-get','identity-credentials-get')}} {{Experimental_Inline}}
+
   - : Controls whether the current document is allowed to use the [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API), and more specifically the {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} method with an `identity` option. Where this policy forbids use of the API, the {{jsxref("Promise")}} returned by the `get()` call will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 
 - {{httpheader('Permissions-Policy/idle-detection','idle-detection')}} {{Experimental_Inline}}

--- a/files/en-us/web/http/headers/permissions-policy/local-fonts/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/local-fonts/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: local-fonts"
 slug: Web/HTTP/Headers/Permissions-Policy/local-fonts
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.local-fonts

--- a/files/en-us/web/http/headers/permissions-policy/magnetometer/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/magnetometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: magnetometer"
 slug: Web/HTTP/Headers/Permissions-Policy/magnetometer
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.magnetometer

--- a/files/en-us/web/http/headers/permissions-policy/microphone/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/microphone/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: microphone"
 slug: Web/HTTP/Headers/Permissions-Policy/microphone
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.microphone
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/midi/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/midi/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: midi"
 slug: Web/HTTP/Headers/Permissions-Policy/midi
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.midi

--- a/files/en-us/web/http/headers/permissions-policy/payment/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/payment/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: payment"
 slug: Web/HTTP/Headers/Permissions-Policy/payment
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.payment

--- a/files/en-us/web/http/headers/permissions-policy/picture-in-picture/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/picture-in-picture/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: picture-in-picture"
 slug: Web/HTTP/Headers/Permissions-Policy/picture-in-picture
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.picture-in-picture

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: publickey-credentials-get"
 slug: Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.publickey-credentials-get

--- a/files/en-us/web/http/headers/permissions-policy/screen-wake-lock/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/screen-wake-lock/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: screen-wake-lock"
 slug: Web/HTTP/Headers/Permissions-Policy/screen-wake-lock
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.screen-wake-lock

--- a/files/en-us/web/http/headers/permissions-policy/serial/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/serial/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: serial"
 slug: Web/HTTP/Headers/Permissions-Policy/serial
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.serial

--- a/files/en-us/web/http/headers/permissions-policy/speaker-selection/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/speaker-selection/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: speaker-selection"
 slug: Web/HTTP/Headers/Permissions-Policy/speaker-selection
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.speaker-selection

--- a/files/en-us/web/http/headers/permissions-policy/usb/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/usb/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: usb"
 slug: Web/HTTP/Headers/Permissions-Policy/usb
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.usb

--- a/files/en-us/web/http/headers/permissions-policy/web-share/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/web-share/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: web-share"
 slug: Web/HTTP/Headers/Permissions-Policy/web-share
+page-type: http-permissions-policy-directive
 browser-compat: http.headers.Permissions-Policy.web-share
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/xr-spatial-tracking/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/xr-spatial-tracking/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: xr-spatial-tracking"
 slug: Web/HTTP/Headers/Permissions-Policy/xr-spatial-tracking
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.xr-spatial-tracking

--- a/files/en-us/web/http/headers/pragma/index.md
+++ b/files/en-us/web/http/headers/pragma/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pragma
 slug: Web/HTTP/Headers/Pragma
+page-type: http-header
 status:
   - deprecated
 browser-compat: http.headers.Pragma

--- a/files/en-us/web/http/headers/proxy-authenticate/index.md
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Proxy-Authenticate
 slug: Web/HTTP/Headers/Proxy-Authenticate
+page-type: http-header
 browser-compat: http.headers.Proxy-Authenticate
 ---
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -1,6 +1,7 @@
 ---
 title: Proxy-Authorization
 slug: Web/HTTP/Headers/Proxy-Authorization
+page-type: http-header
 spec-urls: https://httpwg.org/specs/rfc9110.html#field.proxy-authorization
 ---
 

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range
 slug: Web/HTTP/Headers/Range
+page-type: http-header
 browser-compat: http.headers.Range
 ---
 

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Referer
 slug: Web/HTTP/Headers/Referer
+page-type: http-header
 browser-compat: http.headers.Referer
 ---
 

--- a/files/en-us/web/http/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/headers/referrer-policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Referrer-Policy
 slug: Web/HTTP/Headers/Referrer-Policy
+page-type: http-header
 browser-compat: http.headers.Referrer-Policy
 ---
 

--- a/files/en-us/web/http/headers/retry-after/index.md
+++ b/files/en-us/web/http/headers/retry-after/index.md
@@ -1,6 +1,7 @@
 ---
 title: Retry-After
 slug: Web/HTTP/Headers/Retry-After
+page-type: http-header
 browser-compat: http.headers.Retry-After
 ---
 

--- a/files/en-us/web/http/headers/rtt/index.md
+++ b/files/en-us/web/http/headers/rtt/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTT
 slug: Web/HTTP/Headers/RTT
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.rtt

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Save-Data
 slug: Web/HTTP/Headers/Save-Data
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Save-Data

--- a/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-Prefers-Reduced-Motion
 slug: Web/HTTP/Headers/Sec-CH-Prefers-Reduced-Motion
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-Prefers-Reduced-Motion

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Arch
 slug: Web/HTTP/Headers/Sec-CH-UA-Arch
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Arch

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Bitness
 slug: Web/HTTP/Headers/Sec-CH-UA-Bitness
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Bitness

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Full-Version-List
 slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version-List
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Full-Version-List

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Full-Version
 slug: Web/HTTP/Headers/Sec-CH-UA-Full-Version
+page-type: http-header
 status:
   - deprecated
 browser-compat: http.headers.Sec-CH-UA-Full-Version

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Mobile
 slug: Web/HTTP/Headers/Sec-CH-UA-Mobile
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Mobile

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Model
 slug: Web/HTTP/Headers/Sec-CH-UA-Model
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Model

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Platform-Version
 slug: Web/HTTP/Headers/Sec-CH-UA-Platform-Version
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Platform-Version

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA-Platform
 slug: Web/HTTP/Headers/Sec-CH-UA-Platform
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA-Platform

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-UA
 slug: Web/HTTP/Headers/Sec-CH-UA
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-UA

--- a/files/en-us/web/http/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-Fetch-Dest
 slug: Web/HTTP/Headers/Sec-Fetch-Dest
+page-type: http-header
 browser-compat: http.headers.Sec-Fetch-Dest
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-mode/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-Fetch-Mode
 slug: Web/HTTP/Headers/Sec-Fetch-Mode
+page-type: http-header
 browser-compat: http.headers.Sec-Fetch-Mode
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-site/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-site/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-Fetch-Site
 slug: Web/HTTP/Headers/Sec-Fetch-Site
+page-type: http-header
 browser-compat: http.headers.Sec-Fetch-Site
 ---
 

--- a/files/en-us/web/http/headers/sec-fetch-user/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-user/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-Fetch-User
 slug: Web/HTTP/Headers/Sec-Fetch-User
+page-type: http-header
 browser-compat: http.headers.Sec-Fetch-User
 ---
 

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-GPC
 slug: Web/HTTP/Headers/Sec-GPC
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-GPC

--- a/files/en-us/web/http/headers/sec-websocket-accept/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-WebSocket-Accept
 slug: Web/HTTP/Headers/Sec-WebSocket-Accept
+page-type: http-header
 browser-compat: http.headers.Sec-WebSocket-Accept
 ---
 

--- a/files/en-us/web/http/headers/server-timing/index.md
+++ b/files/en-us/web/http/headers/server-timing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Server-Timing
 slug: Web/HTTP/Headers/Server-Timing
+page-type: http-header
 browser-compat: http.headers.Server-Timing
 ---
 

--- a/files/en-us/web/http/headers/server/index.md
+++ b/files/en-us/web/http/headers/server/index.md
@@ -1,6 +1,7 @@
 ---
 title: Server
 slug: Web/HTTP/Headers/Server
+page-type: http-header
 browser-compat: http.headers.Server
 ---
 

--- a/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
+++ b/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
@@ -1,6 +1,7 @@
 ---
 title: Service-Worker-Navigation-Preload
 slug: Web/HTTP/Headers/Service-Worker-Navigation-Preload
+page-type: http-header
 browser-compat: http.headers.Service-Worker-Navigation-Preload
 ---
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -1,6 +1,7 @@
 ---
 title: Set-Cookie
 slug: Web/HTTP/Headers/Set-Cookie
+page-type: http-header
 browser-compat: http.headers.Set-Cookie
 ---
 

--- a/files/en-us/web/http/headers/sourcemap/index.md
+++ b/files/en-us/web/http/headers/sourcemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: SourceMap
 slug: Web/HTTP/Headers/SourceMap
+page-type: http-header
 browser-compat: http.headers.SourceMap
 ---
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -1,6 +1,7 @@
 ---
 title: Strict-Transport-Security
 slug: Web/HTTP/Headers/Strict-Transport-Security
+page-type: http-header
 browser-compat: http.headers.Strict-Transport-Security
 ---
 

--- a/files/en-us/web/http/headers/te/index.md
+++ b/files/en-us/web/http/headers/te/index.md
@@ -1,6 +1,7 @@
 ---
 title: TE
 slug: Web/HTTP/Headers/TE
+page-type: http-header
 browser-compat: http.headers.TE
 ---
 

--- a/files/en-us/web/http/headers/timing-allow-origin/index.md
+++ b/files/en-us/web/http/headers/timing-allow-origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Timing-Allow-Origin
 slug: Web/HTTP/Headers/Timing-Allow-Origin
+page-type: http-header
 browser-compat: http.headers.Timing-Allow-Origin
 ---
 

--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tk
 slug: Web/HTTP/Headers/Tk
+page-type: http-header
 status:
   - deprecated
 browser-compat: http.headers.Tk

--- a/files/en-us/web/http/headers/trailer/index.md
+++ b/files/en-us/web/http/headers/trailer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Trailer
 slug: Web/HTTP/Headers/Trailer
+page-type: http-header
 browser-compat: http.headers.Trailer
 ---
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
+page-type: http-header
 browser-compat: http.headers.Transfer-Encoding
 ---
 

--- a/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade-Insecure-Requests
 slug: Web/HTTP/Headers/Upgrade-Insecure-Requests
+page-type: http-header
 browser-compat: http.headers.Upgrade-Insecure-Requests
 ---
 

--- a/files/en-us/web/http/headers/upgrade/index.md
+++ b/files/en-us/web/http/headers/upgrade/index.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade
 slug: Web/HTTP/Headers/Upgrade
+page-type: http-header
 browser-compat: http.headers.Upgrade
 ---
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox user agent string reference
 slug: Web/HTTP/Headers/User-Agent/Firefox
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/headers/user-agent/index.md
+++ b/files/en-us/web/http/headers/user-agent/index.md
@@ -1,6 +1,7 @@
 ---
 title: User-Agent
 slug: Web/HTTP/Headers/User-Agent
+page-type: http-header
 browser-compat: http.headers.User-Agent
 ---
 

--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -1,6 +1,7 @@
 ---
 title: Vary
 slug: Web/HTTP/Headers/Vary
+page-type: http-header
 browser-compat: http.headers.Vary
 ---
 

--- a/files/en-us/web/http/headers/via/index.md
+++ b/files/en-us/web/http/headers/via/index.md
@@ -1,6 +1,7 @@
 ---
 title: Via
 slug: Web/HTTP/Headers/Via
+page-type: http-header
 browser-compat: http.headers.Via
 ---
 

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -1,6 +1,7 @@
 ---
 title: Viewport-Width
 slug: Web/HTTP/Headers/Viewport-Width
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/want-digest/index.md
+++ b/files/en-us/web/http/headers/want-digest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Want-Digest
 slug: Web/HTTP/Headers/Want-Digest
+page-type: http-header
 browser-compat: http.headers.Want-Digest
 ---
 

--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -1,6 +1,7 @@
 ---
 title: Warning
 slug: Web/HTTP/Headers/Warning
+page-type: http-header
 status:
   - deprecated
 browser-compat: http.headers.Warning

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: Width
 slug: Web/HTTP/Headers/Width
+page-type: http-header
 status:
   - deprecated
   - non-standard

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WWW-Authenticate
 slug: Web/HTTP/Headers/WWW-Authenticate
+page-type: http-header
 browser-compat: http.headers.WWW-Authenticate
 ---
 

--- a/files/en-us/web/http/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/headers/x-content-type-options/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-Content-Type-Options
 slug: Web/HTTP/Headers/X-Content-Type-Options
+page-type: http-header
 browser-compat: http.headers.X-Content-Type-Options
 ---
 

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-DNS-Prefetch-Control
 slug: Web/HTTP/Headers/X-DNS-Prefetch-Control
+page-type: http-header
 status:
   - non-standard
 browser-compat: http.headers.X-DNS-Prefetch-Control

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-Forwarded-For
 slug: Web/HTTP/Headers/X-Forwarded-For
+page-type: http-header
 status:
   - non-standard
 ---

--- a/files/en-us/web/http/headers/x-forwarded-host/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-Forwarded-Host
 slug: Web/HTTP/Headers/X-Forwarded-Host
+page-type: http-header
 status:
   - non-standard
 ---

--- a/files/en-us/web/http/headers/x-forwarded-proto/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-proto/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-Forwarded-Proto
 slug: Web/HTTP/Headers/X-Forwarded-Proto
+page-type: http-header
 status:
   - non-standard
 ---

--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
+page-type: http-header
 browser-compat: http.headers.X-Frame-Options
 ---
 

--- a/files/en-us/web/http/headers/x-xss-protection/index.md
+++ b/files/en-us/web/http/headers/x-xss-protection/index.md
@@ -1,6 +1,7 @@
 ---
 title: X-XSS-Protection
 slug: Web/HTTP/Headers/X-XSS-Protection
+page-type: http-header
 status:
   - non-standard
 browser-compat: http.headers.X-XSS-Protection

--- a/files/en-us/web/http/link_prefetching_faq/index.md
+++ b/files/en-us/web/http/link_prefetching_faq/index.md
@@ -1,6 +1,7 @@
 ---
 title: Link prefetching FAQ
 slug: Web/HTTP/Link_prefetching_FAQ
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP Messages
 slug: Web/HTTP/Messages
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/methods/connect/index.md
+++ b/files/en-us/web/http/methods/connect/index.md
@@ -1,6 +1,7 @@
 ---
 title: CONNECT
 slug: Web/HTTP/Methods/CONNECT
+page-type: http-method
 browser-compat: http.methods.CONNECT
 ---
 

--- a/files/en-us/web/http/methods/delete/index.md
+++ b/files/en-us/web/http/methods/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: DELETE
 slug: Web/HTTP/Methods/DELETE
+page-type: http-method
 browser-compat: http.methods.DELETE
 ---
 

--- a/files/en-us/web/http/methods/get/index.md
+++ b/files/en-us/web/http/methods/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: GET
 slug: Web/HTTP/Methods/GET
+page-type: http-method
 browser-compat: http.methods.GET
 ---
 

--- a/files/en-us/web/http/methods/head/index.md
+++ b/files/en-us/web/http/methods/head/index.md
@@ -1,6 +1,7 @@
 ---
 title: HEAD
 slug: Web/HTTP/Methods/HEAD
+page-type: http-method
 browser-compat: http.methods.HEAD
 ---
 

--- a/files/en-us/web/http/methods/index.md
+++ b/files/en-us/web/http/methods/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP request methods
 slug: Web/HTTP/Methods
+page-type: landing-page
 browser-compat: http.methods
 ---
 

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -1,6 +1,7 @@
 ---
 title: OPTIONS
 slug: Web/HTTP/Methods/OPTIONS
+page-type: http-method
 browser-compat: http.methods.OPTIONS
 ---
 

--- a/files/en-us/web/http/methods/patch/index.md
+++ b/files/en-us/web/http/methods/patch/index.md
@@ -1,6 +1,7 @@
 ---
 title: PATCH
 slug: Web/HTTP/Methods/PATCH
+page-type: http-method
 spec-urls: https://www.rfc-editor.org/rfc/rfc5789
 ---
 

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -1,6 +1,7 @@
 ---
 title: POST
 slug: Web/HTTP/Methods/POST
+page-type: http-method
 browser-compat: http.methods.POST
 ---
 

--- a/files/en-us/web/http/methods/put/index.md
+++ b/files/en-us/web/http/methods/put/index.md
@@ -1,6 +1,7 @@
 ---
 title: PUT
 slug: Web/HTTP/Methods/PUT
+page-type: http-method
 browser-compat: http.methods.PUT
 ---
 

--- a/files/en-us/web/http/methods/trace/index.md
+++ b/files/en-us/web/http/methods/trace/index.md
@@ -1,6 +1,7 @@
 ---
 title: TRACE
 slug: Web/HTTP/Methods/TRACE
+page-type: http-method
 browser-compat: http.methods.TRACE
 ---
 

--- a/files/en-us/web/http/network_error_logging/index.md
+++ b/files/en-us/web/http/network_error_logging/index.md
@@ -1,6 +1,7 @@
 ---
 title: Network Error Logging
 slug: Web/HTTP/Network_Error_Logging
+page-type: guide
 status:
   - experimental
 browser-compat: http.headers.NEL

--- a/files/en-us/web/http/overview/index.md
+++ b/files/en-us/web/http/overview/index.md
@@ -1,6 +1,7 @@
 ---
 title: An overview of HTTP
 slug: Web/HTTP/Overview
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/permissions_policy/index.md
+++ b/files/en-us/web/http/permissions_policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions Policy
 slug: Web/HTTP/Permissions_Policy
+page-type: guide
 browser-compat: http.headers.Permissions-Policy
 ---
 

--- a/files/en-us/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/protocol_upgrade_mechanism/index.md
@@ -1,6 +1,7 @@
 ---
 title: Protocol upgrade mechanism
 slug: Web/HTTP/Protocol_upgrade_mechanism
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/proxy_servers_and_tunneling/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/index.md
@@ -1,6 +1,7 @@
 ---
 title: Proxy servers and tunneling
 slug: Web/HTTP/Proxy_servers_and_tunneling
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -1,6 +1,7 @@
 ---
 title: Proxy Auto-Configuration (PAC) file
 slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/range_requests/index.md
+++ b/files/en-us/web/http/range_requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP range requests
 slug: Web/HTTP/Range_requests
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/redirections/index.md
+++ b/files/en-us/web/http/redirections/index.md
@@ -1,6 +1,7 @@
 ---
 title: Redirections in HTTP
 slug: Web/HTTP/Redirections
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/resources_and_specifications/index.md
+++ b/files/en-us/web/http/resources_and_specifications/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP resources and specifications
 slug: Web/HTTP/Resources_and_specifications
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/resources_and_uris/index.md
+++ b/files/en-us/web/http/resources_and_uris/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resources and URIs
 slug: Web/HTTP/Resources_and_URIs
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -1,6 +1,7 @@
 ---
 title: A typical HTTP session
 slug: Web/HTTP/Session
+page-type: guide
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/status/100/index.md
+++ b/files/en-us/web/http/status/100/index.md
@@ -1,6 +1,7 @@
 ---
 title: 100 Continue
 slug: Web/HTTP/Status/100
+page-type: http-status-code
 browser-compat: http.status.100
 ---
 

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -1,6 +1,7 @@
 ---
 title: 101 Switching Protocols
 slug: Web/HTTP/Status/101
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.101
 ---
 

--- a/files/en-us/web/http/status/102/index.md
+++ b/files/en-us/web/http/status/102/index.md
@@ -1,6 +1,7 @@
 ---
 title: 102 Processing
 slug: Web/HTTP/Status/102
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2518.html#section-10.1
 ---
 

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -1,6 +1,7 @@
 ---
 title: 103 Early Hints
 slug: Web/HTTP/Status/103
+page-type: http-status-code
 status:
   - experimental
 browser-compat: http.status.103

--- a/files/en-us/web/http/status/200/index.md
+++ b/files/en-us/web/http/status/200/index.md
@@ -1,6 +1,7 @@
 ---
 title: 200 OK
 slug: Web/HTTP/Status/200
+page-type: http-status-code
 browser-compat: http.status.200
 ---
 

--- a/files/en-us/web/http/status/201/index.md
+++ b/files/en-us/web/http/status/201/index.md
@@ -1,6 +1,7 @@
 ---
 title: 201 Created
 slug: Web/HTTP/Status/201
+page-type: http-status-code
 browser-compat: http.status.201
 ---
 

--- a/files/en-us/web/http/status/202/index.md
+++ b/files/en-us/web/http/status/202/index.md
@@ -1,6 +1,7 @@
 ---
 title: 202 Accepted
 slug: Web/HTTP/Status/202
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.202
 ---
 

--- a/files/en-us/web/http/status/203/index.md
+++ b/files/en-us/web/http/status/203/index.md
@@ -1,6 +1,7 @@
 ---
 title: 203 Non-Authoritative Information
 slug: Web/HTTP/Status/203
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.203
 ---
 

--- a/files/en-us/web/http/status/204/index.md
+++ b/files/en-us/web/http/status/204/index.md
@@ -1,6 +1,7 @@
 ---
 title: 204 No Content
 slug: Web/HTTP/Status/204
+page-type: http-status-code
 browser-compat: http.status.204
 ---
 

--- a/files/en-us/web/http/status/205/index.md
+++ b/files/en-us/web/http/status/205/index.md
@@ -1,6 +1,7 @@
 ---
 title: 205 Reset Content
 slug: Web/HTTP/Status/205
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.205
 ---
 

--- a/files/en-us/web/http/status/206/index.md
+++ b/files/en-us/web/http/status/206/index.md
@@ -1,6 +1,7 @@
 ---
 title: 206 Partial Content
 slug: Web/HTTP/Status/206
+page-type: http-status-code
 browser-compat: http.status.206
 ---
 

--- a/files/en-us/web/http/status/207/index.md
+++ b/files/en-us/web/http/status/207/index.md
@@ -1,6 +1,7 @@
 ---
 title: 207 Multi-Status
 slug: Web/HTTP/Status/207
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.1
 ---
 

--- a/files/en-us/web/http/status/208/index.md
+++ b/files/en-us/web/http/status/208/index.md
@@ -1,6 +1,7 @@
 ---
 title: 208 Already Reported
 slug: Web/HTTP/Status/208
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc5842.html#section-7.1
 ---
 

--- a/files/en-us/web/http/status/226/index.md
+++ b/files/en-us/web/http/status/226/index.md
@@ -1,6 +1,7 @@
 ---
 title: 226 IM Used
 slug: Web/HTTP/Status/226
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc3229.html#section-10.4.1
 ---
 

--- a/files/en-us/web/http/status/300/index.md
+++ b/files/en-us/web/http/status/300/index.md
@@ -1,6 +1,7 @@
 ---
 title: 300 Multiple Choices
 slug: Web/HTTP/Status/300
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.300
 ---
 

--- a/files/en-us/web/http/status/301/index.md
+++ b/files/en-us/web/http/status/301/index.md
@@ -1,6 +1,7 @@
 ---
 title: 301 Moved Permanently
 slug: Web/HTTP/Status/301
+page-type: http-status-code
 browser-compat: http.status.301
 ---
 

--- a/files/en-us/web/http/status/302/index.md
+++ b/files/en-us/web/http/status/302/index.md
@@ -1,6 +1,7 @@
 ---
 title: 302 Found
 slug: Web/HTTP/Status/302
+page-type: http-status-code
 browser-compat: http.status.302
 ---
 

--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -1,6 +1,7 @@
 ---
 title: 303 See Other
 slug: Web/HTTP/Status/303
+page-type: http-status-code
 browser-compat: http.status.303
 ---
 

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -1,6 +1,7 @@
 ---
 title: 304 Not Modified
 slug: Web/HTTP/Status/304
+page-type: http-status-code
 browser-compat: http.status.304
 ---
 

--- a/files/en-us/web/http/status/307/index.md
+++ b/files/en-us/web/http/status/307/index.md
@@ -1,6 +1,7 @@
 ---
 title: 307 Temporary Redirect
 slug: Web/HTTP/Status/307
+page-type: http-status-code
 browser-compat: http.status.307
 ---
 

--- a/files/en-us/web/http/status/308/index.md
+++ b/files/en-us/web/http/status/308/index.md
@@ -1,6 +1,7 @@
 ---
 title: 308 Permanent Redirect
 slug: Web/HTTP/Status/308
+page-type: http-status-code
 browser-compat: http.status.308
 ---
 

--- a/files/en-us/web/http/status/400/index.md
+++ b/files/en-us/web/http/status/400/index.md
@@ -1,6 +1,7 @@
 ---
 title: 400 Bad Request
 slug: Web/HTTP/Status/400
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.400
 ---
 

--- a/files/en-us/web/http/status/401/index.md
+++ b/files/en-us/web/http/status/401/index.md
@@ -1,6 +1,7 @@
 ---
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
+page-type: http-status-code
 browser-compat: http.status.401
 ---
 

--- a/files/en-us/web/http/status/402/index.md
+++ b/files/en-us/web/http/status/402/index.md
@@ -1,6 +1,7 @@
 ---
 title: 402 Payment Required
 slug: Web/HTTP/Status/402
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.402
 ---
 

--- a/files/en-us/web/http/status/403/index.md
+++ b/files/en-us/web/http/status/403/index.md
@@ -1,6 +1,7 @@
 ---
 title: 403 Forbidden
 slug: Web/HTTP/Status/403
+page-type: http-status-code
 browser-compat: http.status.403
 ---
 

--- a/files/en-us/web/http/status/404/index.md
+++ b/files/en-us/web/http/status/404/index.md
@@ -1,6 +1,7 @@
 ---
 title: 404 Not Found
 slug: Web/HTTP/Status/404
+page-type: http-status-code
 browser-compat: http.status.404
 ---
 

--- a/files/en-us/web/http/status/405/index.md
+++ b/files/en-us/web/http/status/405/index.md
@@ -1,6 +1,7 @@
 ---
 title: 405 Method Not Allowed
 slug: Web/HTTP/Status/405
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.405
 ---
 

--- a/files/en-us/web/http/status/406/index.md
+++ b/files/en-us/web/http/status/406/index.md
@@ -1,6 +1,7 @@
 ---
 title: 406 Not Acceptable
 slug: Web/HTTP/Status/406
+page-type: http-status-code
 browser-compat: http.status.406
 ---
 

--- a/files/en-us/web/http/status/407/index.md
+++ b/files/en-us/web/http/status/407/index.md
@@ -1,6 +1,7 @@
 ---
 title: 407 Proxy Authentication Required
 slug: Web/HTTP/Status/407
+page-type: http-status-code
 browser-compat: http.status.407
 ---
 

--- a/files/en-us/web/http/status/408/index.md
+++ b/files/en-us/web/http/status/408/index.md
@@ -1,6 +1,7 @@
 ---
 title: 408 Request Timeout
 slug: Web/HTTP/Status/408
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.408
 ---
 

--- a/files/en-us/web/http/status/409/index.md
+++ b/files/en-us/web/http/status/409/index.md
@@ -1,6 +1,7 @@
 ---
 title: 409 Conflict
 slug: Web/HTTP/Status/409
+page-type: http-status-code
 browser-compat: http.status.409
 ---
 

--- a/files/en-us/web/http/status/410/index.md
+++ b/files/en-us/web/http/status/410/index.md
@@ -1,6 +1,7 @@
 ---
 title: 410 Gone
 slug: Web/HTTP/Status/410
+page-type: http-status-code
 browser-compat: http.status.410
 ---
 

--- a/files/en-us/web/http/status/411/index.md
+++ b/files/en-us/web/http/status/411/index.md
@@ -1,6 +1,7 @@
 ---
 title: 411 Length Required
 slug: Web/HTTP/Status/411
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.411
 ---
 

--- a/files/en-us/web/http/status/412/index.md
+++ b/files/en-us/web/http/status/412/index.md
@@ -1,6 +1,7 @@
 ---
 title: 412 Precondition Failed
 slug: Web/HTTP/Status/412
+page-type: http-status-code
 browser-compat: http.status.412
 ---
 

--- a/files/en-us/web/http/status/413/index.md
+++ b/files/en-us/web/http/status/413/index.md
@@ -1,6 +1,7 @@
 ---
 title: 413 Content Too Large
 slug: Web/HTTP/Status/413
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.413
 ---
 

--- a/files/en-us/web/http/status/414/index.md
+++ b/files/en-us/web/http/status/414/index.md
@@ -1,6 +1,7 @@
 ---
 title: 414 URI Too Long
 slug: Web/HTTP/Status/414
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.414
 ---
 

--- a/files/en-us/web/http/status/415/index.md
+++ b/files/en-us/web/http/status/415/index.md
@@ -1,6 +1,7 @@
 ---
 title: 415 Unsupported Media Type
 slug: Web/HTTP/Status/415
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.415
 ---
 

--- a/files/en-us/web/http/status/416/index.md
+++ b/files/en-us/web/http/status/416/index.md
@@ -1,6 +1,7 @@
 ---
 title: 416 Range Not Satisfiable
 slug: Web/HTTP/Status/416
+page-type: http-status-code
 browser-compat: http.status.416
 ---
 

--- a/files/en-us/web/http/status/417/index.md
+++ b/files/en-us/web/http/status/417/index.md
@@ -1,6 +1,7 @@
 ---
 title: 417 Expectation Failed
 slug: Web/HTTP/Status/417
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.417
 ---
 

--- a/files/en-us/web/http/status/418/index.md
+++ b/files/en-us/web/http/status/418/index.md
@@ -1,6 +1,7 @@
 ---
 title: 418 I'm a teapot
 slug: Web/HTTP/Status/418
+page-type: http-status-code
 browser-compat: http.status.418
 ---
 

--- a/files/en-us/web/http/status/421/index.md
+++ b/files/en-us/web/http/status/421/index.md
@@ -1,6 +1,7 @@
 ---
 title: 421 Misdirected Request
 slug: Web/HTTP/Status/421
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc9110#name-421-misdirected-request
 ---
 

--- a/files/en-us/web/http/status/422/index.md
+++ b/files/en-us/web/http/status/422/index.md
@@ -1,6 +1,7 @@
 ---
 title: 422 Unprocessable Content
 slug: Web/HTTP/Status/422
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.422
 ---
 

--- a/files/en-us/web/http/status/423/index.md
+++ b/files/en-us/web/http/status/423/index.md
@@ -1,6 +1,7 @@
 ---
 title: 423 Locked
 slug: Web/HTTP/Status/423
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.3
 ---
 

--- a/files/en-us/web/http/status/424/index.md
+++ b/files/en-us/web/http/status/424/index.md
@@ -1,6 +1,7 @@
 ---
 title: 424 Failed Dependency
 slug: Web/HTTP/Status/424
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.4
 ---
 

--- a/files/en-us/web/http/status/425/index.md
+++ b/files/en-us/web/http/status/425/index.md
@@ -1,6 +1,7 @@
 ---
 title: 425 Too Early
 slug: Web/HTTP/Status/425
+page-type: http-status-code
 browser-compat: http.status.425
 ---
 

--- a/files/en-us/web/http/status/426/index.md
+++ b/files/en-us/web/http/status/426/index.md
@@ -1,6 +1,7 @@
 ---
 title: 426 Upgrade Required
 slug: Web/HTTP/Status/426
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.426
 ---
 

--- a/files/en-us/web/http/status/428/index.md
+++ b/files/en-us/web/http/status/428/index.md
@@ -1,6 +1,7 @@
 ---
 title: 428 Precondition Required
 slug: Web/HTTP/Status/428
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-3
 ---
 

--- a/files/en-us/web/http/status/429/index.md
+++ b/files/en-us/web/http/status/429/index.md
@@ -1,6 +1,7 @@
 ---
 title: 429 Too Many Requests
 slug: Web/HTTP/Status/429
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-4
 ---
 

--- a/files/en-us/web/http/status/431/index.md
+++ b/files/en-us/web/http/status/431/index.md
@@ -1,6 +1,7 @@
 ---
 title: 431 Request Header Fields Too Large
 slug: Web/HTTP/Status/431
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-5
 ---
 

--- a/files/en-us/web/http/status/451/index.md
+++ b/files/en-us/web/http/status/451/index.md
@@ -1,6 +1,7 @@
 ---
 title: 451 Unavailable For Legal Reasons
 slug: Web/HTTP/Status/451
+page-type: http-status-code
 browser-compat: http.status.451
 ---
 

--- a/files/en-us/web/http/status/500/index.md
+++ b/files/en-us/web/http/status/500/index.md
@@ -1,6 +1,7 @@
 ---
 title: 500 Internal Server Error
 slug: Web/HTTP/Status/500
+page-type: http-status-code
 browser-compat: http.status.500
 ---
 

--- a/files/en-us/web/http/status/501/index.md
+++ b/files/en-us/web/http/status/501/index.md
@@ -1,6 +1,7 @@
 ---
 title: 501 Not Implemented
 slug: Web/HTTP/Status/501
+page-type: http-status-code
 browser-compat: http.status.501
 ---
 

--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -1,6 +1,7 @@
 ---
 title: 502 Bad Gateway
 slug: Web/HTTP/Status/502
+page-type: http-status-code
 browser-compat: http.status.502
 ---
 

--- a/files/en-us/web/http/status/503/index.md
+++ b/files/en-us/web/http/status/503/index.md
@@ -1,6 +1,7 @@
 ---
 title: 503 Service Unavailable
 slug: Web/HTTP/Status/503
+page-type: http-status-code
 browser-compat: http.status.503
 ---
 

--- a/files/en-us/web/http/status/504/index.md
+++ b/files/en-us/web/http/status/504/index.md
@@ -1,6 +1,7 @@
 ---
 title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
+page-type: http-status-code
 browser-compat: http.status.504
 ---
 

--- a/files/en-us/web/http/status/505/index.md
+++ b/files/en-us/web/http/status/505/index.md
@@ -1,6 +1,7 @@
 ---
 title: 505 HTTP Version Not Supported
 slug: Web/HTTP/Status/505
+page-type: http-status-code
 spec-urls: https://httpwg.org/specs/rfc9110.html#status.505
 ---
 

--- a/files/en-us/web/http/status/506/index.md
+++ b/files/en-us/web/http/status/506/index.md
@@ -1,6 +1,7 @@
 ---
 title: 506 Variant Also Negotiates
 slug: Web/HTTP/Status/506
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2295#section-8.1
 ---
 

--- a/files/en-us/web/http/status/507/index.md
+++ b/files/en-us/web/http/status/507/index.md
@@ -1,6 +1,7 @@
 ---
 title: 507 Insufficient Storage
 slug: Web/HTTP/Status/507
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.5
 ---
 

--- a/files/en-us/web/http/status/508/index.md
+++ b/files/en-us/web/http/status/508/index.md
@@ -1,6 +1,7 @@
 ---
 title: 508 Loop Detected
 slug: Web/HTTP/Status/508
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc5842#section-7.2
 ---
 

--- a/files/en-us/web/http/status/510/index.md
+++ b/files/en-us/web/http/status/510/index.md
@@ -1,6 +1,7 @@
 ---
 title: 510 Not Extended
 slug: Web/HTTP/Status/510
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc2774#section-7
 ---
 

--- a/files/en-us/web/http/status/511/index.md
+++ b/files/en-us/web/http/status/511/index.md
@@ -1,6 +1,7 @@
 ---
 title: 511 Network Authentication Required
 slug: Web/HTTP/Status/511
+page-type: http-status-code
 spec-urls: https://www.rfc-editor.org/rfc/rfc6585#section-6
 ---
 

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP response status codes
 slug: Web/HTTP/Status
+page-type: landing-page
 browser-compat: http.status
 ---
 


### PR DESCRIPTION
Part of https://github.com/openwebdocs/project/issues/91.

Applies page types as defined in https://github.com/mdn/content/issues/22761, except:

- `http-content-security-policy-directive` -> `http-csp-directive`
- `http-feature-policy-directive` -> `http-permissions-policy-directive`