### PR TITLE
Fixed grammar mistake on line 107 of index.md

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -104,7 +104,7 @@ You could use these to insert a string of text, such as in the live example belo
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/before.html", '100%', 400)}}
 
-Inserting strings of text from CSS isn't really something we do very often on the web however, as that text is inaccessible to some screen readers and might be hard for someone to find and edit in the future.
+Inserting strings of text from CSS isn't really something we do very often on the web. However, as that text is inaccessible to some screen readers and might be hard for someone to find and edit in the future.
 
 A more valid use of these pseudo-elements is to insert an icon, for example the little arrow added in the example below, which is a visual indicator that we wouldn't want read out by a screen reader:
 


### PR DESCRIPTION
I noticed a grammatical error in the text on line 107 and corrected it. The mistake was causing a sentence to be structured incorrectly. This commit resolves the issue and ensures that the sentence appears correctly on the page.

"Insterting strings of text from CSS isn´t really really something we do very often on the web. However, as text ..."

Incorrect original version:

"Inserting strings of text from CSS isn't really something we do very often on the web however, as that text ..."

This change separates the two thoughts into two sentences, which is a clearer and more standard way of presenting them.