### PR TITLE
Use long lang form

### DIFF
--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -144,7 +144,7 @@ div[lang="pt"] {
 }
 
 /* All divs in Chinese are red, whether
-   simplified (zh-CN) or traditional (zh-TW). */
+   simplified (zh-Hans-CN) or traditional (zh-Hant-TW). */
 div[lang|="zh"] {
   color: red;
 }
@@ -153,7 +153,7 @@ div[lang|="zh"] {
    `data-lang` are purple. */
 /* Note: You could also use hyphenated attributes
    without double quotes */
-div[data-lang="zh-TW"] {
+div[data-lang="zh-Hant-TW"] {
   color: purple;
 }
 ```
@@ -163,9 +163,9 @@ div[data-lang="zh-TW"] {
 ```html
 <div lang="en-us en-gb en-au en-nz">Hello World!</div>
 <div lang="pt">Olá Mundo!</div>
-<div lang="zh-CN">世界您好！</div>
-<div lang="zh-TW">世界您好！</div>
-<div data-lang="zh-TW">世界您好！</div>
+<div lang="zh-Hans-CN">世界您好！</div>
+<div lang="zh-Hant-TW">世界您好！</div>
+<div data-lang="zh-Hant-TW">世界您好！</div>
 ```
 
 #### Result


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Firefox does not seemed to recognize `zh-CN` and `zh-TW` for lang, so use `zh-Hans-CN` and `zh-Hant-TW` instead.

More information in https://github.com/getzola/zola/issues/2169, I don't quite know what is correct but currently this fixed the issue.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The original language tags does not seemed to work well in browsers.