### PR TITLE
Add missing space

### DIFF
--- a/files/en-us/web/http/headers/accept-ranges/index.md
+++ b/files/en-us/web/http/headers/accept-ranges/index.md
@@ -39,7 +39,7 @@ Accept-Ranges: none
 - `<range-unit>`
   - : Defines the range unit that the server supports. Though `bytes` is the only
     range unit formally defined by {{RFC("7233")}}, additional range units may be
-    registered in the[HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units).
+    registered in the [HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units).
 - `none`
   - : Indicates that no range unit is supported. This makes the header equivalent of its own absence
     and is therefore, rarely used. Although in some browsers, like IE9, this setting is used to


### PR DESCRIPTION
### Description

There's a missing space before "HTTP Range Unit Registry"

### Motivation

Improve readability

### Additional details

N/A

### Related issues and pull requests

N/A