### PR TITLE
`history.state` show in wrong format

### DIFF
--- a/files/en-us/web/api/history/state/index.md
+++ b/files/en-us/web/api/history/state/index.md
@@ -27,7 +27,7 @@ The next line logs the value to the console again, showing that
 
 ```js
 // Should be null because we haven't modified the history stack yet
-console.log(`History.state before pushState: ${history.state}`);
+console.log("History.state before pushState: ", history.state);
 
 // Now push something on the stack
 history.pushState({ name: "Example" }, "pushState example", "page3.html");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`history.state` show in wrong format, it is no same with the following `history.state`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
