### PR TITLE
WebGL 2 doesn't need extensions for half floating point textures

### DIFF
--- a/files/en-us/web/api/oes_texture_half_float_linear/index.md
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.md
@@ -12,7 +12,7 @@ The **`OES_texture_half_float_linear`** extension is part of the [WebGL API](/en
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the extension is not needed.
 
 ## Linear filtering
 


### PR DESCRIPTION
### Description

Update per spec: https://registry.khronos.org/webgl/extensions/OES_texture_half_float_linear/

"No longer available as of the [WebGL API 2.0](http://www.khronos.org/registry/webgl/specs/2.0/) specification."

### Motivation

This came up in BCD https://github.com/mdn/browser-compat-data/pull/19620

### Additional details

See also https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_half_float where this is also the case.

### Related issues and pull requests

None.