### PR TITLE
fix: update og:image

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -168,7 +168,7 @@ For example, [Open Graph Data](https://ogp.me/) is a metadata protocol that Face
 ```html
 <meta
   property="og:image"
-  content="https://developer.mozilla.org/static/img/opengraph-logo.png" />
+  content="/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides

--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -168,7 +168,7 @@ For example, [Open Graph Data](https://ogp.me/) is a metadata protocol that Face
 ```html
 <meta
   property="og:image"
-  content="/mdn-social-share.png" />
+  content="https://developer.mozilla.org/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace the image linked as `og:image`.

### Motivation

We get 40k weekly hits on `https://developer.mozilla.org/static/img/opengraph-logo.72382e605ce3.png`, which 404s, because `opengraph-logo.png` has been replaced by [mdn-social-share.png](https://developer.mozilla.org/mdn-social-share.png).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See also https://github.com/mdn/translated-content/pull/13501 for the same change in translated-content.
