### PR TITLE
events considered part of DOM

### DIFF
--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -39,7 +39,9 @@ No notable changes.
 - The `'unsafe-hashes'` value for {{HTTPHeader("Content-Security-Policy")}} source directives is now supported.
   For more information, see [CSP unsafe-hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_hashes) ([Firefox bug 1343950](https://bugzil.la/1343950)).
 
-### DOM
+### APIs
+
+#### DOM
 
 - The `scrollend` events are now supported, which indicate that the user has completed scrolling in {{domxref("Element")}} and {{domxref("Document")}} objects.
   For more information, see [Element: `scrollend` event](/en-US/docs/Web/API/Element/scrollend_event) and [Document: `scrollend` event](/en-US/docs/Web/API/Document/scrollend_event) ([Firefox bug 1797013](https://bugzil.la/1797013), [Firefox bug 1803435](https://bugzil.la/1803435)).

--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -39,7 +39,7 @@ No notable changes.
 - The `'unsafe-hashes'` value for {{HTTPHeader("Content-Security-Policy")}} source directives is now supported.
   For more information, see [CSP unsafe-hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_hashes) ([Firefox bug 1343950](https://bugzil.la/1343950)).
 
-### APIs
+### DOM
 
 - The `scrollend` events are now supported, which indicate that the user has completed scrolling in {{domxref("Element")}} and {{domxref("Document")}} objects.
   For more information, see [Element: `scrollend` event](/en-US/docs/Web/API/Element/scrollend_event) and [Document: `scrollend` event](/en-US/docs/Web/API/Document/scrollend_event) ([Firefox bug 1797013](https://bugzil.la/1797013), [Firefox bug 1803435](https://bugzil.la/1803435)).


### PR DESCRIPTION
Minor heading edit. Events like scrollend are typically considered part of the DOM. Though "API" is not incorrect,  "DOM" is a more precise heading for this, more consistent with our other dev release notes.
