### PR TITLE
Update inconsistant headers

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
@@ -5,9 +5,7 @@ page-type: guide
 browser-compat: webextensions.manifest
 ---
 
-{{AddonSidebar}}
-
-{{Compat}}
+{{AddonSidebar}}{{Compat}}
 
 > **Note:**
 

--- a/files/en-us/web/api/console/timelog/index.md
+++ b/files/en-us/web/api/console/timelog/index.md
@@ -6,9 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.console.timeLog
 ---
 
-{{APIRef("Console API")}}
-
-{{AvailableInWorkers}}
+{{APIRef("Console API")}}{{AvailableInWorkers}}
 
 The **`console.timeLog()`** method logs the current value of a timer that was previously started by calling {{domxref("console.time()")}}.
 

--- a/files/en-us/web/api/css/factory_functions_static/index.md
+++ b/files/en-us/web/api/css/factory_functions_static/index.md
@@ -6,7 +6,6 @@ browser-compat: api.CSS
 ---
 
 {{APIRef("CSSOM")}}
-{{SeeCompatTable}}
 
 The **CSS numeric factory
 functions**, such as `CSS.em()` and

--- a/files/en-us/web/api/cssimportrule/supportstext/index.md
+++ b/files/en-us/web/api/cssimportrule/supportstext/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CSSImportRule.supportsText
 ---
 
-{{APIRef("CSSOM")}}
+{{APIRef("CSSOM")}}{{SeeCompatTable}}
 
 The read-only **`supportsText`** property of the {{domxref("CSSImportRule")}} interface returns the supports condition specified by the {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 

--- a/files/en-us/web/api/document/scrollend_event/index.md
+++ b/files/en-us/web/api/document/scrollend_event/index.md
@@ -7,7 +7,6 @@ browser-compat: api.Document.scrollend_event
 ---
 
 {{APIRef}}
-{{SeeCompatTable}}
 
 The **`scrollend`** event fires when the document view has completed scrolling.
 Scrolling is considered completed when the scroll position has no more pending updates and the user has completed their gesture.

--- a/files/en-us/web/api/element/scrollend_event/index.md
+++ b/files/en-us/web/api/element/scrollend_event/index.md
@@ -7,7 +7,6 @@ browser-compat: api.Element.scrollend_event
 ---
 
 {{APIRef}}
-{{SeeCompatTable}}
 
 The **`scrollend`** event fires when element scrolling has completed.
 Scrolling is considered completed when the scroll position has no more pending updates and the user has completed their gesture.

--- a/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Element.webkitmouseforcechanged_event
 ---
 
-{{APIRef}}{{Non-standard_header()}}
+{{APIRef}}{{Non-standard_header}}
 
 The non-standard **`webkitmouseforcechanged`** event is fired by Safari each time the amount of pressure changes on the trackpad/touchscreen.
 

--- a/files/en-us/web/api/element/webkitmouseforceup_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforceup_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Element.webkitmouseforceup_event
 ---
 
-{{APIRef}}{{Non-standard_header()}}
+{{APIRef}}{{Non-standard_header}}
 
 The non-standard **`webkitmouseforceup`** event is fired by Safari at an {{domxref("Element")}} some time after the {{domxref("Element/webkitmouseforcedown_event", "webkitmouseforcedown")}} event, when pressure on the button has been reduced sufficiently to end the "force click".
 

--- a/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Element.webkitmouseforcewillbegin_event
 ---
 
-{{APIRef}}{{Non-standard_header()}}
+{{APIRef}}{{Non-standard_header}}
 
 Safari for macOS fires the non-standard **`webkitmouseforcewillbegin`** event at an {{domxref("Element")}} before firing the initial {{domxref("Element/mousedown_event", "mousedown")}} event.
 

--- a/files/en-us/web/api/force_touch_events/index.md
+++ b/files/en-us/web/api/force_touch_events/index.md
@@ -4,9 +4,7 @@ slug: Web/API/Force_Touch_events
 page-type: web-api-overview
 ---
 
-{{DefaultAPISidebar("Force Touch events")}}
-
-{{Non-standard_header()}}
+{{DefaultAPISidebar("Force Touch events")}}{{Non-standard_header}}
 
 **Force Touch events** are a proprietary, Apple-specific feature which makes possible (where supported by the input hardware) new interactions based on how hard the user clicks or presses down on the touchscreen or trackpad.
 

--- a/files/en-us/web/api/htmlelement/mscandidatewindowhide_event/index.md
+++ b/files/en-us/web/api/htmlelement/mscandidatewindowhide_event/index.md
@@ -7,9 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("HTML DOM")}}
-
-{{Non-standard_header()}}
+{{APIRef("HTML DOM")}}{{Non-standard_header}}
 
 The **`mscandidatewindowhide`** event is thrown after the Input Method Editor (IME) candidate window closes and is fully hidden.
 

