### PR TITLE
Added info for 'muted' driven emission

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMediaElement.volumechange_event
 
 {{APIRef("HTMLMediaElement")}}
 
-The `volumechange` event is fired when either the volume attribute or the muted attribute has changed.
+The `volumechange` event is fired when either the {{domxref("HTMLMediaElement.volume", "volume")}} attribute or the {{domxref("HTMLMediaElement.muted", "muted")}}  attribute has changed.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMediaElement.volumechange_event
 
 {{APIRef("HTMLMediaElement")}}
 
-The `volumechange` event is fired when the volume has changed.
+The `volumechange` event is fired when either the volume attribute or the muted attribute has changed.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMediaElement.volumechange_event
 
 {{APIRef("HTMLMediaElement")}}
 
-The `volumechange` event is fired when either the {{domxref("HTMLMediaElement.volume", "volume")}} attribute or the {{domxref("HTMLMediaElement.muted", "muted")}}  attribute has changed.
+The `volumechange` event is fired when either the {{domxref("HTMLMediaElement.volume", "volume")}} attribute or the {{domxref("HTMLMediaElement.muted", "muted")}} attribute has changed.
 
 This event is not cancelable and does not bubble.
 


### PR DESCRIPTION
Fixing missing information that muting also fires this event. Standard spec: https://html.spec.whatwg.org/multipage/media.html#event-media-volumechange

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
