### PR TITLE
Fix links to "ARIA: document structural roles"

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -102,7 +102,7 @@ The `aria-labelledby` attribute is **NOT** supported in:
 - [`paragraph`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) / [`none`](/en-US/docs/Web/Accessibility/ARIA/Roles/none_role)
 - [`strong`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
-- [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/supscript_role)
+- [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`superscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Roles/suggestion_role)
 - [`term`](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -92,21 +92,21 @@ Used in almost all roles **except** roles that can not be provided an accessible
 
 The `aria-labelledby` attribute is **NOT** supported in:
 
-- [`code`](/en-US/docs/Web/Accessibility/ARIA/Roles/code_role)
-- [`caption`](/en-US/docs/Web/Accessibility/ARIA/Roles/caption_role)
-- [`deletion`](/en-US/docs/Web/Accessibility/ARIA/Roles/deletion_role)
-- [`emphasis`](/en-US/docs/Web/Accessibility/ARIA/Roles/emphasis_role)
+- [`code`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [`caption`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [`deletion`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [`emphasis`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`generic`](/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role)
-- [`insertion`](/en-US/docs/Web/Accessibility/ARIA/Roles/_role)
+- [`insertion`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`mark`](/en-US/docs/Web/Accessibility/ARIA/Roles/mark_role)
-- [`paragraph`](/en-US/docs/Web/Accessibility/ARIA/Roles/paragraph_role)
+- [`paragraph`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) / [`none`](/en-US/docs/Web/Accessibility/ARIA/Roles/none_role)
-- [`strong`](/en-US/docs/Web/Accessibility/ARIA/Roles/strong_role)
+- [`strong`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/supscript_role)
-- [`superscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/superscript_role)
+- [`superscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Roles/suggestion_role)
 - [`term`](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role)
-- [`time`](/en-US/docs/Web/Accessibility/ARIA/Roles/time_role)
+- [`time`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
@@ -49,7 +49,7 @@ If a complete set of available nodes is not present in the DOM due to dynamic lo
 
 Used in roles:
 
-- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemkey_role)
+- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`comment`](/en-US/docs/Web/Accessibility/ARIA/Roles/comment_role)
 - [`heading`](/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role)
 - [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -50,8 +50,8 @@ In a [`feed`](/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role), each {{HTMLEl
 Used in roles:
 
 - [`article`](/en-US/docs/Web/Accessibility/ARIA/Roles/article_role)
-- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemkey_role)
-- [`associationlistitemvalue`](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemvalue_role)
+- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [`associationlistitemvalue`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`comment`](/en-US/docs/Web/Accessibility/ARIA/Roles/comment_role)
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
 - [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
@@ -60,8 +60,8 @@ To orient the user, assistive technologies would list the bananas above as "item
 Used in roles:
 
 - [`article`](/en-US/docs/Web/Accessibility/ARIA/Roles/article_role)
-- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemkey_role)
-- [`associationlistitemvalue`](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemvalue_role)
+- [`associationlistitemkey`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [`associationlistitemvalue`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [`comment`](/en-US/docs/Web/Accessibility/ARIA/Roles/comment_role)
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
 - [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role)

--- a/files/en-us/web/accessibility/aria/roles/section_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/section_role/index.md
@@ -12,7 +12,7 @@ The **`section` role**, an abstract role, is superclass role for renderable stru
 ## Description
 
 The structural `section` role is an abstract role for categorizing all the section subclass roles. The role must not be used. Some subclasses, like [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role),
-[`note`](/en-US/docs/Web/Accessibility/ARIA/Roles/note_role), and [`tooltip`](/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role), are useful, and can be used to add semantics when no semantic HTML elements quite fits the purpose of a component. Others, like [`code`](/en-US/docs/Web/Accessibility/ARIA/Roles/code_role), [`figure`](/en-US/docs/Web/Accessibility/ARIA/Roles/figure_role), and [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/subscript_role), aren't necessary, as there are HTML element equivalents. In this case, {{HTMLElement('code')}} {{HTMLElement('figure')}} and {{HTMLElement('subscript')}}, respectively.
+[`note`](/en-US/docs/Web/Accessibility/ARIA/Roles/note_role), and [`tooltip`](/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role), are useful, and can be used to add semantics when no semantic HTML elements quite fits the purpose of a component. Others, like [`code`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles), [`figure`](/en-US/docs/Web/Accessibility/ARIA/Roles/figure_role), and [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles), aren't necessary, as there are HTML element equivalents. In this case, {{HTMLElement('code')}} {{HTMLElement('figure')}} and {{HTMLElement('subscript')}}, respectively.
 
 ## Best Practices
 
@@ -26,20 +26,20 @@ Do not use.
 
 - [ARIA: `structure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role)
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
-- [ARIA: `associationlist` role](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlist_role)
-- [ARIA: `associationlistitemkey` role](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemkey_role)
-- [ARIA: `associationlistitemvalue` role](/en-US/docs/Web/Accessibility/ARIA/Roles/associationlistitemvalue_role)
-- [ARIA: `blockquote` role](/en-US/docs/Web/Accessibility/ARIA/Roles/blockquote_role)
-- [ARIA: `caption` role](/en-US/docs/Web/Accessibility/ARIA/Roles/caption_role)
+- [ARIA: `associationlist` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `associationlistitemkey` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `associationlistitemvalue` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `blockquote` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `caption` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `cell` role](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role)
-- [ARIA: `code` role](/en-US/docs/Web/Accessibility/ARIA/Roles/code_role)
+- [ARIA: `code` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `definition` role](/en-US/docs/Web/Accessibility/ARIA/Roles/definition_role)
-- [ARIA: `deletion` role](/en-US/docs/Web/Accessibility/ARIA/Roles/deletion_role)
-- [ARIA: `emphasis` role](/en-US/docs/Web/Accessibility/ARIA/Roles/emphasis_role)
+- [ARIA: `deletion` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `emphasis` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `figure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/figure_role)
 - [ARIA: `group` role](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role)
 - [ARIA: `img` role](/en-US/docs/Web/Accessibility/ARIA/Roles/img_role)
-- [ARIA: `insertion` role](/en-US/docs/Web/Accessibility/ARIA/Roles/insertion_role)
+- [ARIA: `insertion` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `landmark` role](/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role)
 - [ARIA: `list` role](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role)
 - [ARIA: `listitem` role](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
@@ -48,16 +48,16 @@ Do not use.
 - [ARIA: `marquee` role](/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role)
 - [ARIA: `math` role](/en-US/docs/Web/Accessibility/ARIA/Roles/math_role)
 - [ARIA: `note` role](/en-US/docs/Web/Accessibility/ARIA/Roles/note_role)
-- [ARIA: `paragraph` role](/en-US/docs/Web/Accessibility/ARIA/Roles/paragraph_role)
+- [ARIA: `paragraph` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `status` role](/en-US/docs/Web/Accessibility/ARIA/Roles/status_role)
-- [ARIA: `strong` role](/en-US/docs/Web/Accessibility/ARIA/Roles/strong_role)
-- [ARIA: `subscript` role](/en-US/docs/Web/Accessibility/ARIA/Roles/subscript_role)
+- [ARIA: `strong` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
+- [ARIA: `subscript` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `suggestion` role](/en-US/docs/Web/Accessibility/ARIA/Roles/suggestion_role)
-- [ARIA: `superscript` role](/en-US/docs/Web/Accessibility/ARIA/Roles/superscript_role)
+- [ARIA: `superscript` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `table` role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)
 - [ARIA: `tabpanel` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role)
 - [ARIA: `term` role](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role)
-- [ARIA: `time` role](/en-US/docs/Web/Accessibility/ARIA/Roles/time_role)
+- [ARIA: `time` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles)
 - [ARIA: `tooltip` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)
 
 <section id="Quick_links">


### PR DESCRIPTION
### Description

There are some pages on "[WAI-ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)" that weren't suppose to have their own pages, but got linked anyways. This PR fixes it.

### Motivation

Hopefully self-explanatory.

### Additional details

None

### Related issues and pull requests

None

