### PR TITLE
docs(relnote): Fx114 - CSS :lang() pseudo accepts comma-separated params, improved matching semantics

### DIFF
--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -17,6 +17,9 @@ This article provides information about the changes in Firefox 114 that affect d
 
 ### CSS
 
+- The [`:lang()`](/en-US/docs/Web/CSS/:lang) pseudo-class now uses string-matching semantics (including `*` wildcards) for matching language codes rather than prefix-matching semantics.
+  Additionally, comma-separated lists of languages are now supported for matching multiple languages ([Firefox bug 1121792](https://bugzil.la/1121792)).
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -18,21 +18,29 @@ The **`:lang()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/
 ### Formal syntax
 
 ```css-nolint
-:lang(<language-code>) {
+:lang(<language-code> [,<language-code> ]*)
   /* ... */
 }
 ```
 
-### Parameter
+### Parameters
 
 - `<language-code>`
-  - : A {{cssxref("&lt;string&gt;")}} representing the language you want to target. Acceptable values are specified in the [HTML](/en-US/docs/Web/HTML) spec.
+  - : A comma separated list of one or more {{cssxref("&lt;string&gt;")}}s that target an element with a language value according to [BCP 47](https://tools.ietf.org/html/bcp47) language codes.
+    Matching by language range is case-insensitive.
+
+## Description
+
+When selecting languages, there is implicit wildcard matching, so `:lang(de-DE)` will match `de-DE`, `de-DE-1996`, `de-Latn-DE`, `de-Latf-DE`, and `de-Latn-DE-1996`.
+Explicitly using wildcards must include a full match of a language subtag, so `:lang("*-F*")` is invalid but `:lang("*-Fr")` is valid.
 
 ## Examples
 
+### Matching children of a given language
+
 In this example, the `:lang()` pseudo-class is used to match the parents of quote elements ({{htmlElement("q")}}) using [child combinators](/en-US/docs/Web/CSS/Child_combinator). Note that this doesn't illustrate the only way to do this, and that the best method to use depends on the type of document. Also note that {{glossary("Unicode")}} values are used to specify some of the special quote characters.
 
-### HTML
+#### HTML
 
 ```html
 <div lang="en">
@@ -46,7 +54,7 @@ In this example, the `:lang()` pseudo-class is used to match the parents of quot
 </div>
 ```
 
-### CSS
+#### CSS
 
 ```css
 :lang(en) > q {
@@ -60,9 +68,54 @@ In this example, the `:lang()` pseudo-class is used to match the parents of quot
 }
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample('Examples', 350)}}
+{{EmbedLiveSample('Matching_children_of_a_given_language', '', '80')}}
+
+### Matching multiple languages
+
+The following example shows how to match multiple languages by providing a comma-separated list of language codes.
+It's also possible to use a wildcard to match languages in a given language range.
+
+```css hidden
+p {
+  margin: 0;
+}
+```
+
+#### CSS
+
+```css
+/* Matches nl and de */
+:lang("nl", "de") {
+  color: green;
+}
+
+/* Omitting quotes & case-insensitive matching */
+:lang(EN, FR) {
+  color: blue;
+}
+
+/* Wildcard matching a language range */
+:lang("*-Latn") {
+  color: red;
+}
+```
+
+#### HTML
+
+```html
+<p lang="nl">Dit is een Nederlandse paragraaf.</p>
+<p lang="de">Dies ist ein deutscher Satz.</p>
+<p lang="en">This is an English sentence.</p>
+<p lang="en-GB">Matching the language range of English.</p>
+<p lang="fr">Ceci est un paragraphe français.</p>
+<p lang="fr-Latn-FR">Ceci est un paragraphe français en latin.</p>
+```
+
+#### Result
+
+{{EmbedLiveSample('Matching_multiple_languages', '', '120')}}
 
 ## Specifications
 
@@ -74,7 +127,7 @@ In this example, the `:lang()` pseudo-class is used to match the parents of quot
 
 ## See also
 
-- Language-related pseudo-classes: {{cssxref(":lang")}}, {{cssxref(":dir")}}
+- The {{cssxref(":dir")}} pseudo-class that matches by directionality of text
 - HTML [`lang`](/en-US/docs/Web/HTML/Global_attributes#lang) attribute
 - HTML [`translate`](/en-US/docs/Web/HTML/Global_attributes#translate) attribute
-- {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}
+- {{RFC(5646, "Tags for Identifying Languages (also known as BCP47)")}}

--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -130,4 +130,4 @@ p {
 - The {{cssxref(":dir")}} pseudo-class that matches by directionality of text
 - HTML [`lang`](/en-US/docs/Web/HTML/Global_attributes#lang) attribute
 - HTML [`translate`](/en-US/docs/Web/HTML/Global_attributes#translate) attribute
-- {{RFC(5646, "Tags for Identifying Languages (also known as BCP47)")}}
+- {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}


### PR DESCRIPTION
Fx 114 supports comma-separated values as params for the `:lang()` CSS pseudo.
Additionally included is compliant string-based matching for language codes / subtags so that explicit wildcards `*-Latn` may be used, e.g.:

```css
:lang("nl", "de") {
  color: green;
}
:lang("*-Latn") {
  color: red;
}
```
__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/26688
- [x] BCD - https://github.com/mdn/browser-compat-data/pull/19957

__Bugzilla:__
- Tracking bug: BUG-1121792


