### PR TITLE
Fix description of IDBObjectStore.get()

### DIFF
--- a/files/en-us/web/api/idbobjectstore/get/index.md
+++ b/files/en-us/web/api/idbobjectstore/get/index.md
@@ -10,7 +10,7 @@ browser-compat: api.IDBObjectStore.get
 
 The **`get()`** method of the {{domxref("IDBObjectStore")}}
 interface returns an {{domxref("IDBRequest")}} object, and, in a separate thread,
-returns the object store selected by the specified key. This is for retrieving
+returns the object selected by the specified key. This is for retrieving
 specific records from an object store.
 
 If a value is successfully found, then a structured clone of it is created and set as


### PR DESCRIPTION
Typo

### Description

IDBObjectStore.get() gives an object stored, not the object store itself ...

### Motivation

Glory

### Additional details

May be also be replaced by `returns the object stored `

### Related issues and pull requests

none