### PR TITLE
FF113 RTCPeerConnectionStats - add docs

### DIFF
--- a/files/en-us/web/api/rtcaudiosourcestats/id/index.md
+++ b/files/en-us/web/api/rtcaudiosourcestats/id/index.md
@@ -8,8 +8,7 @@ browser-compat: api.RTCStatsReport.type_media-source.id
 
 {{APIRef("WebRTC")}}
 
-The **`id`** property of the {{domxref("RTCAudioSourceStats")}} dictionary is a string which uniquely identifies the object
-for which this object provides statistics.
+The **`id`** property of the {{domxref("RTCAudioSourceStats")}} dictionary is a string which uniquely identifies the object for which this object provides statistics.
 
 Using the `id`, you can correlate this statistics object with others, in order to monitor statistics over time for a given WebRTC object, such as an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
@@ -1,0 +1,26 @@
+---
+title: "RTCPeerConnectionStats: dataChannelsClosed property"
+short-title: dataChannelsClosed
+slug: Web/API/RTCPeerConnectionStats/dataChannelsClosed
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionStats.dataChannelsClosed
+---
+
+{{APIRef("WebRTC")}}
+
+The {{domxref("RTCPeerConnectionStats")}} dictionary's **`dataChannelsClosed`** property indicates the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+
+A channel will leave the open state if either end of the connection or the underlying transport is closed.
+Note that channels that transition to "closing" or "closed" without ever being "open" are not counted in this number.
+
+## Value
+
+A positive integer that indicates the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
@@ -8,9 +8,9 @@ browser-compat: api.RTCStatsReport.type_peer-connection.dataChannelsClosed
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCPeerConnectionStats")}} dictionary's **`dataChannelsClosed`** property indicates the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+The **`dataChannelsClosed`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary indicates the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
 
-A channel will leave the open state if either end of the connection or the underlying transport is closed.
+A channel will leave the `open` state if either end of the connection or the underlying transport is closed.
 Note that channels that transition to "closing" or "closed" without ever being "open" are not counted in this number.
 
 ## Value

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnectionStats: dataChannelsClosed property"
 short-title: dataChannelsClosed
 slug: Web/API/RTCPeerConnectionStats/dataChannelsClosed
 page-type: web-api-instance-property
-browser-compat: api.RTCPeerConnectionStats.dataChannelsClosed
+browser-compat: api.RTCStatsReport.type_peer-connection.dataChannelsClosed
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsclosed/index.md
@@ -11,7 +11,7 @@ browser-compat: api.RTCStatsReport.type_peer-connection.dataChannelsClosed
 The **`dataChannelsClosed`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary indicates the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
 
 A channel will leave the `open` state if either end of the connection or the underlying transport is closed.
