### PR TITLE
modified select styling content

### DIFF
--- a/files/en-us/learn/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn/forms/advanced_form_styling/index.md
@@ -270,6 +270,8 @@ form > div {
 
 select {
   appearance: none;
+  width: 100%;
+  height: 100%;
 }
 
 .select-wrapper {
@@ -279,7 +281,7 @@ select {
 .select-wrapper::after {
   content: "▼";
   font-size: 1rem;
-  top: 6px;
+  top: 3px;
   right: 10px;
   position: absolute;
 }
@@ -403,7 +405,7 @@ We then use generated content to generate a little down arrow, and put it in the
 }
 ```
 
-The second, slightly more major issue is that you don't have control over the box that appears containing the options when you click on the `<select>` box to open it. You'll notice that the options don't inherit the font set on the parent. You also can't consistently set things like spacing and colors. For example, Firefox will apply [`color`](/en-US/docs/Web/CSS/color) and [`background-color`](/en-US/docs/Web/CSS/background-color) when set on the [`<option>`](/en-US/docs/Web/HTML/Element/option) elements. Neither of them will apply any kind of spacing (e.g. [`padding`](/en-US/docs/Web/CSS/padding)). The same is also true of the autocomplete list that appears for the datalist.
+The second, slightly more major issue is that you don't have control over the box that appears containing the options when you click on the `<select>` box to open it. You can inherit font set on the parent but you won't be able to set things like spacing and colors. The same is also true of the autocomplete list that appears for the datalist.
 
 If you really need full control over the option styling, you'll have to either use some kind of library to generate a custom control, or build your own custom control, or in the case of select use the `multiple` attribute, which makes all the options appear on the page, sidestepping this particular problem:
 

--- a/files/en-us/learn/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn/forms/advanced_form_styling/index.md
@@ -405,7 +405,7 @@ We then use generated content to generate a little down arrow, and put it in the
 }
 ```
 
-The second, slightly more major issue is that you don't have control over the box that appears containing the options when you click on the `<select>` box to open it. You can inherit font set on the parent but you won't be able to set things like spacing and colors. The same is also true of the autocomplete list that appears for the datalist.
+The second, slightly more important issue is that you don't have control over the box that appears containing the options when you click on the `<select>` box to open it. You can inherit the font set on the parent, but you won't be able to set things like spacing and colors. The same is true for the autocomplete list that appears with {{HTMLElement("datalist")}}.
 
 If you really need full control over the option styling, you'll have to either use some kind of library to generate a custom control, or build your own custom control, or in the case of select use the `multiple` attribute, which makes all the options appear on the page, sidestepping this particular problem:
 


### PR DESCRIPTION
### Description

In this PR, I have fixed two scenarios that seem problematic to me:

First, I have modified the CSS mentioned in [selects and data list](https://developer.mozilla.org/en-US/docs/Learn/Forms/Advanced_form_styling#selects_and_datalists) section. The current CSS mentioned in this section renders the following result.

<img width="1440" alt="Screenshot 2023-05-02 at 8 18 41 PM" src="https://user-images.githubusercontent.com/39165319/235703921-39993455-e46c-4f14-8131-cecafc3950af.png">

As you can see, the downward arrow is not part of the select box as it should be, so it makes more sense for the user trying out the example. 
With the changes made around CSS, we would be able to; it would render the following.

<img width="1440" alt="Screenshot 2023-05-02 at 8 19 08 PM" src="https://user-images.githubusercontent.com/39165319/235704663-054aeff9-82a4-4870-aa78-7125f74df47c.png">

The second point raised in the issue was that we are now able to modify CSS properties such as color and spacing for <option> tag, but I have verified the same on both chrome and firefox, we still can't do the same. Moreover, it is mentioned in the current docs that we can modify color and background-color properties for <options> in firefox, but I have also verified this and it is not happening right now.

I have attached the screenshot where you can see that the "color" CSS properties on <option> is being ignored in firefox.

<img width="1440" alt="Screenshot 2023-05-02 at 8 34 22 PM" src="https://user-images.githubusercontent.com/39165319/235706581-cced7119-53fb-4851-9269-ad5f696f9a42.png">


### Motivation

Correctness of the doc 

### Related issues and pull requests

Issue :-  [#26182](https://github.com/mdn/content/issues/26182)
