### PR TITLE
Follow up to PR 24921

### DIFF
--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -36,7 +36,7 @@ In this example we have two buttons, labeled "Commit styles" and "Fill forwards"
 
 The difference, though, is that "Fill forwards" only uses `fill: "forwards"` to persist the animation's final state: this means that the browser has to maintain the animation's state indefinitely, or until it can be automatically removed.
 
-However, "Commit styles" button waits for the animation to finish, then calls `commitStyles()`, then cancels the animation, so the finished style is captured as the value of the `style` attribute, rather than as the animation state.
+However, the "Commit styles" button waits for the animation to finish, then calls `commitStyles()`, then cancels the animation, so the finished style is captured as the value of the `style` attribute, rather than as the animation state.
 
 #### HTML
 

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -8,7 +8,11 @@ browser-compat: api.Animation.commitStyles
 
 {{APIRef("Web Animations")}}
 
-The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface writes the [computed values](/en-US/docs/Web/CSS/computed_value) of the animation's current styles into its target element's {{htmlattrxref("style")}} attribute. `commitStyles()` works even if the animation has been [automatically removed](/en-US/docs/Web/API/Animation#automatically_removing_filling_animations).
+The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface writes the [computed values](/en-US/docs/Web/CSS/computed_value) of the animation's current styles into its target element's [`style`](/en-US/docs/Web/HTML/Global_attributes#style) attribute. `commitStyles()` works even if the animation has been [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations).
+
+`commitStyles()` can be used in combination with `fill` to cause the final state of an animation to persist after the animation ends. The same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://w3c.github.io/csswg-drafts/web-animations-1/#fill-behavior). Animations [take precedence over all static styles](/en-US/docs/Web/CSS/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
+
+Using `commitStyles()` writes the styling state into the element's [`style`](/en-US/docs/Web/HTML/Global_attributes#style) attribute, where they can be modified and replaced as normal.
 
 ## Syntax
 
@@ -28,40 +32,59 @@ None ({{jsxref("undefined")}}).
 
 ### Committing the final state of an animation
 
-`commitStyles()` can be used in combination with `fill` to cause the final state of an animation to persist after the animation ends.
+In this example we have two buttons, labeled "Commit styles" and "Fill forwards". Both buttons animate when you click them, and both buttons persist the final state of the animation.
 
-> **Note:**
-> The same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://w3c.github.io/csswg-drafts/web-animations-1/#fill-behavior). Animations [take precedence over all static styles](/en-US/docs/Web/CSS/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
->
-> Using `commitStyles()` writes the styling state into the element's {{htmlattrxref("style")}} attribute, where they can be modified and replaced as normal.
+The difference, though, is that "Fill forwards" only uses `fill: "forwards"` to persist the animation's final state: this means that the browser has to maintain the animation's state indefinitely, or until it can be automatically removed.
 
-#### Javascript
+However, "Commit styles" button waits for the animation to finish, then calls `commitStyles()`, then cancels the animation, so the finished style is captured as the value of the `style` attribute, rather than as the animation state.
+
+#### HTML
+
+```html
+<button class="commit-styles">Commit styles</button>
+<br />
+<button class="fill-forwards">Fill forwards</button>
+```
+
+```css hidden
+button {
+  margin: 0.5rem;
+}
+```
+
+#### JavaScript
 
 ```js
-const button = document.querySelector("button");
-let offset = 0;
+const commitStyles = document.querySelector(".commit-styles");
+let offset1 = 0;
 
-button.addEventListener("click", async (event) => {
+commitStyles.addEventListener("click", async (event) => {
   // Start the animation
-  offset = 100 - offset;
-  const animation = button.animate(
-    { transform: `translate(${offset}px)` },
+  offset1 = 100 - offset1;
+  const animation = commitStyles.animate(
+    { transform: `translate(${offset1}px)` },
     { duration: 500, fill: "forwards" }
   );
 
   // Wait for the animation to finish
   await animation.finished;
-  // Commit animation state to style attr
+  // Commit animation state to style attribute
   animation.commitStyles();
   // Cancel the animation
   animation.cancel();
 });
-```
 
-#### HTML
+const fillForwards = document.querySelector(".fill-forwards");
+let offset2 = 0;
 
-```html
-<button>Animate</button>
+fillForwards.addEventListener("click", async (event) => {
+  // Start the animation
+  offset2 = 100 - offset2;
+  const animation = fillForwards.animate(
+    { transform: `translate(${offset2}px)` },
+    { duration: 500, fill: "forwards" }
+  );
+});
 ```
 
 #### Result

--- a/files/en-us/web/api/animation/index.md
+++ b/files/en-us/web/api/animation/index.md
@@ -35,7 +35,7 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
 - {{domxref("Animation.ready")}} {{ReadOnlyInline}}
   - : Returns the current ready Promise for this animation.
 - {{domxref("Animation.replaceState")}} {{ReadOnlyInline}}
-  - : Returns the replace state of the animation. This will be `removed` if the animation has been replaced and removed, or `persisted` if {{domxref("Animation.persist()")}} has been invoked on it.
+  - : Indicates whether the animation is active, has been automatically removed after being replaced by another animation, or has been explicitly persisted by a call to {{domxref("Animation.persist()")}}.
 - {{domxref("Animation.startTime")}}
   - : Gets or sets the scheduled time when an animation's playback should begin.
 - {{domxref("Animation.timeline")}}
@@ -51,8 +51,8 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
   - : Seeks either end of an animation, depending on whether the animation is playing or reversing.
 - {{domxref("Animation.pause()")}}
   - : Suspends playing of an animation.
-- {{domxref("animation.persist()")}}
-  - : Explicitly persists an animation, preventing it from being [automatically removed](#automatically_removing_filling_animations) when another animation replaces it.
+- {{domxref("Animation.persist()")}}
+  - : Explicitly persists an animation, preventing it from being [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations) when another animation replaces it.
 - {{domxref("Animation.play()")}}
   - : Starts or resumes playing of an animation, or begins the animation again if it previously finished.
 - {{domxref("Animation.reverse()")}}
@@ -68,26 +68,6 @@ The **`Animation`** interface of the [Web Animations API](/en-US/docs/Web/API/We
   - : Fires when the animation finishes playing.
 - {{domxref("animation.remove_event", "remove")}}
   - : Fires when the animation is [automatically removed](#automatically_removing_filling_animations) by the browser.
-
-## Automatically removing filling animations
-
-It is possible to trigger a large number of animations on the same element. If they are indefinite (i.e., forwards-filling), this can result in a huge animations list, which could create a memory leak. For this reason, browsers automatically remove filling animations after they are replaced by newer animations, unless the developer explicitly specifies to keep them.
-
-Animations are removed when all of the following are true:
-
-- The animation is filling (its `fill` is `forwards` if it is playing forwards, `backwards` if it is playing backwards, or `both`).
-- The animation is finished. (Note that because of the `fill` it will still be in effect.)
-- The animation's timeline is monotonically increasing. (This is always true for {{domxref("DocumentTimeline")}}; other timelines such as {{cssxref("scroll-timeline")}} can run backwards.)
-- The animation is not being controlled by declarative markup such as CSS.
-- Every styling effect of the animation's {{domxref("AnimationEffect")}} is being overridden by another animation that also satisfies all the conditions above. (Typically, when two animations would set the same style property of the same element, the one created last overrides the other.)
-
-The first four conditions ensure that, without intervention by JavaScript code, the animation's effect will never change or end. The last condition ensures that the animation will never actually affect the style of any element: it has been entirely replaced.
-
-The related JavaScript features are:
-
-- The {{domxref("animation/remove_event", "remove")}} event on the {{domxref("Animation")}} interface fires when the animation is removed (i.e., put into the `removed` replace state).
-- {{domxref("animation.persist()")}} for when you explicitly want an animation to be retained.
-- {{domxref("animation.replaceState")}} to return the replace state of the animation. This will be `removed` if the animation has been removed, or `persisted` if {{domxref("Animation.persist", "persist()")}} has been invoked.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/api/animation/persist/index.md
+++ b/files/en-us/web/api/animation/persist/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Animation.persist
 
 {{APIRef("Web Animations")}}
 
-The `persist()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface explicitly persists an animation, preventing it from being [automatically removed](/en-US/docs/Web/API/Animation#automatically_removing_filling_animations) when it is replaced by another animation.
+The `persist()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface explicitly persists an animation, preventing it from being [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations) when it is replaced by another animation.
 
 ## Syntax
 
@@ -27,6 +27,46 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ### Using `persist()`
+
+In this example, we have three buttons:
+
+- "Add persistent animation" and "Add transient animation" each add a new transform animation to the red square. The animations alternate direction: so the first is left to right, the second is right to left, and so on. "Add persistent animation" calls `persist()` on the animation it creates.
+
+- The third button, "Cancel an animation", cancels the most recently added animation.
+
+The example displays a list of all animations that have not been canceled, in the order they were added, along with each animation's `replaceState`.
+
+#### HTML
+
+```html
+<div id="animation-target"></div>
+<button id="start-persistent">Add persistent animation</button>
+<button id="start-transient">Add transient animation</button>
+<button id="cancel">Cancel an animation</button>
+<ol id="stack"></ol>
+```
+
+```html hidden
+<template id="list-item-template">
+  <li>
+    <span class="replaceState"></span>,
+    <span class="description"></span>
+  </li>
+</template>
+```
+
+#### CSS
+
+```css
+div {
+  width: 100px;
+  height: 100px;
+  background: red;
+  transform: translate(100px);
+}
+```
+
+#### JavaScript
 
 ```js
 const target = document.getElementById("animation-target");
@@ -84,44 +124,13 @@ function show(animation, offset) {
 }
 ```
 
-#### HTML
-
-```html
-<div id="animation-target"></div>
-<button id="start-persistent">Add persistent animation</button>
-<button id="start-transient">Add transient animation></button>
-<button id="cancel">Cancel an animation</button>
-<ol id="stack"></ol>
-```
-
-```html hidden
-<template id="list-item-template">
-  <li>
-    <span class="replaceState"></span>,
-    <span class="description"></span>
-  </li>
-</template>
-```
-
-#### CSS
-
-```css
-div {
-  width: 100px;
-  height: 100px;
-  background: red;
-  transform: translate(100px);
-}
-```
-
 #### Result
 
+Note that adding a new transient animation will replace any previously added transient animation. Those animations will be automatically removed, and their `replaceState` will be `"removed"`. However, persistent animations will not be removed.
+
+Also note that removed animations don't affect the display; the position of the {{htmlelement("div")}} is determined by the most recent active or persisted animation.
+
 {{EmbedLiveSample("using_persist","",300)}}
-
-Things to notice:
-
-- `persisted` animations are not `removed` when replaced, while `active` animations are.
-- `removed` animations don't affect the display; the position of the {{htmlelement("div")}} is determined by the most recent `active` or `persisted` animation.
 
 ## Specifications
 

--- a/files/en-us/web/api/animation/remove_event/index.md
+++ b/files/en-us/web/api/animation/remove_event/index.md
@@ -38,7 +38,7 @@ _In addition to the properties listed below, properties from the parent interfac
 
 ### Removing replaced animations
 
-In this example we have a `<button id="start">` element, and an event listener that runs whenever the mouse moves. The {{domxref("Element.mousemove_event","mousemove")}} event handler sets up an animation that animates the `<button>` to the position of the mouse pointer. This could result in a huge animations list, which could create a memory leak. For this reason, modern browsers automatically remove forward filling animations that are overridden by other animations.
+In this example we have a `<button id="start">` element, and an event listener that runs whenever the mouse moves. The {{domxref("Element.mousemove_event","mousemove")}} event handler sets up an animation that animates the `<button>` to the position of the mouse pointer. This could result in a huge animations list, which could create a memory leak. For this reason, modern browsers automatically remove forwards-filling animations that are overridden by other animations.
 
 The number of animations created is displayed. A `remove` event listener is used to count and display the number of animations removed as well.
 

--- a/files/en-us/web/api/animation/remove_event/index.md
+++ b/files/en-us/web/api/animation/remove_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Animation.remove_event
 
 {{ APIRef("Web Animations") }}
 
-The **`remove`** event of the {{domxref("Animation")}} interface fires when the animation is [automatically removed](/en-US/docs/Web/API/Animation#automatically_removing_filling_animations) by the browser.
+The **`remove`** event of the {{domxref("Animation")}} interface fires when the animation is [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations) by the browser.
 
 ## Syntax
 
@@ -38,10 +38,45 @@ _In addition to the properties listed below, properties from the parent interfac
 
 ### Removing replaced animations
 
-#### Javascript
+In this example we have a `<button id="start">` element, and an event listener that runs whenever the mouse moves. The {{domxref("Element.mousemove_event","mousemove")}} event handler sets up an animation that animates the `<button>` to the position of the mouse pointer. This could result in a huge animations list, which could create a memory leak. For this reason, modern browsers automatically remove forward filling animations that are overridden by other animations.
+
+The number of animations created is displayed. A `remove` event listener is used to count and display the number of animations removed as well.
+
+All but one of the animations should eventually be removed.
+
+#### HTML
+
+```html
+<button id="start">Click to drag</button>
+<br />
+<button id="reset">Reset example</button>
+<p>
+  Click the button to start the animation (disabled by default to protect those
+  who suffer migraines when experiencing such animations).
+</p>
+<p>Animations created: <span id="count-created">0</span></p>
+<p>Animations removed: <span id="count-removed">0</span></p>
+```
+
+#### CSS
+
+```css
+:root,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+button {
+  margin: 0.5rem 0;
+}
+```
+
+#### JavaScript
 
 ```js
-const button = document.querySelector("button");
+const button = document.querySelector("#start");
 let created = 0;
 let removed = 0;
 
@@ -70,40 +105,16 @@ function showCounts() {
   document.getElementById("count-created").textContent = created;
   document.getElementById("count-removed").textContent = removed;
 }
-```
 
-#### HTML
-
-```html
-<button>Click to drag</button>
-<p>
-  Click the button to start the animation (disabled by default to protect those
-  who suffer migraines when experiencing such animations).
-</p>
-<p>Animations created: <span id="count-created">0</span></p>
-<p>Animations removed: <span id="count-removed">0</span></p>
-```
-
-#### CSS
-
-```css
-:root,
-body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-}
+const reset = document.querySelector("#reset");
+reset.addEventListener("click", () => {
+  document.location.reload();
+});
 ```
 
 #### Result
 
 {{embedlivesample("Removing_replaced_animations","",250)}}
-
-Here we have a `<button>` element, and an event listener that runs whenever the mouse moves. The {{domxref("Element.mousemove_event","mousemove")}} event handler sets up an animation that animates the `<button>` to the position of the mouse pointer. This could result in a huge animations list, which could create a memory leak. For this reason, modern browsers automatically remove forward filling animations that are overridden by other animations.
-
-The number of animations created is displayed. A `remove` event listener is used to count and display the number of animations removed as well.
-
-All but one of the animations should eventually be removed.
 
 ## Specifications
 

--- a/files/en-us/web/api/animation/replacestate/index.md
+++ b/files/en-us/web/api/animation/replacestate/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Animation.replaceState
 
 {{ APIRef("Web Animations") }}
 
-The read-only **`Animation.replaceState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) indicates whether the animation has been automatically removed after being replaced by another animation.
+The read-only **`Animation.replaceState`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) indicates whether the animation has been [removed by the browser automatically](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations) after being replaced by another animation.
 
 ## Value
 
@@ -19,7 +19,7 @@ A string that represents the replace state of the animation. The value can be on
 - `persisted`
   - : The animation has been explicitly persisted by invoking {{domxref("Animation.persist()")}} on it.
 - `removed`
-  - : The animation has been removed by the browser's [Automatically removing filling animations](/en-US/docs/Web/API/Animation#automatically_removing_filling_animations) behavior.
+  - : The animation has been removed by the browser automatically.
 
 ## Specifications
 

--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -260,7 +260,7 @@ When the animation is automatically removed, the animation's {{domxref("animatio
 
 To prevent the browser from automatically removing animations, call the animation's {{domxref("Animation.persist", "persist()")}} method.
 
-The animation's {{domxref("animation.replaceState")}} property will be `removed` iof the animation has been removed, `persisted` if you have called {{domxref("Animation.persist", "persist()")}} on the animation, or `active` otherwise.
+The animation's {{domxref("animation.replaceState")}} property will be `removed` if the animation has been removed, `persisted` if you have called {{domxref("Animation.persist", "persist()")}} on the animation, or `active` otherwise.
 
 ## Getting information out of animations
 

--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -233,6 +233,35 @@ document.addEventListener("touchstart", goFaster);
 
 The background elements also have `playbackRate`s that are impacted when you click or tap. What happens when you make Alice and the Red Queen run twice as fast? What happens when you let them slow down?
 
+## Persisting animation styles
+
+When animating elements, a common use case is to persist the final state of the animation, after the animation has finished. One method sometimes used for this is to set the animation's [fill mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to `forwards`. However, it is not recommended to use fill modes to persist the effect of an animation indefinitely, for two reasons:
+
+- The browser has to maintain the state of the animation while it is still active, so the animation continues to consume resources even though it is no longer animating. Note that this is somewhat alleviated by the browser [automatically removing filling animations](#automatically_removing_filling_animations).
+- Styles applied by animations have a [higher precedence in the cascade](/en-US/docs/Web/CSS/Cascade#cascading_order) than specified styles, so it can be difficult to override them when needed.
+
+A better approach is to use the {{domxref("Animation.commitStyles()")}} method. This writes the computed values of the animation's current styles into its target element's [`style`](/en-US/docs/Web/HTML/Global_attributes#style) attribute, after which the element can be restyled normally.
+
+## Automatically removing filling animations
+
+It is possible to trigger a large number of animations on the same element. If they are indefinite (i.e., forwards-filling), this can result in a huge animations list, which could create a memory leak. For this reason, browsers automatically remove filling animations after they are replaced by newer animations, unless the developer explicitly specifies to keep them.
+
+Animations are removed when all of the following are true:
+
+- The animation is filling (its `fill` is `forwards` if it is playing forwards, `backwards` if it is playing backwards, or `both`).
+- The animation is finished. (Note that because of the `fill` it will still be in effect.)
+- The animation's timeline is monotonically increasing. (This is always true for {{domxref("DocumentTimeline")}}; other timelines such as {{cssxref("scroll-timeline")}} can run backwards.)
+- The animation is not being controlled by declarative markup such as CSS.
+- Every styling effect of the animation's {{domxref("AnimationEffect")}} is being overridden by another animation that also satisfies all the conditions above. (Typically, when two animations would set the same style property of the same element, the one created last overrides the other.)
+
+The first four conditions ensure that, without intervention by JavaScript code, the animation's effect will never change or end. The last condition ensures that the animation will never actually affect the style of any element: it has been entirely replaced.
+
+When the animation is automatically removed, the animation's {{domxref("animation/remove_event", "remove")}} event fires.
+
+To prevent the browser from automatically removing animations, call the animation's {{domxref("Animation.persist", "persist()")}} method.
+
+The animation's {{domxref("animation.replaceState")}} property will be `removed` iof the animation has been removed, `persisted` if you have called {{domxref("Animation.persist", "persist()")}} on the animation, or `active` otherwise.
+
 ## Getting information out of animations
 
 Imagine other ways we could use playbackRate, such as improving accessibility for users with vestibular disorders by letting them slow down animations across an entire site. That's impossible to do with CSS without recalculating durations in every CSS rule, but with the Web Animations API, we could use the {{domxref("Document.getAnimations")}} method to loop over each animation on the page and halve their `playbackRate`s, like so:


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/24921. I had some comments on that PR, but they didn't get applied. But the PR corrected some errors so I merged it anyway.

This PR applies my comments.

In particular:
- moved the explanation of `commitStyles()` from the example into the main prose section
- expanded the example for `commitStyles()`
- moved the bit about automatically removing animations from the reference page for `Animation` into the "Using animations" guide
- added a section to the "Using animations" guide about persisting animation styles
- reordered some live samples according to our standard (HTML, CSS, JS).
- some little fixes here and there