### PR TITLE
Remove broken link from HTMLFormElement to XHR Guide

### DIFF
--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -235,10 +235,6 @@ Submit a `<form>` into a new window:
 </html>
 ```
 
-### Submitting forms and uploading files using XMLHttpRequest
-
-If you want to know how to serialize and submit a form using the {{domxref("XMLHttpRequest")}} API, please read [this paragraph](/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files).
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
### Description

The section on 'Submitting forms and uploading files' in the XHR guide that this links to was removed in #25383, so this link now goes to a broken anchor.

### Motivation

The page doesn't mention forms at all now, so it's no longer useful to link to it at all from this page.

### Additional details

N/A

### Related issues and pull requests

Not that I could find

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
