### PR TITLE
Specify webRequest.onAuthRequired prerequisites

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.webRequest.onAuthRequired
 
 {{AddonSidebar()}}
 
-Fired when the server sends a `401` or `407` status code (that is, when the server is asking the client to provide authentication credentials, such as a username and password).
+Fired when the server sends a `401` or `407` status code and a `WWW-Authenticate` header using the `Basic` scheme (that is, when the server is asking the client to provide authentication credentials, such as a username and password).
 
 The listener can respond in one of four different ways:
 


### PR DESCRIPTION
### Description

The `webRequest.onAuthRequired` event is only fired when the server responds with 401/407 and the `WWW-Authenticate` header uses the `Basic` scheme. This second precondition is used by the browser to prompt the user for credentials. However, it wasn't clear in the docs that other authentication schemes are ignored by the webRequest API.

### Motivation

I was trying to achieve something using Web extensions that cannot actually be achieved the way I intended because of this precondition, but it took me a while to realize because the docs didn't specifically call this out. I suspect if this wasn't clear to me, it could also be unclear for other developers.

### Additional details

N/A

### Related issues and pull requests

N/A
