### PR TITLE
Change all CSS spec URLs back to drafts.csswg.org

### DIFF
--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Animation.commitStyles
 
 The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface writes the [computed values](/en-US/docs/Web/CSS/computed_value) of the animation's current styles into its target element's [`style`](/en-US/docs/Web/HTML/Global_attributes#style) attribute. `commitStyles()` works even if the animation has been [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations).
 
-`commitStyles()` can be used in combination with `fill` to cause the final state of an animation to persist after the animation ends. The same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://w3c.github.io/csswg-drafts/web-animations-1/#fill-behavior). Animations [take precedence over all static styles](/en-US/docs/Web/CSS/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
+`commitStyles()` can be used in combination with `fill` to cause the final state of an animation to persist after the animation ends. The same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://drafts.csswg.org/web-animations-1/#fill-behavior). Animations [take precedence over all static styles](/en-US/docs/Web/CSS/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
 
 Using `commitStyles()` writes the styling state into the element's [`style`](/en-US/docs/Web/HTML/Global_attributes#style) attribute, where they can be modified and replaced as normal.
 

--- a/files/en-us/web/api/css_custom_highlight_api/index.md
+++ b/files/en-us/web/api/css_custom_highlight_api/index.md
@@ -8,7 +8,7 @@ browser-compat:
   - api.Highlight
   - api.HighlightRegistry
   - css.selectors.highlight
-spec-urls: https://w3c.github.io/csswg-drafts/css-highlight-api-1/
+spec-urls: https://drafts.csswg.org/css-highlight-api-1/
 ---
 
 {{DefaultAPISidebar("CSS Custom Highlight API")}}{{SeeCompatTable}}

--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -15,7 +15,7 @@ In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, oth
 
 When applied to anchor elements, the truncating can happen in the middle of the text, not necessarily at the end.
 
-> **Note:** This property was originally implemented in WebKit and has some issues. It got standardized in [CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef--webkit-line-clamp) for legacy support. The [CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef-line-clamp) specification also defines a {{cssxref("line-clamp")}} property, which is meant to replace this property and avoid its issues.
+> **Note:** This property was originally implemented in WebKit and has some issues. It got standardized in [CSS Overflow Module Level 4](https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp) for legacy support. The [CSS Overflow Module Level 4](https://drafts.csswg.org/css-overflow-4/#propdef-line-clamp) specification also defines a {{cssxref("line-clamp")}} property, which is meant to replace this property and avoid its issues.
 
 ## Syntax
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -64,7 +64,7 @@ src: url("trickster-COLRv1.otf") format(opentype) tech(color-COLRv1), url("trick
 
 - `<font-face-name>`
   - : Specifies the full name or postscript name of a locally-installed font face using the `local()` component value, which uniquely identifies a single font face within a larger family.
-    The name can optionally be enclosed in quotes. The font face name [is not case-sensitive](https://w3c.github.io/csswg-drafts/css-fonts-3/#font-family-casing).
+    The name can optionally be enclosed in quotes. The font face name [is not case-sensitive](https://drafts.csswg.org/css-fonts-3/#font-family-casing).
 
 > **Note:** The {{domxref("Local Font Access API", "Local Font Access API", "", "nocode")}} can be used to access the user's locally installed font data — this includes higher-level details such as names, styles, and families, as well as the raw bytes of the underlying font files.
 

--- a/files/en-us/web/css/_doublecolon_view-transition-group/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-group/index.md
@@ -30,7 +30,7 @@ By default, selected elements initially mirror the size and position of the {{cs
 
 If there's both an "old" and "new" view state, styles in the view transition style sheet animate this pseudo-element's {{cssxref("width")}} and {{cssxref("height")}} from the size of the "old" view state's border box to that of the "new" view state's border box.
 
-> **Note:** View transition style sheet styles are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
+> **Note:** View transition style sheet styles are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
 
 In addition, the element's transform is animated from the "old" view state's screen space transform to the new view state's screen space transform. This style is generated dynamically since the values of animated properties are determined at the time that the transition begins.
 

--- a/files/en-us/web/css/_doublecolon_view-transition-new/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-new/index.md
@@ -36,7 +36,7 @@ html::view-transition-new(*) {
 }
 ```
 
-> **Note:** Additional view transition style sheet styles are also setup to animate `::view-transition-new`. These are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
+> **Note:** Additional view transition style sheet styles are also setup to animate `::view-transition-new`. These are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
 
 ## Syntax
 

--- a/files/en-us/web/css/_doublecolon_view-transition-old/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-old/index.md
@@ -36,7 +36,7 @@ html::view-transition-old(*) {
 }
 ```
 
-> **Note:** Additional view transition style sheet styles are also setup to animate `::view-transition-old`. These are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://w3c.github.io/csswg-drafts/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
+> **Note:** Additional view transition style sheet styles are also setup to animate `::view-transition-old`. These are dynamically generated during the view transition; see the specification [setup transition pseudo-elements](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) and [update pseudo-element styles](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) sections for more details.
 
 ## Syntax
 

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -6,7 +6,7 @@ page-type: landing-page
 
 {{CSSRef}}
 
-[CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's _animation type_ determines how values [combine](https://w3c.github.io/csswg-drafts/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three combination methods.
+[CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions) rely on the concept of **animatable** properties, and all CSS properties are animatable unless otherwise specified. Each property's _animation type_ determines how values [combine](https://drafts.csswg.org/css-values/#combining-values) - interpolate, add, or accumulate - for this property. Transitions only involve interpolation, whereas animations may use all three combination methods.
 
 > **Note:** The animation type for each CSS property is listed in its "Formal definition" table (E.g., {{CSSXref("color", "", "#formal_definition")}}).
 
@@ -14,7 +14,7 @@ page-type: landing-page
 
 ## Animation types
 
-There are mainly four animation types as defined in the [Web Animations](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties) specification:
+There are mainly four animation types as defined in the [Web Animations](https://drafts.csswg.org/web-animations-1/#animating-properties) specification:
 
 - Not animatable
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -3,8 +3,8 @@ title: CSS animations
 slug: Web/CSS/CSS_Animations
 page-type: css-module
 spec-urls:
-  - https://w3c.github.io/csswg-drafts/css-animations-2/
-  - https://w3c.github.io/csswg-drafts/css-animations/
+  - https://drafts.csswg.org/css-animations-2/
+  - https://drafts.csswg.org/css-animations/
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -145,18 +145,18 @@ Its possible values are:
 
 ### Relevant to the user
 
-The specification refers to the concept of [relevant to the user](https://w3c.github.io/csswg-drafts/css-contain/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it is visible, and/or being interacted with by the user.
+The specification refers to the concept of [relevant to the user](https://drafts.csswg.org/css-contain/#relevant-to-the-user). An element that is relevant to the user should be rendered, as it is visible, and/or being interacted with by the user.
 
 To be precise, an element is relevant to the user if any of the following are true:
 
 - The element appears in the viewport, or a user-agent-defined margin around the viewport (50% of the viewport dimensions, to give the app time to prepare for when the element visibility changes).
 - The element or its contents receive focus.
 - The element or its contents are selected, for example by dragging over the text with the mouse cursor or by some other highlight operation.
-- The element or its contents are placed in the [top layer](https://w3c.github.io/csswg-drafts/css-position-4/#top-layer).
+- The element or its contents are placed in the [top layer](https://drafts.csswg.org/css-position-4/#top-layer).
 
 ### Skips its contents
 
-The specification refers to the concept of [skips its contents](https://w3c.github.io/csswg-drafts/css-contain/#skips-its-contents). This means that the element referred to is not relevant to the user and will not be rendered to improve performance.
+The specification refers to the concept of [skips its contents](https://drafts.csswg.org/css-contain/#skips-its-contents). This means that the element referred to is not relevant to the user and will not be rendered to improve performance.
 
 To be precise, when an element skips its contents:
 

--- a/files/en-us/web/css/css_scrollbars/index.md
+++ b/files/en-us/web/css/css_scrollbars/index.md
@@ -5,7 +5,7 @@ page-type: css-module
 browser-compat:
   - css.properties.scrollbar-color
   - css.properties.scrollbar-width
-spec-urls: https://w3c.github.io/csswg-drafts/css-scrollbars/
+spec-urls: https://drafts.csswg.org/css-scrollbars/
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -154,7 +154,7 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
 
     - `contents`
 
-      - : These elements don't produce a specific box by themselves. They are replaced by their pseudo-box and their child boxes. Please note that the CSS Display Level 3 spec defines how the `contents` value should affect "unusual elements" — elements that aren't rendered purely by CSS box concepts such as replaced elements. See [Appendix B: Effects of display: contents on Unusual Elements](https://w3c.github.io/csswg-drafts/css-display/#unbox) for more details.
+      - : These elements don't produce a specific box by themselves. They are replaced by their pseudo-box and their child boxes. Please note that the CSS Display Level 3 spec defines how the `contents` value should affect "unusual elements" — elements that aren't rendered purely by CSS box concepts such as replaced elements. See [Appendix B: Effects of display: contents on Unusual Elements](https://drafts.csswg.org/css-display/#unbox) for more details.
 
     - `none`
       - : Turns off the display of an element so that it has no effect on layout (the document is rendered as though the element did not exist). All descendant elements also have their display turned off.

--- a/files/en-us/web/text_fragments/index.md
+++ b/files/en-us/web/text_fragments/index.md
@@ -104,7 +104,7 @@ If you don't see one or more of your text fragments highlighted and you are sure
 
 ### Styling matched text fragments
 
-Browsers are free to style the highlighted text in whatever default way they choose. The [CSS Pseudo-Elements Module Level 4](https://w3c.github.io/csswg-drafts/css-pseudo/#selectordef-target-text) defines a pseudo-element, {{cssxref("::target-text")}}, which allows you to specifying custom styling.
+Browsers are free to style the highlighted text in whatever default way they choose. The [CSS Pseudo-Elements Module Level 4](https://drafts.csswg.org/css-pseudo/#selectordef-target-text) defines a pseudo-element, {{cssxref("::target-text")}}, which allows you to specifying custom styling.
 
 For example, in our [scroll-to-text demo](https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance) we have the following CSS:
 


### PR DESCRIPTION
All w3c.github.io/csswg-drafts URLs now redirect to drafts.csswg.org URLs. Relates to https://github.com/mdn/content/issues/26613.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/19890.