### PR TITLE
Clean up pages linking to "Animatable CSS properties"

### DIFF
--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -9,8 +9,6 @@ browser-compat: css.properties.animation
 
 The **`animation`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property applies an animation between styles. It is a shorthand for {{cssxref("animation-name")}}, {{cssxref("animation-duration")}}, {{cssxref("animation-timing-function")}}, {{cssxref("animation-delay")}}, {{cssxref("animation-iteration-count")}}, {{cssxref("animation-direction")}}, {{cssxref("animation-fill-mode")}}, and {{cssxref("animation-play-state")}}.
 
-A [description of which properties are animatable](/en-US/docs/Web/CSS/CSS_animated_properties) is available; it's worth noting that this description is also valid for [CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions).
-
 {{EmbedInteractiveExample("pages/css/animation.html")}}
 
 ## Constituent properties

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -17,7 +17,7 @@ CSS transitions let you decide which properties to animate (by _listing them exp
 
 ## Which CSS properties can be transitioned?
 
-The Web author can define which property has to be animated and in which way. This allows the creation of complex transitions. As it doesn't make sense to animate some properties, the [list of animatable properties](/en-US/docs/Web/CSS/CSS_animated_properties) is limited to a finite set.
+The Web author can define which property has to be animated and in which way. This allows the creation of complex transitions. However, some properties are [not animatable](/en-US/docs/Web/CSS/CSS_animated_properties) as it doesn't make sense to animate them.
 
 > **Note:** The set of properties that can be animated is changing as the specification develops.
 

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -19,8 +19,6 @@ CSS transitions let you decide which properties to animate (by _listing them exp
 
 The Web author can define which property has to be animated and in which way. This allows the creation of complex transitions. However, some properties are [not animatable](/en-US/docs/Web/CSS/CSS_animated_properties) as it doesn't make sense to animate them.
 
-> **Note:** The set of properties that can be animated is changing as the specification develops.
-
 > **Note:** The `auto` value is often a very complex case. The specification recommends not animating from and to `auto`. Some user agents, like those based on Gecko, implement this requirement and others, like those based on WebKit, are less strict. Using animations with `auto` may lead to unpredictable results, depending on the browser and its version, and should be avoided.
 
 ## Defining transitions

--- a/files/en-us/web/css/transition-property/index.md
+++ b/files/en-us/web/css/transition-property/index.md
@@ -11,8 +11,6 @@ The **`transition-property`** [CSS](/en-US/docs/Web/CSS) property sets the CSS p
 
 {{EmbedInteractiveExample("pages/css/transition-property.html")}}
 
-> **Note:** The [set of properties that can be animated](/en-US/docs/Web/CSS/CSS_animated_properties) is subject to change. As such, you should avoid including any properties in the list that don't currently animate, as someday they might, causing unexpected results.
-
 If you specify a shorthand property (e.g., {{cssxref("background")}}), all of its longhand sub-properties that can be animated will be.
 
 ## Syntax


### PR DESCRIPTION
### Description

This PR changes or removes the descriptions on pages that link to [Animatable CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties).

### Motivation

A follow-up to #26364.

### Additional details

### Related issues and pull requests