### PR TITLE
Fix typo in link

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/rowheader_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/rowheader_role/index.md
@@ -147,7 +147,7 @@ none
 - [HTML table tutorial](/en-US/docs/Learn/HTML/Tables/Basics)
 - [ARIA `cell` role](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
 - [ARIA `row` role](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role)
-- [ARIA `gridcell` role](/en-US/docs/Web/Accessibility/ARIA/Roles/gridell_role)
+- [ARIA `gridcell` role](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role)
 
 <section id="Quick_links">
 


### PR DESCRIPTION
This "unbreaks" the link, as we have the related documentation.