### PR TITLE
Repurpose the "Animatable CSS properties" page

### DIFF
--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -1,15 +1,47 @@
 ---
-title: Animatable CSS properties
+title: Animating CSS properties
 slug: Web/CSS/CSS_animated_properties
 page-type: landing-page
 ---
 
 {{CSSRef}}
 
-A CSS property is _animatable_ if its value can be made to change over a given amount of time. **Certain CSS properties can be animated** using [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) or [CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions). CSS properties that define animation parameters such as [animation-direction](/en-US/docs/Web/CSS/animation-direction) and [animation-name](/en-US/docs/Web/CSS/animation-name) are not animatable because animating them would create complex recursive behavior.
+[CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's **animation type** determines how values [combine](https://w3c.github.io/csswg-drafts/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three methods of combination.
 
-> **Note:** To check whether or not a CSS property can be animated, see the "Formal definition" section on the property's page on MDN Web Docs. For example, check out the "Animation type" field in the "Formal definition" section for [padding-bottom](/en-US/docs/Web/CSS/padding-bottom#formal_definition) and [animation-direction](/en-US/docs/Web/CSS/animation-direction#formal_definition).
+> **Note:** The animation type for each CSS property is listed in its "Formal definition" table (e.g. {{CSSXref("color", "", "#formal_definition")}}).
 
-The following CSS properties are animatable:
+> **Note:** The interpolation method for each CSS data type is described in its "Interpolation" section (e.g. {{CSSXref("&lt;length&gt;", "", "#interpolation")}}).
 
-{{CSSAnimatedProperties}}
+## Animation types
+
+There are mainly four animation types: not animatable, discrete, by computed value, and repeatable list.
+
+> **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to their "Interpolation" sections (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
+
+### Not animatable
+
+The property is not animatable. It is not processed when listed in an animation keyframe, and is not affected by transitions.
+
+> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect, e.g. firing the {{DOMXref("animationstart_event", "animationstart")}} event.
+
+### Discrete
+
+The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
+
+  - : If `p < 0.5`, then `V_result = V_start`;
+  - : If `p ≥ 0.5`, then `V_result = V_end`.
+
+### By computed value
+
+Corresponding individual components of the computed values are combined using the indicated procedure for that value type.
+
+If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
+
+### Repeatable list
+
+Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple number of items. Each item is then combined by computed value. If a pair of values cannot be combined or if any component value uses discrete animation, then the property values combine as discrete.
+
+## See also
+
+- [Using CSS Animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
+- [Using CSS Transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -18,9 +18,9 @@ There are mainly four animation types as defined in the [Web Animations](https:/
 
 - Not animatable
 
-  The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
+  - : The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
 
-  > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (E.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
+    > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (E.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
 
 - Discrete
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -14,27 +14,28 @@ page-type: landing-page
 
 ## Animation types
 
-There are mainly four animation types as defined in the [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties) specification: not animatable, discrete, by computed value, and repeatable list.
-
-> **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to the property's "Interpolation" section (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
+There are mainly four animation types as defined in the [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties) specification:
 
 - Not animatable
-- : The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
-  > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
+
+  - : The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
+
+      > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
 
 - Discrete
-- : The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
+
+  - : The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
 
   - If `p < 0.5`, then `V_result = V_start`;
   - If `p ≥ 0.5`, then `V_result = V_end`.
 
 - By computed value
-- : Corresponding individual components of the computed values are combined using the indicated procedure for that value type.
 
-  If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
+  - : Corresponding individual components of the computed values are combined using the indicated procedure for that value type. If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
 
 - Repeatable list
-- : Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
+
+  - : Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
 
 ## Animating custom properties
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -24,18 +24,18 @@ There are mainly four animation types as defined in the [Web Animations](https:/
 
 - Discrete
 
-  The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
+  - : The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
 
-  - If `p < 0.5`, then `V_result = V_start`;
-  - If `p ≥ 0.5`, then `V_result = V_end`.
+    - If `p < 0.5`, then `V_result = V_start`;
+    - If `p ≥ 0.5`, then `V_result = V_end`.
 
 - By computed value
 
-  Corresponding individual components of the computed values are combined using the indicated procedure for that value type. If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
+  - : Corresponding individual components of the computed values are combined using the indicated procedure for that value type. If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
 
 - Repeatable list
 
-  Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
+  - : Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
 
 Some properties have specific interpolation behavior not covered by these four types. In this case, refer to the property's "Interpolation" section (E.g., {{CSSXref("visibility", "", "#interpolation")}}).
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -1,5 +1,5 @@
 ---
-title: Animating CSS properties
+title: Animatable CSS properties
 slug: Web/CSS/CSS_animated_properties
 page-type: landing-page
 ---

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -18,24 +18,26 @@ There are mainly four animation types as defined in the [Web Animations](https:/
 
 - Not animatable
 
-  - : The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
+  The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
 
-      > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
+  > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (E.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
 
 - Discrete
 
-  - : The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
+  The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
 
   - If `p < 0.5`, then `V_result = V_start`;
   - If `p ≥ 0.5`, then `V_result = V_end`.
 
 - By computed value
 
-  - : Corresponding individual components of the computed values are combined using the indicated procedure for that value type. If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
+  Corresponding individual components of the computed values are combined using the indicated procedure for that value type. If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
 
 - Repeatable list
 
-  - : Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
+  Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
+
+Some properties have specific interpolation behavior not covered by these four types. In this case, refer to the property's "Interpolation" section (E.g., {{CSSXref("visibility", "", "#interpolation")}}).
 
 ## Animating custom properties
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -8,7 +8,7 @@ page-type: landing-page
 
 [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's **animation type** determines how values [combine](https://w3c.github.io/csswg-drafts/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three methods of combination.
 
-> **Note:** The animation type for each CSS property is listed in its "Formal definition" table (e.g. {{CSSXref("color", "", "#formal_definition")}}).
+> **Note:** The animation type for each CSS property is listed in its "Formal definition" table (E.g., {{CSSXref("color", "", "#formal_definition")}}).
 
 > **Note:** The interpolation method for each CSS data type is described in its "Interpolation" section (E.g., {{CSSXref("&lt;length&gt;", "", "#interpolation")}}).
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -43,7 +43,7 @@ Same as by computed value except that if the two lists have differing numbers of
 
 ## Animating custom properties
 
-For custom properties registered using the {{DOMXref("CSS/registerProperty", "registerProperty()")}} method, the animation type is by compute value, with the computed value type [determined](https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values) by the property's syntax definition.
+For custom properties registered using the {{DOMXref("CSS/registerProperty", "registerProperty()")}} method, the animation type is by computed value, with the computed value type [determined](https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values) by the property's syntax definition.
 
 For unregistered custom properties, the animation type is discrete.
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -22,7 +22,7 @@ There are mainly four animation types as defined in [Web Animations](https://w3c
 
 The property is not animatable. It is not processed when listed in an animation keyframe, and is not affected by transitions.
 
-> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect, e.g. firing the {{DOMXref("animationstart_event", "animationstart")}} event.
+> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect, e.g. firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event.
 
 ### Discrete
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -10,7 +10,7 @@ page-type: landing-page
 
 > **Note:** The animation type for each CSS property is listed in its "Formal definition" table (e.g. {{CSSXref("color", "", "#formal_definition")}}).
 
-> **Note:** The interpolation method for each CSS data type is described in its "Interpolation" section (e.g. {{CSSXref("&lt;length&gt;", "", "#interpolation")}}).
+> **Note:** The interpolation method for each CSS data type is described in its "Interpolation" section (E.g., {{CSSXref("&lt;length&gt;", "", "#interpolation")}}).
 
 ## Animation types
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -6,7 +6,7 @@ page-type: landing-page
 
 {{CSSRef}}
 
-[CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's **animation type** determines how values [combine](https://w3c.github.io/csswg-drafts/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three methods of combination.
+[CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's _animation type_ determines how values [combine](https://w3c.github.io/csswg-drafts/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three combination methods.
 
 > **Note:** The animation type for each CSS property is listed in its "Formal definition" table (E.g., {{CSSXref("color", "", "#formal_definition")}}).
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -14,7 +14,7 @@ page-type: landing-page
 
 ## Animation types
 
-There are mainly four animation types: not animatable, discrete, by computed value, and repeatable list.
+There are mainly four animation types as defined in [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties): not animatable, discrete, by computed value, and repeatable list.
 
 > **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to their "Interpolation" sections (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
 
@@ -28,8 +28,8 @@ The property is not animatable. It is not processed when listed in an animation 
 
 The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
 
-  - : If `p < 0.5`, then `V_result = V_start`;
-  - : If `p ≥ 0.5`, then `V_result = V_end`.
+- If `p < 0.5`, then `V_result = V_start`;
+- If `p ≥ 0.5`, then `V_result = V_end`.
 
 ### By computed value
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -14,15 +14,15 @@ page-type: landing-page
 
 ## Animation types
 
-There are mainly four animation types as defined in [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties): not animatable, discrete, by computed value, and repeatable list.
+There are mainly four animation types as defined in the [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties) specification: not animatable, discrete, by computed value, and repeatable list.
 
-> **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to their "Interpolation" sections (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
+> **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to the property's "Interpolation" section (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
 
 ### Not animatable
 
 The property is not animatable. It is not processed when listed in an animation keyframe, and is not affected by transitions.
 
-> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect, e.g. firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event.
+> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g. firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
 
 ### Discrete
 
@@ -40,6 +40,12 @@ If the number of components or the types of corresponding components do not matc
 ### Repeatable list
 
 Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple number of items. Each item is then combined by computed value. If a pair of values cannot be combined or if any component value uses discrete animation, then the property values combine as discrete.
+
+## Animating custom properties
+
+For custom properties registered using the {{DOMXref("CSS/registerProperty", "registerProperty()")}} method, the animation type is by compute value, with the computed value type [determined](https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values) by the property's syntax definition.
+
+For unregistered custom properties, the animation type is discrete.
 
 ## See also
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -18,28 +18,23 @@ There are mainly four animation types as defined in the [Web Animations](https:/
 
 > **Note:** Some properties have specific interpolation behavior not covered by the four types. In this case, refer to the property's "Interpolation" section (e.g. {{CSSXref("visibility", "", "#interpolation")}}).
 
-### Not animatable
+- Not animatable
+- : The property is not animatable. It is not processed when listed in an animation keyframe and is unaffected by transitions.
+  > **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g., firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
 
-The property is not animatable. It is not processed when listed in an animation keyframe, and is not affected by transitions.
+- Discrete
+- : The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
 
-> **Note:** An animation effect targeting only properties that are not animatable will still exhibit the usual behavior for an animation effect (e.g. firing the {{DOMXref("Element/animationstart_event", "animationstart")}} event).
+  - If `p < 0.5`, then `V_result = V_start`;
+  - If `p ≥ 0.5`, then `V_result = V_end`.
 
-### Discrete
+- By computed value
+- : Corresponding individual components of the computed values are combined using the indicated procedure for that value type.
 
-The property's values are not additive, and interpolation swaps from the start value to the end value at `50%`. Specifically, denoting by `p` the progress value:
+  If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
 
-- If `p < 0.5`, then `V_result = V_start`;
-- If `p ≥ 0.5`, then `V_result = V_end`.
-
-### By computed value
-
-Corresponding individual components of the computed values are combined using the indicated procedure for that value type.
-
-If the number of components or the types of corresponding components do not match, or if any component value uses discrete animation and the two corresponding values do not match, then the property values combine as discrete.
-
-### Repeatable list
-
-Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple number of items. Each item is then combined by computed value. If a pair of values cannot be combined or if any component value uses discrete animation, then the property values combine as discrete.
+- Repeatable list
+- : Same as by computed value except that if the two lists have differing numbers of items, they are first repeated to the least common multiple numbers of items. Each item is then combined by computed value. If a pair of values cannot be combined or any component value uses discrete animation, then the property values combine as discrete.
 
 ## Animating custom properties
 


### PR DESCRIPTION
### Description

This PR:

  1. Reuses the existing "Animatable CSS properties" page to adds contents to explain the common animation types;
  2. Has *not* edited the following affected pages that link to this page:
     - `web/css/animation`,
     - `web/css/css_transitions/using_css_transitions`,
     - `web/css/transition-property`;
  3. Does *not* remove the to-be-deprecated `{{CSSAnimatedProperties}}` macro.

### Motivation

See https://github.com/orgs/mdn/discussions/367.

### Additional details

Most contents are reproduced from the relevant section in the Web Animations spec:
https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties

### Related issues and pull requests

Fixes #17768.