### PR TITLE
Accentuate month being 0-index in getMonth example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -325,7 +325,7 @@ date.toLocaleTimeString(); // 6:50:21 PM
 ### To get Date, Month and Year or Time
 
 ```js
-const date = new Date("2000-01-17");
+const date = new Date("2000-01-17T16:45:30Z");
 const [month, day, year] = [
   date.getMonth(),
   date.getDate(),

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -325,7 +325,7 @@ date.toLocaleTimeString(); // 6:50:21 PM
 ### To get Date, Month and Year or Time
 
 ```js
-const date = new Date("2000-01-17T16:45:30Z");
+const date = new Date("2000-01-17T16:45:30");
 const [month, day, year] = [
   date.getMonth(),
   date.getDate(),

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -325,7 +325,7 @@ date.toLocaleTimeString(); // 6:50:21 PM
 ### To get Date, Month and Year or Time
 
 ```js
-const date = new Date('Jan 17, 2000 16:45:30');
+const date = new Date("2000-01-17");
 const [month, day, year] = [
   date.getMonth(),
   date.getDate(),

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -325,17 +325,19 @@ date.toLocaleTimeString(); // 6:50:21 PM
 ### To get Date, Month and Year or Time
 
 ```js
-const date = new Date();
+const date = new Date('Jan 17, 2000 16:45:30');
 const [month, day, year] = [
   date.getMonth(),
   date.getDate(),
   date.getFullYear(),
 ];
+// [0, 17, 2000] as month are 0-indexed
 const [hour, minutes, seconds] = [
   date.getHours(),
   date.getMinutes(),
   date.getSeconds(),
 ];
+// [16, 45, 30]
 ```
 
 ### Interpretation of two-digit years


### PR DESCRIPTION
### Description

In the documentation of the Javascript Date object, in the section showing how to get the main components of the date, add a specific date and a pair of comment with the actual output of the methods.

### Motivation

`Date.getMonth` behavior differ slightly from the similar method as it return the index of the month and is 0-indexed, while the other method return ordinal values instead of index and don't have this distinction.

Adding a comment with the actual output put emphasis on this difference in behavior and might prevent people being surprised by that after the fact. I personally assumed `getMonth` return an iso-compatible month number and didn't notice 4 wasn't the correct number for may until I wrote similar code using PHP date format instead of string formatting and noticing I did get different output for the same date.

### Additional details

The value chosen for the date is partly random, as in chosen arbitrary.
2000 is the first year not starting with 19; January cause the month part to be 0 which should call attention to itself; 17 is high enough so it cannot be a month and I like it; 16 is in the 24h hour clock; 45 is high enough to not be confused with an hour; 30 is here for lack of imagination.

### Related issues and pull requests

Nothing that I know of