### PR TITLE
Add page for Response.json() static method

### DIFF
--- a/files/en-us/web/api/response/json_static/index.md
+++ b/files/en-us/web/api/response/json_static/index.md
@@ -1,0 +1,40 @@
+---
+title: "Response: json() static method"
+short-title: json()
+slug: Web/API/Response/json_static
+page-type: web-api-static-method
+---
+
+{{APIRef("Fetch API")}}
+
+The **`json()`** static method of the {{domxref("Response")}} interface returns a `Response` which contains the provided JSON data as body and a {{HTTPHeader("Content-Type")}} header which is set to `application/json`.
+
+## Syntax
+
+```js-nolint
+Response.json(data)
+Response.json(data, options)
+```
+
+### Parameters
+
+- `data`
+  - : The JSON data that will be used as response body.
+- `options` {{optional_inline}}
+  - : An options object containing any custom settings. This is the same as the options parameter of the {{domxref("Response.Response", "Response()")}} constructor.
+
+### Return value
+
+A {{domxref("Response")}} object.
+
+## Examples
+
+```js
+Response.json({my: "data"});
+```
+
+## See also
+
+- [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API)
+- [HTTP access control (CORS)](/en-US/docs/Web/HTTP/CORS)
+- [HTTP](/en-US/docs/Web/HTTP)

--- a/files/en-us/web/api/response/json_static/index.md
+++ b/files/en-us/web/api/response/json_static/index.md
@@ -30,7 +30,7 @@ A {{domxref("Response")}} object.
 ## Examples
 
 ```js
-Response.json({my: "data"});
+Response.json({ my: "data" });
 ```
 
 ## See also


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a new page for the `Response.json()` method.

### Motivation

For a long time I've been looking for a browser support table. And while this PR doesn't include compatibility data, I'm hoping this will be a good start.

### Additional details

https://fetch.spec.whatwg.org/#response-class
The other static method pages contain a note that these methods are mainly meant for use in service workers. But that didn't feel right in this case since it is also used in server side JavaScript a lot.

#22970 contains a change that adds a link to the `Response` overview page. So I deliberately left that out in this PR.

### Related issues and pull requests

Related to #22970


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
