### PR TITLE
Fix slug capitalization for inheritance

### DIFF
--- a/files/en-us/web/css/inheritance/index.md
+++ b/files/en-us/web/css/inheritance/index.md
@@ -1,6 +1,6 @@
 ---
 title: Inheritance
-slug: Web/CSS/inheritance
+slug: Web/CSS/Inheritance
 page-type: guide
 ---
 


### PR DESCRIPTION
We use sentence capitalization in MDN slugs (except for keywords). Inheritance is not a keyword so the article's slug should start with a capital letter, like the title.