### PR TITLE
Modify input param of the EmbedLiveSample macro

### DIFF
--- a/files/en-us/web/html/element/table/index.md
+++ b/files/en-us/web/html/element/table/index.md
@@ -655,7 +655,7 @@ The [`scope`](/en-US/docs/Web/HTML/Element/th#scope) attribute on header element
 
 ##### Result
 
-{{EmbedLiveSample('Examples')}}
+{{EmbedLiveSample('Scoping_rows_and_columns')}}
 
 Providing a declaration of `scope="col"` on a {{HTMLElement("th")}} element will help describe that the cell is at the top of a column. Providing a declaration of `scope="row"` on a {{HTMLElement("th")}} element will help describe that the cell is the first in a row.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The parameter of EmbedLiveSample was wrong here.It should be Scoping_rows_and_columns so that it can find the correct code.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
There are many same problems like this, should I modify here or create a new issue?
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
[Wrong live samples due to ambiguous headers #26273](https://github.com/mdn/content/issues/26273)

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
