### PR TITLE
chore(CI): disable prettier check on pull requests

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -45,8 +45,3 @@ jobs:
           yarn markdownlint-cli2 ${files_to_lint}
           echo "Linting front-matter"
           node scripts/front-matter_linter.js ${files_to_lint}
-
-      - name: Prettier markdown files
-        run: |
-          files_to_lint="${{ env.DIFF_DOCUMENTS }}"
-          yarn prettier -c ${files_to_lint}


### PR DESCRIPTION
Disabling the Prettier check on pull requests due to some speedbumps in reviewing

### Motivation

We have some contributors hitting this which is causing some friction, particularly on PRs opened from GitHub's UI. There is no option to [downgrade the errors to warnings](https://prettier.io/docs/en/cli.html#exit-codes) that I'm aware of.

### Additional details

We <strike>may want to instead</strike> already have this scheduled auto fix PR run Prettier instead:

https://github.com/mdn/content/blob/main/.github/workflows/markdown-lint-fix.yml#L30 

i.e.:

```yaml
      - name: Lint markdown files
        run: |
          yarn fix:md
          yarn fix:fm
```

https://github.com/mdn/content/blob/main/package.json#L17


### Related issues and pull requests

* PR that introduced this check https://github.com/mdn/content/pull/20674
* https://github.com/mdn/content/pull/26888
* https://github.com/mdn/content/pull/27017
