### PR TITLE
declarative_net_request availability

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -56,6 +56,7 @@ This article provides information about the changes in Firefox 113 that affect d
 ## Changes for add-on developers
 
 - When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up, instead of only the first one ([Firefox bug 1798655](https://bugzil.la/1798655)).
+- Support is now provided for the {{WebExtAPIRef("declarativeNetRequest")}} API ([Firefox bug 1782685](https://bugzil.la/1782685)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Adds a release note for the availability of the  'declarative_net_request' API in 113.

Addresses the documentation requirements of [Bug 1782685](https://bugzilla.mozilla.org/show_bug.cgi?id=1782685) 
[DNR] Ship DNR API on release