### PR TITLE
docs: replace character sequence by Unicode character

### DIFF
--- a/files/en-us/web/http/headers/content-language/index.md
+++ b/files/en-us/web/http/headers/content-language/index.md
@@ -72,7 +72,7 @@ The global [`lang`](/en-US/docs/Web/HTML/Global_attributes/lang) attribute is us
 Do **not** use this meta element like this for stating a document language:
 
 ```html example-bad
-<!-- /!\ This is bad practice -->
+<!-- ⚠️ This is bad practice -->
 <meta http-equiv="content-language" content="de" />
 ```
 


### PR DESCRIPTION
### Description

Replacing a character sequence that seems little accessible and doesn’t seem to be needed.