### PR TITLE
Set front-matter lineWidth to infinity

### DIFF
--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -1,5 +1,5 @@
 {
-  "lineWidth": 80,
+  "lineWidth": -1,
   "schema": {
     "title": "Front matter schema",
     "type": "object",


### PR DESCRIPTION
We've [decided to have infinite line length](https://github.com/mdn/content/pull/26482#issuecomment-1529424893).\
There are no line break opportunities in any of the current front-matter attributes(except sometimes in `title`), so the yaml parser makes the values more unreadable.

**Note:** As a result of this 127 content filles will have chomping `>-` removed from front-matter. In order to test the nightly cron job, I am not committing those changes with his PR. Hopefully the bot will  do it tomorrow. As this is an indentation related change no PR will be affected.

cc/ @teoli2003, @wbamberg 
