### PR TITLE
Fix code comment in dialog example

### DIFF
--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -106,7 +106,7 @@ selectEl.addEventListener('change', (e) => {
   confirmBtn.value = selectEl.value;
 });
 
-// "Confirm" button triggers "close" on dialog because of [method="dialog"]
+// "Confirm" button triggers "close" on dialog because of [formmethod="dialog"]
 favDialog.addEventListener('close', (e) => {
   outputBox.value = favDialog.returnValue === 'default' ? "No return value." : `ReturnValue: ${favDialog.returnValue}.`; // Have to check for "default" rather than empty string
 });


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The comment says `method="dialog"`, while the HTML snippet above has `formmethod="dialog"`.