### PR TITLE
DNR redirect rule behavior clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -30,6 +30,12 @@ The declarative rules are defined by four fields:
   - modify headers from a network request.
   - prevent another matching rule from being applied.
 
+> **Note:**
+> A redirect action does not redirect the request, and the request continues as usual when:
+>
+> - the action does not change the request.
+> - the redirect URL is invalid (e.g., the value of {{WebExtAPIRef("declarativeNetRequest.redirect","redirect.regexSubstitution")}} is not a valid URL).
+
 This is an example rule that blocks all script requests originating from `"foo.com"` to any URL with `"abc"` as a substring:
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
@@ -9,6 +9,12 @@ browser-compat: webextensions.api.declarativeNetRequest.Redirect
 
 Details describing how a redirect should be performed. Only valid for redirect rules.
 
+> **Note:**
+> A redirect action does not redirect the request, and the request continues as usual when:
+>
+> - the action does not change the request.
+> - the redirect URL is invalid (e.g., the value of {{WebExtAPIRef("declarativeNetRequest.redirect","redirect.regexSubstitution")}} is not a valid URL).
+
 ## Type
 
 Values of this type are objects. They contain these properties:


### PR DESCRIPTION
### Description

Add a note about the circumstances where redirect doesn't action. Addresses the documentation request for [Bug 1829404](https://bugzilla.mozilla.org/show_bug.cgi?id=1829404) DNR redirect rule issue: "The page isn’t redirecting properly"