### PR TITLE
Update the title meta of `Array.length`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Array: length"
+title: Array.length
 slug: Web/JavaScript/Reference/Global_Objects/Array/length
 page-type: javascript-instance-data-property
 browser-compat: javascript.builtins.Array.length


### PR DESCRIPTION
### Description

I am proofreading and updating the translations of the `Array` section(see https://github.com/mdn/translated-content/issues/12761), and I have noticed that the title meta of the `Array.length` was different from other documents of `Array`. So if it was on purpose, please close this PR.

### Motivation

Ditto.

### Additional details

None.