### PR TITLE
Fix descriptions to fit to `TextDecoderStream` interface

### DIFF
--- a/files/en-us/web/api/textdecoderstream/encoding/index.md
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.md
@@ -8,9 +8,9 @@ browser-compat: api.TextDecoderStream.encoding
 
 {{APIRef("Encoding API")}}
 
-The **`encoding`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a string containing the name of the encoding algorithm used by the specific encoder.
+The **`encoding`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a string containing the name of the encoding algorithm used by the specific decoder.
 
-The encoding is set by the [constructor](/en-US/docs/Web/API/TextDecoder/TextDecoder) `label` parameter, and defaults to `utf-8`.
+The encoding is set by the [constructor](/en-US/docs/Web/API/TextDecoderStream/TextDecoderStream) `label` parameter, and defaults to `utf-8`.
 
 ## Value
 

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
@@ -27,7 +27,7 @@ new TextDecoderStream(label, options)
   - : An object with the property:
 
     - `fatal`
-      - : A boolean value indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a {{jsxref("TypeError")}} when decoding invalid data.
+      - : A boolean value indicating if this object must throw a {{jsxref("TypeError")}} when decoding invalid data.
         It defaults to `false`, which means that the decoder will substitute malformed data with a replacement character.
 
 ### Exceptions


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix descriptions to fit to `TextDecoderStream` interface.

### Motivation

Some descriptions seem to be imported from documents of other interfaces.
Some of them are incorrect.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
