### PR TITLE
Update navigation.navigate()'s "NotSupportedError" conditions

### DIFF
--- a/files/en-us/web/api/navigation/navigate/index.md
+++ b/files/en-us/web/api/navigation/navigate/index.md
@@ -56,8 +56,6 @@ Either one of these promises rejects if the navigation has failed for some reaso
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the `history` option is set to `push`, and any of the following special circumstances are true:
     - The browser is currently showing the initial `about:blank` document.
-    - The current {{domxref("Document")}} is not yet loaded.
-    - The `url` parameter is set to the current URL.
     - The `url`'s scheme is `javascript`.
 
 ## Examples


### PR DESCRIPTION
See https://whatpr.org/html/8502/browsing-the-web.html#the-navigation-must-be-a-replace.

### Description

Remove two no-longer-true conditions for when navigation.navigate() throws a "NotSupportedError" DOMException.

### Motivation

Because the previous text is no longer correct.

### Additional details

This changed in the spec in https://github.com/whatwg/html/pull/8502/commits/0e2536f4957f0883fdbc3a5b210da672a63eddae and in Chromium in https://chromium-review.googlesource.com/c/chromium/src/+/4175895 , which landed in Chromium 112.0.5573.0.

I imagine it might be interesting to add this detail to the browser support table. But, IIUC that is a complicated process involving some data files in a different repository, which I unfortunately don't have the bandwidth for right now. So I thought just correcting the docs to be up to date with modern Chromium would be good.

### Related issues and pull requests

None