### PR TITLE
Adds documentation for commands.onChanged

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -25,6 +25,8 @@ Listen for the user executing commands that you have registered using the [`comm
 
 ## Events
 
+- {{WebExtAPIRef("commands.onChanged")}}
+  - : Fired when the keyboard shortcut for a command is changed.
 - {{WebExtAPIRef("commands.onCommand")}}
   - : Fired when a command is executed using its associated keyboard shortcut.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
@@ -54,7 +54,7 @@ You could log changes to command shortcuts like this:
 ```js
 function handleChanged(name, newShortcut, oldShortcut) {
   console.log(`Shortcut for: ${name} changed`);
-  console.log(`Fron: ${oldShortcut}`);
+  console.log(`From: ${oldShortcut}`);
   console.log(`To: ${newShortcut}`);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
@@ -21,7 +21,7 @@ browser.commands.onChanged.hasListener(listener)
 
 Events have three functions:
 
-- `addListener(callback)`
+- `addListener(listener)`
   - : Adds a listener to this event.
 - `removeListener(listener)`
   - : Stop listening to this event. The `listener` argument is the listener to remove.
@@ -32,7 +32,7 @@ Events have three functions:
 
 ### Parameters
 
-- `callback`
+- `listener`
 
   - : Function that is called when a command's shortcut changes. The function is passed these:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
@@ -1,0 +1,66 @@
+---
+title: onChanged
+slug: Mozilla/Add-ons/WebExtensions/API/commands/onChanged
+page-type: webextension-api-event
+browser-compat: webextensions.api.commands.onChanged
+---
+
+{{AddonSidebar()}}
+
+Fired when the keyboard shortcut for a command is changed.
+
+The listener is passed the command's name. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).
+
+## Syntax
+
+```js-nolint
+browser.commands.onChanged.addListener(listener)
+browser.commands.onChanged.removeListener(listener)
+browser.commands.onChanged.hasListener(listener)
+```
+
+Events have three functions:
+
+- `addListener(callback)`
+  - : Adds a listener to this event.
+- `removeListener(listener)`
+  - : Stop listening to this event. The `listener` argument is the listener to remove.
+- `hasListener(listener)`
+  - : Check whether `listener` is registered for this event. Returns `true` if it is listening, `false` otherwise.
+
+## addListener syntax
+
+### Parameters
+
+- `callback`
+
+  - : Function that is called when a command's shortcut changes. The function is passed these:
+
+    - `name`
+      - : `string`. Name of the command. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).
+    - `newShortcut`
+      - : `string`. The new active shortcut for this command, or blank if no shortcut is active.
+    - `oldShortcut`
+      - : `string`. The shortcut that was active for this command, or blank if no shortcut was active.
+
+## Browser compatibility
+
+{{Compat}}
+
+## Examples
+
+You could log changes to command shortcuts like this:
+
+```js
+function handleChanged(name, newShortcut, oldShortcut) {
+  console.log(`Shortcut for: ${name} changed`);
+  console.log(`Fron: ${oldShortcut}`);
+  console.log(`To: ${newShortcut}`);
+}
+
+function handleClick() {
+  browser.commands.onChanged.addListener(handleChanged);
+}
+```
+
+{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -21,7 +21,7 @@ browser.commands.onCommand.hasListener(listener)
 
 Events have three functions:
 
-- `addListener(callback)`
+- `addListener(listener)`
   - : Adds a listener to this event.
 - `removeListener(listener)`
   - : Stop listening to this event. The `listener` argument is the listener to remove.
@@ -32,7 +32,7 @@ Events have three functions:
 
 ### Parameters
 
-- `callback`
+- `listener`
 
   - : Function that will be called when a user enters the command's shortcut. The function will be passed the following arguments:
 

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -56,6 +56,7 @@ This article provides information about the changes in Firefox 115 that affect d
 ## Changes for add-on developers
 
 - To support its deprecation from Manifest V3 extensions, manifest key property [`browser_style`](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles) defaults to `false` in [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) and [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) for Manifest V3 extensions ([Firefox bug 1830710](https://bugzil.la/1830710)). See [Manifest v3 migration](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for information about transitioning from `browser_style` in Manifest V3 extensions.
+- Adds {{WebExtAPIRef("commands.onChanged")}} which enables web extensions to listen for changes to command shortcuts ([Firefox bug 1801531](https://bugzil.la/1801531))
 
 ### Removals
 


### PR DESCRIPTION
#### Summary

Add details for the addition of commands.onChanged in 115.

### Related issues and pull requests

Addresses the dev-docs-needed requirement of [Bug 1801531](https://bugzilla.mozilla.org/show_bug.cgi?id=1801531) Implement browser.commands.onChanged.

Related BCD changes in [#19944](https://github.com/mdn/browser-compat-data/pull/19944)