### PR TITLE
docs(:not()): Update the syntax and example titles

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -18,8 +18,9 @@ The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected result
 The `:not()` pseudo-class requires a comma-separated list of one or more selectors as its argument. The list must not contain another negation selector or a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements).
 
 ```css-nolint
-:not(<complex-selector-list>) {
-  /* ... */
+<selector>:not(<complex-selector-list>) {
+  /* CSS styles */
+  /* <property>: <value> */
 }
 ```
 
@@ -37,7 +38,9 @@ There are several unusual effects and outcomes when using `:not()` that you shou
 
 ## Examples
 
-### Basic set of :not() examples
+### Using :not() with valid selectors
+
+This example shows some simple cases of using `:not()`.
 
 #### HTML
 
@@ -86,9 +89,9 @@ h2 :not(span.foo) {
 
 #### Result
 
-{{EmbedLiveSample('Basic_set_of_not_examples', '100%', 320)}}
+{{EmbedLiveSample('Using_not_with_valid_selectors', '100%', 320)}}
 
-### :not() with invalid selectors
+### Using :not() with invalid selectors
 
 This example shows the use of `:not()` with invalid selectors and how to prevent invalidation.
 
@@ -132,7 +135,7 @@ div:not(:is(.foo, .bar)) {
 
 #### Result
 
-{{EmbedLiveSample('not_with_invalid_selectors', '100%', 320)}}
+{{EmbedLiveSample('Using_not_with_invalid_selectors', '100%', 320)}}
 
 The `p:not(.foo, :invalid-pseudo-class)` rule is invalid because it contains an invalid selector. The `:is()` pseudo-class accepts a forgiving selector list, so the `:is(.foo, :invalid-pseudo-class)` rule is valid and equivalent to `:is(.foo)`. Thus, the `p:not(:is(.foo, :invalid-pseudo-class))` rule is valid and equivalent to `p:not(.foo)`.
 

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -18,9 +18,8 @@ The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected result
 The `:not()` pseudo-class requires a comma-separated list of one or more selectors as its argument. The list must not contain another negation selector or a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements).
 
 ```css-nolint
-<selector>:not(<complex-selector-list>) {
-  /* CSS styles */
-  /* <property>: <value> */
+:not(<complex-selector-list>) {
+  /* ... */
 }
 ```
 

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -460,4 +460,3 @@ A few things to remember about specificity:
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
   - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)
-- [How :not() chains multiple selectors](/en-US/blog/css-not-pseudo-multiple-selectors/) on the MDN blog (2023)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Added more details to the `:not()` syntax
- Updated the example titles
- Removed the blog link from the specificity page

