### PR TITLE
Add a note on browser support for desktop orientation events

### DIFF
--- a/files/en-us/web/api/device_orientation_events/index.md
+++ b/files/en-us/web/api/device_orientation_events/index.md
@@ -30,7 +30,7 @@ Some typical features for which you might want to use the device orientation eve
 
 - for gesture recognition — for example, recognizing a "shake" gesture and using it to perform some action such as clearing an input area when the user shakes the device
 
-> **Note:** This API is widely supported on mobile browsers. While some desktop or laptop browsers may have limitations due to hardware differences, these constraints are rarely significant given the API's primary usage on sensor-equipped devices.
+> **Note:** This API is widely supported on mobile browsers. While some desktop-only browsers may have limitations due to hardware differences, these constraints are rarely significant given the API's primary usage on sensor-equipped devices.
 
 ## Interfaces
 

--- a/files/en-us/web/api/device_orientation_events/index.md
+++ b/files/en-us/web/api/device_orientation_events/index.md
@@ -30,6 +30,8 @@ Some typical features for which you might want to use the device orientation eve
 
 - for gesture recognition — for example, recognizing a "shake" gesture and using it to perform some action such as clearing an input area when the user shakes the device
 
+> **Note:** This API is widely supported on mobile browsers. While some desktop or laptop browsers may have limitations due to hardware differences, these constraints are rarely significant given the API's primary usage on sensor-equipped devices.
+
 ## Interfaces
 
 - {{domxref("DeviceOrientationEvent")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds a note to to clarify that whilst some desktop-only browsers don't support Device orientation events, that is not important most of the time.

### Motivation

Make it clearer to devs unaware of the difference between Safari and Safari iOS that Device Orientation Events are widely supported 

### Additional details

[Discussion on Discord](https://discord.com/channels/1009925603572600863/1050154738718605393/1113777688876949565)

### Related issues and pull requests

Fixes #27138
