### PR TITLE
Scrollport glossary entry doesn't exist anymore

### DIFF
--- a/files/en-us/web/css/css_scrollbars/index.md
+++ b/files/en-us/web/css/css_scrollbars/index.md
@@ -87,7 +87,6 @@ for us to breathe.
 - {{cssxref("scroll-snap-type")}} CSS property
 - {{CSSxRef("::-webkit-scrollbar")}} pseudo-element
 - {{glossary("scroll container")}} glossary term
-- {{Glossary("scrollport")}} glossary term
 - [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) ARIA role
 
 ## Specifications


### PR DESCRIPTION
It redirects to the previous entry on the list: removing it.