### PR TITLE
Rephrase the example for the CSS function `sin()`; fix grammar

### DIFF
--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -46,21 +46,21 @@ The sine of an `angle` will always return a number between `−1` and `1`.
 
 ## Examples
 
-### Boxes Size
+### Changing box sizes
 
-For example, when creating a 100x100 box based on external parameters, in this case `sin(90deg)`. Thus `sin(90deg)` will return `1` making the box `100px` width and `100px` height.
+In this example, `sin(30deg)` will return `0.5`, making the box have a `50px` width and a `50px` height.
 
 ```css
 div {
   background-color: red;
-  width: calc(sin(90deg) * 100px);
-  height: calc(sin(90deg) * 100px);
+  width: calc(sin(30deg) * 100px);
+  height: calc(sin(30deg) * 100px);
 }
 ```
 
-### Controlling Animation Duration
+### Controlling animation duration
 
-Another use-case is to control the {{cssxref("animation-duration")}}. Reducing duration based on the sine value. In this case, the animation duration will be `1s`.
+Another use case is to control the {{cssxref("animation-duration")}}, reducing the duration based on the sine value. In this case, the animation duration will be `1s`.
 
 ```css
 div {


### PR DESCRIPTION
### Description

This PR:

  1. Changes the section headings to lower cases;
  2. Corrects some grammar issues;
  3. Rephrases the first example with slight alterations.

### Motivation

The original phrasing of the first example is rather difficult to decipher (the first sentence is even broken), neither does it show where comes the external parameter, so I rephrased it. In addition, since multiplying `sin(90deg)` really changes nothing, I changed `90deg` to `30deg` instead.

### Additional details

Honestly speaking, both examples seem uninteresting and far from real use cases. :shrug:

### Related issues and pull requests

This blocks the l10n of this page.