### PR TITLE
WebGPU - Add secure context info

### DIFF
--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -585,7 +585,7 @@ You can find more information about WebGPU error handling in the explainer — s
 
 ## Security requirements
 
-- Access to the whole APIis available only in a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
+The whole API is available only in a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 
 ## Examples
 

--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.GPU
 ---
 
-{{SeeCompatTable}}{{DefaultAPISidebar("WebGPU API")}}
+{{DefaultAPISidebar("WebGPU API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **WebGPU API** enables web developers to use the underlying system's GPU (Graphics Processing Unit) to carry out high-performance computations and draw complex images that can be rendered in the browser.
 
@@ -582,6 +582,10 @@ You can find more information about WebGPU error handling in the explainer — s
   - : The event object type for the {{domxref("GPUDevice")}} {{domxref("GPUDevice.uncapturederror_event", "uncapturederror")}} event.
 - {{domxref("GPUValidationError")}}
   - : One of the types of errors surfaced by {{domxref("GPUDevice.popErrorScope")}} and the {{domxref("GPUDevice")}} {{domxref("GPUDevice.uncapturederror_event", "uncapturederror")}} event. Describes an application error indicating that an operation did not pass the WebGPU API's validation constraints.
+
+## Security requirements
+
+- Access to the whole APIis available only in a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 
 ## Examples
 

--- a/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/features_restricted_to_secure_contexts/index.md
@@ -31,6 +31,7 @@ This section lists APIs that specifications make available only in secure contex
 - [Web Bluetooth](/en-US/docs/Web/API/Web_Bluetooth_API)
 - [Web MIDI](/en-US/docs/Web/API/Web_MIDI_API)
 - [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API)
+- [WebGPU API](/en-US/docs/Web/API/WebGPU_API)
 - [Web Share API](/en-US/docs/Web/API/Web_Share_API)
 
 In addition, the following methods require a secure context (even if the associated API does not):


### PR DESCRIPTION
This adds WebGPU to the list of APIs that require a secure context, and also adds the secure-context header to the API page.

May not be necessary, but I also added a "Security Requirement" section that reflects this same information. Trying to do the right thing for the future.

@Elchi3 @chrisdavidmills Appreciate your comments.

Other FF113 docs work for this  can be tracked in https://github.com/mdn/content/issues/26157
