### PR TITLE
fix:  candidates provided by a STUN are not considered as relay

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -102,7 +102,7 @@ new RTCPeerConnection(configuration)
         - `"public"` {{deprecated_inline}}
           - : Only ICE candidates with public IP addresses will be considered. _Removed from the specification's May 13, 2016 working draft._
         - `"relay"`
-          - : Only ICE candidates whose IP addresses are being relayed, such as those being passed through a STUN or TURN server, will be considered.
+          - : Only ICE candidates whose IP addresses are being relayed, such as those being passed through a TURN server, will be considered.
 
     - `peerIdentity` {{optional_inline}}
       - : A string


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

ICE candidates provided by a STUN server are not considered as `relay` candidates. When `iceTransportPolicy = "relay"` no STUN server is requested by the API. Only TURN servers are consulted

### Motivation

Because i fall myself into the mistake with this documentation

### Additional details

[W3C Editor's Draft 13 April 2023](https://w3c.github.io/webrtc-pc/#dom-rtcicetransportpolicy-relay)


### Related issues and pull requests
N/B
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
