### PR TITLE
Add a note on how navigation.navigate()'s url parameter is resolved.

### DIFF
--- a/files/en-us/web/api/navigation/navigate/index.md
+++ b/files/en-us/web/api/navigation/navigate/index.md
@@ -23,7 +23,7 @@ navigate(url, options)
 ### Parameters
 
 - `url`
-  - : The destination URL to navigate to.
+  - : The destination URL to navigate to. Note that when calling `navigate()` on a another window's `navigation` object, the URL will be resolved relative to the target window's URL, not the calling window's URL. This matching the behavior of {{domxref("History_API", "the History API")}}, but not the behavior of the {{domxref("Location", "the location API")}}.
 - `options` {{optional_inline}}
   - : An options object containing the following properties:
     - `state`

--- a/files/en-us/web/api/navigation/navigate/index.md
+++ b/files/en-us/web/api/navigation/navigate/index.md
@@ -23,7 +23,7 @@ navigate(url, options)
 ### Parameters
 
 - `url`
-  - : The destination URL to navigate to. Note that when calling `navigate()` on a another window's `navigation` object, the URL will be resolved relative to the target window's URL, not the calling window's URL. This matching the behavior of {{domxref("History_API", "the History API")}}, but not the behavior of the {{domxref("Location", "the location API")}}.
+  - : The destination URL to navigate to. Note that when calling `navigate()` on a another window's `navigation` object, the URL will be resolved relative to the target window's URL, not the calling window's URL. This matches the behavior of the [History API](/en-US/docs/Web/API/History_API), but not the behavior of the [Location API](/en-US/docs/Web/API/Location).
 - `options` {{optional_inline}}
   - : An options object containing the following properties:
     - `state`


### PR DESCRIPTION
### Description

This provides a clarification on how navigaton.navigate()'s url parameter behaves when calling navigate() on another window's navigation interface.

### Motivation

If a web developer is migrating to the navigation API from the location API, this may cause unexpected behavior.  I hit a case like this while writing conformance tests during implementation of the navigation API.

### Additional details

Spec PR for the navigation API: https://github.com/whatwg/html/pull/8502
Explainer of the API: https://github.com/WICG/navigation-api

### Related issues and pull requests
N/A