### PR TITLE
Adjustment for refactor(macros/AddonSidebar): use page titles

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -1,5 +1,5 @@
 ---
-title: Building a cross-browser extension
+title: Build a cross-browser extension
 slug: Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
 page-type: guide
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -1,5 +1,5 @@
 ---
-title: Extending the developer tools
+title: Extend the developer tools
 slug: Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
 page-type: guide
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Browser Extensions
+title: Browser extensions
 slug: Mozilla/Add-ons/WebExtensions
 page-type: landing-page
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -1,5 +1,5 @@
 ---
-title: Match patterns in extension manifests
+title: Match patterns
 slug: Mozilla/Add-ons/WebExtensions/Match_patterns
 page-type: guide
 browser-compat: webextensions.match_patterns.scheme

--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -1,5 +1,6 @@
 ---
-title: Safely inserting external content into a page
+title: Safely insert external content into a page
+short-title: Insert external content
 slug: Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page
 page-type: guide
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sharing objects with page scripts
+title: Share objects with page scripts
 slug: Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
 page-type: guide
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.md
@@ -1,5 +1,5 @@
 ---
-title: Working with files
+title: Work with files
 slug: Mozilla/Add-ons/WebExtensions/Working_with_files
 page-type: guide
 ---

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -1,5 +1,5 @@
 ---
-title: Working with the Tabs API
+title: Work with the Tabs API
 slug: Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API
 page-type: guide
 ---


### PR DESCRIPTION
### Description

Yari PR refactor(macros/AddonSidebar): use page titles + cleanup [#8995](https://github.com/mdn/yari/pull/8995) is amending the way that the sidebar menu text is generated. After this change the frontmatter page titles are used rather than text embedded in the AddonSidebar.ejs macro.

This change aligns the page titles with the current menu titles where appropriate or adds a short title alternative for the menu.
