### PR TITLE
fix(learn): Prism key for syntax highlighting apache code is 'apacheconf'

### DIFF
--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
@@ -19,7 +19,7 @@ Most of the following blocks use the [IfModule](https://httpd.apache.org/docs/2.
 
 There are times when we need to tell users that a resource has moved, either temporarily or permanently. This is what we use `Redirect` and `RedirectMatch` for.
 
-```apache
+```apacheconf
 <IfModule mod_alias.c>
   # Redirect to a URL on a different host
   Redirect "/service" "http://foo2.example.com/service"
@@ -60,7 +60,7 @@ For security reasons, browsers restrict cross-origin HTTP requests initiated fro
 
 This directive will add the CORS header for all resources in the directory from any website.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header set Access-Control-Allow-Origin "*"
 </IfModule>
@@ -70,7 +70,7 @@ Unless you override the directive later in the configuration or in the configura
 
 One alternative is to explicitly state what domains have access to the content of your site. In the example below, we restrict access to a subdomain of our main site (example.com). This is more secure and, likely, what you intended to do.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header set Access-Control-Allow-Origin "subdomain.example.com"
 </IfModule>
@@ -82,7 +82,7 @@ As reported in the [Chromium Blog](https://blog.chromium.org/2011/07/using-cross
 
 To mitigate the possibility of these attacks, you should use the `crossorigin` attribute in the images you request and the code snippet below in your `.htaccess` to set the CORS header from the server.
 
-```apache
+```apacheconf
 <IfModule mod_setenvif.c>
   <IfModule mod_headers.c>
     <FilesMatch "\.(bmp|cur|gif|ico|jpe?g|a?png|svgz?|webp|heic|heif|avif)$">
@@ -95,7 +95,7 @@ To mitigate the possibility of these attacks, you should use the `crossorigin` a
 
 Google Chrome's [Google Fonts troubleshooting guide](https://developers.google.com/fonts/docs/troubleshooting) tells us that, while Google Fonts may send the CORS header with every response, some proxy servers may strip it before the browser can use it to render the font.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   <FilesMatch "\.(eot|otf|tt[cf]|woff2?)$">
     Header set Access-Control-Allow-Origin "*"
@@ -111,7 +111,7 @@ The [Timing-Allow-Origin](/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin) resp
 
 If a resource isn't served with a `Timing-Allow-Origin` or if the header does not include the origin, after making the request some attributes of the `PerformanceResourceTiming` object will be set to zero.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header set Timing-Allow-Origin: "*"
 </IfModule>
@@ -125,7 +125,7 @@ The error pages are presented as URLs. These URLs can begin with a slash (/) for
 
 See the [ErrorDocument Directive](https://httpd.apache.org/docs/current/mod/core.html#errordocument) documentation on the HTTPD documentation site for more information.
 
-```apache
+```apacheconf
 ErrorDocument 500 /errors/500.html
 ErrorDocument 404 /errors/400.html
 ErrorDocument 401 https://example.com/subscription_info.html
@@ -140,7 +140,7 @@ The effect of `MultiViews` is as follows: if the server receives a request for /
 
 The setting disables `MultiViews` for the directory this configuration applies to and prevents Apache from returning a 404 error as the result of a rewrite when the directory with the same name does not exist
 
-```apache
+```apacheconf
 Options -MultiViews
 ```
 
@@ -158,7 +158,7 @@ Associates media types with one or more extensions to make sure the resources wi
 
 Servers should use text/javascript for JavaScript resources as indicated in the [HTML specification](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages)
 
-```apache
+```apacheconf
 <IfModule mod_expires.c>
   # Data interchange
     AddType application/atom+xml      atom
@@ -224,7 +224,7 @@ Every piece of content on the web has a character set. Most, if not all, the con
 
 Use [AddDefaultCharset](https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset) to serve all resources labeled as `text/html` or `text/plain` with the `UTF-8` charset.
 
-```apache
+```apacheconf
 <IfModule mod_mime.c>
   AddDefaultCharset utf-8
 </IfModule>
@@ -234,7 +234,7 @@ Use [AddDefaultCharset](https://httpd.apache.org/docs/current/mod/core.html#addd
 
 Serve the following file types with the `charset` parameter set to `UTF-8` using the [AddCharset](https://httpd.apache.org/docs/current/mod/mod_mime.html#addcharset) directive available in `mod_mime`.
 
-```apache
+```apacheconf
 <IfModule mod_mime.c>
   AddCharset utf-8 .appcache \
     .bbaw \
@@ -277,7 +277,7 @@ The required steps are:
    - See [Rackspace FAQ](https://web.archive.org/web/20151223141222/http://www.rackspace.com/knowledge_center/frequently-asked-question/why-is-modrewrite-not-working-on-my-site) and the [HTTPD documentation](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritebase)
    - Depending on how your server is set up, you may also need to use the [`RewriteOptions`](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriteoptions) directive to enable some options for the rewrite engine
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   Options +FollowSymlinks
@@ -291,7 +291,7 @@ The required steps are:
 
 These Rewrite rules will redirect from the `http://` insecure version to the `https://` secure version of the URL as described in the [Apache HTTPD wiki](https://cwiki.apache.org/confluence/display/httpd/RewriteHTTPToHTTPS).
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteCond %{HTTPS} !=on
@@ -301,7 +301,7 @@ These Rewrite rules will redirect from the `http://` insecure version to the `ht
 
 If you're using cPanel AutoSSL or the Let's Encrypt webroot method to create your SSL certificates, it will fail to validate the certificate if validation requests are redirected to HTTPS. Turn on the condition(s) you need.
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteCond %{HTTPS} !=on
@@ -322,7 +322,7 @@ Set `%{ENV:PROTO}` variable, to allow rewrites to redirect with the appropriate 
 
 The rule assumes by default that both HTTP and HTTPS environments are available for redirection.
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteCond %{HTTPS} =on
@@ -347,7 +347,7 @@ The rule assumes by default that both HTTP and HTTPS environments are available 
 
 The following might not be a good idea if you use "real" subdomains for certain parts of your website.
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteCond %{HTTPS} =on
@@ -374,7 +374,7 @@ While you could send the `X-Frame-Options` header for all of your website's page
 
 Nonetheless, you should ensure that you send the `X-Frame-Options` header for all pages that allow a user to make a state-changing operation (e.g., pages that contain one-click purchase links, checkout, or bank-transfer confirmation pages, pages that make permanent configuration changes, etc.).
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header always set X-Frame-Options "DENY" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
 </IfModule>
@@ -390,7 +390,7 @@ The example policy below:
 
 To make your CSP implementation easier, you can use an online [CSP header generator](https://report-uri.com/home/generate/). You should also use a [validator](https://csp-evaluator.withgoogle.com) to make sure your header does what you want it to do.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Content-Security-Policy "default-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text\/(html|javascript)|application\/pdf|xml#i"
 </IfModule>
@@ -400,7 +400,7 @@ To make your CSP implementation easier, you can use an online [CSP header genera
 
 This directive will prevent access to directories that don't have an index file present in whatever format the server is configured to use, like `index.html`, or `index.php`.
 
-```apache
+```apacheconf
 <IfModule mod_autoindex.c>
     Options -Indexes
 </IfModule>
@@ -412,7 +412,7 @@ In Macintosh and Linux systems, files that begin with a period are hidden from v
 
 The `.well-known/` directory represents [the standard (RFC 5785)](https://datatracker.ietf.org/doc/html/rfc5785) path prefix for "well-known locations" (e.g.: `/.well-known/manifest.json`, `/.well-known/keybase.txt`), and therefore, access to its visible content should not be blocked.
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteCond %{REQUEST_URI} "!(^|/)\.well-known/([^./]+./?)+$" [NC]
@@ -428,7 +428,7 @@ Block access to backup and source files that may be left by some text editors an
 
 Update the `<FilesMatch>` regular expression in the following example to include any files that might end up on your production server and can expose sensitive information about your website. These files may include: configuration files or files that contain metadata about the project among others.
 
-```apache
+```apacheconf
 <IfModule mod_authz_core.c>
   <FilesMatch "(^#.*#|\.(bak|conf|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op])|~)$">
     Require all denied
@@ -444,7 +444,7 @@ The following header ensures that a browser only connects to your server via HTT
 
 Be aware that Strict Transport Security is not revokable, and you must ensure being able to serve the site over HTTPS for as long as you've specified in the `max-age` directive. If you don't have a valid TLS connection anymore (e.g. due to an expired TLS certificate) your visitors will see an error message even when attempting to connect over HTTP.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   # Header always set
   Strict-Transport-Security "max-age=16070400; includeSubDomains" "expr=%{HTTPS} == 'on'"
@@ -479,7 +479,7 @@ Be aware that Strict Transport Security is not revokable, and you must ensure be
 
 Some older browsers would try and guess the content type of a resource, even when it isn't properly set up on the server configuration. This reduces exposure to drive-by download attacks and cross-origin data leaks.
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
     Header always set X-Content-Type-Options "nosniff"
 </IfModule>
@@ -498,7 +498,7 @@ Use services like the ones below to check your Referrer Policy:
 - [securityheaders.com](https://securityheaders.com/)
 - [Mozilla Observatory](https://observatory.mozilla.org/)
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header always set Referrer-Policy "strict-origin-when-cross-origin" "expr=%{CONTENT_TYPE} =~ m#text\/(css|html|javascript)|application\/pdf|xml#i"
 </IfModule>
@@ -512,7 +512,7 @@ Modern browsers now prevent TRACE requests made via JavaScript, however, other w
 
 If you have access to the main server configuration file, use the [`TraceEnable`](https://httpd.apache.org/docs/current/mod/core.html#traceenable) directive instead.
 
-```apache
+```apacheconf
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteCond %{REQUEST_METHOD} ^TRACE [NC]
@@ -526,7 +526,7 @@ Some frameworks like PHP and ASP.NET set an `X-Powered-By` header that contains 
 
 This header doesn't provide any value, and in some cases, the information it provides can expose vulnerabilities
 
-```apache
+```apacheconf
 <IfModule mod_headers.c>
   Header unset X-Powered-By
   Header always unset X-Powered-By
@@ -543,7 +543,7 @@ expose_php = off;
 
 Prevent Apache from adding a trailing footer line containing information about the server to the server-generated documents (e.g.: error messages, directory listings, etc.). See [ServerSignature Directive](https://httpd.apache.org/docs/current/mod/core.html#serversignature) for more information on what the server signature provides and the [ServerTokens Directive](https://httpd.apache.org/docs/current/mod/core.html#servertokens) for information about configuring the information provided in the signature.
 
-```apache
+```apacheconf
 ServerSignature Off
 ```
 
@@ -551,7 +551,7 @@ ServerSignature Off
 
 Some proxies and security software mangle or strip the `Accept-Encoding` HTTP header. See [Pushing Beyond Gzipping](https://calendar.perfplanet.com/2010/pushing-beyond-gzipping/) for a more detailed explanation.
 
-```apache
+```apacheconf
 <IfModule mod_deflate.c>
   <IfModule mod_setenvif.c>
     <IfModule mod_headers.c>
@@ -566,7 +566,7 @@ Some proxies and security software mangle or strip the `Accept-Encoding` HTTP he
 
 Compress all output labeled with one of the following media types using the [AddOutputFilterByType Directive](https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype).
 
-```apache
+```apacheconf
 <IfModule mod_deflate.c>
   <IfModule mod_filter.c>
     AddOutputFilterByType DEFLATE "application/atom+xml" \
@@ -613,7 +613,7 @@ Compress all output labeled with one of the following media types using the [Add
 
 Map the following filename extensions to the specified encoding type using [AddEncoding](https://httpd.apache.org/docs/current/mod/mod_mime.html#addencoding) so Apache can serve the file types with the appropriate `Content-Encoding` response header (this will NOT make Apache compress them!). If these files types were served without an appropriate `Content-Encoding` response header, client applications (e.g.: browsers) wouldn't know that they first need to uncompress the response, and thus, wouldn't be able to understand the content.
 
-```apache
+```apacheconf
 <IfModule mod_deflate.c>
   <IfModule mod_mime.c>
     AddEncoding gzip svgz
@@ -625,7 +625,7 @@ Map the following filename extensions to the specified encoding type using [AddE
 
 Serve resources with a far-future expiration date using the [mod_expires](https://httpd.apache.org/docs/current/mod/mod_expires.html) module, and [Cache-Control](/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Expires](/en-US/docs/Web/HTTP/Headers/Expires) headers.
 
-```apache
+```apacheconf
 <IfModule mod_expires.c>
     ExpiresActive on
     ExpiresDefault                                      "access plus 1 month"


### PR DESCRIPTION
The correct key for apache configs is `apacheconf` not `apache`. This shows an error during build time.

__References:__

* https://github.com/PrismJS/prism/blob/master/components/prism-apacheconf.js
* https://prismjs.com/download.html#themes=prism&languages=apacheconf

__related issues and pull requests:__
- [x] https://github.com/mdn/yari/pull/8862