### PR TITLE
Fix Intl method intro format

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
@@ -7,8 +7,8 @@ browser-compat: javascript.builtins.Intl.Collator.compare
 
 {{JSRef}}
 
-The **`Intl.Collator.prototype.compare()`** method compares two
-strings according to the sort order of this {{jsxref("Intl.Collator")}} object.
+The **`compare()`** method of {{jsxref("Intl.Collator")}} instances compares two
+strings according to the sort order of this collator object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-compare.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
@@ -7,9 +7,8 @@ browser-compat: javascript.builtins.Intl.Collator.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.Collator.prototype.resolvedOptions()`** method
-returns a new object with properties reflecting the locale and collation options
-computed during initialization of this {{jsxref("Intl.Collator")}} object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.Collator")}} instances returns a new object with properties reflecting the locale and collation options
+computed during initialization of this collator object.
 
 {{EmbedInteractiveExample("pages/js/intl-collator-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.format
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.prototype.format()`** method formats
-a date according to the locale and formatting options of this
-{{jsxref("Intl.DateTimeFormat")}} object.
+The **`format()`** method of {{jsxref("Intl.DateTimeFormat")}} instances formats a date according to the locale and formatting options of this `Intl.DateTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-format.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
@@ -7,10 +7,10 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRange
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.prototype.formatRange()`** formats a
-date range in the most concise way based on the **`locale`** and
-**`options`** provided when instantiating
-{{jsxref("Intl.DateTimeFormat")}} object.
+The **`formatRange()`** method of {{jsxref("Intl.DateTimeFormat")}} instances formats a
+date range in the most concise way based on the locales and
+options provided when instantiating this
+`Intl.DateTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrange.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
@@ -7,9 +7,8 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRangeToParts
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.prototype.formatRangeToParts()`**
-method returns an array of locale-specific tokens representing each part of the formatted date
-range produced by {{jsxref("Intl.DateTimeFormat")}} formatters.
+The **`formatRangeToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of locale-specific tokens representing each part of the formatted date
+range produced by this `Intl.DateTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrangetoparts.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatToParts
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.prototype.formatToParts()`** method
-allows locale-aware formatting of strings produced by {{jsxref("Intl.DateTimeFormat")}}
-formatters.
+The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances allows locale-aware formatting of strings produced by this `Intl.DateTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formattoparts.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.DateTimeFormat.prototype.resolvedOptions()`**
-method returns a new object with properties reflecting the locale and date and time
-formatting options computed during initialization of this {{jsxref("Intl.DateTimeFormat")}}
-object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns a new object with properties reflecting the locale and date and time formatting options computed during initialization of this `Intl.DateTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.DisplayNames.of
 
 {{JSRef}}
 
