### PR TITLE
Fix issue 26048: document security requirements for opening and focus…

### DIFF
--- a/files/en-us/web/api/clients/openwindow/index.md
+++ b/files/en-us/web/api/clients/openwindow/index.md
@@ -39,6 +39,15 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("WindowClient")}} object if
 URL is from the same origin as the service worker or a {{Glossary("null", "null
   value")}} otherwise.
 
+### Exceptions
+
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : The promise is rejected with this exception if none of the windows in the app's origin have [transient activation](/en-US/docs/Web/Security/User_activation).
+
+## Security requirements
+
+- At least one window in the app's origin must have [transient activation](/en-US/docs/Web/Security/User_activation).
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -27,6 +27,15 @@ None.
 
 A {{jsxref("Promise")}} that resolves to the existing {{domxref("WindowClient")}}.
 
+### Exceptions
+
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : The promise is rejected with this exception if none of the windows in the app's origin have [transient activation](/en-US/docs/Web/Security/User_activation).
+
+## Security requirements
+
+- At least one window in the app's origin must have [transient activation](/en-US/docs/Web/Security/User_activation).
+
 ## Examples
 
 ```js


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26048.

Documents security requirements for [`WindowClient.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient/focus) and [`Clients.openWindow()`](https://developer.mozilla.org/en-US/docs/Web/API/Clients/openWindow).

I believe that although the bug report quotes a SO answer that the requirement is that the methods may only be called inside a `notificationclick` handler, that's a very old answer, and from the spec it looks as if the requirement is transient activation:

https://w3c.github.io/ServiceWorker/#clients-openwindow
https://w3c.github.io/ServiceWorker/#client-focus

I wasn't quite sure what "this origin" means here. I have documented it as "the app's origin" but not sure that is correct.