### PR TITLE
Include arguments types passed to the callback

### DIFF
--- a/files/en-us/web/api/mutationobserver/index.md
+++ b/files/en-us/web/api/mutationobserver/index.md
@@ -12,7 +12,7 @@ The {{domxref("MutationObserver")}} interface provides the ability to watch for 
 ## Constructor
 
 - {{domxref("MutationObserver.MutationObserver", "MutationObserver()")}}
-  - : Creates and returns a new `MutationObserver` which will invoke a specified callback function when DOM changes occur.
+  - : Creates and returns a new `MutationObserver` which will invoke a specified callback function when DOM changes occur.  The callback takes up to two arguments, a [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) and the MutationObserver itself.
 
 ## Instance methods
 

--- a/files/en-us/web/api/mutationobserver/index.md
+++ b/files/en-us/web/api/mutationobserver/index.md
@@ -12,7 +12,7 @@ The {{domxref("MutationObserver")}} interface provides the ability to watch for 
 ## Constructor
 
 - {{domxref("MutationObserver.MutationObserver", "MutationObserver()")}}
-  - : Creates and returns a new `MutationObserver` which will invoke a specified callback function when DOM changes occur.  The callback takes up to two arguments, a [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) and the MutationObserver itself.
+  - : Creates and returns a new `MutationObserver` which will invoke a specified callback function when DOM changes occur.  The callback takes up to two arguments, an array of [MutationRecords](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) and the MutationObserver itself.
 
 ## Instance methods
 


### PR DESCRIPTION
Include arguments types and link to  passed to the callback and link to mdn page https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord.  Not big but might save readers a few minutes.

### Description

Added a note about the argument types passed to the MutationObserver callback.

### Motivation

The argument types were not clear to me and I needed to write a quick test. Only 2 minutes, but it might help someone. Accessing the MutationRecord is key to making use of mustionObservers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
