### PR TITLE
clarified distinction between call and apply

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -31,7 +31,7 @@ The result of calling the function with the specified `this` value and arguments
 
 ## Description
 
-> **Note:** This function is almost identical to {{jsxref("Function/call", "call()")}}, except that `call()` accepts an **argument list**, while `apply()` accepts a **single array of arguments** — for example, `func.apply(this, ['eat', 'bananas'])` vs. `func.call(this, 'eat', 'bananas')`.
+> **Note:** This function is almost identical to {{jsxref("Function/call", "call()")}}, except that the function arguments are passed to `call()` individually as a list, while for `apply()` they are combined in one object, typically an array — for example, `func.call(this, "eat", "bananas")` vs. `func.apply(this, ["eat", "bananas"])`.
 
 Normally, when calling a function, the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) inside the function is the object that the function was accessed on. With `apply()`, you can assign an arbitrary value as `this` when calling an existing function, without first attaching the function to the object as a property. This allows you to use methods of one object as generic utility functions.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -32,7 +32,7 @@ The result of calling the function with the specified `this` value and arguments
 
 ## Description
 
-> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that the function arguments are passed to `call()` individually as a **list**, while for `apply()` they are combined in one object, typically an array — for example, `func.call(this, 'eat', 'bananas')` vs. `func.apply(this, ['eat', 'bananas'])`.
+> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that the function arguments are passed to `call()` individually as a list, while for `apply()` they are combined in one object, typically an array — for example, `func.call(this, "eat", "bananas")` vs. `func.apply(this, ["eat", "bananas"])`.
 
 Normally, when calling a function, the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) inside the function is the object that the function was accessed on. With `call()`, you can assign an arbitrary value as `this` when calling an existing function, without first attaching the function to the object as a property. This allows you to use methods of one object as generic utility functions.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -32,7 +32,7 @@ The result of calling the function with the specified `this` value and arguments
 
 ## Description
 
-> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that `call()` accepts an **argument list**, while `apply()` accepts a **single array of arguments** — for example, `func.apply(this, ['eat', 'bananas'])` vs. `func.call(this, 'eat', 'bananas')`.
+> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that `call()` accepts an **argument list**, while `apply()` accepts a **single array or an array-like object of arguments** — for example, `func.call(this, 'eat', 'bananas')` vs. `func.apply(this, ['eat', 'bananas'])`.
 
 Normally, when calling a function, the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) inside the function is the object that the function was accessed on. With `call()`, you can assign an arbitrary value as `this` when calling an existing function, without first attaching the function to the object as a property. This allows you to use methods of one object as generic utility functions.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -32,7 +32,7 @@ The result of calling the function with the specified `this` value and arguments
 
 ## Description
 
-> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that `call()` accepts an **argument list**, while `apply()` accepts a **single array or an array-like object of arguments** — for example, `func.call(this, 'eat', 'bananas')` vs. `func.apply(this, ['eat', 'bananas'])`.
+> **Note:** This function is almost identical to {{jsxref("Function/apply", "apply()")}}, except that the function arguments are passed to `call()` individually as a **list**, while for `apply()` they are combined in one object, typically an array — for example, `func.call(this, 'eat', 'bananas')` vs. `func.apply(this, ['eat', 'bananas'])`.
 
 Normally, when calling a function, the value of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) inside the function is the object that the function was accessed on. With `call()`, you can assign an arbitrary value as `this` when calling an existing function, without first attaching the function to the object as a property. This allows you to use methods of one object as generic utility functions.
 


### PR DESCRIPTION
Added detail that apply can accept an array-like object and reversed the order of the examples to match the previous order in the sentence.

const numbers = [5, 6, 2, 3, 7];

const max = Math.max.apply(null, numbers);

console.log(max);
// Expected output: 7

const min = Math.min.apply(null, numbers);

console.log(min);
// Expected output: 2

const num2 = {
  length: 5,
  0: 5,
  1: 6,
  2: 2,
  3: 3,
  4: 7,
};

const min2 = Math.min.apply(null, num2);
const max2 = Math.max.apply(null, num2);

console.log(max2);
console.log(min2);

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
