### PR TITLE
Correct handler name

### DIFF
--- a/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
+++ b/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
@@ -23,7 +23,7 @@ Use the event name in methods like {{domxref("EventTarget.addEventListener", "ad
 
 ```js
 addEventListener("contentvisibilityautostatechange", (event) => {});
-contentvisibilityautostatechange = (event) => {};
+oncontentvisibilityautostatechange = (event) => {};
 ```
 
 > **Note:** The event object is of type {{domxref("ContentVisibilityAutoStateChangeEvent")}}.


### PR DESCRIPTION
### Description

This PR corrects the handler name for the `contentvisibilityautostatechange` event.

### Motivation

### Additional details

### Related issues and pull requests