### PR TITLE
Introduction to the CSS basic box model - remove spec section

### DIFF
--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -38,10 +38,6 @@ The size of the margin area is determined by the {{cssxref("margin-top")}}, {{cs
 
 Finally, note that for non-replaced inline elements, the amount of space taken up (the contribution to the height of the line) is determined by the {{cssxref('line-height')}} property, even though the borders and padding are still displayed around the content.
 
-## Specifications
-
-{{Specifications}}
-
 ## See also
 
 - [Layout and the containing block](/en-US/docs/Web/CSS/Containing_block)

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -70,10 +70,6 @@ p {
 
 {{EmbedLiveSample('Examples', 'auto', 350)}}
 
-## Specifications
-
-{{Specifications}}
-
 ## See also
 
 - CSS key concepts:


### PR DESCRIPTION
Fixes #27085

Specifications section was not rendering because there was no metadata key. 
The page is a guide, and should typically not include a specifications link section so I just removed it.