### PR TITLE
Fix web_accessible_resources and link relevant DNR examples

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/redirect/index.md
@@ -20,7 +20,7 @@ Details describing how a redirect should be performed, as the `redirect` propert
 Values of this type are objects. They contain these properties:
 
 - `extensionPath` {{optional_inline}}
-  - : A `string`. The path relative to the extension directory. Should start with '/'.
+  - : A `string`. The path relative to the extension directory. Should start with '/'. The initiator of the request can only follow the redirect when the resource is listed in [`web_accessible_resources`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources).
 - `regexSubstitution` {{optional_inline}}
   - : A `string`. The substitution pattern for rules that specify a `regexFilter`. The first match of `regexFilter` within the URL is replaced with this pattern. Within `regexSubstitution`, backslash-escaped digits (`\1` to `\9`) are used to insert the corresponding capture groups. `\0` refers to the entire matching text.
 - `transform` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -46,7 +46,7 @@ With the `web_accessible_resources` key, you list all the packaged resources tha
 
 Note that content scripts don't need to be listed as web accessible resources.
 
-If an extension wants to use {{WebExtAPIRef("webRequest")}} to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the `web_accessible_resources` key.
+If an extension wants to use {{WebExtAPIRef("webRequest")}} or {{WebExtAPIRef("declarativeNetRequest")}} to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the `web_accessible_resources` key.
 
 ### Manifest V2 syntax
 
@@ -62,7 +62,7 @@ In Manifest V2, web accessible resources are added as an array under the key, li
 
 In Manifest V3, the `web_accessible_resources` key is an array of objects like this:
 
-```
+```json
 {
   // …
   "web_accessible_resources": [
@@ -94,21 +94,26 @@ Each object must include a `"resources"` property and either a `"matches"` or `"
       <td>
         <code>extension_ids</code>
       </td>
-      <td><code>String</code></td>
+      <td><code>Array</code> of <code>String</code></td>
       <td>
+        Optional. Defaults to <code>[]</code>, meaning that other extensions cannot access the resource.
+        <p>
         A list of extension IDs specifying the extensions that can access the resources.
+        "*" matches all extensions.
       </td>
     </tr>
     <tr>
       <td><code>matches</code></td>
-      <td><code>String</code></td>
+      <td><code>Array</code> of <code>String</code></td>
       <td>
-        A list of URL match patterns specifying the pages that can access the resources. Only the origin is used to match URLs. Origins include subdomain matching. Paths are ignored.
+        Optional. Defaults to <code>[]</code>, meaning that other websites cannot access the resource.
+        <p>
+        A list of URL <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> specifying the pages that can access the resources. Only the origin is used to match URLs. Origins include subdomain matching. Paths must be set to <code>/*</code>.
       </td>
     </tr>
     <tr>
       <td><code>resources</code></td>
-      <td><code>String</code></td>
+      <td><code>Array</code> of <code>String</code></td>
       <td>
         An array of resources to be exposed. Resources are specified as strings and may contain <code>*</code> for wildcard matches. For example, <code>"/images/*"</code> exposes everything in the extension's <code>/images</code> directory recursively, while <code>"*.png"</code> exposes all PNG files.
       </td>
@@ -117,6 +122,8 @@ Each object must include a `"resources"` property and either a `"matches"` or `"
       <td><code>use_dynamic_url</code></td>
       <td><code>Boolean</code></td>
       <td>
+        Optional. Defaults to <code>false</code>.
+        <p>
         Whether resources to be accessible through the dynamic ID. The dynamic ID is generated per session and regenerated on browser restart or extension reload.
       </td>
     </tr>
@@ -177,11 +184,45 @@ Web-accessible extension resources are not blocked by [CORS](/en-US/docs/Web/HTT
 
 ## Example
 
+### Manifest V2 example
+
 ```json
 "web_accessible_resources": ["images/my-image.png"]
 ```
 
-Make the file at "images/my-image.png" web accessible.
+Make the file at "images/my-image.png" web accessible to any website and extension.
+
+### Manifest V3 example
+
+```json
+"web_accessible_resources": [
+  {
+    "resources": [ "images/my-image.png" ],
+    "extension_ids": ["*"],
+    "matches": [ "*://*/*" ]
+  }
+]
+```
+
+Make the file at "images/my-image.png" web accessible to any website and extension.
+
+It is recommended to only specify `extension_ids` or `matches` if needed.
+For example, if the resource only needs to be accessible to web pages at example.com:
+
+```json
+"web_accessible_resources": [
+  {
+    "resources": [ "images/my-image.png" ],
+    "matches": [ "https://example.com/*" ]
+  }
+]
+```
+
+## Example extensions
+<!-- Ideally we'd use the WebExtExamples template, but examples are not categorized by manifest keys yet - https://github.com/mdn/webextensions-examples/issues/524 -->
+
+- [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify)
+- [dnr-redirect-url](https://github.com/mdn/webextensions-examples/tree/master/dnr-redirect-url)
 
 ## Browser compatibility
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

web_accessible_resources had several flaws:

- The types were not documented to be arrays.
- It was not obvious which properties were optional.
- The "Example" section only listed MV2, not MV3.
- `*` as value in `extension_ids` was not documented.
- The docs states "Paths are ignored.", but that is not the case in any browser, see https://bugzilla.mozilla.org/show_bug.cgi?id=1833415

This PR also links to new examples in the mdn/webextensions-examples repository that demonstrates the use of `web_accessible_resources` in MV2 and MV3.


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
