### PR TITLE
Remove outdated info from `pointer-events`

### DIFF
--- a/files/en-us/web/css/pointer-events/index.md
+++ b/files/en-us/web/css/pointer-events/index.md
@@ -72,8 +72,6 @@ Note that preventing an element from being the target of pointer events by using
 
 Elements with `pointer-events: none` will still receive focus through sequential keyboard navigation using the <kbd>Tab</kbd> key.
 
-We would like to provide finer grained control (than just `auto` and `none`) in HTML for which parts of an element will cause it to "catch" pointer events, and when. To help us in deciding how `pointer-events` should be further extended for HTML, if you have any particular things that you would like to be able to do with this property, then please add them to the Use Cases section of [this wiki page](https://wiki.mozilla.org/SVG:Pointer-events) (don't worry about keeping it tidy).
-
 ## Formal definition
 
 {{cssinfo}}
@@ -110,8 +108,7 @@ This example disables pointer events on the link to `http://example.com`.
 #### CSS
 
 ```css
-a[href="http://example.com"]
-{
+a[href="http://example.com"] {
   pointer-events: none;
 }
 ```
@@ -123,8 +120,6 @@ a[href="http://example.com"]
 ## Specifications
 
 {{Specifications}}
-
-Its extension to HTML elements, though present in early drafts of CSS Basic User Interface Module Level 3, has been pushed to its [level 4](https://wiki.csswg.org/spec/css4-ui#pointer-events).
 
 ## Browser compatibility
 


### PR DESCRIPTION
### Description

This PR mainly removes outdated information on the `point-events` page.

### Motivation

CSSWG has already specced this property for HTML elements in [CSS Basic User Interface Module Level 4](https://drafts.csswg.org/css-ui-4/#pointer-events-control), and any proposal related to this property should therefore be presented to CSSWG instead.

### Additional details

This property's definition was added after March 16, 2021 (see the [change log](https://drafts.csswg.org/css-ui-4/#changes-2021-03-16)).

### Related issues and pull requests

Relates to https://github.com/mdn/browser-compat-data/pull/19365.