-Note that channels that transition to "closing" or "closed" without ever being "open" are not counted in this number.
+Note that channels that transition to [`closing`](/en-US/docs/Web/API/RTCDataChannel/readyState#closing) or [`closed`](/en-US/docs/Web/API/RTCDataChannel/readyState#closed) without ever being `open` are not counted in this number.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCStatsReport.type_peer-connection.dataChannelsOpened
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCPeerConnectionStats")}} dictionary's **`dataChannelsOpened`** property indicates the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+The **`dataChannelsOpened`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary indicates the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
@@ -1,0 +1,23 @@
+---
+title: "RTCPeerConnectionStats: dataChannelsOpened property"
+short-title: dataChannelsOpened
+slug: Web/API/RTCPeerConnectionStats/dataChannelsOpened
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionStats.dataChannelsOpened
+---
+
+{{APIRef("WebRTC")}}
+
+The {{domxref("RTCPeerConnectionStats")}} dictionary's **`dataChannelsOpened`** property indicates the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+
+## Value
+
+A positive integer that indicates the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/datachannelsopened/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnectionStats: dataChannelsOpened property"
 short-title: dataChannelsOpened
 slug: Web/API/RTCPeerConnectionStats/dataChannelsOpened
 page-type: web-api-instance-property
-browser-compat: api.RTCPeerConnectionStats.dataChannelsOpened
+browser-compat: api.RTCStatsReport.type_peer-connection.dataChannelsOpened
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
@@ -8,14 +8,13 @@ browser-compat: api.RTCPeerConnectionStats.id
 
 {{APIRef("WebRTC")}}
 
-The **`id`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string which uniquely identifies the object
-for which this `RTCStats` object provides statistics.
+The **`id`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string which uniquely identifies the object used to populate these statistics.
 
-Using the `id`, you can correlate two or more `RTCStats`-based objects in order to monitor statistics over time for a given WebRTC object, such as an {{Glossary("RTP")}} stream, an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
+Using the `id`, you can correlate this statics object with others, in order to monitor statistics over time for a given WebRTC object, such as an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
 
 ## Value
 
-A string which uniquely identifies the object for which this `RTCStats`-based object provides statistics.
+A string which uniquely identifies the object for which this `RTCPeerConnectionStats` object provides statistics.
 
 The format of the ID string is not defined by the specification, so you cannot reliably make any assumptions about the contents of the string, or assume that the format of the string will remain unchanged for a given object type.
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
@@ -1,0 +1,28 @@
+---
+title: "RTCPeerConnectionStats: id property"
+short-title: id
+slug: Web/API/RTCPeerConnectionStats/id
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionStats.id
+---
+
+{{APIRef("WebRTC")}}
+
+The **`id`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string which uniquely identifies the object
+for which this `RTCStats` object provides statistics.
+
+Using the `id`, you can correlate two or more `RTCStats`-based objects in order to monitor statistics over time for a given WebRTC object, such as an {{Glossary("RTP")}} stream, an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
+
+## Value
+
+A string which uniquely identifies the object for which this `RTCStats`-based object provides statistics.
+
+The format of the ID string is not defined by the specification, so you cannot reliably make any assumptions about the contents of the string, or assume that the format of the string will remain unchanged for a given object type.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
@@ -8,13 +8,13 @@ browser-compat: api.RTCStatsReport.type_peer-connection.id
 
 {{APIRef("WebRTC")}}
 
-The **`id`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string which uniquely identifies the object used to populate these statistics.
+The **`id`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string which uniquely identifies the object for which this object provides statistics.
 
-Using the `id`, you can correlate this statics object with others, in order to monitor statistics over time for a given WebRTC object, such as an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
+Using the `id`, you can correlate this statistics object with others, in order to monitor statistics over time for a given WebRTC object, such as an {{domxref("RTCPeerConnection")}}, or an {{domxref("RTCDataChannel")}}.
 
 ## Value
 
-A string which uniquely identifies the object for which this `RTCPeerConnectionStats` object provides statistics.
+A string that uniquely identifies the object for which this `RTCPeerConnectionStats` object provides statistics.
 
 The format of the ID string is not defined by the specification, so you cannot reliably make any assumptions about the contents of the string, or assume that the format of the string will remain unchanged for a given object type.
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/id/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnectionStats: id property"
 short-title: id
 slug: Web/API/RTCPeerConnectionStats/id
 page-type: web-api-instance-property
-browser-compat: api.RTCPeerConnectionStats.id
+browser-compat: api.RTCStatsReport.type_peer-connection.id
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -19,7 +19,7 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 - {{domxref("RTCPeerConnectionStats.dataChannelsOpened", "dataChannelsOpened")}}
   - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
 - {{domxref("RTCPeerConnectionStats.dataChannelsClosed", "dataChannelsClosed")}}
-  - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime (channels that transition to "closing" or "closed" without ever being "open" are not counted in this number).
+  - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime (channels that transition to [`closing`](/en-US/docs/Web/API/RTCDataChannel/readyState#closing) or [`closed`](/en-US/docs/Web/API/RTCDataChannel/readyState#closed) without ever being `open` are not counted in this number).
     A channel will leave the `open` state if either end of the connection or the underlying transport is closed.
 
 ### Common instance properties

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -7,7 +7,7 @@ browser-compat: api.RTCStatsReport.type_peer-connection
 
 {{APIRef("WebRTC")}}
 
-The [WebRTC API](/en-US/docs/Web/API/WebRTC_API)'s **`RTCPeerConnectionStats`** dictionary provides information about the high level peer connection ({{domxref("RTCPeerConnection")}}).
+The **`RTCPeerConnectionStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides information about the high level peer connection ({{domxref("RTCPeerConnection")}}).
 
 In particular, it provides the number of unique data channels that have been opened, and the number of opened channels that have been closed.
 This allows the current number of open channels to be calculated.
@@ -20,11 +20,11 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
   - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
 - {{domxref("RTCPeerConnectionStats.dataChannelsClosed", "dataChannelsClosed")}}
   - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime (channels that transition to "closing" or "closed" without ever being "open" are not counted in this number).
-    A channel will leave the open state if either end of the connection or the underlying transport is closed.
+    A channel will leave the `open` state if either end of the connection or the underlying transport is closed.
 
 ### Common instance properties
 
-The following properties are common to all statistics objects.
+The following properties are common to all WebRTC statistics objects.
 
 <!-- RTCStats -->
 
@@ -33,7 +33,7 @@ The following properties are common to all statistics objects.
 - {{domxref("RTCPeerConnectionStats.timestamp", "timestamp")}}
   - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
 - {{domxref("RTCPeerConnectionStats.type", "type")}}
-  - : A string with the value `peer-connection`, indicating the type of statistics that the object contains.
+  - : A string with the value `"peer-connection"`, indicating the type of statistics that the object contains.
 
 ## Examples
 
@@ -45,7 +45,7 @@ It then returns the total number of open channels using the data in the report.
 
 ```js
 async function numberOpenConnections (peerConnection) {
-  const stats = await peerConnection.getStats(/* null */);
+  const stats = await peerConnection.getStats();
   let peerConnectionStats = null;
 
   stats.forEach((report) => {

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -1,0 +1,68 @@
+---
+title: RTCPeerConnectionStats
+slug: Web/API/RTCPeerConnectionStats
+page-type: web-api-interface
+browser-compat: api.RTCPeerConnectionStats
+---
+
+{{APIRef("WebRTC")}}
+
+The [WebRTC API](/en-US/docs/Web/API/WebRTC_API)'s **`RTCPeerConnectionStats`** dictionary provides information about the high level peer connection ({{domxref("RTCPeerConnection")}}).
+
+In particular, it provides the number of unique data channels that have been opened, and the number of opened channels that have been closed.
+This allows the current number of open channels to be calculated.
+
+These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}} until you find a report with the [`type`](#type) of `peer-connection`.
+
+## Instance properties
+
+- {{domxref("RTCPeerConnectionStats.dataChannelsOpened", "dataChannelsOpened")}}
+  - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have entered the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime.
+- {{domxref("RTCPeerConnectionStats.dataChannelsClosed", "dataChannelsClosed")}}
+  - : A positive integer value indicating the number of unique {{domxref("RTCDataChannel")}} objects that have left the [`open`](/en-US/docs/Web/API/RTCDataChannel/readyState#open) state during their lifetime (channels that transition to "closing" or "closed" without ever being "open" are not counted in this number).
+    A channel will leave the open state if either end of the connection or the underlying transport is closed.
+
+### Common instance properties
+
+The following properties are common to all statistics objects.
+
+<!-- RTCStats -->
+
+- {{domxref("RTCPeerConnectionStats.id", "id")}}
+  - : A string that uniquely identifies the object that is being monitored to produce this set of statistics.
+- {{domxref("RTCPeerConnectionStats.timestamp", "timestamp")}}
+  - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
+- {{domxref("RTCPeerConnectionStats.type", "type")}}
+  - : A string with the value `peer-connection`, indicating the type of statistics that the object contains.
+
+## Examples
+
+This example shows a function to return the total number of open connections, or `null` if no statistics are provided.
+This might be called in a loop, similar to the approach used in [`RTCPeerConnection.getStats()` example](/en-US/docs/Web/API/RTCPeerConnection/getStats#examples)
+
+The method waits on a waits on a {{domxref("RTCPeerConnection")}} for statistics and then iterates the returned {{domxref("RTCStatsReport")}} to get just the stats of type `peer-connection`.
+It then returns the total number of open channels using the data in the report.
+
+```js
+async function numberOpenConnections (peerConnection) {
+  const stats = await peerConnection.getStats(/* null */);
+  let peerConnectionStats = null;
+
+  stats.forEach((report) => {
+    if (report.type === "peer-connection") {
+      peerConnectionStats = report;
+      break;
+    }
+  });
+
+  return peerConnectionStats.dataChannelsOpened - peerConnectionStats.dataChannelsClosed;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -2,7 +2,7 @@
 title: RTCPeerConnectionStats
 slug: Web/API/RTCPeerConnectionStats
 page-type: web-api-interface
-browser-compat: api.RTCPeerConnectionStats
+browser-compat: api.RTCStatsReport.type_peer-connection
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -40,7 +40,7 @@ The following properties are common to all WebRTC statistics objects.
 This example shows a function to return the total number of open connections, or `null` if no statistics are provided.
 This might be called in a loop, similar to the approach used in [`RTCPeerConnection.getStats()` example](/en-US/docs/Web/API/RTCPeerConnection/getStats#examples)
 
-The method waits on a waits on a {{domxref("RTCPeerConnection")}} for statistics and then iterates the returned {{domxref("RTCStatsReport")}} to get just the stats of type `peer-connection`.
+The function waits for the result of a call to {{domxref("RTCPeerConnection.getStats()")}} and then iterates the returned {{domxref("RTCStatsReport")}} to get just the stats of type `"peer-connection"`.
 It then returns the total number of open channels using the data in the report.
 
 ```js

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -41,7 +41,7 @@ This example shows a function to return the total number of open connections, or
 This might be called in a loop, similar to the approach used in [`RTCPeerConnection.getStats()` example](/en-US/docs/Web/API/RTCPeerConnection/getStats#examples)
 
 The function waits for the result of a call to {{domxref("RTCPeerConnection.getStats()")}} and then iterates the returned {{domxref("RTCStatsReport")}} to get just the stats of type `"peer-connection"`.
-It then returns the total number of open channels using the data in the report.
+It then returns the total number of open channels, or `null`, using the data in the report.
 
 ```js
 async function numberOpenConnections (peerConnection) {
@@ -55,7 +55,8 @@ async function numberOpenConnections (peerConnection) {
     }
   });
 
-  return peerConnectionStats.dataChannelsOpened - peerConnectionStats.dataChannelsClosed;
+result = (typeof peerConnectionStats.dataChannelsOpened === 'undefined' || typeof peerConnectionStats.dataChannelsClosed=== 'undefined') ? null : peerConnectionStats.dataChannelsOpened - peerConnectionStats.dataChannelsClosed;
+return result
 }
 ```
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnectionStats: timestamp property"
 short-title: timestamp
 slug: Web/API/RTCPeerConnectionStats/timestamp
 page-type: web-api-instance-property
-browser-compat: api.RTCPeerConnectionStats.timestamp
+browser-compat: api.RTCStatsReport.type_peer-connection.timestamp
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
@@ -1,0 +1,27 @@
+---
+title: "RTCPeerConnectionStats: timestamp property"
+short-title: timestamp
+slug: Web/API/RTCPeerConnectionStats/timestamp
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionStats.timestamp
+---
+
+{{APIRef("WebRTC")}}
+
+The **`timestamp`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a {{domxref("DOMHighResTimeStamp")}} object specifying the time at which the data in the object was sampled.
+
+The time is given in milliseconds elapsed since the first moment of January 1, 1970, UTC (also known as [Unix time](/en-US/docs/Glossary/Unix_time)).
+
+## Value
+
+A {{domxref("DOMHighResTimeStamp")}} value indicating the time at which the activity described by the statistics in this object was recorded, in milliseconds elapsed since the beginning of January 1, 1970, UTC.
+
+The value should be accurate to within a few milliseconds but may not be entirely precise, either because of hardware or operating system limitations or because of [fingerprinting](/en-US/docs/Glossary/Fingerprinting) protection in the form of reduced clock precision or accuracy.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/timestamp/index.md
@@ -10,8 +10,6 @@ browser-compat: api.RTCStatsReport.type_peer-connection.timestamp
 
 The **`timestamp`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a {{domxref("DOMHighResTimeStamp")}} object specifying the time at which the data in the object was sampled.
 
-The time is given in milliseconds elapsed since the first moment of January 1, 1970, UTC (also known as [Unix time](/en-US/docs/Glossary/Unix_time)).
-
 ## Value
 
 A {{domxref("DOMHighResTimeStamp")}} value indicating the time at which the activity described by the statistics in this object was recorded, in milliseconds elapsed since the beginning of January 1, 1970, UTC.

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnectionStats: type property"
 short-title: type
 slug: Web/API/RTCPeerConnectionStats/type
 page-type: web-api-instance-property
-browser-compat: api.RTCPeerConnectionStats.type
+browser-compat: api.RTCStatsReport.type_peer-connection.type
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -10,7 +10,9 @@ browser-compat: api.RTCStatsReport.type_peer-connection.type
 
 The **`type`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string with the value `"peer-connection"`.
 
-The type of `peer-connection` identifies the type of statistics as {{domxref("RTCPeerConnectionStats")}} when iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}}.
+Different statistics are obtained by iterating the {{domxref("RTCStatsReport")}} object returned by a call to {{domxref("RTCPeerConnection.getStats()")}}.
+The type indicates the set of statistics available through the object in a particular iteration step.
+A value of `"peer-connection"` indicates that the statistics available in the current step are those defined in {{domxref("RTCPeerConnectionStats")}}.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCPeerConnectionStats: type property"
+short-title: type
+slug: Web/API/RTCPeerConnectionStats/type
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionStats.type
+---
+
+{{APIRef("WebRTC")}}
+
+The {{domxref("RTCPeerConnectionStats")}} dictionary's property **`type`** is a string with value `peer-connection`.
+
+The type of `peer-connection` uniquely identifies the type of statistics as {{domxref("RTCPeerConnectionStats")}} when iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}}.
+
+## Value
+
+A string which with value `peer-connection`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -8,13 +8,13 @@ browser-compat: api.RTCStatsReport.type_peer-connection.type
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCPeerConnectionStats")}} dictionary's property **`type`** is a string with value `peer-connection`.
+The **`type`** property of the {{domxref("RTCPeerConnectionStats")}} dictionary is a string with the value `"peer-connection"`.
 
 The type of `peer-connection` identifies the type of statistics as {{domxref("RTCPeerConnectionStats")}} when iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}}.
 
 ## Value
 
-A string with the value `peer-connection`.
+A string with the value `"peer-connection"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCStatsReport.type_peer-connection.type
 
 The {{domxref("RTCPeerConnectionStats")}} dictionary's property **`type`** is a string with value `peer-connection`.
 
-The type of `peer-connection` uniquely identifies the type of statistics as {{domxref("RTCPeerConnectionStats")}} when iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}}.
+The type of `peer-connection` identifies the type of statistics as {{domxref("RTCPeerConnectionStats")}} when iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}}.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/type/index.md
@@ -14,7 +14,7 @@ The type of `peer-connection` uniquely identifies the type of statistics as {{do
 
 ## Value
 
-A string which with value `peer-connection`.
+A string with the value `peer-connection`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -40,6 +40,7 @@ The various dictionaries that are used to define the contents of the objects tha
 
   - {{domxref("RTCAudioSourceStats")}} contains statistics about audio media sources.
   - {{domxref("RTCVideoSourceStats")}} contains statistics about video media sources.
+  - {{domxref("RTCPeerConnectionStats")}} adds to `RTCStats` information about the connection.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -38,7 +38,6 @@ The various dictionaries that are used to define the contents of the objects tha
       - {{domxref("RTCOutboundRtpStreamStats")}} contains statistics about the local sending endpoint of an RTP stream.
       - {{domxref("RTCRemoteOutboundRtpStreamStats")}} holds statistics related to the remote sending end an RTP stream.
 
-
   - {{domxref("RTCAudioSourceStats")}} contains statistics about audio media sources.
   - {{domxref("RTCVideoSourceStats")}} contains statistics about video media sources.
   - {{domxref("RTCPeerConnectionStats")}} adds to `RTCStats` information about the connection.

--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -38,6 +38,7 @@ The various dictionaries that are used to define the contents of the objects tha
       - {{domxref("RTCOutboundRtpStreamStats")}} contains statistics about the local sending endpoint of an RTP stream.
       - {{domxref("RTCRemoteOutboundRtpStreamStats")}} holds statistics related to the remote sending end an RTP stream.
 
+
   - {{domxref("RTCAudioSourceStats")}} contains statistics about audio media sources.
   - {{domxref("RTCVideoSourceStats")}} contains statistics about video media sources.
   - {{domxref("RTCPeerConnectionStats")}} adds to `RTCStats` information about the connection.


### PR DESCRIPTION
This adds docs for the WebRTC `RTCPeerConnectionStats` dictionary.

Note that there was much discussion about whether this should be a dictionary or not. The end result was that this should be a _flattened dictionary_. 

The docs for the dictionary are themselves complete. Note however that there are surrounding docs such as `RTCStats` that will require iteration (I do the bare minimum here). That will be a post process.

This is part of #26146