--- a/files/en-us/web/api/htmlelement/mscandidatewindowshow_event/index.md
+++ b/files/en-us/web/api/htmlelement/mscandidatewindowshow_event/index.md
@@ -7,9 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("HTML DOM")}}
-
-{{Non-standard_header()}}
+{{APIRef("HTML DOM")}}{{Non-standard_header}}
 
 The **`mscandidatewindowshow`** event is thrown immediately after the Input Method Editor (IME) candidate window is set to appear, but before it renders.
 

--- a/files/en-us/web/api/htmlelement/mscandidatewindowupdate_event/index.md
+++ b/files/en-us/web/api/htmlelement/mscandidatewindowupdate_event/index.md
@@ -7,9 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("HTML DOM")}}
-
-{{Non-standard_header()}}
+{{APIRef("HTML DOM")}}{{Non-standard_header}}
 
 The **`mscandidatewindowupdate`** event is thrown after the Input Method Editor (IME) candidate window has been identified as needing to change size, but before any visual updates have rendered.
 

--- a/files/en-us/web/api/mediaerror/msextendedcode/index.md
+++ b/files/en-us/web/api/mediaerror/msextendedcode/index.md
@@ -5,9 +5,7 @@ slug: Web/API/MediaError/msExtendedCode
 page-type: web-api-instance-property
 ---
 
-{{APIRef("DOM")}}
-
-{{Non-standard_header()}}
+{{APIRef("DOM")}}{{Non-standard_header}}
 
 In the event of an error, the media element's error event will be fired. The element's error property will then contain an **`msExtendedCode`** read-only property with platform-specific error code information.
 

--- a/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.MerchantValidationEvent.MerchantValidationEvent
 ---
 
-{{deprecated_header}}{{securecontext_header}}{{APIRef()}}
+{{deprecated_header}}{{securecontext_header}}{{APIRef}}
 
 The **`MerchantValidationEvent()`** constructor creates a new {{domxref("MerchantValidationEvent")}} object. You should not have to create these events yourself; instead, just handle the {{domxref("PaymentRequest.merchantvalidation_event", "merchantvalidation")}} event.
 

--- a/files/en-us/web/api/mouseevent/webkit_force_at_force_mouse_down_static/index.md
+++ b/files/en-us/web/api/mouseevent/webkit_force_at_force_mouse_down_static/index.md
@@ -7,7 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("UI Events")}}{{Non-standard_header()}}
+{{APIRef("UI Events")}}{{Non-standard_header}}
 
 **`MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN`** is a proprietary, WebKit-specific, static numeric property whose value is the minimum force necessary for a force click.
 

--- a/files/en-us/web/api/mouseevent/webkit_force_at_mouse_down_static/index.md
+++ b/files/en-us/web/api/mouseevent/webkit_force_at_mouse_down_static/index.md
@@ -7,7 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("UI Events")}}{{Non-standard_header()}}
+{{APIRef("UI Events")}}{{Non-standard_header}}
 
 **`MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN`** is a proprietary, WebKit-specific, static numeric property whose value is the minimum force necessary for a normal click.
 

--- a/files/en-us/web/api/mouseevent/webkitforce/index.md
+++ b/files/en-us/web/api/mouseevent/webkitforce/index.md
@@ -7,7 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("UI Events")}}{{Non-standard_header()}}
+{{APIRef("UI Events")}}{{Non-standard_header}}
 
 **`MouseEvent.webkitForce`** is a proprietary, WebKit-specific numeric property whose value represents the amount of pressure that is being applied on the touchpad or touchscreen.
 

