### PR TITLE
fix: use `console.log` instead of `console.error`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
@@ -49,10 +49,10 @@ SyntaxError(message, fileName, lineNumber)
 try {
   eval("hoo bar");
 } catch (e) {
-  console.error(e instanceof SyntaxError); // true
-  console.error(e.message);
-  console.error(e.name); // "SyntaxError"
-  console.error(e.stack); // Stack of the error
+  console.log(e instanceof SyntaxError); // true
+  console.log(e.message);
+  console.log(e.name); // "SyntaxError"
+  console.log(e.stack); // Stack of the error
 }
 ```
 
@@ -62,10 +62,10 @@ try {
 try {
   throw new SyntaxError("Hello");
 } catch (e) {
-  console.error(e instanceof SyntaxError); // true
-  console.error(e.message); // "Hello"
-  console.error(e.name); // "SyntaxError"
-  console.error(e.stack); // Stack of the error
+  console.log(e instanceof SyntaxError); // true
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "SyntaxError"
+  console.log(e.stack); // Stack of the error
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Thanks to @Josh-Cena suggest using `console.log` here, because we are not actually giving out indications of exceptions, just information about an `Error` object.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Relates to #26961
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
