### PR TITLE
Fix scrollIntoView behavior options

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -43,7 +43,6 @@ scrollIntoView(scrollIntoViewOptions)
     - `behavior` {{optional_inline}}
       - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
         - `smooth`: scrolling should animate smoothly
-        - `instant`: scrolling should happen instantly in a single jump
         - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
     - `block` {{optional_inline}}
       - : Defines vertical alignment.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I removed the Instant option from scrollIntoView's behavior parameters
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Removed Instant from scroll-behavior type in [microsoft/TypeScript-DOM-lib-generator](https://github.com/microsoft/TypeScript-DOM-lib-generator/commit/fe01c9a6d6afde86bd15f2588dc9360416a2beb4)
Therefore, Instant of the behavior option cannot be specified in TypeScript.

![behavior](https://github.com/mdn/content/assets/48472989/5a34d1e3-7839-42d8-94cc-cff7a56a17e8)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
