### PR TITLE
Adding  note for compound selector use cases

### DIFF
--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -16,6 +16,23 @@ img ~ p {
   color: red;
 }
 ```
+Things get a little tricky when the combinator is used to join two compound selectors meant to ensure the matching elements are both in the same hierarchy.
+
+When there is a compound selector in the subsequent selector (right side of combinator), this entire subsequent selector must match UNDER the parent of the matching child in the preceding selector (left-side of combinator). 
+
+```css
+.foo p ~ .foo span {
+  color: green;
+}
+```
+
+If the desired result is to ensure both elements match the same compound selector, the compound statement in the subsequent selector is unnecessary since it would be implied if it was a sibling of the matching element in the preceding selector.
+
+```css
+.foo p ~ span {
+  color: blue;
+}
+```
 
 ## Syntax
 
@@ -30,6 +47,14 @@ former_element ~ target_element { style properties }
 ```css
 p ~ span {
   color: red;
+}
+
+.foo p ~ .foo span {
+  color: green;
+}
+
+.foo p ~ span {
+  color: blue;
 }
 ```
 
@@ -46,6 +71,13 @@ p ~ span {
 <p>Whatever it may be, keep smiling.</p>
 <h1>Dream big</h1>
 <span>And yet again this is a red span!</span>
+<div class="foo">
+  <p>Here is another paragraph.</p>
+  <span>A blue span</span>
+  <div class="foo">
+      <span>A green span</span>
+  </div>
+</div>
 ```
 
 ### Result

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -21,7 +21,8 @@ Things get a little tricky when the combinator is used to join two compound sele
 When there is a compound selector in the subsequent selector (right side of combinator), this entire subsequent selector must match UNDER the parent of the matching child in the preceding selector (left-side of combinator). 
 
 ```css
-.foo p ~ .foo span {
+/* Will NOT match `span` as a sibling of `p` when both are decendants of `.foo` */
+.foo p ~ .foo span {  
   color: green;
 }
 ```
@@ -29,7 +30,8 @@ When there is a compound selector in the subsequent selector (right side of comb
 If the desired result is to ensure both elements match the same compound selector, the compound statement in the subsequent selector is unnecessary since it would be implied if it was a sibling of the matching element in the preceding selector.
 
 ```css
-.foo p ~ span {
+/* Will match `span` as a sibling of `p`; both must be decendants of `.foo` */
+.foo p ~ span {  
   color: blue;
 }
 ```

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -22,7 +22,8 @@ Things get a little tricky when the combinator is used to join two compound sele
 When there is a compound selector in the subsequent selector (right side of combinator), this entire subsequent selector must match UNDER the parent of the matching child in the preceding selector (left-side of combinator).
 
 ```css
-/* Will NOT match `span` as a sibling of `p` when both are decendants of `.foo` */
+/* Will NOT match `span` as a sibling of `p` when both are descendants of `.foo` */
+/* Will match  `span` descendant of `.foo` if that `.foo` is a sibling of `p` both nested in an ancestor `.foo` */
 .foo p ~ .foo span {  
   color: green;
 }

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -16,9 +16,10 @@ img ~ p {
   color: red;
 }
 ```
+
 Things get a little tricky when the combinator is used to join two compound selectors meant to ensure the matching elements are both in the same hierarchy.
 
-When there is a compound selector in the subsequent selector (right side of combinator), this entire subsequent selector must match UNDER the parent of the matching child in the preceding selector (left-side of combinator). 
+When there is a compound selector in the subsequent selector (right side of combinator), this entire subsequent selector must match UNDER the parent of the matching child in the preceding selector (left-side of combinator).
 
 ```css
 /* Will NOT match `span` as a sibling of `p` when both are decendants of `.foo` */


### PR DESCRIPTION
The way this combinator works with compound selectors can be confusing and it was a surprise (to me) to see how it actually worked.  I think it can easily be misinterpreted with out this specific previous knowledge. 

It comes up more when using SCSS transpilation since its more common to throw around the `&` to refer to the hierarchy.  
For example, the following may look like it will match when an element with class `.bar` follows another element that matches `.bar` when both are children of `.foo` but it does not. 

```css
.foo {
  .bar {
    & ~ & { ... }
  }
}
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I added a note and example for how this combinator handles compound selectors as it seemed non-obvious and important to understand. 


### Motivation
I came to MDN to find this clarity on how compound selectors were handled by the combinator. I would like to save others some time. 

### Additional details

n/a

### Related issues and pull requests

n/a

