### PR TITLE
Remove outdated info from `user-select`

### DIFF
--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -52,7 +52,7 @@ user-select: unset;
 - `contain`
   - : Enables selection to start within the element; however, the selection will be contained by the bounds of that element.
 
-> **Note:** CSS UI 4 [renames `user-select: element` to `contain`](https://github.com/w3c/csswg-drafts/commit/3f1d9db96fad8d9fc787d3ed66e2d5ad8cfadd05).
+    > **Note:** CSS UI 4 [renamed](https://github.com/w3c/csswg-drafts/commit/3f1d9db96fad8d9fc787d3ed66e2d5ad8cfadd05) the `element` value to `contain`.
 
 ## Formal definition
 
@@ -77,18 +77,14 @@ user-select: unset;
 ```css
 .unselectable {
   -webkit-user-select: none; /* Safari */
-  -ms-user-select: none; /* IE 10+ */
   user-select: none;
 }
 
 .all {
   -webkit-user-select: all;
-  -ms-user-select: all;
   user-select: all;
 }
 ```
-
-> **Note:** `-webkit-user-select: all;` doesn't work in Safari; use only "none" or "text", or else it will allow typing in the `<html>` container. See the [browser compatibility table](#browser-compatibility) for up-to-date information.
 
 ### Result
 


### PR DESCRIPTION
### Description

This PR:

  1. removes outdated information on the `user-select` page according to BCD;
  2. removes legacy prefixed properties from the example;
  3. tweaks the format of an external link.

### Motivation

### Additional details

The BCD for this property:
https://github.com/mdn/browser-compat-data/blob/main/css/properties/user-select.json

### Related issues and pull requests