### PR TITLE
Fix capitalization of inheritance

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -732,7 +732,7 @@
 /en-US/docs/CSS/image-orientation	/en-US/docs/Web/CSS/image-orientation
 /en-US/docs/CSS/image-rendering	/en-US/docs/Web/CSS/image-rendering
 /en-US/docs/CSS/inherit	/en-US/docs/Web/CSS/inherit
-/en-US/docs/CSS/Inheritance	/en-US/docs/Web/CSS/Inheritance
+/en-US/docs/CSS/inheritance	/en-US/docs/Web/CSS/Inheritance
 /en-US/docs/CSS/inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/Inheritance
 /en-US/docs/CSS/initial	/en-US/docs/Web/CSS/initial
 /en-US/docs/CSS/initial_value	/en-US/docs/Web/CSS/initial_value

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -732,8 +732,8 @@
 /en-US/docs/CSS/image-orientation	/en-US/docs/Web/CSS/image-orientation
 /en-US/docs/CSS/image-rendering	/en-US/docs/Web/CSS/image-rendering
 /en-US/docs/CSS/inherit	/en-US/docs/Web/CSS/inherit
-/en-US/docs/CSS/inheritance	/en-US/docs/Web/CSS/inheritance
-/en-US/docs/CSS/inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/inheritance
+/en-US/docs/CSS/Inheritance	/en-US/docs/Web/CSS/Inheritance
+/en-US/docs/CSS/inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/Inheritance
 /en-US/docs/CSS/initial	/en-US/docs/Web/CSS/initial
 /en-US/docs/CSS/initial_value	/en-US/docs/Web/CSS/initial_value
 /en-US/docs/CSS/integer	/en-US/docs/Web/CSS/integer
@@ -1039,8 +1039,8 @@
 /en-US/docs/CSS:height	/en-US/docs/Web/CSS/height
 /en-US/docs/CSS:hidden	/en-US/docs/Web/CSS/visibility
 /en-US/docs/CSS:inherit	/en-US/docs/Web/CSS/inherit
-/en-US/docs/CSS:inheritance	/en-US/docs/Web/CSS/inheritance
-/en-US/docs/CSS:inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/inheritance
+/en-US/docs/CSS:inheritance	/en-US/docs/Web/CSS/Inheritance
+/en-US/docs/CSS:inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/Inheritance
 /en-US/docs/CSS:initial	/en-US/docs/Web/CSS/initial
 /en-US/docs/CSS:initial_value	/en-US/docs/Web/CSS/initial_value
 /en-US/docs/CSS:integer	/en-US/docs/Web/CSS/integer
@@ -11436,7 +11436,7 @@
 /en-US/docs/Web/CSS/image/image-set()	/en-US/docs/Web/CSS/image/image-set
 /en-US/docs/Web/CSS/image/paint()	/en-US/docs/Web/CSS/image/paint
 /en-US/docs/Web/CSS/imagefunction	/en-US/docs/Web/CSS/image/image
-/en-US/docs/Web/CSS/inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/inheritance
+/en-US/docs/Web/CSS/inherited_and_non-inherited_properties	/en-US/docs/Web/CSS/Inheritance
 /en-US/docs/Web/CSS/kerning	/en-US/docs/Web/CSS/font-kerning
 /en-US/docs/Web/CSS/lighting-color	/en-US/docs/Web/SVG/Attribute/lighting-color
 /en-US/docs/Web/CSS/linear-gradient	/en-US/docs/Web/CSS/gradient/linear-gradient

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -86542,7 +86542,7 @@
       "DBaron"
     ]
   },
