### PR TITLE
do not render the macro example

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -15,7 +15,7 @@ This article describes the more important banners, and how they are added.
 
 Banners are added using macros.
 Banners macros should be inserted below the page metadata, alongside the page sidebar macro.
-For example, the `{{SeeCompatTable}}` macro is added below to indicate that the [Ink API](/en-US/docs/Web/API/Ink_API) is [Experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
+For example, the `\{{SeeCompatTable}}` macro is added below to indicate that the [Ink API](/en-US/docs/Web/API/Ink_API) is [Experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 
 ```
 ---


### PR DESCRIPTION
### Description

The example of macro call is rendered, but we should not render it here.
