### PR TITLE
Small correction to ctz description

### DIFF
--- a/files/en-us/webassembly/reference/numeric/count_trailing_zeros/index.md
+++ b/files/en-us/webassembly/reference/numeric/count_trailing_zeros/index.md
@@ -5,7 +5,7 @@ slug: WebAssembly/Reference/Numeric/Count_trailing_zeros
 
 {{WebAssemblySidebar}}
 
-The **`ctz`** instructions, short for _count trailing zeros_, are used to count the amount of zeros at the start of the numbers binary representation.
+The **`ctz`** instructions, short for _count trailing zeros_, are used to count the amount of zeros at the end of the numbers binary representation.
 
 {{EmbedInteractiveExample("pages/wat/ctz.html", "tabbed-taller")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Correcting the description for Wasm's `ctz` instruction to indicate it counts zeroes at the end of the number instead of at the start.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current description looks incorrect to me since `ctz` counts trailing zeroes at the end of the number and not leading zeroes at the beginning of the number like `clz`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

From https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#integer-count-trailing-zeros:
> The ctz instruction returns the number of trailing zeros in its operand. The trailing zeros are the longest contiguous sequence of zero-bits starting at the least significant bit and extending upward.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
