### PR TITLE
Update link to color-mix documentation

### DIFF
--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -49,7 +49,7 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
   - [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch)
   - [`color()`](/en-US/docs/Web/CSS/color_value/color)
 - [`color-contrast()`](/en-US/docs/Web/CSS/color_value/color-contrast) {{Experimental_Inline}}
-- [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-contrast)
+- [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix)
 - [`device-cmyk()`](/en-US/docs/Web/CSS/color_value/device-cmyk) {{Experimental_Inline}}
 
 ### Data types


### PR DESCRIPTION
### Description

Updates a hyperlink pointing at the wrong page

### Motivation

The link to the documentation page for `color-mix()` was erroneously linking to `color-contrast()` instead

Fixing this link will allow users to navigate to the `color-mix()` documentation as intended
