### PR TITLE
Fix 27207: link to correct event

### DIFF
--- a/files/en-us/web/api/idbtransaction/error_event/index.md
+++ b/files/en-us/web/api/idbtransaction/error_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.IDBTransaction.error_event
 
 The `error` event is fired on `IDBTransaction` when a request returns an error and the event bubbles up to the transaction object.
 
-> **Note:** To handle all non-successful completion of the transaction, consider listening {{domxref("IDBTransaction.error_event", "error")}} instead.
+> **Note:** To handle all the ways a transaction can fail, consider listening for the {{domxref("IDBTransaction.abort_event", "abort")}} event instead.
 
 ## Syntax
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/27207.

https://github.com/mdn/content/pull/13040 merged `onerror` into this page as part of event refactoring, copying this note but introducing the mistake in the process.

the original -> https://github.com/mdn/content/blob/2b3935c476f058880c1f9d40eae3037741b42a44/files/en-us/web/api/idbtransaction/onerror/index.md
