### PR TITLE
Remove SVGDocument from sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1321,7 +1321,6 @@
         "SVGCursorElement",
         "SVGDefsElement",
         "SVGDescElement",
-        "SVGDocument",
         "SVGElement",
         "SVGEllipseElement",
         "SVGFEBlendElement",


### PR DESCRIPTION
`SVGDocument` is not part of the SVG2 spec and is not implemented in Gecko, Chromium, nor WebKit.

We don't have a page for it, so it is a very obvious red link in the sidebar of every SVG-related API page.

Time to remove it; it also outputs a warning when building the site.

Before:
![Capture d’écran 2023-04-25 à 10 32 15](https://user-images.githubusercontent.com/1466293/234220530-6c3d3a9b-4708-4442-88b1-011046d9ae29.png)

After: the same without the entry.