### PR TITLE
WebRTC Stats: capture what stats might be in sender and receiver

### DIFF
--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
@@ -8,11 +8,7 @@ browser-compat: api.RTCRtpReceiver.getStats
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCRtpReceiver")}} method **`getStats()`**
-asynchronously requests an {{domxref("RTCStatsReport")}} object which provides
-statistics about incoming traffic on the owning {{domxref("RTCPeerConnection")}},
-returning a {{jsxref("Promise")}} whose fulfillment handler will be called once the
-results are available.
+The {{domxref("RTCRtpReceiver")}} method **`getStats()`** asynchronously requests an {{domxref("RTCStatsReport")}} object which provides statistics about incoming traffic on the owning {{domxref("RTCPeerConnection")}}, returning a {{jsxref("Promise")}} whose fulfillment handler will be called once the results are available.
 
 ## Syntax
 
@@ -26,18 +22,16 @@ None.
 
 ### Return value
 
-A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are
-available. The promise's fulfillment handler receives as a parameter a
-{{domxref("RTCStatsReport")}} object containing the collected statistics.
+A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are available.
+The promise's fulfillment handler receives as a parameter a {{domxref("RTCStatsReport")}} object containing the collected statistics.
 
-The returned statistics include those from all streams which are coming in through the
-`RTCRtpReceiver`, as well as any of their dependencies.
+The returned statistics include those from all streams which are coming in through the `RTCRtpReceiver`, as well as any of their dependencies.
+
+These might include, for example, statistics with [types](/en-US/docs/Web/API/RTCStatsReport#the_statistic_types): [`inbound-rtp`](/en-US/docs/Web/API/RTCInboundRtpStreamStats), [`candidate-pair`](/en-US/docs/Web/API/RTCIceCandidatePairStats), [`local-candidate`](/en-US/docs/Web/API/RTCIceCandidateStats), [`remote-candidate`](/en-US/docs/Web/API/RTCIceCandidateStats).
 
 ## Examples
 
-This simple example obtains the statistics for an `RTCRtpReceiver` and
-updates an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the number of
-packets lost.
+This simple example obtains the statistics for an `RTCRtpReceiver` and updates an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the number of packets lost.
 
 ```js
 receiver.getStats().then((stats) => {

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.md
@@ -8,11 +8,7 @@ browser-compat: api.RTCRtpSender.getStats
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCRtpSender")}} method **`getStats()`**
-asynchronously requests an {{domxref("RTCStatsReport")}} object which provides
-statistics about outgoing traffic on the {{domxref("RTCPeerConnection")}} which owns the
-sender, returning a {{jsxref("Promise")}} which is fulfilled when the results are
-available.
+The {{domxref("RTCRtpSender")}} method **`getStats()`** asynchronously requests an {{domxref("RTCStatsReport")}} object which provides statistics about outgoing traffic on the {{domxref("RTCPeerConnection")}} which owns the sender, returning a {{jsxref("Promise")}} which is fulfilled when the results are available.
 
 ## Syntax
 
@@ -26,19 +22,16 @@ None.
 
 ### Return value
 
-A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are
-available. The promise's fulfillment handler receives as a parameter a
-{{domxref("RTCStatsReport")}} object containing the collected statistics.
+A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are available.
+The promise's fulfillment handler receives as a parameter a {{domxref("RTCStatsReport")}} object containing the collected statistics.
 
-The returned `RTCStatsReport` accumulates the statistics for all of the
-streams being sent using the `RTCRtpSender`, as well as the statistics for
-any dependencies those streams have.
+The returned `RTCStatsReport` accumulates the statistics for all of the streams being sent using the `RTCRtpSender`, as well as the statistics for any dependencies those streams have.
+
+These might include, for example, statistics with [types](2/en-US/docs/Web/API/RTCStatsReport#the_statistic_types): [`outbound-rtp`](/en-US/docs/Web/API/RTCOutboundRtpStreamStats), [`candidate-pair`](/en-US/docs/Web/API/RTCIceCandidatePairStats), [`local-candidate`](/en-US/docs/Web/API/RTCIceCandidateStats), [`remote-candidate`](/en-US/docs/Web/API/RTCIceCandidateStats).
 
 ## Examples
 
-This simple example obtains the statistics for an `RTCRtpSender` and updates
-an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the current round
-trip time for requests on the sender.
+This simple example obtains the statistics for an `RTCRtpSender` and updates an element's {{domxref("HTMLElement/innerText", "innerText")}} to display the current round trip time for requests on the sender.
 
 ```js
 sender.getStats().then((stats) => {


### PR DESCRIPTION
WebRTS statistics may be returned in getStats() methods on the reciever, sender, or peerconnection. The docs are a bit hand wavey about what is returned for senders and receivers - statements like "all streams coming in through the receiver as well as their dependencies". I can't test and I can't tell if, say, a codec or certificate might be a dependency.

What this does is just add a note about the things that are returned for sure. I hope we can expand these at some point with more detail about those dependencies.

These are determined from WPT tests like http://wpt.live/webrtc/RTCRtpReceiver-getStats.https.html