### PR TITLE
Release note for storage.session

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -56,8 +56,8 @@ This article provides information about the changes in Firefox 115 that affect d
 ## Changes for add-on developers
 
 - To support its deprecation from Manifest V3 extensions, manifest key property [`browser_style`](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles) defaults to `false` in [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) and [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) for Manifest V3 extensions ([Firefox bug 1830710](https://bugzil.la/1830710)). See [Manifest v3 migration](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for information about transitioning from `browser_style` in Manifest V3 extensions.
-- Adds {{WebExtAPIRef("commands.onChanged")}} which enables web extensions to listen for changes to command shortcuts ([Firefox bug 1801531](https://bugzil.la/1801531)).
-- Adds support for {{WebExtAPIRef("storage.session")}} providing the ability to store data in memory for the duration of the browser session ([Firefox bug 18237131](https://bugzil.la/1823713)).
+- The {{WebExtAPIRef("commands.onChanged")}} event, which enables web extensions to listen for changes to command shortcuts, has been added ([Firefox bug 1801531](https://bugzil.la/1801531)).
+- Support has been added for {{WebExtAPIRef("storage.session")}}, which provides the ability to store data in memory for the duration of the browser session ([Firefox bug 18237131](https://bugzil.la/1823713)).
 
 ### Removals
 

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -56,7 +56,8 @@ This article provides information about the changes in Firefox 115 that affect d
 ## Changes for add-on developers
 
 - To support its deprecation from Manifest V3 extensions, manifest key property [`browser_style`](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles) defaults to `false` in [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) and [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) for Manifest V3 extensions ([Firefox bug 1830710](https://bugzil.la/1830710)). See [Manifest v3 migration](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for information about transitioning from `browser_style` in Manifest V3 extensions.
-- Adds {{WebExtAPIRef("commands.onChanged")}} which enables web extensions to listen for changes to command shortcuts ([Firefox bug 1801531](https://bugzil.la/1801531))
+- Adds {{WebExtAPIRef("commands.onChanged")}} which enables web extensions to listen for changes to command shortcuts ([Firefox bug 1801531](https://bugzil.la/1801531)).
+- Adds support for {{WebExtAPIRef("storage.session")}} providing the ability to store data in memory for the duration of the browser session ([Firefox bug 18237131](https://bugzil.la/1823713)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Add a release note about support for session.storage in Firefox 115. See [Bug 1823713](https://bugzilla.mozilla.org/show_bug.cgi?id=1823713) Implement storage.session in extension process.