### PR TITLE
Updates: CSS Multicol guides

### DIFF
--- a/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
@@ -82,7 +82,7 @@ This CSS would give the same result as [example 2](#specifying_the_width_of_colu
 }
 ```
 
-This CSS would give the same result as example 3, with both `column-count` and `column-width` set.
+This CSS would give the same result as [example 3](#specifying-both-number-and-width-of-columns), with both `column-count` and `column-width` set.
 
 ```css
 .container {

--- a/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
@@ -12,7 +12,7 @@ Multi-column layout, usually referred to as multicol layout, is a specification 
 
 Multicol is unlike any of the other layout methods we have in CSS; it fragments the content, including all descendant elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) by creating a print stylesheet.
 
-In this guide, we will be discussing several of the properties defined by the specification, including:
+In this guide, we will be discussing the properties defined by the specification, including:
 
 - {{cssxref("column-width")}}
 - {{cssxref("column-count")}}
@@ -24,6 +24,9 @@ In this guide, we will be discussing several of the properties defined by the sp
 - {{cssxref("column-span")}}
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
+- {{cssxref("break-after")}}
+- {{cssxref("break-before")}}
+- {{cssxref("break-inside")}}
 
 ## Defining columns
 

--- a/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
@@ -8,11 +8,11 @@ page-type: guide
 
 Multi-column layout, usually referred to as multicol layout, is a specification for laying out content into a set of column boxes much like columns in a newspaper. This guide explains how the specification works with some common use case examples.
 
-## Key concepts and terminology
+## Key properties
 
-Multicol is unlike any of the other layout methods we have in CSS; it fragments the content, including all descendant elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) by creating a print stylesheet.
+Multicol layout is unlike any of the other layout methods in CSS; it fragments the content, including all descendant elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) by creating a print stylesheet.
 
-In this guide, we will be discussing the properties defined by the specification, including:
+In this and subsequent guides, we will be discussing the following properties defined in the [CSS multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout) module:
 
 - {{cssxref("column-width")}}
 - {{cssxref("column-count")}}
@@ -30,7 +30,7 @@ In this guide, we will be discussing the properties defined by the specification
 
 ## Defining columns
 
-By adding `column-count` or `column-width` to an element, or the `columns` shorthand, the element becomes a _multi-column container_ or _multicol container_ for short. The columns are anonymous boxes and are described as column boxes in the specification.
+By adding the `column-count` or the `column-width` property to an element, or using the `columns` shorthand, the element becomes a _multi-column container_ or _multicol container_ for short. The columns are anonymous boxes; they're described as _column boxes_ in the specification.
 
 ### Specifying the number of columns
 
@@ -40,15 +40,15 @@ In the below example, we use the `column-count` property to create three columns
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
-In the above example, the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new [Block Formatting Context (BFC)](/en-US/docs/Web/Guide/CSS/Block_formatting_context) which means margins on child elements do not collapse with any margin on the container.
+In the above example, the content is wrapped within the paragraph `<p>` tags with the default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a [block formatting context (BFC)](/en-US/docs/Web/Guide/CSS/Block_formatting_context) because of which margins on child elements do not collapse with any margin on the container.
 
 ### Specifying the width of columns
 
-The `column-width` property is used to set the optimal width for every column box. If you declare a column width, the browser will work out how many columns of that width will fit into the multicol container and distribute any extra space equally between the columns. Therefore, the column width should be seen as a minimum width, as column boxes are likely to be wider due to the additional space.
+The `column-width` property is used to set the optimal width for every column box. If you declare a column width, the browser will work out how many columns of that width will fit into the multicol container and distribute any extra space equally between the columns. Therefore, the column width should be seen as minimum width because the column boxes are likely to be wider due to the additional space.
 
-The column box will only shrink to be smaller than the declared column width in the case of a single column with less available width than the value of `column-width`.
+In the case of a single column with less width available than the value of `column-width`, the column box will shrink to be smaller than the declared column width.
 
-In the below example, we use the `column-width` property with a value of `200px`. We get as many 200-pixel columns as will fit the container, with the extra space shared equally.
+In the example below, the `column-width` property is set to `200px`. We get as many 200-pixel columns as will fit the container, with the extra space shared equally.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-width.html", '100%', 550)}}
 
@@ -64,9 +64,9 @@ In this next example, we use `column-width` of `200px` and `column-count` of `2`
 
 ### Shorthand for column properties
 
-You can use the `columns` shorthand to set `column-count` and `column-width`. If you set a length unit, this will be used for `column-width`, set an integer and it will be used for `column-count`. You can set both, separating the two values with a space.
+You can use the `columns` shorthand to set the `column-count` and `column-width` values. If you specify a length unit, the value will be used for `column-width`, and if you specify an integer, the value will be used for `column-count`. You can set both the properties, separating the two values with a space.
 
