### PR TITLE
Remove mention of ISO8601 to avoid wrong expectations

### DIFF
--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -17,7 +17,7 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
 
 ## Value
 
-A string representing the date entered in the input. The date is formatted according to ISO8601, described in [Date strings format](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings).
+A string representing the date entered in the input. The date is formatted according to [Date strings format](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings).
 
 You can set a default value for the input with a date inside the [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute, like so:
 


### PR DESCRIPTION
### Description

Removes mention of ISO8601 from the date input type's `value` description.

### Motivation

Mentioning ISO8601 implies both `2023-02-09` and `2023-02-09T22:00:00.000Z` strings would work. The latter is not supported despite being valid ISO8610. This can also imply `dateInput.value = new Date().toISOString()` should work, but it does not.

### Additional details

None

### Related issues and pull requests

None
