### PR TITLE
Fix attribute name on SVGGradientElement page

### DIFF
--- a/files/en-us/web/api/svgradialgradientelement/index.md
+++ b/files/en-us/web/api/svgradialgradientelement/index.md
@@ -17,7 +17,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGradient
 
 - {{domxref("SVGRadialGradientElement.cx")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("cx")}} attribute of the given {{SVGElement("RadialGradient")}} element.
-- {{domxref("SVGRadialGradientElement.cx")}} {{ReadOnlyInline}}
+- {{domxref("SVGRadialGradientElement.cy")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("cy")}} attribute of the given {{SVGElement("RadialGradient")}} element.
 - {{domxref("SVGRadialGradientElement.r")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("r")}} attribute of the given {{SVGElement("RadialGradient")}} element.


### PR DESCRIPTION
### Description

Fixes a typo where the `cy` attribute of the `SVGGradientElement` was incorrectly referred to as `cx`. 

### Motivation

To reduce the number of typos in the world :) 

