### PR TITLE
Reference iframe in getRootNode() API

### DIFF
--- a/files/en-us/web/api/node/getrootnode/index.md
+++ b/files/en-us/web/api/node/getrootnode/index.md
@@ -35,7 +35,7 @@ An object inheriting from {{domxref('Node')}}. This will differ in exact form de
 on where you called `getRootNode()`; for example:
 
 - Calling it on an element inside a standard web page will return an
-  {{domxref("HTMLDocument")}} object representing the entire page.
+  {{domxref("HTMLDocument")}} object representing the entire page (or {{HTMLElement("iframe")}}).
 - Calling it on an element inside a shadow DOM will return the associated
   {{domxref("ShadowRoot")}}.
 


### PR DESCRIPTION
### Description

I added an reference to iframe parent.

### Motivation

I was pretty sure that getRootNode() will return the document inside the iframe and not the global one. But this is not clear right now in the description.

```
> document === evt.target.getRootNode()
false
> evt.target.ownerDocument === evt.target.getRootNode()
true
```
