### PR TITLE
typedarray#sort doesn't use string sorting

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -32,6 +32,8 @@ sort(compareFn)
     - `b`
       - : The second element for comparison. Will never be `undefined`.
 
+    If omitted, the array elements are sorted according to numeric value.
+
 ### Return value
 
 The sorted typed array.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -32,8 +32,6 @@ sort(compareFn)
     - `b`
       - : The second element for comparison. Will never be `undefined`.
 
-    If omitted, the array elements are converted to strings, then sorted according to each character's Unicode code point value.
-
 ### Return value
 
 The sorted typed array.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a likely copy/paste error from `array#sort()`: typedarrays don't convert to strings to sort.

### Motivation

Something is wrong on the internet.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
