### PR TITLE
FF113 CanvasRenderingContext2D/OffscreenCanvasRenderingContext2D.rese…

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -37,6 +37,9 @@ This article provides information about the changes in Firefox 113 that affect d
 
 ### APIs
 
+- [`CanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/CanvasRenderingContext2D/reset) and [`OffscreenCanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset) are now supported, and can be used to return the associated rendering context to its default state.
+  ([Firefox bug 1709347](https://bugzil.la/1709347)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -265,7 +265,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
   - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
 - {{domxref("CanvasRenderingContext2D.getContextAttributes()")}}
   - : Returns an object containing the actual context attributes. Context attributes can be requested with {{domxref("HTMLCanvasElement.getContext()")}}.
-- {{domxref("CanvasRenderingContext2D.reset()")}} {{Experimental_Inline}}
+- {{domxref("CanvasRenderingContext2D.reset()")}}
   - : Resets the rendering context, including the backing buffer, the drawing state stack, path, and styles.
 - {{domxref("CanvasRenderingContext2D.isContextLost()")}} {{Experimental_Inline}}
   - : Returns `true` if the rendering context was lost.

--- a/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/reset/index.md
@@ -3,12 +3,10 @@ title: "CanvasRenderingContext2D: reset() method"
 short-title: reset()
 slug: Web/API/CanvasRenderingContext2D/reset
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CanvasRenderingContext2D.reset
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`CanvasRenderingContext2D.reset()`** method of the Canvas 2D API resets the rendering context to its default state, allowing it to be reused for drawing something else without having to explicitly reset all the properties.
 

--- a/files/en-us/web/api/offscreencanvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/offscreencanvasrenderingcontext2d/index.md
@@ -263,7 +263,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
   - : A read-only reference to an `OffscreenCanvas` object.
 - {{domxref("CanvasRenderingContext2D.getContextAttributes()")}}
   - : Returns an object containing the actual context attributes. Context attributes can be requested with {{domxref("HTMLCanvasElement.getContext()")}}.
-- {{domxref("CanvasRenderingContext2D.reset()")}} {{Experimental_Inline}}
+- {{domxref("CanvasRenderingContext2D.reset()")}}
   - : Resets the current drawing style state to the default values.
 
 ### Filters


### PR DESCRIPTION
FF113 adds support for [`CanvasRenderingContext2D.reset()`](https://developer.mozilla.org/en-US/en-US/docs/Web/API/CanvasRenderingContext2D/reset) and [`OffscreenCanvasRenderingContext2D.reset()`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset) in https://bugzilla.mozilla.org/show_bug.cgi?id=1709347

The docs were already present. This just removes the experimental tagging on the pages and linking parent topics, and adds a release note.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26148