### PR TITLE
Fix broken link on device orientation events WEB APIs docs 

### DIFF
--- a/files/en-us/web/api/device_orientation_events/index.md
+++ b/files/en-us/web/api/device_orientation_events/index.md
@@ -60,4 +60,4 @@ Some typical features for which you might want to use the device orientation eve
 
 ## See also
 
-- [Device Orientation & Motion](https://web.dev/native-hardware-device-orientation/) at web.dev
+- [Device Orientation & Motion](https://web.dev/device-orientation/) at web.dev


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The link to "[Device Orientation & Motion](https://web.dev/native-hardware-device-orientation/) at web.dev" is currently broken, as the page has been moved without adding a redirect. This PR fixes the broken link.

### Motivation

404 bad 🫡

### Related issues and pull requests

Fixes: #27092
