### PR TITLE
Fix: Use language keywords instead of framework type names in the examples of 'WebSocket'

### DIFF
--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
@@ -74,13 +74,13 @@ Methods:
 - Writes bytes from buffer, offset and size determine length of message.
 
   ```cs
-  Write(Byte[] buffer, int offset, int size)
+  Write(byte[] buffer, int offset, int size)
   ```
 
 - Reads bytes to `buffer`. `offset` and `size` determine the length of the message.
 
   ```cs
-  Read(Byte[] buffer, int offset, int size)
+  Read(byte[] buffer, int offset, int size)
   ```
 
 Let us extend our example.
@@ -96,7 +96,7 @@ NetworkStream stream = client.GetStream();
 while (true) {
     while (!stream.DataAvailable);
 
-    Byte[] bytes = new Byte[client.Available];
+    byte[] bytes = new byte[client.Available];
 
     stream.Read(bytes, 0, bytes.Length);
 }
@@ -117,7 +117,7 @@ while(client.Available < 3)
    // wait for enough bytes to be available
 }
 
-Byte[] bytes = new Byte[client.Available];
+byte[] bytes = new byte[client.Available];
 
 stream.Read(bytes, 0, bytes.Length);
 
@@ -145,7 +145,7 @@ if (new System.Text.RegularExpressions.Regex("^GET").IsMatch(data))
 {
     const string eol = "\r\n"; // HTTP/1.1 defines the sequence CR LF as the end-of-line marker
 
-    Byte[] response = Encoding.UTF8.GetBytes("HTTP/1.1 101 Switching Protocols" + eol
+    byte[] response = Encoding.UTF8.GetBytes("HTTP/1.1 101 Switching Protocols" + eol
         + "Connection: Upgrade" + eol
         + "Upgrade: websocket" + eol
         + "Sec-WebSocket-Accept: " + Convert.ToBase64String(
@@ -207,12 +207,12 @@ where _D_ is the decoded message array, _E_ is the encoded message array, _M_ is
 Example in C#:
 
 ```cs
-Byte[] decoded = new Byte[3];
-Byte[] encoded = new Byte[3] {112, 16, 109};
-Byte[] mask = new Byte[4] {61, 84, 35, 6};
+byte[] decoded = new byte[3];
+byte[] encoded = new byte[3] {112, 16, 109};
+byte[] mask = new byte[4] {61, 84, 35, 6};
 
 for (int i = 0; i < encoded.Length; i++) {
-    decoded[i] = (Byte)(encoded[i] ^ mask[i % 4]);
+    decoded[i] = (byte)(encoded[i] ^ mask[i % 4]);
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
With these examples, you get a warning that name "Byte" can be simplified (IDE0049).
So I changed this to lowercase for no more warning and more readability.

See: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
