### PR TITLE
26156 content image syntax release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -21,7 +21,7 @@ No notable changes.
 - The [`:nth-child of <selector>` syntax](/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax) allows you to target a group of children based upon the `An+B` rule that also matches a defined selector.
   See ([Firefox bug 1808229](https://bugzil.la/1808229)) for more details.
 - The [`scripting`](/en-US/docs/Web/CSS/@media/scripting) media feature is now supported. See ([Firefox bug 1166581](https://bugzil.la/1166581)) for more details.
-- The [`content`](/en-US/docs/Web/CSS/content) property now supports all image type including, `<gradient>`, `image-set()` and `url()`. See ([Firefox bug 1684958](https://bugzil.la/1684958)) for more details. There is currently an issue with the `::before` and `::after` pseudo selectors that mains that they don't paint `<gradient>`. See ([Firefox bug 1832901](https://bugzil.la/1832901)) for more details.
+- The [`content`](/en-US/docs/Web/CSS/content) property now supports all image type including, `<gradient>`, `image-set()` and `url()`. See ([Firefox bug 1684958](https://bugzil.la/1684958)) for more details. There is currently an issue with the `::before` and `::after` pseudo selectors that means that they don't paint `<gradient>`s. See ([Firefox bug 1832901](https://bugzil.la/1832901)) for more details.
 
 ### JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -21,6 +21,7 @@ No notable changes.
 - The [`:nth-child of <selector>` syntax](/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax) allows you to target a group of children based upon the `An+B` rule that also matches a defined selector.
   See ([Firefox bug 1808229](https://bugzil.la/1808229)) for more details.
 - The [`scripting`](/en-US/docs/Web/CSS/@media/scripting) media feature is now supported. See ([Firefox bug 1166581](https://bugzil.la/1166581)) for more details.
+- The [`content`](/en-US/docs/Web/CSS/content) property now supports all image type including, `<gradient>`, `image-set()` and `url()`. See ([Firefox bug 1684958](https://bugzil.la/1684958)) for more details. There is currently an issue with the `::before` and `::after` pseudo selectors that mains that they don't paint `<gradient>`. See ([Firefox bug 1832901](https://bugzil.la/1832901)) for more details.
 
 ### JavaScript
 


### PR DESCRIPTION
### Description

Added examples for `content: linear-gradient(…)` and `content: image-set(…)`
Added see also links for `<gradient>` and `image-set(…)`

### Motivation

Working on [[CSS] Implement full <image> syntax for 'content' property](https://github.com/mdn/content/issues/26156) issue.

### Additional details

[Relate Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1684958)

### Related issues and pull requests

[Content](https://github.com/mdn/content/pull/26922)
[BCD](https://github.com/mdn/browser-compat-data/pull/19896)
