### PR TITLE
markdownlint: update versions and disable rule MD034

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -100,6 +100,7 @@
         "var"
       ]
     },
+    "MD034": false,
     // Pending https://github.com/mdn/content/pull/20115
     "MD037": false,
     "MD040": false,

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "env-cmd": "10.1.0",
     "husky": "8.0.3",
     "lint-staged": "13.2.1",
-    "markdownlint-cli2": "0.6.0",
-    "markdownlint-rule-search-replace": "1.0.9",
+    "markdownlint-cli2": "0.7.0",
+    "markdownlint-rule-search-replace": "1.0.10",
     "prettier": "2.8.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,10 +2126,10 @@ glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globby@13.1.3:
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.3.tgz#f62baf5720bcb2c1330c8d4ef222ee12318563ff"
-  integrity sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==
+globby@13.1.4:
+  version "13.1.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.4.tgz#2f91c116066bcec152465ba36e5caa4a13c01317"
+  integrity sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==
   dependencies:
     dir-glob "^3.0.1"
     fast-glob "^3.2.11"
@@ -3204,41 +3204,49 @@ markdown-table@^3.0.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
 
-markdownlint-cli2-formatter-default@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.3.tgz#5aecd6e576ad18801b76e58bbbaf0e916c583ab8"
-  integrity sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==
+markdownlint-cli2-formatter-default@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.4.tgz#81e26b0a50409c0357c6f0d38d8246946b236fab"
+  integrity sha512-xm2rM0E+sWgjpPn1EesPXx5hIyrN2ddUnUwnbCsD/ONxYtw3PX6LydvdH6dciWAoFDpwzbHM1TO7uHfcMd6IYg==
 
-markdownlint-cli2@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.6.0.tgz#ffa6aee4098e61f781e5e69528db60f7f39f737c"
-  integrity sha512-Bv20r6WGdcHMWi8QvAFZ3CBunf4i4aYmVdTfpAvXODI/1k3f09DZZ0i0LcX9ZMhlVxjoOzbVDz1NWyKc5hwTqg==
+markdownlint-cli2@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.7.0.tgz#4ce5444d79b6a0f1526fb77299a08d5df3e8c6af"
+  integrity sha512-67r1t9ep+z0fa6g9TgL3tiPQeWo297ip165Et2u54UquJAkXWnq6e+dXFBjSPft/iLaGJfU0fUHXhXueqNUkGQ==
   dependencies:
-    globby "13.1.3"
-    markdownlint "0.27.0"
-    markdownlint-cli2-formatter-default "0.0.3"
+    globby "13.1.4"
+    markdownlint "0.28.1"
+    markdownlint-cli2-formatter-default "0.0.4"
     micromatch "4.0.5"
     strip-json-comments "5.0.0"
     yaml "2.2.1"
 
-markdownlint-rule-helpers@~0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.18.0.tgz#aafa3ea6437333c711ba04c520a3df4e511dbcc1"
-  integrity sha512-UEdWfsoLr8ylXxfh4fzY5P6lExN+7Un7LbfqDXPlq5VLwwEDFdcZ7EMXoaEKNzncBKG/KWrt2sVt7KiCJgPyMQ==
+markdownlint-micromark@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/markdownlint-micromark/-/markdownlint-micromark-0.1.2.tgz#5520e04febffa46741875a2f297509ffdb561f5c"
+  integrity sha512-jRxlQg8KpOfM2IbCL9RXM8ZiYWz2rv6DlZAnGv8ASJQpUh6byTBnEsbuMZ6T2/uIgntyf7SKg/mEaEBo1164fQ==
 
-markdownlint-rule-search-replace@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.0.9.tgz#bcc5529e9706e27650f03c2b90724b806b018459"
-  integrity sha512-Qrd+wPvCoED1XFR1uL9PdA8ktOGDtCFHPtw7IVzh2TQbLRRHa2MY/moO9jpLj2maexVevIYH9DS0NLWdU3W1Cg==
+markdownlint-rule-helpers@~0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.19.0.tgz#0924be6b58fe2b0fe5a31077b810f2fbeb841485"
+  integrity sha512-hXx0ZsXtNwyeFg02ImUhGjBmv/MDILKtcgpU+ur3WazJBv6dxaVzq9GEjVb+u3zoFE9+PURRIttVUIPA43dLpQ==
   dependencies:
-    markdownlint-rule-helpers "~0.18.0"
+    markdownlint-micromark "0.1.2"
 
-markdownlint@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.27.0.tgz#9dabf7710a4999e2835e3c68317f1acd0bc89049"
-  integrity sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==
+markdownlint-rule-search-replace@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.0.10.tgz#6b2a2b86d2047b48e9b86899bcdedf5755de0bf2"
+  integrity sha512-G86L6hM4P5G21MyeMEZwIdotNfwiKPfDnf7tCwSZy2h8nb/Gzg4crql4OkcO0bw4rYsXs9WHMYe3njff/Me9qA==
+  dependencies:
+    markdownlint-rule-helpers "~0.19.0"
+
+markdownlint@0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.28.1.tgz#7978f7e4393edbe08527417d44ffdc2ab865a61f"
+  integrity sha512-8At2DbgGKT/RVBinkqIPqLETopPXyQFGWSiTCJSr9Y6wVVyY70cDJ9dw3FXePn4AkytIUclgrsgI6KVeqeHFoA==
   dependencies:
     markdown-it "13.0.1"
+    markdownlint-micromark "0.1.2"
 
 md5-file@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
They've updated the `MD034/no-bare-urls` rule, now it clashes with our macros:
```diff
-- {{JSFiddleEmbed("https://jsfiddle.net/end3r/m85148b4/","","350")}}
++ {{JSFiddleEmbed("<https://jsfiddle.net/end3r/m85148b4/>","","350")}}
```

The PR updates the dependencies and disables the rule. 