-The **`Intl.DisplayNames.prototype.of()`** method receives a code and returns a string based on the locale and options provided when instantiating `Intl.DisplayNames`.
+The **`of()`** method of {{jsxref("Intl.DisplayNames")}} instances receives a code and returns a string based on the locale and options provided when instantiating this `Intl.DisplayNames` object.
 
 {{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Intl.DisplayNames.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.DisplayNames.prototype.resolvedOptions()`** method
+The **`resolvedOptions()`** method of {{jsxref("Intl.DisplayNames")}} instances
 returns a new object with properties reflecting the locale and style formatting
-options computed during the construction of the current {{jsxref("Intl.DisplayNames")}}
+options computed during the construction of this `Intl.DisplayNames`
 object.
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.formatToParts
 
 {{JSRef}}
 
-The **`Intl.ListFormat.prototype.formatToParts()`** method
+The **`formatToParts()`** method of {{jsxref("Intl.ListFormat")}} instances
 returns an {{jsxref("Array")}} of objects representing the different components that
 can be used to format a list of values in a locale-aware fashion.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
@@ -7,10 +7,9 @@ browser-compat: javascript.builtins.Intl.ListFormat.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.ListFormat.prototype.resolvedOptions()`** method
+The **`resolvedOptions()`** method of {{jsxref("Intl.ListFormat")}} instances
 returns a new object with properties reflecting the locale and style formatting
-options computed during the construction of the current {{jsxref("Intl.ListFormat")}}
-object.
+options computed during the construction of this `Intl.ListFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-listformat-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
@@ -7,8 +7,8 @@ browser-compat: javascript.builtins.Intl.Locale.maximize
 
 {{JSRef}}
 
-The **`Intl.Locale.prototype.maximize()`** method gets the
-most likely values for the language, script, and region of the locale based on
+The **`maximize()`** method of {{jsxref("Intl.Locale")}} instances gets the
+most likely values for the language, script, and region of this locale based on
 existing values.
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-maximize.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
@@ -7,8 +7,8 @@ browser-compat: javascript.builtins.Intl.Locale.minimize
 
 {{JSRef}}
 
-The **`Intl.Locale.prototype.minimize()`** method attempts to
-remove information about the locale that would be added by calling
+The **`minimize()`** method of {{jsxref("Intl.Locale")}} instances attempts to
+remove information about this locale that would be added by calling
 {{jsxref("Intl/Locale/maximize", "maximize()")}}.
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.Locale.toString
 
 {{JSRef}}
 
-The **`Intl.Locale.prototype.toString()`** method returns the Locale's full [locale identifier string](https://www.unicode.org/reports/tr35/#Unicode_locale_identifier).
+The **`toString()`** method of {{jsxref("Intl.Locale")}} instances returns this Locale's full [locale identifier string](https://www.unicode.org/reports/tr35/#Unicode_locale_identifier).
 
 {{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.format
 
 {{JSRef}}
 
-The **`Intl.NumberFormat.prototype.format()`** method formats a number according to the [locale and formatting options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) of this {{jsxref("Intl.NumberFormat")}} object.
+The **`format()`** method of {{jsxref("Intl.NumberFormat")}} instances formats a number according to the [locale and formatting options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) of this `Intl.NumberFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-format.html", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrange/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatRange
 
 {{JSRef}}
 
-The **`Intl.NumberFormat.prototype.formatRange()`** method formats a range of numbers according to the locale and formatting options of the {{jsxref("Intl.NumberFormat")}} object from which the method is called.
+The **`formatRange()`** method of {{jsxref("Intl.NumberFormat")}} instances formats a range of numbers according to the locale and formatting options of this `Intl.NumberFormat` object.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatRangeToParts
 
 {{JSRef}}
 
-The **`Intl.Numberformat.prototype.formatRangeToParts()`** method enables locale-aware formatting of strings produced by `NumberFormat` formatters.
-
-It returns an {{jsxref("Array")}} of objects containing the locale-specific tokens from which it is possible to build custom strings while preserving the locale-specific parts.
-This makes it possible to provide locale-aware custom formatting ranges of number strings.
+The **`formatRangeToParts()`** method of {{jsxref("Intl.NumberFormat")}} instances returns an {{jsxref("Array")}} of objects containing the locale-specific tokens from which it is possible to build custom strings while preserving the locale-specific parts. This makes it possible to provide locale-aware custom formatting ranges of number strings.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatToParts
 
 {{JSRef}}
 
-The **`Intl.NumberFormat.prototype.formatToParts()`** method
-allows locale-aware formatting of strings produced by `NumberFormat`
-formatters.
+The **`formatToParts()`** method of {{jsxref("Intl.NumberFormat")}} instances allows locale-aware formatting of strings produced by this `Intl.NumberFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-formattoparts.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.NumberFormat.prototype.resolvedOptions()`** method returns a new object with properties reflecting the [locale and number formatting options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) computed during initialization of this {{jsxref("Intl.NumberFormat")}} object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.NumberFormat")}} instances returns a new object with properties reflecting the [locale and number formatting options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) computed during initialization of this `Intl.NumberFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.PluralRules.prototype.resolvedOptions()`** method
-returns a new object with properties reflecting the locale and plural formatting
-options computed during initialization of this {{jsxref("Intl.PluralRules")}} object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.PluralRules")}} instances returns a new object with properties reflecting the locale and plural formatting options computed during initialization of this `Intl.PluralRules` object.
 
 {{EmbedInteractiveExample("pages/js/intl-pluralrules-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.select
 
 {{JSRef}}
 
-The **`Intl.PluralRules.prototype.select()`** method returns a
-string indicating which plural rule to use for locale-aware formatting.
+The **`select()`** method of {{jsxref("Intl.PluralRules")}} instances returns a string indicating which plural rule to use for locale-aware formatting.
 
 {{EmbedInteractiveExample("pages/js/intl-pluralrules-prototype-select.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.selectRange
 
 {{JSRef}}
 
-The **`Intl.PluralRules.prototype.selectRange()`** method receives two values and returns a string indicating which plural rule to use for locale-aware formatting.
+The **`selectRange()`** method of {{jsxref("Intl.PluralRules")}} instances receives two values and returns a string indicating which plural rule to use for locale-aware formatting.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.format
 
 {{JSRef}}
 
-The **`Intl.RelativeTimeFormat.prototype.format()`** method formats a `value` and `unit` according to the locale and formatting options of this {{jsxref("Intl.RelativeTimeFormat")}} object.
+The **`format()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances formats a `value` and `unit` according to the locale and formatting options of this `Intl.RelativeTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-format.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.formatToParts
 
 {{JSRef}}
 
-The **`Intl.RelativeTimeFormat.prototype.formatToParts()`** method returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.
+The **`formatToParts()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-formattoparts.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -8,7 +8,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.RelativeTimeFormat.prototype.resolvedOptions()`** method returns a new object with properties reflecting the locale and relative time formatting options computed during initialization of this {{jsxref("Intl.RelativeTimeFormat")}} object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns a new object with properties reflecting the locale and relative time formatting options computed during initialization of this `Intl.RelativeTimeFormat` object.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/resolvedoptions/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.resolvedOptions
 
 {{JSRef}}
 
-The **`Intl.Segmenter.prototype.resolvedOptions()`** method returns a new object with properties reflecting the locale and granularity options computed during the initialization of this [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object.
+The **`resolvedOptions()`** method of {{jsxref("Intl.Segmenter")}} instances returns a new object with properties reflecting the locale and granularity options computed during the initialization of this `Intl.Segmenter` object.
 
 {{EmbedInteractiveExample("pages/js/intl-segmenter-prototype-resolvedoptions.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.segment
 
 {{JSRef}}
 
-The **`Intl.Segmenter.prototype.segment()`** method segments a string according to the locale and granularity of this [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object.
+The **`segment()`** method of {{jsxref("Intl.Segmenter")}} instances segments a string according to the locale and granularity of this `Intl.Segmenter` object.
 
 {{EmbedInteractiveExample("pages/js/intl-segmenter-prototype-segment.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
@@ -8,7 +8,7 @@ browser-compat: javascript.builtins.Intl.Segments.containing
 
 {{JSRef}}
 
-The **`containing()`** method of a `Segments` object returns an object describing the segment in the string that includes the code unit at the specified index.
+The **`containing()`** method of [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) instances returns an object describing the segment in the string that includes the code unit at the specified index.
 
 {{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the `X.prototype.m()` syntax from the intro.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