-This CSS would give the same result as example 1, `column-count` set to `3`.
+This CSS would give the same result as [example 1](#specifying_the_number_of_columns), with `column-count` set to `3`.
 
 ```css
 .container {
@@ -74,7 +74,7 @@ This CSS would give the same result as example 1, `column-count` set to `3`.
 }
 ```
 
-This CSS would give the same result as example 2, with `column-width` of `200px`.
+This CSS would give the same result as [example 2](#specifying_the_width_of_columns), with `column-width` of `200px`.
 
 ```css
 .container {

--- a/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
@@ -10,26 +10,24 @@ Multi-column layout, usually referred to as multicol layout, is a specification 
 
 ## Key concepts and terminology
 
-Multicol is unlike any of the other layout methods we have in CSS; it fragments the content, including all descendant elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS Paged Media](/en-US/docs/Web/CSS/CSS_paged_media) by creating a print stylesheet.
+Multicol is unlike any of the other layout methods we have in CSS; it fragments the content, including all descendant elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) by creating a print stylesheet.
 
-The properties defined by the specification are:
+In this guide, we will be discussing several of the properties defined by the specification, including:
 
 - {{cssxref("column-width")}}
 - {{cssxref("column-count")}}
-- {{cssxref("columns")}}
+- {{cssxref("columns")}} shorthand
 - {{cssxref("column-rule-color")}}
 - {{cssxref("column-rule-style")}}
 - {{cssxref("column-rule-width")}}
-- {{cssxref("column-rule")}}
+- {{cssxref("column-rule")}} shorthand
 - {{cssxref("column-span")}}
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
 
-By adding `column-count` or `column-width` to an element, the element becomes a _multi-column container_ or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
-
 ## Defining columns
 
-To create a multicol container, you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
+By adding `column-count` or `column-width` to an element, or the `columns` shorthand, the element becomes a _multi-column container_ or _multicol container_ for short. The columns are anonymous boxes and are described as column boxes in the specification.
 
 ### Specifying the number of columns
 
@@ -39,15 +37,15 @@ In the below example, we use the `column-count` property to create three columns
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
-In the above example, the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
+In the above example, the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new [Block Formatting Context (BFC)](/en-US/docs/Web/Guide/CSS/Block_formatting_context) which means margins on child elements do not collapse with any margin on the container.
 
 ### Specifying the width of columns
 
-The `column-width` property is used to set the optimal width for every column box. If you declare a column-width, the browser will work out how many columns of that width will fit into the multicol container and distribute any extra space equally between the columns. Therefore, the column width should be seen as a minimum width, as column boxes are likely to be wider due to the additional space.
+The `column-width` property is used to set the optimal width for every column box. If you declare a column width, the browser will work out how many columns of that width will fit into the multicol container and distribute any extra space equally between the columns. Therefore, the column width should be seen as a minimum width, as column boxes are likely to be wider due to the additional space.
 
 The column box will only shrink to be smaller than the declared column width in the case of a single column with less available width than the value of `column-width`.
 
-In the below example, we use the `column-width` property with a value of 200px. We get as many 200 pixel columns as will fit the container, with the extra space shared equally.
+In the below example, we use the `column-width` property with a value of `200px`. We get as many 200-pixel columns as will fit the container, with the extra space shared equally.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-width.html", '100%', 550)}}
 
@@ -57,7 +55,7 @@ If you specify both the properties on a multicol container, then `column-count` 
 
 When using both properties together, you may get fewer columns than specified in the value for `column-count`.
 
-In this next example, we use `column-width` of 200px and `column-count` of 2. Even if there is space for more than two columns, we get two. If there is not enough space for two columns of 200px, however, we get one.
+In this next example, we use `column-width` of `200px` and `column-count` of `2`. Even if there is space for more than two columns, we get two. If there is not enough space for two columns of at least 200 pixels each, we get one.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count-width.html", '100%', 550)}}
 
@@ -65,7 +63,7 @@ In this next example, we use `column-width` of 200px and `column-count` of 2. Ev
 
 You can use the `columns` shorthand to set `column-count` and `column-width`. If you set a length unit, this will be used for `column-width`, set an integer and it will be used for `column-count`. You can set both, separating the two values with a space.
 
-This CSS would give the same result as example 1, `column-count` set to 3.
+This CSS would give the same result as example 1, `column-count` set to `3`.
 
 ```css
 .container {
@@ -73,7 +71,7 @@ This CSS would give the same result as example 1, `column-count` set to 3.
 }
 ```
 
-This CSS would give the same result as example 2, with `column-width` of 200px.
+This CSS would give the same result as example 2, with `column-width` of `200px`.
 
 ```css
 .container {

--- a/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
@@ -59,6 +59,4 @@ In the example below, we are using the `orphans` property to control the number 
 
 ## When things don't work as expected
 
-If you have small amounts of content and are trying to control breaks in a number of ways or on several elements, your content needs to break somewhere, so you may not always get the result you intended. To some extent your use of fragmentation is always a suggestion to the browser, to control breaks in this way if it is possible.
-
-In addition to the above, browser support for these properties is a little patchy. The compatibility data charts on the individual property pages here on MDN can help you see which browsers support which features. In most cases, the fallback to breaks not being controlled is something you can live with, with suboptimal breaking being untidy rather than a disaster to your layout.
+If you have small amounts of content and are trying to control breaks on several elements, your content needs to break somewhere, so you may not always get the result you intended. To some extent, your use of fragmentation is always a suggestion to the browser, to control breaks in this way if it is possible. If the content doesn't break where you intended, the result may be untidy, but the content is still available for your users.

--- a/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
@@ -6,13 +6,13 @@ page-type: guide
 
 {{CSSRef}}
 
-Content is broken between column boxes in multi-column layout in the same way that it is broken between pages in paged media. In both contexts, we control where and how things break by using properties of the CSS Fragmentation specification. In this guide, we see how fragmentation works in a _multi-column container_ or _multicol container_ for short.
+Content between column boxes in multi-column layout breaks in the same way that it is broken between pages in paged media. In both contexts, we control where and how things break by using properties of the CSS Fragmentation specification. In this guide, we see how fragmentation works in a _multi-column container_ or _multicol container_ for short.
 
 ## Fragmentation basics
 
-The [CSS Fragmentation specification](https://www.w3.org/TR/css-break-3/) details how content breaks between the fragmentation containers or _fragmentainers_. In multicol, the fragmentainer is the column box.
+While the [CSS fragmentation](/en-US/docs/Web/CSS/CSS_fragmentation/) module provides details on how content breaks between the fragmentation containers or _fragmentainers_, as in multicol layout, the column box is a fragment container, the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/) module defines the {{cssxref("break-after")}}, {{cssxref("break-before")}}, and {{cssxref("break-inside")}} properties that provide some control within and between columns.
 
-A column box can contain other markup and there are many places where a break would not be ideal. For example, we would generally prefer that the figcaption of an image not be separated into a new column away from the image it refers to and ending a column with a heading looks strange. The fragmentation properties give us ways to exercise some control over this.
+A column box can contain other markup and there are many places where a break would not be ideal. For example, we would generally prefer that the caption of an image not be separated into a new column away from the image it refers to. Also, ending a column with a heading looks strange. The multicol fragmentation properties give us ways to exercise some control over this.
 
 There are various places we might want to control our breaks:
 
@@ -49,9 +49,9 @@ In this next example, we are forcing a column break before an `h2` element.
 
 ## Breaks between lines
 
-The {{cssxref("orphans")}} and {{cssxref("widows")}} properties are also useful. The orphans property controls the number of lines left on their own at the end of a fragment. The widows property controls the number left on their own at the start of a fragment.
+The {{cssxref("orphans")}} and {{cssxref("widows")}} properties, part of the [CSS fragmentation](/en-US/docs/Web/CSS/CSS_fragmentation/) module, are also useful and worth mentioning. The `orphans` property controls the number of lines left on their own at the end of a fragment. The `widows` property controls the number left on their own at the start of a fragment.
 
-The `orphans` and `widows` properties take an integer as a value, which represents the number of lines to keep together at the end and start of a fragment, respectively. Note that these properties only work inside a block container, such as a paragraph. If the block has fewer lines in it than the number that you specify as a value, all lines will be kept together.
+The `orphans` and `widows` properties take an {{CSSXref("integer")}} as a value, which represents the number of lines to keep together at the end and start of a fragment, respectively. Note that these properties only work inside a block container, such as a paragraph. If the block has fewer lines in it than the number that you specify as a value, all lines will be kept together.
 
 In the example below, we are using the `orphans` property to control the number of lines left at the bottom of a column. You can change that value to see the effect on the breaking of the content.
 

--- a/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
@@ -6,11 +6,11 @@ page-type: guide
 
 {{CSSRef}}
 
-Content between column boxes in multi-column layout breaks in the same way that it is broken between pages in paged media. In both contexts, we control where and how things break by using properties of the CSS Fragmentation specification. In this guide, we see how fragmentation works in a _multi-column container_ or _multicol container_ for short.
+Content between column boxes in a multicol layout breaks in the same way that it breaks between pages in paged media. In both contexts, you can control where and how content breaks by using properties of the [CSS fragmentation](/en-US/docs/Web/CSS/CSS_fragmentation) module. In this guide, we see how fragmentation works in a _multi-column container_ or _multicol container_ for short.
 
 ## Fragmentation basics
 
-While the [CSS fragmentation](/en-US/docs/Web/CSS/CSS_fragmentation/) module provides details on how content breaks between the fragmentation containers or _fragmentainers_, as in multicol layout, the column box is a fragment container, the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/) module defines the {{cssxref("break-after")}}, {{cssxref("break-before")}}, and {{cssxref("break-inside")}} properties that provide some control within and between columns.
+The CSS fragmentation module provides details on how content breaks between the fragmentation containers or _fragmentainers_. The [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout) module, on the other hand, defines the {{cssxref("break-after")}}, {{cssxref("break-before")}}, and {{cssxref("break-inside")}} properties that provide some control within and between columns. In multicol layout, a column box is a fragment container.
 
 A column box can contain other markup and there are many places where a break would not be ideal. For example, we would generally prefer that the caption of an image not be separated into a new column away from the image it refers to. Also, ending a column with a heading looks strange. The multicol fragmentation properties give us ways to exercise some control over this.
 
@@ -49,7 +49,7 @@ In this next example, we are forcing a column break before an `h2` element.
 
 ## Breaks between lines
 
-The {{cssxref("orphans")}} and {{cssxref("widows")}} properties, part of the [CSS fragmentation](/en-US/docs/Web/CSS/CSS_fragmentation/) module, are also useful and worth mentioning. The `orphans` property controls the number of lines left on their own at the end of a fragment. The `widows` property controls the number left on their own at the start of a fragment.
+The {{cssxref("orphans")}} and {{cssxref("widows")}} properties, part of the CSS fragmentation module, are also useful and worth mentioning. The `orphans` property controls the number of lines left on their own at the end of a fragment. The `widows` property controls the number left on their own at the start of a fragment.
 
 The `orphans` and `widows` properties take an {{CSSXref("integer")}} as a value, which represents the number of lines to keep together at the end and start of a fragment, respectively. Note that these properties only work inside a block container, such as a paragraph. If the block has fewer lines in it than the number that you specify as a value, all lines will be kept together.
 

--- a/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
@@ -12,13 +12,13 @@ In this guide, we look at how to deal with overflow in a multi-column (_multicol
 
 An overflow situation happens when an item's size is larger than the column box. For example, the situation could happen when an image in a column is wider than the `column-width` value or the width of the column based on the number of columns declared with `column-count`.
 
-In this situation, the content should visibly overflow into the next column, rather than be clipped by the column box. You can see an example of this below, with an image of the expected rendering as, at the time of writing, browsers deal with this differently.
+In this situation, the content should visibly overflow into the next column, rather than be clipped by the column box.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/image.html", '100%', 800)}}
 
-![There are two columns of text. In the left column there is a photo that is wider than the column. The image expands into that second column, appearing behind the text of the right column. The flow of text in the right column isn't effected by the protruding photo, but the appearance is.](image-overflow-multicol.png)
+There are two columns of text. In the left column, there is a photo that is wider than the column. The image expands into that second column, appearing behind the text of the right column. The flow of text in the right column isn't affected by the protruding photo, but the appearance is.
 
-If you want an image to size down to fit the column box, the standard responsive images solution of setting `max-width: 100%` will achieve that for you.
+If you want an image to fit the column box, setting `max-width: 100%` will prevent the image from growing beyond its container, in this case, the column box.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/image-max-width.html", '100%', 800)}}
 
@@ -26,22 +26,20 @@ If you want an image to size down to fit the column box, the standard responsive
 
 How overflowing columns are handled depends on whether the media context is fragmented, such as print, or is continuous, such as a web page.
 
-In fragmented media, after a fragment (for example, a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web this means that you will get a horizontal scrollbar.
+In fragmented media, after a fragment (for example, a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web, this means that you will get a horizontal scrollbar.
 
-The example below shows this overflow behavior. The multicol container has a height and there is more text than space to create columns; therefore, we get columns created outside of the container.
+The example below shows this overflow behavior. The multicol container has a set {{CSSXref("height")}} and there is more text than space to create columns; therefore, we get columns created outside of the container.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/overflow-inline.html", '100%', 800)}}
 
-In a future version of the specification, it would be useful to be able to have overflow columns in continuous media display in the block direction, therefore allowing the reader to scroll down to view the next set of columns.
-
 ## Using vertical media queries
 
-One issue with multicol on the web is that, if your columns are taller than the viewport, the reader will need to scroll up and down to read, which is not good user experience. One way to avoid this is to only apply the column properties if you know you have enough height.
+One issue with multicol on the web is that, if your columns are taller than the viewport, the reader will need to scroll up and down to read, which is not a good user experience. One way to avoid this is to only apply the column properties if you know you have enough vertical space.
 
-In the example below, we have used a `min-height` query to check the height before applying the column properties.
+In the example below, we used a {{CSSXref("min-height")}} [@media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to ensure there is enough vertical space before applying the column properties.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/min-height.html", '100%', 800)}}
 
 ## Next steps
 
-In the final guide in this series, we will see [how multicol works with the Fragmentation spec](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol_layout) to give us control over how content breaks between columns.
+In the final guide in this series, we will see [how fragmentation works with multicol layouts](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol_layout) to give us control over how content breaks between columns.

--- a/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
@@ -34,7 +34,7 @@ The example below shows this overflow behavior. The multicol container has a set
 
 ## Using vertical media queries
 
-One issue with multicol on the web is that, if your columns are taller than the viewport, the reader will need to scroll up and down to read, which is not a good user experience. One way to avoid this is to only apply the column properties if you know you have enough vertical space.
+One issue with multicol on the web is that if the columns are taller than the viewport, the reader will need to scroll the page up and down to read, which is not a good user experience. One way to avoid this is to only apply the column properties if you know there is enough vertical space.
 
 In the example below, we used a {{CSSXref("min-height")}} [@media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to ensure there is enough vertical space before applying the column properties.
 

--- a/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
@@ -8,15 +8,13 @@ page-type: guide
 
 In this guide, we look at how to make elements span across columns inside the multi-column (_multicol_) container and how to control how the columns are filled.
 
-> **Note:** The spanning and balancing functionality covered in this guide is not as well supported across browsers as the functionality covered in the previous two sections in this guide.
-
 ## Spanning the columns
 
-To cause an item to span across columns use the property {{cssxref("column-span")}} with a value of `all`. This will cause the element to span all of the columns.
+To man an item span across columns, use the property {{cssxref("column-span")}} with a value of `all`. This will cause the element to span all of the columns.
 
-Any descendant element of the multicol container may become a _spanner_ including both direct and indirect children. For example, a heading nested directly inside the container could become a spanner, as could a heading nested inside a section nested inside the multicol container.
+Any descendant element of the multicol container may become a _spanner_, including both direct and indirect children. For example, a heading nested directly inside the container could become a spanner, as could a heading nested inside a section nested inside the multicol container.
 
-In the example below, the h2 element is set to `column-span: all` and spans all of the columns.
+In the example below, the `<h2>` element is set to `column-span: all` and spans all of the columns.
 
 {{EmbedGHLiveSample("css-examples/multicol/spanning/h2-span.html", '100%', 800)}}
 
@@ -24,37 +22,35 @@ In this second example, the heading is inside an {{HTMLElement("article")}} elem
 
 {{EmbedGHLiveSample("css-examples/multicol/spanning/nested-h2-span.html", '100%', 800)}}
 
-When a spanner is introduced, it breaks the flow of columns and columns restart after the spanner, effectively creating a new set of column boxes. The content does not jump over a spanning element.
+When a spanner is introduced, it breaks the flow of columns; columns restart after the spanner effectively creating a new set of column boxes. The content does not jump over a spanning element.
 
 ### Limitations of column-span
 
-In the current level 1 specification, there are only two allowable values for `column-span`. The value `none` is the initial value and means that the item does not span and remains within a column. The value `all` means that the item spans all of the columns. This means that, for example, you cannot cause an item to span two out of three columns.
+There are only two allowable values for `column-span`. The initial value `none` means the item does not span and remains within a column. The value `all` means the item spans all of the columns. There are no values that enable partial spanning, such as having an item span two out of three columns.
 
 ### Things to watch out for
 
-If the spanning element is inside another element which has margins, padding and a border or a background color, it is possible to end up with the top of the box appearing above the spanner and the rest displaying below, as shown in the next example. For this reason, some care should be taken when deciding to make an element a spanner and ensure this scenario is accounted for.
+If the spanning element is inside another element with margins, padding, and a border or a background color, it is possible the top of the box will appear above the spanner with the rest of the content being displayed below. For this reason, care should be taken when setting an element to span all the columns, ensuring this scenario is accounted for.
 
 {{EmbedGHLiveSample("css-examples/multicol/spanning/mpb-span.html", '100%', 800)}}
 
-Additionally, if a spanning element appears later in the content it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the intended effect.
+Additionally, if a spanning element appears later in the content it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the effect you intended.
 
 ## Filling and balancing columns
 
-A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing comes into play when the amount of content does not match the amount of space provided, such as when a height is declared on the container.
+A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing is relevant when the amount of content does not match the amount of space provided, such as when a {{CSSXref("height")}} is declared on the container.
 
-The initial value of multicol for {{cssxref("column-fill")}} is `balance`. The value of balance means all columns are as balanced as is possible. In fragmented contexts such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. This means that on the last page the final set of column boxes will be balanced.
+The initial value for {{cssxref("column-fill")}} is `balance`. The value of balance means all columns are as balanced as possible. In fragmented contexts such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. This means that on the last page, the final set of column boxes is balanced.
 
-There is a second value for balancing, `balance-all`, which attempts to balance all columns in fragmented contexts and not just the columns on the final fragment.
+The other balancing value, `balance-all`, balances all columns in fragmented contexts.
 
-In this example, we have columns containing an image and some text which are balanced. The image cannot break and so goes into the first column and the other columns fill with equal amounts of text.
+In this example, we have columns containing an image and some text which are balanced. The image, which cannot break, is in the first column. The other columns are balanced, filling with equal amounts of text.
 
 {{EmbedGHLiveSample("css-examples/multicol/balancing/balance.html", '100%', 550)}}
 
-The other value for `column-fill` is `auto`. In this case, rather than filling all the columns equally so their heights are balanced, the columns are filled sequentially. In the example below we have changed `column-fill` to `auto` and the columns are now filled, in order, to the height of the multicol container, leaving some columns empty at the end.
+The `auto` value for `column-fill` fills the columns sequentially, rather than balancing and filling all the columns equally. In this example, we changed `column-fill` to `auto`. The columns are filled to the height of the container, leaving empty columns at the end.
 
 {{EmbedGHLiveSample("css-examples/multicol/balancing/auto.html", '100%', 550)}}
-
-Note that column balancing is not supported by all browsers. Check that you are getting the sort of effect that you expect in the browsers you support.
 
 ## Next steps
 

--- a/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
@@ -10,9 +10,9 @@ In this guide, we look at how to make elements span across columns inside the mu
 
 ## Spanning the columns
 
-To man an item span across columns, use the property {{cssxref("column-span")}} with a value of `all`. This will cause the element to span all of the columns.
+To cause an item to span across columns, use the {{cssxref("column-span")}} property with a value of `all`. This will cause the element to become a _spanner_, spanning all the columns.
 
-Any descendant element of the multicol container may become a _spanner_, including both direct and indirect children. For example, a heading nested directly inside the container could become a spanner, as could a heading nested inside a section nested inside the multicol container.
+Any descendant element of the multicol container may be turned into a spanner, including both direct and indirect children. For example, a heading nested directly inside the container could become a spanner, as could a heading nested inside a {{HTMLElement("section")}} nested inside the multicol container.
 
 In the example below, the `<h2>` element is set to `column-span: all` and spans all of the columns.
 
@@ -22,25 +22,25 @@ In this second example, the heading is inside an {{HTMLElement("article")}} elem
 
 {{EmbedGHLiveSample("css-examples/multicol/spanning/nested-h2-span.html", '100%', 800)}}
 
-When a spanner is introduced, it breaks the flow of columns; columns restart after the spanner effectively creating a new set of column boxes. The content does not jump over a spanning element.
+When a spanner is introduced, it breaks the flow of columns; columns restart after the spanner, effectively creating a new set of column boxes. The content does not jump over a spanning element.
 
 ### Limitations of column-span
 
-There are only two allowable values for `column-span`. The initial value `none` means the item does not span and remains within a column. The value `all` means the item spans all of the columns. There are no values that enable partial spanning, such as having an item span two out of three columns.
+The `column-span` only has two values. The initial value `none` means the item does not span and remains within a column. The value `all` means the item spans all of the columns. There are no values that enable partial spanning, such as having an item span two out of three columns.
 
 ### Things to watch out for
 
-If the spanning element is inside another element with margins, padding, and a border or a background color, it is possible the top of the box will appear above the spanner with the rest of the content being displayed below. For this reason, care should be taken when setting an element to span all the columns, ensuring this scenario is accounted for.
+If the spanning element is inside another element with margins, padding, and a border or background color, the box may appear above the spanner with the rest of the content being displayed below. For this reason, care should be taken when setting an element to span all the columns, ensuring this scenario is accounted for.
 
 {{EmbedGHLiveSample("css-examples/multicol/spanning/mpb-span.html", '100%', 800)}}
 
-Additionally, if a spanning element appears later in the content it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the effect you intended.
+Additionally, if a spanning element appears later in the content, it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the effect you intended.
 
 ## Filling and balancing columns
 
-A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing is relevant when the amount of content does not match the amount of space provided, such as when a {{CSSXref("height")}} is declared on the container.
+A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing are relevant when the amount of content does not match the amount of space provided, such as when a {{CSSXref("height")}} is declared on the container.
 
-The initial value for {{cssxref("column-fill")}} is `balance`. The value of balance means all columns are as balanced as possible. In fragmented contexts such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. This means that on the last page, the final set of column boxes is balanced.
+The initial value for {{cssxref("column-fill")}} is `balance`. The value of `balance` means all columns are as balanced as possible. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. This means that on the last page, the final set of column boxes is balanced.
 
 The other balancing value, `balance-all`, balances all columns in fragmented contexts.
 
@@ -48,10 +48,10 @@ In this example, we have columns containing an image and some text which are bal
 
 {{EmbedGHLiveSample("css-examples/multicol/balancing/balance.html", '100%', 550)}}
 
-The `auto` value for `column-fill` fills the columns sequentially, rather than balancing and filling all the columns equally. In this example, we changed `column-fill` to `auto`. The columns are filled to the height of the container, leaving empty columns at the end.
+The `auto` value for `column-fill` fills a column sequentially, filling the first column in the inline-start direction, before placing content in subsequent columns, rather than balancing and filling all the columns equally. In this example, we changed `column-fill` to `auto`. The columns are filled to the height of the container, leaving empty columns at the end.
 
 {{EmbedGHLiveSample("css-examples/multicol/balancing/auto.html", '100%', 550)}}
 
 ## Next steps
 
-In the next guide, you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout), both within columns and where there are more columns than will fit the container.
+In the next guide, you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout), both within columns and where there are more columns than can fit in the container.

--- a/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
@@ -26,7 +26,7 @@ When a spanner is introduced, it breaks the flow of columns; columns restart aft
 
 ### Limitations of column-span
 
-The `column-span` only has two values. The initial value `none` means the item does not span and remains within a column. The value `all` means the item spans all of the columns. There are no values that enable partial spanning, such as having an item span two out of three columns.
+The `column-span` can have only two values. The initial value `none` means the item does not span and remains within a column. The value `all` means the item spans all of the columns. There are no values that enable partial spanning, such as having an item span two out of three columns.
 
 ### Things to watch out for
 
@@ -44,7 +44,7 @@ The initial value for {{cssxref("column-fill")}} is `balance`. The value of `bal
 
 The other balancing value, `balance-all`, balances all columns in fragmented contexts.
 
-In this example, we have columns containing an image and some text which are balanced. The image, which cannot break, is in the first column. The other columns are balanced, filling with equal amounts of text.
+The columns in this example contain an image and some text, which are balanced. The image, which cannot break, is in the first column. The other columns are balanced, filling with equal amounts of text.
 
 {{EmbedGHLiveSample("css-examples/multicol/balancing/balance.html", '100%', 550)}}
 
@@ -54,4 +54,4 @@ The `auto` value for `column-fill` fills a column sequentially, filling the firs
 
 ## Next steps
 
-In the next guide, you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout), both within columns and where there are more columns than can fit in the container.
+In the next guide, you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout) within columns and when there are more columns than can fit in the container.

--- a/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
@@ -10,7 +10,7 @@ As column boxes created inside multi-column (_multicol_) containers are anonymou
 
 ## Column gaps
 
-The gap between columns is controlled using the {{CSSXref("column-gap")}} or {{CSSXref("gap")}} property. The `column-gap` property is defined in the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout) module. The `gap` property is defined in the [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module. This is a unified property to define gaps between boxes in all layouts that support gaps, including [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout) and [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items).
+The gap between columns is controlled using the {{CSSXref("column-gap")}} or {{CSSXref("gap")}} property. The `column-gap` property is defined in the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout) module. The `gap` property is defined in the [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module. This is a unified property to define gaps between boxes in all layouts that support gaps, including [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout) and [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items).
 
 The initial value of `column-gap` is `1em`, which prevents columns from running into each other. In other layout methods, `column-gap` is supported as a synonym for `gap`, but with an initial value of `0`. The keyword value `normal` sets `column-gap` to the initial value.
 

--- a/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
@@ -10,7 +10,7 @@ As column boxes created inside multi-column (_multicol_) containers are anonymou
 
 ## Column gaps
 
-The gap between columns is controlled using the {{CSSXref("column-gap")}} or {{CSSXref("gap")}} properties. This `column-gap` property is defined in the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/) specification. The `gap` property, defined in the [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) specification, provides a unified property to define gaps between boxes all layout specifications that support gaps, including [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout) and [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items).
+The gap between columns is controlled using the {{CSSXref("column-gap")}} or {{CSSXref("gap")}} property. The `column-gap` property is defined in the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout) module. The `gap` property is defined in the [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module. This is a unified property to define gaps between boxes in all layouts that support gaps, including [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout) and [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items).
 
 The initial value of `column-gap` is `1em`, which prevents columns from running into each other. In other layout methods, `column-gap` is supported as a synonym for `gap`, but with an initial value of `0`. The keyword value `normal` sets `column-gap` to the initial value.
 
@@ -24,7 +24,7 @@ The allowed value for `column-gap` is a {{cssxref("length-percentage")}}, meanin
 
 The specification defines {{CSSXref("column-rule-width")}}, {{CSSXref("column-rule-style")}} and {{CSSXref("column-rule-color")}}, providing a shorthand {{CSSXref("column-rule")}}. These properties work in exactly the same way as the {{CSSXref("border")}} properties: any {{CSSXref("line-style")}} can be used as a `column-rule-style`, just as for valid {{CSSXref("border-style")}}.
 
-These properties are applied to the element which is the multicol container and therefore all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules are also only drawn between columns that have content.
+These properties are applied to the element, which is the multicol container, and therefore, all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules are also only drawn between columns that have content.
 
 In this next example, a 5px-dotted rule with a color of `rebeccapurple` has been created using the longhand values.
 

--- a/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
@@ -10,21 +10,21 @@ As column boxes created inside multi-column (_multicol_) containers are anonymou
 
 ## Column gaps
 
-The gap between columns is controlled using the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) in order to unify gaps between boxes in other specifications such as [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout).
+The gap between columns is controlled using the {{CSSXref("column-gap")}} or {{CSSXref("gap")}} properties. This `column-gap` property is defined in the [multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/) specification. The `gap` property, defined in the [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) specification, provides a unified property to define gaps between boxes all layout specifications that support gaps, including [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout) and [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items).
 
-The initial value of `column-gap` is `1em`, which prevents columns from running into each other. In other layout methods, the initial value for `column-gap` is 0. If you use the keyword value "normal", the gap will be set to 1em.
+The initial value of `column-gap` is `1em`, which prevents columns from running into each other. In other layout methods, `column-gap` is supported as a synonym for `gap`, but with an initial value of `0`. The keyword value `normal` sets `column-gap` to the initial value.
 
-You can change the gap by using any length unit as the value of `column-gap`. In the example below, the `column-gap` is set to 40px.
+You can change the gap by using any {{cssxref("length")}} value. In the example below, the `column-gap` is set to `40px`.
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-gap.html", '100%', 750)}}
 
-The allowed value for `column-gap` is a `<length-percentage>`, this means percentages are allowed. Percentage values for `column-gap` are calculated as a percentage of the width of the multicol container.
+The allowed value for `column-gap` is a {{cssxref("length-percentage")}}, meaning percentages are allowed. Percentage values for `column-gap` are calculated as a percentage of the width of the multicol container.
 
 ## Column rules
 
-The specification defines `column-rule-width`, `column-rule-style` and `column-rule-color`, providing a shorthand `column-rule`. These properties work in exactly the same way as the `border` properties: any valid `border-style` can be used as a `column-rule-style`.
+The specification defines {{CSSXref("column-rule-width")}}, {{CSSXref("column-rule-style")}} and {{CSSXref("column-rule-color")}}, providing a shorthand {{CSSXref("column-rule")}}. These properties work in exactly the same way as the {{CSSXref("border")}} properties: any {{CSSXref("line-style")}} can be used as a `column-rule-style`, just as for valid {{CSSXref("border-style")}}.
 
-These properties are applied to the element which is the multicol container and therefore all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules should also only be drawn between columns which have content.
+These properties are applied to the element which is the multicol container and therefore all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules are also only drawn between columns that have content.
 
 In this next example, a 5px-dotted rule with a color of `rebeccapurple` has been created using the longhand values.
 
@@ -32,7 +32,7 @@ In this next example, a 5px-dotted rule with a color of `rebeccapurple` has been
 
 Note that the rule itself does not take up any space: a wide rule will not push the columns apart to make space for the rule. Instead, the rule overlays the gap.
 
-The example below uses a very wide rule of 40px and a 10px gap. The rule displays under the content of the columns. To make space on both sides of the rule, the gap would need to be increased to be larger than 40px.
+The example below uses a very wide rule of `40px` and a `10px` gap. The rule displays under the column content. To make space on both sides of the rule, the gap would need to be increased to be larger than `40px`.
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-rule-wide.html", '100%', 550)}}
 

--- a/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/styling_columns/index.md
@@ -6,17 +6,13 @@ page-type: guide
 
 {{CSSRef}}
 
-As column boxes created inside multi-column (_multicol_) containers are anonymous boxes, there is little we can do to style them. However, we do have a few things that we can do. This guide explains how to change the gap and style rules between columns.
-
-## Styling column boxes
-
-Sadly, column boxes cannot be styled at present. The anonymous boxes that make up your columns can't be targeted in any way, meaning it isn't possible to change a box's background color or have one column larger than the others. Perhaps in future versions of the specification it might be. For now, however, we are able to change the spacing and add lines between columns.
+As column boxes created inside multi-column (_multicol_) containers are anonymous boxes, styling individual columns is not possible, but we can style the gaps between the columns and the container in general. This guide explains how to change the gap and style rules between columns.
 
 ## Column gaps
 
-The gap between columns is controlled using the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment) in order to unify gaps between boxes in other specifications such as [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout).
+The gap between columns is controlled using the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) in order to unify gaps between boxes in other specifications such as [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_CSS_grid_layout).
 
-The initial value of `column-gap` in multicol is `1em`. This means your columns will not run into each other. In other layout methods, the initial value for `column-gap` is 0. If you use the keyword value "normal", the gap will be set to 1em.
+The initial value of `column-gap` is `1em`, which prevents columns from running into each other. In other layout methods, the initial value for `column-gap` is 0. If you use the keyword value "normal", the gap will be set to 1em.
 
 You can change the gap by using any length unit as the value of `column-gap`. In the example below, the `column-gap` is set to 40px.
 

--- a/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-The properties defined in the **CSS multi-column layout module** extends the _block layout mode_ , enabling the easy definition of multiple columns of text. People have trouble reading text if lines are too long. If it takes too long for the eyes to move from the end of one line to the beginning of the next, readers can lose track of which line they were on. To provide for a better user experience when reading text making use of a large screen, you should limit the width of text by using columns of text placed side by side, just as newspapers do.
+The properties defined in the **CSS multi-column layout module** extend the _block layout mode_ , enabling the easy definition of multiple columns of text. People have trouble reading text if lines are too long. If it takes too long for the eyes to move from the end of one line to the beginning of the next, readers can lose track of which line they were on. To provide for a better user experience when reading text making use of a large screen, you should limit the width of text by using columns of text placed side by side, just as newspapers do.
 
 ## Using columns
 
@@ -84,11 +84,11 @@ The `column-width` property sets the minimum desired column width. If `column-co
 
 {{EmbedLiveSample("Example_2", "100%")}}
 
-In a multi-column block, content is automatically flowed from one column into the next as needed. All HTML, CSS, and DOM functionality is supported within columns, as are editing and printing.
+In a multi-column block, content automatically flows from one column into the next as needed. All HTML, CSS, and DOM functionality is supported within columns, as are editing and printing.
 
 ### The columns shorthand
 
-Most of the time, a Web designer will use one of the two CSS properties: {{cssxref("column-count")}} or {{cssxref("column-width")}}. As values for these properties do not overlap, it is often convenient to use the shorthand {{cssxref("columns")}}.
+You can use either {{cssxref("column-count")}} or {{cssxref("column-width")}}. Because values for these properties do not overlap, it is often convenient to use the shorthand {{cssxref("columns")}}.
 
 ## Example 3
 
@@ -175,9 +175,9 @@ The two CSS declarations `column-width: 8em` and `column-count: 12` can be repla
 
 {{EmbedLiveSample("Example_5", "100%")}}
 
-Assuming a default 1em gap between columns, if the container is wider than 103ems (12 columns \* 8em width each + 7 1-em gaps), there will be 12 columns, each with a width of 8ems or more. If the container is less than 103ems wide, there will be fewer than 12 columns. If the container is less than 17ems (8em column + 8em column + 1em gap), the content will be displayed as a single column with no column gap.
+Assuming a default `1em` gap between columns, if the container is wider than `103ems` (12 columns \* `8em` width each + 7 `1em` gaps), there will be 12 columns, each with a width of `8ems` or more. If the container is less than `103ems` wide, there will be fewer than 12 columns. If the container is less than `17ems` wide (`8em` column + `8em` column + `1em` gap), the content will be displayed as a single column with no column gap.
 
-### Height Balancing
+### Height balancing
 
 CSS columns require that the column heights must be balanced: that is, the browser automatically sets the maximum column height so that the heights of the content in each column are approximately equal. Firefox does this.
 

--- a/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
@@ -175,7 +175,7 @@ The two CSS declarations `column-width: 8em` and `column-count: 12` can be repla
 
 {{EmbedLiveSample("Example_5", "100%")}}
 
-Assuming a default 1em gap between columns, if the container is wider than 103ems (12 columns * 8em width each + 7 1-em gaps), there will be 12 columns, each with a width of 8ems or more. If the container is less than 103ems wide, there will be fewer than 12 columns. If the container is less than 17ems (8em column + 8em column + 1em gap), the content will be displayed as a single column with no column gap.
+Assuming a default 1em gap between columns, if the container is wider than 103ems (12 columns \* 8em width each + 7 1-em gaps), there will be 12 columns, each with a width of 8ems or more. If the container is less than 103ems wide, there will be fewer than 12 columns. If the container is less than 17ems (8em column + 8em column + 1em gap), the content will be displayed as a single column with no column gap.
 
 ### Height Balancing
 

--- a/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/using_multicol_layouts/index.md
@@ -6,9 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-The **CSS Multi-column Layout Module** extends the _block layout mode_ to allow the easy definition of multiple columns of text. People have trouble reading text if lines are too long; if it takes too long for the eyes to move from the end of the one line to the beginning of the next, they lose track of which line they were on. Therefore, to make maximum use of a large screen, authors should have limited-width columns of text placed side by side, just as newspapers do.
-
-Unfortunately this is impossible to do with CSS and HTML without forcing column breaks at fixed positions, or severely restricting the markup allowed in the text, or using heroic scripting. This limitation is solved by adding new CSS properties to extend the traditional block layout mode.
+The properties defined in the **CSS multi-column layout module** extends the _block layout mode_ , enabling the easy definition of multiple columns of text. People have trouble reading text if lines are too long. If it takes too long for the eyes to move from the end of one line to the beginning of the next, readers can lose track of which line they were on. To provide for a better user experience when reading text making use of a large screen, you should limit the width of text by using columns of text placed side by side, just as newspapers do.
 
 ## Using columns
 
@@ -53,7 +51,7 @@ The `column-count` property sets the number of columns to a particular number. E
 
 ### Result
 
-The content will be displayed in two columns (if you're using a multi-column compliant browser):
+The content will be displayed in two columns:
 
 {{EmbedLiveSample("Example_1", "100%")}}
 
@@ -86,17 +84,15 @@ The `column-width` property sets the minimum desired column width. If `column-co
 
 {{EmbedLiveSample("Example_2", "100%")}}
 
-The exact details are described in [CSS Multi-column Layout Module Level 1](https://www.w3.org/TR/css-multicol-1/).
-
-In a multi-column block, content is automatically flowed from one column into the next as needed. All HTML, CSS and DOM functionality is supported within columns, as are editing and printing.
+In a multi-column block, content is automatically flowed from one column into the next as needed. All HTML, CSS, and DOM functionality is supported within columns, as are editing and printing.
 
 ### The columns shorthand
 
-Most of the time, a Web designer will use one of the two CSS properties: {{cssxref("column-count")}} or {{cssxref("column-width")}}. As values for these properties do not overlap, it is often convenient to use the shorthand {{cssxref("columns")}}. E.g.
-
-The CSS declaration `column-width: 12em` can be replaced by `columns: 12em`.
+Most of the time, a Web designer will use one of the two CSS properties: {{cssxref("column-count")}} or {{cssxref("column-width")}}. As values for these properties do not overlap, it is often convenient to use the shorthand {{cssxref("columns")}}.
 
 ## Example 3
+
+In this example, the CSS declaration `column-width: 12em` is replaced by `columns: 12em`.
 
 ### HTML
 
@@ -121,9 +117,9 @@ The CSS declaration `column-width: 12em` can be replaced by `columns: 12em`.
 
 {{EmbedLiveSample("Example_3", "100%")}}
 
-The CSS declaration `column-count: 4` can be replaced by `columns: 4`.
-
 ## Example 4
+
+In this example, the CSS declaration `column-count: 4` is replaced by `columns: 4`.
 
 ### HTML
 
@@ -150,9 +146,9 @@ The CSS declaration `column-count: 4` can be replaced by `columns: 4`.
 
 {{EmbedLiveSample("Example_4", "100%")}}
 
-The two CSS declarations `column-width: 8em` and `column-count: 12` can be replaced by `columns: 12 8em`.
-
 ## Example 5
+
+The two CSS declarations `column-width: 8em` and `column-count: 12` can be replaced by `columns: 12 8em`. The `column-count` portion of the shorthand is the maximum number of columns that will be present. The `column-width` is the minimum width each column should be.
 
 ### HTML
 
@@ -178,6 +174,8 @@ The two CSS declarations `column-width: 8em` and `column-count: 12` can be repla
 ### Result
 
 {{EmbedLiveSample("Example_5", "100%")}}
+
+Assuming a default 1em gap between columns, if the container is wider than 103ems (12 columns * 8em width each + 7 1-em gaps), there will be 12 columns, each with a width of 8ems or more. If the container is less than 103ems wide, there will be fewer than 12 columns. If the container is less than 17ems (8em column + 8em column + 1em gap), the content will be displayed as a single column with no column gap.
 
 ### Height Balancing
 
@@ -217,10 +215,6 @@ There is a gap between columns. The recommended default is `1em`. This size can 
 
 {{EmbedLiveSample("Example_6", "100%")}}
 
-## Graceful Degradation
-
-The column properties will just be ignored by non-columns-supporting browsers. Therefore it's relatively easy to create a layout that will display in a single column in those browsers and use multiple columns in supporting browsers.
-
 ## Conclusion
 
-CSS columns are a layout primitive that will help Web developers make the best use of screen real estate. Imaginative developers may find many uses for them, especially with the automatic height balancing feature.
+CSS columns are a layout primitive that can help make large blocks of text easier to read when responsive content is viewed on wide viewports. Imaginative developers may find many uses for them, especially in conjunction with [container queries](/en-US/docs/Web/CSS/CSS_container_queries) and with the automatic height balancing feature.


### PR DESCRIPTION
Removed all "this isn't supported" language. Multi columns is well supported, except for break-* properties in FF and some newer values which are not yet well supported but also not discussed in these guides.