### PR TITLE
fix(prefers-reduced-motion): Edit text and improve example

### DIFF
--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -118,7 +118,7 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
 
 {{EmbedLiveSample("Toning down the animation scaling")}}
 
-You can enable the setting for reducing motion on [your device](#user_preferences) to view the change in animation scaling. This example uses the box color and the line over the text to visually highlight when the animations switch in response to the setting being enabled or disabled.
+You can enable the setting for reducing motion on [your device](#user_preferences) to view the change in animation scaling. This example uses the background color and the line over the text to visually highlight when the keyframe animation switches in response to the setting being enabled or disabled.
 
 ## Specifications
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -9,7 +9,7 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 
 > **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
 
-The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes or replaces motion-based animations that trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations like scaling or panning large objects can cause vestibular motion triggers.
+The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes or replaces motion-based animations that trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations such as scaling or panning large objects can cause vestibular motion triggers.
 
 ```css
 @media (prefers-reduced-motion) {
@@ -43,7 +43,7 @@ For Firefox, the `reduce` request is honoured if:
 
 ## Examples
 
-This example uses a scaling animation for the purpose of demonstrating `prefers-reduced-motion`. In this example, if a user has enabled reduced motion in the accessibility preferences on their device, the `prefers-reduced-motion` media query will detect it and the CSS rule defined below will tone down the animation to a simple `dissolve` without causing vestibular motion triggers.
+This example uses a scaling animation for the purpose of demonstrating `prefers-reduced-motion`. In this example, if a user has enabled a setting for reduced motion in the accessibility preferences on their device, the `prefers-reduced-motion` media query will detect it and the CSS rule defined below will tone down the [animation](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) on the box to a simple `dissolve` without causing vestibular motion triggers.
 
 ### Toning down the animation scaling
 
@@ -58,19 +58,20 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
 ```css
 .animation {
   animation: pulse 1s linear infinite both;
+  background-color: purple;
 }
 
 /* Tone down the animation to avoid vestibular motion triggers. */
 @media (prefers-reduced-motion) {
   .animation {
-    animation: dissolve 2s linear infinite both;
+    animation: dissolve 4s linear infinite both;
+    background-color: green;
   }
 }
 ```
 
 ```css hidden
 .animation {
-  background-color: #306;
   color: #fff;
   font: 1.2em sans-serif;
   width: 10em;
@@ -102,7 +103,7 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
     opacity: 1;
   }
   50% {
-    opacity: 0.8;
+    opacity: 0.3;
   }
   100% {
     opacity: 1;
@@ -113,6 +114,8 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
 #### Result
 
 {{EmbedLiveSample("Toning down the animation scaling")}}
+
+You can enable the reduce motion setting on [your device](#user_preferences) to view the change in animation scaling. The change in the box color when `pulse` animation switches to `dissolve` or vice versa is used only to convey the change in animation when the reduce motion setting is enabled or disabled.
 
 ## Specifications
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -9,7 +9,9 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 
 > **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
 
-The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes or replaces motion-based animations that trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations such as scaling or panning large objects can cause vestibular motion triggers.
+The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes, reduces, or replaces motion-based animations.
+
+Such animations can trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations such as scaling or panning large objects can be vestibular motion triggers.
 
 ```css
 @media (prefers-reduced-motion) {
@@ -20,9 +22,9 @@ The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-
 ## Syntax
 
 - `no-preference`
-  - : Indicates that a user has made no preference known on the device.
+  - : Indicates that a user has made no preference known on the device. This keyword value evaluates as false.
 - `reduce`
-  - : Indicates that a user has enabled the setting on their device for reduced motion.
+  - : Indicates that a user has enabled the setting on their device for reduced motion. This keyword value evaluates as true.
 
 ## User preferences
 
@@ -43,7 +45,7 @@ For Firefox, the `reduce` request is honoured if:
 
 ## Examples
 
-This example uses a scaling animation for the purpose of demonstrating `prefers-reduced-motion`. In this example, if a user has enabled a setting for reduced motion in the accessibility preferences on their device, the `prefers-reduced-motion` media query will detect it and the CSS rule defined below will tone down the [animation](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) on the box to a simple `dissolve` without causing vestibular motion triggers.
+This example uses a scaling animation for the purpose of demonstrating `prefers-reduced-motion`. If you enable the setting for reducing motion in the accessibility preferences on your device, the `prefers-reduced-motion` media query will detect your preference and the CSS within the reduced motion rules, with the same [specificity](/en-US/docs/Web/CSS/Specificity) but coming later in the [CSS source order](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#source_order), will take precedence. As a result, the [animation](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) on the box will tone down to the `dissolve` animation, which is a more muted animation that is not a vestibular motion trigger.
 
 ### Toning down the animation scaling
 
@@ -66,6 +68,7 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
   .animation {
     animation: dissolve 4s linear infinite both;
     background-color: green;
+    text-decoration: overline;
   }
 }
 ```
@@ -115,7 +118,7 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
 
 {{EmbedLiveSample("Toning down the animation scaling")}}
 
-You can enable the reduce motion setting on [your device](#user_preferences) to view the change in animation scaling. The change in the box color when `pulse` animation switches to `dissolve` or vice versa is used only to convey the change in animation when the reduce motion setting is enabled or disabled.
+You can enable the setting for reducing motion on [your device](#user_preferences) to view the change in animation scaling. This example uses the box color and the line over the text to visually highlight when the animations switch in response to the setting being enabled or disabled.
 
 ## Specifications
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -9,20 +9,20 @@ browser-compat: css.at-rules.media.prefers-reduced-motion
 
 > **Warning:** An embedded example at the bottom of this page has a scaling movement that may be problematic for some readers. Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation.
 
-The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is used to detect if the user has requested that the system either minimize the amount of non-essential motion used or remove animations altogether, depending on available user preference setting.
+The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes or replaces motion-based animations that trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations like scaling or panning large objects can cause vestibular motion triggers.
 
 ```css
 @media (prefers-reduced-motion) {
-  /* styles to apply if the user's settings are set to reduced motion */
+  /* styles to apply if a user's device settings are set to reduced motion */
 }
 ```
 
 ## Syntax
 
 - `no-preference`
-  - : Indicates that the user has made no preference known to the system.
+  - : Indicates that a user has made no preference known on the device.
 - `reduce`
-  - : Indicates that the user has notified the system that they prefer an interface that removes or replaces the types of motion-based animation.
+  - : Indicates that a user has enabled the setting on their device for reduced motion.
 
 ## User preferences
 
@@ -43,22 +43,24 @@ For Firefox, the `reduce` request is honoured if:
 
 ## Examples
 
-This example has a scaling animation by default. If Reduce Motion or Remove Animations is enabled in your accessibility preferences, the animation is toned down to a simple dissolve without vestibular motion triggers.
+This example uses a scaling animation for the purpose of demonstrating `prefers-reduced-motion`. In this example, if a user has enabled reduced motion in the accessibility preferences on their device, the `prefers-reduced-motion` media query will detect it and the CSS rule defined below will tone down the animation to a simple `dissolve` without causing vestibular motion triggers.
 
-### HTML
+### Toning down the animation scaling
+
+#### HTML
 
 ```html
 <div class="animation">animated box</div>
 ```
 
-### CSS
+#### CSS
 
 ```css
 .animation {
   animation: pulse 1s linear infinite both;
 }
 
-/* Tone down the animation to avoid vestibular motion triggers like scaling or panning large objects. */
+/* Tone down the animation to avoid vestibular motion triggers. */
 @media (prefers-reduced-motion) {
   .animation {
     animation: dissolve 2s linear infinite both;
@@ -108,9 +110,9 @@ This example has a scaling animation by default. If Reduce Motion or Remove Anim
 }
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples")}}
+{{EmbedLiveSample("Toning down the animation scaling")}}
 
 ## Specifications
 
@@ -122,5 +124,5 @@ This example has a scaling animation by default. If Reduce Motion or Remove Anim
 
 ## See also
 
-- [An Introduction to the Reduced Motion Media Query (CSS Tricks)](https://css-tricks.com/introduction-reduced-motion-media-query/)
-- [Responsive Design for Motion (WebKit Blog)](https://webkit.org/blog/7551/responsive-design-for-motion/) includes vestibular motion trigger examples.
+- [An introduction to the reduced motion media query](https://css-tricks.com/introduction-reduced-motion-media-query/) on CSS-Tricks (April 24, 2019)
+- [Responsive design for motion](https://webkit.org/blog/7551/responsive-design-for-motion/) on WebKit Blog (May 15, 2017)


### PR DESCRIPTION
### Description

Fx113 introduces `prefers-reduced-transparency` (https://github.com/mdn/content/issues/25773).

While going through the existing page on a similar media query, `prefers-reduced-motion`, I came across the following things that could be improved for clarity:

- replaced "system" with "device"
- replaced pronouns like "it" with the doer for clarity
- moved pieces of info from syntax descriptions to the intro paragraph
- added a link that explains "vestibular motion disorders"
- rewrote "Examples" description to add more context and added a description to the example "Result"
- tweaked the example so that a change is actually visible when "Reduce motion" is enabled
- made "See also" items compliant with the [new guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section)

### Motivation

To improve clarity of the text
