### PR TITLE
Fix 26561: Make object example live

### DIFF
--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -46,17 +46,21 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Examples
 
-### Embed a YouTube Video
+### Embed a video
+
+#### HTML
 
 ```html
 <object
   type="video/mp4"
-  data="https://www.youtube.com/watch?v=Sp9ZfSvpf7A"
-  width="1280"
-  height="720"></object>
+  data="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+  width="600"
+  height="140"></object>
 ```
 
-Note that a `type` field is normally specified, but is not needed for YouTube videos.
+#### Result
+
+{{EmbedLiveSample}}
 
 ## Technical summary
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26561.

We can't make YouTube videos embedded because of https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options, but embedding https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm seems to work...