### PR TITLE
Unify the format for static methods

### DIFF
--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -8,7 +8,7 @@ browser-compat: api.AbortSignal.abort
 
 {{APIRef("DOM")}}
 
-The static **`AbortSignal.abort()`** method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an {{domxref("AbortSignal/abort_event","abort")}} event).
+The **`AbortSignal.abort()`** static method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an {{domxref("AbortSignal/abort_event","abort")}} event).
 
 This is shorthand for the following code:
 

--- a/files/en-us/web/api/abortsignal/timeout/index.md
+++ b/files/en-us/web/api/abortsignal/timeout/index.md
@@ -8,7 +8,7 @@ browser-compat: api.AbortSignal.timeout
 
 {{APIRef("DOM")}}
 
-The static **`AbortSignal.timeout()`** method returns an {{domxref("AbortSignal")}} that will automatically abort after a specified time.
+The **`AbortSignal.timeout()`** static method returns an {{domxref("AbortSignal")}} that will automatically abort after a specified time.
 
 The signal aborts with a `TimeoutError` {{domxref("DOMException")}} on timeout, or with `AbortError` {{domxref("DOMException")}} due to pressing a browser stop button (or some other inbuilt "stop" operation).
 This allow UIs to differentiate timeout errors, which typically require user notification, from user-triggered aborts that do not.

--- a/files/en-us/web/api/css/registerproperty/index.md
+++ b/files/en-us/web/api/css/registerproperty/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSS.registerProperty
 
 {{APIRef("CSSOM")}}
 
-The **`CSS.registerProperty()`** method registers
+The **`CSS.registerProperty()`** static method registers
 {{cssxref('--*', 'custom properties')}}, allowing for property type checking, default
 values, and properties that do or do not inherit their value.
 

--- a/files/en-us/web/api/css/supports/index.md
+++ b/files/en-us/web/api/css/supports/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSS.supports
 
 {{APIRef("CSSOM")}}
 
-The **`CSS.supports()`** method returns a boolean value
+The **`CSS.supports()`** static method returns a boolean value
 indicating if the browser supports a given CSS feature, or not.
 
 ## Syntax

--- a/files/en-us/web/api/cssnumericvalue/parse/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSNumericValue.parse
 
 {{APIRef("CSS Typed OM")}}
 
-The **`parse()`** method of the
+The **`parse()`** static method of the
 {{domxref("CSSNumericValue")}} interface converts a value string into an object whose
 members are value and the units.
 

--- a/files/en-us/web/api/dompoint/frompoint/index.md
+++ b/files/en-us/web/api/dompoint/frompoint/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMPoint.fromPoint
 
 {{APIRef("DOM")}}
 
-The static **{{domxref("DOMPoint")}}** method
+The **{{domxref("DOMPoint")}}** static method
 `fromPoint()` creates and returns a new mutable `DOMPoint`
 object given a source point.
 

--- a/files/en-us/web/api/idbkeyrange/bound/index.md
+++ b/files/en-us/web/api/idbkeyrange/bound/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IDBKeyRange.bound
 
 {{ APIRef("IndexedDB") }}
 
-The **`bound()`** method of the {{domxref("IDBKeyRange")}}
+The **`bound()`** static method of the {{domxref("IDBKeyRange")}}
 interface creates a new key range with the specified upper and lower bounds. The
 bounds can be open (that is, the bounds exclude the endpoint values) or closed (that
 is, the bounds include the endpoint values). By default, the bounds are closed.

--- a/files/en-us/web/api/idbkeyrange/lowerbound/index.md
+++ b/files/en-us/web/api/idbkeyrange/lowerbound/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IDBKeyRange.lowerBound
 
 {{ APIRef("IndexedDB") }}
 
-The **`lowerBound()`** method of the
+The **`lowerBound()`** static method of the
 {{domxref("IDBKeyRange")}} interface creates a new key range with only a lower bound.
 By default, it includes the lower endpoint value and is closed.
 

--- a/files/en-us/web/api/idbkeyrange/only/index.md
+++ b/files/en-us/web/api/idbkeyrange/only/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IDBKeyRange.only
 
 {{ APIRef("IndexedDB") }}
 
-The **`only()`** method of the {{domxref("IDBKeyRange")}}
+The **`only()`** static method of the {{domxref("IDBKeyRange")}}
 interface creates a new key range containing a single value.
 
 {{AvailableInWorkers}}

--- a/files/en-us/web/api/idbkeyrange/upperbound/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperbound/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IDBKeyRange.upperBound
 
 {{ APIRef("IndexedDB") }}
 
-The **`upperBound()`** method of the
+The **`upperBound()`** static method of the
 {{domxref("IDBKeyRange")}} interface creates a new upper-bound key range. By default,
 it includes the upper endpoint value and is closed.
 

--- a/files/en-us/web/api/notification/requestpermission/index.md
+++ b/files/en-us/web/api/notification/requestpermission/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Notification.requestPermission
 
 > **Note:** Safari still uses the callback syntax to get the permission. Read [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API) for a good example of how to feature detect this and run code as appropriate.
 
-The **`requestPermission()`** method of the {{domxref("Notification")}} interface requests permission from the user for the current origin to display notifications.
+The **`requestPermission()`** static method of the {{domxref("Notification")}} interface requests permission from the user for the current origin to display notifications.
 
 ## Syntax
 

--- a/files/en-us/web/api/response/error/index.md
+++ b/files/en-us/web/api/response/error/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Response.error
 
 {{APIRef("Fetch API")}}
 
-The **`error()`** method of the {{domxref("Response")}} interface returns a new `Response` object associated with a network error.
+The **`error()`** static method of the {{domxref("Response")}} interface returns a new `Response` object associated with a network error.
 
 > **Note:** This is mainly relevant to [ServiceWorkers](/en-US/docs/Web/API/Service_Worker_API); the error method is used to return an error if you so wish it.
 > An error response has its {{domxref("Response.type","type")}} set to `error`.

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Response.redirect
 
 {{APIRef("Fetch API")}}
 
-The **`redirect()`** method of the {{domxref("Response")}} interface returns a `Response` resulting in a redirect to the specified URL.
+The **`redirect()`** static method of the {{domxref("Response")}} interface returns a `Response` resulting in a redirect to the specified URL.
 
 > **Note:** This is mainly relevant to the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API).
 > A controlling service worker could intercept a page's request and redirect it as desired.


### PR DESCRIPTION
### Description

This PR unifies the announcing format for Web API's static methods.

### Motivation

Most of the changed pages lacked the "static" word, and this PR tries to clearly and uniformly spell them out.

### Additional details

All pages are found with `/static-method.*?\*\*.*?\*\* method/s`.

### Related issues and pull requests