### PR TITLE
Clarify how deleted elements are treated in Array's `.toSpliced()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
@@ -48,7 +48,7 @@ A new array that consists of all elements before `start`, `item1`, `item2`, …,
 
 ## Description
 
-The `toSpliced()` method, like `splice()`, does multiple things at once: it removes the given number of elements from the array, starting at a given index, and then inserts the given elements at the same index. However, it returns a new array instead of modifying the original array. The deleted elements therefore are not accessible after calling this method.
+The `toSpliced()` method, like `splice()`, does multiple things at once: it removes the given number of elements from the array, starting at a given index, and then inserts the given elements at the same index. However, it returns a new array instead of modifying the original array. The deleted elements therefore are not returned from this method.
 
 The `toSpliced()` method never produces a [sparse array](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays). If the source array is sparse, the empty slots will be replaced with `undefined` in the new array.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

A sentence about `.toSpliced()` was not very clear. It said that it doesn't return the deleted elements (like `.splice()`) with the words "not accessible", so I clarified.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Deleted elements are very much accessible, by accessing the original array that `.toSpliced()` was called on.

The point of the paragraph is to describe `.toSpliced()`. In this sentence specifically, I think it's meant to describe how it's different from `.splice()`. Therefore I think it's more important and more clear to say they are "not returned".

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
