### PR TITLE
Update WebGPU onsubmittedworkdone

### DIFF
--- a/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
+++ b/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
@@ -18,7 +18,7 @@ This includes the completion of any {{domxref("GPUBuffer.mapAsync", "mapAsync()"
 Note: In most cases, you do _not_ need to call `onSubmittedWorkDown()`. You do **_not_** need to call it for mapping a buffer. `mapAsync` guarantees work submitted
 to the queue before calling `mapAsync` happens before the `mapAsync` returns (see [WebGPU spec: section 5.2](https://www.w3.org/TR/webgpu/#buffer-mapping))
 
-The two use-cases for `onSubmittedWorkDone`
+The two use cases for `onSubmittedWorkDone`
 
 1. Waiting for multiple buffer mapping (slow)
 

--- a/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
+++ b/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
@@ -15,10 +15,49 @@ The **`onSubmittedWorkDone()`** method of the
 
 This includes the completion of any {{domxref("GPUBuffer.mapAsync", "mapAsync()")}} calls made on `GPUBuffer`s used in commands submitted to the queue, before `onSubmittedWorkDone()` is called.
 
+Note: In most cases, you do NOT need to call `onSubmittedWorkDown()`. You do **NOT** need to call it for mapping a buffer. `mapAsync` guarantees work submitted
+to the queue before calling `mapAsync` happens before the `mapAsync` returns (see [WebGPU spec: section 5.2](https://www.w3.org/TR/webgpu/#buffer-mapping))
+
+The 2 use-cases for `onSubmittedWorkDone`
+
+1. Waiting for multiple buffer mapping (slow)
+
+   ```js
+   // good
+   await Promise.all([
+     buffer1.mapAsync(),
+     buffer2.mapAsync(),
+     buffer3.mapAsync(),
+   ]);
+   data1 = buffer1.getMappedRange();
+   data2 = buffer2.getMappedRange();
+   data3 = buffer3.getMappedRange();
+   ```
+
+   ```js
+   // works but slow
+   buffer1.mapAsync();
+   buffer2.mapAsync();
+   buffer3.mapAsync();
+   await device.queue.onSubmittedWorkDone();
+   data1 = buffer1.getMappedRange();
+   data2 = buffer2.getMappedRange();
+   data3 = buffer3.getMappedRange();
+   ```
+
+   The reason the 2nd method is slow is the implementation may be able to map the buffers before all the submitted work is done.
+   For example, if all the buffers are finished being used but more work, un-related to the buffers, is already submitted then
+   you'll end up waiting longer using the second method than the first.
+
+2. Throttling work
+
+   If you are doing heavy compute work and you submit too much work at once, the browser may kill your work.
+   You can throttle the work by only submitting more work when the work you've already submitted is done.
+
 ## Syntax
 
 ```js-nolint
-onSubmittedWorkDone()
+device.queue.onSubmittedWorkDone()
 ```
 
 ### Parameters
@@ -32,11 +71,10 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}}.
 ## Examples
 
 ```js
+device.queue.submit([commandEncoder.finish()]);
 device.queue.onSubmittedWorkDone().then(() => {
   console.log("All submitted commands processed.");
 });
-
-device.queue.submit([commandEncoder.finish()]);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
+++ b/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
@@ -15,10 +15,10 @@ The **`onSubmittedWorkDone()`** method of the
 
 This includes the completion of any {{domxref("GPUBuffer.mapAsync", "mapAsync()")}} calls made on `GPUBuffer`s used in commands submitted to the queue, before `onSubmittedWorkDone()` is called.
 
-Note: In most cases, you do NOT need to call `onSubmittedWorkDown()`. You do **NOT** need to call it for mapping a buffer. `mapAsync` guarantees work submitted
+Note: In most cases, you do _not_ need to call `onSubmittedWorkDown()`. You do **_not_** need to call it for mapping a buffer. `mapAsync` guarantees work submitted
 to the queue before calling `mapAsync` happens before the `mapAsync` returns (see [WebGPU spec: section 5.2](https://www.w3.org/TR/webgpu/#buffer-mapping))
 
-The 2 use-cases for `onSubmittedWorkDone`
+The two use-cases for `onSubmittedWorkDone`
 
 1. Waiting for multiple buffer mapping (slow)
 
@@ -45,8 +45,8 @@ The 2 use-cases for `onSubmittedWorkDone`
    data3 = buffer3.getMappedRange();
    ```
 
-   The reason the 2nd method is slow is the implementation may be able to map the buffers before all the submitted work is done.
-   For example, if all the buffers are finished being used but more work, un-related to the buffers, is already submitted then
+   The reason the second method is slow is, the implementation may be able to map the buffers before all the submitted work is done.
+   For example, if all the buffers are finished being used, but more work (unrelated to the buffers) is already submitted, then
    you'll end up waiting longer using the second method than the first.
 
 2. Throttling work


### PR DESCRIPTION
I see people misunderstanding `onSubmittedWorkDone`. It's important to get the word out that you shouldn't be calling it to map buffers.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Mention that you don't need to call `onSumbittedWorkDone` to correctly map a buffer.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I see people adding un-needed calls to `onSubmittedWorkDone`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
