### PR TITLE
chore: remove tailing slash of MDN docs' urls

### DIFF
--- a/files/en-us/games/index.md
+++ b/files/en-us/games/index.md
@@ -27,7 +27,7 @@ To get started, see:
 
 ## Examples
 
-For a list of web game examples, see our [tutorials page](/en-US/docs/Games/Tutorials/). Also, check out [games.mozilla.org](https://games.mozilla.org/) for more useful resources!
+For a list of web game examples, see our [tutorials page](/en-US/docs/Games/Tutorials). Also, check out [games.mozilla.org](https://games.mozilla.org/) for more useful resources!
 
 ## See also
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
@@ -72,7 +72,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 
 Used in roles:
 
-- [`table`](/en-US/docs/Web/Accessibility/ARIA/Role/Table_role)
+- [`table`](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)
 
 Inherits into roles:
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
@@ -72,7 +72,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 
 Used in roles:
 
-- [`table`](/en-US/docs/Web/Accessibility/ARIA/Role/Table_role/)
+- [`table`](/en-US/docs/Web/Accessibility/ARIA/Role/Table_role)
 
 Inherits into roles:
 

--- a/files/en-us/web/accessibility/aria/roles/input_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/input_role/index.md
@@ -31,7 +31,7 @@ Do not use.
 - [ARIA: `slider` role](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role)
 - [ARIA: `spinbutton` role](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role)
 - [ARIA: `textbox` role](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role)
-- [HTML: the `input` element](/en-US/docs/Web/HTML/Element/input/)
+- [HTML: the `input` element](/en-US/docs/Web/HTML/Element/input)
 
 <section id="Quick_links">
 

--- a/files/en-us/web/css/backdrop-filter/index.md
+++ b/files/en-us/web/css/backdrop-filter/index.md
@@ -125,5 +125,5 @@ body {
 - {{cssxref("filter")}}
 - {{cssxref("&lt;filter-function&gt;")}}
 - {{cssxref("background-blend-mode")}}, {{cssxref("mix-blend-mode")}}
-- [CSS filter effects](/en-us/docs/Web/CSS/filter_effects/)
+- [CSS filter effects](/en-us/docs/Web/CSS/filter_effects)
 - [CSS compositing and blending](/en-US/docs/Web/CSS/Compositing_and_Blending)

--- a/files/en-us/web/css/backdrop-filter/index.md
+++ b/files/en-us/web/css/backdrop-filter/index.md
@@ -125,5 +125,5 @@ body {
 - {{cssxref("filter")}}
 - {{cssxref("&lt;filter-function&gt;")}}
 - {{cssxref("background-blend-mode")}}, {{cssxref("mix-blend-mode")}}
-- [CSS filter effects](/en-us/docs/Web/CSS/filter_effects)
-- [CSS compositing and blending](/en-US/docs/Web/CSS/Compositing_and_Blending)
+- [CSS filter effects](/en-US/docs/Web/CSS/CSS_filter_effects)
+- [CSS compositing and blending](/en-US/docs/Web/CSS/CSS_compositing_and_blending)

--- a/files/en-us/web/progressive_web_apps/reference/index.md
+++ b/files/en-us/web/progressive_web_apps/reference/index.md
@@ -11,7 +11,7 @@ This reference describes the technologies, features, and APIs that [Progressive 
 
 ## Web app manifest
 
-- [Web app manifest members](/en-US/docs/Web/Manifest/)
+- [Web app manifest members](/en-US/docs/Web/Manifest)
   - : Developers can use web app manifest members to describe a PWA, customize its appearance, and more deeply integrate it into the operating system.
 
 ## Service Worker APIs


### PR DESCRIPTION
### Description

remove tailing slash of MDN docs' urls
