### PR TITLE
Remove unnecessary infinite loop from `ReadableStream` page

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -152,19 +152,17 @@ fetch("http://example.com/somefile.txt")
   // Retrieve its body as ReadableStream
   .then((response) => {
     const reader = response.body.getReader();
-    while (true) {
-      // read() returns a promise that resolves when a value has been received
-      reader.read().then(function pump({ done, value }) {
-        if (done) {
-          // Do something with last chunk of data then exit reader
-          return;
-        }
-        // Otherwise do something here to process current chunk
+    // read() returns a promise that resolves when a value has been received
+    reader.read().then(function pump({ done, value }) {
+      if (done) {
+        // Do something with last chunk of data then exit reader
+        return;
+      }
+      // Otherwise do something here to process current chunk
 
-        // Read some more, and call this function again
-        return reader.read().then(pump);
-      });
-    }
+      // Read some more, and call this function again
+      return reader.read().then(pump);
+    });
   })
   .catch((err) => console.error(err));
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description + Motivation

There doesn't appear to be a need for the `while (true)` loop here as continuous reading is taken care of by calling the `pump` function recursively, so have removed the loop.
