### PR TITLE
Window.print() - FF android support moved from 113 to 114

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -47,7 +47,6 @@ This article provides information about the changes in Firefox 113 that affect d
   ([Firefox bug 1709347](https://bugzil.la/1709347)).
 - The [Compression Streams API](/en-US/docs/Web/API/Compression_Streams_API) is now supported.
   The interfaces provided by this API are used to compress and decompress data using the `gzip` and `deflate` formats ([Firefox bug 1823619](https://bugzil.la/1823619)).
-- [`Window.print()`](/en-US/docs/Web/API/Window/print) now opens a print dialog on Firefox for Android, allowing the current document to be printed ([Firefox bug 1809922](https://bugzil.la/1809922)).
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -37,6 +37,8 @@ This article provides information about the changes in Firefox 114 that affect d
 
 ### APIs
 
+- [`Window.print()`](/en-US/docs/Web/API/Window/print) now opens a print dialog on Firefox for Android, allowing the current document to be printed ([Firefox bug 1809922](https://bugzil.la/1809922)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
This just updates the release notes for 113 and 114  to reflect the version in which the feature was added