### PR TITLE
Fix popup blocker description

### DIFF
--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -96,7 +96,7 @@ window.open("https://www.mozilla.org/", "mozillaTab");
 
 Alternatively, the following example demonstrates how to open a popup, using the `popup` feature.
 
-> **Warning:** Modern browsers have built-in popup blockers, limiting the opening of such popups to being in direct respond to user input. Popups opened outside the context of a click may cause a notification to appear, giving the option to enable or discard them).
+> **Warning:** Modern browsers have built-in popup blockers, limiting the opening of such popups to being in direct response to user input. Popups opened outside the context of a click may cause a notification to appear, giving the option to enable or discard them.
 
 ```js
 window.open("https://www.mozilla.org/", "mozillaWindow", "popup");

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -96,7 +96,7 @@ window.open("https://www.mozilla.org/", "mozillaTab");
 
 Alternatively, the following example demonstrates how to open a popup, using the `popup` feature.
 
-> **Warning:** Modern browsers have built-in popup blockers, preventing the opening of such popups. Users must have changed their browser settings to enable popups or enable them on a site-per-site basis from the browser's user interface (a notification may appear when the site attempts to open a popup for the first time, giving the option to enable or discard them).
+> **Warning:** Modern browsers have built-in popup blockers, limiting the opening of such popups to being in direct respond to user input. Popups opened outside the context of a click may cause a notification to appear, giving the option to enable or discard them).
 
 ```js
 window.open("https://www.mozilla.org/", "mozillaWindow", "popup");


### PR DESCRIPTION
### Description

Browsers don't block all popups, only those which occur outside the context of "user activation" (eg. a click).

### Motivation

It's incorrect. Popups are used ALL across the web (eg. many login buttons) and they don't require the user to modify their browser settings. There's no reason to discourage this type of popup.

### Additional details

See https://html.spec.whatwg.org/#tracking-user-activation for details

### Related issues and pull requests
