### PR TITLE
Fix confusing comment on WebGL1 texImage2D function prototypes

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -15,8 +15,8 @@ image.
 
 ```js-nolint
 // WebGL1
-texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels can be a TypedArray or a DataView or null
-texImage2D(target, level, internalformat, format, type, pixels) // pixels cannot be a TypedArray or a DataView or null
+texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels may be any allowed type
+texImage2D(target, level, internalformat, format, type, pixels) // pixels must be a type with an intrinsic size, e.g. ImageData, HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, or ImageBitmap.
 
 
 // WebGL2

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -15,8 +15,8 @@ image.
 
 ```js-nolint
 // WebGL1
-texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels may be any allowed type
-texImage2D(target, level, internalformat, format, type, pixels) // pixels must be a type with an intrinsic size, e.g. ImageData, HTMLImageElement, HTMLCanvasElement, HTMLVideoElement, or ImageBitmap.
+texImage2D(target, level, internalformat, width, height, border, format, type, pixels)
+texImage2D(target, level, internalformat, format, type, pixels)
 
 
 // WebGL2
@@ -802,7 +802,15 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
 
 - `pixels`
 
-  - : One of the following objects can be used as a pixel source for the texture:
+  - : The following types can always be used as a pixel source for the texture:
+
+    - {{domxref("ImageData")}},
+    - {{domxref("HTMLImageElement")}},
+    - {{domxref("HTMLCanvasElement")}},
+    - {{domxref("HTMLVideoElement")}},
+    - {{domxref("ImageBitmap")}}.
+
+  - : The following types can only be used as a pixel source when `width`, `height`, and `border` are specified:
 
     - {{jsxref("Uint8Array")}} (must be used if `type` is `gl.UNSIGNED_BYTE`)
     - {{jsxref("Uint16Array")}} (must be used if `type` is either
@@ -811,11 +819,6 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
       `ext.HALF_FLOAT_OES`)
     - {{jsxref("Uint32Array")}} (must be used if `type` is `gl.UNSIGNED_INT` or `ext.UNSIGNED_INT_24_8_WEBGL`)
     - {{jsxref("Float32Array")}} (must be used if `type` is `gl.FLOAT`)
-    - {{domxref("ImageData")}},
-    - {{domxref("HTMLImageElement")}},
-    - {{domxref("HTMLCanvasElement")}},
-    - {{domxref("HTMLVideoElement")}},
-    - {{domxref("ImageBitmap")}}.
 
 - `offset`
   - : (WebGL 2 only) A {{domxref("WebGL_API/Types", "GLintptr")}} byte offset into the

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -810,7 +810,7 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
     - {{domxref("HTMLVideoElement")}},
     - {{domxref("ImageBitmap")}}.
 
-  - : The following types can only be used as a pixel source when `width`, `height`, and `border` are specified:
+    The following types can only be used as a pixel source when `width`, `height`, and `border` are specified:
 
     - {{jsxref("Uint8Array")}} (must be used if `type` is `gl.UNSIGNED_BYTE`)
     - {{jsxref("Uint16Array")}} (must be used if `type` is either


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change fixes a confusing comment on the WebGL1 texImage2D function prototypes.

### Motivation

The phrase "pixels can be a TypedArray or a DataView or null" made me think these were the only three allowed types.  Then the next comment said these types aren't allowed.  So which types *are* allowed?  This change answers that question and avoids the original confusion I had.