### PR TITLE
Remove broken link to Mozilla's Chrome specific document

### DIFF
--- a/files/en-us/web/api/file/index.md
+++ b/files/en-us/web/api/file/index.md
@@ -65,4 +65,3 @@ _The `File` interface doesn't define any methods, but inherits methods from the 
 
 - [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files_from_web_applications)
 - {{DOMxRef("FileReader")}}
-- [Using the DOM File API in chrome code](/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code) (for privileged code running in Gecko, such as Firefox add-ons)


### PR DESCRIPTION
These docs have been removed from MDN years ago.