### PR TITLE
Fix small typos in Basic math in JavaScript — numbers and operators page

### DIFF
--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -364,11 +364,11 @@ In this exercise, you will manipulate some numbers and operators to change the s
 
 In the editable code box above, there are two lines marked with a comment that we'd like you to update to make the box grow/shrink to certain sizes, using certain operators and/or values in each case. Let's try the following:
 
-- Change the line that calculates x so the box is still 50px wide, but the 50 is calculated using the numbers 43 and 7 and an arithmetic operator.
-- Change the line that calculates y so the box is 75px high, but the 75 is calculated using the numbers 25 and 3 and an arithmetic operator.
+- Change the line that calculates x so the box is still 50px wide, but the 50 is calculated using the numbers 43 and 7 and the arithmetic operator.
+- Change the line that calculates y so the box is 75px high, but the 75 is calculated using the numbers 25 and 3 and the multiplication operator.
 - Change the line that calculates x so the box is 250px wide, but the 250 is calculated using two numbers and the remainder (modulo) operator.
 - Change the line that calculates y so the box is 150px high, but the 150 is calculated using three numbers and the subtraction and division operators.
-- Change the line that calculates x so the box is 200px wide, but the 200 is calculated using the number 4 and an assignment operator.
+- Change the line that calculates x so the box is 200px wide, but the 200 is calculated using the number 4 and the assignment operator.
 - Change the line that calculates y so the box is 200px high, but the 200 is calculated using the numbers 50 and 3, the multiplication operator, and the addition assignment operator.
 
 Don't worry if you totally mess the code up. You can always press the Reset button to get things working again. After you've answered all the above questions correctly, feel free to play with the code some more or create your own challenges.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This pull request fixes some small typos in the Basic math in JavaScript — numbers and operators page. 
* Fixes a challenge asking for the arithmetic operator rather than the multiplication operator. 
* Switches some indefinite articles to definite articles for consistent styling.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Spelling errors can be distracting, and when a reader is able to fix the typos, why not?
This change will help improve readability by removing distractions in spelling and help make the challenge/example easier. 
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
While the challenge (use 25, 3, and '+' to = 75) is possible, the above example already uses the arithmetic operator and this challenge can be solved much easier with the multiplication operator.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
This pull request does not resolve an issue or depend on another.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
