### PR TITLE
Move `error_event` from `Element`  to `HTMLElement`

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1231,7 +1231,7 @@
 /en-US/docs/DOM/DOM_event_reference/compositionend	/en-US/docs/Web/API/Element/compositionend_event
 /en-US/docs/DOM/DOM_event_reference/compositionstart	/en-US/docs/Web/API/Element/compositionstart_event
 /en-US/docs/DOM/DOM_event_reference/compositionupdate	/en-US/docs/Web/API/Element/compositionupdate_event
-/en-US/docs/DOM/DOM_event_reference/error	/en-US/docs/Web/API/Element/error_event
+/en-US/docs/DOM/DOM_event_reference/error	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/DOM/DOM_event_reference/input	/en-US/docs/Web/API/HTMLElement/input_event
 /en-US/docs/DOM/DOM_event_reference/mouseenter	/en-US/docs/Web/API/Element/mouseenter_event
 /en-US/docs/DOM/DOM_event_reference/mouseleave	/en-US/docs/Web/API/Element/mouseleave_event
@@ -1446,7 +1446,7 @@
 /en-US/docs/DOM/Mozilla_event_reference/endEvent	/en-US/docs/Web/API/SVGAnimationElement/endEvent_event
 /en-US/docs/DOM/Mozilla_event_reference/ended	/en-US/docs/Web/API/HTMLMediaElement/ended_event
 /en-US/docs/DOM/Mozilla_event_reference/ended_(Web_Audio)	/en-US/docs/Web/API/HTMLMediaElement/ended_event
-/en-US/docs/DOM/Mozilla_event_reference/error	/en-US/docs/Web/API/Element/error_event
+/en-US/docs/DOM/Mozilla_event_reference/error	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/DOM/Mozilla_event_reference/error_(ProgressEvent)	/en-US/docs/Web/API/XMLHttpRequest/error_event
 /en-US/docs/DOM/Mozilla_event_reference/error_indexedDB	/en-US/docs/Web/API/IDBRequest/error_event
 /en-US/docs/DOM/Mozilla_event_reference/error_serversentevents	/en-US/docs/Web/API/EventSource/error_event
@@ -6258,7 +6258,7 @@
 /en-US/docs/Mozilla_event_reference/emptied	/en-US/docs/Web/API/HTMLMediaElement/emptied_event
 /en-US/docs/Mozilla_event_reference/endEvent	/en-US/docs/Web/API/SVGAnimationElement/endEvent_event
 /en-US/docs/Mozilla_event_reference/ended	/en-US/docs/Web/API/HTMLMediaElement/ended_event
-/en-US/docs/Mozilla_event_reference/error	/en-US/docs/Web/API/Element/error_event
+/en-US/docs/Mozilla_event_reference/error	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/Mozilla_event_reference/error_(ProgressEvent)	/en-US/docs/Web/API/XMLHttpRequest/error_event
 /en-US/docs/Mozilla_event_reference/error_(ProgressEvent)-redirect-1	/en-US/docs/Web/API/XMLHttpRequest/error_event
 /en-US/docs/Mozilla_event_reference/error_indexedDB	/en-US/docs/Web/API/IDBRequest/error_event
@@ -8098,6 +8098,7 @@
 /en-US/docs/Web/API/Element/cancel_event	/en-US/docs/Web/API/HTMLDialogElement/cancel_event
 /en-US/docs/Web/API/Element/contentvisibilityautostatechanged_event	/en-US/docs/Web/API/Element/contentvisibilityautostatechange_event
 /en-US/docs/Web/API/Element/createShadowRoot	/en-US/docs/Web/API/Element/shadowRoot
+/en-US/docs/Web/API/Element/error_event	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/Web/API/Element/fullscreenchange	/en-US/docs/Web/API/Element/fullscreenchange_event
 /en-US/docs/Web/API/Element/mozRequestFullScreen	/en-US/docs/Web/API/Element/requestFullScreen
 /en-US/docs/Web/API/Element/msMatchesSelector	/en-US/docs/Web/API/Element/matches
@@ -11678,7 +11679,7 @@
 /en-US/docs/Web/Events/end_(SpeechSynthesis)	/en-US/docs/Web/API/SpeechSynthesisUtterance/end_event
 /en-US/docs/Web/Events/ended	/en-US/docs/Web/API/HTMLMediaElement/ended_event
 /en-US/docs/Web/Events/ended_(Web_Audio)	/en-US/docs/Web/API/HTMLMediaElement/ended_event
-/en-US/docs/Web/Events/error	/en-US/docs/Web/API/Element/error_event
+/en-US/docs/Web/Events/error	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/Web/Events/error_(ProgressEvent)	/en-US/docs/Web/API/XMLHttpRequest/error_event
 /en-US/docs/Web/Events/error_(SpeechRecognitionError)	/en-US/docs/Web/API/SpeechRecognition/error_event
 /en-US/docs/Web/Events/error_(SpeechSynthesis)	/en-US/docs/Web/API/SpeechSynthesisUtterance/error_event
