### PR TITLE
RTCRtpSender.setStreams() - tidy formatting of syntax blocl

### DIFF
--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -18,7 +18,7 @@ Some user agents subclass this interface to provide more precise information or 
 ## Constructor
 
 - {{domxref("MediaStream.MediaStream", "MediaStream()")}}
-  - : Creates and returns a new MediaStream object. You can create an empty stream, a stream which is based upon an existing stream, or a stream that contains a specified list of tracks (specified as an array of {{domxref("MediaStreamTrack")}} objects).
+  - : Creates and returns a new `MediaStream` object. You can create an empty stream, a stream which is based upon an existing stream, or a stream that contains a specified list of tracks (specified as an array of {{domxref("MediaStreamTrack")}} objects).
 
 ## Instance properties
 

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.md
@@ -8,25 +8,23 @@ browser-compat: api.RTCRtpSender.setStreams
 
 {{DefaultAPISidebar("WebRTC API")}}
 
-The {{domxref("RTCRtpSender")}} method **`setStreams()`**
-associates the sender's {{domxref("RTCRtpSender.track", "track")}} with the specified
-{{domxref("MediaStream")}} or array of `MediaStream` objects.
+The {{domxref("RTCRtpSender")}} method **`setStreams()`** associates the sender's {{domxref("RTCRtpSender.track", "track")}} with the specified {{domxref("MediaStream")}} objects.
 
 ## Syntax
 
 ```js-nolint
 setStreams()
-setStreams(mediaStream)
-setStreams(mediaStreams)
+setStreams(mediaStream0)
+setStreams(mediaStream0, mediaStream1)
+setStreams(mediaStream0, mediaStream1, /* … ,*/ mediaStreamN)
 ```
 
 ### Parameters
 
-- `mediaStream` or `mediaStreams` {{optional_inline}}
-  - : An {{domxref("MediaStream")}} object or an array of multiple
-    `MediaStream` objects—identifying the streams to which the
-    `RTCRtpSender`'s {{domxref("RTCRtpSender.track", "track")}} belongs. If
-    this parameter isn't specified, no new streams will be associated with the track.
+- `mediaStreamN` {{optional_inline}}
+  - : An arbitrary number of {{domxref("MediaStream")}} objects specified as arguments, that identify the streams to which the
+    `RTCRtpSender`'s {{domxref("RTCRtpSender.track", "track")}} belongs.
+    If this parameter isn't specified, no new streams will be associated with the track.
 
 ### Return value
 
@@ -39,19 +37,14 @@ None ({{jsxref("undefined")}}).
 
 ## Description
 
-`setStreams()` is purely additive. It doesn't remove the track from any
-streams; it adds it to new ones. If you specify streams to which the track already
-belongs, that stream is unaffected.
+`setStreams()` is purely additive. It doesn't remove the track from any streams; it adds it to new ones.
+If you specify streams to which the track already belongs, that stream is unaffected.
 
-Once the track has been added to all of the streams, renegotiation of the connection
-will be triggered by the {{domxref("RTCPeerConnection.negotiationneeded_event",
-  "negotiationneeded")}} event being dispatched to the {{domxref("RTCPeerConnection")}} to
-which the sender belongs.
+Once the track has been added to all of the streams, renegotiation of the connection will be triggered by the {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} event being dispatched to the {{domxref("RTCPeerConnection")}} to which the sender belongs.
 
 ## Examples
 
-This example adds all of an {{domxref("RTCPeerConnection")}}'s tracks to the specified
-stream.
+This example adds all of an {{domxref("RTCPeerConnection")}}'s tracks to the specified stream.
 
 ```js
 function addTracksToStream(stream) {
@@ -65,12 +58,8 @@ function addTracksToStream(stream) {
 }
 ```
 
-After calling the {{domxref("RTCPeerConnection")}} method
-{{domxref("RTCPeerConnection.getSenders", "getSenders()")}} to get the list of the
-connection's senders, the `addTracksToStream()` function iterates over the
-list. For each sender, if the sender's track is non-null and its transport's state is
-`connected`, we call `setStreams()` to add the track to the
-`stream` specified.
+After calling the {{domxref("RTCPeerConnection")}} method {{domxref("RTCPeerConnection.getSenders", "getSenders()")}} to get the list of the connection's senders, the `addTracksToStream()` function iterates over the list.
+For each sender, if the sender's track is non-null and its transport's state is `connected`, we call `setStreams()` to add the track to the `stream` specified.
 
 ## Specifications
 


### PR DESCRIPTION
`RTCRtpSender.setStreams()` - just a tidy for the syntax block, which I think was incorrect.

This is part of general tidy work for #26146