### PR TITLE
docs(relnote): Fx114 - ARIA attribute reflection enabled on nightly, landmark roles bugfix

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -98,6 +98,46 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
   </tbody>
 </table>
 
+### Reflecting ARIA attributes
+
+[ARIA](/en-US/docs/Web/Accessibility/ARIA) reflection is enabled for non-IDREF attributes which allows authors to get and set ARIA attributes on DOM elements directly via JavaScript APIs, rather than by using `setAttribute` and `getAttribute`, (see [Firefox bug 1824980](https://bugzil.la/1824980) for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>114</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>114</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>114</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>114</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>accessibility.ARIAReflection.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -11,6 +11,9 @@ This article provides information about the changes in Firefox 114 that affect d
 
 ### Developer Tools
 
+- Fixed an issue where the [Accessibility Inspector](/en-US/docs/Tools/Accessibility_inspector) did not correctly show ARIA roles on elements which affected how [landmark roles](/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role) were displayed.
+  Roles which cannot be mapped to ARIA use a Gecko internal role name ([Firefox bug 1572512](https://bugzil.la/1572512)).
+
 ### HTML
 
 #### Removals


### PR DESCRIPTION
Rolling in the following two:

* Nightly enables ARIA attr reflection by default with the pref `accessibility.ARIAReflection.enabled` set to true.
* Bugfix for Dev Tools where known landmark roles visible in A11y inspector

<details>

* __Left:__ Fx nightly with correct landmark roles displayed, 
* __Right:__ Fx113 with `landmark` instead of correct role name

![image (2)](https://github.com/mdn/content/assets/43580235/bdd10977-fad2-457a-8530-88a4d3a5763c)

</details>


__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/26689
- BCD?

__Bugzilla:__
- ARIA landmark roles: BUG-1572512
- Attribute reflection: BUG-1824980

__Resources:__
* ARIA reflection:
  * Explainer https://github.com/WICG/aom/blob/gh-pages/aria-reflection-explainer.md
  * WPT: [Fx113, Fx115, Chrome stable, Safari stable](https://wpt.fyi/results/html/dom/aria-attribute-reflection.html?label=master&product=firefox%5Bstable%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&product=chrome%5Bstable%5D&aligned&q=aria)
  * pen: https://codepen.io/bsmth/pen/dygxzJQ
* Landmark roles WPT: [Fx nightly, Fx stable](https://wpt.fyi/results/html-aam/roles.html?label=master&product=firefox%5Bexperimental%5D&product=firefox%5Bstable%5D&aligned)
  * code sandbox: https://codesandbox.io/s/1qyfug?file=/index.html


