### PR TITLE
relnote(112): CSS exponential functions

### DIFF
--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -19,6 +19,8 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ### CSS
 
+- [Exponential functions](/en-US/docs/Web/CSS/CSS_Functions#exponential_functions) are now enabled by default.
+  This allows the use of `pow()`, `sqrt()`, `hypot()`, `log()` and `exp()` functions ([Firefox bug 1814469](https://bugzil.la/1814469)).
 - The `overlay` keyword value for the {{cssxref("overflow")}} property is now supported as a legacy alias of the keyword value `auto` ([Firefox bug 1817189](https://bugzil.la/1817189)).
 
 #### Removals


### PR DESCRIPTION
### Description

Added the firefox release note for CSS Exponential functions

### Motivation

Documenting andthese features and closing the [Bug 1814469](https://bugzilla.mozilla.org/show_bug.cgi?id=1814469)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

[Content](https://github.com/mdn/content/pull/26187)
[Browser Compat Data](https://github.com/mdn/browser-compat-data/pull/19366)
