### PR TITLE
Update length values description

### DIFF
--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -40,7 +40,7 @@ width: unset;
 ### Values
 
 - {{cssxref("&lt;length&gt;")}}
-  - : Defines the width as a length value.
+  - : Defines the width as a distance value.
 - {{cssxref("&lt;percentage&gt;")}}
   - : Defines the width as a percentage of the containing block's width.
 - `auto`

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -40,7 +40,7 @@ width: unset;
 ### Values
 
 - {{cssxref("&lt;length&gt;")}}
-  - : Defines the width as an absolute value.
+  - : Defines the width as a length value.
 - {{cssxref("&lt;percentage&gt;")}}
   - : Defines the width as a percentage of the containing block's width.
 - `auto`


### PR DESCRIPTION
length values are not always absolute. For example we can use 2em for width property as a length value but it is not absolute. I corrected this in the Values section.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
