### PR TITLE
chore: rename "anchor" to "anchors"

### DIFF
--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -80,7 +80,7 @@ following:
 
 The following session features and reference spaces can be requested, either as `optionalFeatures` or `requiredFeatures`.
 
-- `anchor`
+- `anchors`
   - : Enable use of {{domxref("XRAnchor")}} objects.
 - `bounded-floor`
   - : Similar to the `local` type, except the user is not expected to move outside a predetermined boundary, given by the {{domxref("XRBoundedReferenceSpace.boundsGeometry", "boundsGeometry")}} in the returned object.


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`anchor` is not valid but `anchors` is which is why it would be nice if the text would be corrected.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- https://developer.mozilla.org/en-US/docs/Web/API/XRAnchor

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
