### PR TITLE
Window.beforeunload event requires sticky activation

### DIFF
--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -39,7 +39,8 @@ In addition to the `Window` interface, the event handler property `onbeforeunloa
 
 ## Security
 
-[Transient user activation](/en-US/docs/Web/Security/User_activation) is required. The user has to interact with the page or a UI element in order for this feature to work.
+[Sticky activation](/en-US/docs/Glossary/Sticky_activation) is required.
+The user has to have interacted with the page in order for this feature to work.
 
 ## Usage notes
 


### PR DESCRIPTION
Fixes #26751

I am pretty sure the error report is correct. If you look at the spec it indicates sticky rather than transient activation is required: https://html.spec.whatwg.org/multipage/browsing-the-web.html#preventing-navigation:event-beforeunload (see relevant section in linked issue).