### PR TITLE
Fix various API members which are static

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7639,6 +7639,10 @@
 /en-US/docs/Web/API/BluetoothGattService/uuid	/en-US/docs/Web/API/BluetoothRemoteGATTService/uuid
 /en-US/docs/Web/API/BluetoothRemoteGATTService/getIncludedService	/en-US/docs/Web/API/BluetoothRemoteGATTService
 /en-US/docs/Web/API/BluetoothRemoteGATTService/getIncludedServices	/en-US/docs/Web/API/BluetoothRemoteGATTService
+/en-US/docs/Web/API/BluetoothUUID/canonicalUUID	/en-US/docs/Web/API/BluetoothUUID/canonicalUUID_static
+/en-US/docs/Web/API/BluetoothUUID/getCharacteristic	/en-US/docs/Web/API/BluetoothUUID/getCharacteristic_static
+/en-US/docs/Web/API/BluetoothUUID/getDescriptor	/en-US/docs/Web/API/BluetoothUUID/getDescriptor_static
+/en-US/docs/Web/API/BluetoothUUID/getService	/en-US/docs/Web/API/BluetoothUUID/getService_static
 /en-US/docs/Web/API/Body/arrayBuffer	/en-US/docs/Web/API/Response/arrayBuffer
 /en-US/docs/Web/API/Body/blob	/en-US/docs/Web/API/Response/blob
 /en-US/docs/Web/API/Body/body	/en-US/docs/Web/API/Response/body
@@ -7679,6 +7683,8 @@
 /en-US/docs/Web/API/CSSStyleSheet.deleteRule	/en-US/docs/Web/API/CSSStyleSheet/deleteRule
 /en-US/docs/Web/API/CSSStyleSheet.insertRule	/en-US/docs/Web/API/CSSStyleSheet/insertRule
 /en-US/docs/Web/API/CSSStyleValue/CSSUnitValue	/en-US/docs/Web/API/CSSUnitValue/CSSUnitValue
+/en-US/docs/Web/API/CSSStyleValue/parse	/en-US/docs/Web/API/CSSStyleValue/parse_static
+/en-US/docs/Web/API/CSSStyleValue/parseAll	/en-US/docs/Web/API/CSSStyleValue/parseAll_static
 /en-US/docs/Web/API/CSSUnitValue/CSSUnitValue()	/en-US/docs/Web/API/CSSUnitValue/CSSUnitValue
 /en-US/docs/Web/API/CSSUnitValue/CSSUnitValue.CSSUnitValue	/en-US/docs/Web/API/CSSUnitValue/CSSUnitValue
 /en-US/docs/Web/API/CSSValueList/CSSValueList.length	/en-US/docs/Web/API/CSSValueList/length
@@ -8750,6 +8756,7 @@
 /en-US/docs/Web/API/IDBVersionChangeEvent/version	/en-US/docs/Web/API/IDBVersionChangeEvent
 /en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse()	/en-US/docs/Web/API/IIRFilterNode/getFrequencyResponse
 /en-US/docs/Web/API/IdleDetector/onchange	/en-US/docs/Web/API/IdleDetector/change_event
+/en-US/docs/Web/API/IdleDetector/requestPermission	/en-US/docs/Web/API/IdleDetector/requestPermission_static
 /en-US/docs/Web/API/Image	/en-US/docs/Web/API/HTMLImageElement/Image
 /en-US/docs/Web/API/ImageBitmapFactories/createImageBitmap	/en-US/docs/Web/API/createImageBitmap
 /en-US/docs/Web/API/ImageBitmapRenderingContext/transferImageBitmap	/en-US/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap
@@ -9386,6 +9393,7 @@
 /en-US/docs/Web/API/PushManager.register	/en-US/docs/Web/API/PushManager/register
 /en-US/docs/Web/API/PushManager.registrations	/en-US/docs/Web/API/PushManager/registrations
 /en-US/docs/Web/API/PushManager.unregister	/en-US/docs/Web/API/PushManager/unregister
