### PR TITLE
refactor: migrate media.prod.mdn.mozit.cloud URLs

### DIFF
--- a/files/en-us/web/api/document/afterscriptexecute_event/index.md
+++ b/files/en-us/web/api/document/afterscriptexecute_event/index.md
@@ -38,7 +38,7 @@ document.addEventListener("afterscriptexecute", finished, true);
 document.onafterscriptexecute = finished;
 ```
 
-[View Live Example](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html)
+[View Live Example](https://mdn.dev/archives/media/samples/html/currentScript.html)
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/document/beforescriptexecute_event/index.md
@@ -38,7 +38,7 @@ document.addEventListener("beforescriptexecute", starting, true);
 document.onbeforescriptexecute = starting;
 ```
 
-[View Live Example](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html)
+[View Live Example](https://mdn.dev/archives/media/samples/html/currentScript.html)
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -30,7 +30,7 @@ if (document.currentScript.async) {
 }
 ```
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/html/currentScript.html)
 
 ## Specifications
 

--- a/files/en-us/web/api/document/mozsetimageelement/index.md
+++ b/files/en-us/web/api/document/mozsetimageelement/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 This example changes the background of a {{ HTMLElement("div") }} block each time the
 block is clicked by the user.
 
-[View this example live](https://media.prod.mdn.mozit.cloud/samples/domref/mozSetImageElement.html).
+[View this example live](https://mdn.dev/archives/media/samples/domref/mozSetImageElement.html).
 
 ```html
 <style>

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -82,7 +82,7 @@ which we'll be injecting the new content. The next two lines handle importing th
 contents of our new document into the new document's context. Finally, line 20 actually
 replaces the contents of the frame with the new document's contents.
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/domref/createHTMLDocument.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/domref/createHTMLDocument.html)
 
 The returned document is pre-constructed with the following HTML:
 

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -93,7 +93,7 @@ clicking and holding down on an element.
 </html>
 ```
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/domref/mousecapture.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/domref/mousecapture.html)
 
 ## Notes
 

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -85,7 +85,7 @@ In addition, navigating to another page, changing tabs, or switching to another 
 
 In this example, a video is presented in a web page. Pressing the <kbd>Return</kbd> or <kbd>Enter</kbd> key lets the user toggle between windowed and fullscreen presentation of the video.
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/domref/fullscreen.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/domref/fullscreen.html)
 
 ### Watching for the Enter key
 

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -88,7 +88,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom 10px;

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -88,7 +88,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom 10px;

--- a/files/en-us/web/css/blend-mode/index.md
+++ b/files/en-us/web/css/blend-mode/index.md
@@ -386,7 +386,7 @@ In the following example, we have a `<div>` with two background images set on it
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
       no-repeat center, linear-gradient(to bottom, blue, orange);
 }
 ```

--- a/files/en-us/web/css/box-decoration-break/index.md
+++ b/files/en-us/web/css/box-decoration-break/index.md
@@ -92,13 +92,13 @@ This one results in:
 
 ![A screenshot of the rendering of an inline element styled with box-decoration-break:clone and styles given in the example](box-decoration-break-inline-clone.png)
 
