### PR TITLE
 docs(relnote): Release notes prep for Fx113

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -9,14 +9,10 @@ This article provides information about the changes in Firefox 111 that affect d
 
 ## Changes for web developers
 
-### Developer Tools
-
 ### HTML
 
 - The [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize) global attribute is now supported by default. The default value for the attribute is `none`, so no capitalization occurs ([Firefox bug 1692007](https://bugzil.la/1692007)).
 - The [`translate`](/en-US/docs/Web/HTML/Global_attributes/translate) global attribute is now supported ([Firefox bug 1418449](https://bugzil.la/1418449)).
-
-#### Removals
 
 ### CSS
 
@@ -24,29 +20,19 @@ This article provides information about the changes in Firefox 111 that affect d
   These features are disabled by default and can be enabled by setting the preference `layout.css.more_color_4.enabled` to true.
   For more information, see the [CSS color value](/en-US/docs/Web/CSS/color_value) documentation ([Firefox bug 1352757](https://bugzil.la/1352757) and [Firefox bug 1128204](https://bugzil.la/1128204)).
 
-#### Removals
-
 ### JavaScript
 
-#### Removals
+No notable changes.
 
 ### SVG
 
 - The `context-stroke` and `context-fill` values are now supported inside `<marker>` elements.
   For more information on using these values with `fill` and `stroke` properties, see the [`<marker>`](/en-US/docs/Web/SVG/Element/marker) documentation ([Firefox bug 752638](https://bugzil.la/752638)).
 
-#### Removals
-
 ### HTTP
 
 - The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from cross origin redirects.
   See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
-
-#### Removals
-
-### Security
-
-#### Removals
 
 ### APIs
 
@@ -67,12 +53,6 @@ This article provides information about the changes in Firefox 111 that affect d
   This allows developers to associate `inbound-rtp` statistics with a particular track when using {{domxref("RTCPeerConnection.getStats()")}}.
   (For more information see [Firefox bug 1804676](https://bugzil.la/1804676).)
 
-#### Removals
-
-### WebAssembly
-
-#### Removals
-
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi
@@ -88,10 +68,6 @@ This article provides information about the changes in Firefox 111 that affect d
 - `matchDiacritics` has been added to the {{WebExtAPIRef("Find.find")}} API. This option enables searches to distinguish between accented letters and their base letters. For example, when set to `true`, searching for "résumé" does not find a match for "resume" [Firefox bug 1680606](https://bugzil.la/1680606).
 - {{WebExtAPIRef("search.query")}} has been added, providing search API compatibility with Chromium-based browsers [Firefox bug 1804357](https://bugzil.la/1804357).
 - The `disposition` property has been added to {{WebExtAPIRef("search.search")}}, enabling results to be displayed in a new tab or window [Firefox bug 1811274](https://bugzil.la/1811274).
-
-### Removals
-
-### Other
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -9,13 +9,9 @@ This article provides information about the changes in Firefox 112 that affect d
 
 ## Changes for web developers
 
-### Developer Tools
-
 ### HTML
 
 - The {{domxref("HTMLElement")}} property [**`inert`**](/en-US/docs/Web/HTML/Global_attributes/inert) is now fully enabled. It allows the browser to ignore content or interactive elements that are within an HTMLElement with the `inert` attribute. See [Firefox bug 1764263](https://bugzil.la/1764263) for more details.
-
-#### Removals
 
 ### CSS
 
@@ -26,23 +22,9 @@ This article provides information about the changes in Firefox 112 that affect d
 - The `linear()` [easing function](/en-US/docs/Web/CSS/easing-function) is now supported.
   This defines easing functions that interpolate linearly between a set of points and is useful for approximating complex animations ([Firefox bug 1819447](https://bugzil.la/1819447), [Firefox bug 1764126](https://bugzil.la/1764126)).
 
-#### Removals
-
 ### JavaScript
 
-#### Removals
-
-### SVG
-
-#### Removals
-
-### HTTP
-
-#### Removals
-
-### Security
-
-#### Removals
+No notable changes.
 
 ### APIs
 
@@ -52,19 +34,11 @@ This article provides information about the changes in Firefox 112 that affect d
   See [Firefox bug 1756175](https://bugzil.la/1756175) for more details.
 - The deprecated and non-standard `CanvasRenderingContext2D.mozTextStyle` attribute is now disabled by default ([Firefox bug 1818409](https://bugzil.la/1818409)).
 
-#### DOM
-
-#### Media, WebRTC, and Web Audio
-
 #### Removals
 
 - Removes support for `IDBMutableFile`, `IDBFileRequest`, `IDBFileHandle`, and `IDBDatabase.createMutableFile()`.
   These interfaces are not present in any specification, have been behind a preference since version 102, and have been removed from the other main browser engines for some years.
   ([Firefox bug 1500343](https://bugzil.la/1500343).)
-
-### WebAssembly
-
-#### Removals
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -84,10 +58,6 @@ This article provides information about the changes in Firefox 112 that affect d
 
 - The properties `usedDelegatedCredentials`, `usedEch`, `usedOcsp`, and `usedPrivateDns` have been added to {{WebExtAPIRef("webRequest.SecurityInfo")}}. These properties provide information about the security of the connection used for a web request ([Firefox bug 1804460](https://bugzil.la/1804460)).
 - The property `"type"` is supported in the [`"background"` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background). Setting this key to `"module"` loads background scripts specified with `"scripts"` as ES modules, avoiding the need to switch to background pages to use ES modules ([Firefox bug 1811443](https://bugzil.la/1811443)).
-
-### Removals
-
-### Other
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/113
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [May 09, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 113 that affect developers. Firefox 113 was released on May 09, 2023.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -9,11 +9,9 @@ This article provides information about the changes in Firefox 113 that affect d
 
 ## Changes for web developers
 
-### Developer Tools
-
 ### HTML
 
-#### Removals
+No notable changes.
 
 ### CSS
 
@@ -23,23 +21,9 @@ This article provides information about the changes in Firefox 113 that affect d
 - The [`:nth-child of <selector>` syntax](/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax) allows you to target a group of children based upon the `An+B` rule that also matches a defined selector.
   See ([Firefox bug 1808229](https://bugzil.la/1808229)) for more details.
 
-#### Removals
-
 ### JavaScript
 
-#### Removals
-
-### SVG
-
-#### Removals
-
-### HTTP
-
-#### Removals
-
-### Security
-
-#### Removals
+No notable changes.
 
 ### APIs
 
@@ -47,8 +31,6 @@ This article provides information about the changes in Firefox 113 that affect d
   ([Firefox bug 1709347](https://bugzil.la/1709347)).
 - The [Compression Streams API](/en-US/docs/Web/API/Compression_Streams_API) is now supported.
   The interfaces provided by this API are used to compress and decompress data using the `gzip` and `deflate` formats ([Firefox bug 1823619](https://bugzil.la/1823619)).
-
-#### DOM
 
 #### Media, WebRTC, and Web Audio
 
@@ -58,25 +40,11 @@ This article provides information about the changes in Firefox 113 that affect d
 
 - The deprecated and non-standard `CanvasRenderingContext2D.mozTextStyle` attribute was permanently removed. This was previously hidden behind a preference. ([Firefox bug 1294362](https://bugzil.la/1294362)).
 
-### WebAssembly
-
-#### Removals
-
-### WebDriver conformance (WebDriver BiDi, Marionette)
-
-#### WebDriver BiDi
-
-#### Marionette
-
 ## Changes for add-on developers
 
 - When an extension registers multiple listeners for the same event, all the event listeners are called when the event page wakes up, instead of only the first one ([Firefox bug 1798655](https://bugzil.la/1798655)).
 - Support is now provided for the {{WebExtAPIRef("declarativeNetRequest")}} API ([Firefox bug 1782685](https://bugzil.la/1782685)).
 - The `gecko_android` subkey has been added to the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This subkey enables an extension to specify the range of Firefox for Android versions it is compatible with ([Firefox bug 1824237](https://bugzil.la/1824237)).
-
-### Removals
-
-### Other
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -5,7 +5,7 @@ slug: Mozilla/Firefox/Releases/114
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 114 that affect developers. Firefox 114 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [June 06, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 114 that affect developers. Firefox 114 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [June 06, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -1,0 +1,64 @@
+---
+title: Firefox 115 for developers
+slug: Mozilla/Firefox/Releases/115
+---
+
+{{FirefoxSidebar}}
+
+This article provides information about the changes in Firefox 115 that affect developers. Firefox 115 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [July 04, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+
+## Changes for web developers
+
+### Developer Tools
+
+### HTML
+
+#### Removals
+
+### CSS
+
+#### Removals
+
+### JavaScript
+
+#### Removals
+
+### SVG
+
+#### Removals
+
+### HTTP
+
+#### Removals
+
+### Security
+
+#### Removals
+
+### APIs
+
+#### DOM
+
+#### Media, WebRTC, and Web Audio
+
+#### Removals
+
+### WebAssembly
+
+#### Removals
+
+### WebDriver conformance (WebDriver BiDi, Marionette)
+
+#### WebDriver BiDi
+
+#### Marionette
+
+## Changes for add-on developers
+
+### Removals
+
+### Other
+
+## Older versions
+
+{{Firefox_for_developers(114)}}


### PR DESCRIPTION
This PR preps 113, 114, and 115 release note pages for Fx113 tomorrow, May 09.

__Deletions:__
* removed sections with no info, added "No notable changes." when under HTML, JS, or CSS.
