### PR TITLE
Fix: typo in `Array.reduceRight()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -47,7 +47,7 @@ The `reduceRight()` method is an [iterative method](/en-US/docs/Web/JavaScript/R
 
 `callbackFn` is invoked only for array indexes which have assigned values. It is not invoked for empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
 
-Unlike other [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods), `reduce()` does not accept a `thisArg` argument. `callbackFn` is always called with `undefined` as `this`, which gets substituted with `globalThis` if `callbackFn` is non-strict.
+Unlike other [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods), `reduceRight()` does not accept a `thisArg` argument. `callbackFn` is always called with `undefined` as `this`, which gets substituted with `globalThis` if `callbackFn` is non-strict.
 
 `reduceRight()` does not mutate the array on which it is called, but the function provided as `callbackFn` can. Note, however, that the length of the array is saved _before_ the first invocation of `callbackFn`. Therefore:
 


### PR DESCRIPTION
### Description

Such as the title. Typo: `reduce()` -> `reduceRight()` in the document of `reduceRight`.

### Motivation

Ditto.

### Additional details

None.

### Related issues and pull requests

None.