### PR TITLE
missing `reult blocks` added

### DIFF
--- a/files/en-us/web/html/element/strong/index.md
+++ b/files/en-us/web/html/element/strong/index.md
@@ -49,7 +49,7 @@ While `<em>` is used to change the meaning of a sentence as spoken emphasis does
 </p>
 ```
 
-The resulting output:
+#### Result
 
 {{EmbedLiveSample("Basic_example", 650, 80)}}
 
@@ -62,7 +62,7 @@ The resulting output:
 </p>
 ```
 
-This results in:
+#### Result
 
 {{EmbedLiveSample("Labeling_warnings", 650, 80)}}
 

--- a/files/en-us/web/html/element/style/index.md
+++ b/files/en-us/web/html/element/style/index.md
@@ -60,6 +60,8 @@ In the following example, we apply a very simple stylesheet to a document:
 </html>
 ```
 
+#### Result
+
 {{EmbedLiveSample('A_simple_stylesheet', '100%', '100')}}
 
 ### Multiple style elements
@@ -93,6 +95,8 @@ In this example we've included two `<style>` elements — notice how the conflic
 </html>
 ```
 
+#### Result
+
 {{EmbedLiveSample('Multiple_style_elements', '100%', '100')}}
 
 ### Including a media query
@@ -125,6 +129,8 @@ In this example we build on the previous one, including a `media` attribute on t
   </body>
 </html>
 ```
+
+#### Result
 
 {{EmbedLiveSample('Including_a_media_query', '100%', '100')}}
 

--- a/files/en-us/web/html/element/sub/index.md
+++ b/files/en-us/web/html/element/sub/index.md
@@ -56,7 +56,7 @@ Traditional footnotes are denoted using numbers which are rendered in subscript.
 </p>
 ```
 
-The resulting output looks like this:
+#### Result
 
 {{EmbedLiveSample("Footnote_numbers", 650, 80)}}
 
@@ -71,7 +71,7 @@ In mathematics, families of variables related to the same concept (such as dista
 </p>
 ```
 
-The resulting output:
+#### Result
 
 {{EmbedLiveSample("Variable_subscripts", 650, 80)}}
 
@@ -89,7 +89,7 @@ Another example:
 </p>
 ```
 
-The output:
+#### Result
 
 {{EmbedLiveSample("Chemical_formulas", 650, 120)}}
 

--- a/files/en-us/web/html/element/summary/index.md
+++ b/files/en-us/web/html/element/summary/index.md
@@ -54,6 +54,8 @@ A simple example showing the use of `<summary>` in a {{HTMLElement("details")}} 
 </details>
 ```
 
+#### Result
+
 {{EmbedLiveSample("Basic_example", 650, 120)}}
 
 ### Summaries as headings
@@ -70,6 +72,8 @@ You can use heading elements in `<summary>`, like this:
   </ol>
 </details>
 ```
+
+#### Result
 
 {{EmbedLiveSample("Summaries_as_headings", 650, 120)}}
 
@@ -91,6 +95,8 @@ This example adds some semantics to the `<summary>` element to indicate the labe
   </ol>
 </details>
 ```
+
+#### Result
 
 {{EmbedLiveSample("HTML_in_summaries", 650, 120)}}
 

--- a/files/en-us/web/html/element/sup/index.md
+++ b/files/en-us/web/html/element/sup/index.md
@@ -54,7 +54,7 @@ Exponents, or powers of a number, are among the most common uses of superscripte
 </p>
 ```
 
-The resulting output looks like this:
+#### Result
 
 {{EmbedLiveSample("Exponents", 650, 80)}}
 
@@ -66,7 +66,7 @@ Superior lettering is not technically the same thing as superscript. However, it
 <p>Robert a présenté son rapport à M<sup>lle</sup> Bernard.</p>
 ```
 
-The resulting output:
+#### Result
 
 {{EmbedLiveSample("Superior_lettering", 650, 80)}}
 
@@ -84,7 +84,7 @@ Ordinal numbers, such as "fourth" in English or "quinto" in Spanish may be abbre
 </ul>
 ```
 
-The output:
+#### Result
 
 {{EmbedLiveSample("Ordinal_numbers", 650, 160)}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I modified files to apply MDN's [ recommendation](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Live_samples):

> After the different code blocks, please use a last "Result" block before using the EmbedLiveSample macro (see above). This way, the semantic of the example is made clearer for both the reader and any tools that would parse the page (e.g. screen reader, web crawler).

So missing headings are added. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
