### PR TITLE
 docs(fx113-exp-relnote): Update nightly support for content-visibility

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -199,8 +199,8 @@ The [`content-visibility`](/en-US/docs/Web/CSS/content-visibility) CSS property 
   <tbody>
     <tr>
       <th>Nightly</th>
-      <td>109</td>
-      <td>No</td>
+      <td>113</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Developer Edition</th>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fx bug https://bugzilla.mozilla.org/show_bug.cgi?id=1820058 enables `content-visibility` on Nightly by default.

### Related issues and pull requests

Doc issue: https://github.com/mdn/content/issues/26155

