### PR TITLE
Change Github to GitHub

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -505,7 +505,7 @@ Select **Deploy from GitHub repo**.
 All projects in the GitHub repos you shared with Railway during setup are displayed.
 Select your GitHub repository for the local library: `<user-name>/django-locallibrary-tutorial`.
 
-![Railway popup showing github repos that can be deployed](railway_new_project_button_deploy_github_selectrepo.png)
+![Railway popup showing GitHub repos that can be deployed](railway_new_project_button_deploy_github_selectrepo.png)
 
 Confirm your deployment by selecting **Deploy Now**.
 
@@ -540,7 +540,7 @@ Select the **New** button, which is used to add services to the current project.
 
 Select **Database** when prompted about the type of service to add:
 
-![Railway popup showing options for a new service, such as database, github repo, empty service etc](railway_database_add.png)
+![Railway popup showing options for a new service, such as database, GitHub repo, empty service etc](railway_database_add.png)
 
 Then select **Add MongoDB** to start adding the database
 
@@ -593,7 +593,7 @@ You can add data through the website interface and it should work in the same wa
 Download and install the Railway client for your local operating system by following the [instructions here](https://docs.railway.app/develop/cli).
 
 After the client is installed you will be able run commands.
-Some of the more important operations include deploying the current directory of your computer to an associated Railway project (without having to upload to github), and running your project locally using the same settings as you have on the production server.
+Some of the more important operations include deploying the current directory of your computer to an associated Railway project (without having to upload to GitHub), and running your project locally using the same settings as you have on the production server.
 
 You can get a list of all the possible commands by entering the following in a terminal.
 

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -304,7 +304,7 @@ For example, an application that uses a database must get the address using a va
 The database service itself may be hosted by Railway or some other provider.
 
 Developers interact with Railway through the Railway site, and using a special [Command Line Interface (CLI)](https://docs.railway.app/develop/cli) tool.
-The CLI allows you to associate a local Github repository with a railway project, upload the repository from the local branch to the live site, inspect the logs of the running process, set and get configuration variables and much more.
+The CLI allows you to associate a local GitHub repository with a railway project, upload the repository from the local branch to the live site, inspect the logs of the running process, set and get configuration variables and much more.
 One of the most useful features is that you can use the CLI to run your local project with the same environment variables as the live project.
 
 In order to get our application to work on Railway, we'll need to put our Express web application into a git repository and make a few minor modifications.
@@ -314,11 +314,11 @@ That's all the overview you need in order to get started.
 
 ### Creating an application repository in GitHub
 
-Railway is closely integrated with Github and the **git** source code version control system, and you can configure it to automatically deploy updates when changes are made to a particular repository or branch on Github.
+Railway is closely integrated with GitHub and the **git** source code version control system, and you can configure it to automatically deploy updates when changes are made to a particular repository or branch on GitHub.
 Alternatively you can push your current local code branch direct to the railway deployment using the CLI.
 
-> **Note:** Using a source code management system like Github is good software development practice.
-> Skip this step if you're already using Github to manage your source.
+> **Note:** Using a source code management system like GitHub is good software development practice.
+> Skip this step if you're already using GitHub to manage your source.
 
 There are a lot of ways to work with git, but one of the easiest is to first set up an account on [GitHub](https://github.com/), create the repository there, and then sync to it locally:
 
@@ -486,24 +486,24 @@ We should now be ready to start deploying _LocalLibrary_ on Railway.
 To start using Railway you will first need to create an account:
 
 - Go to [railway.app](https://railway.app/) and click the **Login** link in the top toolbar.
-- Select Github in the popup to login using your Github credentials
+- Select GitHub in the popup to login using your GitHub credentials
 - You may then need to go to your email and verify your account.
 - You'll then be logged in to the Railway.app dashboard: <https://railway.app/dashboard>.
 
-### Deploy on Railway from Github
+### Deploy on Railway from GitHub
 
-Next we'll setup Railway to deploy our library from Github.
+Next we'll setup Railway to deploy our library from GitHub.
 First choose the **Dashboard** option from the site top menu, then select the **New Project** button:
 
 ![Railway website dashboard showing new project button](railway_new_project_button.png)
 
-Railway will display a list of options for the new project, including the option to deploy a project from a template that is first created in your Github account, and a number of databases.
+Railway will display a list of options for the new project, including the option to deploy a project from a template that is first created in your GitHub account, and a number of databases.
 Select **Deploy from GitHub repo**.
 
-![Railway popup showing deployment options with Deploy from Github repo option highlighted](railway_new_project_button_deploy_github_repo.png)
+![Railway popup showing deployment options with Deploy from GitHub repo option highlighted](railway_new_project_button_deploy_github_repo.png)
 
-All projects in the Github repos you shared with Railway during setup are displayed.
-Select your Github repository for the local library: `<user-name>/django-locallibrary-tutorial`.
+All projects in the GitHub repos you shared with Railway during setup are displayed.
+Select your GitHub repository for the local library: `<user-name>/django-locallibrary-tutorial`.
 
 ![Railway popup showing github repos that can be deployed](railway_new_project_button_deploy_github_selectrepo.png)
 


### PR DESCRIPTION
### Description

Changed Github to GitHub

### Motivation

Consistency and accuracy throughout page. For some reason GitHub was formatted as Github several times on this page.

