### PR TITLE
docs(relnote): Fx114 - crossorigin attribute for image and feImage elements in SVGs

### DIFF
--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -35,6 +35,8 @@ This article provides information about the changes in Firefox 114 that affect d
 
 ### SVG
 
+- The [`crossOrigin`](/en-US/docs/Web/SVG/Attribute/crossOrigin) attribute is now supported on [`image`](/en-US/docs/Web/SVG/Element/image) and [`feImage`](/en-US/docs/Web/SVG/Element/feImage) elements ([Firefox bug 1240357](https://bugzil.la/1240357)).
+
 #### Removals
 
 ### HTTP

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -35,7 +35,7 @@ This article provides information about the changes in Firefox 114 that affect d
 
 ### SVG
 
-- The [`crossOrigin`](/en-US/docs/Web/SVG/Attribute/crossOrigin) attribute is now supported on [`image`](/en-US/docs/Web/SVG/Element/image) and [`feImage`](/en-US/docs/Web/SVG/Element/feImage) elements ([Firefox bug 1240357](https://bugzil.la/1240357)).
+- The [`crossorigin`](/en-US/docs/Web/SVG/Attribute/crossorigin) attribute is now supported on [`image`](/en-US/docs/Web/SVG/Element/image) and [`feImage`](/en-US/docs/Web/SVG/Element/feImage) elements ([Firefox bug 1240357](https://bugzil.la/1240357)).
 
 #### Removals
 

--- a/files/en-us/web/svg/attribute/crossorigin/index.md
+++ b/files/en-us/web/svg/attribute/crossorigin/index.md
@@ -2,49 +2,34 @@
 title: "SVG attribute: crossorigin"
 slug: Web/SVG/Attribute/crossorigin
 page-type: svg-attribute
-browser-compat: api.SVGImageElement.crossOrigin
+browser-compat: svg.elements.image.crossorigin
 ---
 
 {{SVGRef}}
 
-The crossorigin attribute, valid on the {{ SVGElement("image") }} element, provides support for [CORS](/en-US/docs/Web/HTTP/CORS), defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. It is a CORS settings attribute.
+The crossorigin attribute, valid on the {{SVGElement("image")}} and {{SVGElement("feImage")}} elements, provides support for configuration of the Cross-Origin Resource Sharing ([CORS](/en-US/docs/Web/HTTP/CORS)) requests for the element's fetched data.
 
-This table shows all possible keywords and their meaning:
+This table shows possible keywords and their meaning:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th>Keyword</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>anonymous</code></td>
-      <td>
-        CORS requests for this element will have the credentials flag set to
-        'same-origin'.
-      </td>
-    </tr>
-    <tr>
-      <td><code>use-credentials</code></td>
-      <td>
-        CORS requests for this element will have the credentials flag set to
-        'include'.
-      </td>
-    </tr>
-    <tr>
-      <td><code>""</code></td>
-      <td>
-        Setting the attribute name to an empty value, like
-        <code>crossorigin</code> or <code>crossorigin=""</code>, is the same as
-        <code>anonymous</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Keyword           | Description                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `anonymous`       | Client CORS requests for this element will have the credentials flag set to 'same-origin'.                        |
+| `use-credentials` | Client CORS requests for this element will have the credentials flag set to 'include'.                            |
+| `""`              | Setting the attribute name to an empty value, like `crossorigin` or `crossorigin=""`, is the same as `anonymous`. |
 
 It follows the same processing rules as the HTML attribute [`crossorigin`](/en-US/docs/Web/HTML/Global_attributes#crossorigin).
+
+## Example
+
+```html
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  <image
+    href="https://example.com/mdn_logo_dark.png"
+    height="200"
+    width="200"
+    crossorigin="use-credentials" />
+</svg>
+```
 
 ## Specifications
 
@@ -53,12 +38,6 @@ It follows the same processing rules as the HTML attribute [`crossorigin`](/en-U
 ## Browser compatibility
 
 {{Compat}}
-
-<!-- TODO: This should link to an attribute of the element instead
-https://github.com/mdn/browser-compat-data/blob/178137547bc29a79b712cec221af099329b1f4a0/svg/elements/image.json
--->
-
-> **Note:** The above compatibility table is broken and needs fixing.
 
 ## See also
 

--- a/files/en-us/web/svg/element/feimage/index.md
+++ b/files/en-us/web/svg/element/feimage/index.md
@@ -26,6 +26,7 @@ The **`<feImage>`** [SVG](/en-US/docs/Web/SVG) filter primitive fetches image da
 
 ### Specific attributes
 
+- {{SVGAttr("crossorigin")}}
 - {{SVGAttr("preserveAspectRatio")}}
 - {{SVGAttr("xlink:href")}}
 
@@ -41,7 +42,9 @@ This element implements the {{domxref("SVGFEImageElement")}} interface.
 <svg
   viewBox="0 0 200 200"
   xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="200"
+  height="200">
   <defs>
     <filter id="image">
       <feImage xlink:href="mdn_logo_only_color.png" />
@@ -54,7 +57,7 @@ This element implements the {{domxref("SVGFEImageElement")}} interface.
 
 ### Result
 
-{{EmbedLiveSample("Example", 200, 200)}}
+{{EmbedLiveSample("Example", 200, 210)}}
 
 ## Specifications
 


### PR DESCRIPTION
Fx 114 supports `crossorigin` attribute on `<image>` and `<feimage>` elements which allow for specifying client behaviour for cross-origin resource requests.

```html
<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
  <image
    href="https://example.com/mdn_logo_dark.png"
    height="200"
    width="200"
    crossorigin="use-credentials" />
</svg>
```
__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26690
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/19999

__Bugzilla:__
- Tracking bug: BUG-1240357

__Resources:__
* WPT: https://wpt.live/svg/embedded/image-crossorigin.sub.html
* WPT overview: https://wpt.fyi/results/svg/embedded/image-crossorigin.sub.html?label=master&product=chrome%5Bstable%5D&product=edge%5Bstable%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&aligned


