### PR TITLE
removed vendor prefix advice

### DIFF
--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -93,7 +93,7 @@ Prefixed, non-standard features are provided by browser developers for you to ex
 
 ### When using cutting-edge features (even standard ones) that are not universally implemented, make sure to test fallback paths
 
-Make sure to test what happens in a browser that doesn't implement the feature you're using, especially if you don't use such a browser day-to-day while working on the site. Also, use Javascript [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) and CSS [@supports](/en-US/docs/Web/CSS/@supports). 
+Make sure to test what happens in a browser that doesn't implement the feature you're using, especially if you don't use such a browser day-to-day while working on the site. Also, use Javascript [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) and CSS [@supports](/en-US/docs/Web/CSS/@supports).
 
 ### Don't use unprefixed versions of CSS properties or APIs until at least one browser supports them
 

--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -93,22 +93,7 @@ Prefixed, non-standard features are provided by browser developers for you to ex
 
 ### When using cutting-edge features (even standard ones) that are not universally implemented, make sure to test fallback paths
 
-Make sure to test what happens in a browser that doesn't implement the feature you're using, especially if you don't use such a browser day-to-day while working on the site.
-
-### Don't use vendor-prefixed features except to target old buggy versions
-
-Vendor-prefixed features can change behavior in future releases. Once a browser has shipped a feature unprefixed, however, you can use the prefixed version to target old releases by making sure to always use the unprefixed version of the feature when available. A good example, for a browser vendor using the `-vnd` CSS prefix that has shipped an unprefixed implementation of the `make-it-pretty` property, with a behavior for the value `"sometimes"` that differs from the prefixed version:
-
-```html
-<style>
-  .pretty-element {
-    -vnd-make-it-pretty: sometimes;
-    make-it-pretty: sometimes;
-  }
-</style>
-```
-
-The order of the declarations in the rule above is important: the unprefixed one needs to come last.
+Make sure to test what happens in a browser that doesn't implement the feature you're using, especially if you don't use such a browser day-to-day while working on the site. Also, use Javascript [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) and CSS [@supports](/en-US/docs/Web/CSS/@supports). 
 
 ### Don't use unprefixed versions of CSS properties or APIs until at least one browser supports them
 

--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -101,9 +101,9 @@ Until there's decently widespread support of the unprefixed version of something
 
 ## Code hygiene
 
-### Avoid missing `>`
+### Use best practices when coding
 
-Passing a validator is one way to ensure this, but even if your website doesn't validate entirely you should make sure all your `>` characters are present. Missing those can lead to unexpected situations due to a following tag name being treated as an attribute on a previous tag. This can work for a bit, then break if a specification attaches a meaning to that attribute. Here's an example that works in browsers without HTML5 support but breaks in a browser supporting HTML5:
+Passing a validator is one way to ensure your code is valid. But even if your website doesn't validate entirely you should make sure there are no errors, such as ensuring all your `>` characters are present. Missing those can lead to unexpected situations due to a following tag name being treated as an attribute on a previous tag. This can work for a bit, then break if a specification attaches a meaning to that attribute. Here's an example that worked in older browsers but breaks in all modern browsers:
 
 ```html
 <form action="http://www.example.com">


### PR DESCRIPTION
This page is woefully outdated, but with ever green browsers the vendor prefix advice was actually wrong (you don't want to serve prefixed features to old, slow mobile android for example). 

Also added links to feature detection and `@supports`

also addressed this comment: https://github.com/mdn/content/issues/19717#issuecomment-1220369058