### PR TITLE
Add interfaces to static method syntax blocks

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -34,12 +34,12 @@ A few rules to follow in terms of markup within the syntax block:
 - Do **not** use \<code> within the syntax block (or within any code sample block on MDN, either). Not only is it generally useless, but our markup does not want it, and will not render the way you want it to look if you include it.
 - Only specify the function and arguments. Example showing "corrected" examples below
 
-  ```js
-  querySelector(selector);
-  //responseStr = element.querySelector(selector);
+  ```js-nolint
+  querySelector(selector)
+  //responseStr = element.querySelector(selector)
 
-  new IntersectionObserver(callback, options);
-  // const observer = new IntersectionObserver(callback, options);
+  new IntersectionObserver(callback, options)
+  // const observer = new IntersectionObserver(callback, options)
   ```
 
 ### Constructors and methods
@@ -48,14 +48,20 @@ A few rules to follow in terms of markup within the syntax block:
 
 Start with a syntax block, like this (from the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):
 
-```js
-new IntersectionObserver(callback, options);
+```js-nolint
+new IntersectionObserver(callback, options)
 ```
 
-or this (from {{DOMxRef("Document.hasStorageAccess")}}):
+or this (from {{DOMxRef("Document.hasStorageAccess()")}}):
 
-```js
-hasStorageAccess();
+```js-nolint
+hasStorageAccess()
+```
+
+When the method is static, for example {{DOMxRef("URL.createObjectURL()")}}, then provide its interface as well:
+
+```js-nolint
+URL.createObjectURL(object)
 ```
 
 ##### Multiple lines/Optional parameters
@@ -64,31 +70,31 @@ Methods that can be used in many different ways should be expanded out into mult
 
 Each option should be on its own line, omitting both per-option comments and assignment. For example, {{jsxref("Array.prototype.slice()")}} has two optional parameters, and would be documented as shown below:
 
-```js
-slice();
-slice(begin);
-slice(begin, end);
+```js-nolint
+slice()
+slice(begin)
+slice(begin, end)
 ```
 
 Similarly, for {{DOMxRef("CanvasRenderingContext2D.drawImage")}}:
 
-```js
-drawImage(image, dx, dy);
-drawImage(image, dx, dy, dWidth, dHeight);
-drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+```js-nolint
+drawImage(image, dx, dy)
+drawImage(image, dx, dy, dWidth, dHeight)
+drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
 ```
 
 Similarly for the {{jsxref("Date")}} constructor:
 
-```js
-new Date();
-new Date(value);
-new Date(dateString);
-new Date(year, monthIndex);
-new Date(year, monthIndex, day);
-new Date(year, monthIndex, day, hours);
-new Date(year, monthIndex, day, hours, minutes);
-new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds);
+```js-nolint
+new Date()
+new Date(value)
+new Date(dateString)
+new Date(year, monthIndex)
+new Date(year, monthIndex, day)
+new Date(year, monthIndex, day, hours)
+new Date(year, monthIndex, day, hours, minutes)
+new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds)
 ```
 
 ##### Formal syntax
@@ -97,7 +103,7 @@ Formal syntax notation (using [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%9
 
 While the formal notation provides a concise mechanism for describing complex syntax, it is not familiar to many developers, and can _conflict_ with valid syntax for particular programming languages. For example, "`[ ]`" indicates both an "optional parameter" and a JavaScript {{jsxref("Array")}}. You can see this in the formal syntax for {{jsxref("Array.prototype.slice()")}} below:
 
-```js
+```js-nolint
 arr.slice([begin[, end]])
 ```
 
@@ -107,25 +113,25 @@ For specific cases where it is seen as beneficial, a separate **Formal syntax** 
 
 The aim is to make the syntax block as pure and unambiguous a definition of the feature's syntax as possible — don't include any irrelevant syntax. For example, you may see this syntax form used to describe promises in many places on the site:
 
-```js
+```js-nolint
 caches.match(request, options).then(function (response) {
   // Do something with the response
-});
+})
 ```
 
 But this version is much more concise, and doesn't include the superfluous {{JSxRef("Promise.prototype.then()")}} method call:
 
-```js
-match(request, options);
+```js-nolint
+match(request, options)
 ```
 
 ##### Callback syntax blocks
 
 For methods accepting a callback function, show the callback as a parameter, not as an arrow function or `function` expression.
 
-```js
-filter(callbackFn);
-filter(callbackFn, thisArg);
+```js-nolint
+filter(callbackFn)
+filter(callbackFn, thisArg)
 ```
 
 Then, in the "Parameters" section, list the callback function's parameters and what it's expected to return.
@@ -145,11 +151,11 @@ Then, in the "Parameters" section, list the callback function's parameters and w
 
 For methods that accept an arbitrary number of parameters, the syntax block is written like this:
 
-```js
-unshift();
-unshift(element0);
-unshift(element0, element1);
-unshift(element0, element1, /* … ,*/ elementN);
+```js-nolint
+unshift()
+unshift(element0)
+unshift(element0, element1)
+unshift(element0, element1, /* … ,*/ elementN)
 ```
 
 #### Parameters section


### PR DESCRIPTION
- Addresses https://github.com/orgs/mdn/discussions/361#discussioncomment-5588028
- Also, https://github.com/mdn/content/pull/24049 added semicolons `;` to the syntax blocs. Reverted them as well.

cc/ @teoli2003 