### PR TITLE
input event can only be triggered by user action

### DIFF
--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLElement.input_event
 
 {{APIRef}}
 
-The **`input`** event fires when the `value` of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element has been changed.
+The **`input`** event fires when the `value` of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element has been changed as a result of a user action.
 
 The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on. In the case of `contenteditable` and `designMode`, the event target is the _editing host_. If these properties apply to multiple elements, the editing host is the nearest ancestor element whose parent isn't editable.
 


### PR DESCRIPTION
Modified text as per the suggestion
"Fixes #27044"

