### PR TITLE
DNR: Clarify precedence order across browsers.

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -122,18 +122,18 @@ When the browser evaluates how to handle requests, it checks each extension's ru
    3. "block" cancels the request.
    4. "upgradeScheme" upgrades the scheme of the request.
    5. "redirect" redirects the request.
-   6. "modifyHeaders" rewrites request and/or response headers.
+   6. "modifyHeaders" rewrites request or response headers or both.
 
-> **Note:** When there are multiple matching rules with the same rule priority and rule action type, a problem occurs when the matched action support additional properties. These can result in different outcomes that cannot be combined. For example:
+> **Note:** When matching rules have the same rule priority and rule action type, a problem occurs when the matched action support additional properties. These properties can result in outcomes that cannot be combined. For example:
 >
 > - The "block" action does not support additional properties, so there is no problem: all matching "block" actions would result in the same outcome.
-> - The "redirect" action redirects a request to one destination. When multiple "redirect" actions match, all but one "redirect" action is ignored. Note that it is still possible to redirect repeatedly, but only if the new request associated with the redirect is matched again by a rule condition.
+> - The "redirect" action redirects a request to one destination. When multiple "redirect" actions match, all but one "redirect" action is ignored. It is still possible to redirect repeatedly when the redirected request matches another rule condition.
 > - Multiple "modifyHeaders" action are allowed, until they touch the same header as explained at {{WebExtAPIRef("declarativeNetRequest.ModifyHeaderInfo")}}. The evaluation order of "modifyHeaders" is therefore important.
 >
-> To control the order of applying actions, assign distinct `priority` values to rules whose order of precedence is important.
+> To control the order in which actions are applied, assign distinct `priority` values to rules whose order of precedence is important.
 
 > **Note:** After rule priority and rule action, Firefox considers the ruleset the rule belongs to, in this order of precedence: session > dynamic > session rulesets.
-> This cannot be relied upon across browsers yet, see [WECG issue 280](https://github.com/w3c/webextensions/issues/280).
+> This cannot be relied upon across browsers, see [WECG issue 280](https://github.com/w3c/webextensions/issues/280).
 
 If only one extension provides a rule for the request, that rule is applied. However, where more than one extension has a matching rule, the browser chooses the one to apply in this order of precedence:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -122,14 +122,18 @@ When the browser evaluates how to handle requests, it checks each extension's ru
    3. "block" cancels the request.
    4. "upgradeScheme" upgrades the scheme of the request.
    5. "redirect" redirects the request.
-   6. "modifyHeaders" rewrites request and response headers.
-   If this doesn't result in one rule to apply:
-3. the ruleset the rule belongs to, in this order of precedence:
-   1. session
-   2. dynamic
-   3. static
-   If this doesn't result in one rule to apply:
-4. the order of the rule in the ruleset, determined as the lowest value rule ID.
+   6. "modifyHeaders" rewrites request and/or response headers.
+
+> **Note:** When there are multiple matching rules with the same rule priority and rule action type, a problem occurs when the matched action support additional properties. These can result in different outcomes that cannot be combined. For example:
+>
+> - The "block" action does not support additional properties, so there is no problem: all matching "block" actions would result in the same outcome.
+> - The "redirect" action redirects a request to one destination. When multiple "redirect" actions match, all but one "redirect" action is ignored. Note that it is still possible to redirect repeatedly, but only if the new request associated with the redirect is matched again by a rule condition.
+> - Multiple "modifyHeaders" action are allowed, until they touch the same header as explained at {{WebExtAPIRef("declarativeNetRequest.ModifyHeaderInfo")}}. The evaluation order of "modifyHeaders" is therefore important.
+>
+> To control the order of applying actions, assign distinct `priority` values to rules whose order of precedence is important.
+
+> **Note:** After rule priority and rule action, Firefox considers the ruleset the rule belongs to, in this order of precedence: session > dynamic > session rulesets.
+> This cannot be relied upon across browsers yet, see [WECG issue 280](https://github.com/w3c/webextensions/issues/280).
 
 If only one extension provides a rule for the request, that rule is applied. However, where more than one extension has a matching rule, the browser chooses the one to apply in this order of precedence:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -124,11 +124,11 @@ When the browser evaluates how to handle requests, it checks each extension's ru
    5. "redirect" redirects the request.
    6. "modifyHeaders" rewrites request or response headers or both.
 
-> **Note:** When matching rules have the same rule priority and rule action type, a problem occurs when the matched action support additional properties. These properties can result in outcomes that cannot be combined. For example:
+> **Note:** When multiple matching rules have the same rule priority and rule action type, the outcome can be ambiguous when the matched action support additional properties. These properties can result in outcomes that cannot be combined. For example:
 >
-> - The "block" action does not support additional properties, so there is no problem: all matching "block" actions would result in the same outcome.
+> - The "block" action does not support additional properties, and therefore there is no ambiguity: all matching "block" actions would result in the same outcome.
 > - The "redirect" action redirects a request to one destination. When multiple "redirect" actions match, all but one "redirect" action is ignored. It is still possible to redirect repeatedly when the redirected request matches another rule condition.
-> - Multiple "modifyHeaders" action are allowed, until they touch the same header as explained at {{WebExtAPIRef("declarativeNetRequest.ModifyHeaderInfo")}}. The evaluation order of "modifyHeaders" is therefore important.
+> - Multiple "modifyHeaders" actions can be applied independently when they touch different headers. The result is ambiguous when they touch the same header, because some combination of operations are not allowed (as explained at ("declarativeNetRequest.ModifyHeaderInfo")}}). The evaluation order of "modifyHeaders" actions is therefore important.
 >
 > To control the order in which actions are applied, assign distinct `priority` values to rules whose order of precedence is important.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The currently documented order is not cross-browser, see https://github.com/w3c/webextensions/issues/280. Therefore, drop that part of the documentation and replace it with guidance on how to create stable rules.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
People following the documentation with the expectation of having the same browser across browsers will be disappointed. The documentation should offer guidance to have consistent behavior across browsers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The documentation currently lists 4 ways of affecting the outcome. Only the first two are kept, as these are also documented in Chrome's documentation (https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#implementation-matching-algorithm). The other two (ruleset and rule ID) are not documented in Chrome, and cannot be relied upon. Therefore that part has been removed in favor of a note to emphasize the risk of having ambiguous outcomes, along with recommendations to resolve this.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- https://github.com/w3c/webextensions/issues/280

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
