### PR TITLE
Document URLSearchParams: size property

### DIFF
--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -25,6 +25,11 @@ for (const [key, value] of mySearchParams.entries()) {
 - {{domxref("URLSearchParams.URLSearchParams", 'URLSearchParams()')}}
   - : Returns a `URLSearchParams` object instance.
 
+## Instance properties
+
+- {{domxref("URLSearchParams.size", 'size')}}
+  - : Indicates the total number of search parameter entries.
+
 ## Instance methods
 
 - {{domxref("URLSearchParams.append()")}}

--- a/files/en-us/web/api/urlsearchparams/size/index.md
+++ b/files/en-us/web/api/urlsearchparams/size/index.md
@@ -16,6 +16,8 @@ A number indicating the total number of search parameter entries in the {{domxre
 
 ## Examples
 
+### Getting the amount of search parameter entries
+
 You can get the total number of search parameter entries like so:
 
 ```js
@@ -23,7 +25,15 @@ const searchParams = new URLSearchParams("c=4&a=2&b=3&a=1");
 searchParams.size; // 4
 ```
 
-The `size` property is also useful for checking whether there are any search parameters at all:
+Note how the `a` parameter is given twice, but `size` returns the number of all given entries (4) and not 3. To get the amount of unique keys, you can use a {{jsxref("Set")}}, for example:
+
+```js
+[...new Set(searchParams.keys())].length; // 3
+```
+
+### Checking if search parameters exist
+
+The `size` property is useful for checking whether there are any search parameters at all:
 
 ```js
 const url = new URL("https://example.com?foo=1&bar=2");
@@ -44,3 +54,4 @@ if (url.searchParams.size) {
 ## See also
 
 - {{domxref("URL.searchParams")}}
+- [Polyfill of `URLSearchParams` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)

--- a/files/en-us/web/api/urlsearchparams/size/index.md
+++ b/files/en-us/web/api/urlsearchparams/size/index.md
@@ -1,0 +1,46 @@
+---
+title: "URLSearchParams: size property"
+short-title: size
+slug: Web/API/URLSearchParams/size
+page-type: web-api-instance-property
+browser-compat: api.URLSearchParams.size
+---
+
+{{APIRef("URL API")}}
+
+The read-only **`URLSearchParams.size`** property indicates the total number of search parameter entries.
+
+## Value
+
+A number indicating the total number of search parameter entries in the {{domxref("URLSearchParams")}} object.
+
+## Examples
+
+You can get the total number of search parameter entries like so:
+
+```js
+const searchParams = new URLSearchParams("c=4&a=2&b=3&a=1");
+searchParams.size; // 4
+```
+
+The `size` property is also useful for checking whether there are any search parameters at all:
+
+```js
+const url = new URL("https://example.com?foo=1&bar=2");
+
+if (url.searchParams.size) {
+  console.log("URL has search parameters!");
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("URL.searchParams")}}


### PR DESCRIPTION
BCD: https://github.com/mdn/browser-compat-data/pull/19437
Spec https://url.spec.whatwg.org/#dom-urlsearchparams-size

Fixes https://github.com/mdn/content/issues/24760