### PR TITLE
Remove non-standard error properties in examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -51,15 +51,12 @@ compatibility with earlier versions of the specification.
 
 ```js
 try {
-  throw new EvalError("Hello", "someFile.js", 10);
+  throw new EvalError("Hello");
 } catch (e) {
   console.log(e instanceof EvalError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "EvalError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
@@ -39,15 +39,12 @@ _Inherits instance methods from its parent {{jsxref("Error")}}_.
 
 ```js
 try {
-  throw new EvalError("Hello", "someFile.js", 10);
+  throw new EvalError("Hello");
 } catch (e) {
   console.log(e instanceof EvalError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "EvalError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
@@ -44,10 +44,7 @@ try {
   console.log(e instanceof ReferenceError); // true
   console.log(e.message); // "undefinedVariable is not defined"
   console.log(e.name); // "ReferenceError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 6
-  console.log(e.stack); // "@Scratchpad/2:2:7\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -55,15 +52,12 @@ try {
 
 ```js
 try {
-  throw new ReferenceError("Hello", "someFile.js", 10);
+  throw new ReferenceError("Hello");
 } catch (e) {
   console.log(e instanceof ReferenceError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "ReferenceError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
@@ -52,10 +52,7 @@ try {
   console.log(e instanceof ReferenceError); // true
   console.log(e.message); // "undefinedVariable is not defined"
   console.log(e.name); // "ReferenceError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 6
-  console.log(e.stack); // "@Scratchpad/2:2:7\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -63,15 +60,12 @@ try {
 
 ```js
 try {
-  throw new ReferenceError("Hello", "someFile.js", 10);
+  throw new ReferenceError("Hello");
 } catch (e) {
   console.log(e instanceof ReferenceError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "ReferenceError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -63,7 +63,7 @@ try {
   console.error(e.fileName); // someFile.js
   console.error(e.lineNumber); // 10
   console.error(e.columnNumber); // 0
-  console.error(e.stack); // @debugger eval code:3:9
+  console.error(e.stack); // @debugger eval code:2:9
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -41,13 +41,10 @@ _Inherits instance methods from its parent {{jsxref("Error")}}_.
 try {
   eval("hoo bar");
 } catch (e) {
-  console.error(e instanceof SyntaxError);
-  console.error(e.message);
-  console.error(e.name);
-  console.error(e.fileName);
-  console.error(e.lineNumber);
-  console.error(e.columnNumber);
-  console.error(e.stack);
+  console.log(e instanceof SyntaxError); // true
+  console.log(e.message);
+  console.log(e.name); // "SyntaxError"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -55,15 +52,12 @@ try {
 
 ```js
 try {
-  throw new SyntaxError("Hello", "someFile.js", 10);
+  throw new SyntaxError("Hello");
 } catch (e) {
-  console.error(e instanceof SyntaxError); // true
-  console.error(e.message); // Hello
-  console.error(e.name); // SyntaxError
-  console.error(e.fileName); // someFile.js
-  console.error(e.lineNumber); // 10
-  console.error(e.columnNumber); // 0
-  console.error(e.stack); // @debugger eval code:2:9
+  console.log(e instanceof SyntaxError); // true
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "SyntaxError"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
@@ -49,13 +49,10 @@ SyntaxError(message, fileName, lineNumber)
 try {
   eval("hoo bar");
 } catch (e) {
-  console.error(e instanceof SyntaxError);
+  console.error(e instanceof SyntaxError); // true
   console.error(e.message);
-  console.error(e.name);
-  console.error(e.fileName);
-  console.error(e.lineNumber);
-  console.error(e.columnNumber);
-  console.error(e.stack);
+  console.error(e.name); // "SyntaxError"
+  console.error(e.stack); // Stack of the error
 }
 ```
 
@@ -63,15 +60,12 @@ try {
 
 ```js
 try {
-  throw new SyntaxError("Hello", "someFile.js", 10);
+  throw new SyntaxError("Hello");
 } catch (e) {
   console.error(e instanceof SyntaxError); // true
-  console.error(e.message); // Hello
-  console.error(e.name); // SyntaxError
-  console.error(e.fileName); // someFile.js
-  console.error(e.lineNumber); // 10
-  console.error(e.columnNumber); // 0
-  console.error(e.stack); // @debugger eval code:3:9
+  console.error(e.message); // "Hello"
+  console.error(e.name); // "SyntaxError"
+  console.error(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
@@ -50,10 +50,7 @@ try {
   console.log(e instanceof TypeError); // true
   console.log(e.message); // "null has no properties"
   console.log(e.name); // "TypeError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 2
-  console.log(e.stack); // "@Scratchpad/2:2:3\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -61,15 +58,12 @@ try {
 
 ```js
 try {
-  throw new TypeError("Hello", "someFile.js", 10);
+  throw new TypeError("Hello");
 } catch (e) {
   console.log(e instanceof TypeError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "TypeError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/typeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/typeerror/index.md
@@ -52,10 +52,7 @@ try {
   console.log(e instanceof TypeError); // true
   console.log(e.message); // "null has no properties"
   console.log(e.name); // "TypeError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 2
-  console.log(e.stack); // "@Scratchpad/2:2:3\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -63,15 +60,12 @@ try {
 
 ```js
 try {
-  throw new TypeError("Hello", "someFile.js", 10);
+  throw new TypeError("Hello");
 } catch (e) {
   console.log(e instanceof TypeError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "TypeError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/index.md
@@ -44,10 +44,7 @@ try {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "malformed URI sequence"
   console.log(e.name); // "URIError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 2
-  console.log(e.stack); // "@Scratchpad/2:2:3\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -55,15 +52,12 @@ try {
 
 ```js
 try {
-  throw new URIError("Hello", "someFile.js", 10);
+  throw new URIError("Hello");
 } catch (e) {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "URIError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/urierror/urierror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/urierror/index.md
@@ -52,10 +52,7 @@ try {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "malformed URI sequence"
   console.log(e.name); // "URIError"
-  console.log(e.fileName); // "Scratchpad/1"
-  console.log(e.lineNumber); // 2
-  console.log(e.columnNumber); // 2
-  console.log(e.stack); // "@Scratchpad/2:2:3\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -63,15 +60,12 @@ try {
 
 ```js
 try {
-  throw new URIError("Hello", "someFile.js", 10);
+  throw new URIError("Hello");
 } catch (e) {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "Hello"
   console.log(e.name); // "URIError"
-  console.log(e.fileName); // "someFile.js"
-  console.log(e.lineNumber); // 10
-  console.log(e.columnNumber); // 0
-  console.log(e.stack); // "@Scratchpad/2:2:9\n"
+  console.log(e.stack); // Stack of the error
 }
 ```
 


### PR DESCRIPTION
### Description

Just a small typo in referencing the error

### Motivation

by referencing the correct line caused the error, Hope that's could actually help readers

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
