### PR TITLE
Fix arrow syntax explanation

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -245,7 +245,7 @@ textBox.addEventListener("keydown", (event) =>
 If the function only takes one parameter, you can also omit the brackets around the parameter:
 
 ```js
-textBox.addEventListener("keydown", (event) =>
+textBox.addEventListener("keydown", event =>
   console.log(`You pressed "${event.key}".`)
 );
 ```

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -234,15 +234,7 @@ textBox.addEventListener("keydown", (event) => {
 });
 ```
 
-If the function only has one line in the curly brackets, you omit the curly brackets:
-
-```js
-textBox.addEventListener("keydown", (event) =>
-  console.log(`You pressed "${event.key}".`)
-);
-```
-
-If the function only takes one parameter, you can also omit the brackets around the parameter:
+If the function only takes one parameter, you can omit the brackets around the parameter:
 
 ```js-nolint
 textBox.addEventListener("keydown", event => {
@@ -250,7 +242,7 @@ textBox.addEventListener("keydown", event => {
 });
 ```
 
-Finally, if your function needs to return a value, and contains only one line, you can also omit the `return` statement. In the following example we're using the {{jsxref("Array.prototype.map()","map()")}} method of `Array` to double every value in the original array:
+Finally, if your function contains only one line that's a `return` statement, you can also omit the braces and the `return` keyword, and implicitly return the expression. In the following example we're using the {{jsxref("Array.prototype.map()","map()")}} method of `Array` to double every value in the original array:
 
 ```js
 const originals = [1, 2, 3];
@@ -269,6 +261,16 @@ function doubleItem(item) {
   return item * 2;
 }
 ```
+
+You can use the same concise syntax to rewrite the `addEventListener` example.
+
+```js
+textBox.addEventListener("keydown", (event) =>
+  console.log(`You pressed "${event.key}".`)
+);
+```
+
+In this case, the value of `console.log()`, which is `undefined`, is implicitly returned from the callback function.
 
 We recommend that you use arrow functions, as they can make your code shorter and more readable. To learn more, see the [section on arrow functions in the JavaScript guide](/en-US/docs/Web/JavaScript/Guide/Functions#arrow_functions), and our [reference page on arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -245,9 +245,9 @@ textBox.addEventListener("keydown", (event) =>
 If the function only takes one parameter, you can also omit the brackets around the parameter:
 
 ```js-nolint
-textBox.addEventListener("keydown", event =>
-  console.log(`You pressed "${event.key}".`)
-);
+textBox.addEventListener("keydown", event => {
+  console.log(`You pressed "${event.key}".`);
+});
 ```
 
 Finally, if your function needs to return a value, and contains only one line, you can also omit the `return` statement. In the following example we're using the {{jsxref("Array.prototype.map()","map()")}} method of `Array` to double every value in the original array:

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -244,7 +244,7 @@ textBox.addEventListener("keydown", (event) =>
 
 If the function only takes one parameter, you can also omit the brackets around the parameter:
 
-```js
+```js-nolint
 textBox.addEventListener("keydown", event =>
   console.log(`You pressed "${event.key}".`)
 );


### PR DESCRIPTION
The example should omit the brackets around the parameter, as described in the explanation above this code.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
According to the description above this code, the brackets around the parameter can be removed if there is only one parameter.But in the code the bracket remains around the arrow function with `event` being the only parameter.

<!-- ✍️ Summarize your changes in one or two sentences -->
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
