### PR TITLE
Correct userVerification enum description

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -218,9 +218,9 @@ The [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) enables
 
     The value can be one of the following:
 
-    - `"discouraged"`: The relying party requires user verification, and the operation will fail if it does not occur.
+    - `"required"`: The relying party requires user verification, and the operation will fail if it does not occur.
     - `"preferred"`: The relying party prefers user verification if possible, but the operation will not fail if it does not occur.
-    - `"required"`: The relying party does not want user verification, in the interests of making user interaction as smooth as possible.
+    - `"discouraged"`: The relying party does not want user verification, in the interests of making user interaction as smooth as possible.
 
     If `userVerification` is omitted, it will default to `"preferred"`.
 


### PR DESCRIPTION
### Description

Makes the descriptions for the userVerification enum in CredentialsContainer.get() match with their values (see the specification).

### Motivation

There was an obvious mistake in the enum descriptions, likely caused by a different order in the specification (see below).

### Additional details

- [Relevant Specification](https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement) (Would it also make sense to add this spec to the "Specifications" section? If so, I don't know how to do that...)

### Related issues and pull requests

- Relates to #25922
