### PR TITLE
Use decompress throughout DecompressionStream

### DIFF
--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -23,12 +23,12 @@ new DecompressionStream(format)
   - : One of the following compression formats:
 
     - `"gzip"`
-      - : Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+      - : Decompress the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
     - `"deflate"`
-      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
+      - : Decompress the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
         The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
     - `"deflate-raw"`
-      - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+      - : Decompress the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
 
 ## Exceptions
 
@@ -37,7 +37,7 @@ new DecompressionStream(format)
 
 ## Examples
 
-In this example a blob is decompressed using gzip compression.
+In this example a gzip-compressed blob is decompressed.
 
 ```js
 const ds = new DecompressionStream("gzip");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The DecompressionStream API uses the verb "compress" in its parameters, likely copied from the CompressionStream API. This PR changes it to "decompress" where appropriate.

### Motivation

Clarify that this is the decompression API and compression.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
