### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/index.md
+++ b/files/en-us/web/api/mediastreamtrack/index.md
@@ -37,7 +37,7 @@ In addition to the properties listed below, `MediaStreamTrack` has constrainable
 
 - {{domxref("MediaStreamTrack.readyState")}} {{ReadOnlyInline}}
 
-  - : Returns an enumerated value giving the status of the track. This will be one of the following values:
+  - : Returns an enumerated string giving the status of the track. This will be one of the following values:
 
     - `"live"` which indicates that an input is connected and does its best-effort in providing real-time data. In that case, the output of data can be switched on or off using the {{domxref("MediaStreamTrack.enabled", "enabled")}} attribute.
     - `"ended"` which indicates that the input is not giving any more data and will never provide new data.


### PR DESCRIPTION
### Description

All other properties of the `MediaStreamTrack` are described with the return types, except `readyState`. I propose adding the explicit return type of the enumerated values.

### Motivation

I am creating a presentation for colleagues and found the explicit return type was not mentioned in the `MediaStreamTrack.readState` description.