@@ -12673,7 +12674,7 @@
 /en-US/docs/Web/Reference/Events/endEvent	/en-US/docs/Web/API/SVGAnimationElement/endEvent_event
 /en-US/docs/Web/Reference/Events/ended	/en-US/docs/Web/API/HTMLMediaElement/ended_event
 /en-US/docs/Web/Reference/Events/ended_(Web_Audio)	/en-US/docs/Web/API/HTMLMediaElement/ended_event
-/en-US/docs/Web/Reference/Events/error	/en-US/docs/Web/API/Element/error_event
+/en-US/docs/Web/Reference/Events/error	/en-US/docs/Web/API/HTMLElement/error_event
 /en-US/docs/Web/Reference/Events/error_(ProgressEvent)	/en-US/docs/Web/API/XMLHttpRequest/error_event
 /en-US/docs/Web/Reference/Events/error_indexedDB	/en-US/docs/Web/API/IDBRequest/error_event
 /en-US/docs/Web/Reference/Events/error_serversentevents	/en-US/docs/Web/API/EventSource/error_event

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -31590,22 +31590,6 @@
       "louisremi"
     ]
   },
-  "Web/API/Element/error_event": {
-    "modified": "2020-10-15T21:19:30.575Z",
-    "contributors": [
-      "mfuji09",
-      "chrisdavidmills",
-      "wbamberg",
-      "Sheppy",
-      "mfluehr",
-      "ExE-Boss",
-      "fscholz",
-      "Nickolay",
-      "teoli",
-      "ethertank",
-      "louisremi"
-    ]
-  },
   "Web/API/Element/firstElementChild": {
     "modified": "2020-10-15T21:06:48.193Z",
     "contributors": [
@@ -38224,6 +38208,22 @@
       "GT",
       "Callek",
       "JesseW"
+    ]
+  },
+  "Web/API/HTMLElement/error_event": {
+    "modified": "2020-10-15T21:19:30.575Z",
+    "contributors": [
+      "mfuji09",
+      "chrisdavidmills",
+      "wbamberg",
+      "Sheppy",
+      "mfluehr",
+      "ExE-Boss",
+      "fscholz",
+      "Nickolay",
+      "teoli",
+      "ethertank",
+      "louisremi"
     ]
   },
   "Web/API/HTMLElement/focus": {

--- a/files/en-us/web/api/htmlelement/error_event/index.md
+++ b/files/en-us/web/api/htmlelement/error_event/index.md
@@ -119,4 +119,7 @@ imgError.addEventListener("click", () => {
 
 ## See also
 
-- This event on `Window` targets: {{domxref("Window/error_event", "error")}} event
+- Related events
+
+  - Window: {{domxref("Window/error_event", "error")}} event
+  - HTMLElement: {{domxref("HTMLElement/load_event", "load")}} event

--- a/files/en-us/web/api/htmlelement/error_event/index.md
+++ b/files/en-us/web/api/htmlelement/error_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLElement.error_event
 
 {{APIRef}}
 
-The `error` event is fired on an {{domxref("HTMLElement")}} object when a resource failed to load, or can't be used. For example, if a script has an execution error or an image can't be found or is invalid.
+The `error` event is fired on an element when a resource failed to load, or can't be used. For example, if a script has an execution error or an image can't be found or is invalid.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/htmlelement/error_event/index.md
+++ b/files/en-us/web/api/htmlelement/error_event/index.md
@@ -3,7 +3,7 @@ title: "HTMLElement: error event"
 short-title: error
 slug: Web/API/HTMLElement/error_event
 page-type: web-api-event
-browser-compat: api.Element.error_event
+browser-compat: api.HTMLElement.error_event
 ---
 
 {{APIRef}}

--- a/files/en-us/web/api/htmlelement/error_event/index.md
+++ b/files/en-us/web/api/htmlelement/error_event/index.md
@@ -1,14 +1,14 @@
 ---
-title: "Element: error event"
+title: "HTMLElement: error event"
 short-title: error
-slug: Web/API/Element/error_event
+slug: Web/API/HTMLElement/error_event
 page-type: web-api-event
 browser-compat: api.Element.error_event
 ---
 
 {{APIRef}}
 
-The `error` event is fired on an {{domxref("Element")}} object when a resource failed to load, or can't be used. For example, if a script has an execution error or an image can't be found or is invalid.
+The `error` event is fired on an {{domxref("HTMLElement")}} object when a resource failed to load, or can't be used. For example, if a script has an execution error or an image can't be found or is invalid.
 
 This event is not cancelable and does not bubble.
 


### PR DESCRIPTION
### Description

Moved the `error` event API reference from `Element` to `HTMLElement` to be consistent with Web IDL spec.

### Motivation

The page currently misleads readers by suggesting that the `error` event is defined on the `Element` interface. However, according to the [`Element` interface Web IDL spec](https://dom.spec.whatwg.org/#element), `onerror` is **_not_** included. Moreover, if we check in the browser:
```js
// `onerror` is not found on the `Element` prototype
Object.hasOwn(Element.prototype, "onerror") // false
```

On the other hand, the `error` event is defined on the [`HTMLElement`](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) interface via [`GlobalEventHandlers`](https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers). We can also confirm this in the browser:
```js
// `onerror` is found on the `HTMLElement` prototype
Object.hasOwn(HTMLElement.prototype, "onerror") // true
```

### Related issues and pull requests

- Fixes #26489 