+/en-US/docs/Web/API/PushManager/supportedContentEncodings	/en-US/docs/Web/API/PushManager/supportedContentEncodings_static
 /en-US/docs/Web/API/Push_API/Using_the_Push_API	/en-US/docs/Web/API/Push_API
 /en-US/docs/Web/API/RTCAnswerOptions	/en-US/docs/Web/API/RTCPeerConnection/createAnswer
 /en-US/docs/Web/API/RTCConfiguration	/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -23261,12 +23261,12 @@
     "modified": "2020-12-01T07:00:49.309Z",
     "contributors": ["Wuzzel", "jpmedley"]
   },
-  "Web/API/CSSStyleValue/parse": {
-    "modified": "2020-10-15T22:07:03.007Z",
+  "Web/API/CSSStyleValue/parseAll_static": {
+    "modified": "2020-10-15T22:07:02.186Z",
     "contributors": ["estelle", "Wuzzel", "jpmedley"]
   },
-  "Web/API/CSSStyleValue/parseAll": {
-    "modified": "2020-10-15T22:07:02.186Z",
+  "Web/API/CSSStyleValue/parse_static": {
+    "modified": "2020-10-15T22:07:03.007Z",
     "contributors": ["estelle", "Wuzzel", "jpmedley"]
   },
   "Web/API/CSSSupportsRule": {
@@ -53842,7 +53842,7 @@
       "teoli"
     ]
   },
-  "Web/API/PushManager/supportedContentEncodings": {
+  "Web/API/PushManager/supportedContentEncodings_static": {
     "modified": "2020-10-15T21:57:40.045Z",
     "contributors": ["fscholz", "jpmedley"]
   },

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
@@ -15,7 +15,7 @@ The **`canonicalUUID()`** static method of the {{domxref("BluetoothUUID")}} inte
 ## Syntax
 
 ```js-nolint
-canonicalUUID(alias)
+BluetoothUUID.canonicalUUID(alias)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
@@ -1,8 +1,8 @@
 ---
-title: "BluetoothUUID: canonicalUUID() method"
+title: "BluetoothUUID: canonicalUUID() static method"
 short-title: canonicalUUID()
-slug: Web/API/BluetoothUUID/canonicalUUID
-page-type: web-api-instance-method
+slug: Web/API/BluetoothUUID/canonicalUUID_static
+page-type: web-api-static-method
 status:
   - experimental
 browser-compat: api.BluetoothUUID.canonicalUUID
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothUUID.canonicalUUID
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
-The **`canonicalUUID()`** method of the {{domxref("BluetoothUUID")}} interface returns the 128-bit UUID when passed a 16- or 32-bit UUID alias.
+The **`canonicalUUID()`** static method of the {{domxref("BluetoothUUID")}} interface returns the 128-bit UUID when passed a 16- or 32-bit UUID alias.
 
 ## Syntax
 

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
@@ -1,8 +1,8 @@
 ---
-title: "BluetoothUUID: getCharacteristic() method"
+title: "BluetoothUUID: getCharacteristic() static method"
 short-title: getCharacteristic()
-slug: Web/API/BluetoothUUID/getCharacteristic
-page-type: web-api-instance-method
+slug: Web/API/BluetoothUUID/getCharacteristic_static
+page-type: web-api-static-method
 status:
   - experimental
 browser-compat: api.BluetoothUUID.getCharacteristic
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothUUID.getCharacteristic
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
-The **`getCharacteristic()`** method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered characteristic when passed a name or the 16- or 32-bit UUID alias.
+The **`getCharacteristic()`** static method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered characteristic when passed a name or the 16- or 32-bit UUID alias.
 
 ## Syntax
 

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
@@ -15,7 +15,7 @@ The **`getCharacteristic()`** static method of the {{domxref("BluetoothUUID")}} 
 ## Syntax
 
 ```js-nolint
-getCharacteristic(name)
+BluetoothUUID.getCharacteristic(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
@@ -1,8 +1,8 @@
 ---
-title: "BluetoothUUID: getDescriptor() method"
+title: "BluetoothUUID: getDescriptor() static method"
 short-title: getDescriptor()
-slug: Web/API/BluetoothUUID/getDescriptor
-page-type: web-api-instance-method
+slug: Web/API/BluetoothUUID/getDescriptor_static
+page-type: web-api-static-method
 status:
   - experimental
 browser-compat: api.BluetoothUUID.getDescriptor
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothUUID.getDescriptor
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
-The **`getDescriptor()`** method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered descriptor when passed a name or the 16- or 32-bit UUID alias.
+The **`getDescriptor()`** static method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered descriptor when passed a name or the 16- or 32-bit UUID alias.
 
 ## Syntax
 

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
@@ -15,7 +15,7 @@ The **`getDescriptor()`** static method of the {{domxref("BluetoothUUID")}} inte
 ## Syntax
 
 ```js-nolint
-getDescriptor(name)
+BluetoothUUID.getDescriptor(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
@@ -15,7 +15,7 @@ The **`getService()`** static method of the {{domxref("BluetoothUUID")}} interfa
 ## Syntax
 
 ```js-nolint
-getService(name)
+BluetoothUUID.getService(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
@@ -1,8 +1,8 @@
 ---
-title: "BluetoothUUID: getService() method"
+title: "BluetoothUUID: getService() static method"
 short-title: getService()
-slug: Web/API/BluetoothUUID/getService
-page-type: web-api-instance-method
+slug: Web/API/BluetoothUUID/getService_static
+page-type: web-api-static-method
 status:
   - experimental
 browser-compat: api.BluetoothUUID.getService
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothUUID.getService
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
-The **`getService()`** method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered service when passed a name or the 16- or 32-bit UUID alias.
+The **`getService()`** static method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered service when passed a name or the 16- or 32-bit UUID alias.
 
 ## Syntax
 

--- a/files/en-us/web/api/bluetoothuuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/index.md
@@ -17,23 +17,15 @@ The Bluetooth registry contains lists of descriptors, services, and characterist
 
 The `BluetoothUUID` interface provides methods to retrieve these 128-bit UUIDs.
 
-## Instance properties
+## Static methods
 
-None.
-
-### Event handlers
-
-None.
-
-## Instance methods
-
-- {{domxref("BluetoothUUID.canonicalUUID()")}} {{Experimental_Inline}}
+- [`BluetoothUUID.canonicalUUID()`](/en-us/docs/Web/API/BluetoothUUID/canonicalUUID_static) {{Experimental_Inline}}
   - : Returns the 128-bit UUID when passed the 16- or 32-bit UUID alias.
-- {{domxref("BluetoothUUID.getCharacteristic()")}} {{Experimental_Inline}}
+- [`BluetoothUUID.getCharacteristic()`](/en-us/docs/Web/API/BluetoothUUID/getCharacteristic_static) {{Experimental_Inline}}
   - : Returns the 128-bit UUID representing a registered characteristic when passed a name or the 16- or 32-bit UUID alias.
-- {{domxref("BluetoothUUID.getDescriptor()")}} {{Experimental_Inline}}
+- [`BluetoothUUID.getDescriptor()`](/en-us/docs/Web/API/BluetoothUUID/getDescriptor_static) {{Experimental_Inline}}
   - : Returns a UUID representing a registered descriptor when passed a name or the 16- or 32-bit UUID alias.
-- {{domxref("BluetoothUUID.getService()")}} {{Experimental_Inline}}
+- [`BluetoothUUID.getService()`](/en-us/docs/Web/API/BluetoothUUID/getService_static) {{Experimental_Inline}}
   - : Returns a UUID representing a registered service when passed a name or the 16- or 32-bit UUID alias.
 
 ## Examples

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -20,11 +20,11 @@ Below is a list of interfaces based on the `CSSStyleValue` interface.
 - {{domxref('CSSTransformValue')}}
 - {{domxref('CSSUnparsedValue')}}
 
-## Instance methods
+## Static methods
 
-- {{domxref("CSSStyleValue.parse()")}}
+- [`CSSStyleValue.parse()`](/en-us/docs/Web/API/CSSStyleValue/parse_static)
   - : Sets a specific CSS property to the specified values and returns the first value as a {{domxref('CSSStyleValue')}} object.
-- {{domxref("CSSStyleValue.parseAll()")}}
+- [`CSSStyleValue.parseAll()`](/en-us/docs/Web/API/CSSStyleValue/parseAll_static)
   - : Sets all occurrences of a specific CSS property to the specified value and returns an array of {{domxref('CSSStyleValue')}} objects, each containing one of the supplied values.
 
 ## Specifications

--- a/files/en-us/web/api/cssstylevalue/parse_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse_static/index.md
@@ -15,7 +15,7 @@ value as a {{domxref('CSSStyleValue')}} object.
 ## Syntax
 
 ```js-nolint
-parse(property, cssText)
+CSSStyleValue.parse(property, cssText)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylevalue/parse_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse_static/index.md
@@ -1,14 +1,14 @@
 ---
-title: "CSSStyleValue: parse() method"
+title: "CSSStyleValue: parse() static method"
 short-title: parse()
-slug: Web/API/CSSStyleValue/parse
-page-type: web-api-instance-method
+slug: Web/API/CSSStyleValue/parse_static
+page-type: web-api-static-method
 browser-compat: api.CSSStyleValue.parse
 ---
 
 {{APIRef("CSS Typed Object Model API")}}
 
-The **`parse()`** method of the {{domxref("CSSStyleValue")}}
+The **`parse()`** static method of the {{domxref("CSSStyleValue")}}
 interface sets a specific CSS property to the specified values and returns the first
 value as a {{domxref('CSSStyleValue')}} object.
 
@@ -57,6 +57,7 @@ CSSTransformValue {0: CSSTranslate, 1: CSSScale, length: 2, is2D: false}
 
 ## See also
 
-- {{domxref("CSSStyleValue.parseAll()")}}
+- [`CSSStyleValue.parseAll()`](/en-us/docs/Web/API/CSSStyleValue/parseAll_static)
+
 - [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssstylevalue/parseall_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall_static/index.md
@@ -16,7 +16,7 @@ supplied values.
 ## Syntax
 
 ```js-nolint
-parseAll(property, value)
+CSSStyleValue.parseAll(property, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylevalue/parseall_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall_static/index.md
@@ -1,14 +1,14 @@
 ---
-title: "CSSStyleValue: parseAll() method"
+title: "CSSStyleValue: parseAll() static method"
 short-title: parseAll()
-slug: Web/API/CSSStyleValue/parseAll
-page-type: web-api-instance-method
+slug: Web/API/CSSStyleValue/parseAll_static
+page-type: web-api-static-method
 browser-compat: api.CSSStyleValue.parseAll
 ---
 
 {{APIRef("CSS Typed Object Model API")}}
 
-The **`parseAll()`** method of the {{domxref("CSSStyleValue")}}
+The **`parseAll()`** static method of the {{domxref("CSSStyleValue")}}
 interface sets all occurrences of a specific CSS property to the specified value and
 returns an array of {{domxref('CSSStyleValue')}} objects, each containing one of the
 supplied values.
@@ -42,6 +42,6 @@ values.
 
 ## See also
 
-- {{domxref("CSSStyleValue.parse()")}}
+- [`CSSStyleValue.parse()`](/en-us/docs/Web/API/CSSStyleValue/parse_static)
 - [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/idledetector/index.md
+++ b/files/en-us/web/api/idledetector/index.md
@@ -33,13 +33,14 @@ This interface requires a secure context.
 - {{domxref("IdleDetector.change_event", "change")}} {{Experimental_Inline}}
   - : Called when the value of `userState` or `screenState` has changed.
 
-## Instance methods
+## Static methods
 
-- {{domxref("IdleDetector.requestPermission()")}} {{Experimental_Inline}}
-
+- [`IdleDetector.requestPermission()`](/en-us/docs/Web/API/IdleDetector/requestPermission_static) {{Experimental_Inline}}
   - : Returns a {{jsxref('Promise')}} that resolves when the user has chosen
     whether to grant the origin access to their idle state. Resolves with
     `"granted"` on acceptance and `"denied"` on refusal.
+
+## Instance methods
 
 - {{domxref("IdleDetector.start()")}} {{Experimental_Inline}}
   - : Returns a `Promise` that resolves when the detector starts listening for

--- a/files/en-us/web/api/idledetector/requestpermission_static/index.md
+++ b/files/en-us/web/api/idledetector/requestpermission_static/index.md
@@ -1,8 +1,8 @@
 ---
-title: "IdleDetector: requestPermission() method"
+title: "IdleDetector: requestPermission() static method"
 short-title: requestPermission()
-slug: Web/API/IdleDetector/requestPermission
-page-type: web-api-instance-method
+slug: Web/API/IdleDetector/requestPermission_static
+page-type: web-api-static-method
 status:
   - experimental
 browser-compat: api.IdleDetector.requestPermission
@@ -10,7 +10,7 @@ browser-compat: api.IdleDetector.requestPermission
 
 {{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
-The **`requestPermission()`** method of the {{domxref("IdleDetector")}}
+The **`requestPermission()`** static method of the {{domxref("IdleDetector")}}
 interface returns a {{jsxref('Promise')}} that resolves with a string when the user has chosen
 whether to grant the origin access to their idle state. Resolves with
 `"granted"` on acceptance and `"denied"` on refusal.

--- a/files/en-us/web/api/idledetector/requestpermission_static/index.md
+++ b/files/en-us/web/api/idledetector/requestpermission_static/index.md
@@ -18,7 +18,7 @@ whether to grant the origin access to their idle state. Resolves with
 ## Syntax
 
 ```js-nolint
-requestPermission()
+IdleDetector.requestPermission()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/pushmanager/index.md
+++ b/files/en-us/web/api/pushmanager/index.md
@@ -11,9 +11,9 @@ The **`PushManager`** interface of the [Push API](/en-US/docs/Web/API/Push_API) 
 
 This interface is accessed via the {{domxref("ServiceWorkerRegistration.pushManager")}} property.
 
-## Instance properties
+## Static properties
 
-- {{domxref("PushManager.supportedContentEncodings")}}
+- [`PushManager.supportedContentEncodings`](/en-us/docs/Web/API/PushManager/supportedContentEncodings_static)
   - : Returns an array of supported content codings that can be used to encrypt the payload of a push message.
 
 ## Instance methods

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings_static/index.md
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings_static/index.md
@@ -1,14 +1,14 @@
 ---
-title: "PushManager: supportedContentEncodings property"
+title: "PushManager: supportedContentEncodings static property"
 short-title: supportedContentEncodings
-slug: Web/API/PushManager/supportedContentEncodings
-page-type: web-api-instance-property
+slug: Web/API/PushManager/supportedContentEncodings_static
+page-type: web-api-static-property
 browser-compat: api.PushManager.supportedContentEncodings
 ---
 
 {{APIRef("Push API")}}
 
-The **`supportedContentEncodings`** read-only property of the
+The **`supportedContentEncodings`** read-only static property of the
 {{domxref("PushManager")}} interface returns an array of supported content codings that
 can be used to encrypt the payload of a push message.
 


### PR DESCRIPTION
These API members are actually static and so the slug should have the `_static` suffix and the page types should be static etc.