### PR TITLE
CSS `text-decoration` example box modified

### DIFF
--- a/files/en-us/web/css/text-decoration/index.md
+++ b/files/en-us/web/css/text-decoration/index.md
@@ -110,7 +110,9 @@ The `text-decoration` property is specified as one or more space-separated value
 </p>
 ```
 
-{{EmbedLiveSample('Examples','auto','320')}}
+#### Result
+
+{{EmbedLiveSample('Examples','auto','520')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -101,7 +101,7 @@ The following code shows all the heading levels, in use.
 <h6>Heading level 6</h6>
 ```
 
-Here is the result of this code:
+#### Result
 
 {{ EmbedLiveSample('All_headings', '280', '300', '') }}
 
@@ -125,7 +125,7 @@ The following code shows a few headings with some content under them.
 <p>Some text here…</p>
 ```
 
-Here is the result of this code:
+#### Result
 
 {{ EmbedLiveSample('Example_page', '280', '480', '') }}
 
@@ -197,7 +197,7 @@ Another common navigation technique for users of screen reading software is to g
 
 Sectioning content can be labeled using a combination of the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`id`](/en-US/docs/Web/HTML/Global_attributes#id) attributes, with the label concisely describing the purpose of the section. This technique is useful for situations where there is more than one sectioning element on the same page.
 
-#### Example
+#### Examples
 
 ```html
 <header>
@@ -216,6 +216,10 @@ Sectioning content can be labeled using a combination of the [`aria-labelledby`]
   </nav>
 </footer>
 ```
+
+##### Result
+
+{{EmbedLiveSample('Examples')}}
 
 In this example, screen reading technology would announce that there are two {{HTMLElement("nav")}} sections, one called "Primary navigation" and one called "Footer navigation". If labels were not provided, the person using screen reading software may have to investigate each `nav` element's contents to determine their purpose.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added a result bloc to the example, because [here](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Live_samples) is mentioned:

> After the different code blocks, please use a last "Result" block before using the EmbedLiveSample macro (see above). This way, the semantic of the example is made clearer for both the reader and any tools that would parse the page (e.g. screen reader, web crawler).

Besides the height of the example was to increased to remove the scrollbar.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
