### PR TITLE
The async props of `SvgImageElement` is not correctly documented.

### DIFF
--- a/files/en-us/web/api/svgimageelement/decoding/index.md
+++ b/files/en-us/web/api/svgimageelement/decoding/index.md
@@ -24,9 +24,11 @@ A string representing the decoding hint. Possible values are:
 ## Examples
 
 ```js
-const img = new Image();
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const img = document.createElementNS(SVG_NS, "image");
 img.decoding = "sync";
-img.src = "img/logo.svg";
+img.setAttribute("href", "img/logo.svg");
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example provided here is wrong, this chapter is talking about `SvgImageElement` but not `HTMLImageElement`

### Motivation

This example does not correctly demonstrate how to use async in `SVGImageElement`, and the API usage of  `HTMLImageElement` and `SvgImageElement` is very different.

### Additional details

https://www.w3.org/TR/SVG11/struct.html#ImageElement


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
