### PR TITLE
Corrected capturing group lookahead/lookbehind examples

### DIFF
--- a/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
@@ -49,9 +49,9 @@ Capturing groups can be [quantified](/en-US/docs/Web/JavaScript/Reference/Regula
 Capturing groups can be used in [lookahead](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) and [lookbehind](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) assertions. Because lookbehind assertions match their atoms backwards, the final match corresponding to this group is the one that appears to the _left_ end of the string. However, the indices of the match groups still correspond to their relative locations in the regex source.
 
 ```js
-/c(?=(ab))/.exec("cab"); // ['', 'ab']
-/(?<=(a)(b))c/.exec("abc"); // ['', 'a', 'b']
-/(?<=([ab])+)c/.exec("abc"); // ['', 'a']; because "a" is seen by the lookbehind after the lookbehind has seen "b"
+/c(?=(ab))/.exec("cab"); // ['c', 'ab']
+/(?<=(a)(b))c/.exec("abc"); // ['c', 'a', 'b']
+/(?<=([ab])+)c/.exec("abc"); // ['c', 'a']; because "a" is seen by the lookbehind after the lookbehind has seen "b"
 ```
 
 Capturing groups can be nested, in which case the outer group is numbered first, then the inner group, because they are ordered by their opening parentheses. If a nested group is repeated by a quantifier, then each time the group matches, the subgroups' results are all overwritten, sometimes with `undefined`.


### PR DESCRIPTION
Changes made as discussed in the following issue: https://github.com/mdn/content/issues/27187

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrected result arrays in the examples of capturing groups being used in lookaheads/lookbehinds

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The new regular expression reference is invaluable documentation for both new and professional developers. This correction will further assist readers in understanding the concepts in the reference.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Examples are corrected to match the behavior of the lookahead/lookbehind assertions as specified in the following pages:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #27187

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
