### PR TITLE
fix: Add the missing experimental banner and status to scripting media page

### DIFF
--- a/files/en-us/web/css/@media/scripting/index.md
+++ b/files/en-us/web/css/@media/scripting/index.md
@@ -2,10 +2,12 @@
 title: scripting
 slug: Web/CSS/@media/scripting
 page-type: css-media-feature
+status:
+  - experimental
 browser-compat: css.at-rules.media.scripting
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`scripting`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test whether scripting (such as JavaScript) is available.
 
@@ -72,5 +74,5 @@ p {
 
 ## See also
 
-- [Using Media Queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
 - [@media](/en-US/docs/Web/CSS/@media)
+- [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [`scripting`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting) media feature is currently supported only in [Firefox](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting#browser_compatibility). So this PR adds the experimental status and banner. 

