### PR TITLE
correct the name of link

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -161,7 +161,7 @@ Removing content from MDN Web Docs will inevitably result in updating the existi
 
 ## Editing existing pages
 
-To edit a page, you need to find the page source in our [content](https://github.com/mdn/content) repository. The easiest way to find it is to navigate to the page you want to edit, go to the bottom of the page, and click on the "Source on GitHub" link.
+To edit a page, you need to find the page source in our [content](https://github.com/mdn/content) repository. The easiest way to find it is to navigate to the page you want to edit, go to the bottom of the page, and click on the "View the source on GitHub" link.
 
 ### Preview changes
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The link should be 'edit the page on github'(or 'view the source on github'?), currently it's confusing the readers

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
![image](https://user-images.githubusercontent.com/40999116/235427440-7201fc3e-1e61-4c2b-8239-f606d301d825.png)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
