### PR TITLE
PWAs can be installed on iOS/iPadOS 16.4+ by any browser

### DIFF
--- a/files/en-us/web/progressive_web_apps/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/installing/index.md
@@ -67,7 +67,7 @@ Installation is supported on all modern desktop and mobile devices. Whether the 
 
 Firefox requires a [PWA extension](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/).
 
-Apple is unique when it comes to PWAs: PWAs can be installed on macOS from any browser **except** Safari. The opposite is true for iOS, where PWAs can **only** be installed in Safari.
+Apple is unique when it comes to PWAs: PWAs can be installed on macOS from any browser **except** Safari. The opposite is true for iOS versions before 16.4, where PWAs could **only** be installed in Safari. PWAs can be installed on iOS/iPadOS 16.4 or later from any supporting browser.
 
 When an installed PWA is launched, it can be displayed in its own standalone window (without the full browser UI) but it still effectively runs in a browser window, even if the usual browser UI elements, such as the address bar or back button, aren't visible. The application will be found where the OS saves other applications, within a folder specific to the browser.
 


### PR DESCRIPTION
Per https://ios.gadgethacks.com/how-to/these-browsers-let-you-add-web-apps-and-bookmarks-your-iphones-home-screen-0385351/ as of iOS/iPadOS 16.4, any supporting browser can support the Add to Home Screen feature beyond Mobile Safari, and some already do e.g. Microsoft Edge and a few others (listed in that article).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