-You can [try the two inline examples above](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html) in your browser.
+You can [try the two inline examples above](https://mdn.dev/archives/media/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html) in your browser.
 
 Here's an example of an inline element using a large `border-radius` value. The second `"iM"` has a line-break between the `"i"` and the `"M"`. For comparison, the first `"iM"` is without line breaks. Note that if you stack the rendering of the two fragments horizontally next to each other it will result in the non-fragmented rendering.
 
 ![A screenshot of the rendering of the second inline element example.](box-decoration-break-slice-inline-2.png)
 
-[Try the above example](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html) in your browser.
+[Try the above example](https://mdn.dev/archives/media/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html) in your browser.
 
 ### Block box fragments
 
@@ -118,7 +118,7 @@ Now, the same example but styled with `box-decoration-break: clone` results in:
 
 Note here that each fragment has an identical replicated border, box-shadow, and background.
 
-You can [try the block examples above](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html) in your browser.
+You can [try the block examples above](https://mdn.dev/archives/media/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html) in your browser.
 
 ## Specifications
 

--- a/files/en-us/web/css/break-inside/index.md
+++ b/files/en-us/web/css/break-inside/index.md
@@ -92,7 +92,7 @@ By default, it is possible for you to get a break between the image and its capt
 
   <figure>
     <img
-      src="https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png" />
+      src="https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png" />
     <figcaption>The Firefox logo — fox wrapped around the world</figcaption>
   </figure>
 

--- a/files/en-us/web/css/scaling_of_svg_backgrounds/index.md
+++ b/files/en-us/web/css/scaling_of_svg_backgrounds/index.md
@@ -33,7 +33,7 @@ This image is both dimensionless and proportionless. It doesn't care what size i
 
 ![no-dimensions-or-ratio.png](no-dimensions-or-ratio.png)
 
-[SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
+[SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
 
 ### One specified dimension and proportionless
 
@@ -41,7 +41,7 @@ This image specifies a width of 100 pixels but no height or intrinsic ratio. Thi
 
 ![100px-wide-no-height-or-ratio.png](100px-wide-no-height-or-ratio.png)
 
-[SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
+[SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
 
 ### One specified dimension with intrinsic ratio
 
@@ -51,7 +51,7 @@ This is very much like specifying a specific width and height, since once you ha
 
 ![100px-height-3x4-ratio.png](100px-height-3x4-ratio.png)
 
-[SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
+[SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
 
 ### No width or height with intrinsic ratio
 
@@ -59,7 +59,7 @@ This image doesn't specify either a width or a height; instead, it specifies an 
 
 ![no-dimensions-1x1-ratio.png](no-dimensions-1x1-ratio.png)
 
-[SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
+[SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
 
 ## Scaling examples
 

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -127,7 +127,7 @@ textarea.addEventListener("input", function () {
 
 ## Triggering built-in events
 
-This example demonstrates simulating a click (that is programmatically generating a click event) on a checkbox using DOM methods. [View the example in action.](https://media.prod.mdn.mozit.cloud/samples/domref/dispatchEvent.html)
+This example demonstrates simulating a click (that is programmatically generating a click event) on a checkbox using DOM methods. [View the example in action.](https://mdn.dev/archives/media/samples/domref/dispatchEvent.html)
 
 ```js
 function simulateClick() {

--- a/files/en-us/web/guide/printing/index.md
+++ b/files/en-us/web/guide/printing/index.md
@@ -87,7 +87,7 @@ If you want to be able to automatically close a [popup window](/en-US/docs/Web/A
 </html>
 ```
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/domref/printevents.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/domref/printevents.html)
 
 ### Print an external page without opening it
 

--- a/files/en-us/web/svg/namespaces_crash_course/example/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/example/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 In this example, we use [XHTML](/en-US/docs/Glossary/XHTML), [SVG](/en-US/docs/Web/SVG), [JavaScript](/en-US/docs/Web/JavaScript), and the [DOM](/en-US/docs/Web/API/Document_Object_Model) to animate a swarm of "motes". These motes are governed by two simple principles. First, each mote tries to move towards the mouse cursor, and second each mote tries to move away from the average mote position. Combined, we get this very natural-looking behavior.
 
-[View the example](https://media.prod.mdn.mozit.cloud/samples/svg/swarm-of-motes.xhtml). The linked example was written with 2006 best practices. The example below has been updated to modern JavaScript best practices. Both work.
+[View the example](https://mdn.dev/archives/media/samples/svg/swarm-of-motes.xhtml). The linked example was written with 2006 best practices. The example below has been updated to modern JavaScript best practices. Both work.
 
 ```xml
 <?xml version='1.0'?>

--- a/files/en-us/web/svg/svg_animation_with_smil/index.md
+++ b/files/en-us/web/svg/svg_animation_with_smil/index.md
@@ -99,7 +99,7 @@ In this example, a blue circle bounces between the left and right edges of a bla
 
 {{ EmbedLiveSample('Example_1_Linear_motion', '100%', 120) }}
 
-[View live sample](https://media.prod.mdn.mozit.cloud/samples/svg/svganimdemo1.html)
+[View live sample](https://mdn.dev/archives/media/samples/svg/svganimdemo1.html)
 
 ### Example 2: Curved motion
 

--- a/files/en-us/web/svg/tutorial/getting_started/index.md
+++ b/files/en-us/web/svg/tutorial/getting_started/index.md
@@ -26,7 +26,7 @@ Let us dive straight in with a simple example. Take a look at the following code
 </svg>
 ```
 
-Copy the code and paste it in a file, demo1.svg. Then open the file in a browser. It will render as shown in the following screenshot. (Firefox users: click [here](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
+Copy the code and paste it in a file, demo1.svg. Then open the file in a browser. It will render as shown in the following screenshot. (Firefox users: click [here](https://mdn.dev/archives/media/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
 
 ![Red background composed of a centered green circle. White text centered inside the circle is SVG.](svgdemo1.png)
 


### PR DESCRIPTION
### Description

Migrates URLs linking to https://media.prod.mdn.mozit.cloud/ to point to the archived URL at https://mdn.dev/archives/media/.

### Motivation

The contents of https://media.prod.mdn.mozit.cloud/ have been archived at https://mdn.dev/archives/media/, and we will soon decommission the `media.prod.mdn.mozit.cloud` domain, so those links won't work afterwards.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:
- https://github.com/mdn/yari/pull/8873
- https://github.com/mdn/translated-content/pull/13291
