### PR TITLE
Popover API - add live examples for Web API

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
@@ -33,14 +33,14 @@ This example shows the basic use of the popover API with a "toggle" value set fo
 The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
 First we define an HTML `<button>` element that we will use to show and hide the popover, and a `<div>` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the `<button>` or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <button id="toggleBtn">Toggle popover</button>
 <div id="mypopover">This is popover content!</div>
 ```
 
-The JavaScript code first gets a handle to the div element and the button.
+The JavaScript code first gets a handle to the `<div>` and `<button>` elements.
 It then defines a function to check for popover support.
 
 ```js
@@ -53,13 +53,13 @@ function supportsPopover() {
 }
 ```
 
-If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
-We then set the `popoverTargetAction` of the button to `"toggle"`.
+If the popover API is supported the code sets the `<div>` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the `<button>` to `"toggle"`.
 If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
-  // Set the div element to be an auto popover
+  // Set the <div> element to be an auto popover
   popover.popover = "auto";
   // Set the button popover target to be the popover
   toggleBtn.popoverTargetElement = popover;
@@ -83,9 +83,9 @@ The `"auto"` popover can also be "light dismissed" by selecting outside the boun
 ### Show/hide popover action with a manual popover
 
 This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
-The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
-The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
+The code is near identical to the previous example, except that there are two `<button>` elements, and the popover is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state).
+A `manual` popover must be closed explicitly, and not "light dismissed" by selecting outside the popover area.
 
 ```html
 <button id="showBtn">Show popover</button>
