### PR TITLE
Correct the `index` parameter description of `Array.prototype.with()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/with/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/with/index.md
@@ -19,8 +19,7 @@ array.with(index, value)
 
 - `index`
   - : Zero-based index at which to change the array, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
-    - Negative index counts back from the end of the array — if `start < 0`, `start + array.length` is used.
-    - If `start` is omitted, `0` is used.
+    - Negative index counts back from the end of the array — if `index < 0`, `index + array.length` is used.
     - If the index after normalization is out of bounds, a {{jsxref("RangeError")}} is thrown.
 - `value`
   - : Any value to be assigned to the given index.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

1. Correct parameter name in description.
2. Remove ambiguous parameter description.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

1. Correct parameter name to `index` instead of `start`.
2. Omitting of the `index` parameter does not make any sense in `with()` method, this is probably a mistake.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
