### PR TITLE
media/formats/containers: FF for Android supports AV1 in mp4

### DIFF
--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -476,7 +476,7 @@ In addition, you can [add the `codecs` parameter](/en-US/docs/Web/Media/Formats/
       <td></td>
       <td>
         <p>Yes</p>
-        <p>Firefox support for AV1 is disabled on Android ([Firefox bug 1672276](https://bugzil.la/1672276)) and on Windows on ARM (enable by setting the preference <code>media.av1.enabled</code> to <code>true</code>).</p>
+        <p>Firefox support for AV1 is disabled on Windows on ARM (enable by setting the preference <code>media.av1.enabled</code> to <code>true</code>).</p>
       </td>
       <td></td>
     </tr>


### PR DESCRIPTION
bug is resolved, released with FF 113.

See also https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#av1

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

✍️ Update AV1 support in mp4 for FF Android.

### Motivation

data was outdated.

### Additional details

https://bugzilla.mozilla.org/show_bug.cgi?id=1672276

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
