### PR TITLE
Remove link to window.content

### DIFF
--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -242,7 +242,6 @@ The following is a brief list of common APIs in web and XML page scripting using
 - `element.{{domxref("element.setAttribute", "setAttribute", "", "1")}}()`
 - `element.{{domxref("element.getAttribute", "getAttribute", "", "1")}}()`
 - `element.{{domxref("EventTarget.addEventListener", "addEventListener", "", "1")}}()`
-- `{{domxref("window.content", "", "", "1")}}`
 - `{{domxref("Window.load_event", "Window.onload", "", "1")}}`
 - `{{domxref("window.scrollTo", "", "", "1")}}()`
 


### PR DESCRIPTION
`window.content` has been removed in Firefox 57 and deleted recently from MDN. No need to list as a Core interface of the DOM.