### PR TITLE
Add subsection headings for CSS Color-related pages

### DIFF
--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -48,6 +48,8 @@ color-mix(in hsl longer hue, hsl(120 100% 50%) 20%, white);
 
 In a supporting browser, the items have more blue, and therefore less white, as a higher percentage of `#34c9eb` is mixed in. When no value is given, the percentage defaults to 50%.
 
+#### HTML
+
 ```html
 <ul>
   <li>0%</li>
@@ -58,6 +60,8 @@ In a supporting browser, the items have more blue, and therefore less white, as 
   <li></li>
 </ul>
 ```
+
+#### CSS
 
 ```css hidden
 ul {
@@ -105,6 +109,8 @@ li:nth-child(6) {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample('Mixing two colors','100%', 150)}}
 
 ### Using hue interpolation methods
@@ -114,12 +120,16 @@ For `shorter` the result will be the shortest distance between the two angles (t
 
 For `increasing`, the result will be the angle between 0 and 360 degrees and for `decreasing` the result will be the angle between -360 and 0 degrees.
 
+#### HTML
+
 ```html
 <div id="shorter">shorter</div>
 <div id="longer">longer</div>
 <div id="increasing">increasing</div>
 <div id="decreasing">decreasing</div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -168,6 +178,8 @@ div {
   );
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Using hue interpolation methods','100%', 150)}}
 

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -40,6 +40,8 @@ color(display-p3 1 0.5 0 / .5);
 
 The following example shows the effect of varying the lightness, a-axis, and b-axis values of the `color()` function.
 
+#### HTML
+
 ```html
 <div data-color="red-a98-rgb"></div>
 <div data-color="red-prophoto-rgb"></div>
@@ -48,6 +50,8 @@ The following example shows the effect of varying the lightness, a-axis, and b-a
 <div data-color="blue-rec2020"></div>
 <div data-color="blue-srgb"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -81,17 +85,23 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample('Using_predefined_colorspaces_with_color')}}
 
 ### Using xyz colorspaces with color()
 
 The following example shows how to use `xyz` colorspaces to specify a color.
 
+#### HTML
+
 ```html
 <div data-color="red"></div>
 <div data-color="green"></div>
 <div data-color="blue"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -118,17 +128,23 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample('Using_xyz_colorspaces_with_color')}}
 
 ### Using color-gamut media queries with color()
 
 This example shows how to use the [`color-gamut`](/en-US/docs/Web/CSS/@media/color-gamut) media query to detect support for a particular colorspace and use that colorspace to specify a color.
 
+#### HTML
+
 ```html
 <div></div>
 <div></div>
 <div></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -160,6 +176,8 @@ div {
   }
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Using_color-gamut_media_queries_with_color')}}
 

--- a/files/en-us/web/css/color_value/lab/index.md
+++ b/files/en-us/web/css/color_value/lab/index.md
@@ -42,6 +42,8 @@ lab(52.2345% 40.1645 59.9971 / .5);
 
 The following example shows the effect of varying the lightness, a-axis, and b-axis values of the `lab()` function.
 
+#### HTML
+
 ```html
 <div data-color="red"></div>
 <div data-color="red-a"></div>
@@ -52,6 +54,8 @@ The following example shows the effect of varying the lightness, a-axis, and b-a
 <div data-color="blue"></div>
 <div data-color="blue-light"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -87,6 +91,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample("Adjusting_lightness_and_color_axes_with_lab")}}
 
 ### Adjusting opacity with lab()
@@ -95,12 +101,16 @@ The following example shows the effect of varying the `A` (alpha) value of the `
 The `red` and `red-alpha` elements overlap the `#background-div` element to demonstrate the effect of opacity.
 Giving `A` a value of `0.4` makes the color 40% opaque.
 
+#### HTML
+
 ```html
 <div id="background-div">
   <div data-color="red"></div>
   <div data-color="red-alpha"></div>
 </div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -126,6 +136,8 @@ div {
   background-color: lab(100 125 125 / 0.4);
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Adjusting_opacity_with_lab')}}
 

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -42,6 +42,8 @@ lch(52.2345% 72.2 56.2 / .5);
 
 The following example shows the effect of varying the `L` (lightness), `C` (chroma), and `H` (hue) values of the `lch()` functional notation.
 
+#### HTML
+
 ```html
 <div data-color="blue"></div>
 <div data-color="blue-light"></div>
