### PR TITLE
Update "Formal syntax" for `@font-face/src`

### DIFF
--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -147,19 +147,7 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 ## Formal syntax
 
-```
-<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<font-face-name>)
-
-<font-format>= [<string> | collection | embedded-opentype | opentype
- | svg | truetype | woff | woff2 ]
-
-<font-tech>= [<font-feature-tech> | <color-font-tech>
- | variations | palettes | incremental ]
-
-<font-feature-tech>= [feature-opentype | feature-aat | feature-graphite]
-
-<color-font-tech>= [color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -149,7 +149,7 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 ```css
 <url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]?  |
-local(<family-name>)
+local( <family-name> )
 
 <font-format> = [ <string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -147,7 +147,19 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 ## Formal syntax
 
-{{CSSSyntax}}
+```css
+<url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]?  |
+local(<family-name>)
+
+<font-format> = [ <string> | collection | embedded-opentype | opentype
+ | svg | truetype | woff | woff2 ]
+
+<font-tech> = [ <font-features-tech> | <color-font-tech> | variations | palettes | incremental-patch | incremental-range | incremental-auto ]
+
+<font-features-tech> = [ features-opentype | features-aat | features-graphite ]
+
+<color-font-tech> = [ color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -151,8 +151,7 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 <url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]?  |
 local(<family-name>)
 
-<font-format> = [ <string> | collection | embedded-opentype | opentype
- | svg | truetype | woff | woff2 ]
+<font-format> = [ <string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]
 
 <font-tech> = [ <font-features-tech> | <color-font-tech> | variations | palettes | incremental-patch | incremental-range | incremental-auto ]
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -147,7 +147,7 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 ## Formal syntax
 
-```css
+```plain
 <url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]?  |
 local( <family-name> )
 


### PR DESCRIPTION
### Description

~This PR replaces the content of the "Formal Syntax" section on the `@font-face/src` [page](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src) with the `{{CSSSyntax}}` macro.~

Since the [spec](https://w3c.github.io/csswg-drafts/css-fonts/#src-desc) uses "see prose" as the value of this descriptor, I did the following:

  1. Copy the current prose from the spec;
  2. Fake the format like other "Formal syntax" sections, e.g. the [one](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows#formal_syntax) on the `grid-template`.

The second step seems suboptimal, though.

### Motivation

### Additional details

See https://github.com/w3c/csswg-drafts/issues/7632 for the `src` syntax definition.

### Related issues and pull requests

Fixes https://github.com/mdn/data/issues/521.