### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@
 /.github/     @mdn/core-dev
 /*            @mdn/core-dev
 /*.md         @mdn/core-yari-content
-# These are @schalkneethling because the auto-merge GHA workflow uses my PAT and will assign me.
-# If we add another reviewer, the auto-merge will cease to be automatic.
-/package.json @schalkneethling
-/yarn.lock    @schalkneethling
+# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
+# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
+/package.json @mdn-bot
+/yarn.lock    @mdn-bot


### PR DESCRIPTION
Change the specified username in CODEOWNERS to mdn-bot. I believe the PAT listed in the repo already uses the one from the `mdn-bot` account. If the auto merge fails, a new PAT token will need to be generated and added.