@@ -52,6 +54,8 @@ The following example shows the effect of varying the `L` (lightness), `C` (chro
 <div data-color="green"></div>
 <div data-color="green-hue"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -87,6 +91,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample('Adjusting_lightness,_chroma,_and_hue_with_lch')}}
 
 ### Adjusting opacity with lch()
@@ -95,12 +101,16 @@ The following example shows the effect of varying the `A` (alpha) value of the `
 The `red` and `red-alpha` elements overlap the `#background-div` element to demonstrate the effect of opacity.
 Giving `A` a value of `0.4` makes the color 40% opaque.
 
+#### HTML
+
 ```html
 <div id="background-div">
   <div data-color="red"></div>
   <div data-color="red-alpha"></div>
 </div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -126,6 +136,8 @@ div {
   background-color: lch(50% 130 20 / 0.4);
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Adjusting_opacity_with_lch')}}
 

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -48,6 +48,8 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
 
 The following example shows the effect of varying the lightness, a-axis, and b-axis values of the `oklab()` function.
 
+#### HTML
+
 ```html
 <div data-color="blue"></div>
 <div data-color="blue-light"></div>
@@ -58,6 +60,8 @@ The following example shows the effect of varying the lightness, a-axis, and b-a
 <div data-color="green"></div>
 <div data-color="green-b"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -93,6 +97,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample("Adjusting_the_lightness_and_axes", "100%", 155)}}
 
 ### Adjusting opacity with oklab()
@@ -101,12 +107,16 @@ The following example shows the effect of varying the `A` (alpha) value of the `
 The `red` and `red-alpha` elements overlap the `#background-div` element to demonstrate the effect of opacity.
 Giving the `red-alpha` element an opacity of `0.4` makes it appear more transparent than the `red` element.
 
+#### HTML
+
 ```html
 <div id="background-div">
   <div data-color="red"></div>
   <div data-color="red-alpha"></div>
 </div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -132,6 +142,8 @@ div {
   background-color: oklab(50% 130 20 / 0.4);
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample("Adjusting_opacity_with_oklab", "100%", 155)}}
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -39,6 +39,8 @@ oklch(59.69% 0.156 49.77 / .5)
 
 The following example shows the effect of varying the `L` (lightness), `C` (chroma), and `H` (hue) values of the `oklch()` color function.
 
+#### HTML
+
 ```html
 <div data-color="blue"></div>
 <div data-color="blue-light"></div>
@@ -49,6 +51,8 @@ The following example shows the effect of varying the `L` (lightness), `C` (chro
 <div data-color="green"></div>
 <div data-color="green-hue"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -84,6 +88,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample('Adjusting_the_lightness_chroma_and_hue_of_a_color')}}
 
 ### Adjusting the alpha value of a color
@@ -92,12 +98,16 @@ The following example shows the effect of varying the `A` (alpha) value of the `
 The `red` and `red-alpha` elements overlap the `#background-div` element to demonstrate the effect of opacity.
 Giving `A` a value of `0.4` makes the color 40% opaque.
 
+#### HTML
+
 ```html
 <div id="background-div">
   <div data-color="red"></div>
   <div data-color="red-alpha"></div>
 </div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -123,6 +133,8 @@ div {
   background-color: oklch(50% 130 20 / 0.4);
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Adjusting_the_alpha_value_of_a_color')}}
 

--- a/files/en-us/web/css/hex-color/index.md
+++ b/files/en-us/web/css/hex-color/index.md
@@ -100,5 +100,5 @@ div {
 
 ## See also
 
-- [`<color>`](/en-US/docs/Web/CSS/color_value): the data type these values belong to
+- [`<color>`](/en-US/docs/Web/CSS/color_value): the color data type
 - [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb): the function allowing to set the three components of the color, as well as its transparency, using decimal values

--- a/files/en-us/web/css/hex-color/index.md
+++ b/files/en-us/web/css/hex-color/index.md
@@ -35,9 +35,11 @@ A `<hex-color>` value can be used everywhere where a [`<color>`](/en-US/docs/Web
 
 ## Examples
 
-```html
-<p>Hexadecimal syntax for a fully opaque hot pink</p>
+### Hexadecimal syntax for a fully opaque hot pink
 
