### PR TITLE
Fix broken link references

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -13,7 +13,7 @@ When you have a very long table or when you purposefully want to display just a 
 
 The `aria-rowindextext` should only be included **in addition to**, not as a replacement of, the `aria-rowindex`. Some assistive technologies use the numeric row index for the purpose of keeping track of the user's position or providing alternative table navigation. The `aria-rowindextext` is useful if that integer value isn't meaningful or does not reflect the displayed index, such as a game of Chess or Battleship.
 
-The `aria-rowindextext` is added to each {{HTMLElement('row')}} or to elements with the `row` role. It can also be addition to cells or owned elements of each row.
+The `aria-rowindextext` is added to each {{HTMLElement('tr')}} or to elements with the `row` role. It can also be addition to cells or owned elements of each row.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -18,7 +18,7 @@ The `aria-rowindextext` is added to each {{HTMLElement('row')}} or to elements w
 ## Values
 
 - `<string>`
-  - The human-readable text alternative of the numeric [`aria-spanindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-spanindex)
+  - The human-readable text alternative of the numeric [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 
 ## Associated roles
 


### PR DESCRIPTION
### Description

_I believe_ this is meant to be referencing `aria-rowindex`, not `aria-spanindex`, which, as far as I can tell, does not exist.

### Motivation

Link/reference material is broken

### Additional details

N/A

### Related issues and pull requests

N/A
