### PR TITLE
Mention that Set iterators have a defined order

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Map.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of {{jsxref("Map")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows maps to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns a [map iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the key-value pairs of the map.
+The **`[@@iterator]()`** method of {{jsxref("Map")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows maps to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns a [map iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the key-value pairs of the map in insertion order.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Map.prototype.entries")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Set.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of {{jsxref("Set")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set.
+The **`[@@iterator]()`** method of {{jsxref("Set")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set in the order that they were added.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Set.prototype.values")}} property.
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Set.@@iterator
 
 {{JSRef}}
 
-The **`[@@iterator]()`** method of {{jsxref("Set")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set in the order that they were added.
+The **`[@@iterator]()`** method of {{jsxref("Set")}} instances implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows sets to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [set iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the values of the set in insertion order.
 
 The initial value of this property is the same function object as the initial value of the {{jsxref("Set.prototype.values")}} property.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->


Mention that Set iterators have a well-defined order. It isn't stated directly in the spec, but the [algorithm](https://tc39.es/ecma262/multipage/keyed-collections.html#sec-createsetiterator) used is a linear scan by index over the `[[SetData]]` List, which `add()` is [defined](https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.add) as appending to.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

While doing a PR I was about to warn someone that they shoudn't be relying on the order of a Set (which is a common bug in other languages), but decided to verify that it wasn't guaranteed by JS first. MDN didn't say anything about the order, so I had to dig into the spec, which does require an order, but doesn't say so directly.

Hopefully this will save someone else the time to  look this up in the future.

### Additional details

There are probably other places that should have a similar change, eg `Set.prototype.values()` and all of the `Map` iterator methods.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
