### PR TITLE
Remove link for a long gone page.

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -66,7 +66,7 @@ const abyte = filestream.charCodeAt(x) & 0xff; // throw away high-order byte (f7
 
 The example above fetches the byte at offset `x` within the loaded binary data. The valid range for `x` is from 0 to `filestream.length-1`.
 
-See [downloading binary streams with XMLHttpRequest](https://web.archive.org/web/20071103070418/http://mgran.blogspot.com/2006/08/downloading-binary-streams-with.html) for a detailed explanation. See also [downloading files](/en-US/docs/Code_snippets/Downloading_Files).
+See [downloading binary streams with XMLHttpRequest](https://web.archive.org/web/20071103070418/http://mgran.blogspot.com/2006/08/downloading-binary-streams-with.html) for a detailed explanation.
 
 ## Sending binary data
 


### PR DESCRIPTION
These code snippets were removed years ago.