### PR TITLE
Remove red links to features removed in Safari 15.4

### DIFF
--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -35,7 +35,6 @@ Applications based on WebKit or Blink, such as Safari and Chrome, support a numb
 - {{CSSxRef("border-inline-end-color","-webkit-border-end-color")}}\*\*
 - {{CSSxRef("border-inline-end-style","-webkit-border-end-style")}}\*\*
 - {{CSSxRef("border-inline-end-width","-webkit-border-end-width")}}\*\*
-- {{CSSxRef("border-image-repeat", "-webkit-border-fit")}}
 - {{CSSxRef("-webkit-border-horizontal-spacing", "-webkit-border-horizontal-spacing")}}
 - {{CSSxRef("border-inline-start", "-webkit-border-start")}}\*\*
 - {{CSSxRef("border-inline-start-color", "-webkit-border-start-color")}}\*\*
@@ -425,7 +424,7 @@ The following properties are supported with the `-webkit-` prefix in Firefox. Ma
 The following properties were once supported with the -webkit- prefix but are no longer supported in evergreen browsers, with or without the `-webkit-` prefix.
 
 - `-webkit-alt*`
-- {{CSSxRef("-webkit-background-composite", "-webkit-background-composite")}}
+- `-webkit-background-composite`
 - `-webkit-border-fit`
 - `-webkit-color-correction`
 - `-webkit-flow-from`
@@ -436,11 +435,11 @@ The following properties were once supported with the -webkit- prefix but are no
 - `-webkit-image-set (See {{CSSxRef("image/image-set", "image-set")}})
 - `-webkit-mask-attachment`
 - `-webkit-match-nearest-mail-blockquote-color`
-- {{CSSxRef("-webkit-margin-collapse", "-webkit-margin-collapse")}}
-- {{CSSxRef("-webkit-margin-after-collapse", "-webkit-margin-after-collapse")}}
-- {{CSSxRef("-webkit-margin-before-collapse", "-webkit-margin-before-collapse")}}
-- {{CSSxRef("-webkit-margin-bottom-collapse", "-webkit-margin-bottom-collapse")}}
-- {{CSSxRef("-webkit-margin-top-collapse", "-webkit-margin-top-collapse")}}
+- `-webkit-margin-collapse`
+- `-webkit-margin-after-collapse`
+- `-webkit-margin-before-collapse`
+- `-webkit-margin-bottom-collapse`
+- `-webkit-margin-top-collapse`
 - {{CSSxRef("-webkit-overflow-scrolling", "-webkit-overflow-scrolling")}}
 - `-webkit-region-break-after`
 - `-webkit-region-break-before`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Removed red links to features actually removed from WebKit: we will never document these.

### Motivation

From https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes

![Capture d’écran 2023-04-27 à 10 35 27](https://user-images.githubusercontent.com/1466293/234806824-ce1521b7-e72e-4ac0-b890-add9d58f9305.png)
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

- There may be more, but I was only looking at the features removed in Safari 15.4
- There are still flaws on this page; this is "normal".
