### PR TITLE
WebGLRenderingContext has no commit method

### DIFF
--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -130,4 +130,3 @@ For a full example, see our [OffscreenCanvas worker example](https://github.com/
 - {{domxref("ImageBitmap")}}
 - {{domxref("ImageBitmapRenderingContext")}}
 - {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}
-- {{domxref("WebGLRenderingContext.commit()")}}

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -30,8 +30,6 @@ The following properties and methods provide general information and functionali
 
 - {{domxref("WebGLRenderingContext.canvas")}}
   - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
-- {{domxref("WebGLRenderingContext.commit()")}} {{Experimental_Inline}}
-  - : Pushes frames back to the original {{domxref("HTMLCanvasElement")}}, if the context is not directly fixed to a specific canvas.
 - {{domxref("WebGLRenderingContext.drawingBufferWidth")}}
   - : The read-only width of the current drawing buffer. Should match the width of the canvas element associated with this context.
 - {{domxref("WebGLRenderingContext.drawingBufferHeight")}}


### PR DESCRIPTION
My understanding of the spec is that there is only a `commit()` method on the `OffscreenCanvasRenderingContext2D` interface.

Spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreen-2d-rendering-context
BCD: https://github.com/mdn/browser-compat-data/pull/20011