### PR TITLE
replace Anonymous with anonymous when setting image crossOrigin attri…

### DIFF
--- a/files/en-us/web/html/cors_enabled_image/index.md
+++ b/files/en-us/web/html/cors_enabled_image/index.md
@@ -66,7 +66,7 @@ function startDownload() {
   let imageDescription = "The Mozilla logo";
 
   downloadedImg = new Image();
-  downloadedImg.crossOrigin = "Anonymous";
+  downloadedImg.crossOrigin = "anonymous";
   downloadedImg.addEventListener("load", imageReceived, false);
   downloadedImg.alt = imageDescription;
   downloadedImg.src = imageURL;


### PR DESCRIPTION
…bute

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace "Anonymous" with "anonymous" when setting the image attribute in download image example.

### Motivation

The [crossOrigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute doc lists possible values:
`anonymous`, `use-credentials` and `""`, it seems confused using "Anonymous" here.

