### PR TITLE
Improve example for `margin-left`

### DIFF
--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -159,19 +159,16 @@ The `margin-left` property is specified as the keyword `auto`, or a `<length>`, 
 
 ```html
 <p>
-  A large rose-tree stood near the entrance of the garden:
-  the roses growing on it were white, but there were three
-  gardeners at it, busily painting them red.
+  A large rose-tree stood near the entrance of the garden: the roses growing on
+  it were white, but there were three gardeners at it, busily painting them red.
 </p>
-<p class=example>
-  Alice thought this a very curious thing, and she went
-  nearer to watch them, and just as she came up to them she
-  heard one of them say, "Look out now, Five! Don't go
-  splashing paint over me like that!"
+<p class="example">
+  Alice thought this a very curious thing, and she went nearer to watch them,
+  and just as she came up to them she heard one of them say, "Look out now,
+  Five! Don't go splashing paint over me like that!"
 </p>
 <p>
-  "I couldn't help it," said Five, in a sulky tone;
-  "Seven jogged my elbow."
+  "I couldn't help it," said Five, in a sulky tone; "Seven jogged my elbow."
 </p>
 ```
 

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -147,19 +147,37 @@ The `margin-left` property is specified as the keyword `auto`, or a `<length>`, 
 
 ## Examples
 
-### Setting left margin using pixels and percentages
+### CSS
 
 ```css
-.content {
-  margin-left: 5%;
-}
-.sidebox {
-  margin-left: 10px;
-}
-.logo {
-  margin-left: -5px;
+.example {
+  margin-left: 50%;
 }
 ```
+
+### HTML
+
+```html
+<p>
+  A large rose-tree stood near the entrance of the garden:
+  the roses growing on it were white, but there were three
+  gardeners at it, busily painting them red.
+</p>
+<p class=example>
+  Alice thought this a very curious thing, and she went
+  nearer to watch them, and just as she came up to them she
+  heard one of them say, "Look out now, Five! Don't go
+  splashing paint over me like that!"
+</p>
+<p>
+  "I couldn't help it," said Five, in a sulky tone;
+  "Seven jogged my elbow."
+</p>
+```
+
+### Result
+
+{{EmbedLiveSample("","","250")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -147,6 +147,8 @@ The `margin-left` property is specified as the keyword `auto`, or a `<length>`, 
 
 ## Examples
 
+Percentage values for `margin-left` are relative to the container's inline size.
+
 ### CSS
 
 ```css


### PR DESCRIPTION
While I was working on https://github.com/mdn/translated-content/pull/13022 I went with reworking the example to have an EmbedLiveSample which (I think) was better at showing the effect of the property. This PR intends to "downstream" this improvement to mdn/content (cf. https://github.com/mdn/translated-content/pull/13022#issuecomment-1570022239) 