### PR TITLE
Remove old contents from AnimationEvent.pseudoElement

### DIFF
--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -26,7 +26,6 @@ A string, starting with `'::'`, containing the name of the [pseudo-element](/en-
 
 ## See also
 
-- [Chromium Issue 437132](https://crbug.com/437132)
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
 - Animation-related CSS properties and at-rules: {{cssxref("animation")}},
   {{cssxref("animation-delay")}}, {{cssxref("animation-direction")}},

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -8,8 +8,6 @@ browser-compat: api.AnimationEvent.pseudoElement
 
 {{APIRef("Web Animations")}}
 
-## Summary
-
 The **`AnimationEvent.pseudoElement`** read-only property is a
 string, starting with `'::'`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on.
 If the animation doesn't run on a pseudo-element but on the element, an empty string: `''`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes a link without any description. This kind of data is what browser compat table is for anyway.

Also removes the "Summary" heading which doesn't align with current format.

### Motivation

Browser compat table exists.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
