### PR TITLE
fix: correct the slug case of `registerProperty()`

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9510,7 +9510,7 @@
 /en-US/docs/Web/API/Range.Range()	/en-US/docs/Web/API/Range/Range
 /en-US/docs/Web/API/ReadableByteStream	/en-US/docs/Web/API/ReadableStream
 /en-US/docs/Web/API/Reference	/en-US/docs/Web/API
-/en-US/docs/Web/API/RegisterProperty	/en-US/docs/Web/API/CSS/RegisterProperty
+/en-US/docs/Web/API/RegisterProperty	/en-US/docs/Web/API/CSS/registerProperty
 /en-US/docs/Web/API/RemotePlayback/onconnect	/en-US/docs/Web/API/RemotePlayback/connect_event
 /en-US/docs/Web/API/RemotePlayback/onconnecting	/en-US/docs/Web/API/RemotePlayback/connecting_event
 /en-US/docs/Web/API/RemotePlayback/ondisconnect	/en-US/docs/Web/API/RemotePlayback/disconnect_event

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -22342,10 +22342,6 @@
       "kscarfone"
     ]
   },
-  "Web/API/CSS/RegisterProperty": {
-    "modified": "2020-10-15T22:23:15.780Z",
-    "contributors": ["Wind1808", "harrylewis", "chrisdavidmills", "estelle"]
-  },
   "Web/API/CSS/escape": {
     "modified": "2020-10-15T21:26:49.626Z",
     "contributors": [
@@ -22369,6 +22365,10 @@
   "Web/API/CSS/paintWorklet": {
     "modified": "2020-10-15T22:14:39.186Z",
     "contributors": ["ExE-Boss", "estelle", "jpmedley", "Sheppy"]
+  },
+  "Web/API/CSS/registerProperty": {
+    "modified": "2020-10-15T22:23:15.780Z",
+    "contributors": ["Wind1808", "harrylewis", "chrisdavidmills", "estelle"]
   },
   "Web/API/CSS/supports": {
     "modified": "2020-10-15T21:21:12.267Z",

--- a/files/en-us/web/api/css/registerproperty/index.md
+++ b/files/en-us/web/api/css/registerproperty/index.md
@@ -1,7 +1,7 @@
 ---
 title: "CSS: registerProperty() static method"
 short-title: registerProperty()
-slug: Web/API/CSS/RegisterProperty
+slug: Web/API/CSS/registerProperty
 page-type: web-api-static-method
 browser-compat: api.CSS.registerProperty
 ---


### PR DESCRIPTION
### Description

correct the slug case of `registerProperty()`.

Done this by running `yarn content move Web/API/CSS/RegisterProperty Web/API/CSS/registerProperty`.

### Related issues and pull requests

Fixes: #26365.
