### PR TITLE
Removed incorrect capital in slug

### DIFF
--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -435,7 +435,7 @@ console.log(`${someString}`); // "hi"
 
 ## See also
 
-- [Iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators)
+- [Iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators)
 - {{jsxref("Statements/function*", "function*")}}
 - {{jsxref("Symbol.iterator")}}
 - {{jsxref("Iterator")}}


### PR DESCRIPTION
The slug capitalization has been fixed. This PR fixes a link to it.