### PR TITLE
Add the normative link to "top layer"

### DIFF
--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -145,7 +145,7 @@ Its possible values are:
 
 ### Relevant to the user
 
-The specification refers to the concept of [relevant to the user](https://www.w3.org/TR/css-contain-2/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it is visible, and/or being interacted with by the user.
+The specification refers to the concept of [relevant to the user](https://w3c.github.io/csswg-drafts/css-contain/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it is visible, and/or being interacted with by the user.
 
 To be precise, an element is relevant to the user if any of the following are true:
 
@@ -156,7 +156,7 @@ To be precise, an element is relevant to the user if any of the following are tr
 
 ### Skips its contents
 
-The specification refers to the concept of [skips its contents](https://www.w3.org/TR/css-contain-2/#skips-its-contents). This means that the element referred to is not relevant to the user and will not be rendered to improve performance.
+The specification refers to the concept of [skips its contents](https://w3c.github.io/csswg-drafts/css-contain/#skips-its-contents). This means that the element referred to is not relevant to the user and will not be rendered to improve performance.
 
 To be precise, when an element skips its contents:
 

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -145,14 +145,14 @@ Its possible values are:
 
 ### Relevant to the user
 
-The specification refers to the concept of [relevant to the user](https://www.w3.org/TR/css-contain-2/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it visible, and/or being interacted with by the user.
+The specification refers to the concept of [relevant to the user](https://www.w3.org/TR/css-contain-2/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it is visible, and/or being interacted with by the user.
 
 To be precise, an element is relevant to the user if any of the following are true:
 
 - The element appears in the viewport, or a user-agent-defined margin around the viewport (50% of the viewport dimensions, to give the app time to prepare for when the element visibility changes).
 - The element or its contents receive focus.
 - The element or its contents are selected, for example by dragging over the text with the mouse cursor or by some other highlight operation.
-- The element or its contents are placed in the top layer.
+- The element or its contents are placed in the [top layer](https://w3c.github.io/csswg-drafts/css-position-4/#top-layer).
 
 ### Skips its contents
 


### PR DESCRIPTION
### Description

This PR adds on the "CSS Containment" page the link pointing to the definition of "top layer" in [CSS Positioned Layout Module Level 4](https://w3c.github.io/csswg-drafts/css-position-4/#top-layer). It also updated the spec link for CSS Containment Module following https://github.com/mdn/browser-compat-data/pull/19380.

### Motivation

General readers might take this phrase as a casual way of saying elements stacked above others, but it does have a concrete definition in CSS.

### Additional details

This concept was previously defined in [Fullscreen API Standard](https://fullscreen.spec.whatwg.org/#top-layer), but the [note](https://fullscreen.spec.whatwg.org/#top-layer) above the definition there mentions pending updates to CSS, which are (soon) to be done in https://github.com/whatwg/fullscreen/pull/223.

### Related issues and pull requests

This blocks the l10n of this page.