### PR TITLE
Remove list of 3rd-party libraries from “Web Components” article

### DIFF
--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -140,15 +140,3 @@ We are building up a number of examples in our [web-components-examples](https:/
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [Open Web Components](https://open-wc.org/) — Guides, tools and libraries for developing web components.
-- [DataFormsJS](https://www.dataformsjs.com/) — Open source web components library — Set of Web Components that can be used to build Single Page Apps (SPA), Display JSON data from API's and Web Services, and bind data to different elements on screen. All Web Components are plain JavaScript and require no build process.
-- [FAST](https://www.fast.design/) is a web component library built by Microsoft which offers several packages to leverage depending on your project needs. [Fast Element](https://github.com/microsoft/fast/tree/master/packages/web-components/fast-element) is a lightweight means to easily build performant, memory-efficient, standards-compliant Web Components. [Fast Foundation](https://github.com/microsoft/fast/tree/master/packages/web-components/fast-foundation) is a library of Web Component classes, templates, and other utilities built on fast-element intended to be composed into registered Web Components.
-- [Hybrids](https://github.com/hybridsjs/hybrids) — Open source web components library, which favors plain objects and pure functions over `class` and `this` syntax. It provides a simple and functional API for creating custom elements.
-- [Lit](https://lit.dev/) — Google's web components library, the core of which is a component base class designed to reduce boilerplate while providing reactive state, scoped styles, and a declarative template system.
-- [Snuggsi](https://github.com/devpunks/snuggsi#readme) — Easy Web Components in \~1kB _Including polyfill_ — All you need is a browser and basic understanding of HTML, CSS, and JavaScript classes to be productive.
-- [Slim.js](https://github.com/slimjs/slim.js) — Open source web components library — a high-performant library for rapid and easy component authoring; extensible and pluggable and cross-framework compatible.
-- [Stencil](https://stenciljs.com/) — Toolchain for building reusable, scalable design systems in web components.
-- [omi](https://tencent.github.io/omi/) - Front End Cross-Frameworks Framework


### PR DESCRIPTION
The “See also” section in the “Web Components” article is entirely an unvetted and unmaintained list of links to third-party libraries. This change removes it all.