### PR TITLE
prefers-reduced-transparency isn't enabled by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -776,7 +776,7 @@ See ([Firefox bug 1736914](https://bugzil.la/1736914)) for more details.
     <tr>
       <th>Nightly</th>
       <td>113</td>
-      <td>Yes</td>
+      <td>No</td>
     </tr>
     <tr>
       <th>Developer Edition</th>


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1822176 for the plan to enable.