### PR TITLE
Minor typofix square > circle

### DIFF
--- a/files/en-us/web/html/element/script/type/importmap/index.md
+++ b/files/en-us/web/html/element/script/type/importmap/index.md
@@ -95,7 +95,7 @@ Note that in this case the property and mapped path must both have a trailing fo
 We could then import a circle module as shown.
 
 ```js
-import { name as squareName, draw } from "shapes/circle.js";
+import { name as circleName, draw } from "shapes/circle.js";
 ```
 
 ### Paths in the module specifier map key

--- a/files/en-us/web/html/element/script/type/importmap/index.md
+++ b/files/en-us/web/html/element/script/type/importmap/index.md
@@ -95,7 +95,7 @@ Note that in this case the property and mapped path must both have a trailing fo
 We could then import a circle module as shown.
 
 ```js
-import { name as circleName, draw } from "shapes/circle.js";
+import { name as circleName } from "shapes/circle.js";
 ```
 
 ### Paths in the module specifier map key


### PR DESCRIPTION
A trivial typo spotted while I was working on translating this.
Edit: removed the `draw` import which was only there earlier for `square` and not `circle`