### PR TITLE
Unifying the section name for `content-visibility`

### DIFF
--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -129,7 +129,7 @@ p {
 }
 ```
 
-#### JS
+#### JavaScript
 
 ```js
 const handleClick = (event) => {


### PR DESCRIPTION
### Description

This PR changes the title of the "JS" section to "JavaScript".

### Motivation

Make the format conform to [Writing guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples#formatting_live_samples).

### Additional details

### Related issues and pull requests

Blocks https://github.com/mdn/translated-content/pull/12745.