### PR TITLE
Update docs on how to enable prefers-reduced-motion in GNOME

### DIFF
--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -30,7 +30,7 @@ For Firefox, the `reduce` request is honoured if:
 
 - In GTK/GNOME: Settings > Accessibility > Seeing > Reduced animation is turned on.
 
-  - In older versions of GNOME, GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off. 
+  - In older versions of GNOME, GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
   - Alternatively, add `gtk-enable-animations = false` to the `[Settings]` block of [the GTK 3 configuration file](https://wiki.archlinux.org/title/GTK#Configuration).
 
 - In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -28,8 +28,9 @@ The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-
 
 For Firefox, the `reduce` request is honoured if:
 
-- In GTK/GNOME: GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
+- In GTK/GNOME: Settings > Accessibility > Seeing > Reduced animation is turned on.
 
+  - In older versions of GNOME, GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off. 
   - Alternatively, add `gtk-enable-animations = false` to the `[Settings]` block of [the GTK 3 configuration file](https://wiki.archlinux.org/title/GTK#Configuration).
 
 - In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".


### PR DESCRIPTION
### Description

This PR updates the prefers-reduced-motion document with information about how to enable that setting in GNOME 44.

### Motivation

The existing documentation wasn't matching the latest version of GNOME: that setting is no longer available in GNOME Tweaks and instead is available in the default GNOME Settings app.

### Additional details

[GNOME 44 release notes about the Accessibility screen of the Settings app](https://release.gnome.org/44/#accessibility)

### Related issues and pull requests

n/a