### PR TITLE
Replace link to disambiguation with direct link

### DIFF
--- a/files/en-us/glossary/nat/index.md
+++ b/files/en-us/glossary/nat/index.md
@@ -9,4 +9,4 @@ page-type: glossary-definition
 ## See also
 
 - [WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
-- [NAT](https://en.wikipedia.org/wiki/NAT) on Wikipedia
+- [Network address translation](https://en.wikipedia.org/wiki/Network_address_translation) on Wikipedia


### PR DESCRIPTION
Replaces a link to a Wikipedia disambiguation article with a link that directly opens the intended article.