### PR TITLE
WebDriver conformance changes for Firefox 114

### DIFF
--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -74,14 +74,14 @@ This article provides information about the changes in Firefox 114 that affect d
 
 - Added support for the commands `input.performActions` and `input.releaseActions`, which can be used to emulate user input for interacting with elements on web pages. Similar to Marionette all the available input sources of the WebDriver specification are supported, which are `key`, `pointer`, and `wheel` ([Firefox bug 1832380](https://bugzil.la/1832380)).
 - Added support for custom browser to client messages, which allows to send a `script.message` event from within a script formerly installed via `script.addPreloadScript` ([Firefox bug 1824187](https://bugzil.la/1824187)).
-- Added the `serializationOptions` parameter for `script.evaluate` and `script.callFunction` to customize the `RemoteValue` serialization ([Firefox bug 1824953](https://bugzil.la/1824953)).
+- Added support for the `serializationOptions` parameter for `script.evaluate` and `script.callFunction` to customize the `RemoteValue` serialization ([Firefox bug 1824953](https://bugzil.la/1824953)).
 - Fixed an issue where both the `script.evaluate` and `script.callFunction` commands did not include the stack trace and failed to properly build the exception details for a rejected Promise ([Firefox bug 1829630](https://bugzil.la/1829630)).
 - Fixed an issue where the `browsingContext.domContentLoaded` and `browsingContext.load` events did not report the correct `url`, when the page defined a `<base>` meta tag ([Firefox bug 1825634](https://bugzil.la/1825634)).
 
 #### Marionette
 
 - Fixed an issue where the command `WebDriver:GetComputedRole` didn't properly return the WAI-ARIA roles ([Firefox bug 1822112](https://bugzil.la/1822112)).
-- Fixed an issue where modifier keys are now correctly reset when they are used again within the same `WebDriver:ElementSendKeys` command ([Firefox bug 1776190](https://bugzil.la/1776190)).
+- Fixed an issue where modifier keys were not reset when they were used again within the same `WebDriver:ElementSendKeys` command ([Firefox bug 1776190](https://bugzil.la/1776190)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -72,7 +72,16 @@ This article provides information about the changes in Firefox 114 that affect d
 
 #### WebDriver BiDi
 
+- Added support for the commands `input.performActions` and `input.releaseActions`, which can be used to emulate user input for interacting with elements on web pages. Similar to Marionette all the available input sources of the WebDriver specification are supported, which are `key`, `pointer`, and `wheel` ([Firefox bug 1832380](https://bugzil.la/1832380)).
+- Added support for custom browser to client messages, which allows to send a `script.message` event from within a script formerly installed via `script.addPreloadScript` ([Firefox bug 1824187](https://bugzil.la/1824187)).
+- Added the `serializationOptions` parameter for `script.evaluate` and `script.callFunction` to customize the `RemoteValue` serialization ([Firefox bug 1824953](https://bugzil.la/1824953)).
+- Fixed an issue where both the `script.evaluate` and `script.callFunction` commands did not include the stack trace and failed to properly build the exception details for a rejected Promise ([Firefox bug 1829630](https://bugzil.la/1829630)).
+- Fixed an issue where the `browsingContext.domContentLoaded` and `browsingContext.load` events did not report the correct `url`, when the page defined a `<base>` meta tag ([Firefox bug 1825634](https://bugzil.la/1825634)).
+
 #### Marionette
+
+- Fixed an issue where the command `WebDriver:GetComputedRole` didn't properly return the WAI-ARIA roles ([Firefox bug 1822112](https://bugzil.la/1822112)).
+- Fixed an issue where modifier keys are now correctly reset when they are used again within the same `WebDriver:ElementSendKeys` command ([Firefox bug 1776190](https://bugzil.la/1776190)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
This adds the [WebDriver conformance changes for Firefox 114](https://bugzilla.mozilla.org/buglist.cgi?status_whiteboard=%5Bwebdriver%3Arelnote%5D&resolution=FIXED&query_format=advanced&v1=fixed&j_top=OR&status_whiteboard_type=substring&o1=equals&f1=cf_status_firefox114).

@juliandescottes and @lutien can you please check that all is fine? Thanks