### PR TITLE
changed schemaType of genre field of BookSchema

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -744,7 +744,7 @@ const BookSchema = new Schema({
   author: { type: Schema.Types.ObjectId, ref: "Author", required: true },
   summary: { type: String, required: true },
   isbn: { type: String, required: true },
-  genre: [{ type: Schema.Types.ObjectId, ref: "Genre" }],
+  genre: [{ type: Array, ref: "Genre" }],
 });
 
 // Virtual for book's URL


### PR DESCRIPTION
The bookCreate() method in the 'populatedb.js' file takes an array of genres as one of the arguments instead of the expected objectId schemaType.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- changed schemaType of the genre field of BookSchema from Schema.Types.ObjectId to Array.

### Motivation

- Database population fails when populatedb.js is run. This happens because Book model validation fails. Mongoose expects schemaType.Types.ObjectId instead of an Array of genre objects when invoking the bookCreate method. The change satisfies this expectation.

### Additional details

- https://mongoosejs.com/docs/schematypes.html
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
