### PR TITLE
Correct return value description for LockManager.request

### DIFF
--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -72,7 +72,7 @@ request(name, options, callback)
 
 ### Return value
 
-A {{jsxref('Promise')}} that resolves with `undefined` when the request is granted.
+A {{jsxref('Promise')}} that resolves (or rejects) with the result of the callback after the lock is released, or rejects if the request is aborted.
 
 ### Exceptions
 


### PR DESCRIPTION
The documentation for LockManager.request() claimed that the return value was a Promise that would resolve to undefined, which is not correct unless the callback returns undefined.

See the [spec](https://w3c.github.io/web-locks/#api-lock-manager-request):

> The returned promise resolves (or rejects) with the result of the callback after the lock is released, or rejects if the request is aborted.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
