### PR TITLE
Add TransformStream note about returning a promise

### DIFF
--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -30,7 +30,7 @@ new TransformStream(transformer, writableStrategy, readableStrategy)
     - `start(controller)`
       - : Called when the `TransformStream` is constructed. It is typically used to enqueue chunks using {{domxref("TransformStreamDefaultController.enqueue()")}}.
     - `transform(chunk, controller)`
-      - : Called when a chunk written to the writable side is ready to be transformed, and performs the work of the transformation stream. If no `transform()` method is supplied, the identity transform is used, and the chunk will be enqueued with no changes.
+      - : Called when a chunk written to the writable side is ready to be transformed, and performs the work of the transformation stream. It can return a promise to signal success or failure of the write operation. If no `transform()` method is supplied, the identity transform is used, and the chunk will be enqueued with no changes.
     - `flush(controller)`
       - : Called after all chunks written to the writable side have been successfully transformed, and the writable side is about to be closed.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `transform` method didn't mention returning a promise. This part works like a `WritableStream`, so I copied the text from there.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This is how transform streams apply backpressure.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://streams.spec.whatwg.org/#dom-transformer-transform
https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/WritableStream

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
