### PR TITLE
Remove unnecessary heading in popover global attr page

### DIFF
--- a/files/en-us/web/html/global_attributes/popover/index.md
+++ b/files/en-us/web/html/global_attributes/popover/index.md
@@ -19,8 +19,6 @@ For detailed information on usage, see the {{domxref("Popover API", "Popover API
 
 ## Examples
 
-## Basic example
-
 The following will render a button which will open a popover element.
 
 ```html


### PR DESCRIPTION
Either the heading level of "Basic examples" should be h3, either one of the headings should be removed: I went with the latter