### PR TITLE
Remove extra 'with' when referring to the img tag

### DIFF
--- a/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
+++ b/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
@@ -52,7 +52,7 @@ There are three attributes and one nested element worth noting:
 
 ## Best practices
 
-When an SVG is included via with {{HTMLElement('img')}}, the `alt` attribute provides alternative text making the image accessible. Inline SVG does not support the `alt` attribute. But it does support several other ways of making it accessible. With inline SVGs, the source is available in the DOM, meaning all the markup within an inline SVG file is accessible to the Accessibility Object Model, or AOM. Including the `<title>` element provides that alternative text.
+When an SVG is included via an {{HTMLElement('img')}} tag, the `alt` attribute provides alternative text making the image accessible. Inline SVG does not support the `alt` attribute. But it does support several other ways of making it accessible. With inline SVGs, the source is available in the DOM, meaning all the markup within an inline SVG file is accessible to the Accessibility Object Model, or AOM. Including the `<title>` element provides that alternative text.
 
 If the image conveys more than a short title, include a longer description with the [`<desc>`](/en-US/docs/Web/SVG/Element/desc) element. The `<desc>` element provides an accessible, long-text description. Similar to `<title>` text, the text within the `<desc>` is not rendered to the screen.
 

--- a/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
+++ b/files/en-us/web/svg/tutorial/svg_in_html_introduction/index.md
@@ -52,7 +52,7 @@ There are three attributes and one nested element worth noting:
 
 ## Best practices
 
-When an SVG is included via an {{HTMLElement('img')}} tag, the `alt` attribute provides alternative text making the image accessible. Inline SVG does not support the `alt` attribute. But it does support several other ways of making it accessible. With inline SVGs, the source is available in the DOM, meaning all the markup within an inline SVG file is accessible to the Accessibility Object Model, or AOM. Including the `<title>` element provides that alternative text.
+When an SVG is included via an {{HTMLElement('img')}} element, the `alt` attribute provides alternative text making the image accessible. Inline SVG does not support the `alt` attribute. But it does support several other ways of making it accessible. With inline SVGs, the source is available in the DOM, meaning all the markup within an inline SVG file is accessible to the Accessibility Object Model, or AOM. Including the `<title>` element provides that alternative text.
 
 If the image conveys more than a short title, include a longer description with the [`<desc>`](/en-US/docs/Web/SVG/Element/desc) element. The `<desc>` element provides an accessible, long-text description. Similar to `<title>` text, the text within the `<desc>` is not rendered to the screen.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Cleaning up a small typo with 'via with' both being included.

### Motivation

Fixes a small typo.

### Additional details

No additional details.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
