### PR TITLE
Fix 27143: use a different mouse event

### DIFF
--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -18,38 +18,22 @@ A boolean value, where `true` indicates that the key is pressed, and `false` ind
 
 ## Examples
 
-This example logs the `ctrlKey` property when you trigger a {{domxref("Element/mouseenter_event", "mouseenter")}} event.
+This example logs the `ctrlKey` property when you trigger a {{domxref("Element/mousemove_event", "mousemove")}} event.
 
 ### HTML
 
 ```html
-<p id="target">
-  Move the mouse over this element to test the
-  <code>ctrlKey</code> property.
-</p>
-<p id="log"></p>
-```
-
-### CSS
-
-```css
-#target {
-  padding: 1rem;
-  border: 5px solid turquoise;
-  border-radius: 0.5rem;
-}
+<p id="log">The ctrl key was pressed while the cursor was moving: false</p>
 ```
 
 ### JavaScript
 
 ```js
-const target = document.querySelector("#target");
 const log = document.querySelector("#log");
-
-target.addEventListener("mouseenter", logKey);
+window.addEventListener("mousemove", logKey);
 
 function logKey(e) {
-  log.textContent = `The ctrl key is pressed: ${e.ctrlKey}`;
+  log.textContent = `The ctrl key was pressed while the cursor was moving: ${e.ctrlKey}`;
 }
 ```
 

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -10,7 +10,7 @@ browser-compat: api.MouseEvent.ctrlKey
 
 The **`MouseEvent.ctrlKey`** read-only property is a boolean value that indicates whether the <kbd>ctrl</kbd> key was pressed or not when a given mouse event occurs.
 
-On Macintosh keyboards, this key is labeled the <kbd>control</kbd> key. Also, note that on a Mac a click combined with the <kbd>control</kbd> key is intercepted by the operating system and used to open a context menu, so `ctrlKey` is not detectable on click events.
+On Macintosh keyboards, this key is labeled the <kbd>control</kbd> key. Also, note that on a Mac, a click combined with the <kbd>control</kbd> key is intercepted by the operating system and used to open a context menu, so `ctrlKey` is not detectable on click events.
 
 ## Value
 

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -18,20 +18,35 @@ A boolean value, where `true` indicates that the key is pressed, and `false` ind
 
 ## Examples
 
-This example logs the `ctrlKey` property when you trigger a {{domxref("Element/click_event", "click")}} event.
+This example logs the `ctrlKey` property when you trigger a {{domxref("Element/mouseenter_event", "mouseenter")}} event.
 
 ### HTML
 
 ```html
-<p>Click anywhere to test the <code>ctrlKey</code> property.</p>
+<p id="target">
+  Move the mouse over this element to test the
+  <code>ctrlKey</code> property.
+</p>
 <p id="log"></p>
+```
+
+### CSS
+
+```css
+#target {
+  padding: 1rem;
+  border: 5px solid turquoise;
+  border-radius: 0.5rem;
+}
 ```
 
 ### JavaScript
 
 ```js
-let log = document.querySelector("#log");
-document.addEventListener("click", logKey);
+const target = document.querySelector("#target");
+const log = document.querySelector("#log");
+
+target.addEventListener("mouseenter", logKey);
 
 function logKey(e) {
   log.textContent = `The ctrl key is pressed: ${e.ctrlKey}`;

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -10,7 +10,7 @@ browser-compat: api.MouseEvent.ctrlKey
 
 The **`MouseEvent.ctrlKey`** read-only property is a boolean value that indicates whether the <kbd>ctrl</kbd> key was pressed or not when a given mouse event occurs.
 
-> **Note:** On Macintosh keyboards, this key is the <kbd>control</kbd> key.
+On Macintosh keyboards, this key is labeled the <kbd>control</kbd> key. Also, note that on a Mac a click combined with the <kbd>control</kbd> key is intercepted by the operating system and used to open a context menu, so `ctrlKey` is not detectable on click events.
 
 ## Value
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/27143 , by using a different event that macOS doesn't intercept.