### PR TITLE
Add note about module not yet installed

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -132,7 +132,7 @@ Note that the template values for the data are the keys that were specified when
 
 ## What does it look like?
 
-At this point we should have created everything needed to display the index page. Run the application and open your browser to `http://localhost:3000/`. If everything is set up correctly, your site should look something like the following screenshot.
+At this point we should have created everything needed to display the index page. Comment out the line of code that requires the express-validator module for now. Run the application and open your browser to `http://localhost:3000/`. If everything is set up correctly, your site should look something like the following screenshot.
 
 ![Home page - Express Local Library site](locallibary_express_home.png)
 


### PR DESCRIPTION
### Description

Running the program exactly as-is at this point will return the following error: 
Error: Cannot find module 'express-validator'
The tutorial either needs to instruct people to install express-validator or comment out the code for now.

### Motivation

Following the tutorial exactly as written should not result in errors. Another solution would be to not include the express-validator line at this point, but add it at a later time when the tutorial actually requests installing and using the module.
const { body, validationResult } = require("express-validator");

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
