### PR TITLE
removed extraneous characters on element/template

### DIFF
--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -214,5 +214,5 @@ container.appendChild(secondClone);
 
 ## See also
 
-- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>`)}})
+- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>`)
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)


### PR DESCRIPTION
### Description

there were some trash characters in the document

### Motivation

removing trash to makes for a cleaner read
