### PR TITLE
Remove duplicated cssinfo macros

### DIFF
--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -24,8 +24,6 @@ The **`-moz-user-focus`** [CSS](/en-US/docs/Web/CSS) property is used to indicat
 
 By setting its value to `ignore`, you can disable focusing the element, which means that the user will not be able to activate the element. The element will be skipped in the tab sequence.
 
-{{cssinfo}}
-
 ## Syntax
 
 ### Values

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -36,8 +36,6 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 -webkit-mask-position-x: unset;
 ```
 
-{{cssinfo}}
-
 ## Syntax
 
 ### Values

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -36,8 +36,6 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 -webkit-mask-position-y: unset;
 ```
 
-{{cssinfo}}
-
 ## Syntax
 
 ### Values

--- a/files/en-us/web/css/border-block-start-width/index.md
+++ b/files/en-us/web/css/border-block-start-width/index.md
@@ -28,8 +28,6 @@ border-block-start-width: unset;
 
 Related properties are {{cssxref("border-block-end-width")}}, {{cssxref("border-inline-start-width")}}, and {{cssxref("border-inline-end-width")}}, which define the other border widths of the element.
 
-{{cssinfo}}
-
 ### Values
 
 - `<'border-width'>`

--- a/files/en-us/web/css/border-inline-start-style/index.md
+++ b/files/en-us/web/css/border-inline-start-style/index.md
@@ -29,8 +29,6 @@ border-inline-start-style: unset;
 
 Related properties are {{cssxref("border-block-start-style")}}, {{cssxref("border-block-end-style")}}, and {{cssxref("border-inline-end-style")}}, which define the other border styles of the element.
 
-{{cssinfo}}
-
 ### Values
 
 - `<'border-style'>`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `{{cssinfo}}` macro was duplicated on several files. 

### Motivation

This removes duplicated and inconsistently placed information. I left the one under the `Formal Definition` header for consistency with other pages.

### Additional details

Impacted files-

- -moz-user-focus
- -webkit-mask-position-x
- -webkit-mask-position-y
- -border-inline-start-style
- -border-block-start-width

Doing a search shows that there are now 480 instances of `{{cssinfo}}` in 480 files, meaning this should be all the duplicates. This was a case insensitive search, as instances of `{{cssinfo}}` and `{{CSSInfo}}` both are present.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/17075, which fixed this for `border-inline-start-color`.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
