### PR TITLE
Remove misleading statements for the `exp()` and `log()` CSS functions

### DIFF
--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.exp
 
 The **`exp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that takes an number as an argument and returns the mathematical constant `e` raised to the power of the given number.
 
-The mathematical constant [e](<https://en.wikipedia.org/wiki/E_(mathematical_constant)>) represents Euler's number and is the base of natural logarithms, and is approximately `2.718281828459045`.
+The mathematical constant [e](<https://en.wikipedia.org/wiki/E_(mathematical_constant)>) is the base of natural logarithms, and is approximately `2.718281828459045`.
 
 The `exp(number)` function contains a calculation which returns the same value as {{CSSxRef("pow", "pow(e, number)")}}.
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.log
 
 The **`log()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns the logarithm of a number.
 
-The [logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of {{CSSxRef("exp", "exponentiation")}}; it is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter.
+[Logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of exponentiation. It is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter.
 
 In CSS, when a single parameter is passed, the natural logarithm `e`, or approximately `2.7182818`, is used, though the base can be set to any value with an optional second parameter.
 

--- a/files/en-us/web/css/log/index.md
+++ b/files/en-us/web/css/log/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.log
 
 The **`log()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is an exponential function that returns the logarithm of a number.
 
-[Logarithm, or log](https://en.wikipedia.org/wiki/Logarithm), is the inverse of exponentiation. It is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter.
+[Logarithm](https://en.wikipedia.org/wiki/Logarithm) is the inverse of exponentiation. It is the number that a fixed base has to be raised to in order to yield the number passed as the first parameter.
 
 In CSS, when a single parameter is passed, the natural logarithm `e`, or approximately `2.7182818`, is used, though the base can be set to any value with an optional second parameter.
 


### PR DESCRIPTION
### Description

This PR removes two misleading/inaccurate statements on `exp()` and `log()`.

### Motivation

  1. Neither [Euler number](https://mathworld.wolfram.com/EulerNumber.html) nor [Euler's constant](https://mathworld.wolfram.com/Euler-MascheroniConstant.html) refers to the constant `e`, and there's even a parenthetical note in the first paragraph of the latter that it can be confused with `e`.
  2. Only natural logarithm (`log(x)`) is the inverse of `exp(x)`, whereas general logarithm (`log(x, b)`), regarding `b` as a constant and `x` a variable, is the inverse of `pow(b, x)`.
  3. Conflating "lograithm" (general logarithm) with "log" (or `log`, natural logarithm) also causes confusion in the same way.

This blocks the l10n of these pages.

### Additional details

### Related issues and pull requests