### PR TITLE
Rename nonexistent globalScope to globalThis in service worker event examples

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -37,7 +37,7 @@ _Doesn't implement any specific properties, but inherits properties from its par
 The following snippet shows how you could use an `activate` event handler to upgrade a cache.
 
 ```js
-globalThis.addEventListener("activate", (event) => {
+self.addEventListener("activate", (event) => {
   const cacheAllowlist = ["v2"];
 
   event.waitUntil(
@@ -53,7 +53,7 @@ globalThis.addEventListener("activate", (event) => {
 You can also set up the event handler using the `onactivate` property:
 
 ```js
-globalThis.onactivate = (event) => {
+sekf.onactivate = (event) => {
   // ...
 };
 ```

--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -53,7 +53,7 @@ self.addEventListener("activate", (event) => {
 You can also set up the event handler using the `onactivate` property:
 
 ```js
-sekf.onactivate = (event) => {
+self.onactivate = (event) => {
   // ...
 };
 ```

--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -37,7 +37,7 @@ _Doesn't implement any specific properties, but inherits properties from its par
 The following snippet shows how you could use an `activate` event handler to upgrade a cache.
 
 ```js
-globalScope.addEventListener("activate", (event) => {
+globalThis.addEventListener("activate", (event) => {
   const cacheAllowlist = ["v2"];
 
   event.waitUntil(
@@ -53,7 +53,7 @@ globalScope.addEventListener("activate", (event) => {
 You can also set up the event handler using the `onactivate` property:
 
 ```js
-globalScope.onactivate = (event) => {
+globalThis.onactivate = (event) => {
   // ...
 };
 ```

--- a/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
@@ -37,7 +37,7 @@ _Doesn't implement any specific properties, but inherits properties from its par
 The following snippet shows how an `install` event handler can be used to populate a cache with a number of responses, which the service worker can then use to serve assets offline:
 
 ```js
-this.addEventListener("install", (event) => {
+globalThis.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open("v1")
@@ -62,7 +62,7 @@ this.addEventListener("install", (event) => {
 You can also set up the event handler using the `oninstall` property:
 
 ```js
-globalScope.oninstall = (event) => {
+globalThis.oninstall = (event) => {
   // ...
 };
 ```

--- a/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
@@ -37,7 +37,7 @@ _Doesn't implement any specific properties, but inherits properties from its par
 The following snippet shows how an `install` event handler can be used to populate a cache with a number of responses, which the service worker can then use to serve assets offline:
 
 ```js
-globalThis.addEventListener("install", (event) => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open("v1")
@@ -62,7 +62,7 @@ globalThis.addEventListener("install", (event) => {
 You can also set up the event handler using the `oninstall` property:
 
 ```js
-globalThis.oninstall = (event) => {
+self.oninstall = (event) => {
   // ...
 };
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The service worker install and activate event examples used nonexistent identifiers `globalScope` and `this`. These changes replace them with `globalThis`.

**Consider** if they should use `self` for consistency with other service worker examples instead. (`self` is also a reference to the global object in workers.)

### Motivation

The examples cannot work because they use incorrect identifiers for the global object.

### Additional details

I did a quick search on `globalThis` using SourceGraph and found only these two files using `globalScope`: [`repo:mdn/content content:"globalScope" case:yes`](https://sourcegraph.com/search?q=context:global+repo:mdn/content+content:%22globalScope%22&patternType=standard&case=yes&sm=1&groupBy=repo).

Note that it is necessary to search case sensitively to get useful results from SourceGraph though that option does not seem to appear on their UI. I could not work out how to do this with GitHub search and found the SourceGraph suggestion for case sensitive search from a StackOverflow post.

I also fixed one case of using `this.addEventListener` in the install_event example. While `this` may work on `type: "script"` workers it won't work on those of `type: "module"`. However the SourceGraph search for [`repo:mdn/content content:"this.addEventListener" case:yes`](https://sourcegraph.com/search?q=repo%3Amdn%2Fcontent+content%3A%22this.addEventListener%22&patternType=standard&case=yes&sm=1&groupBy=repo) shows several other broken examples which I have not fixed in this pull request: 