+#### HTML
+
+```html
 <span>
   #f09
   <div class="c1"></div>
@@ -55,6 +57,8 @@ A `<hex-color>` value can be used everywhere where a [`<color>`](/en-US/docs/Web
   <div class="c4"></div>
 </span>
 ```
+
+#### CSS
 
 ```css
 div {
@@ -75,7 +79,9 @@ div {
 }
 ```
 
-{{EmbedLiveSample("Examples", "100%", "450")}}
+#### Result
+
+{{EmbedLiveSample("Hexadecimal_syntax_for_a_fully_opaque_hot_pink", "100%", "450")}}
 
 ## Specifications
 
@@ -87,5 +93,5 @@ div {
 
 ## See also
 
-- [`<color>`](/en-US/docs/Web/CSS/color_value) the data type these values belong to.
-- [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb), the function allowing to set the three components of the color, as well as its transparency, using decimal values.
+- [`<color>`](/en-US/docs/Web/CSS/color_value): the data type these values belong to
+- [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb): the function allowing to set the three components of the color, as well as its transparency, using decimal values

--- a/files/en-us/web/css/hex-color/index.md
+++ b/files/en-us/web/css/hex-color/index.md
@@ -60,6 +60,13 @@ A `<hex-color>` value can be used everywhere where a [`<color>`](/en-US/docs/Web
 
 #### CSS
 
+```css hidden
+body {
+  display: flex;
+  justify-content: space-evenly;
+}
+```
+
 ```css
 div {
   width: 40px;
@@ -81,7 +88,7 @@ div {
 
 #### Result
 
-{{EmbedLiveSample("Hexadecimal_syntax_for_a_fully_opaque_hot_pink", "100%", "450")}}
+{{EmbedLiveSample("Hexadecimal_syntax_for_a_fully_opaque_hot_pink", "100%", 100)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/hue/index.md
+++ b/files/en-us/web/css/hue/index.md
@@ -53,11 +53,15 @@ As an `<angle>` is periodic, normalized to the range of `0deg` to `360deg`. It i
 
 The following example shows the effect of changing the `hue` value of the [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl) functional notation on a color.
 
+#### HTML
+
 ```html
 <input type="range" min="0" max="360" value="0" id="hue-slider" />
 <p>Hue: <span id="hue-value">0deg</span></p>
 <div id="box"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -85,6 +89,8 @@ span {
 }
 ```
 
+#### JavaScript
+
 ```js
 const hue = document.querySelector("#hue-slider");
 const box = document.querySelector("#box");
@@ -94,6 +100,8 @@ hue.addEventListener("input", () => {
 });
 ```
 
+#### Result
+
 {{EmbedLiveSample("Changing the hue of a color using a slider", "100%", "200")}}
 
 ### Approximating red hues in different color spaces
@@ -101,12 +109,16 @@ hue.addEventListener("input", () => {
 The following example shows a similar red color in different color spaces.
 The values in the `lch()` and `oklch()` functions are rounded for readability.
 
+#### HTML
+
 ```html
 <div data-color="hsl-red">hsl()</div>
 <div data-color="hwb-red">hwb()</div>
 <div data-color="lch-red">lch()</div>
 <div data-color="oklch-red">oklch()</div>
 ```
+
+#### CSS
 
 ```css
 [data-color="hsl-red"] {
@@ -138,6 +150,8 @@ div {
 }
 ```
 
+#### Result
+
 {{EmbedLiveSample("Approximating red hues in different color spaces", "100%", "150")}}
 
 ### Interpolating hue values
@@ -149,10 +163,14 @@ Conversely, `longer` uses the larger value between the two hue angles.
 
 > **Note:** For more information on using this functional notation, see the [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix) reference.
 
+#### HTML
+
 ```html
 <div id="shorter"></div>
 <div id="longer"></div>
 ```
+
+#### CSS
 
 ```css hidden
 div {
@@ -183,6 +201,8 @@ div {
   );
 }
 ```
+
+#### Result
 
 {{EmbedLiveSample('Interpolating hue values', '100%', '200')}}
 


### PR DESCRIPTION
### Description

This PR:

  1. Adds missing subsection headings for live samples for CSS Color Module-related pages following the [Writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples#formatting_live_samples);
  2. Improves the "Example" section of `<hex-color>`.

### Motivation

This blocks the l10n of these page.

### Additional details

### Related issues and pull requests