### PR TITLE
Adding the `dir` and `lang` pages of the Web App Manifest

### DIFF
--- a/files/en-us/web/manifest/dir/index.md
+++ b/files/en-us/web/manifest/dir/index.md
@@ -1,0 +1,66 @@
+---
+title: dir
+slug: Web/Manifest/dir
+browser-compat: html.manifest.dir
+---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Type</th>
+      <td><code>String</code></td>
+    </tr>
+  </tbody>
+</table>
+
+The `dir` property specifies the base direction for the localizable members of the manifest.
+The default value is `auto`.
+
+## Values
+
+The possible values are:
+
+<table class="fullwidth-table standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Base direction</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>auto</code></td>
+      <td>
+        No explicit directionality.
+      </td>
+    </tr>
+    <tr>
+      <td><code>ltr</code></td>
+      <td>
+        Left-to-right text.
+      </td>
+    </tr>
+    <tr>
+      <td><code>rtl</code></td>
+      <td>
+        Right-to-left text.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Example
+
+```json
+"dir": "ltr"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/manifest/lang/index.md
+++ b/files/en-us/web/manifest/lang/index.md
@@ -1,0 +1,36 @@
+---
+title: lang
+slug: Web/Manifest/lang
+browser-compat: html.manifest.lang
+---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Type</th>
+      <td><code>String</code></td>
+    </tr>
+  </tbody>
+</table>
+
+The `lang` key can be used to define the primary language of the web application in a web app manifest file. The value should be a string representing a BCP 47 language tag. For example, `fr` for French or `en-US` for American English.
+
+The "lang" property value must respect the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}} standard. For example, the value `en-US` is valid, but `en_US` is not.
+
+> **Note:** The "lang" property is not used to specify the language of the web application's user interface; instead, it is used to specify the primary language that the web application's content is written in.
+
+## Examples
+
+```json
+"lang": "en-US"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
## Description

These pages (`lang` and `dir`) were missing on manifest's MDN documentation

### Motivation

These properties are mentioned in `description` and `short_name`, and they exist on https://w3c.github.io/manifest/ but their page is not created.

### Additional details

I found these properties on https://w3c.github.io/manifest/