### PR TITLE
Correct typo

### DIFF
--- a/files/en-us/web/javascript/reference/operators/subtraction/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.md
@@ -19,7 +19,7 @@ x - y
 
 ## Description
 
-The `*` operator is overloaded for two types of operands: number and [BigInt](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt). It first [coerces both operands to numeric values](/en-US/docs/Web/JavaScript/Data_structures#numeric_coercion) and tests the types of them. It performs BigInt subtraction if both operands becomes BigInts; otherwise, it performs number subtraction. A {{jsxref("TypeError")}} is thrown if one operand becomes a BigInt but the other becomes a number.
+The `-` operator is overloaded for two types of operands: number and [BigInt](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt). It first [coerces both operands to numeric values](/en-US/docs/Web/JavaScript/Data_structures#numeric_coercion) and tests the types of them. It performs BigInt subtraction if both operands becomes BigInts; otherwise, it performs number subtraction. A {{jsxref("TypeError")}} is thrown if one operand becomes a BigInt but the other becomes a number.
 
 ## Examples
 


### PR DESCRIPTION
Refer to the correct operator at the top of the description.

### Description

The multiplication operator is mentioned when the sentence is about the subtraction operator.