### PR TITLE
Consistent place for accessor property values

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
@@ -19,7 +19,9 @@ Array[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from array methods that create new arrays.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct return values from array methods that create new arrays.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
@@ -19,7 +19,9 @@ ArrayBuffer[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from array buffer methods that create new array buffers.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct return values from array buffer methods that create new array buffers.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
@@ -11,9 +11,13 @@ The **`byteLength`** accessor property of {{jsxref("ArrayBuffer")}} instances re
 
 {{EmbedInteractiveExample("pages/js/arraybuffer-bytelength.html")}}
 
-## Description
+## Syntax
 
-The `byteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the array is constructed and cannot be changed. This property returns 0 if this `ArrayBuffer` has been detached.
+### Return value
+
+The getter for `byteLength` returns an integer whose value is established via the first `length` parameter of the {{jsxref("ArrayBuffer/ArrayBuffer", "ArrayBuffer()")}} constructor. It returns 0 if this `ArrayBuffer` has been detached.
+
+There is no setter for `byteLength`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/maxbytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/maxbytelength/index.md
@@ -11,11 +11,13 @@ The **`maxByteLength`** accessor property of {{jsxref("ArrayBuffer")}} instances
 
 {{EmbedInteractiveExample("pages/js/arraybuffer-maxbytelength.html")}}
 
-## Description
+## Syntax
 
-The `maxByteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the array is constructed, set via the `maxByteLength` option of the {{jsxref("ArrayBuffer/ArrayBuffer", "ArrayBuffer()")}} constructor, and cannot be changed.
+### Return value
 
-This property returns 0 if this `ArrayBuffer` has been detached. If this `ArrayBuffer` was constructed without specifying a `maxByteLength` value, this property returns a value equal to the value of the `ArrayBuffer`'s {{jsxref("ArrayBuffer/byteLength", "byteLength")}}.
+The getter for `maxByteLength` returns an integer whose value is established via the `maxByteLength` option of the {{jsxref("ArrayBuffer/ArrayBuffer", "ArrayBuffer()")}} constructor. If this `ArrayBuffer` is [not resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), it returns the same value as the `ArrayBuffer`'s {{jsxref("ArrayBuffer/byteLength", "byteLength")}}. It returns 0 if this `ArrayBuffer` has been detached.
+
+There is no setter for `maxByteLength`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/resizable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/resizable/index.md
@@ -11,9 +11,13 @@ The **`resizable`** accessor property of {{jsxref("ArrayBuffer")}} instances ret
 
 {{EmbedInteractiveExample("pages/js/arraybuffer-resizable.html")}}
 
-## Description
+## Syntax
 
-The `resizable` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the array is constructed. If the `maxByteLength` option was set in the constructor, `resizable` will return `true`; if not, it will return `false`.
+### Return value
+
+The getter for `resizable` returns a boolean value, which is `true` if the `maxByteLength` option was set in the constructor, and `false` otherwise.
+
+There is no setter for `resizable`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.md
@@ -11,9 +11,13 @@ The **`buffer`** accessor property of {{jsxref("DataView")}} instances returns t
 
 {{EmbedInteractiveExample("pages/js/dataview-buffer.html")}}
 
-## Description
+## Syntax
 
-The `buffer` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the `DataView` is constructed and cannot be changed.
+### Return value
+
+The getter for `buffer` returns the underlying {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}} of this `DataView`, established via the first `buffer` parameter of the {{jsxref("DataView/DataView", "DataView()")}} constructor.
+
+There is no setter for `buffer`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.md
@@ -11,9 +11,13 @@ The **`byteLength`** accessor property of {{jsxref("DataView")}} instances retur
 
 {{EmbedInteractiveExample("pages/js/dataview-bytelength.html")}}
 
-## Description
+## Syntax
 
-The `byteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when an `DataView` is constructed and cannot be changed. If the `DataView` is not specifying an offset or a `byteLength`, the `byteLength` of the referenced `ArrayBuffer` or `SharedArrayBuffer` will be returned.
+### Return value
+
+The getter for `byteLength` returns an integer whose value is either explicitly specified via the third `byteLength` parameter of the {{jsxref("DataView/DataView", "DataView()")}} constructor, or implicitly calculated by the `byteOffset` parameter and the `byteLength` of the referenced {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}.
+
+There is no setter for `byteLength`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.md
@@ -13,7 +13,9 @@ The **`byteOffset`** accessor property of {{jsxref("DataView")}} instances retur
 
 ## Description
 
-The `byteOffset` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when an `DataView` is constructed and cannot be changed.
+The getter for `byteOffset` returns an integer whose value is established via the second `byteOffset` parameter of the {{jsxref("DataView/DataView", "DataView()")}} constructor.
+
+There is no setter for `byteOffset`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/arguments/index.md
@@ -14,13 +14,20 @@ browser-compat: javascript.builtins.Function.arguments
 
 The **`arguments`** accessor property of {{jsxref("Function")}} instances returns the arguments passed to this function. For [strict](/en-US/docs/Web/JavaScript/Reference/Strict_mode), arrow, async, and generator functions, accessing the `arguments` property throws a {{jsxref("TypeError")}}.
 
+## Syntax
+
+### Return value
+
+The getter for `arguments`, when accessed on a non-strict plain function, returns an [arguments object](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) that contains the arguments passed to the last occurrence of the function on the call stack. It returns {{jsxref("Operators/null", "null")}} if this function does not appear on the call stack (either the function was never called or has already returned).
+
+The setter for `arguments`, when accessed on a non-strict plain function, does nothing.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown by both the getter and the setter if accessed on a strict, arrow, async, or generator function.
+
 ## Description
-
-The value of `arguments` is an array-like object corresponding to the arguments passed to a function.
-
-In the case of recursion, i.e. if function `f` appears several times on the call stack, the value of `f.arguments` represents the arguments corresponding to the most recent invocation of the function.
-
-The value of the `arguments` property is normally {{jsxref("Operators/null", "null")}} if there is no outstanding invocation of the function in progress (that is, the function has been called but has not yet returned).
 
 Note that the only behavior specified by the ECMAScript specification is that `Function.prototype` has an initial `arguments` accessor that unconditionally throws a {{jsxref("TypeError")}} for any `get` or `set` request (known as a "poison pill accessor"), and that implementations are not allowed to change this semantic for any function except non-strict plain functions. The actual behavior of the `arguments` property, if it's anything other than throwing an error, is implementation-defined. For example, Chrome defines it as an own data property, while Firefox and Safari extend the initial poison-pill `Function.prototype.arguments` accessor to specially handle `this` values that are non-strict functions.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/caller/index.md
@@ -14,9 +14,20 @@ browser-compat: javascript.builtins.Function.caller
 
 The **`caller`** accessor property of {{jsxref("Function")}} instances returns the function that invoked this function. For [strict](/en-US/docs/Web/JavaScript/Reference/Strict_mode), arrow, async, and generator functions, accessing the `caller` property throws a {{jsxref("TypeError")}}.
 
-## Description
+## Syntax
 
-If the function `f` was invoked by the top-level code, the value of `f.caller` is {{jsxref("Operators/null", "null")}}; otherwise it's the function that called `f`. If the function that called `f` is a strict mode function, the value of `f.caller` is also `null`.
+### Return value
+
+The getter for `caller`, when accessed on a non-strict plain function, returns the function that's immediately below this function in the call stack. It returns {{jsxref("Operators/null", "null")}} if this function does not appear on the call stack (either the function was never called or has already returned), or if this function is called by top-level code. If the function that called this function is a strict mode function, the `caller` getter also returns `null`.
+
+The setter for `caller`, when accessed on a non-strict plain function, does nothing.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown by both the getter and the setter if accessed on a strict, arrow, async, or generator function.
+
+## Description
 
 Note that the only behavior specified by the ECMAScript specification is that `Function.prototype` has an initial `caller` accessor that unconditionally throws a {{jsxref("TypeError")}} for any `get` or `set` request (known as a "poison pill accessor"), and that implementations are not allowed to change this semantic for any function except non-strict plain functions, in which case it must not have the value of a strict mode function. The actual behavior of the `caller` property, if it's anything other than throwing an error, is implementation-defined. For example, Chrome defines it as an own data property, while Firefox and Safari extend the initial poison-pill `Function.prototype.caller` accessor to specially handle `this` values that are non-strict functions.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.md
@@ -9,11 +9,17 @@ browser-compat: javascript.builtins.Intl.Locale.baseName
 
 The **`baseName`** accessor property of {{jsxref("Intl.Locale")}} instances returns a substring of this locale's string representation, containing core information about this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `baseName` returns a string containing the `language ["-" script] ["-" region] *("-" variant)` subsequence of the [unicode_language_id grammar](https://www.unicode.org/reports/tr35/#Identifiers), whose value is established either via the locale identifier or via the `language`, `script`, and `region` options of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor.
+
+There is no setter for `baseName`, so you cannot change this property's value using assignment.
+
 ## Description
 
 An {{jsxref("Intl/Locale", "Intl.Locale")}} object represents a parsed local and options for that locale. The `baseName` property returns basic, core information about the Locale in the form of a substring of the complete data string. Specifically, the property returns the substring containing the language, and the script and region if available.
-
-`baseName` returns the `language ["-" script] ["-" region] *("-" variant)` subsequence of the [unicode_language_id grammar](https://www.unicode.org/reports/tr35/#Identifiers).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
@@ -9,13 +9,17 @@ browser-compat: javascript.builtins.Intl.Locale.calendar
 
 The **`calendar`** accessor property of {{jsxref("Intl.Locale")}} instances returns the calendar type for this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `calendar` returns a string whose value is established either via the `ca` key of the locale identifier or via the `calendar` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`. For a list of supported calendar types, see [`Intl.Locale.prototype.getCalendars()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars#supported_calendar_types).
+
+There is no setter for `calendar`, so you cannot change this property's value using assignment.
+
 ## Description
 
-While most of the world uses the Gregorian calendar, there are several regional calendar eras used around the world. The `calendar` property's value is set at construction time, either through the `ca` key of the locale identifier or through the `calendar` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
-
-For a list of supported calendar types, see [`Intl.Locale.prototype.getCalendars()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars#supported_calendar_types).
-
-The set accessor of `calendar` is `undefined`. You cannot change this property directly.
+While most of the world uses the Gregorian calendar, there are several regional calendar eras used around the world. The `calendar` property returns the calendar era type that would be used if the locale is used in a date formatting context, such as {{jsxref("Intl.DateTimeFormat")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
@@ -9,25 +9,32 @@ browser-compat: javascript.builtins.Intl.Locale.caseFirst
 
 The **`caseFirst`** accessor property of {{jsxref("Intl.Locale")}} instances returns whether case is taken into account for this locale's collation rules.
 
+## Syntax
+
+### Return value
+
+The getter for `caseFirst` returns a string whose value is established either via the `kf` key of the locale identifier or via the `caseFirst` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`. Supported values are:
+
+- `"upper"`
+  - : Upper case to be sorted before lower case.
+- `"lower"`
+  - : Lower case to be sorted before upper case.
+- `"false"`
+  - : No special case ordering.
+
+There is no setter for `caseFirst`, so you cannot change this property's value using assignment.
+
 ## Description
 
-A locale's collation rules are used to determine how strings are ordered in that locale. Certain locales use a character's case (UPPERCASE or lowercase) in the collation process. This additional rule can be expressed in a {{jsxref("Intl/Locale", "Locale's")}} `caseFirst` property.
-
-There are 3 values that the `caseFirst` property can have, outlined in the table below.
-
-### `caseFirst` values
-
-| Value   | Description                                |
-| ------- | ------------------------------------------ |
-| `upper` | Upper case to be sorted before lower case. |
-| `lower` | Lower case to be sorted before upper case. |
-| `false` | No special case ordering.                  |
+A locale's collation rules are used to determine how strings are ordered in that locale. Certain locales use a character's case (UPPERCASE or lowercase) in the collation process. This additional rule can be expressed in a locale's `caseFirst` property.
 
 ## Examples
 
+Like other locale subtags, the `caseFirst` type can be added to the {{jsxref("Intl.Locale")}} object via the locale string, or a configuration object argument to the constructor.
+
 ### Setting the caseFirst value via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `caseFirst` represents correspond to the key `kf`. `kf` is treated as a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `caseFirst` value can be added to the initial locale identifier string that is passed into the `Locale` constructor. To add the `caseFirst` value, first add the `-u` extension key to the string. Next, add the `-kf` extension key to indicate that you are adding a value for `caseFirst`. Finally, add the `caseFirst` value to the string.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), `caseFirst` values are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the `caseFirst` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To add the `caseFirst` value, first add the `-u` extension to the string. Next, add the `-kf` extension to indicate that you are adding a `caseFirst` value. Finally, add the `caseFirst` value to the string.
 
 ```js
 const locale = new Intl.Locale("fr-Latn-FR-u-kf-upper");
@@ -36,7 +43,7 @@ console.log(locale.caseFirst); // Prints "upper"
 
 ### Setting the caseFirst value via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `caseFirst` property of the configuration object to your desired `caseFirst` value, and then pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can contain any of several extension types, including `caseFirst`. Set the `caseFirst` property of the configuration object to your desired `caseFirst` value, and then pass it into the constructor.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US", { caseFirst: "lower" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -9,13 +9,17 @@ browser-compat: javascript.builtins.Intl.Locale.collation
 
 The **`collation`** accessor property of {{jsxref("Intl.Locale")}} instances returns the [collation type](https://www.unicode.org/reports/tr35/tr35-collation.html#CLDR_Collation) for this locale, which is used to order strings according to the locale's rules.
 
+## Syntax
+
+### Return value
+
+The getter for `collation` returns a string whose value is set at construction time, either through the `co` key of the locale identifier or through the `collation` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`. For a list of supported collation types, see [`Intl.Locale.prototype.getCollations()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations#supported_collation_types).
+
+There is no setter for `collation`, so you cannot change this property's value using assignment.
+
 ## Description
 
-Collation is the process of ordering strings of characters. It is used whenever strings must be sorted and placed into a certain order, from search query results to ordering records in a database. While the idea of placing strings in order might seem trivial, the idea of order can vary from region to region and language to language. The `collation` property's value is set at construction time, either through the `co` key of the locale identifier or through the `collation` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
-
-For a list of supported collation types, see [`Intl.Locale.prototype.getCollations()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations#supported_collation_types).
-
-The set accessor of `collation` is `undefined`. You cannot change this property directly.
+Collation is the process of ordering strings of characters. It is used whenever strings must be sorted and placed into a certain order, from search query results to ordering records in a database. While the idea of placing strings in order might seem trivial, the idea of order can vary from region to region and language to language. The `collation` property returns the collation type that would be used if the locale is used in a collation context, such as {{jsxref("Intl.Collator")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
@@ -9,13 +9,17 @@ browser-compat: javascript.builtins.Intl.Locale.hourCycle
 
 The **`hourCycle`** accessor property of {{jsxref("Intl.Locale")}} instances returns the hour cycle type for this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `hourCycle` returns a string whose value is set at construction time, either through the `hc` key of the locale identifier or through the `hourCycle` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`. For a list of supported hour cycle types, see [`Intl.Locale.prototype.getHourCycles()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles#supported_hour_cycle_types).
+
+There is no setter for `hourCycle`, so you cannot change this property's value using assignment.
+
 ## Description
 
-There are 2 main types of time keeping conventions (clocks) used around the world: the 12 hour clock and the 24 hour clock. The `hourCycle` property's value is set at construction time, either through the `hc` key of the locale identifier or through the `hourCycle` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
-
-For a list of supported hour cycle types, see [`Intl.Locale.prototype.getHourCycles()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles#supported_hour_cycle_types).
-
-The set accessor of `hourCycle` is `undefined`. You cannot change this property directly.
+There are 2 main types of time keeping conventions (clocks) used around the world: the 12 hour clock and the 24 hour clock. The `hourCycle` property returns the collation type that would be used if the locale is used in a time formatting context, such as {{jsxref("Intl.DateTimeFormat")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
@@ -9,6 +9,14 @@ browser-compat: javascript.builtins.Intl.Locale.language
 
 The **`language`** accessor property of {{jsxref("Intl.Locale")}} instances returns the language associated with this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `language` returns a string representing the language subtag of the locale, without any other subtags such as region or script.
+
+There is no setter for `language`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Language is one of the core features of a locale. The Unicode specification treats the language identifier of a locale as the language and the region together (to make a distinction between dialects and variations, e.g. British English vs. American English). The `language` property of a {{jsxref("Intl/Locale", "Locale")}} returns strictly the locale's language subtag.

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
@@ -9,11 +9,17 @@ browser-compat: javascript.builtins.Intl.Locale.numberingSystem
 
 The **`numberingSystem`** accessor property of {{jsxref("Intl.Locale")}} instances returns the [numeral system](https://en.wikipedia.org/wiki/Numeral_system) for this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `numberingSystem` returns a string whose value is set at construction time, either through the `nu` key of the locale identifier or through the `numberingSystem` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`. For a list of supported numbering system types, see [`Intl.Locale.prototype.getNumberingSystems()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems#supported_numbering_system_types).
+
+There is no setter for `numberingSystem`, so you cannot change this property's value using assignment.
+
 ## Description
 
-A numeral system is a system for expressing numbers. The `numberingSystem` property's value is set at construction time, either through the `nu` key of the locale identifier or through the `numberingSystem` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
-
-For a list of supported numbering system types, see [`Intl.Locale.prototype.getNumberingSystems()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems#supported_numbering_system_types).
+A numeral system is a system for expressing numbers. The `numberingSystem` property returns the numbering system type that would be used if the locale is used in a number formatting context, such as {{jsxref("Intl.NumberFormat")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
@@ -9,15 +9,25 @@ browser-compat: javascript.builtins.Intl.Locale.numeric
 
 The **`numeric`** accessor property of {{jsxref("Intl.Locale")}} instances returns whether this locale has special collation handling for numeric characters.
 
+## Syntax
+
+### Return value
+
+The getter for `numeric` returns a boolean whose value is set at construction time, either through the `kn` key of the locale identifier or through the `numeric` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
+
+There is no setter for `numeric`, so you cannot change this property's value using assignment.
+
 ## Description
 
-Like {{jsxref("Intl/Locale/caseFirst", "caseFirst")}}, `numeric` represents a modification to the collation rules utilized by the locale. `numeric` is a boolean value, which means that it can be either `true` or `false`. If `numeric` is set to `false`, there will be no special handling of numeric values in strings. If `numeric` is set to `true`, then the locale will take numeric characters into account when collating strings. This special numeric handling means that sequences of decimal digits will be compared as numbers. For example, the string "A-21" will be considered less than "A-123".
+Like {{jsxref("Intl/Locale/caseFirst", "caseFirst")}}, `numeric` represents a modification to the collation rules utilized by the locale. If a locale has special numeric handling, it means that sequences of decimal digits will be compared as numbers. For example, the string "A-21" will be considered less than "A-123".
 
 ## Examples
 
+Like other locale subtags, the `numeric` type can be added to the {{jsxref("Intl.Locale")}} object via the locale string, or a configuration object argument to the constructor.
+
 ### Setting the numeric value via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numeric` represents correspond to the key `kn`. `kn` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `numeric` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To set the `numeric` value, first add the `-u` extension key to the string. Next, add the `-kn` extension key to indicate that you are adding a value for `numeric`. Finally, add the `numeric` value to the string. If you want to set `numeric` to `true`, adding the `kn` key will suffice. To set the value to `false`, you must specify in by adding `"false"` after the `kn` key.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), `numeric` values are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the `numeric` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To add the `numeric` value, first add the `-u` extension to the string. Next, add the `-kn` extension to indicate that you are adding a `numeric` value. Finally, add the `numeric` value to the string. If you want to set `numeric` to `true`, adding the `kn` key will suffice. To set the value to `false`, you must specify in by adding `"false"` after the `kn` key.
 
 ```js
 const locale = new Intl.Locale("fr-Latn-FR-u-kn-false");
@@ -26,7 +36,7 @@ console.log(locale.numeric); // Prints "false"
 
 ### Setting the numeric value via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numeric` property of the configuration object to your desired `numeric` value and pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can contain any of several extension types, including `numeric`. Set the `numeric` property of the configuration object to your desired `numeric` value, and then pass it into the constructor.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US", { numeric: true });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -9,6 +9,14 @@ browser-compat: javascript.builtins.Intl.Locale.region
 
 The **`region`** accessor property of {{jsxref("Intl.Locale")}} instances returns the region of the world (usually a country) associated with this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `region` returns a string representing the region subtag of the locale, without any other subtags such as language or script. It returns `undefined` if the locale does not have a region subtag.
+
+There is no setter for `region`, so you cannot change this property's value using assignment.
+
 ## Description
 
 The region is an essential part of the locale identifier, as it places the locale in a specific area of the world. Knowing the locale's region is vital to identifying differences between locales. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world.
@@ -17,7 +25,7 @@ The region is an essential part of the locale identifier, as it places the local
 
 ### Setting the region in the locale identifier string argument
 
-The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The region is a mandatory part of a
+The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the region is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -9,6 +9,14 @@ browser-compat: javascript.builtins.Intl.Locale.script
 
 The **`script`** accessor property of {{jsxref("Intl.Locale")}} instances returns the script used for writing the particular language used in this locale.
 
+## Syntax
+
+### Return value
+
+The getter for `script` returns a string representing the script subtag of the locale, without any other subtags such as language or region. It returns `undefined` if the locale does not have a script subtag.
+
+There is no setter for `script`, so you cannot change this property's value using assignment.
+
 ## Description
 
 A script, sometimes called writing system, is one of the core attributes of a locale. It indicates the set of symbols, or glyphs, that are used to write a particular language. For instance, the script associated with English is Latin, whereas the script typically associated with Korean is Hangul. In many cases, denoting a script is not strictly necessary, since the language (which is necessary) is only written in a single script. There are exceptions to this rule, however, and it is important to indicate the script whenever possible, in order to have a complete Unicode language identifier.

--- a/files/en-us/web/javascript/reference/global_objects/map/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@species/index.md
@@ -17,7 +17,9 @@ Map[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct copied `Map` instances.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct copied `Map` instances.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/map/size/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/size/index.md
@@ -11,11 +11,13 @@ The **`size`** accessor property of {{jsxref("Map")}} instances returns the numb
 
 {{EmbedInteractiveExample("pages/js/map-prototype-size.html")}}
 
-## Description
+## Syntax
 
-The value of `size` is an integer representing how many entries the `Map` object
-has. A set accessor function for `size` is `undefined`; you can not change this
-property.
+### Return value
+
+The getter for `size` returns an integer representing how many entries the `Map` object has.
+
+There is no setter for `size`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
@@ -25,18 +25,18 @@ obj.__proto__
 
 ### Return value
 
-If used as a getter, returns the object's `[[Prototype]]`.
+The getter for `__proto__` returns an object or `null` that is the prototype of the object on which it is accessed (`this`).
+
+The setter for `__proto__` mutates the prototype chain of `this`. The value provided must be an object or `null`. Providing any other value does nothing.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if attempting to set the prototype of a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible) object or an [immutable prototype exotic object](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-immutable-prototype-exotic-objects), such as `Object.prototype` or [`window`](/en-US/docs/Web/API/Window).
+  - : Thrown by the setter if attempting to set the prototype of a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible) object or an [immutable prototype exotic object](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-immutable-prototype-exotic-objects), such as `Object.prototype` or [`window`](/en-US/docs/Web/API/Window).
 
 ## Description
 
 The `__proto__` getter function exposes the value of the internal `[[Prototype]]` of an object. For objects created using an object literal, this value is `Object.prototype`. For objects created using array literals, this value is [`Array.prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array). For functions, this value is {{JSxRef("Function.prototype")}}. You can read more about the prototype chain in [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).
-
-The `__proto__` setter allows the `[[Prototype]]` of an object to be mutated. The value provided must be an object or {{JSxRef("Operators/null", "null")}}. Providing any other value will do nothing.
 
 Unlike {{jsxref("Object.getPrototypeOf()")}} and {{jsxref("Object.setPrototypeOf()")}}, which are always available on `Object` as static properties and always reflect the `[[Prototype]]` internal property, the `__proto__` property doesn't always exist as a property on all objects, and as a result doesn't reflect `[[Prototype]]` reliably.
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -19,7 +19,9 @@ Promise[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from promise chaining methods that create new promises.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct return values from promise chaining methods that create new promises.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.md
@@ -21,7 +21,9 @@ RegExp[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct copied `RegExp` instances.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct copied `RegExp` instances.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -11,9 +11,17 @@ The **`dotAll`** accessor property of {{jsxref("RegExp")}} instances returns whe
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-dotall.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `dotAll` returns a boolean which is `true` if the `s` flag was used, and `false` otherwise.
+
+There is no setter for `dotAll`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.dotAll` has the value `true` if the `s` flag was used; otherwise, `false`. The `s` flag indicates that the dot special character (`.`) should additionally match the following line terminator ("newline") characters in a string, which it would not match otherwise:
+The `s` flag indicates that the dot special character (`.`) should additionally match the following line terminator ("newline") characters in a string, which it would not match otherwise:
 
 - U+000A LINE FEED (LF) (`\n`)
 - U+000D CARRIAGE RETURN (CR) (`\r`)
@@ -21,8 +29,6 @@ The **`dotAll`** accessor property of {{jsxref("RegExp")}} instances returns whe
 - U+2029 PARAGRAPH SEPARATOR
 
 This effectively means the dot will match any character on the Unicode Basic Multilingual Plane (BMP). To allow it to match astral characters, the `u` (unicode) flag should be used. Using both flags in conjunction allows the dot to match any Unicode character, without exceptions.
-
-The set accessor of `dotAll` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -11,13 +11,19 @@ The **`flags`** accessor property of {{jsxref("RegExp")}} instances returns the 
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-flags.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `flags` returns a string where each letter represents a flag set on the regular expression. The letters are sorted in ascending alphabetical order (e.g. `"dgimsuvy"`).
+
+There is no setter for `flags`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.flags` has a string as its value. Flags in the `flags` property are sorted alphabetically (from left to right, e.g. `"dgimsuvy"`). It actually invokes the other flag accessors ([`hasIndices`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices), [`global`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global), etc.) one-by-one and concatenates the results.
+The `flags` getter actually invokes the other flag accessors ([`hasIndices`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices), [`global`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global), etc.) one-by-one and concatenates the results.
 
 All built-in functions read the `flags` property instead of reading individual flag accessors.
-
-The set accessor of `flags` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/global/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/global/index.md
@@ -11,13 +11,19 @@ The **`global`** accessor property of {{jsxref("RegExp")}} instances returns whe
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-global.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `global` returns a boolean which is `true` if the `g` flag was used, and `false` otherwise.
+
+There is no setter for `global`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.global` has the value `true` if the `g` flag was used; otherwise, `false`. The `g` flag indicates that the regular expression should be tested against all possible matches in a string. Each call to [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) will update its [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property, so that the next call to `exec()` will start at the next character.
+The `g` flag indicates that the regular expression should be tested against all possible matches in a string. Each call to [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) will update its [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property, so that the next call to `exec()` will start at the next character.
 
 Some methods, such as [`String.prototype.matchAll()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) and [`String.prototype.replaceAll()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll), will validate that, if the parameter is a regex, it is global. The regex's [`@@match`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match) and [`@@replace`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace) methods (called by [`String.prototype.match()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) and [`String.prototype.replace()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)) would also have different behaviors when the regex is global.
-
-The set accessor of `global` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.md
@@ -11,13 +11,19 @@ The **`hasIndices`** accessor property of {{jsxref("RegExp")}} instances returns
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-hasindices.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `hasIndices` returns a boolean which is `true` if the `d` flag was used, and `false` otherwise.
+
+There is no setter for `hasIndices`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.hasIndices` has the value `true` if the `d` flag was used; otherwise, `false`. The `d` flag indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group. It does not change the regex's interpretation or matching behavior in any way, but only provides additional information in the matching result.
+The `d` flag indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group. It does not change the regex's interpretation or matching behavior in any way, but only provides additional information in the matching result.
 
 This flag primarily affects the return value of [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec). If the `d` flag is present, the array returned by `exec()` has an additional `indices` property as described in the `exec()` method's [return value](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#return_value). Because all other regex-related methods (such as {{jsxref("String.prototype.match()")}}) call `exec()` internally, they will also return the indices if the regex has the `d` flag.
-
-The set accessor of `hasIndices` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -11,15 +11,21 @@ The **`ignoreCase`** accessor property of {{jsxref("RegExp")}} instances returns
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-ignorecase.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `ignoreCase` returns a boolean which is `true` if the `i` flag was used, and `false` otherwise.
+
+There is no setter for `ignoreCase`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.ignoreCase` has the value `true` if the `i` flag was used; otherwise, `false`. The `i` flag indicates that case should be ignored while attempting a match in a string. Case-insensitive matching is done by mapping both the expected character set and the matched string to the same casing.
+The `i` flag indicates that case should be ignored while attempting a match in a string. Case-insensitive matching is done by mapping both the expected character set and the matched string to the same casing.
 
 If the regex is [Unicode-aware](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), the case mapping happens through _simple case folding_ specified in [`CaseFolding.txt`](https://unicode.org/Public/UCD/latest/ucd/CaseFolding.txt). The mapping always maps to a single code point, so it does not map, for example, `ß` (U+00DF LATIN SMALL LETTER SHARP S) to `ss` (which is _full case folding_, not _simple case folding_). It may however map code points outside the Basic Latin block to code points within it — for example, `ſ` (U+017F LATIN SMALL LETTER LONG S) case-folds to `s` (U+0073 LATIN SMALL LETTER S) and `K` (U+212A KELVIN SIGN) case-folds to `k` (U+006B LATIN SMALL LETTER K). Therefore, `ſ` and `K` can be matched by `/[a-z]/ui`.
 
 If the regex is Unicode-unaware, case mapping uses the [Unicode Default Case Conversion](https://unicode-org.github.io/icu/userguide/transforms/casemappings.html) — the same algorithm used in {{jsxref("String.prototype.toUpperCase()")}}. For example, `Ω` (U+2126 OHM SIGN) and `Ω` (U+03A9 GREEK CAPITAL LETTER OMEGA) are both mapped by Default Case Conversion to themselves but by simple case folding to `ω` (U+03C9 GREEK SMALL LETTER OMEGA), so `"ω"` is matched by `/[\u2126]/ui` and `/[\u03a9]/ui` but not by `/[\u2126]/i` or `/[\u03a9]/i`. This algorithm prevents code points outside the Basic Latin block to be mapped to code points within it, so `ſ` and `K` mentioned previously are not matched by `/[a-z]/i`.
-
-The set accessor of `ignoreCase` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/input/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/input/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.input
 
 The **`RegExp.input`** static accessor property returns the string against which a regular expression is matched. `RegExp.$_` is an alias for this property.
 
+## Syntax
+
+### Return value
+
+The getter for `input` returns a string containing the input from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, it returns an empty string.
+
+You can set the value of `input` because it has a setter, but this does not affect other behaviors of the regex, and the value will be overwritten again when the next successful match is made.
+
 ## Description
 
 Because `input` is a static property of {{jsxref("RegExp")}}, you always use it as `RegExp.input` or `RegExp.$_`, rather than as a property of a `RegExp` object you created.
-
-The value of `input` updates whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, `input` is an empty string. You can set the value of `input`, but this does not affect other behaviors of the regex, and the value will be overwritten again when the next successful match is made.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastmatch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastmatch/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.lastMatch
 
 The **`RegExp.lastMatch`** static accessor property returns the last matched substring. `RegExp["$&"]` is an alias for this property.
 
+## Syntax
+
+### Return value
+
+The getter for `lastMatch` returns a string containing the matched substring from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, it returns an empty string.
+
+There is no setter for `lastMatch`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Because `lastMatch` is a static property of {{jsxref("RegExp")}}, you always use it as `RegExp.lastMatch` or `RegExp["$&"]`, rather than as a property of a `RegExp` object you created.
-
-The value of `lastMatch` updates whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, `lastMatch` is an empty string. The set accessor of `lastMatch` is `undefined`, so you cannot change this property directly.
 
 You cannot use the shorthand alias with the dot property accessor (`RegExp.$&`), because `&` is not a valid identifier part, so this causes a {{jsxref("SyntaxError")}}. Use the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) instead.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.lastParen
 
 The **`RegExp.lastParen`** static accessor property returns the last parenthesized substring match, if any. `RegExp["$+"]` is an alias for this property.
 
+## Syntax
+
+### Return value
+
+The getter for `lastParen` returns a string containing the last parenthesized substring match from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, or if the most recent regex execution contains no capturing groups, it returns an empty string.
+
+There is no setter for `lastParen`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Because `lastParen` is a static property of {{jsxref("RegExp")}}, you always use it as `RegExp.lastParen` or `RegExp["$+"]`, rather than as a property of a `RegExp` object you created.
-
-The value of `lastParen` updates whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, or if the most recent regex execution contains no capturing groups, `lastParen` is an empty string. The set accessor of `lastParen` is `undefined`, so you cannot change this property directly.
 
 You cannot use the shorthand alias with the dot property accessor (`RegExp.$+`), because `+` is not a valid identifier part, so this causes a {{jsxref("SyntaxError")}}. Use the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) instead.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.leftContext
 
 The **`RegExp.leftContext`** static accessor property returns the substring preceding the most recent match. `` RegExp["$`"] `` is an alias for this property.
 
+## Syntax
+
+### Return value
+
+The getter for `leftContext` returns a string containing the substring preceding the matched substring from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, it returns an empty string.
+
+There is no setter for `leftContext`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Because `leftContext` is a static property of {{jsxref("RegExp")}}, you always use it as `RegExp.leftContext` or `` RegExp["$`"] ``, rather than as a property of a `RegExp` object you created.
-
-The value of `leftContext` updates whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, `leftContext` is an empty string. The set accessor of `leftContext` is `undefined`, so you cannot change this property directly.
 
 You cannot use the shorthand alias with the dot property accessor (`` RegExp.$`  ``), because `` ` `` is not a valid identifier part, so this causes a {{jsxref("SyntaxError")}}. Use the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) instead.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -11,11 +11,17 @@ The **`multiline`** accessor property of {{jsxref("RegExp")}} instances returns 
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-multiline.html", "taller")}}
 
+## Syntax
+
+### Return value
+
+The getter for `multiline` returns a boolean which is `true` if the `m` flag was used, and `false` otherwise.
+
+There is no setter for `multiline`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.multiline` has the value `true` if the `m` flag was used; otherwise, `false`. The `m` flag indicates that a multiline input string should be treated as multiple lines. For example, if `m` is used, `^` and `$` change from matching at only the start or end of the entire string to the start or end of any line within the string.
-
-The set accessor of `multiline` is `undefined`. You cannot change this property directly.
+The `m` flag indicates that a multiline input string should be treated as multiple lines. For example, if `m` is used, `^` and `$` change from matching at only the start or end of the entire string to the start or end of any line within the string.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/n/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/n/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.n
 
 The **`RegExp.$1, …, RegExp.$9`** static accessor properties return parenthesized substring matches.
 
+## Syntax
+
+### Return value
+
+The getter for `$1, …, $9` returns a string containing the corresponding parenthesized submatch from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, or if the last match does not have the corresponding capturing group, the respective property is an empty string.
+
+There is no setter for each property, so you cannot change their values using assignment.
+
 ## Description
 
 Because `$1`–`$9` are static properties of {{jsxref("RegExp")}}, you always use them as `RegExp.$1`, `RegExp.$2`, etc., rather than as properties of a `RegExp` object you created.
-
-The values of `$1, …, $9` update whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, or if the last match does not have the corresponding capturing group, the respective property is an empty string. The set accessor of each property is `undefined`, so you cannot change the properties directly.
 
 The number of possible parenthesized substrings is unlimited, but the `RegExp` object can only hold the first nine. You can access all parenthesized substrings through the returned array's indexes.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -13,11 +13,17 @@ browser-compat: javascript.builtins.RegExp.rightContext
 
 The **`RegExp.rightContext`** static accessor property returns the substring following the most recent match. `RegExp["$'"]` is an alias for this property.
 
+## Syntax
+
+### Return value
+
+The getter for `rightContext` returns a string containing the substring following the matched substring from the last time when a `RegExp` (but not a `RegExp` subclass) instance made a successful match. If no matches have been made, it returns an empty string.
+
+There is no setter for `rightContext`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Because `rightContext` is a static property of {{jsxref("RegExp")}}, you always use it as `RegExp.rightContext` or `RegExp["$'"]`, rather than as a property of a `RegExp` object you created.
-
-The value of `rightContext` updates whenever a `RegExp` (but not a `RegExp` subclass) instance makes a successful match. If no matches have been made, `rightContext` is an empty string. The set accessor of `rightContext` is `undefined`, so you cannot change this property directly.
 
 You cannot use the shorthand alias with the dot property accessor (`RegExp.$'`), because `'` is not a valid identifier part, so this causes a {{jsxref("SyntaxError")}}. Use the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) instead.
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/source/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/source/index.md
@@ -11,6 +11,14 @@ The **`source`** accessor property of {{jsxref("RegExp")}} instances returns a s
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-source.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `source` returns a string containing the source text of this regular expression, without the two forward slashes on both sides or any flags, such that when the `source` is passed to the `RegExp()` constructor, the new `RegExp` object will have the same behavior as the original one if the same flags are used. Some characters may be escaped.
+
+There is no setter for `source`, so you cannot change this property's value using assignment.
+
 ## Description
 
 Conceptually, the `source` property is the text between the two forward slashes in the regular expression literal. The language requires the returned string to be properly escaped, so that when the `source` is concatenated with a forward slash on both ends, it would form a parsable regex literal. For example, for `new RegExp("/")`, the `source` is `\\/`, because if it generates `/`, the resulting literal becomes `///`, which is a line comment. Similarly, all [line terminators](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators) will be escaped because line terminator _characters_ would break up the regex literal. There's no requirement for other characters, as long as the result is parsable. For empty regular expressions, the string `(?:)` is returned.

--- a/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
@@ -11,11 +11,17 @@ The **`sticky`** accessor property of {{jsxref("RegExp")}} instances returns whe
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-sticky.html", "taller")}}
 
+## Syntax
+
+### Return value
+
+The getter for `sticky` returns a boolean which is `true` if the `y` flag was used, and `false` otherwise.
+
+There is no setter for `sticky`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.sticky` has the value `true` if the `y` flag was used; otherwise, `false`. The `y` flag indicates that the regex attempts to match the target string only from the index indicated by the {{jsxref("RegExp/lastIndex", "lastIndex")}} property (and unlike a global regex, does not attempt to match from any later indexes).
-
-The set accessor of `sticky` is `undefined`. You cannot change this property directly.
+The `y` flag indicates that the regex attempts to match the target string only from the index indicated by the {{jsxref("RegExp/lastIndex", "lastIndex")}} property (and unlike a global regex, does not attempt to match from any later indexes).
 
 For both sticky regexes and [global](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global) regexes:
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.md
@@ -11,17 +11,23 @@ The **`unicode`** accessor property of {{jsxref("RegExp")}} instances returns wh
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-unicode.html", "taller")}}
 
+## Syntax
+
+### Return value
+
+The getter for `unicode` returns a boolean which is `true` if the `u` flag was used, and `false` otherwise.
+
+There is no setter for `unicode`, so you cannot change this property's value using assignment.
+
 ## Description
 
-`RegExp.prototype.unicode` has the value `true` if the `u` flag was used; otherwise, `false`. The `u` flag enables various Unicode-related features. With the "u" flag:
+The `u` flag enables various Unicode-related features. With the "u" flag:
 
 - Any [Unicode code point escapes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\u{xxxx}`, `\p{UnicodePropertyValue}`) will be interpreted as such instead of identity escapes. For example `/\u{61}/u` matches `"a"`, but `/\u{61}/` (without `u` flag) matches `"u".repeat(61)`, where the `\u` is equivalent to a single `u`.
 - Surrogate pairs will be interpreted as whole characters instead of two separate characters. For example, `/[😄]/u` would only match `"😄"` but not `"\ud83d"`.
 - When [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) is automatically advanced (such as when calling [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec)), unicode regexes advance by Unicode code points instead of UTF-16 code units.
 
 There are other changes to the parsing behavior that prevent possible syntax mistakes (which are analogous to [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) for regex syntax). These syntaxes are all [deprecated and only kept for web compatibility](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#regexp), and you should not rely on them.
-
-The set accessor of `unicode` is `undefined`. You cannot change this property directly.
 
 ### Unicode-aware mode
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@species/index.md
@@ -17,7 +17,9 @@ Set[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct copied `Set` instances.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct copied `Set` instances.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/set/size/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/size/index.md
@@ -11,9 +11,13 @@ The **`size`** accessor property of {{jsxref("Set")}} instances returns the numb
 
 {{EmbedInteractiveExample("pages/js/set-prototype-size.html")}}
 
-## Description
+## Syntax
 
-The value of `size` is an integer representing how many entries the `Set` object has. A set accessor function for `size` is `undefined`; you cannot change this property.
+### Return value
+
+The getter for `size` returns an integer representing how many entries the `Set` object has.
+
+There is no setter for `size`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/@@species/index.md
@@ -19,7 +19,9 @@ SharedArrayBuffer[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from array buffer methods that create new array buffer.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct return values from array buffer methods that create new array buffer.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
@@ -11,9 +11,13 @@ The **`byteLength`** accessor property of {{jsxref("SharedArrayBuffer")}} instan
 
 {{EmbedInteractiveExample("pages/js/sharedarraybuffer-bytelength.html","shorter")}}
 
-## Description
+## Syntax
 
-The `byteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the shared array is constructed and cannot be changed.
+### Return value
+
+The getter for `byteLength` returns an integer whose value is established via the first `length` parameter of the {{jsxref("SharedArrayBuffer/SharedArrayBuffer", "SharedArrayBuffer()")}} constructor.
+
+There is no setter for `byteLength`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/growable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/growable/index.md
@@ -9,9 +9,13 @@ browser-compat: javascript.builtins.SharedArrayBuffer.growable
 
 The **`growable`** accessor property of {{jsxref("SharedArrayBuffer")}} instances returns whether this `SharedArrayBuffer` can be grow or not.
 
-## Description
+## Syntax
 
-The `growable` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the array is constructed. If a `maxByteLength` option was set in the constructor, `growable` will return `true`; if not, it will return `false`.
+### Return value
+
+The getter for `growable` returns a boolean value, which is `true` if the `maxByteLength` option was set in the constructor, and `false` otherwise.
+
+There is no setter for `growable`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/maxbytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/maxbytelength/index.md
@@ -9,11 +9,13 @@ browser-compat: javascript.builtins.SharedArrayBuffer.maxByteLength
 
 The **`maxByteLength`** accessor property of {{jsxref("SharedArrayBuffer")}} instances returns the maximum length (in bytes) that this `SharedArrayBuffer` can be grown to.
 
-## Description
+## Syntax
 
-The `maxByteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the shared array is constructed, set via the `maxByteLength` option of the {{jsxref("SharedArrayBuffer/SharedArrayBuffer", "SharedArrayBuffer()")}} constructor, and cannot be changed.
+### Return value
 
-If this `SharedArrayBuffer` was constructed without specifying a `maxByteLength` value, this property returns a value equal to the value of the `SharedArrayBuffer`'s {{jsxref("SharedArrayBuffer/byteLength", "byteLength")}}.
+The getter for `maxByteLength` returns an integer whose value is established via the `maxByteLength` option of the {{jsxref("SharedArrayBuffer/SharedArrayBuffer", "SharedArrayBuffer()")}} constructor. If this `SharedArrayBuffer` is [not growable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable), it returns the same value as the `SharedArrayBuffer`'s {{jsxref("SharedArrayBuffer/byteLength", "byteLength")}}.
+
+There is no setter for `maxByteLength`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/description/index.md
@@ -11,9 +11,17 @@ The **`description`** accessor property of {{jsxref("Symbol")}} values returns a
 
 {{EmbedInteractiveExample("pages/js/symbol-prototype-description.html")}}
 
+## Syntax
+
+### Return value
+
+The getter for `description` returns a string containing the description of this symbol, or `undefined` if the symbol has no description.
+
+There is no setter for `description`, so you cannot change this property's value using assignment.
+
 ## Description
 
-{{JSxRef("Symbol")}} objects can be created with an optional description which can be used for debugging but not to access the symbol itself. The `Symbol.prototype.description` property can be used to read that description. It is different to `Symbol.prototype.toString()` as it does not contain the enclosing `"Symbol()"` string. See the examples.
+{{JSxRef("Symbol")}} objects can be created with an optional description which can be used for debugging but not to access the symbol itself. The `Symbol.prototype.description` property can be used to read that description. It is different to `Symbol.prototype.toString()` as it does not contain the enclosing `"Symbol()"` string.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.md
@@ -19,7 +19,9 @@ TypedArray[Symbol.species]
 
 ### Return value
 
-The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from typed array methods that create new typed arrays.
+The getter for `@@species` returns the constructor (`this`) on which `@@species` was accessed. The return value is used to construct return values from typed array methods that create new typed arrays.
+
+There is no setter for `@@species`, so you cannot change this property's value using assignment.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -11,9 +11,15 @@ The **`buffer`** accessor property of {{jsxref("TypedArray")}} instances returns
 
 {{EmbedInteractiveExample("pages/js/typedarray-buffer.html","shorter")}}
 
-## Description
+## Syntax
 
-The `buffer` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when the _TypedArray_ is constructed and cannot be changed. _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+### Return value
+
+The getter for `buffer` returns the underlying {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}} of this typed array, established via the first `buffer` parameter of the {{jsxref("TypedArray")}} constructor, where _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+
+There is no setter for `buffer`, so you cannot change this property's value using assignment.
+
+## Description
 
 Because a typed array is a _view_ of a buffer, the underlying buffer may be longer than the typed array itself.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.md
@@ -11,9 +11,17 @@ The **`byteLength`** accessor property of {{jsxref("TypedArray")}} instances ret
 
 {{EmbedInteractiveExample("pages/js/typedarray-bytelength.html","shorter")}}
 
+## Syntax
+
+### Return value
+
+The getter for `byteLength` returns an integer whose value is either explicitly specified via the `length` parameter of the {{jsxref("TypedArray")}} constructor, or implicitly calculated by the `byteOffset` parameter and the `byteLength` of the referenced {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}, where _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+
+There is no setter for `byteLength`, so you cannot change this property's value using assignment.
+
 ## Description
 
-The `byteLength` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when a _TypedArray_ is constructed and cannot be changed. If the _TypedArray_ is not specifying a `byteOffset` or a `length`, the `length` of the referenced `ArrayBuffer` will be returned. _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+The value of `byteLength` is always equal to the value of {{jsxref("TypedArray/length", "length")}} times {{jsxref("TypedArray/BYTES_PER_ELEMENT", "BYTES_PER_ELEMENT")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -9,9 +9,13 @@ browser-compat: javascript.builtins.TypedArray.byteOffset
 
 The **`byteOffset`** accessor property of {{jsxref("TypedArray")}} instances returns the offset (in bytes) of this typed array from the start of its {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}.
 
-## Description
+## Syntax
 
-The `byteOffset` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when a _TypedArray_ is constructed and cannot be changed. _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+### Return value
+
+The getter for `byteOffset` returns an integer whose value is established via the second `byteOffset` parameter of the {{jsxref("TypedArray")}} constructor, where _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+
+There is no setter for `byteOffset`, so you cannot change this property's value using assignment.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -11,9 +11,17 @@ The **`length`** accessor property of {{jsxref("TypedArray")}} instances returns
 
 {{EmbedInteractiveExample("pages/js/typedarray-length.html","shorter")}}
 
+## Syntax
+
+### Return value
+
+The getter for `length` returns an integer whose value is either explicitly specified via the `length` parameter of the {{jsxref("TypedArray")}} constructor, or implicitly calculated by the `byteOffset` parameter and the `byteLength` of the referenced {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}, where _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+
+There is no setter for `length`, so you cannot change this property's value using assignment.
+
 ## Description
 
-The `length` property is an accessor property whose set accessor function is `undefined`, meaning that you can only read this property. The value is established when a _TypedArray_ is constructed and cannot be changed. If the _TypedArray_ is not specifying a `byteOffset` or a `length`, the length of the referenced {{jsxref("ArrayBuffer")}} will be returned. _TypedArray_ is one of the [TypedArray objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).
+The value of `length` is always equal to the value of {{jsxref("TypedArray/byteLength", "byteLength")}} divided by {{jsxref("TypedArray/BYTES_PER_ELEMENT", "BYTES_PER_ELEMENT")}}.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Since we already use the "Syntax" subheading with accessor properties, expanding this convention to every page seems beneficial.

1. It allows us to document any possible side-effects with getter/setters.
2. It allows us to document possible exceptions.
3. It provides a consistent place to add the note that "there's no setter for this property".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
