### PR TITLE
Reword the Notifications section of the PWA 'Notifications and Push' article

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -17,7 +17,7 @@ They work outside of the browser window, just like service workers, so updates c
 
 ## Notifications
 
-Let's start with notifications — they can work by themselves, but become more useful when combined with push. Let's look at the APIs in isolation to begin with.
+Let's start with notifications — they can work by themselves, but become more useful when combined with push. Let's look at notifications in isolation to begin with.
 
 ### Request permission
 

--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -17,7 +17,7 @@ They work outside of the browser window, just like service workers, so updates c
 
 ## Notifications
 
-Let's start with notifications — they can work without push, but are very useful when combined with them. Let's look at them in isolation to begin with.
+Let's start with notifications — they can work by themselves, but become more useful when combined with push. Let's look at the APIs in isolation to begin with.
 
 ### Request permission
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I clarified the two sentences under the Notifications heading on the 'How to make PWAs re-engageable using Notifications and Push' article.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I think the reword helps readers understand the intro to this section of the article a bit better. The main thing that confused me was the usage of 'them' at the end of the first sentence on line 20, but I modified the sentences around it in order to fully clarify.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
