### PR TITLE
Fix word order for static/instance and public/private

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -218,7 +218,7 @@ class Subclass extends ClassWithPrivateStaticField {
 Subclass.callSuperMethod(); // TypeError: Cannot read private member #privateStaticField from an object whose class did not declare it
 ```
 
-You are advised to always access static private fields through the class name, not through `this`, so inheritance doesn't break the method.
+You are advised to always access private static fields through the class name, not through `this`, so inheritance doesn't break the method.
 
 ### Private methods
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.classes.public_class_fields
 
 {{JsSidebar("Classes")}}
 
-Both static and instance **public fields** are writable, enumerable, and configurable properties. As such, unlike their private counterparts, they participate in prototype inheritance.
+**Public fields** are writable, enumerable, and configurable properties. As such, unlike their private counterparts, they participate in prototype inheritance.
 
 ## Syntax
 


### PR DESCRIPTION
Fix the only two occurrences in the MDN documentation where static/instance is before public/private.