### PR TITLE
Frames can't exist within a <body>

### DIFF
--- a/files/en-us/web/html/element/frame/index.md
+++ b/files/en-us/web/html/element/frame/index.md
@@ -39,11 +39,12 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 A frameset document has a {{HTMLElement("frameset")}} element instead of a {{HTMLElement("body")}} element. The `<frame>` elements are placed within the `<frameset>`.
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <head>
-    <!-- Headers here -->
+    <!-- Document metadata goes here -->
   </head>
-  <frameset cols="50%,50%">
+  <frameset cols="400, 500">
     <frame src="https://developer.mozilla.org/en/HTML/Element/iframe" />
     <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
   </frameset>

--- a/files/en-us/web/html/element/frame/index.md
+++ b/files/en-us/web/html/element/frame/index.md
@@ -34,12 +34,23 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 
 ## Example
 
+### A frameset document
+
+A frameset document has a {{HTMLElement("frameset")}} element instead of a {{HTMLElement("body")}} element. The `<frame>` elements are placed within the `<frameset>`.
+
 ```html
-<frameset cols="50%,50%">
-  <frame src="https://developer.mozilla.org/en/HTML/Element/iframe" />
-  <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
-</frameset>
+<html>
+  <head>
+    <!-- Headers here -->
+  </head>
+  <frameset cols="50%,50%">
+    <frame src="https://developer.mozilla.org/en/HTML/Element/iframe" />
+    <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
+  </frameset>
+</html>
 ```
+
+If you want to embed another HTML page into the {{HTMLElement("body")}} of a document, use an {{HTMLElement("iframe")}} element.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/frameset/index.md
+++ b/files/en-us/web/html/element/frameset/index.md
@@ -24,14 +24,23 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 
 ## Example
 
+### A frameset document
+
+A frameset document has a `<frameset>` element instead of a {{HTMLElement("body")}} element. The {{HTMLElement("frame")}} elements are placed within the `<frameset>`.
+
 ```html
-<frameset cols="50%,50%">
-  <frame
-    src="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/frameset" />
-  <frame
-    src="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/frame" />
-</frameset>
+<html>
+  <head>
+    <!-- Headers here -->
+  </head>
+  <frameset cols="50%,50%">
+    <frame src="https://developer.mozilla.org/en/HTML/Element/iframe" />
+    <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
+  </frameset>
+</html>
 ```
+
+If you want to embed another HTML page into the {{HTMLElement("body")}} of a document, use an {{HTMLElement("iframe")}} element.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/frameset/index.md
+++ b/files/en-us/web/html/element/frameset/index.md
@@ -29,11 +29,12 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 A frameset document has a `<frameset>` element instead of a {{HTMLElement("body")}} element. The {{HTMLElement("frame")}} elements are placed within the `<frameset>`.
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <head>
-    <!-- Headers here -->
+    <!-- Document metadata goes here -->
   </head>
-  <frameset cols="50%,50%">
+  <frameset cols="50%, 50%">
     <frame src="https://developer.mozilla.org/en/HTML/Element/iframe" />
     <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
   </frameset>

--- a/files/en-us/web/html/element/noframes/index.md
+++ b/files/en-us/web/html/element/noframes/index.md
@@ -26,16 +26,21 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 In this example, we see a frameset with two frames. In addition, `<noframes>` is used to present an explanatory message if the {{Glossary("user agent")}} doesn't support frames.
 
 ```html
-<frameset cols="50%,50%">
-  <frame src="https://developer.mozilla.org/en/HTML/Element/frameset" />
-  <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
-  <noframes>
-    <p>
-      It seems your browser does not support frames or is configured to not
-      allow them.
-    </p>
-  </noframes>
-</frameset>
+<html>
+  <head>
+    <!-- Headers here -->
+  </head>
+  <frameset cols="50%,50%">
+    <frame src="https://developer.mozilla.org/en/HTML/Element/frameset" />
+    <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
+    <noframes>
+      <p>
+        It seems your browser does not support frames or is configured to not
+        allow them.
+      </p>
+    </noframes>
+  </frameset>
+</html>
 ```
 
 ## Specifications

--- a/files/en-us/web/html/element/noframes/index.md
+++ b/files/en-us/web/html/element/noframes/index.md
@@ -26,11 +26,12 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 In this example, we see a frameset with two frames. In addition, `<noframes>` is used to present an explanatory message if the {{Glossary("user agent")}} doesn't support frames.
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <head>
-    <!-- Headers here -->
+    <!-- Document metadata goes here -->
   </head>
-  <frameset cols="50%,50%">
+  <frameset rows="45%, 55%">
     <frame src="https://developer.mozilla.org/en/HTML/Element/frameset" />
     <frame src="https://developer.mozilla.org/en/HTML/Element/frame" />
     <noframes>


### PR DESCRIPTION
### Description

Make the example code more complete by adding `<html>`, `<head>` and some usage notes to say that `<frameset> `elements can't actually exist in a `<body>`.

### Motivation

This came up in https://github.com/mdn/browser-compat-data/pull/19681