### PR TITLE
fix(arrow_functions): fix mistaken comment about function output

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -202,7 +202,7 @@ const obj = {
 Object.defineProperty(obj, "b", {
   get: () => {
     console.log(this.a, typeof this.a, this); // undefined 'undefined' Window { /* … */ } (or the global object)
-    return this.a + 10; // represents global object 'Window', therefore 'this.a' returns 'undefined'
+    return this.a + 10; // since 'this' equals undefined, addressing the property a of undefined will throw a TypeError
   },
 });
 ```


### PR DESCRIPTION
### Description

Arrow function will not  treat 'this' as global object in a strict mode. Thus, the comment about return is wrong.

### Motivation

After changes readers will be able to learn correct outcome of the code.

