### PR TITLE
fix typo: index.md

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -72,7 +72,7 @@ exports.index = asyncHandler(async (req, res, next) => {
     BookInstance.countDocuments({}).exec(),
     BookInstance.countDocuments({ status: "Available" }).exec(),
     Author.countDocuments({}).exec(),
-    Author.countDocuments({}).exec(),
+    Genre.countDocuments({}).exec(),
   ]);
 
   res.render("index", {


### PR DESCRIPTION
renamed `Author.countDocuments({}).exec()` to `Genre.countDocuments({}).exec()` to eliminate duplication and sync with respective database query for document counts



