### PR TITLE
fix(urlsearchparams): truncated constructor typo

### DIFF
--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -38,7 +38,7 @@ The following example shows how to create a {{domxref("URLSearchParams")}} objec
 various inputs.
 
 ```js
-// Retrieve params via url.search, passed into ctor
+// Retrieve params via url.search, passed into constructor
 const url = new URL("https://example.com?foo=1&bar=2");
 const params1 = new URLSearchParams(url.search);
 


### PR DESCRIPTION
in comment of example

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
On https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#:~:text=search%2C%20passed%20into-,ctor,-const%20url%20%3D in one of the examples it only said `ctor` in a comment, instead of `constructor`.
This commit fixes that typo.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It makes the example easier to understand, as the description is not faulty.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Occurrence: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#:~:text=search%2C%20passed%20into-,ctor,-const%20url%20%3D 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
