### PR TITLE
Add page-type to Web/Tutorials

### DIFF
--- a/files/en-us/web/tutorials/index.md
+++ b/files/en-us/web/tutorials/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tutorials
 slug: Web/Tutorials
+page-type: landing-page
 ---
 
 The links on this page lead to a variety of tutorials and training materials. Whether you are just starting, learning the basics, or are an old hand at web development, you can find helpful resources here for best practices.


### PR DESCRIPTION
There is only one page here: a landing page linking to tutorials all over MDN.

In our utopia, in the future, there may be a lot of things in this directory (the Divio system), but for the moment, it isn't the case.

This is part of openwebdocs/project#91