### PR TITLE
Fixing stale variable reference for MediaQueryListEvent

### DIFF
--- a/files/en-us/web/api/mediaquerylistevent/media/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/media/index.md
@@ -33,7 +33,7 @@ mql.addEventListener("change", (event) => {
     document.body.style.backgroundColor = "blue";
   }
 
-  console.log(e.media);
+  console.log(event.media);
 });
 ```
 


### PR DESCRIPTION
### Description

A variable was renamed in the past, one usage was missed though.

### Motivation

Fixes the code example for MediaQueryListEvent

### Additional details

Commit cc3f48b34e78e64379cc94c47c9e3cf0e650077a introduced changes to a variable name but not all usages were adjusted.

### Related issues and pull requests

n/a