--- a/files/en-us/web/api/ndefreadingevent/index.md
+++ b/files/en-us/web/api/ndefreadingevent/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.NDEFReadingEvent
 ---
 
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}{{SeeCompatTable}}
+{{securecontext_header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`NDEFReadingEvent`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) represents events dispatched on new NFC readings obtained by {{DOMxRef("NDEFReader")}}.
 

--- a/files/en-us/web/api/performancetiming/msfirstpaint/index.md
+++ b/files/en-us/web/api/performancetiming/msfirstpaint/index.md
@@ -7,9 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("Performance API API")}}
-
-{{Non-standard_header()}}
+{{APIRef("Performance API API")}}{{Non-standard_header}}
 
 **`msFirstPaint`** is a read-only property which gets the time
 when the document loaded by the window object began to be displayed to the user.

--- a/files/en-us/web/api/svgaelement/target/index.md
+++ b/files/en-us/web/api/svgaelement/target/index.md
@@ -8,8 +8,6 @@ browser-compat: api.SVGAElement.target
 
 {{APIRef("SVGAElement")}}
 
-{{SeeCompatTable}}
-
 The **`SVGAElement.target`** read-only property of {{domxref("SVGAElement")}} returns an {{domxref("SVGAnimatedString")}} object that specifies the portion of a target window, frame, pane into which a document is to be opened when a link is activated.
 
 This property is used when there are multiple possible targets for the ending resource, like when the parent document is a multi-frame HTML or XHTML document.

--- a/files/en-us/web/api/svgaltglyphelement/format/index.md
+++ b/files/en-us/web/api/svgaltglyphelement/format/index.md
@@ -10,8 +10,6 @@ browser-compat: api.SVGAltGlyphElement.format
 
 {{APIRef("SVGAltGlyphElement")}}{{Deprecated_Header}}
 
-{{Deprecated_header}}
-
 The **`SVGAltGlyphElement.format`** property is a
 string that defines the format of the given font. It has the same
 meaning as the 'format' property of {{domxref("SVGGlyphRefElement")}} property. If the

--- a/files/en-us/web/api/window/querylocalfonts/index.md
+++ b/files/en-us/web/api/window/querylocalfonts/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.queryLocalFonts
 ---
 
-{{APIRef("Local Font Access API")}}{{SeeCompatTable()}}
+{{APIRef("Local Font Access API")}}{{SeeCompatTable}}
 
 The **`window.queryLocalFonts()`** method returns a {{jsxref("Promise")}} that fulfills with an array of {{domxref("FontData")}} objects representing the font faces available locally.
 

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -9,7 +9,7 @@ status:
 browser-compat: api.Window.requestFileSystem
 ---
 
-{{APIRef("HTML DOM")}} {{Deprecated_Header}} {{non-standard_header()}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{non-standard_header}}
 
 The non-standard {{domxref("Window")}} method
 **`requestFileSystem()`** method is a Google Chrome-specific

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -8,9 +8,7 @@ status:
 browser-compat: api.Window.convertPointFromNodeToPage
 ---
 
-{{APIRef}}
-
-{{Non-standard_header}}
+{{APIRef}}{{Non-standard_header}}
 
 Given a {{domxref("WebKitPoint")}} specified in a particular DOM {{domxref("Node")}}'s
 coordinate system, the {{domxref("Window")}} method

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -5,8 +5,7 @@ page-type: http-header
 browser-compat: http.headers.Expect-CT
 ---
 
-{{HTTPSidebar}}
-{{Deprecated_Header}}
+{{HTTPSidebar}}{{Deprecated_Header}}
 
 The `Expect-CT` header lets sites opt in to reporting and/or enforcement of [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) requirements. Certificate Transparency (CT) aims to prevent the use of misissued certificates for that site from going unnoticed.
 


### PR DESCRIPTION
The PR does header section cleanup to avoid clashes with BCD_sync.
Refer https://github.com/mdn/content/pull/26610#issuecomment-1537034220 for the context.

For changes in `supporttext/index.md` refer https://github.com/mdn/content/pull/26609#discussion_r1186646471 .

Would be better if we decide structure for the banner section. :roll_eyes: 
