### PR TITLE
Remove mention of spec status

### DIFF
--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -40,20 +40,20 @@ A subset of nested statements, which can be used as a statement of a style sheet
 
 - {{cssxref("@media")}} — A conditional group rule that will apply its content if the device meets the criteria of the condition defined using a _media query_.
 - {{cssxref("@supports")}} — A conditional group rule that will apply its content if the browser meets the criteria of the given condition.
-- {{cssxref("@document")}} {{deprecated_inline}} — A conditional group rule that will apply its content if the document in which the style sheet is applied meets the criteria of the given condition. _(deferred to Level 4 of CSS Spec)_
+- {{cssxref("@document")}} {{deprecated_inline}} — A conditional group rule that will apply its content if the document in which the style sheet is applied meets the criteria of the given condition.
 - {{cssxref("@page")}} — Describes the aspect of layout changes that will be applied when printing the document.
 - {{cssxref("@font-face")}} — Describes the aspect of an external font to be downloaded.
 - {{cssxref("@keyframes")}} — Describes the aspect of intermediate steps in a CSS animation sequence.
-- {{cssxref("@counter-style")}} — Defines specific counter styles that are not part of the predefined set of styles. _(at the Candidate Recommendation stage, but only implemented in Gecko as of writing)_
-- {{cssxref("@font-feature-values")}} (plus `@swash`, `@ornaments`, `@annotation`, `@stylistic`, `@styleset` and `@character-variant`) — Define common names in {{cssxref("font-variant-alternates")}} for feature activated differently in OpenType. _(at the Candidate Recommendation stage, but only implemented in Gecko as of writing)_
-- {{cssxref("@property")}} — Describes the aspect of custom properties and variables. _(currently at the Working Draft stage)_
+- {{cssxref("@counter-style")}} — Defines specific counter styles that are not part of the predefined set of styles.
+- {{cssxref("@font-feature-values")}} (plus `@swash`, `@ornaments`, `@annotation`, `@stylistic`, `@styleset` and `@character-variant`) — Define common names in {{cssxref("font-variant-alternates")}} for feature activated differently in OpenType.
+- {{cssxref("@property")}} — Describes the aspect of custom properties and variables.
 - {{cssxref("@layer")}} – Declares a cascade layer and defines the order of precedence in case of multiple cascade layers.
 
 ## Conditional group rules
 
 Much like the values of properties, each at-rule has a different syntax. Nevertheless, several of them can be grouped into a special category named **conditional group rules**. These statements share a common syntax and each of them can include _nested statements_—either _rulesets_ or _nested at-rules_. Furthermore, they all convey a common semantic meaning—they all link some type of condition, which at any time evaluates to either **true** or **false**. If the condition evaluates to **true**, then all of the statements within the group will be applied.
 
-Conditional group rules are defined in [CSS Conditionals Level 3](https://drafts.csswg.org/css-conditional-3/) and are:
+Conditional group rules are:
 
 - {{cssxref("@media")}},
 - {{cssxref("@supports")}},


### PR DESCRIPTION
- This is unmaintainable (we don't have a signal when the spec status change and we don't know where we mention it)
- It is useless for web devs (They don't care the status of the spec)
- The W3C status of the spec is useless for implementers (they always look at the latest draft)