### PR TITLE
fix: Typo Object.isExtensible -> Object.preventExtensions

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -33,7 +33,7 @@ A {{jsxref("Boolean")}} indicating whether or not the target was successfully se
 
 ## Description
 
-`Reflect.preventExtensions()` provides the reflective semantic of preventing extensions of an object. The differences with {{jsxref("Object.isExtensible()")}} are:
+`Reflect.preventExtensions()` provides the reflective semantic of preventing extensions of an object. The differences with {{jsxref("Object.preventExtensions()")}} are:
 
 - `Reflect.preventExtensions()` throws a {{jsxref("TypeError")}} if the target is not an object, while `Object.preventExtensions()` always returns non-object targets as-is.
 - `Reflect.preventExtensions()` returns a {{jsxref("Boolean")}} indicating whether or not the target was successfully set to prevent extensions, while `Object.preventExtensions()` returns the target object.


### PR DESCRIPTION
### Description

This list on the [Reflect.preventExtensions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions#description) page is comparing `Reflect.preventExtensions` with `Object.preventExtensions`, but currently it begins "The differences with [Object.isExtensible()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible) are". This PR corrects the method reference.

### Motivation

Improve accuracy of page.

### Additional details

N/A

### Related issues and pull requests

N/A