### PR TITLE
docs: update code snippet

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -247,7 +247,7 @@ Finally, if your function contains only one line that's a `return` statement, yo
 ```js
 const originals = [1, 2, 3];
 
-const doubled = originals.map((item) => item * 2);
+const doubled = originals.map(item => item * 2);
 
 console.log(doubled); // [2, 4, 6]
 ```

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -244,7 +244,7 @@ textBox.addEventListener("keydown", event => {
 
 Finally, if your function contains only one line that's a `return` statement, you can also omit the braces and the `return` keyword, and implicitly return the expression. In the following example we're using the {{jsxref("Array.prototype.map()","map()")}} method of `Array` to double every value in the original array:
 
-```js
+```js-nolint
 const originals = [1, 2, 3];
 
 const doubled = originals.map(item => item * 2);


### PR DESCRIPTION
### Description
Arrow function section suggest omitting the brackets around the parameter when there's only one

```js
textBox.addEventListener("keydown", event => {
  console.log(`You pressed "${event.key}".`);
});
```

Since the latter example also has only one parameter, it should be omitted too

### Motivation

Apply the principles learned immediately; otherwise, learners might get confused - why isn't it applied here?

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
