### PR TITLE
fix wording in 'tolocaltimestring' documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -65,7 +65,7 @@ console.log(date.toLocaleTimeString());
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleTimeString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleTimeString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of support for the latter:
 
 ```js
 function toLocaleTimeStringSupportsLocales() {


### PR DESCRIPTION
Fix sentence wording.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This is to fix the wording of documentation on the 'toLocaleTimeString' function so the meaning is clear and distinct.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This helps improve the clarity of the documentation by making the meaning of the changed sentence clear and distinct.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
