### PR TITLE
Fix incorrect DocType.systemId example code

### DIFF
--- a/files/en-us/web/api/documenttype/systemid/index.md
+++ b/files/en-us/web/api/documenttype/systemid/index.md
@@ -27,7 +27,7 @@ const docType = document.implementation.createDocumentType(
   "http://www.w3.org/2000/svg"
 );
 
-console.log(docType.publicId); // Displays "http://www.w3.org/2000/svg"
+console.log(docType.systemId); // Displays "http://www.w3.org/2000/svg"
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

Fix incorrect DocType.systemId example code

### Motivation

As Above

### Additional details

[https://developer.mozilla.org/en-US/docs/Web/API/DocumentType/systemId](https://developer.mozilla.org/en-US/docs/Web/API/DocumentType/systemId)

### Related issues and pull requests
