### PR TITLE
FF113 Removes CanvasRenderingContext2D::mozTextStyle

### DIFF
--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -43,19 +43,21 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ### APIs
 
-- Removes support for `IDBMutableFile`, `IDBFileRequest`, `IDBFileHandle`, and `IDBDatabase.createMutableFile()`.
-  These interfaces are not present in any specification, have been behind a preference since version 102, and have been removed from the other main browser engines for some years.
-  ([Firefox bug 1500343](https://bugzil.la/1500343).)
 - {{domxref("navigator.getAutoplayPolicy()")}} is now supported, allowing developers to configure [autoplay](/en-US/docs/Web/Media/Autoplay_guide) of media elements and audio contexts based on whether autoplay is allowed, disallowed, or only allowed if the audio is muted.
   See [Firefox bug 1773551](https://bugzil.la/1773551) for more details.
 - Rounded rectangles can now be drawn in 2D canvases using {{domxref("CanvasRenderingContext2D.roundRect()")}}, [`Path2D.roundRect()`](/en-US/docs/Web/API/Path2D#path2d.roundrect) and [`OffscreenCanvasRenderingContext2D.roundRect()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.roundrect).
   See [Firefox bug 1756175](https://bugzil.la/1756175) for more details.
+- The deprecated and non-standard `CanvasRenderingContext2D.mozTextStyle` attribute is now disabled by default ([Firefox bug 1818409](https://bugzil.la/1818409)).
 
 #### DOM
 
 #### Media, WebRTC, and Web Audio
 
 #### Removals
+
+- Removes support for `IDBMutableFile`, `IDBFileRequest`, `IDBFileHandle`, and `IDBDatabase.createMutableFile()`.
+  These interfaces are not present in any specification, have been behind a preference since version 102, and have been removed from the other main browser engines for some years.
+  ([Firefox bug 1500343](https://bugzil.la/1500343).)
 
 ### WebAssembly
 

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -45,6 +45,8 @@ This article provides information about the changes in Firefox 113 that affect d
 
 #### Removals
 
+- The deprecated and non-standard `CanvasRenderingContext2D.mozTextStyle` attribute was permanently removed. This was previously hidden behind a preference. ([Firefox bug 1294362](https://bugzil.la/1294362)).
+
 ### WebAssembly
 
 #### Removals

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
@@ -8,11 +8,8 @@ browser-compat: api.CanvasRenderingContext2D.font
 
 {{APIRef}}
 
-The
-**`CanvasRenderingContext2D.font`**
-property of the Canvas 2D API specifies the current text style to use when drawing text.
-This string uses the same syntax as the [CSS font](/en-US/docs/Web/CSS/font)
-specifier.
+The **`CanvasRenderingContext2D.font`** property of the Canvas 2D API specifies the current text style to use when drawing text.
+This string uses the same syntax as the [CSS font](/en-US/docs/Web/CSS/font) specifier.
 
 ## Value
 
@@ -22,8 +19,7 @@ A string parsed as CSS {{cssxref("font")}} value. The default font is 10px sans-
 
 ### Using a custom font
 
-In this example we use the `font` property to specify a custom font weight,
-size, and family.
+In this example we use the `font` property to specify a custom font weight, size, and family.
 
 #### HTML
 
@@ -47,8 +43,7 @@ ctx.strokeText("Hello world", 50, 100);
 
 ### Loading fonts with the CSS Font Loading API
 
-With the help of the {{domxref("FontFace")}} API, you can explicitly load fonts before
-using them in a canvas.
+With the help of the {{domxref("FontFace")}} API, you can explicitly load fonts before using them in a canvas.
 
 ```js
 let f = new FontFace("test", "url(x)");
@@ -66,16 +61,10 @@ f.load().then(() => {
 
 {{Compat}}
 
-### Gecko-specific notes
+### Firefox-specific notes
 
-- In Gecko-based browsers, such as Firefox, a non-standard and deprecated property
-  `ctx.mozTextStyle` is implemented besides this property. Use
-  `ctx.font` instead.
-- In Gecko, when setting a system font as the value of a canvas 2D context's
-  {{domxref("CanvasRenderingContext2D.font", "font")}} (e.g., `menu`),
-  getting the font value used to fail to return the expected font (it returns nothing).
-  This is fixed in Firefox's [Quantum/Stylo](https://wiki.mozilla.org/Quantum/Stylo) parallel CSS engine,
-  released in Firefox 57 ([Firefox bug 1374885](https://bugzil.la/1374885)).
+- Prior to Firefox 57 ([Firefox bug 1374885](https://bugzil.la/1374885)), when setting a system font as the value of a canvas 2D context's {{domxref("CanvasRenderingContext2D.font", "font")}} (e.g., `menu`),
+  no font would be returned.
 
 ## See also
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
@@ -61,11 +61,6 @@ f.load().then(() => {
 
 {{Compat}}
 
-### Firefox-specific notes
-
-- Prior to Firefox 57 ([Firefox bug 1374885](https://bugzil.la/1374885)), when setting a system font as the value of a canvas 2D context's {{domxref("CanvasRenderingContext2D.font", "font")}} (e.g., `menu`),
-  no font would be returned.
-
 ## See also
 
 - The interface defining this property: {{domxref("CanvasRenderingContext2D")}}


### PR DESCRIPTION
FF113 removed `CanvasRenderingContext2D.mozTextStyle` in https://bugzilla.mozilla.org/show_bug.cgi?id=1294362.
This was replaced a long time ago by `CanvasRenderingContext2D.font`, and had been deprecated and hidden behind a pref for ages.

All this does is add a release note and remove an old gecko note.

Related docs work can be tracked in #26148