### PR TITLE
Correct description of LockManager.query() return value.

### DIFF
--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -25,8 +25,8 @@ None.
 A {{jsxref('Promise')}} that resolves with an object containing a snapshot of the {{domxref("LockManager")}} state.
 The object has the following properties:
 
-- `held`: An array of {{domxref('Lock')}} objects for held locks.
-- `pending`: An array of {{domxref('Lock')}} objects for pending lock requests.
+- `held`: An array of {{domxref('LockInfo')}} objects for held locks.
+- `pending`: An array of {{domxref('LockInfo')}} objects for pending lock requests.
 
 ### Exceptions
 


### PR DESCRIPTION
The "held" and "pending" members of the resolved return value of LockManager.query() have LockInfo type, not Lock.

See https://w3c.github.io/web-locks/#lockmanager

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
