### PR TITLE
Remove link to deleted <shadow> element

### DIFF
--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -214,5 +214,5 @@ container.appendChild(secondClone);
 
 ## See also
 
-- Web components: {{HTMLElement("slot")}} (and historical: {{HTMLElement("shadow")}})
+- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>)}})
 - [Using templates and slots](/en-US/docs/Web/Web_Components/Using_templates_and_slots)

--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -214,5 +214,5 @@ container.appendChild(secondClone);
 
 ## See also
 
-- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>)}})
+- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>`)}})
 - [Using templates and slots](/en-US/docs/Web/Web_Components/Using_templates_and_slots)


### PR DESCRIPTION
`<shadow>` is long gone; we can still mention it but not link to it.