### PR TITLE
Remove broken link to Share API

### DIFF
--- a/files/en-us/games/introduction/index.md
+++ b/files/en-us/games/introduction/index.md
@@ -72,8 +72,7 @@ You can truly think of the Web as a better target platform for your game. As we 
       <td>
         <a href="/en-US/docs/Web/HTML">HTML</a>,
         <a href="/en-US/docs/Web/CSS">CSS</a>,
-        <a href="/en-US/docs/Web/SVG">SVG</a>,
-        <a href="/en-US/docs/Social_API">Social API</a> (and much more!)
+        <a href="/en-US/docs/Web/SVG">SVG</a> (and much more!)
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Fix #26208 The Social API (a Mozilla attempt almost a decade ago) is long gone (and was not even really useful in this context)