### PR TITLE
relnote(Fx112): CSS linear() easing functions are now supported

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -554,47 +554,6 @@ The [`:has()`](/en-US/docs/Web/CSS/:has) pseudo-class selects elements that cont
   </tbody>
 </table>
 
-### linear() easing function
-
-The `linear()` [easing function](/en-US/docs/Web/CSS/easing-function) defines a piecewise linear function, allowing you to approximate more complex animations.
-(See [Firefox bug 1764126](https://bugzil.la/1764126) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>104</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>104</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.linear-easing-function.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### animation-composition property
 
 The [`animation-composition`](/en-US/docs/Web/CSS/animation-composition) property specifies the composite operation to perform when multiple animations affect the same property simultaneously.

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -23,7 +23,7 @@ This article provides information about the changes in Firefox 112 that affect d
   This allows the use of `pow()`, `sqrt()`, `hypot()`, `log()` and `exp()` functions ([Firefox bug 1814469](https://bugzil.la/1814469)).
 - The `overlay` keyword value for the {{cssxref("overflow")}} property is now supported as a legacy alias of the keyword value `auto` ([Firefox bug 1817189](https://bugzil.la/1817189)).
 - The `<ray_size>` parameter is now optional in the `ray()` function that is used to define an [`offset-path`](/en-US/docs/Web/CSS/offset-path). If no `<ray_size>` parameter is provided, it has a default value of `closest-side` ([Firefox bug 1820071](https://bugzil.la/1820071)).
-- The `linear()` [easing function](/en-US/docs/Web/CSS/easing-function) is now enabled by default.
+- The `linear()` [easing function](/en-US/docs/Web/CSS/easing-function) is now supported.
   This defines easing functions that interpolate linearly between a set of points and is useful for approximating complex animations ([Firefox bug 1819447](https://bugzil.la/1819447), [Firefox bug 1764126](https://bugzil.la/1764126)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -23,6 +23,8 @@ This article provides information about the changes in Firefox 112 that affect d
   This allows the use of `pow()`, `sqrt()`, `hypot()`, `log()` and `exp()` functions ([Firefox bug 1814469](https://bugzil.la/1814469)).
 - The `overlay` keyword value for the {{cssxref("overflow")}} property is now supported as a legacy alias of the keyword value `auto` ([Firefox bug 1817189](https://bugzil.la/1817189)).
 - The `<ray_size>` parameter is now optional in the `ray()` function that is used to define an [`offset-path`](/en-US/docs/Web/CSS/offset-path). If no `<ray_size>` parameter is provided, it has a default value of `closest-side` ([Firefox bug 1820071](https://bugzil.la/1820071)).
+- The `linear()` [easing function](/en-US/docs/Web/CSS/easing-function) is now enabled by default.
+  This defines easing functions that interpolate linearly between a set of points and is useful for approximating complex animations ([Firefox bug 1819447](https://bugzil.la/1819447), [Firefox bug 1764126](https://bugzil.la/1764126)).
 
 #### Removals
 


### PR DESCRIPTION
__Additions:__
* Relnote that the CSS `linear()` function is now supported

__Removals:__
* Bringing this out of experimental features now that it's supported in stable

__Related issues and pull requests:__

- [x] parent issue https://github.com/mdn/content/issues/25357
- [x] BCD https://github.com/mdn/browser-compat-data/pull/19179
- [x] implementation docs https://github.com/mdn/content/issues/19709