### PR TITLE
Form control appearance

### DIFF
--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -40,7 +40,7 @@ For each property there are two possible renderings:
 
 ## Compatibility tables
 
-Altering the appearance of form controls with CSS, such as with  {{cssxref("border")}}, {{cssxref("background")}}, {{cssxref("border-radius")}}, and {{cssxref("height")}} can partially or fully turn off the native look & feel of widgets on some browsers. Be careful when you use them.
+Altering the appearance of form controls with CSS, such as with {{cssxref("border")}}, {{cssxref("background")}}, {{cssxref("border-radius")}}, and {{cssxref("height")}} can partially or fully turn off the native look & feel of widgets on some browsers. Be careful when you use them.
 
 ### Text fields
 

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -40,20 +40,7 @@ For each property there are two possible renderings:
 
 ## Compatibility tables
 
-### Global behaviors
-
-Some behaviors are common to many browsers at a global level:
-
-- {{cssxref("border")}}, {{cssxref("background")}}, {{cssxref("border-radius")}}, {{cssxref("height")}}
-  - : Using one of these properties can partially or fully turn off the native look & feel of widgets on some browsers. Be careful when you use them.
-- {{cssxref("line-height")}}
-  - : This property is supported inconsistently across browsers and you should avoid it.
-- {{cssxref("text-decoration")}}
-  - : This property is not supported by Opera on form widgets.
-- {{cssxref("text-overflow")}}
-  - : Opera, Safari, and IE9 do not support this property on form widgets.
-- {{cssxref("text-shadow")}}
-  - : Opera does not support {{cssxref("text-shadow")}} on form widgets and IE9 does not support it at all.
+Altering the appearance of form controls with CSS, such as with  {{cssxref("border")}}, {{cssxref("background")}}, {{cssxref("border-radius")}}, and {{cssxref("height")}} can partially or fully turn off the native look & feel of widgets on some browsers. Be careful when you use them.
 
 ### Text fields
 

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -1655,7 +1655,7 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and `{{htmlel
 
 ### Datalist
 
-See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements and the [`list` attribute](/en-US/docs/Web/HTML/Attributes/list).
+See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements and the [`list`](/en-US/docs/Web/HTML/Element/input#list) attribute.
 
 <table>
   <thead>


### PR DESCRIPTION
so much of this page is wrong and it should likely be deleted, but we definitely don't need to be mentioning IE9 and opera definitely supports text decoration, text-shadow, and overflow text on inputs, so removed stuff that.