### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -444,7 +444,7 @@ console.log(
 // "4.33"
 ```
 
-The minimum factional digits have no effect if the value already has more than 2 fractional digits:
+The minimum fractional digits have no effect if the value already has more than 2 fractional digits:
 
 ```js
 // Minimum fractions have no effect if value is higher precision.
@@ -494,7 +494,7 @@ console.log(
 
 #### Using SignificantDigits
 
-The number of _significant digits_ is the total number of digits including both integer and factional parts.
+The number of _significant digits_ is the total number of digits including both integer and fractional parts.
 The `maximumSignificantDigits` is used to indicate the total number of digits from the original value to display.
 
 The examples below show how this works.


### PR DESCRIPTION


### Description

I noticed 2 instances of `factional` when I believe it should be `fractional`.


### Motivation

I noticed the typos while reading the documentation. I would like to help to improve the accuracy of the documentation.

### Additional details

I believe these are typos for 2 reasons:

1. Based on context; The word `factional` does not make sense in the context of the surrounding text.
2. Based on frequency; There are only 2 instances of the word `factional` while there are 77 instances of the word `fractional`

### Related issues and pull requests

Fixes #26127


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
