### PR TITLE
Add 'slot' and 'template' to phrasing content list

### DIFF
--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -179,12 +179,14 @@ Elements belonging to this category are:
 - {{HTMLElement("samp")}}
 - {{HTMLElement("script")}}
 - {{HTMLElement("select")}}
+- {{HTMLElement("slot")}}
 - {{HTMLElement("small")}}
 - {{HTMLElement("span")}}
 - {{HTMLElement("strong")}}
 - {{HTMLElement("sub")}}
 - {{HTMLElement("sup")}}
 - {{SVGElement("svg")}}
+- {{HTMLElement("template")}}
 - {{HTMLElement("textarea")}}
 - {{HTMLElement("time")}}
 - {{HTMLElement("u")}}


### PR DESCRIPTION
### Description

In Html Standart and on mdn, both elements are Phrase content.

### Additional details

[slot element spec](https://html.spec.whatwg.org/#the-slot-element)
[template element spec](https://html.spec.whatwg.org/#the-template-element)


