### PR TITLE
docs(fx112-css): Add overlay example

### DIFF
--- a/files/en-us/web/css/overflow-x/index.md
+++ b/files/en-us/web/css/overflow-x/index.md
@@ -45,6 +45,7 @@ If {{cssxref("overflow-y")}} is `hidden`, `scroll`, or `auto` and this property 
   - : Overflow content is clipped if necessary to fit horizontally inside the element's padding box. Browsers display scroll bars in the horizontal direction whether or not any content is actually clipped. (This prevents scroll bars from appearing or disappearing when the content changes.) Printers may still print overflowing content.
 - `auto`
   - : Overflow content is clipped at the element's padding box, and overflow content can be scrolled into view. Unlike `scroll`, user agents display scroll bars _only if_ the content is overflowing and hide scroll bars by default. If content fits inside the element's padding box, it looks the same as with `visible`, but still establishes a new block-formatting context. Desktop browsers provide scroll bars if content overflows.
+    > **Note:** The keyword value `overlay` is a legacy value alias for `auto`. With `overlay`, the scroll bars are drawn on top of the content instead of taking up space.
 
 ## Formal definition
 

--- a/files/en-us/web/css/overflow-y/index.md
+++ b/files/en-us/web/css/overflow-y/index.md
@@ -44,7 +44,9 @@ If {{cssxref("overflow-x")}} is `hidden`, `scroll`, or `auto` and this property 
 - `scroll`
   - : Overflow content is clipped if necessary to fit vertically inside the element's padding box. Browsers display scroll bars in the vertical direction whether or not any content is actually clipped. (This prevents scroll bars from appearing or disappearing when the content changes.) Printers may still print overflowing content.
 - `auto`
-  - : Depends on the user agent. If content fits inside the element's padding box, it looks the same as with `visible`, but still establishes a new block-formatting context. Desktop browsers provide scroll bars if content overflows.
+  - : Overflow content is clipped at the element's padding box, and overflow content can be scrolled into view.Unlike `scroll`, user agents display scroll bars _only if_ the content is overflowing and hide scroll bars by default. If content fits inside the element's padding box, it looks the same as with `visible`, but still establishes a new block-formatting context. Desktop browsers provide scroll bars if content overflows.
+
+> **Note:** The keyword value `overlay` is a legacy value alias for `auto`. With `overlay`, the scroll bars are drawn on top of the content instead of taking up space.
 
 ## Formal definition
 

--- a/files/en-us/web/css/overflow-y/index.md
+++ b/files/en-us/web/css/overflow-y/index.md
@@ -44,7 +44,7 @@ If {{cssxref("overflow-x")}} is `hidden`, `scroll`, or `auto` and this property 
 - `scroll`
   - : Overflow content is clipped if necessary to fit vertically inside the element's padding box. Browsers display scroll bars in the vertical direction whether or not any content is actually clipped. (This prevents scroll bars from appearing or disappearing when the content changes.) Printers may still print overflowing content.
 - `auto`
-  - : Overflow content is clipped at the element's padding box, and overflow content can be scrolled into view.Unlike `scroll`, user agents display scroll bars _only if_ the content is overflowing and hide scroll bars by default. If content fits inside the element's padding box, it looks the same as with `visible`, but still establishes a new block-formatting context. Desktop browsers provide scroll bars if content overflows.
+  - : Overflow content is clipped at the element's padding box, and overflow content can be scrolled into view. Unlike `scroll`, user agents display scroll bars _only if_ the content is overflowing, hiding scroll bars by default. If content fits inside the element's padding box, it looks the same as with `visible`, but still establishes a new block-formatting context.
 
 > **Note:** The keyword value `overlay` is a legacy value alias for `auto`. With `overlay`, the scroll bars are drawn on top of the content instead of taking up space.
 

--- a/files/en-us/web/css/overflow/index.md
+++ b/files/en-us/web/css/overflow/index.md
@@ -124,11 +124,20 @@ The following nuances should be kept in mind while using the various keywords fo
     feel."
   </p>
 </div>
+
+<div>
+  <code>overlay</code>
+  <p class="overlay">
+    Maya Angelou: "I've learned that people will forget what you said, people
+    will forget what you did, but people will never forget how you made them
+    feel."
+  </p>
+</div>
 ```
 
 #### CSS
 
-```css
+```css hidden
 body {
   display: flex;
   flex-wrap: wrap;
@@ -141,12 +150,19 @@ div {
 }
 
 p {
-  width: 8em;
+  width: 5em;
   height: 5em;
   border: dotted;
   margin-top: 0.5em;
 }
 
+div:nth-of-type(5),
+div:nth-of-type(6) {
+  margin-top: 200px;
+}
+```
+
+```css
 p.visible {
   overflow: visible;
 }
@@ -167,11 +183,15 @@ p.scroll {
 p.auto {
   overflow: auto;
 }
+
+p.overlay {
+  overflow: overlay;
+}
 ```
 
 #### Result
 
-{{EmbedLiveSample("Demonstrating results of various overflow keywords", "600", "500")}}
+{{EmbedLiveSample("Demonstrating results of various overflow keywords", "500", "600")}}
 
 ## Accessibility concerns
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is a follow up to https://github.com/mdn/content/pull/25749.

In this PR:
- `overflow` page: An example is added for `overlay` to show difference from `auto`.
- `overflow-x` and `overflow-y` pages: The `overlay` note is added alongside the `auto` description. Missed adding this in https://github.com/mdn/content/pull/25749.

### Related issues and pull requests

Doc issue tracker: https://github.com/mdn/content/issues/25355
Spec: https://w3c.github.io/csswg-drafts/css-overflow/#overflow-control

/cc @estelle 