### PR TITLE
Tag Django template code blocks with django

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -204,7 +204,7 @@ Update the `TEMPLATES` section's `'DIRS'` line as shown:
 
 Create a new HTML file called /**locallibrary/templates/registration/login.html** and give it the following contents:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -265,7 +265,7 @@ If you navigate to the logout URL (`http://127.0.0.1:8000/accounts/logout/`) the
 
 Create and open **/locallibrary/templates/registration/logged_out.html**. Copy in the text below:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -288,7 +288,7 @@ The following templates can be used as a starting point.
 
 This is the form used to get the user's email address (for sending the password reset email). Create **/locallibrary/templates/registration/password_reset_form.html**, and give it the following contents:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -307,7 +307,7 @@ This is the form used to get the user's email address (for sending the password 
 
 This form is displayed after your email address has been collected. Create **/locallibrary/templates/registration/password_reset_done.html**, and give it the following contents:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -319,7 +319,7 @@ This form is displayed after your email address has been collected. Create **/lo
 
 This template provides the text of the HTML email containing the reset link that we will send to users. Create **/locallibrary/templates/registration/password_reset_email.html**, and give it the following contents:
 
-```html
+```django
 Someone asked for password reset for email \{{ email }}. Follow the link below:
 \{{ protocol }}://\{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 ```
@@ -328,7 +328,7 @@ Someone asked for password reset for email \{{ email }}. Follow the link below:
 
 This page is where you enter your new password after clicking the link in the password reset email. Create **/locallibrary/templates/registration/password_reset_confirm.html**, and give it the following contents:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -364,7 +364,7 @@ This page is where you enter your new password after clicking the link in the pa
 
 This is the last password-reset template, which is displayed to notify you when the password reset has succeeded. Create **/locallibrary/templates/registration/password_reset_complete.html**, and give it the following contents:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -404,7 +404,7 @@ Typically you will first test against the `\{{ user.is_authenticated }}` templat
 
 Open the base template (**/locallibrary/catalog/templates/base_generic.html**) and copy the following text into the `sidebar` block, immediately before the `endblock` template tag.
 
-```html
+```django
   <ul class="sidebar-nav">
 
     …
@@ -575,7 +575,7 @@ urlpatterns += [
 
 Now, all we need to do for this page is add a template. First, create the template file **/catalog/templates/catalog/bookinstance_list_borrowed_user.html** and give it the following contents:
 
-```python
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}

--- a/files/en-us/learn/server-side/django/forms/index.md
+++ b/files/en-us/learn/server-side/django/forms/index.md
@@ -400,7 +400,7 @@ def renew_book_librarian(request, pk):
 
 Create the template referenced in the view (**/catalog/templates/catalog/book_renew_librarian.html**) and copy the code below into it:
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -426,7 +426,8 @@ The form code is relatively simple. First, we declare the `form` tags, specifyin
 
 > **Note:** Add the `{% csrf_token %}` to every Django template you create that uses `POST` to submit data. This will reduce the chance of forms being hijacked by malicious users.
 
-All that's left is the `\{{ form }}` template variable, which we passed to the template in the context dictionary. Perhaps unsurprisingly, when used as shown this provides the default rendering of all the form fields, including their labels, widgets, and help text — the rendering is as shown below:
+All that's left is the `\{{ form }}` template variable, which we passed to the template in the context dictionary.
+Perhaps unsurprisingly, when used as shown this provides the default rendering of all the form fields, including their labels, widgets, and help text — the rendering is as shown below:
 
 ```html
 <tr>
@@ -510,7 +511,7 @@ The view might look similar to this:
 We can add a link to the book renew page next to each item by appending the following template code to the list item text above.
 Note that this template code can only run inside the `{% for %}` loop, because that is where the `bookinst` value is defined.
 
-```django
+```plain
 {% if perms.catalog.can_mark_returned %}- <a href="{% url 'renew-book-librarian' bookinst.id %}">Renew</a>{% endif %}
 ```
 
@@ -645,7 +646,7 @@ The "create" and "update" views use the same template by default, which will be 
 
 Create the template file `locallibrary/catalog/templates/catalog/author_form.html` and copy the text below.
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -663,7 +664,7 @@ This is similar to our previous forms and renders the fields using a table. Note
 
 The "delete" view expects to find a template named with the format \_`model_name_confirm_delete.html` (again, you can change the suffix using `template_name_suffix` in your view). Create the template file `locallibrary/catalog/templates/catalog/author_confirm_delete.html` and copy the text below.
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}

--- a/files/en-us/learn/server-side/django/forms/index.md
+++ b/files/en-us/learn/server-side/django/forms/index.md
@@ -511,7 +511,7 @@ The view might look similar to this:
 We can add a link to the book renew page next to each item by appending the following template code to the list item text above.
 Note that this template code can only run inside the `{% for %}` loop, because that is where the `bookinst` value is defined.
 
-```plain
+```django
 {% if perms.catalog.can_mark_returned %}- <a href="{% url 'renew-book-librarian' bookinst.id %}">Renew</a>{% endif %}
 ```
 

--- a/files/en-us/learn/server-side/django/generic_views/index.md
+++ b/files/en-us/learn/server-side/django/generic_views/index.md
@@ -124,7 +124,7 @@ Create the HTML file **/locallibrary/catalog/templates/catalog/book_list.html** 
 Templates for generic views are just like any other templates (although of course the context/information passed to the template may differ).
 As with our _index_ template, we extend our base template in the first line and then replace the block named `content`.
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -151,7 +151,7 @@ We use the [`if`](https://docs.djangoproject.com/en/4.0/ref/templates/builtins/#
 If `book_list` is empty, then the `else` clause displays text explaining that there are no books to list.
 If `book_list` is not empty, then we iterate through the list of books.
 
-```html
+```django
 {% if book_list %}
   <!-- code here to list the books -->
 {% else %}
@@ -167,7 +167,7 @@ For more information about conditional operators see: [if](https://docs.djangopr
 The template uses the [for](https://docs.djangoproject.com/en/4.0/ref/templates/builtins/#for) and `endfor` template tags to loop through the book list, as shown below.
 Each iteration populates the `book` template variable with information for the current list item.
 
-```html
+```django
 {% for book in book_list %}
   <li> <!-- code here get information from each book item --> </li>
 {% endfor %}
@@ -175,7 +175,7 @@ Each iteration populates the `book` template variable with information for the c
 
 You might also use the `{% empty %}` template tag to define what happens if the book list is empty (although our template chooses to use a conditional instead):
 
-```html
+```django
 <ul>
   {% for book in book_list %}
     <li> <!-- code here get information from each book item --> </li>
@@ -192,7 +192,7 @@ For example, you can test the `forloop.last` variable to perform conditional pro
 
 The code inside the loop creates a list item for each book that shows both the title (as a link to the yet-to-be-created detail view) and the author.
 
-```html
+```django
 <a href="\{{ book.get_absolute_url }}">\{{ book.title }}</a> (\{{book.author}})
 ```
 
@@ -455,7 +455,7 @@ def book_detail_view(request, primary_key):
 
 Create the HTML file **/locallibrary/catalog/templates/catalog/book_detail.html** and give it the below content. As discussed above, this is the default template file name expected by the generic class-based _detail_ view (for a model named `Book` in an application named `catalog`).
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -490,13 +490,13 @@ Create the HTML file **/locallibrary/catalog/templates/catalog/book_detail.html*
 >
 > - Use the `url` template tag to reverse the 'author-detail' URL (defined in the URL mapper), passing it the author instance for the book:
 >
->   ```python
+>   ```django
 >   <a href="{% url 'author-detail' book.author.pk %}">\{{ book.author }}</a>
 >   ```
 >
 > - Call the author model's `get_absolute_url()` method (this performs the same reversing operation):
 >
->   ```html
+>   ```django
 >   <a href="\{{ book.author.get_absolute_url }}">\{{ book.author }}</a>
 >   ```
 >
@@ -610,13 +610,13 @@ Now that the data is paginated, we need to add support to the template to scroll
 
 Open **/locallibrary/catalog/templates/_base_generic.html_** and find the "content block" (as shown below).
 
-```python
+```django
 {% block content %}{% endblock %}
 ```
 
 Copy in the following pagination block immediately following the `{% endblock %}`. The code first checks if pagination is enabled on the current page. If so, it adds _next_ and _previous_ links as appropriate (and the current page number).
 
-```python
+```django
 {% block pagination %}
     {% if is_paginated %}
         <div class="pagination">
@@ -666,7 +666,7 @@ The code required for the URL mappers and the views should be virtually identica
 > - Once you've created the URL mapper for the author detail page, you should also update the [book detail view template](#creating_the_detail_view_template) (**/locallibrary/catalog/templates/catalog/book_detail.html**) so that the author link points to your new author detail page (rather than being an empty URL).
 >   The recommended way to do this is to call `get_absolute_url()` on the author model as shown below.
 >
->   ```html
+>   ```django
 >   <p><strong>Author:</strong> <a href="\{{ book.author.get_absolute_url }}">\{{ book.author }}</a></p>
 >
 >   ```

--- a/files/en-us/learn/server-side/django/home_page/index.md
+++ b/files/en-us/learn/server-side/django/home_page/index.md
@@ -96,7 +96,7 @@ The `path()` function defines the following:
 The `path()` function also specifies a `name` parameter, which is a unique identifier for _this_ particular URL mapping. You can use the name to "reverse" the mapper, i.e. to dynamically create a URL that points to the resource that the mapper is designed to handle.
 For example, we can use the name parameter to link to our home page from any other page by adding the following link in a template:
 
-```html
+```django
 <a href="{% url 'index' %}">Home</a>.
 ```
 
@@ -178,7 +178,7 @@ You can leave the blocks empty, or include default content to use when rendering
 
 > **Note:** Template _tags_ are functions that you can use in a template to loop through lists, perform conditional operations based on the value of a variable, and so on. In addition to template tags, the template syntax allows you to reference variables that are passed into the template from the view, and use _template filters_ to format variables (for example, to convert a string to lower case).
 
-```html
+```django
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -195,7 +195,7 @@ When defining a template for a particular view, we first specify the base templa
 
 For example, the code snippet below shows how to use the `extends` template tag and override the `content` block. The generated HTML will include the code and structure defined in the base template, including the default content you defined in the `title` block, but the new `content` block in place of the default one.
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -212,7 +212,7 @@ We will use the following code snippet as the base template for the _LocalLibrar
 
 Create a new file **base_generic.html** in **/locallibrary/catalog/templates/** and paste the following code to the file:
 
-```html
+```django
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -260,7 +260,7 @@ The base template also references a local CSS file (**styles.css**) that provide
 Create a new HTML file **index.html** in **/locallibrary/catalog/templates/** and paste the following code in the file.
 This code extends our base template on the first line, and then replaces the default `content` block for the template.
 
-```html
+```django
 {% extends "base_generic.html" %}
 
 {% block content %}
@@ -302,7 +302,7 @@ Your project is likely to use static resources, including JavaScript, CSS, and i
 
 Within the template you first call the `load` template tag specifying "static" to add the template library, as shown in the code sample below. You can then use the `static` template tag and specify the relative URL to the required file.
 
-```html
+```django
 <!-- Add additional CSS in static file -->
 {% load static %}
 <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
@@ -310,7 +310,7 @@ Within the template you first call the `load` template tag specifying "static" t
 
 You can add an image into the page in a similar way, for example:
 
-```html
+```django
 {% load static %}
 <img src="{% static 'catalog/images/local_library_model_uml.png' %}" alt="UML diagram" style="width:555px;height:540px;" />
 ```

--- a/files/en-us/learn/server-side/django/sessions/index.md
+++ b/files/en-us/learn/server-side/django/sessions/index.md
@@ -143,7 +143,7 @@ Here we first get the value of the `'num_visits'` session key, setting the value
 
 Add the line shown at the bottom of the following block to your main HTML template (**/locallibrary/catalog/templates/index.html**) at the bottom of the "Dynamic content" section to display the `num_visits` context variable.
 
-```html
+```django
 <h2>Dynamic content</h2>
 
 <p>The library has the following record counts:</p>


### PR DESCRIPTION
This tags code blocks with `django` if they define Django templates. This provides better rendering than HTML and is supported by yari.
Note that the associated docs may still have some `html` tagged blocks in them, but that is intentional (they contain pure HTML).