### PR TITLE
relnote(Fx113): Compression Streams API supported by default

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -39,7 +39,7 @@ This article provides information about the changes in Firefox 113 that affect d
 
 - [`CanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/CanvasRenderingContext2D/reset) and [`OffscreenCanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset) are now supported, and can be used to return the associated rendering context to its default state.
   ([Firefox bug 1709347](https://bugzil.la/1709347)).
-- The [Compression Streams API](/en-US/docs/Web/API/Compression_Streams_API) is now supported by default.
+- The [Compression Streams API](/en-US/docs/Web/API/Compression_Streams_API) is now supported.
   The interfaces provided by this API are used to compress and decompress data using the `gzip` and `deflate` formats ([Firefox bug 1823619](https://bugzil.la/1823619)).
 
 #### DOM

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -39,6 +39,8 @@ This article provides information about the changes in Firefox 113 that affect d
 
 - [`CanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/CanvasRenderingContext2D/reset) and [`OffscreenCanvasRenderingContext2D.reset()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset) are now supported, and can be used to return the associated rendering context to its default state.
   ([Firefox bug 1709347](https://bugzil.la/1709347)).
+- The [Compression Streams API](/en-US/docs/Web/API/Compression_Streams_API) is now supported by default.
+  The interfaces provided by this API are used to compress and decompress data using the `gzip` and `deflate` formats ([Firefox bug 1823619](https://bugzil.la/1823619)).
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -56,7 +56,7 @@ Highlights:
 - The experimental `CanvasRenderingContext2D.addHitRegion()` method now accepts a `path` option, which allows you to add hit regions to {{domxref("Path2D")}} objects ([Firefox bug 1129147](https://bugzil.la/1129147)).
 - New methods have been added to manipulate {{domxref("FormData")}} objects ([Firefox bug 1085283](https://bugzil.la/1085283)) and `FormData` is now supported in Web workers ([Firefox bug 739173](https://bugzil.la/739173)).
 - The non-standard {{domxref("XMLHttpRequest.sendAsBinary()")}} method has been removed ([Firefox bug 853162](https://bugzil.la/853162)).
-- Progress in our experimental implementation of Web Animations: {{domxref("Animation/startTime", "AnimationPlayer.startTime")}} is now writeable ([Firefox bug 1073379](https://bugzil.la/1073379)).
+- Progress in our experimental implementation of Web Animations: {{domxref("Animation/startTime", "AnimationPlayer.startTime")}} is now writable ([Firefox bug 1073379](https://bugzil.la/1073379)).
 - Progress in our experimental implementation of [Service Workers](/en-US/docs/Web/API/Service_Worker_API): {{domxref("Cache")}} and {{domxref("CacheStorage")}} interfaces are now implemented ([Firefox bug 940273](https://bugzil.la/940273)).
 - The experimental [Fetch API](/en-US/docs/Web/API/Fetch_API) has been activated by default ([Firefox bug 1133861](https://bugzil.la/1133861)).
 - Progress in our experimental implementation of WebGL2: {{domxref("WebGLSync")}} is now implemented ([Firefox bug 1048721](https://bugzil.la/1048721)).

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -55,7 +55,8 @@ Highlights:
 
 - The experimental `CanvasRenderingContext2D.addHitRegion()` method now accepts a `path` option, which allows you to add hit regions to {{domxref("Path2D")}} objects ([Firefox bug 1129147](https://bugzil.la/1129147)).
 - New methods have been added to manipulate {{domxref("FormData")}} objects ([Firefox bug 1085283](https://bugzil.la/1085283)) and `FormData` is now supported in Web workers ([Firefox bug 739173](https://bugzil.la/739173)).
-- The non-standard {{domxref("XMLHttpRequest.sendAsBinary()")}} method has been removed ([Firefox bug 853162](https://bugzil.la/853162)).
+- The non-standard `XMLHttpRequest.sendAsBinary()` method has been removed.
+  Refer to the [Sending and Receiving Binary Data](/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data) documentation for alternatives ([Firefox bug 853162](https://bugzil.la/853162)).
 - Progress in our experimental implementation of Web Animations: {{domxref("Animation/startTime", "AnimationPlayer.startTime")}} is now writable ([Firefox bug 1073379](https://bugzil.la/1073379)).
 - Progress in our experimental implementation of [Service Workers](/en-US/docs/Web/API/Service_Worker_API): {{domxref("Cache")}} and {{domxref("CacheStorage")}} interfaces are now implemented ([Firefox bug 940273](https://bugzil.la/940273)).
 - The experimental [Fetch API](/en-US/docs/Web/API/Fetch_API) has been activated by default ([Firefox bug 1133861](https://bugzil.la/1133861)).

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -22,9 +22,10 @@ new CompressionStream(format)
 
   - : One of the following allowed compression formats:
 
-    - `"gzip"`
-    - `"deflate"`
-    - `"deflate-raw"`
+    - `"gzip"`: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+    - `"deflate"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+      The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
+    - `"deflate-raw"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -23,12 +23,12 @@ new CompressionStream(format)
   - : One of the following allowed compression formats:
 
     - `"gzip"`
-      -: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+      - : Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
     - `"deflate"`
-      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
         The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
     - `"deflate-raw"`
-      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -22,10 +22,13 @@ new CompressionStream(format)
 
   - : One of the following allowed compression formats:
 
-    - `"gzip"`: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
-    - `"deflate"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
-      The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
-    - `"deflate-raw"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+    - `"gzip"`
+      -: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+    - `"deflate"`
+      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+        The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
+    - `"deflate-raw"`
+      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/compressionstream/writable/index.md
+++ b/files/en-us/web/api/compressionstream/writable/index.md
@@ -20,7 +20,7 @@ The following example returns a {{domxref("WritableStream")}} from a `Compressio
 
 ```js
 let stream = new CompressionStream("gzip");
-console.log(stream.writeable); //a WritableStream
+console.log(stream.writable); // A WritableStream
 ```
 
 ## Specifications

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -20,7 +20,7 @@ for there still to be an entry with the type `"Files"` left in the object's
 {{domxref("DataTransfer.types")}} list if there are any files included in the drag.
 
 > **Note:** This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
-> because that's the only time the drag operation's data store is writeable.
+> because that's the only time the drag operation's data store is writable.
 
 ## Syntax
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -23,12 +23,12 @@ new DecompressionStream(format)
   - : One of the following compression formats:
 
     - `"gzip"`
-      -: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+      - : Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
     - `"deflate"`
-      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
         The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
     - `"deflate-raw"`
-      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -22,9 +22,10 @@ new DecompressionStream(format)
 
   - : One of the following compression formats:
 
-    - `"gzip"`
-    - `"deflate"`
-    - `"deflate-raw"`
+    - `"gzip"`: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+    - `"deflate"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+      The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
+    - `"deflate-raw"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -22,10 +22,13 @@ new DecompressionStream(format)
 
   - : One of the following compression formats:
 
-    - `"gzip"`: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
-    - `"deflate"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
-      The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
-    - `"deflate-raw"`: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+    - `"gzip"`
+      -: Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+    - `"deflate"`
+      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+        The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
+    - `"deflate-raw"`
+      -: Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 

--- a/files/en-us/web/api/decompressionstream/writable/index.md
+++ b/files/en-us/web/api/decompressionstream/writable/index.md
@@ -20,7 +20,7 @@ The following example returns a {{domxref("WritableStream")}} from a `Decompress
 
 ```js
 let stream = new DecompressionStream("gzip");
-console.log(stream.writeable); //a WritableStream
+console.log(stream.writable); // A WritableStream
 ```
 
 ## Specifications

--- a/files/en-us/web/api/textdecoderstream/writable/index.md
+++ b/files/en-us/web/api/textdecoderstream/writable/index.md
@@ -20,7 +20,7 @@ Returning a {{domxref("WritableStream")}} from a `TextDecoderStream`.
 
 ```js
 stream = new TextDecoderStream();
-console.log(stream.writeable); //a WritableStream
+console.log(stream.writable); // A WritableStream
 ```
 
 ## Specifications

--- a/files/en-us/web/api/textencoderstream/writable/index.md
+++ b/files/en-us/web/api/textencoderstream/writable/index.md
@@ -20,7 +20,7 @@ The following example demonstrates how to return a `WritableStream` from a `Text
 
 ```js
 stream = new TextEncoderStream();
-console.log(stream.writeable); //a WritableStream
+console.log(stream.writable); // A WritableStream
 ```
 
 ## Specifications


### PR DESCRIPTION
Fx113 adds support for CompressionStream, constructor and co

__additional changes:__
* typo fix `writeable` -> `writable`. This causes an error in the examples, changing leftovers for spelling consistency in relnotes.
* Add details on the compression methods for good measure.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26158

__Bugzilla:__
- Tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1823619

__TODO:__
- [ ] improvements on examples (nice to have)
