### PR TITLE
chore: add missing webidl language def

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -124,7 +124,7 @@ MyInterface implements MyMixin;
 
 Availability in Web workers (of any type) and on the Window scope is defined using an annotation: `[Exposed=(Window,Worker)]`. The annotation applies to the partial interface it is listed with.
 
-```
+```webidl
 [Exposed=(Window,Worker)]
 interface Performance {
    [DependsOn=DeviceState, Affects=Nothing]


### PR DESCRIPTION
We have since landed support for `webidl` (an alias of the `web-idl` key) in Prism syntax highlighting. 

There is one block without a language, which I'm adding here.

__related issues and pull requests:__
- [x] https://github.com/mdn/yari/pull/8899