### PR TITLE
Remove unnecessary event.key checks

### DIFF
--- a/files/en-us/web/api/keyboardevent/key/index.md
+++ b/files/en-us/web/api/keyboardevent/key/index.md
@@ -199,26 +199,21 @@ window.addEventListener(
     }
 
     switch (event.key) {
-      case "Down": // IE/Edge specific value
       case "ArrowDown":
         // Do something for "down arrow" key press.
         break;
-      case "Up": // IE/Edge specific value
       case "ArrowUp":
         // Do something for "up arrow" key press.
         break;
-      case "Left": // IE/Edge specific value
       case "ArrowLeft":
         // Do something for "left arrow" key press.
         break;
-      case "Right": // IE/Edge specific value
       case "ArrowRight":
         // Do something for "right arrow" key press.
         break;
       case "Enter":
         // Do something for "enter" or "return" key press.
         break;
-      case "Esc": // IE/Edge specific value
       case "Escape":
         // Do something for "esc" key press.
         break;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Since IE is deprecated and Edge is now Chromium based, we don't need to check for both the "Down" and "ArrowDown" `event.key` values  for browser compatibility. So we will remove the check for "Down". Similar change has been made to other keys.

### Motivation
Removes unnecessary information.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
