### PR TITLE
Update index.md -- fix a typo

### DIFF
--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -225,7 +225,7 @@ line, `x === undefined && y === 'A'`, hence the result.
 ```js-nolint
 var x = 0;
 function f() {
-  var x = y = 1; // Declares x locally; declares y globally.
+  var x = y = 1; // Declares x globally; declares y locally.
 }
 f();
 


### PR DESCRIPTION
### Description
At: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#initialization_of_several_variables

There is a typo in the comment section of the example

### Motivation

This PR fill fix the typo and make he comment text consistent. 
