### PR TITLE
FF115 Array.fromAsync() - release note and remove exerimental

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -22,7 +22,7 @@ This article provides information about the changes in Firefox 115 that affect d
 ### JavaScript
 
 - The {{jsxref("Array.fromAsync()")}} static method is now supported.
-  The method asynchronously returns a new, shallow-copied `Array` instance from an [async iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), or [array-like](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) object   ([Firefox bug 1795816](https://bugzil.la/1795816)).
+  The method asynchronously returns a new, shallow-copied `Array` instance from an [async iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), or [array-like](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) object ([Firefox bug 1795816](https://bugzil.la/1795816)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -21,6 +21,9 @@ This article provides information about the changes in Firefox 115 that affect d
 
 ### JavaScript
 
+- The {{jsxref("Array.fromAsync()")}} static method is now supported.
+  The method asynchronously returns a new, shallow-copied `Array` instance from an [async iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), or [array-like](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) object   ([Firefox bug 1795816](https://bugzil.la/1795816)).
+
 #### Removals
 
 ### SVG

--- a/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
@@ -2,12 +2,10 @@
 title: Array.fromAsync()
 slug: Web/JavaScript/Reference/Global_Objects/Array/fromAsync
 page-type: javascript-static-method
-status:
-  - experimental
 browser-compat: javascript.builtins.Array.fromAsync
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 The **`Array.fromAsync()`** static method creates a new, shallow-copied `Array` instance from an [async iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), or [array-like](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) object.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -279,7 +279,7 @@ f("a", "b"); // 'a+b'
 
 - {{jsxref("Array.from()")}}
   - : Creates a new `Array` instance from an iterable or array-like object.
-- {{jsxref("Array.fromAsync()")}} {{Experimental_Inline}}
+- {{jsxref("Array.fromAsync()")}}
   - : Creates a new `Array` instance from an async iterable, iterable, or array-like object.
 - {{jsxref("Array.isArray()")}}
   - : Returns `true` if the argument is an array, or `false` otherwise.


### PR DESCRIPTION
FF115 now supports `Array.fromAsync()`. Since Safari also does it is no longer experimental. This adds the release note and removes the experimental tagging.

I don't propose to update other docs - it looks good to me.

Other docs work can be tracked in https://github.com/mdn/content/issues/22145