### PR TITLE
Replace legacy `rgba()`

### DIFF
--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -32,9 +32,8 @@ When animated, values of the `<alpha-value>` CSS data type are {{Glossary("inter
 Here an alpha value is used to set partially transparent text:
 
 ```css
-/* <rgba()> */
-color: rgba(34, 12, 64, 0.6);
-color: rgba(34 12 64 / 60%);
+/* <rgb()> */
+color: rgb(34 12 64 / 60%);
 ```
 
 ### Setting shape image threshold

--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -29,7 +29,8 @@ When animated, values of the `<alpha-value>` CSS data type are {{Glossary("inter
 
 ### Setting text color opacity
 
-Here an alpha value is used to set partially transparent text:
+The [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb) function accepts a fourth optional value to specify an alpha value.
+The following example shows how to apply a color with 60% opacity using the alpha value:
 
 ```css
 /* <rgb()> */


### PR DESCRIPTION
### Description

This PR replaces the legacy `rgba()` along with the legacy syntax in the `<alpha-value>` example.

### Motivation

This blocks the l10n of this page.

### Additional details

### Related issues and pull requests