### PR TITLE
Update legacy color syntax for `accent-color`

### DIFF
--- a/files/en-us/web/css/accent-color/index.md
+++ b/files/en-us/web/css/accent-color/index.md
@@ -27,8 +27,8 @@ accent-color: auto;
 /* <color> values */
 accent-color: darkred;
 accent-color: #5729e9;
-accent-color: rgb(0, 200, 0);
-accent-color: hsl(228, 4%, 24%);
+accent-color: rgb(0 200 0);
+accent-color: hsl(228 4% 24%);
 
 /* Global values */
 accent-color: inherit;


### PR DESCRIPTION
### Description

This PR replaces the legacy syntax for `hsl()` and `rgb()` with the modern one on the `accent-color` page.

### Motivation

As the comma-separating syntax is deemed legacy by the [spec](https://drafts.csswg.org/css-color/#rgb-functions), it's natural to minimize its presence in examples.

This blocks the l10n of this page.

### Additional details

### Related issues and pull requests

#26448 has been left there for a few days by now :no_mouth: