### PR TITLE
Correct the page of the CSS math function `atan2()`

### DIFF
--- a/files/en-us/web/css/atan2/index.md
+++ b/files/en-us/web/css/atan2/index.md
@@ -12,13 +12,13 @@ The **`atan2()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_
 ## Syntax
 
 ```css
-/* Single <number> values */
+/* Two <number> values */
 transform: rotate(atan2(3, 2));
 
-/* Single <dimension> values */
+/* Two <dimension> values */
 transform: rotate(atan2(1rem, -0.5rem));
 
-/* Single <percentage> values */
+/* Two <percentage> values */
 transform: rotate(atan2(20%, -30%));
 
 /* Other values */
@@ -31,13 +31,13 @@ transform: rotate(atan2(e, 30));
 The `atan2(y, x)` function accepts two comma-separated values as its parameters. Each value can be a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}. Both values must be of the same type, although if they are {{cssxref("&lt;dimension&gt;")}} they can be of different units (example: `atan2(100px, 5vw)` is valid).
 
 - `y`
-  - : The y coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.
+  - : The y-coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.
 - `x`
-  - : The x coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.
+  - : The x-coordinate of the point. A calculation which resolves to a {{cssxref("&lt;number&gt;")}}, a {{cssxref("&lt;dimension&gt;")}}, or a {{cssxref("&lt;percentage&gt;")}}.
 
 ### Return value
 
-Given two points `x` and `y`, the function `atan2(y, x)` calculates and returns the {{cssxref("&lt;angle&gt;")}} between the positive `x` axis and the ray from the origin to the point `(x, y)`.
+Given two values `x` and `y`, the function `atan2(y, x)` calculates and returns the {{cssxref("&lt;angle&gt;")}} between the positive x-axis and the ray from the origin to the point `(x, y)`.
 
 ### Formal syntax
 


### PR DESCRIPTION
### Description

This PR:

  1. Changes the CSS comments in the "Syntax" section;
  2. Adds dashes for math terms;
  3. Correct the description that `x` and `y` are points.

### Motivation

  1. `atan2()` accepts two values, so "single values" in the comments seems quite confusing.
  2. Math terms like "x-axis" does need a dash, see e.g. [M & W](https://www.merriam-webster.com/dictionary/x-axis).
  3. The parameters themselves are not points.

### Additional details

### Related issues and pull requests

This blocks the l10n of this page.