### PR TITLE
Update Array.prototype.with() RangeError condition

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/with/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/with/index.md
@@ -31,7 +31,7 @@ A new array with the element at `index` replaced with `value`.
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : Thrown if `index > array.length` or `index < -array.length`.
+  - : Thrown if `index >= array.length` or `index < -array.length`.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is a trivial fix on the condition on when `Array.prototype.with()` throws `RangeError`.

### Motivation

- The original sentence makes me think that `[].with(0, 'Yay')` (an array with `length` 0, and `index` of `with()` is also `0` ) returns `['Yay']`.
- However, in reality it throws `RangeError`. `Array.prototype.with()` cannot return an array with its length different from the original array.

### Additional details

https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.with
![image](https://github.com/mdn/content/assets/108608/840ee451-0f3a-48bc-a925-eb344a877a6c)


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
