### PR TITLE
fix: added mention of not adding body

### DIFF
--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -14,8 +14,9 @@ a {{glossary("Safe/HTTP", "safe")}} method, such as {{HTTPMethod("GET")}} or {{H
 or when the request is conditional and uses an {{HTTPHeader("If-None-Match")}} or an
 {{HTTPHeader("If-Modified-Since")}} header.
 
-The equivalent {{HTTPStatus("200")}} `OK` response would have included the
-headers {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}},
+The response must not contain a body and must include the headers that would
+have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
+{{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}},
 {{HTTPHeader("Date")}}, {{HTTPHeader("ETag")}}, {{HTTPHeader("Expires")}}, and
 {{HTTPHeader("Vary")}}.
 
@@ -40,10 +41,11 @@ headers {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}},
 ### Compatibility notes
 
 - Browser behavior differs if this response erroneously includes a body on persistent
-  connections See [204 No Content](/en-US/docs/Web/HTTP/Status/204) for more
+  connections. See [204 No Content](/en-US/docs/Web/HTTP/Status/204) for more
   detail.
 
 ## See also
 
 - {{HTTPHeader("If-Modified-Since")}}
 - {{HTTPHeader("If-None-Match")}}
+- [204 No Content](/en-US/docs/Web/HTTP/Status/204

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -48,4 +48,4 @@ have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
 
 - {{HTTPHeader("If-Modified-Since")}}
 - {{HTTPHeader("If-None-Match")}}
-- [204 No Content](/en-US/docs/Web/HTTP/Status/204
+- [204 No Content](/en-US/docs/Web/HTTP/Status/204)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

This PR attempts to address the points raised in the issue #26040 and, therefore, closes #26040.

<!-- ✍️ Summarize your changes in one or two sentences -->

The page initially did not clearly mention that the response shouldn't contain a body, other than a slight indication that some browsers WOULD
> erroneously includes a body on persistent connections

<!-- ❓ Why are you making these changes and how do they help readers? -->

These changes are being made for better clarity that responses with this Status Code should not return with a body.