### PR TITLE
Add warning about mutate array in callbackFn  in `Array.some()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -51,6 +51,8 @@ The `some()` method is an [iterative method](/en-US/docs/Web/JavaScript/Referenc
 - Changes to already-visited indexes do not cause `callbackFn` to be invoked on them again.
 - If an existing, yet-unvisited element of the array is changed by `callbackFn`, its value passed to the `callbackFn` will be the value at the time that element gets visited. [Deleted](/en-US/docs/Web/JavaScript/Reference/Operators/delete) elements are not visited.
 
+> **Warning:** Concurrent modifications of the kind described above frequently lead to hard-to-understand code and are generally to be avoided (except in special cases).
+
 The `some()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties.
 
 ## Examples


### PR DESCRIPTION
### Description

Such as the title

### Motivation

For consistency with other methods' documentation (especially `Array.every()`)

### Additional details

Nope.

### Related issues and pull requests

Nope.