### PR TITLE
Fix link to glossary entry (no parenthesis anymore)

### DIFF
--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -97,7 +97,7 @@ The MDN [Web Performance Learning Area](/en-US/docs/Learn/Performance) contains 
 - {{glossary('RAIL')}}
 - {{glossary('Real User Monitoring')}}
 - {{glossary('Resource Timing')}}
-- {{glossary('Round Trip Time (RTT)')}}
+- {{glossary('Round Trip Time', 'Round Trip Time (RTT)')}}
 - {{glossary('Server Timing')}}
 - {{glossary('Speculative parsing')}}
 - {{glossary('Speed index')}}


### PR DESCRIPTION
The page has been renamed (we don't allow parenthesis in page names anymore)