@@ -123,7 +123,6 @@ if (supportsPopover()) {
 ```
 
 The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
-Note that the popover has been set to `"manual"`, so it can't be light dismissed by selecting outside the popover.
 
 {{EmbedLiveSample("Show/hide popover action with a manual popover", "100%")}}
 

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
@@ -105,7 +105,7 @@ const hideBtn = document.getElementById("hideBtn");
 const popoverSupported = supportsPopover();
 
 if (supportsPopover()) {
-  // Set the div element be a manual popover
+  // Set the <div> element be a manual popover
   popover.popover = "manual";
 
   // Set the button targets to be the popover

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLButtonElement.popoverTargetAction
 
 {{ APIRef("DOM") }}{{SeeCompatTable}}
 
-The **`popoverTargetAction`** property of the {{domxref("HTMLButtonElement")}} interface gets and sets the action to be performed (`"hide"`, `"show"`, or `"toggle"`) on a popover element being controlled by a control button.
+The **`popoverTargetAction`** property of the {{domxref("HTMLButtonElement")}} interface gets and sets the action to be performed (`"hide"`, `"show"`, or `"toggle"`) on a popover element being controlled by a button.
 
 It reflects the value of the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute.
 
@@ -27,24 +27,103 @@ An enumerated value. Possible values are:
 
 ## Examples
 
+### Toggle popover action
+
+This example shows the basic use of the popover API with a "toggle" value set for the `popoverTargetAction` property.
+
+First we define an HTML `button` element that we will use to control display and hide the popover, and a `div` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+
+```html
+<button id="toggleBtn">Toggle popover</button>
+<div id="mypopover">This is popover content!</div>
+```
+
+The JavaScript code first gets a handle to the div element and the button.
+It then defines a function to feature check for popover support.
+
+```js
+const popover = document.getElementById("mypopover");
+const toggleBtn = document.getElementById("toggleBtn");
+
+// Feature check for popover API support.
+function supportsPopover() {
+  return HTMLElement.prototype.hasOwnProperty("popover");
+}
+```
+
+If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the button to `"toggle"`.
+If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+
+```js
+if (supportsPopover()) {
+  // Set the div element to be an auto popover
+  popover.popover = "auto";
+  // Set the button popover target to be the popover
+  toggleBtn.popoverTargetElement = popover;
+
+  // Set that the button toggles popover visibility
+  toggleBtn.popoverTargetAction = "toggle";
+} else {
+  popover.textContent = "Popover API not supported.";
+  toggleBtn.hidden = true;
+}
+```
+
+> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+
+You can try out the example below.
+Show and hide the popover by toggling the button.
+The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+
+{{EmbedLiveSample("Toggle popover action", "100%")}}
+
+### Show/hide popover action
+
+This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
+
+The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
+
+```html
+<button id="showBtn">Show popover</button>
+<button id="hideBtn">Hide popover</button>
+<div id="mypopover">This is popover content!</div>
+```
+
 ```js
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
 
 const popover = document.getElementById("mypopover");
-const toggleBtn = document.getElementById("toggleBtn");
+const showBtn = document.getElementById("showBtn");
+const hideBtn = document.getElementById("hideBtn");
 
 const popoverSupported = supportsPopover();
 
-if (popoverSupported) {
-  popover.popover = "auto";
-  toggleBtn.popoverTargetElement = popover;
-  toggleBtn.popoverTargetAction = "toggle";
+if (supportsPopover()) {
+  // Set the div element be a manual popover
+  popover.popover = "manual";
+
+  // Set the button targets to be the popover
+  showBtn.popoverTargetElement = popover;
+  hideBtn.popoverTargetElement = popover;
+
+  // Set the target actions to be show/hide
+  showBtn.popoverTargetAction = "show";
+  hideBtn.popoverTargetAction = "hide";
 } else {
-  console.log("Popover API not supported.");
+  popover.textContent = "Popover API not supported.";
+  showBtn.hidden = true;
+  hideBtn.hidden = true;
 }
 ```
+
+The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
+Note that the popover has been set to `"manual"`, so it can't be dismissed by selecting outside the popover.
+
+{{EmbedLiveSample("Show/hide popover action", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
@@ -27,11 +27,12 @@ An enumerated value. Possible values are:
 
 ## Examples
 
-### Toggle popover action
+### Toggle popover action with an auto popover
 
 This example shows the basic use of the popover API with a "toggle" value set for the `popoverTargetAction` property.
+The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
-First we define an HTML `button` element that we will use to control display and hide the popover, and a `div` that will be the popover.
+First we define an HTML `<button>` element that we will use to show and hide the popover, and a `<div>` that will be the popover.
 In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
 
 ```html
@@ -40,13 +41,13 @@ In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Eleme
 ```
 
 The JavaScript code first gets a handle to the div element and the button.
-It then defines a function to feature check for popover support.
+It then defines a function to check for popover support.
 
 ```js
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-// Feature check for popover API support.
+// Check for popover API support.
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
@@ -54,7 +55,7 @@ function supportsPopover() {
 
 If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the button to `"toggle"`.
-If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
@@ -75,13 +76,14 @@ if (supportsPopover()) {
 
 You can try out the example below.
 Show and hide the popover by toggling the button.
-The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+The `"auto"` popover can also be "light dismissed" by selecting outside the bounds of the popover text.
 
-{{EmbedLiveSample("Toggle popover action", "100%")}}
+{{EmbedLiveSample("Toggle popover action with an auto popover", "100%")}}
 
-### Show/hide popover action
+### Show/hide popover action with a manual popover
 
 This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
+The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
 The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
 
@@ -121,9 +123,9 @@ if (supportsPopover()) {
 ```
 
 The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
-Note that the popover has been set to `"manual"`, so it can't be dismissed by selecting outside the popover.
+Note that the popover has been set to `"manual"`, so it can't be light dismissed by selecting outside the popover.
 
-{{EmbedLiveSample("Show/hide popover action", "100%")}}
+{{EmbedLiveSample("Show/hide popover action with a manual popover", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLButtonElement.popoverTargetElement
 
 {{ APIRef("DOM") }}{{SeeCompatTable}}
 
-The **`popoverTargetElement`** property of the {{domxref("HTMLButtonElement")}} interface gets and sets the popover element to control via a control button.
+The **`popoverTargetElement`** property of the {{domxref("HTMLButtonElement")}} interface gets and sets the popover element to control via a button.
 
 It is the JavaScript equivalent of the [`popovertarget`](/en-US/docs/Web/HTML/Element/button#popovertarget) HTML attribute.
 
@@ -22,17 +22,17 @@ A reference to a popover element in the DOM.
 
 ### Toggle popover action
 
-This example shows the basic use of the popover API, setting a `div` element as a popover, and then setting it as the `popoverTargetElement` of a button.
+This example shows the basic use of the popover API, setting a `<div>` element as a popover, and then setting it as the `popoverTargetElement` of a `<button>`.
 
-First we define an HTML `button` element that we will use to display and hide the popover, and a `div` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+First we define an HTML `<button>` element that we will use to display and hide the popover, and a `<div>` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the <button> or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <button id="toggleBtn">Toggle popover</button>
 <div id="mypopover">This is popover content!</div>
 ```
 
-The JavaScript code first gets a handle to the `div` element and the button.
+The JavaScript code first gets a handle to the `<div>` and `<button>` elements.
 It then defines a function to feature check for popover support.
 
 ```js
@@ -45,13 +45,13 @@ function supportsPopover() {
 }
 ```
 
-If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
-We then set the `popoverTargetAction` of the button to `"toggle"`.
-If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+If the popover API is supported the code sets the `<div>` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the `<button>` to `"toggle"`.
+If the popover API is not supported we simply change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
-  // Set the div element to be an auto popover
+  // Set the <div> element to be an auto popover
   popover.popover = "auto";
 
   // Set the button popover target to be the popover

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
@@ -26,7 +26,7 @@ This example shows the basic use of the popover API, setting a `<div>` element a
 The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
 First we define an HTML `<button>` element that we will use to show and hide the popover, and a `<div>` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the <button> or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the `<button>` or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <button id="toggleBtn">Toggle popover</button>

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
@@ -20,24 +20,58 @@ A reference to a popover element in the DOM.
 
 ## Examples
 
-```js
-function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
-}
+### Toggle popover action
 
+This example shows the basic use of the popover API, setting a `div` element as a popover, and then setting it as the `popoverTargetElement` of a button.
+
+First we define an HTML `button` element that we will use to display and hide the popover, and a `div` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+
+```html
+<button id="toggleBtn">Toggle popover</button>
+<div id="mypopover">This is popover content!</div>
+```
+
+The JavaScript code first gets a handle to the `div` element and the button.
+It then defines a function to feature check for popover support.
+
+```js
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-const popoverSupported = supportsPopover();
-
-if (popoverSupported) {
-  popover.popover = "auto";
-  toggleBtn.popoverTargetElement = popover;
-  toggleBtn.popoverTargetAction = "toggle";
-} else {
-  console.log("Popover API not supported.");
+// Feature check for popover API support.
+function supportsPopover() {
+  return HTMLElement.prototype.hasOwnProperty("popover");
 }
 ```
+
+If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the button to `"toggle"`.
+If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+
+```js
+if (supportsPopover()) {
+  // Set the div element to be an auto popover
+  popover.popover = "auto";
+
+  // Set the button popover target to be the popover
+  toggleBtn.popoverTargetElement = popover;
+
+  // Set that the button toggles popover visibility
+  toggleBtn.popoverTargetAction = "toggle";
+} else {
+  popover.textContent = "Popover API not supported.";
+  toggleBtn.hidden = true;
+}
+```
+
+> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+
+You can try out the example below.
+Show and hide the popover by toggling the button.
+The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+
+{{EmbedLiveSample("Toggle popover action", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
@@ -20,11 +20,12 @@ A reference to a popover element in the DOM.
 
 ## Examples
 
-### Toggle popover action
+### Toggle popover action with an auto popover
 
 This example shows the basic use of the popover API, setting a `<div>` element as a popover, and then setting it as the `popoverTargetElement` of a `<button>`.
+The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
-First we define an HTML `<button>` element that we will use to display and hide the popover, and a `<div>` that will be the popover.
+First we define an HTML `<button>` element that we will use to show and hide the popover, and a `<div>` that will be the popover.
 In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the <button> or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
@@ -33,13 +34,13 @@ In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Eleme
 ```
 
 The JavaScript code first gets a handle to the `<div>` and `<button>` elements.
-It then defines a function to feature check for popover support.
+It then defines a function to check for popover support.
 
 ```js
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-// Feature check for popover API support.
+// Check for popover API support.
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
@@ -47,7 +48,7 @@ function supportsPopover() {
 
 If the popover API is supported the code sets the `<div>` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the `<button>` to `"toggle"`.
-If the popover API is not supported we simply change the text content of the `<div>` element to state this, and hide the toggle button.
+If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
@@ -71,7 +72,7 @@ You can try out the example below.
 Show and hide the popover by toggling the button.
 The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
 
-{{EmbedLiveSample("Toggle popover action", "100%")}}
+{{EmbedLiveSample("Toggle popover action with an auto popover", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -27,11 +27,12 @@ An enumerated value. Possible values are:
 
 ## Examples
 
-### Toggle popover action
+### Toggle popover action with an auto popover
 
 This example shows the basic use of the popover API with a "toggle" value set for the `popoverTargetAction` property.
+The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
-First we define an [`<input>` element](/en-US/docs/Web/HTML/Element/input/button) of `type="button"` that we will use to control display and hide the popover, and a `div` that will be the popover.
+First we define an [`<input>`](/en-US/docs/Web/HTML/Element/input/button) of `type="button"` that we will use to show and hide the popover, and a `<div>` that will be the popover.
 In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
 
 ```html
@@ -40,13 +41,13 @@ In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Eleme
 ```
 
 The JavaScript code first gets a handle to the div element and the button.
-It then defines a function to feature check for popover support.
+It then defines a function to check for popover support.
 
 ```js
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-// Feature check for popover API support.
+// Check for popover API support.
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
@@ -54,7 +55,7 @@ function supportsPopover() {
 
 If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the button to `"toggle"`.
-If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
@@ -77,11 +78,12 @@ You can try out the example below.
 Show and hide the popover by toggling the button.
 The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
 
-{{EmbedLiveSample("Toggle popover action", "100%")}}
+{{EmbedLiveSample("Toggle popover action with an auto popover", "100%")}}
 
-### Show/hide popover action
+### Show/hide popover action with a manual popover
 
 This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
+The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
 The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
 
@@ -121,9 +123,9 @@ if (supportsPopover()) {
 ```
 
 The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
-Note that the popover has been set to `"manual"`, so it can't be dismissed by selecting outside the popover.
+Note that the popover has been set to `"manual"`, so it can't be light dismissed by selecting outside the popover.
 
-{{EmbedLiveSample("Show/hide popover action", "100%")}}
+{{EmbedLiveSample("Show/hide popover action with a manual popover", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -27,24 +27,103 @@ An enumerated value. Possible values are:
 
 ## Examples
 
+### Toggle popover action
+
+This example shows the basic use of the popover API with a "toggle" value set for the `popoverTargetAction` property.
+
+First we define an [`<input>` element](/en-US/docs/Web/HTML/Element/input/button) of `type="button"` that we will use to control display and hide the popover, and a `div` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+
+```html
+<input id="toggleBtn" type="button" value="Toggle popover" />
+<div id="mypopover">This is popover content!</div>
+```
+
+The JavaScript code first gets a handle to the div element and the button.
+It then defines a function to feature check for popover support.
+
+```js
+const popover = document.getElementById("mypopover");
+const toggleBtn = document.getElementById("toggleBtn");
+
+// Feature check for popover API support.
+function supportsPopover() {
+  return HTMLElement.prototype.hasOwnProperty("popover");
+}
+```
+
+If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the button to `"toggle"`.
+If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the toggle button.
+
+```js
+if (supportsPopover()) {
+  // Set the div element to be an auto popover
+  popover.popover = "auto";
+  // Set the button popover target to be the popover
+  toggleBtn.popoverTargetElement = popover;
+
+  // Set that the button toggles popover visibility
+  toggleBtn.popoverTargetAction = "toggle";
+} else {
+  popover.textContent = "Popover API not supported.";
+  toggleBtn.hidden = true;
+}
+```
+
+> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+
+You can try out the example below.
+Show and hide the popover by toggling the button.
+The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+
+{{EmbedLiveSample("Toggle popover action", "100%")}}
+
+### Show/hide popover action
+
+This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
+
+The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
+
+```html
+<input id="showBtn" type="button" value="Show popover" />
+<input id="hideBtn" type="button" value="Hide popover" />
+<div id="mypopover">This is popover content!</div>
+```
+
 ```js
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
 
 const popover = document.getElementById("mypopover");
-const toggleBtn = document.getElementById("toggleBtn");
+const showBtn = document.getElementById("showBtn");
+const hideBtn = document.getElementById("hideBtn");
 
 const popoverSupported = supportsPopover();
 
-if (popoverSupported) {
-  popover.popover = "auto";
-  toggleBtn.popoverTargetElement = popover;
-  toggleBtn.popoverTargetAction = "toggle";
+if (supportsPopover()) {
+  // Set the div element be a manual popover
+  popover.popover = "manual";
+
+  // Set the button targets to be the popover
+  showBtn.popoverTargetElement = popover;
+  hideBtn.popoverTargetElement = popover;
+
+  // Set the target actions to be show/hide
+  showBtn.popoverTargetAction = "show";
+  hideBtn.popoverTargetAction = "hide";
 } else {
-  console.log("Popover API not supported.");
+  popover.textContent = "Popover API not supported.";
+  showBtn.hidden = true;
+  hideBtn.hidden = true;
 }
 ```
+
+The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
+Note that the popover has been set to `"manual"`, so it can't be dismissed by selecting outside the popover.
+
+{{EmbedLiveSample("Show/hide popover action", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -83,9 +83,9 @@ The "auto" popover can also be dismissed by selecting outside the bounds of the 
 ### Show/hide popover action with a manual popover
 
 This example shows how to use the `"show"` and `"hide"` values of the `popoverTargetAction` attribute.
-The `popover` attribute is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state), so the popover must be closed using a button, and not "light dismissed" by selecting outside the popover area.
 
-The code is near identical to the previous example, except that there are two buttons, and the popover is set to "manual".
+The code is near identical to the previous example, except that there are two `<button>` elements, and the popover is set to [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state).
+A `manual` popover must be closed explicitly, and not "light dismissed" by selecting outside the popover area.
 
 ```html
 <input id="showBtn" type="button" value="Show popover" />
@@ -123,7 +123,6 @@ if (supportsPopover()) {
 ```
 
 The popover can be displayed by selecting the "Show popover" button, and dismissed using the "Hide popover" button.
-Note that the popover has been set to `"manual"`, so it can't be light dismissed by selecting outside the popover.
 
 {{EmbedLiveSample("Show/hide popover action with a manual popover", "100%")}}
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -40,7 +40,7 @@ In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Eleme
 <div id="mypopover">This is popover content!</div>
 ```
 
-The JavaScript code first gets a handle to the `<div>` and `<button>` elements.
+The JavaScript code first gets a handle to the `<div>` and `<input>` elements.
 It then defines a function to check for popover support.
 
 ```js

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -33,14 +33,14 @@ This example shows the basic use of the popover API with a "toggle" value set fo
 The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
 First we define an [`<input>`](/en-US/docs/Web/HTML/Element/input/button) of `type="button"` that we will use to show and hide the popover, and a `<div>` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the button or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <input id="toggleBtn" type="button" value="Toggle popover" />
 <div id="mypopover">This is popover content!</div>
 ```
 
-The JavaScript code first gets a handle to the div element and the button.
+The JavaScript code first gets a handle to the `<div>` and `<button>` elements.
 It then defines a function to check for popover support.
 
 ```js
@@ -53,13 +53,13 @@ function supportsPopover() {
 }
 ```
 
-If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+If the popover API is supported the code sets the `<div>` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the button to `"toggle"`.
 If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the toggle button.
 
 ```js
 if (supportsPopover()) {
-  // Set the div element to be an auto popover
+  // Set the <div> element to be an auto popover
   popover.popover = "auto";
   // Set the button popover target to be the popover
   toggleBtn.popoverTargetElement = popover;
@@ -105,7 +105,7 @@ const hideBtn = document.getElementById("hideBtn");
 const popoverSupported = supportsPopover();
 
 if (supportsPopover()) {
-  // Set the div element be a manual popover
+  // Set the <div> element be a manual popover
   popover.popover = "manual";
 
   // Set the button targets to be the popover

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -39,6 +39,59 @@ if (popoverSupported) {
 }
 ```
 
+### Toggle popover action
+
+This example shows the basic use of the popover API, setting a `div` element as a popover, and then setting it as the `popoverTargetElement` of an [`<input>` element](/en-US/docs/Web/HTML/Element/input/button) of `type="button"`.
+
+First we define an input element that we will use to display and hide the popover, and a `div` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the input or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+
+```html
+<input id="toggleBtn" type="button" value="Toggle popover" />
+<div id="mypopover">This is popover content!</div>
+```
+
+The JavaScript code first gets a handle to the `div` element and the button.
+It then defines a function to feature check for popover support.
+
+```js
+const popover = document.getElementById("mypopover");
+const toggleBtn = document.getElementById("toggleBtn");
+
+// Feature check for popover API support.
+function supportsPopover() {
+  return HTMLElement.prototype.hasOwnProperty("popover");
+}
+```
+
+If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+We then set the `popoverTargetAction` of the button to `"toggle"`.
+If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the input element.
+
+```js
+if (supportsPopover()) {
+  // Set the div element to be an auto popover
+  popover.popover = "auto";
+
+  // Set the button popover target to be the popover
+  toggleBtn.popoverTargetElement = popover;
+
+  // Set that the button toggles popover visibility
+  toggleBtn.popoverTargetAction = "toggle";
+} else {
+  popover.textContent = "Popover API not supported.";
+  toggleBtn.hidden = true;
+}
+```
+
+> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+
+You can try out the example below.
+Show and hide the popover by toggling the button.
+The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+
+{{EmbedLiveSample("Toggle popover action", "100%")}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -52,13 +52,13 @@ In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Eleme
 ```
 
 The JavaScript code first gets a handle to the `div` element and the button.
-It then defines a function to feature check for popover support.
+It then defines a function to check for popover support.
 
 ```js
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-// Feature check for popover API support.
+// Check for popover API support.
 function supportsPopover() {
   return HTMLElement.prototype.hasOwnProperty("popover");
 }
@@ -66,7 +66,7 @@ function supportsPopover() {
 
 If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the button to `"toggle"`.
-If the popover API is not supported we simply change the text content of the `div` element to state this, and hide the input element.
+If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the input element.
 
 ```js
 if (supportsPopover()) {
@@ -90,7 +90,7 @@ You can try out the example below.
 Show and hide the popover by toggling the button.
 The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
 
-{{EmbedLiveSample("Toggle popover action", "100%")}}
+{{EmbedLiveSample("Toggle popover action with an auto popover", "100%")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -39,19 +39,20 @@ if (popoverSupported) {
 }
 ```
 
-### Toggle popover action
+### Toggle popover action with an auto popover
 
-This example shows the basic use of the popover API, setting a `div` element as a popover, and then setting it as the `popoverTargetElement` of an [`<input>` element](/en-US/docs/Web/HTML/Element/input/button) of `type="button"`.
+This example shows the basic use of the popover API, setting a `<div>` element as a popover, and then setting it as the `popoverTargetElement` of an [`<input>`](/en-US/docs/Web/HTML/Element/input/button) of `type="button"`.
+The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
-First we define an input element that we will use to display and hide the popover, and a `div` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the input or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `div`, as we will be doing so programmatically.
+First we define an `<input>` that we will use to display and hide the popover, and a `<div>` that will be the popover.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the input or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <input id="toggleBtn" type="button" value="Toggle popover" />
 <div id="mypopover">This is popover content!</div>
 ```
 
-The JavaScript code first gets a handle to the `div` element and the button.
+The JavaScript code first gets a handle to the `<div>` and `<input>` elements.
 It then defines a function to check for popover support.
 
 ```js
@@ -64,13 +65,13 @@ function supportsPopover() {
 }
 ```
 
-If the popover API is supported the code sets the `div` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
+If the popover API is supported the code sets the `<div>` element's `popover` attribute to `"auto"` and makes it the popover target of the toggle button.
 We then set the `popoverTargetAction` of the button to `"toggle"`.
 If the popover API is not supported we change the text content of the `<div>` element to state this, and hide the input element.
 
 ```js
 if (supportsPopover()) {
-  // Set the div element to be an auto popover
+  // Set the <div> element to be an auto popover
   popover.popover = "auto";
 
   // Set the button popover target to be the popover
@@ -88,7 +89,7 @@ if (supportsPopover()) {
 
 You can try out the example below.
 Show and hide the popover by toggling the button.
-The "auto" popover can also be dismissed by selecting outside the bounds of the popover text.
+The "auto" popover can also be light dismissed by selecting outside the bounds of the popover text.
 
 {{EmbedLiveSample("Toggle popover action with an auto popover", "100%")}}
 

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -45,7 +45,7 @@ This example shows the basic use of the popover API, setting a `<div>` element a
 The `popover` attribute is set to [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so the popover can be closed ("light-dismissed") by clicking outside the popover area.
 
 First we define an `<input>` that we will use to display and hide the popover, and a `<div>` that will be the popover.
-In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the input or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
+In this case we don't set the [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction) HTML attribute on the `<input>` or the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute on the `<div>`, as we will be doing so programmatically.
 
 ```html
 <input id="toggleBtn" type="button" value="Toggle popover" />

--- a/files/en-us/web/html/global_attributes/popover/index.md
+++ b/files/en-us/web/html/global_attributes/popover/index.md
@@ -15,6 +15,10 @@ Popover elements are hidden via `display: none` until opened via an invoking/con
 
 When open, popover elements will appear above all other elements in the {{glossary("top layer")}}, and won't be influenced by parent elements' {{cssxref('position')}} or {{cssxref('overflow')}} styling.
 
+A popover attribute can have values [`"auto"`](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss) (default) or [`"manual"`](/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state).
+Popovers that have the `auto` state can be "light dismissed" by selecting outside the popover area, and generally only allow one popover to be displayed on-screen at a time.
+By contrast, `manual` popovers must always be explicitly hidden, but allow for use cases such as nested popovers in menus.
+
 For detailed information on usage, see the {{domxref("Popover API", "Popover API", "", "nocode")}} landing page.
 
 ## Examples


### PR DESCRIPTION
This updates the popover API "Web API" docs with some live examples. The examples are all very similar - they mirror for the button vs input elements. 

This is worth doing IMO because live examples are a very obvious up-front demo of browser support. I also found it useful because it wasn't obvious to me at first that if you declare an element as a popover when popover API is not supported that div displays its content. 

@chrisdavidmills YOu'd be the right person to look at this. I'm very pleased you already documented this - the "Using guide" is really good.

Note that I did not update a live example for the event handler, thought that would be not be hard. If you think it is useful (as I do) let me know and I'll consider extending.

Related docs work in #26694
