### PR TITLE
fix(article_role): example href

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/article_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.md
@@ -71,7 +71,7 @@ This role does not support any specific keyboard interaction.
 
 ## Examples
 
-- The [restaurant recommendations feed display](https://www.w3.org/WAI/ARIA/apg/example-index/feed/feedDisplay.html) along with its separate [documentation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/feed/feed.html) from the WAI-ARIA 1.1 authoring practices feed design pattern
+- The [restaurant recommendations feed display](https://www.w3.org/WAI/ARIA/apg/patterns/feed/examples/feed-display.html) along with its separate [documentation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/feed/feed.html) from the WAI-ARIA 1.1 authoring practices feed design pattern
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Replaced link that previously 404-ed

### Motivation

so that other readers won't get to a not found page

### Additional details

I found the new link here https://www.w3.org/WAI/ARIA/apg/patterns/feed/examples/feed/#ex_label

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
