### PR TITLE
Remove Firefox-only section from `<system-color>`

### DIFF
--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -107,61 +107,6 @@ The following keywords were defined in earlier versions of the CSS Color Module.
 - `WindowText` {{deprecated_inline}}
   - : Text in windows. Should be used with the `Window` background color.
 
-### Firefox non-standard system color extensions
-
-Firefox also supports some non-standard extensions to the system color keyword set.
-
-- `-moz-ButtonDefault` {{non-standard_inline}}
-  - : The border color that goes around buttons that represent the default action for a dialog box.
-- `-moz-ButtonHoverFace` {{non-standard_inline}}
-  - : The background color of a button that the mouse pointer is over (which would be `ThreeDFace` or `ButtonFace` when the mouse pointer is not over it). Should be used with the `-moz-ButtonHoverText` foreground color.
-- `-moz-ButtonHoverText` {{non-standard_inline}}
-  - : The text color of a button that the mouse pointer is over (which would be ButtonText when the mouse pointer is not over it). Should be used with the `-moz-ButtonHoverFace` background color.
-- `-moz-CellHighlight` {{non-standard_inline}}
-  - : Background color for selected item in a tree widget. Should be used with the `-moz-CellHighlightText` foreground color. See also `-moz-html-CellHighlight`.
-- `-moz-CellHighlightText` {{non-standard_inline}}
-  - : Text color for a selected item in a tree. Should be used with the `-moz-CellHighlight` background color. See also `-moz-html-CellHighlightText`.
-- `-moz-Combobox` {{non-standard_inline}}
-  - : Background color for combo-boxes. Should be used with the `-moz-ComboboxText` foreground color. In versions prior to 1.9.2, use `-moz-Field` instead.
-- `-moz-ComboboxText` {{non-standard_inline}}
-  - : Text color for combo-boxes. Should be used with the `-moz-Combobox` background color. In versions prior to 1.9.2, use `-moz-FieldText` instead.
-- `-moz-Dialog` {{non-standard_inline}}
-  - : Background color for dialog boxes. Should be used with the `-moz-DialogText` foreground color.
-- `-moz-DialogText` {{non-standard_inline}}
-  - : Text color for dialog boxes. Should be used with the `-moz-Dialog` background color.
-- `-moz-dragtargetzone` {{non-standard_inline}}
-  - : Highlight color for regions where an element can be dropped during a drag-and-drop operation.
-- `-moz-EvenTreeRow` {{non-standard_inline}}
-  - : Background color for even-numbered rows in a tree. Should be used with the `-moz-FieldText` foreground color. In Gecko versions prior to 1.9, use `-moz-Field`. See also `-moz-OddTreeRow`.
-- `-moz-html-CellHighlight` {{non-standard_inline}}
-  - : Background color for highlighted item in HTML {{HTMLElement("select")}}s. Should be used with the `-moz-html-CellHighlightText` foreground color. Prior to Gecko 1.9, use `-moz-CellHighlight`.
-- `-moz-html-CellHighlightText` {{non-standard_inline}}
-  - : Text color for highlighted items in HTML {{HTMLElement("select")}}s. Should be used with the `-moz-html-CellHighlight` background color. Prior to Gecko 1.9, use `-moz-CellHighlightText`.
-- `-moz-mac-accentdarkestshadow` {{non-standard_inline}}, `-moz-mac-accentdarkshadow` {{non-standard_inline}}, `-moz-mac-accentface` {{non-standard_inline}}, `-moz-mac-accentlightesthighlight` {{non-standard_inline}}, `-moz-mac-accentlightshadow` {{non-standard_inline}}, `-moz-mac-accentregularhighlight` {{non-standard_inline}}, `-moz-mac-accentregularshadow` {{non-standard_inline}}
-  - : Accent colors.
-- `-moz-mac-chrome-active` {{non-standard_inline}}, `-moz-mac-chrome-inactive` {{non-standard_inline}}
-  - : Colors for inactive and active browser chrome.
-- `-moz-mac-focusring` {{non-standard_inline}}, `-moz-mac-menuselect` {{non-standard_inline}}, `-moz-mac-menushadow` {{non-standard_inline}}, `-moz-mac-menutextselect` {{non-standard_inline}}, `-moz-MenuHover` {{non-standard_inline}}
-  - : Background color for hovered menu items. Often similar to `Highlight`. Should be used with the `-moz-MenuHoverText` or `-moz-MenuBarHoverText` foreground color.
-- `-moz-MenuHoverText` {{non-standard_inline}}
-  - : Text color for hovered menu items. Often similar to `HighlightText`. Should be used with the `-moz-MenuHover` background color.
-- `-moz-MenuBarText` {{non-standard_inline}}
-  - : Text color in menu bars. Often similar to `MenuText`. Should be used on top of `Menu` background.
-- `-moz-MenuBarHoverText` {{non-standard_inline}}
-  - : Color for hovered text in menu bars. Often similar to `-moz-MenuHoverText`. Should be used on top of `-moz-MenuHover` background.
-- `-moz-nativehyperlinktext` {{non-standard_inline}}
-  - : Default platform hyperlink color.
-- `-moz-OddTreeRow` {{non-standard_inline}}
-  - : Background color for odd-numbered rows in a tree. Should be used with the `-moz-FieldText` foreground color. In Gecko versions prior to 1.9, use `-moz-Field`. See also `-moz-EvenTreeRow`.
-- `-moz-win-communicationstext` {{non-standard_inline}}
-  - : Should be used for text in objects with `{{cssxref("appearance")}}: -moz-win-communications-toolbox;`.
-- `-moz-win-mediatext` {{non-standard_inline}}
-  - : Should be used for text in objects with `{{cssxref("appearance")}}: -moz-win-media-toolbox`.
-- `-moz-win-accentcolor` {{non-standard_inline}}
-  - : Used to access the Windows 10 custom accent color that you can set on the start menu, taskbar, title bars, etc.
-- `-moz-win-accentcolortext` {{non-standard_inline}}
-  - : Used to access the color of text placed over the Windows 10 custom accent color in the start menu, taskbar, title bars, etc.
-
 ## Examples
 
 ### Using system colors
@@ -206,4 +151,4 @@ In this example we have a button that normally gets its contrast using the {{css
 
 ## See also
 
-- [`<color>`](/en-US/docs/Web/CSS/color_value): the data type these keywords belong to.
+- [`<color>`](/en-US/docs/Web/CSS/color_value): the data type these keywords belong to


### PR DESCRIPTION
### Description

This PR removes the "Firefox non-standard system color extensions" section from `<system-color>`.

### Motivation

This section describes the subject-to-change keywords used internally by Firefox, and authors might better use specced values for interoperability.

### Additional details

### Related issues and pull requests

Fixes #26596.