### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -73,7 +73,7 @@ The order of time values within each animation definition is important: the firs
 
 The order of other values within each animation definition is also important for distinguishing an {{cssxref("animation-name")}} value from other values. If a value in the `animation` shorthand can be parsed as a value for an animation property other than `animation-name`, then the value will be applied to that property first and not to `animation-name`. For this reason, the recommended practice is to specify a value for `animation-name` as the last value in a list of values when using the `animation` shorthand; this holds true even when you specify multiple, comma-separated animations using the `animation` shorthand.
 
-An `animation-name` value is not required to be declared in the `animation` shorthand property. If no name exists, there is no animation to apply on any of the properties.
+An `animation-name` value is required to be declared in the `animation` shorthand property. If no name exists, there is no animation to apply on any of the properties.
 
 When the `animation-duration` value is omitted from the `animation` shorthand property, the value for this property defaults to `0s`. In this case, the animation will still occur (the [`animationStart`](/en-US/docs/Web/API/Element/animationstart_event) and [`animationEnd`](/en-US/docs/Web/API/Element/animationend_event) events will be fired) but no animation will be visible.
 

--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -73,7 +73,7 @@ The order of time values within each animation definition is important: the firs
 
 The order of other values within each animation definition is also important for distinguishing an {{cssxref("animation-name")}} value from other values. If a value in the `animation` shorthand can be parsed as a value for an animation property other than `animation-name`, then the value will be applied to that property first and not to `animation-name`. For this reason, the recommended practice is to specify a value for `animation-name` as the last value in a list of values when using the `animation` shorthand; this holds true even when you specify multiple, comma-separated animations using the `animation` shorthand.
 
-An `animation-name` value is required to be declared in the `animation` shorthand property. If no name exists, there is no animation to apply on any of the properties.
+While an animation name must be set for an animation to be applied, all values of the `animation` shorthand are optional, and default to the initial value for each long-hand `animation` component. The initial value of `animation-name` is `none`, meaning if no `animation-name` value is declared in the `animation` shorthand property, there is no animation to apply on any of the properties.
 
 When the `animation-duration` value is omitted from the `animation` shorthand property, the value for this property defaults to `0s`. In this case, the animation will still occur (the [`animationStart`](/en-US/docs/Web/API/Element/animationstart_event) and [`animationEnd`](/en-US/docs/Web/API/Element/animationend_event) events will be fired) but no animation will be visible.
 


### PR DESCRIPTION
Typo in the description of the animation-name property, it read "An animation-name value is not required to be declared in the animation shorthand property. If no name exists, there is no animation to apply on any of the properties." 

instead of

 "An animation-name value is required to be declared in the animation shorthand property. If no name exists, there is no animation to apply on any of the properties."

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed a typo in the description of the animation-name property, I removed the word "not"

### Motivation

The typo made the definition wrong and could mess up someone's understanding

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
