### PR TITLE
Clarify options of FileSystemFileHandle.createWritable

### DIFF
--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -22,17 +22,19 @@ the temporary file when the writable filestream is closed.
 
 ```js-nolint
 createWritable()
+createWritable(options)
 ```
 
 ### Parameters
 
-- FileSystemCreateWritableOptions
+- `options` {{optional_inline}}
 
-  - : An object representing options to pass into the method. Options are:
+  - : An object with the following properties:
 
-    - `keepExistingData`: If `false` or not specified, the
-      temporary file starts out empty, otherwise the existing file is first copied to
-      this temporary file.
+    - `keepExistingData`
+      - : A {{jsxref('Boolean')}}. Default `false`. When
+        set to `true` if the file exists, the existing file is first copied to
+        the temporary file. Otherwise the temporary file starts out empty.
 
 ### Return value
 


### PR DESCRIPTION
### Description

The changes add the optional parameter `options` to the syntax list.

### Motivation

The syntax with `options` missing can confuse the way that the optional parameter works or even might suggest that such a variant doesn't exist.

### Additional details

[The documentation of FileSystemDirectoryHandle.getFileHandle](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/getFileHandle) guided me.