-  "Web/CSS/inheritance": {
+  "Web/CSS/Inheritance": {
     "modified": "2020-09-16T06:00:09.005Z",
     "contributors": [
       "mfuji09",

--- a/files/en-us/web/css/actual_value/index.md
+++ b/files/en-us/web/css/actual_value/index.md
@@ -13,7 +13,7 @@ The **actual value** of a [CSS](/en-US/docs/Web/CSS) property is the [used value
 
 The {{glossary("user agent")}} performs four steps to calculate a property's actual (final) value:
 
-1. First, the [specified value](/en-US/docs/Web/CSS/specified_value) is determined based on the result of [cascading](/en-US/docs/Web/CSS/Cascade), [inheritance](/en-US/docs/Web/CSS/inheritance), or using the [initial value](/en-US/docs/Web/CSS/initial_value).
+1. First, the [specified value](/en-US/docs/Web/CSS/specified_value) is determined based on the result of [cascading](/en-US/docs/Web/CSS/Cascade), [inheritance](/en-US/docs/Web/CSS/Inheritance), or using the [initial value](/en-US/docs/Web/CSS/initial_value).
 2. Next, the [computed value](/en-US/docs/Web/CSS/computed_value) is calculated according to the specification (for example, a `span` with `position: absolute` will have its computed `display` changed to `block`).
 3. Then, layout is calculated, resulting in the [used value](/en-US/docs/Web/CSS/used_value).
 4. Finally, the used value is transformed according to the limitations of the local environment, resulting in the actual value.
@@ -29,7 +29,7 @@ The {{glossary("user agent")}} performs four steps to calculate a property's act
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -29,7 +29,7 @@ The `all` property is specified as one of the CSS global keyword values. Note th
 - {{cssxref("initial")}}
   - : Specifies that all the element's properties should be changed to their [initial values](/en-US/docs/Web/CSS/initial_value).
 - {{cssxref("inherit")}}
-  - : Specifies that all the element's properties should be changed to their [inherited values](/en-US/docs/Web/CSS/inheritance).
+  - : Specifies that all the element's properties should be changed to their [inherited values](/en-US/docs/Web/CSS/Inheritance).
 - {{cssxref("unset")}}
   - : Specifies that all the element's properties should be changed to their inherited values if they inherit by default, or to their initial values if not.
 - {{cssxref("revert")}}

--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -90,7 +90,7 @@ Since each conditional group may also contain nested statements, there may be an
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -396,7 +396,7 @@ After your content has finished altering styles, it may find itself in a situati
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/comments/index.md
+++ b/files/en-us/web/css/comments/index.md
@@ -52,7 +52,7 @@ The `/* */` comment syntax is used for both single and multiline comments. There
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/computed_value/index.md
+++ b/files/en-us/web/css/computed_value/index.md
@@ -30,7 +30,7 @@ However, for some properties (those where percentages are relative to something 
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -253,7 +253,7 @@ p {
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -53,7 +53,7 @@ Finally, note that for non-replaced inline elements, the amount of space taken u
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -82,7 +82,7 @@ p {
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/index.md
+++ b/files/en-us/web/css/index.md
@@ -55,7 +55,7 @@ Our [CSS Learning Area](/en-US/docs/Learn/CSS) features multiple modules that te
 - CSS key concepts:
 
   - The [syntax and forms of the language](/en-US/docs/Web/CSS/Syntax)
-  - [Specificity](/en-US/docs/Web/CSS/Specificity), [inheritance](/en-US/docs/Web/CSS/inheritance), and [the Cascade](/en-US/docs/Web/CSS/Cascade)
+  - [Specificity](/en-US/docs/Web/CSS/Specificity), [inheritance](/en-US/docs/Web/CSS/Inheritance), and [the Cascade](/en-US/docs/Web/CSS/Cascade)
   - [CSS units and values](/en-US/docs/Web/CSS/CSS_Values_and_Units) and [functional notations](/en-US/docs/Web/CSS/CSS_Functions)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model) and [margin collapse](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
   - The [containing block](/en-US/docs/Web/CSS/Containing_block)

--- a/files/en-us/web/css/inherit/index.md
+++ b/files/en-us/web/css/inherit/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.global_keywords.inherit
 
 The **`inherit`** CSS keyword causes the element to take the [computed value](/en-US/docs/Web/CSS/computed_value) of the property from its parent element. It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
-For [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), this reinforces the default behavior, and is only needed to override another rule.
+For [inherited properties](/en-US/docs/Web/CSS/Inheritance#inherited_properties), this reinforces the default behavior, and is only needed to override another rule.
 
 > **Note:** Inheritance is always from the parent element in the document tree, even when the parent element is not the containing block.
 
@@ -49,7 +49,7 @@ Then, it would be blue.
 
 ## See also
 
-- [Inheritance](/en-US/docs/Web/CSS/inheritance)
+- [Inheritance](/en-US/docs/Web/CSS/Inheritance)
 - Use the {{cssxref("initial")}} keyword to set a property to its initial value.
 - Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
 - Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.

--- a/files/en-us/web/css/initial/index.md
+++ b/files/en-us/web/css/initial/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.global_keywords.initial
 
 The **`initial`** CSS keyword applies the [initial (or default) value](/en-US/docs/Web/CSS/initial_value) of a property to an element. It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}. With `all` set to `initial`, all CSS properties can be restored to their respective initial values in one go instead of restoring each one separately.
 
-On [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, or {{cssxref("revert-layer")}} keywords instead.
+On [inherited properties](/en-US/docs/Web/CSS/Inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, or {{cssxref("revert-layer")}} keywords instead.
 
 ## Examples
 

--- a/files/en-us/web/css/initial_value/index.md
+++ b/files/en-us/web/css/initial_value/index.md
@@ -9,8 +9,8 @@ spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
 
 The **initial value** of a [CSS](/en-US/docs/Web/CSS) property is its default value, as listed in its definition table in the specification. The usage of the initial value depends on whether a property is inherited or not:
 
-- For [inherited properties](/en-US/docs/Web/CSS/inheritance#inherited_properties), the initial value is used on the _root element only_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
-- For [non-inherited properties](/en-US/docs/Web/CSS/inheritance#non-inherited_properties), the initial value is used on _all elements_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
+- For [inherited properties](/en-US/docs/Web/CSS/Inheritance#inherited_properties), the initial value is used on the _root element only_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
+- For [non-inherited properties](/en-US/docs/Web/CSS/Inheritance#non-inherited_properties), the initial value is used on _all elements_, as long as no [specified value](/en-US/docs/Web/CSS/specified_value) is supplied.
 
 You can explicitly specify the initial value by using the {{cssxref("initial")}} keyword.
 
@@ -28,7 +28,7 @@ You can explicitly specify the initial value by using the {{cssxref("initial")}}
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/layout_mode/index.md
+++ b/files/en-us/web/css/layout_mode/index.md
@@ -25,7 +25,7 @@ A [CSS](/en-US/docs/Web/CSS) **layout mode**, sometimes called _layout_, is an a
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -110,7 +110,7 @@ Combinators are selectors that establish a relationship between two or more simp
 - [Cascade](/en-US/docs/Web/CSS/Cascade)
 - [Comments](/en-US/docs/Web/CSS/Comments)
 - [Descriptor](/en-US/docs/Glossary/CSS_Descriptor)
-- [Inheritance](/en-US/docs/Web/CSS/inheritance)
+- [Inheritance](/en-US/docs/Web/CSS/Inheritance)
 - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
 - [Specificity](/en-US/docs/Web/CSS/Specificity)
 - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)

--- a/files/en-us/web/css/replaced_element/index.md
+++ b/files/en-us/web/css/replaced_element/index.md
@@ -57,7 +57,7 @@ Certain CSS properties can be used to specify how the object contained within th
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/resolved_value/index.md
+++ b/files/en-us/web/css/resolved_value/index.md
@@ -23,7 +23,7 @@ For most properties, it is the [computed value](/en-US/docs/Web/CSS/computed_val
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/shorthand_properties/index.md
+++ b/files/en-us/web/css/shorthand_properties/index.md
@@ -175,7 +175,7 @@ See [Cascade and inheritance](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -447,7 +447,7 @@ A few things to remember about specificity:
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/specified_value/index.md
+++ b/files/en-us/web/css/specified_value/index.md
@@ -62,7 +62,7 @@ p {
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -76,7 +76,7 @@ There is another group of statements – the **nested statements**. These are st
   - **CSS syntax**
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/unset/index.md
+++ b/files/en-us/web/css/unset/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.global_keywords.unset
 
 {{CSSRef}}
 
-The **`unset`** CSS keyword resets a property to its inherited value if the property naturally inherits from its parent, and to its [initial value](/en-US/docs/Web/CSS/initial_value) if not. In other words, it behaves like the {{cssxref("inherit")}} keyword in the first case, when the property is an [inherited property](/en-US/docs/Web/CSS/inheritance#inherited_properties), and like the {{cssxref("initial")}} keyword in the second case, when the property is a [non-inherited property](/en-US/docs/Web/CSS/inheritance#non-inherited_properties).
+The **`unset`** CSS keyword resets a property to its inherited value if the property naturally inherits from its parent, and to its [initial value](/en-US/docs/Web/CSS/initial_value) if not. In other words, it behaves like the {{cssxref("inherit")}} keyword in the first case, when the property is an [inherited property](/en-US/docs/Web/CSS/Inheritance#inherited_properties), and like the {{cssxref("initial")}} keyword in the second case, when the property is a [non-inherited property](/en-US/docs/Web/CSS/Inheritance#non-inherited_properties).
 
 **`unset`** can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -105,7 +105,7 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -227,7 +227,7 @@ However, when the values of custom properties are parsed, the browser doesn't ye
 
 Unfortunately, these valid values can be used, via the `var()` functional notation, in a context where they might not make sense. Properties and custom variables can lead to invalid CSS statements, leading to the new concept of _valid at computed time._
 
-When the browser encounters an invalid `var()` substitution, then the [initial](/en-US/docs/Web/CSS/initial_value) or [inherited](/en-US/docs/Web/CSS/inheritance) value of the property is used.
+When the browser encounters an invalid `var()` substitution, then the [initial](/en-US/docs/Web/CSS/initial_value) or [inherited](/en-US/docs/Web/CSS/Inheritance) value of the property is used.
 
 The next two examples illustrate this.
 

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -415,7 +415,7 @@ But not:
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -142,7 +142,7 @@ A block box is a block-level box that is also a block container. As described in
   - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - **Visual formatting models**

--- a/files/en-us/web/guide/css/block_formatting_context/index.md
+++ b/files/en-us/web/guide/css/block_formatting_context/index.md
@@ -235,7 +235,7 @@ In this example we wrap the second `<div>` in an outer one, to create a new BFC 
   - [At-rules](/en-US/docs/Web/CSS/At-rule)
   - [Comments](/en-US/docs/Web/CSS/Comments)
   - [Specificity](/en-US/docs/Web/CSS/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Inheritance](/en-US/docs/Web/CSS/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
   - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)

--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -74,7 +74,7 @@ svg {
 Most attributes on `use` are ignored if the corresponding attribute is already defined on the element _referenced_ by `use`. (This differs from how CSS style attributes override those set 'earlier' in the cascade).
 **Only** the attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}} and {{SVGAttr("href")}} on the `use` element will or may have some effect, described later, if the referenced element has already defined the corresponding attribute. However, _any other attributes_ not set on the referenced element **will** be applied to the `use` element.
 
-Since the cloned nodes are not exposed, care must be taken when using [CSS](/en-US/docs/Web/CSS) to style a `use` element and its cloned descendants. CSS properties are not guaranteed to be inherited by the cloned DOM unless you explicitly request them using [CSS inheritance](/en-US/docs/Web/CSS/inheritance).
+Since the cloned nodes are not exposed, care must be taken when using [CSS](/en-US/docs/Web/CSS) to style a `use` element and its cloned descendants. CSS properties are not guaranteed to be inherited by the cloned DOM unless you explicitly request them using [CSS inheritance](/en-US/docs/Web/CSS/Inheritance).
 
 For security reasons, browsers may apply the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) on `use` elements and may refuse to load a cross-origin URL in the {{SVGAttr("href")}} attribute. There is currently no defined way to set a cross-origin policy for `use` elements.
 


### PR DESCRIPTION
CSS/inheritance has been renamed into CSS/Inheritance (as is the rule on MDN). This PR fixes internal links to the former.