### PR TITLE
New glossary: ink overflow

### DIFF
--- a/files/en-us/glossary/ink_overflow/index.md
+++ b/files/en-us/glossary/ink_overflow/index.md
@@ -1,0 +1,15 @@
+---
+title: Ink overflow
+slug: Glossary/Ink_overflow
+page-type: glossary-definition
+---
+
+The **ink overflow** of a box refers to the part of the box and its contents that creates a visual effect outside of the box's border box. Being visual only, ink overflow does not affect layout as it has not impact on box model properties.
+
+Ink overflow is the overflow of painting effects such as [box shadows](/en-US/docs/Web/CSS/box-shadow), [border images](/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders), [text decoration](/en-US/docs/Web/CSS/CSS_Text_Decoration), [outlines](/en-US/docs/Web/CSS/outline), etc. that do not affect layout or otherwise extend the scrollable overflow area. Ink overflow is also the overhanging of glyphs, such as ascenders and descenders extending outside the em box.
+
+As [replaced elements](/en-US/docs/Web/CSS/Replaced_element) always establish an independent formatting context, any overflow of replaced content is always ink overflow (as opposed to [scrollable overflow](/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content)).
+
+## See also
+
+- [CSS overflow module](/en-US/docs/Web/CSS/CSS_Overflow)


### PR DESCRIPTION
New glossary page for CSS "ink overflow" which describes content that overflows the container but does not impact the box model. 

I will be referencing this from many overflow documentation, and ink overflow creating properties in separate PRs.

https://drafts.csswg.org/css-overflow/#ink-overflow