### PR TITLE
chore: add svg sidebar to all svg documents

### DIFF
--- a/files/en-us/web/svg/attribute/conditional_processing/index.md
+++ b/files/en-us/web/svg/attribute/conditional_processing/index.md
@@ -5,6 +5,8 @@ page-type: svg-attribute
 browser-compat: svg.attributes.conditional_processing
 ---
 
+{{SVGRef}}
+
 The SVG conditional processing attributes are all the attributes that can be specified on some SVG elements to control whether or not the element on which it appears should be rendered.
 
 - [requiredExtensions](#requiredextensions)

--- a/files/en-us/web/svg/attribute/core/index.md
+++ b/files/en-us/web/svg/attribute/core/index.md
@@ -5,6 +5,8 @@ page-type: svg-attribute
 browser-compat: svg.attributes.core
 ---
 
+{{SVGRef}}
+
 The SVG core attributes are all the common attributes that can be specified on any SVG element.
 
 - [`id`](#id)

--- a/files/en-us/web/svg/attribute/events/index.md
+++ b/files/en-us/web/svg/attribute/events/index.md
@@ -5,6 +5,8 @@ page-type: svg-attribute
 browser-compat: svg.attributes.events.global
 ---
 
+{{SVGRef}}
+
 Event attributes always have their name starting with "on" followed by the name of the event for which they are intended. They specifies some script to run when the event of the given type is dispatched to the element on which the attributes are specified.
 
 For every event type that the browser supports, SVG supports that as an event attribute, following the same requirements as for HTML event attributes.

--- a/files/en-us/web/svg/attribute/overline-position/index.md
+++ b/files/en-us/web/svg/attribute/overline-position/index.md
@@ -4,6 +4,8 @@ slug: Web/SVG/Attribute/overline-position
 page-type: svg-attribute
 ---
 
+{{SVGRef}}
+
 The `overline-position` attribute represents the ideal vertical position of the overline. The overline position is expressed in the font's coordinate system.
 
 You can use this attribute with the following SVG elements:

--- a/files/en-us/web/svg/attribute/overline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/overline-thickness/index.md
@@ -4,6 +4,8 @@ slug: Web/SVG/Attribute/overline-thickness
 page-type: svg-attribute
 ---
 
+{{SVGRef}}
+
 The `overline-thickness` attribute represents the ideal thickness of the overline. The overline thickness is expressed in the font's coordinate system.
 
 You can use this attribute with the following SVG elements:

--- a/files/en-us/web/svg/attribute/presentation/index.md
+++ b/files/en-us/web/svg/attribute/presentation/index.md
@@ -5,6 +5,8 @@ page-type: svg-attribute
 browser-compat: svg.attributes.presentation
 ---
 
+{{SVGRef}}
+
 SVG presentation attributes are CSS properties that can be used as attributes on SVG elements.
 
 - [alignment-baseline](#alignment-baseline)

--- a/files/en-us/web/svg/attribute/rotate/index.md
+++ b/files/en-us/web/svg/attribute/rotate/index.md
@@ -7,6 +7,8 @@ status:
 spec-urls: https://svgwg.org/specs/animations/#RotateAttribute
 ---
 
+{{SVGRef}}
+
 The `rotate` attribute specifies how the animated element rotates as it travels along a path specified in an {{SVGElement("animateMotion")}} element.
 
 You can use this attribute with the following SVG elements:

--- a/files/en-us/web/svg/attribute/strikethrough-position/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-position/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/strikethrough-position
 page-type: svg-attribute
 ---
 
-« [SVG Attribute reference home](/en-US/docs/Web/SVG/Attribute)
+{{SVGRef}}
 
 The `strikethrough-position` attribute represents the ideal vertical position of the strikethrough. The strikethrough position is expressed in the font's coordinate system.
 

--- a/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/strikethrough-thickness
 page-type: svg-attribute
 ---
 
-« [SVG Attribute reference home](/en-US/docs/Web/SVG/Attribute)
+{{SVGRef}}
 
 The `strikethrough-thickness` attribute represents the ideal thickness of the strikethrough. The strikethrough thickness is expressed in the font's coordinate system.
 

--- a/files/en-us/web/svg/attribute/styling/index.md
+++ b/files/en-us/web/svg/attribute/styling/index.md
@@ -5,6 +5,8 @@ page-type: svg-attribute
 browser-compat: svg.attributes.style
 ---
 
+{{SVGRef}}
+
 The SVG styling attributes are all the attributes that can be specified on any SVG element to apply CSS styling effects.
 
 - [`class`](#class)

--- a/files/en-us/web/svg/attribute/underline-position/index.md
+++ b/files/en-us/web/svg/attribute/underline-position/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/underline-position
 page-type: svg-attribute
 ---
 
-« [SVG Attribute reference home](/en-US/docs/Web/SVG/Attribute)
+{{SVGRef}}
 
 The `underline-position` attribute represents the ideal vertical position of the underline. The underline position is expressed in the font's coordinate system.
 

--- a/files/en-us/web/svg/attribute/underline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/underline-thickness/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/underline-thickness
 page-type: svg-attribute
 ---
 
-« [SVG Attribute reference home](/en-US/docs/Web/SVG/Attribute)
+{{SVGRef}}
 
 The `underline-thickness` attribute represents the ideal thickness of the underline. The underline thickness is expressed in the font's coordinate system.
 


### PR DESCRIPTION
### Description

I've used `\{\{\s*SVGRef` to check the document which is missing svg sidebar under `web/svg` folder, and then add svg sidebar to those svg documents.
