### PR TITLE
Update setting drag image example

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -94,12 +94,12 @@ function dragstart_handler(ev) {
 By default, the browser supplies an image that appears beside the pointer during a drag operation. However, an application may define a custom image with the {{domxref("DataTransfer.setDragImage","setDragImage()")}} method, as shown in the following example.
 
 ```js
+// Create an image and then use it for the drag image.
+// NOTE: change "example.gif" to a real image URL or the image
+// will not be created and the default drag image will be used.
+let img = new Image();
+img.src = "example.gif";
 function dragstart_handler(ev) {
-  // Create an image and then use it for the drag image.
-  // NOTE: change "example.gif" to a real image URL or the image
-  // will not be created and the default drag image will be used.
-  let img = new Image();
-  img.src = "example.gif";
   ev.dataTransfer.setDragImage(img, 10, 10);
 }
 ```


### PR DESCRIPTION
In this example the image creation is inside the drag handler, which causes it not to work on the first drag. Changed it to create the image out of the handler so it will be seen on the first drag.
