### PR TITLE
Remove block-caps recommendation

### DIFF
--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -57,4 +57,4 @@ Helpful tools and resources for understanding and debugging HTTP.
 - [RedBot](https://redbot.org/)
   - : Tools to check your cache-related headers.
 - [How Browsers Work (2011)](https://web.dev/howbrowserswork/)
-  - : A very comprehensive article on browser internals and request flow through HTTP protocol. A MUST-READ for any web developer.
+  - : A very comprehensive article on browser internals and request flow through HTTP protocol.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

An article about how browsers work hosted on web.dev was recommended as _"A MUST-READ for any web developer."_

### Motivation

There are many good articles, and this one seems to be one of them. However MDN seems to be more encyclopedic than partisan, and as such this claim seems unnecessary.

### Additional details

none

### Related issues and pull requests

none that I know of (didn't look :see_no_evil: )
