### PR TITLE
Remove emphasis on WritableStream controller

### DIFF
--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -23,7 +23,7 @@ new WritableStream(underlyingSink, queuingStrategy)
 - `underlyingSink` {{optional_inline}}
 
   - : An object containing methods and properties that define how the constructed stream
-    instance will behave.  The `controller` parameter passed to this object's methods is a {{domxref("WritableStreamDefaultController")}} that provides abort and error signaling. `underlyingSink` can contain the following:
+    instance will behave. The `controller` parameter passed to this object's methods is a {{domxref("WritableStreamDefaultController")}} that provides abort and error signaling. `underlyingSink` can contain the following:
 
     - `start(controller)` {{optional_inline}}
       - : This is a method, called immediately when the object is constructed. The

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -23,23 +23,18 @@ new WritableStream(underlyingSink, queuingStrategy)
 - `underlyingSink` {{optional_inline}}
 
   - : An object containing methods and properties that define how the constructed stream
-    instance will behave. `underlyingSink` can contain the following:
+    instance will behave.  The `controller` parameter passed to this object's methods is a {{domxref("WritableStreamDefaultController")}} that provides abort and error signalling. `underlyingSink` can contain the following:
 
     - `start(controller)` {{optional_inline}}
       - : This is a method, called immediately when the object is constructed. The
         contents of this method are defined by the developer, and should aim to get access
         to the underlying sink. If this process is to be done asynchronously, it can
-        return a promise to signal success or failure. The `controller`
-        parameter passed to this method is a
-        {{domxref("WritableStreamDefaultController")}}. This can be used by the developer
-        to control the stream during set up.
+        return a promise to signal success or failure.
     - `write(chunk, controller)` {{optional_inline}}
       - : This method, also defined by the developer, will be called when a new chunk of
         data (specified in the `chunk` parameter) is ready to be written to the
         underlying sink. It can return a promise to signal success or failure of the write
-        operation. The `controller` parameter passed to this method is a
-        {{domxref("WritableStreamDefaultController")}} that can be used by the developer
-        to control the stream as more chunks are submitted for writing. This method will
+        operation. This method will
         be called only after previous writes have succeeded, and never after the stream is
         closed or aborted (see below).
     - `close(controller)` {{optional_inline}}
@@ -48,9 +43,7 @@ new WritableStream(underlyingSink, queuingStrategy)
         is necessary to finalize writes to the underlying sink, and release access to it.
         If this process is asynchronous, it can return a promise to signal success or
         failure. This method will be called only after all queued-up writes have
-        succeeded. The `controller` parameter passed to this method is a
-        {{domxref("WritableStreamDefaultController")}}, which can be used to control the
-        stream at the end of writing.
+        succeeded.
     - `abort(reason)` {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals
         that it wishes to abruptly close the stream and put it in an errored state. It can

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -23,7 +23,7 @@ new WritableStream(underlyingSink, queuingStrategy)
 - `underlyingSink` {{optional_inline}}
 
   - : An object containing methods and properties that define how the constructed stream
-    instance will behave.  The `controller` parameter passed to this object's methods is a {{domxref("WritableStreamDefaultController")}} that provides abort and error signalling. `underlyingSink` can contain the following:
+    instance will behave.  The `controller` parameter passed to this object's methods is a {{domxref("WritableStreamDefaultController")}} that provides abort and error signaling. `underlyingSink` can contain the following:
 
     - `start(controller)` {{optional_inline}}
       - : This is a method, called immediately when the object is constructed. The


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove repeated references to write controller

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This controller can't really be used to "control the stream". It just provides an abort `signal` and an `error` method.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://streams.spec.whatwg.org/#ws-default-controller-class

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
