### PR TITLE
Update Layout and the containing block section for contain CSS property

### DIFF
--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -37,7 +37,7 @@ The process for identifying the containing block depends entirely on the value o
    1. A {{cssxref("transform")}} or {{cssxref("perspective")}} value other than `none`
    2. A {{cssxref("will-change")}} value of `transform` or `perspective`
    3. A {{cssxref("filter")}} value other than `none` or a `will-change` value of `filter` (only works on Firefox).
-   4. A {{cssxref("contain")}} value of `paint` (e.g. `contain: paint;`)
+   4. A {{cssxref("contain")}} value of `layout`, `paint`, `strict` or `content` (e.g. `contain: paint;`)
    5. A {{cssxref("backdrop-filter")}} other than `none` (e.g. `backdrop-filter: blur(10px);`)
 
 > **Note:** The containing block in which the root element ({{HTMLElement("html")}}) resides is a rectangle called the **initial containing block**. It has the dimensions of the viewport (for continuous media) or the page area (for paged media).


### PR DESCRIPTION
As described in the note here: https://developer.mozilla.org/en-US/docs/Web/CSS/contain#try_it 
the containing block is created when contain is set to value: layout, paint, strict or content, and not just 'paint'.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The docs for containing block are incomplete they state that just contain value of paint creates a new containing block but the docs for the contain CSS property says otherwise.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
incomplete documentation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/Web/CSS/contain#try_it 
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
