### PR TITLE
Typo in variable name

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -38,7 +38,7 @@ req.onload = (event) => {
   // ...
 };
 
-oReq.send();
+req.send();
 ```
 
 ## Receiving binary data in older browsers


### PR DESCRIPTION
### Description

Changed `oReq` -> `req`.