### PR TITLE
docs(fx113-relnote): add support for "scripting" media

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -20,6 +20,7 @@ No notable changes.
   ([Firefox bug 1352753](https://bugzil.la/1352753), [Firefox bug 1813497](https://bugzil.la/1813497), [Firefox bug 1818819](https://bugzil.la/1818819), [Firefox bug 1824526](https://bugzil.la/1824526)).
 - The [`:nth-child of <selector>` syntax](/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax) allows you to target a group of children based upon the `An+B` rule that also matches a defined selector.
   See ([Firefox bug 1808229](https://bugzil.la/1808229)) for more details.
+- The [`scripting`](/en-US/docs/Web/CSS/@media/scripting) media feature is now supported. See ([Firefox bug 1166581](https://bugzil.la/1166581)) for more details.
 
 ### JavaScript
 


### PR DESCRIPTION
### Description

Fx113 has added support for `scripting` media feature.

### Related issues and pull requests

- Doc issue: https://github.com/mdn/content/issues/26150
- BCD update: https://github.com/mdn/browser-compat-data/pull/19263
- MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting
- Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1166581