### PR TITLE
Fix VisualViewport offsetLeft property name in index.md

### DIFF
--- a/files/en-us/web/api/visualviewport/offsetleft/index.md
+++ b/files/en-us/web/api/visualviewport/offsetleft/index.md
@@ -1,7 +1,7 @@
 ---
-title: "VisualViewport: offsetleft property"
-short-title: offsetleft
-slug: Web/API/VisualViewport/offsetleft
+title: "VisualViewport: offsetLeft property"
+short-title: offsetLeft
+slug: Web/API/VisualViewport/offsetLeft
 page-type: web-api-instance-property
 browser-compat: api.VisualViewport.offsetLeft
 ---


### PR DESCRIPTION
Replace occurrences of "offsetleft" (erroneous property name) with "offsetLeft" (correct property name).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I corrected the capitalization of the `VisualViewport.offsetLeft` property (i.e., `offsetleft` to `offsetLeft`).

### Motivation

I thought it would be a good idea to have the name of the property, as displayed on MDN, match that of the property as it is defined in the specification. (I’m assuming `offsetleft` was simply a typo.)

### Additional details

Here’s [`offsetLeft` in the spec](https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
