### PR TITLE
Fix 26743: Fix return value; improve example

### DIFF
--- a/files/en-us/web/api/range/getclientrects/index.md
+++ b/files/en-us/web/api/range/getclientrects/index.md
@@ -24,15 +24,45 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) sequence of {{domxref("DOMRect")}} objects.
 
 ## Examples
 
-```js
-range = document.createRange();
-range.selectNode(document.getElementsByTagName("div").item(0));
-rectList = range.getClientRects();
+### Logging selected client rect sizes
+
+#### HTML
+
+```html
+<div></div>
+<pre id="output"></pre>
 ```
+
+#### CSS
+
+```css
+div {
+  height: 80px;
+  width: 200px;
+  background-color: blue;
+}
+```
+
+#### JavaScript
+
+```js
+const range = document.createRange();
+range.selectNode(document.querySelector("div"));
+rectList = range.getClientRects();
+
+const output = document.querySelector("#output");
+for (const rect of rectList) {
+  output.textContent = `${output.textContent}\n${rect.width}:${rect.height}`;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample}}
 
 ## Specifications
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26743, and also improves the live sample. I esp wanted to show that the returned value is iterable.

This error was introduced by https://github.com/mdn/content/pull/15585, which apparently added a "Returns none" statement to all method pages that didn't specify `### Return value`. It might be worth checking that list to see if there are any more of these.