### PR TITLE
Add CSSImportRule supportsText attribute

### DIFF
--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -23,6 +23,8 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
   - : Returns the value of the `media` attribute of the associated stylesheet.
 - {{domxref("CSSImportRule.styleSheet")}} {{ReadOnlyInline}}
   - : Returns the associated stylesheet.
+- {{domxref("CSSImportRule.supportsText")}} {{ReadOnlyInline}}
+  - : Returns the supports condition specified by the {{cssxref("@import")}} rule.
 
 ## Instance methods
 

--- a/files/en-us/web/api/cssimportrule/supportstext/index.md
+++ b/files/en-us/web/api/cssimportrule/supportstext/index.md
@@ -1,0 +1,47 @@
+---
+title: "CSSImportRule: supportsText property"
+short-title: supportsText
+slug: Web/API/CSSImportRule/supportsText
+page-type: web-api-instance-property
+browser-compat: api.CSSImportRule.supportsText
+---
+
+{{APIRef("CSSOM")}}
+
+The read-only **`supportsText`** property of the {{domxref("CSSImportRule")}} interface returns the supports condition specified by the {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
+
+## Value
+
+A string, or the `null` object.
+
+## Examples
+
+The document's single stylesheet contains three {{cssxref("@import")}} rules. The first declaration imports a stylesheet if `display: flex` is supported. The second declaration imports a stylesheet if the `:has` selector is supported. The third declaration imports a stylesheet without a supports condition.
+
+The `supportsText` property returns the import conditions associated with the at-rule.
+
+```css
+@import url("style1.css") supports(display: flex);
+@import url("style2.css") supports(selector(p:has(a)));
+@import url("style3.css");
+```
+
+```js
+const myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].supportsText); // returns `"display: flex"`
+console.log(myRules[1].supportsText); // returns `"selector(p:has(a))"`
+console.log(myRules[2].supportsText); // returns `null`
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
+- {{cssxref("@import")}} and {{cssxref("@supports")}}

--- a/files/en-us/web/api/cssimportrule/supportstext/index.md
+++ b/files/en-us/web/api/cssimportrule/supportstext/index.md
@@ -14,7 +14,6 @@ The read-only **`supportsText`** property of the {{domxref("CSSImportRule")}} in
 
 A string, or `null`.
 
-
 ## Examples
 
 The document's single stylesheet contains three {{cssxref("@import")}} rules. The first declaration imports a stylesheet if `display: flex` is supported. The second declaration imports a stylesheet if the `:has` selector is supported. The third declaration imports a stylesheet without a supports condition.

--- a/files/en-us/web/api/cssimportrule/supportstext/index.md
+++ b/files/en-us/web/api/cssimportrule/supportstext/index.md
@@ -12,7 +12,8 @@ The read-only **`supportsText`** property of the {{domxref("CSSImportRule")}} in
 
 ## Value
 
-A string, or the `null` object.
+A string, or `null`.
+
 
 ## Examples
 


### PR DESCRIPTION
### Description

Added page for the new CSSImportRule supportsText attribute.

### Motivation

The new attribute was added to the spec last month (https://github.com/w3c/csswg-drafts/pull/8712) and is undocumented currently..

### Additional details

Firefox intent to ship: https://groups.google.com/a/mozilla.org/g/dev-platform/c/ee9M0DJrNDQ/m/dDc6mE9RAwAJ

### Related issues and pull requests

BCD PR: https://github.com/mdn/browser-compat-data/pull/19606