### PR TITLE
Update discord invite

### DIFF
--- a/files/en-us/mdn/community/communication_channels/index.md
+++ b/files/en-us/mdn/community/communication_channels/index.md
@@ -19,7 +19,7 @@ MDN Web Docs community Discord server is open to the public. This server is a gr
 
 You can ask questions, seek clarifications, and find out how you can get involved. You can also join specific channels based on your areas of interest or expertise.
 
-Join the MDN Web Docs community on Discord [here](https://discord.gg/apa6Rn7uEj).
+Join the MDN Web Docs community on Discord [here](https://discord.gg/aZqEtMrbr7).
 
 ### Matrix chat rooms
 

--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -36,7 +36,7 @@ We have frozen all localized content (meaning that we won't accept any edits to 
 
 ### Korea (ko)
 
-- Discussions: [Discord (#korean channel)](https://discord.gg/apa6Rn7uEj), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
+- Discussions: [Discord (#korean channel)](https://discord.gg/aZqEtMrbr7), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
 - Current contributors: [hochan222](https://github.com/hochan222), [yechoi42](https://github.com/yechoi42), [cos18](https://github.com/cos18), [GwangYeol-Im](https://github.com/GwangYeol-Im), [pje1740](https://github.com/pje1740), [yujo11](https://github.com/yujo11), [wisedog](https://github.com/wisedog), [swimjiy](https://github.com/swimjiy), [jho2301](https://github.com/jho2301), [sunhpark42](https://github.com/sunhpark42)
 
 ### Russian (ru)


### PR DESCRIPTION
As communicated on Discord server:
> Hey @ everyone - if you want to invite someone to this Discord, please use the following link and only the following link. https://discord.gg/aZqEtMrbr7 - We have had a report that there is a way to use Discord invite URLs that expire as an attack vector. Thanks!


cc/ @schalkneethling 