### PR TITLE
Tweaking the `oklab()` and `oklch()` page

### DIFF
--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -24,7 +24,7 @@ The function `oklab()` can represent any color from the Oklab color space that i
 oklab(40.1% 0.1143 0.045);
 oklab(59.69% 0.1007 0.1191);
 
-/* oklab(lightness a-axis b-axis / Alpha) */
+/* oklab(lightness a-axis b-axis / alpha) */
 oklab(59.69% 0.1007 0.1191 / 0.5);
 ```
 
@@ -146,5 +146,5 @@ div {
 ## See also
 
 - The [`<color>` data type](/en-US/docs/Web/CSS/color_value) for a list of all color notations
-- {{cssxref("color_value/oklch",'oklch()')}} use the same color space as `oklab()` but a polar coordinate system.
+- {{cssxref("color_value/oklch",'oklch()')}}: Another functional notation using the same color space as `oklab()` but in a polar coordinate system
 - [A perceptual color space for image processing](https://bottosson.github.io/posts/oklab/)

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.color.oklch
 
 {{CSSRef}}
 
-The **`oklch()`** functional notation expresses a given color in the OKLCH color space. It has the same L axis as {{cssxref("color_value/oklab","oklab()")}}, but uses polar coordinates C (Chroma) and H (Hue).
+The **`oklch()`** functional notation expresses a given color in the Oklch color space. It has the same L axis as {{cssxref("color_value/oklab","oklab()")}}, but uses polar coordinates C (Chroma) and H (Hue).
 
 ## Syntax
 
@@ -139,4 +139,4 @@ div {
 - The [`<color>` data type](/en-US/docs/Web/CSS/color_value) for a list of all color notations
 - [A perceptual color space for image processing](https://bottosson.github.io/posts/oklab/)
 - [OKLCH in CSS](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)
-- [Safari Technology Preview 137 release notes](https://webkit.org/blog/12156/release-notes-for-safari-technology-preview-137/): includes `oklch()` and {{cssxref("color_value/oklab",'oklab()')}} colors.
+- [Safari Technology Preview 137 release notes](https://webkit.org/blog/12156/release-notes-for-safari-technology-preview-137/): includes `oklch()` and {{cssxref("color_value/oklab",'oklab()')}} colors


### PR DESCRIPTION
### Description

This PR:

  1. Corrects the casing for the [name](https://w3c.github.io/csswg-drafts/css-color/#ok-lab) of the Oklch color space.
  2. Formats the "See also" section according to [Writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section).

### Motivation

This blocks the l10n of this page.

### Additional details

### Related issues and pull requests