### PR TITLE
Updated the PWA Badging How-To page based on a new WebKit blog 

### DIFF
--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -59,7 +59,7 @@ Notification.requestPermission().then((result) => {
 });
 
 ```
-Optionally, you can check if a user has previously granted notification permissions using the [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API).
+Optionally, you can check if a user has previously granted notification permissions using the [Permissions API](/en-US/docs/Web/API/Permissions_API).
 
 ### Use badges sparingly
 

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -29,7 +29,7 @@ Safari and Firefox on desktop do not support the Badging API and do not support 
 
 ### Mobile support
 
-On mobile operating systems, badges are supported on Chromium-based browsers running on Android and on WebKit-based browsers, running iOS or iPadOS 16.4 and up.
+Badges are supported on mobile operating systems, including Chromium-based browsers running on Android and in Safari on iOS and iPadOS, starting with iPadOS 16.4.
 
 ## Badge best practices
 

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -51,7 +51,7 @@ Do not rely solely on badges to inform users about the availability of new conte
 
 ### Request notification permissions for iOS and/or iPadOS
 
-While notification badges are supported on WebKit, badges will not appear until your application is granted notification permissions. To request notification permissions, call the [Notification.requestPermission()](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#getting_permission) method, such as in the following basic example:
+While notification badges are supported on iOS and iPadOS, badges will not appear until the application is granted notification permissions. To request notification permissions, call the [Notification.requestPermission()](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#getting_permission) method:
 
 ```js
 Notification.requestPermission().then((result) => {

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -29,7 +29,7 @@ Safari and Firefox on desktop do not support the Badging API and do not support 
 
 ### Mobile support
 
-On mobile operating systems, badges are supported on Chromium-based browsers running on Android.
+On mobile operating systems, badges are supported on Chromium-based browsers running on Android and on WebKit-based browsers, running iOS or iPadOS 16.4 and up.
 
 ## Badge best practices
 
@@ -48,6 +48,18 @@ if (navigator.setAppBadge) {
 ```
 
 Do not rely solely on badges to inform users about the availability of new content. Browsers that support the Badging API may be installed on operating systems that do not support displaying a badge. For example, while Chrome supports the Badging API, badges will not appear on installed application icons on Linux.
+
+### Request notification permissions for iOS and/or iPadOS
+
+While notification badges are supported on WebKit, badges will not appear until your application is granted notification permissions. To request notification permissions, call the [Notification.requestPermission()](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#getting_permission) method, such as in the following basic example:
+
+```js
+Notification.requestPermission().then((result) => {
+  console.log(result);
+});
+
+```
+Optionally, you can check if a user has previously granted notification permissions using the [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API).
 
 ### Use badges sparingly
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Updated PWA Badging to reflect new WebKit support requires notification permissions.
- Explains how to request notification permissions and how to check for prior notification permission grants before attempting to show badging notifications.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This update provides information, documentation and links developers need before implementing PWA Badges on Safari and any other mobile WebKit-based browsers.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Source information from Apple: https://webkit.org/blog/14112/badging-for-home-screen-web-apps/
Note: This is my first ever PR / contribution so I welcome constructive criticism. 

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #26430 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
