### PR TITLE
declarative_net_request availability pt2

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -67,6 +67,8 @@ You can include any of the following here, but not in all browsers: check the co
 - `contextMenus`
 - `cookies`
 - `debugger`
+- `declarativeNetRequestFeedback`
+- `declarativeNetRequestWithHostAccess`
 - `downloads`
 - `downloads.open`
 - `find`
@@ -94,6 +96,7 @@ Of this set, the following permissions are granted silently, without a user prom
 
 - `activeTab`
 - `cookies`
+- `declarativeNetRequestWithHostAccess`
 - `idle`
 - `webRequest`
 - `webRequestBlocking`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -68,7 +68,6 @@ You can include any of the following here, but not in all browsers: check the co
 - `cookies`
 - `debugger`
 - `declarativeNetRequestFeedback`
-- `declarativeNetRequestWithHostAccess`
 - `downloads`
 - `downloads.open`
 - `find`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -95,7 +95,6 @@ Of this set, the following permissions are granted silently, without a user prom
 
 - `activeTab`
 - `cookies`
-- `declarativeNetRequestWithHostAccess`
 - `idle`
 - `webRequest`
 - `webRequestBlocking`


### PR DESCRIPTION
### Description

Update details of optional and no prompt permissions based on information in mozilla-central/toolkit/components/extensions/schemas/[declarative_net_request.json](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/schemas/declarative_net_request.json)