### PR TITLE
Update the description and the example for the CSS function `tan()`

### DIFF
--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -49,7 +49,7 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 
 ### Drawing parallelograms
 
-The `tan()` function can be used to draw a parallelogram.
+The `tan()` function can be used to draw a parallelogram with a given bounding box.
 
 #### HTML
 
@@ -72,18 +72,18 @@ body {
 .parallelogram {
   --w: 400;
   --h: 200;
+  --angle: 30deg;
   position: relative;
   width: calc(1px * var(--w));
   height: calc(1px * var(--h));
 }
 .parallelogram::before {
-  --angle: calc(sin(var(--h) / var(--w)));
   content: "";
   position: absolute;
   width: calc(100% - 100% * var(--h) / var(--w) * tan(var(--angle)));
   height: 100%;
   transform-origin: 0 100%;
-  transform: skew(calc(0 - var(--angle)));
+  transform: skewX(calc(0deg - var(--angle)));
   background-color: red;
 }
 ```

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -39,7 +39,7 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 
 - If `angle` is `infinity`, `-infinity`, or `NaN`, the result is `NaN`.
 - If `angle` is `0⁻`, the result is `0⁻`.
-- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc), the result must be `∞` for `90deg` and all values a multiple of `360deg` from that (such as `-270deg` or `450deg`), and `−∞` for `-90deg` and all values a multiple of `360deg` from that (such as `-450deg` or `270deg`).
+- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc), the result is **explicitly undefined**. Authors *must not* rely on `tan()` returning any particular value for these inputs.
 
 ### Formal syntax
 
@@ -47,9 +47,9 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 
 ## Examples
 
-### Draw parallelograms
+### Drawing parallelograms
 
-The `tan()` function can be used draw a parallelogram.
+The `tan()` function can be used to draw a parallelogram.
 
 #### HTML
 
@@ -90,7 +90,7 @@ body {
 
 #### Result
 
-{{EmbedLiveSample('Draw parallelograms', '100%', '250px')}}
+{{EmbedLiveSample('Drawing parallelograms', '100%', '250px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -39,7 +39,7 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 
 - If `angle` is `infinity`, `-infinity`, or `NaN`, the result is `NaN`.
 - If `angle` is `0⁻`, the result is `0⁻`.
-- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc), the result is **explicitly undefined**. Authors _must not_ rely on `tan()` returning any particular value for these inputs.
+- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc.), the result is _explicitly undefined_. Authors _must not_ rely on `tan()` returning any particular value for these inputs.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -39,7 +39,7 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 
 - If `angle` is `infinity`, `-infinity`, or `NaN`, the result is `NaN`.
 - If `angle` is `0⁻`, the result is `0⁻`.
-- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc), the result is **explicitly undefined**. Authors *must not* rely on `tan()` returning any particular value for these inputs.
+- If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc), the result is **explicitly undefined**. Authors _must not_ rely on `tan()` returning any particular value for these inputs.
 
 ### Formal syntax
 


### PR DESCRIPTION
### Description

This PR:

  1. Changes the description for the special behavior of `tan()` when inputs are asymptote values following https://github.com/w3c/csswg-drafts/issues/8527;
  2. Slightly changes the structure of the example;
  3. Makes grammatic corrections.

### Motivation

For the example:

  1. The current expression for `--angle` in the example, i.e. `calc(sin(var(--h) / var(--w)))`, makes on sense in that it uses a sine value as an angle.
  2. `skew()` is explicitly deprecated by the [spec](https://w3c.github.io/csswg-drafts/css-transforms/#funcdef-transform-skew).
  3. The use of a bare `0` to mean `0deg` is deemed legacy by the [spec](https://w3c.github.io/csswg-drafts/css-values/#angles).

This also blocks the l10n of this page.

### Additional details

### Related issues and pull requests