### PR TITLE
fix: Updated description of example which in `JavaScript.Object` to be more accurate

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -257,7 +257,7 @@ These properties are defined on `Object.prototype` and shared by all `Object` in
 
 ### Constructing empty objects
 
-The following examples store an empty `Object` object in `o`:
+The following example creates empty objects using the `new` keyword with different arguments:
 
 ```js
 const o1 = new Object();


### PR DESCRIPTION
### Description

Such as the title. The associated code was changed but the description wasn't. Consider changing the next paragraph's code and its description to keep a consistent style.

### Motivation

Ditto.

### Additional details

None.

### Related issues and pull requests

None.