### PR TITLE
fix: Broken Link

### DIFF
--- a/files/en-us/web/api/gpurenderpassencoder/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/index.md
@@ -17,7 +17,7 @@ A render pipeline renders graphics to {{domxref("GPUTexture")}} attachments, typ
 
 - A fragment stage, in which a fragment shader computes the color for each pixel covered by the primitives produced by the vertex shader. These computations frequently use inputs such as images (in the form of textures) that provide surface details and the position and color of virtual lights.
 
-A `GPUComputePassEncoder` object instance is created via the {{domxref("GPUCommandEncoder.beginComputePass()")}} property.
+A `GPURenderPassEncoder` object instance is created via the {{domxref("GPUCommandEncoder.beginRenderPass()")}} property.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I have changed this:

> A GPUComputePassEncoder object instance is created via the [GPUCommandEncoder.beginComputePass()](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/beginComputePass) property.

to this:

> A GPURenderPassEncoder object instance is created via the [GPUCommandEncoder.beginRenderPass()](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/beginRenderPass) property.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change will guide the readers to the right resource.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #26637 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
