### PR TITLE
Remove outdated note on "CSS Containment"

### DIFF
--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -118,8 +118,6 @@ The main use case is to prevent situations where a [CSS Counter](/en-US/docs/Web
 
 Using `contain: style` would ensure that the {{cssxref("counter-increment")}} and {{cssxref("counter-set")}} properties created new counters scoped to that subtree only.
 
-> **Note:** `style` containment is "at-risk" in the spec and may not be supported everywhere (it's not currently supported in Firefox).
-
 #### Special values
 
 There are two special values of contain:


### PR DESCRIPTION
### Description

This PR removes the outdated note on the "CSS Containment" page about at-riskness of the `style` value of `contain`.

### Motivation

[CSS Containment Module Level 2](https://w3c.github.io/csswg-drafts/css-contain/#l1-changes) restored this value, and Firefox also landed its support in [Firefox 103](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/103#css).

### Additional details

### Related issues and pull requests

This blocks the l10n of this page.