### PR TITLE
chore: remove untracked property

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -29,8 +29,6 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 
     In some browsers (e.g. Chrome 70.0) autoplay doesn't work if no `muted` attribute is present.
 
-- `autopictureinpicture` {{experimental_inline}}
-  - : A Boolean attribute which if `true` indicates that the element should automatically toggle picture-in-picture mode when the user switches back and forth between this document and another document or application.
 - `controls`
   - : If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
 - `controlslist` {{experimental_inline}}{{non-standard_inline}}


### PR DESCRIPTION
### Description

The `HTMLVideoElement.autoPictureInPicture` property has been removed from mdn, this PR is used to do some cleanups.

### Related issues and pull requests

#26278

This PR blocks mdn/translated-content#12828
