### PR TITLE
Use correct case for navigator.wakeLock property

### DIFF
--- a/files/en-us/web/api/wakelocksentinel/index.md
+++ b/files/en-us/web/api/wakelocksentinel/index.md
@@ -7,7 +7,7 @@ browser-compat: api.WakeLockSentinel
 
 {{securecontext_header}}{{APIRef("Screen Wake Lock API")}}
 
-The **`WakeLockSentinel`** interface of the [Screen Wake Lock API](/en-US/docs/Web/API/Screen_Wake_Lock_API) provides a handle to the underlying platform wake lock and can be manually released and reacquired. An {{jsxref('Object')}} representing the wake lock is returned via the {{domxref('WakeLock.request()','navigator.wakelock.request()')}} method.
+The **`WakeLockSentinel`** interface of the [Screen Wake Lock API](/en-US/docs/Web/API/Screen_Wake_Lock_API) provides a handle to the underlying platform wake lock and can be manually released and reacquired. An {{jsxref('Object')}} representing the wake lock is returned via the {{domxref('WakeLock.request()','navigator.wakeLock.request()')}} method.
 
 An acquired `WakeLockSentinel` can be released manually via the {{domxref('WakeLockSentinel.release','release()')}} method, or automatically via the platform wake lock. This can happen if the document becomes inactive or looses visibility, if the device is low on power or the user turns on a power save mode. Releasing all `WakeLockSentinel` instances of a given wake lock type will cause the underlying platform wake lock to be released.
 


### PR DESCRIPTION
### Description

The correct case for the WakeLock property on `navigator` is `wakeLock`, not `wakelock`.

### Motivation

Th code example further down on the page uses the correct property, but if a user copies the code from the first paragraph, it won't work for them.

### Additional details

Specification: <https://w3c.github.io/screen-wake-lock/#extensions-to-the-navigator-interface>
