### PR TITLE
docs(relnote): Release notes prep for Fx112

### DIFF
--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/112
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 112 that affect developers. Firefox 112 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [April 11, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 112 that affect developers. Firefox 112 was released on April 11, 2023.
 
 ## Changes for web developers
 
@@ -13,7 +13,7 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ### HTML
 
-- {{domxref("HTMLElement")}} property [**`inert`**](/en-US/docs/Web/HTML/Global_attributes/inert) is now fully enabled. It allows the browser to ignore content or interactive elements that are within an HTMLElement with the `inert` attribute. See [Firefox bug 1764263](https://bugzil.la/1764263) for more details.
+- The {{domxref("HTMLElement")}} property [**`inert`**](/en-US/docs/Web/HTML/Global_attributes/inert) is now fully enabled. It allows the browser to ignore content or interactive elements that are within an HTMLElement with the `inert` attribute. See [Firefox bug 1764263](https://bugzil.la/1764263) for more details.
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -48,7 +48,6 @@ This article provides information about the changes in Firefox 112 that affect d
   See [Firefox bug 1773551](https://bugzil.la/1773551) for more details.
 - Rounded rectangles can now be drawn in 2D canvases using {{domxref("CanvasRenderingContext2D.roundRect()")}}, [`Path2D.roundRect()`](/en-US/docs/Web/API/Path2D#path2d.roundrect) and [`OffscreenCanvasRenderingContext2D.roundRect()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.roundrect).
   See [Firefox bug 1756175](https://bugzil.la/1756175) for more details.
-- The {{domxref("HTMLElement")}} property **`inert`** is now fully enabled. It allows the browser to ignore content or interactive elements that are within an HTMLElement with the `inert` attribute. See [Firefox bug 1764263](https://bugzil.la/1764263) for more details.
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/113
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [May 09, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [May 09, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -1,0 +1,66 @@
+---
+title: Firefox 113 for developers
+slug: Mozilla/Firefox/Releases/113
+---
+
+{{FirefoxSidebar}}
+
+This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [May 09, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+
+## Changes for web developers
+
+### Developer Tools
+
+### HTML
+
+#### Removals
+
+### CSS
+
+#### Removals
+
+### JavaScript
+
+#### Removals
+
+### SVG
+
+#### Removals
+
+### HTTP
+
+#### Removals
+
+### Security
+
+#### Removals
+
+### APIs
+
+#### DOM
+
+#### Media, WebRTC, and Web Audio
+
+#### Removals
+
+### WebAssembly
+
+#### Removals
+
+### WebDriver conformance (WebDriver BiDi, Marionette)
+
+#### WebDriver BiDi
+
+#### Marionette
+
+## Changes for add-on developers
+
+- When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up, instead of only the first one ([Firefox bug 1798655](https://bugzil.la/1798655)).
+
+### Removals
+
+### Other
+
+## Older versions
+
+{{Firefox_for_developers(112)}}

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -1,11 +1,11 @@
 ---
-title: Firefox 113 for developers
-slug: Mozilla/Firefox/Releases/113
+title: Firefox 114 for developers
+slug: Mozilla/Firefox/Releases/114
 ---
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [May 09, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [June 06, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 
@@ -54,8 +54,6 @@ This article provides information about the changes in Firefox 113 that affect d
 #### Marionette
 
 ## Changes for add-on developers
-
-- When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up, instead of only the first one ([Firefox bug 1798655](https://bugzil.la/1798655)).
 
 ### Removals
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/114
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [June 06, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 114 that affect developers. Firefox 114 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [June 06, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 
@@ -61,4 +61,4 @@ This article provides information about the changes in Firefox 113 that affect d
 
 ## Older versions
 
-{{Firefox_for_developers(112)}}
+{{Firefox_for_developers(113)}}


### PR DESCRIPTION
This PR preps 112, 113, and 114 release note pages for Fx112 today, April 11.
