### PR TITLE
Update BCD paths for statics

### DIFF
--- a/files/en-us/web/api/abortsignal/abort_static/index.md
+++ b/files/en-us/web/api/abortsignal/abort_static/index.md
@@ -3,7 +3,7 @@ title: "AbortSignal: abort() static method"
 short-title: abort()
 slug: Web/API/AbortSignal/abort_static
 page-type: web-api-static-method
-browser-compat: api.AbortSignal.abort
+browser-compat: api.AbortSignal.abort_static
 ---
 
 {{APIRef("DOM")}}

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -3,7 +3,7 @@ title: "AbortSignal: timeout() static method"
 short-title: timeout()
 slug: Web/API/AbortSignal/timeout_static
 page-type: web-api-static-method
-browser-compat: api.AbortSignal.timeout
+browser-compat: api.AbortSignal.timeout_static
 ---
 
 {{APIRef("DOM")}}

--- a/files/en-us/web/api/audiodecoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/audiodecoder/isconfigsupported_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/AudioDecoder/isConfigSupported_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.AudioDecoder.isConfigSupported
+browser-compat: api.AudioDecoder.isConfigSupported_static
 ---
 
 {{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/audioencoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/audioencoder/isconfigsupported_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/AudioEncoder/isConfigSupported_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.AudioEncoder.isConfigSupported
+browser-compat: api.AudioEncoder.isConfigSupported_static
 ---
 
 {{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/barcodedetector/getsupportedformats_static/index.md
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BarcodeDetector/getSupportedFormats_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.BarcodeDetector.getSupportedFormats
+browser-compat: api.BarcodeDetector.getSupportedFormats_static
 ---
 
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BluetoothUUID/canonicalUUID_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.BluetoothUUID.canonicalUUID
+browser-compat: api.BluetoothUUID.canonicalUUID_static
 ---
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BluetoothUUID/getCharacteristic_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.BluetoothUUID.getCharacteristic
+browser-compat: api.BluetoothUUID.getCharacteristic_static
 ---
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BluetoothUUID/getDescriptor_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.BluetoothUUID.getDescriptor
+browser-compat: api.BluetoothUUID.getDescriptor_static
 ---
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BluetoothUUID/getService_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.BluetoothUUID.getService
+browser-compat: api.BluetoothUUID.getService_static
 ---
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/css/escape_static/index.md
+++ b/files/en-us/web/api/css/escape_static/index.md
@@ -3,7 +3,7 @@ title: "CSS: escape() static method"
 short-title: escape()
 slug: Web/API/CSS/escape_static
 page-type: web-api-static-method
-browser-compat: api.CSS.escape
+browser-compat: api.CSS.escape_static
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/en-us/web/api/css/highlights_static/index.md
+++ b/files/en-us/web/api/css/highlights_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/CSS/highlights_static
 page-type: web-api-static-property
 status:
   - experimental
-browser-compat: api.CSS.highlights
+browser-compat: api.CSS.highlights_static
 ---
 
 {{APIRef("CSSOM")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/css/paintworklet_static/index.md
+++ b/files/en-us/web/api/css/paintworklet_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/CSS/paintWorklet_static
 page-type: web-api-static-property
 status:
   - experimental
-browser-compat: api.CSS.paintWorklet
+browser-compat: api.CSS.paintWorklet_static
 ---
 
 {{APIRef("CSSOM")}}{{SeeCompatTable}}{{SecureContext_Header}}

--- a/files/en-us/web/api/css/registerproperty_static/index.md
+++ b/files/en-us/web/api/css/registerproperty_static/index.md
@@ -3,7 +3,7 @@ title: "CSS: registerProperty() static method"
 short-title: registerProperty()
 slug: Web/API/CSS/registerProperty_static
 page-type: web-api-static-method
-browser-compat: api.CSS.registerProperty
+browser-compat: api.CSS.registerProperty_static
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/en-us/web/api/css/supports_static/index.md
+++ b/files/en-us/web/api/css/supports_static/index.md
@@ -3,7 +3,7 @@ title: "CSS: supports() static method"
 short-title: supports()
 slug: Web/API/CSS/supports_static
 page-type: web-api-static-method
-browser-compat: api.CSS.supports
+browser-compat: api.CSS.supports_static
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/en-us/web/api/cssnumericvalue/parse_static/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse_static/index.md
@@ -3,7 +3,7 @@ title: "CSSNumericValue: parse() static method"
 short-title: parse()
 slug: Web/API/CSSNumericValue/parse_static
 page-type: web-api-static-method
-browser-compat: api.CSSNumericValue.parse
+browser-compat: api.CSSNumericValue.parse_static
 ---
 
 {{APIRef("CSS Typed OM")}}

--- a/files/en-us/web/api/cssstylevalue/parse_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse_static/index.md
@@ -3,7 +3,7 @@ title: "CSSStyleValue: parse() static method"
 short-title: parse()
 slug: Web/API/CSSStyleValue/parse_static
 page-type: web-api-static-method
-browser-compat: api.CSSStyleValue.parse
+browser-compat: api.CSSStyleValue.parse_static
 ---
 
 {{APIRef("CSS Typed Object Model API")}}

--- a/files/en-us/web/api/cssstylevalue/parseall_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall_static/index.md
@@ -3,7 +3,7 @@ title: "CSSStyleValue: parseAll() static method"
 short-title: parseAll()
 slug: Web/API/CSSStyleValue/parseAll_static
 page-type: web-api-static-method
-browser-compat: api.CSSStyleValue.parseAll
+browser-compat: api.CSSStyleValue.parseAll_static
 ---
 
 {{APIRef("CSS Typed Object Model API")}}

--- a/files/en-us/web/api/dompoint/frompoint_static/index.md
+++ b/files/en-us/web/api/dompoint/frompoint_static/index.md
@@ -3,7 +3,7 @@ title: "DOMPoint: fromPoint() static method"
 short-title: fromPoint()
 slug: Web/API/DOMPoint/fromPoint_static
 page-type: web-api-static-method
-browser-compat: api.DOMPoint.fromPoint
+browser-compat: api.DOMPoint.fromPoint_static
 ---
 
 {{APIRef("DOM")}}

--- a/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
+++ b/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
@@ -3,7 +3,7 @@ title: "DOMPointReadOnly: fromPoint() static method"
 short-title: fromPoint()
 slug: Web/API/DOMPointReadOnly/fromPoint_static
 page-type: web-api-static-method
-browser-compat: api.DOMPointReadOnly.fromPoint
+browser-compat: api.DOMPointReadOnly.fromPoint_static
 ---
 
 {{APIRef("DOM")}}

--- a/files/en-us/web/api/domrect/fromrect_static/index.md
+++ b/files/en-us/web/api/domrect/fromrect_static/index.md
@@ -3,7 +3,7 @@ title: "DOMRect: fromRect() static method"
 short-title: fromRect()
 slug: Web/API/DOMRect/fromRect_static
 page-type: web-api-static-method
-browser-compat: api.DOMRect.fromRect
+browser-compat: api.DOMRect.fromRect_static
 ---
 
 {{APIRef("Geometry Interfaces")}}

--- a/files/en-us/web/api/domrectreadonly/fromrect_static/index.md
+++ b/files/en-us/web/api/domrectreadonly/fromrect_static/index.md
@@ -3,7 +3,7 @@ title: "DOMRectReadOnly: fromRect() static method"
 short-title: fromRect()
 slug: Web/API/DOMRectReadOnly/fromRect_static
 page-type: web-api-static-method
-browser-compat: api.DOMRectReadOnly.fromRect
+browser-compat: api.DOMRectReadOnly.fromRect_static
 ---
 
 {{APIRef("Geometry Interfaces")}}

--- a/files/en-us/web/api/htmlscriptelement/supports_static/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports_static/index.md
@@ -3,7 +3,7 @@ title: "HTMLScriptElement: supports() static method"
 short-title: supports()
 slug: Web/API/HTMLScriptElement/supports_static
 page-type: web-api-static-method
-browser-compat: api.HTMLScriptElement.supports
+browser-compat: api.HTMLScriptElement.supports_static
 ---
 
 {{APIRef}}

--- a/files/en-us/web/api/idbkeyrange/bound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/bound_static/index.md
@@ -3,7 +3,7 @@ title: "IDBKeyRange: bound() static method"
 short-title: bound()
 slug: Web/API/IDBKeyRange/bound_static
 page-type: web-api-static-method
-browser-compat: api.IDBKeyRange.bound
+browser-compat: api.IDBKeyRange.bound_static
 ---
 
 {{ APIRef("IndexedDB") }}

--- a/files/en-us/web/api/idbkeyrange/lowerbound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/lowerbound_static/index.md
@@ -3,7 +3,7 @@ title: "IDBKeyRange: lowerBound() static method"
 short-title: lowerBound()
 slug: Web/API/IDBKeyRange/lowerBound_static
 page-type: web-api-static-method
-browser-compat: api.IDBKeyRange.lowerBound
+browser-compat: api.IDBKeyRange.lowerBound_static
 ---
 
 {{ APIRef("IndexedDB") }}

--- a/files/en-us/web/api/idbkeyrange/only_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/only_static/index.md
@@ -3,7 +3,7 @@ title: "IDBKeyRange: only() static method"
 short-title: only()
 slug: Web/API/IDBKeyRange/only_static
 page-type: web-api-static-method
-browser-compat: api.IDBKeyRange.only
+browser-compat: api.IDBKeyRange.only_static
 ---
 
 {{ APIRef("IndexedDB") }}

--- a/files/en-us/web/api/idbkeyrange/upperbound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperbound_static/index.md
@@ -3,7 +3,7 @@ title: "IDBKeyRange: upperBound() static method"
 short-title: upperBound()
 slug: Web/API/IDBKeyRange/upperBound_static
 page-type: web-api-static-method
-browser-compat: api.IDBKeyRange.upperBound
+browser-compat: api.IDBKeyRange.upperBound_static
 ---
 
 {{ APIRef("IndexedDB") }}

--- a/files/en-us/web/api/idledetector/requestpermission_static/index.md
+++ b/files/en-us/web/api/idledetector/requestpermission_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/IdleDetector/requestPermission_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.IdleDetector.requestPermission
+browser-compat: api.IdleDetector.requestPermission_static
 ---
 
 {{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/imagedecoder/istypesupported_static/index.md
+++ b/files/en-us/web/api/imagedecoder/istypesupported_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/ImageDecoder/isTypeSupported_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.ImageDecoder.isTypeSupported
+browser-compat: api.ImageDecoder.isTypeSupported_static
 ---
 
 {{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
@@ -3,7 +3,7 @@ title: "MediaRecorder: isTypeSupported() static method"
 short-title: isTypeSupported()
 slug: Web/API/MediaRecorder/isTypeSupported_static
 page-type: web-api-static-method
-browser-compat: api.MediaRecorder.isTypeSupported
+browser-compat: api.MediaRecorder.isTypeSupported_static
 ---
 
 {{APIRef("MediaStream Recording")}}

--- a/files/en-us/web/api/mediasource/canconstructindedicatedworker_static/index.md
+++ b/files/en-us/web/api/mediasource/canconstructindedicatedworker_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MediaSource/canConstructInDedicatedWorker_static
 page-type: web-api-static-property
 status:
   - experimental
-browser-compat: api.MediaSource.canConstructInDedicatedWorker
+browser-compat: api.MediaSource.canConstructInDedicatedWorker_static
 ---
 
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediasource/istypesupported_static/index.md
+++ b/files/en-us/web/api/mediasource/istypesupported_static/index.md
@@ -3,7 +3,7 @@ title: "MediaSource: isTypeSupported() static method"
 short-title: isTypeSupported()
 slug: Web/API/MediaSource/isTypeSupported_static
 page-type: web-api-static-method
-browser-compat: api.MediaSource.isTypeSupported
+browser-compat: api.MediaSource.isTypeSupported_static
 ---
 
 {{APIRef("Media Source Extensions")}}

--- a/files/en-us/web/api/notification/maxactions_static/index.md
+++ b/files/en-us/web/api/notification/maxactions_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Notification/maxActions_static
 page-type: web-api-static-property
 status:
   - experimental
-browser-compat: api.Notification.maxActions
+browser-compat: api.Notification.maxActions_static
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/notification/permission_static/index.md
+++ b/files/en-us/web/api/notification/permission_static/index.md
@@ -3,7 +3,7 @@ title: "Notification: permission static property"
 short-title: permission
 slug: Web/API/Notification/permission_static
 page-type: web-api-static-property
-browser-compat: api.Notification.permission
+browser-compat: api.Notification.permission_static
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/en-us/web/api/notification/requestpermission_static/index.md
+++ b/files/en-us/web/api/notification/requestpermission_static/index.md
@@ -3,7 +3,7 @@ title: "Notification: requestPermission() static method"
 short-title: requestPermission()
 slug: Web/API/Notification/requestPermission_static
 page-type: web-api-static-method
-browser-compat: api.Notification.requestPermission
+browser-compat: api.Notification.requestPermission_static
 ---
 
 {{APIRef("Web Notifications")}}{{securecontext_header}}

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes_static/index.md
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes_static/index.md
@@ -3,7 +3,7 @@ title: "PerformanceObserver: supportedEntryTypes static property"
 short-title: supportedEntryTypes
 slug: Web/API/PerformanceObserver/supportedEntryTypes_static
 page-type: web-api-static-property
-browser-compat: api.PerformanceObserver.supportedEntryTypes
+browser-compat: api.PerformanceObserver.supportedEntryTypes_static
 ---
 
 {{APIRef("Performance API")}}

--- a/files/en-us/web/api/publickeycredential/isconditionalmediationavailable/index.md
+++ b/files/en-us/web/api/publickeycredential/isconditionalmediationavailable/index.md
@@ -3,7 +3,7 @@ title: "PublicKeyCredential: isConditionalMediationAvailable() static method"
 short-title: isConditionalMediationAvailable()
 slug: Web/API/PublicKeyCredential/isConditionalMediationAvailable
 page-type: web-api-static-method
-browser-compat: api.PublicKeyCredential.isConditionalMediationAvailable
+browser-compat: api.PublicKeyCredential.isConditionalMediationAvailable_static
 ---
 
 {{APIRef("Web Authentication API")}}{{securecontext_header}}

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable_static/index.md
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable_static/index.md
@@ -3,7 +3,7 @@ title: "PublicKeyCredential: isUserVerifyingPlatformAuthenticatorAvailable() sta
 short-title: isUserVerifyingPlatformAuthenticatorAvailable()
 slug: Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable_static
 page-type: web-api-static-method
-browser-compat: api.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable
+browser-compat: api.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable_static
 ---
 
 {{APIRef("Web Authentication API")}}{{securecontext_header}}

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings_static/index.md
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings_static/index.md
@@ -3,7 +3,7 @@ title: "PushManager: supportedContentEncodings static property"
 short-title: supportedContentEncodings
 slug: Web/API/PushManager/supportedContentEncodings_static
 page-type: web-api-static-property
-browser-compat: api.PushManager.supportedContentEncodings
+browser-compat: api.PushManager.supportedContentEncodings_static
 ---
 
 {{APIRef("Push API")}}

--- a/files/en-us/web/api/response/error_static/index.md
+++ b/files/en-us/web/api/response/error_static/index.md
@@ -3,7 +3,7 @@ title: "Response: error() static method"
 short-title: error()
 slug: Web/API/Response/error_static
 page-type: web-api-static-method
-browser-compat: api.Response.error
+browser-compat: api.Response.error_static
 ---
 
 {{APIRef("Fetch API")}}

--- a/files/en-us/web/api/response/json_static/index.md
+++ b/files/en-us/web/api/response/json_static/index.md
@@ -3,6 +3,7 @@ title: "Response: json() static method"
 short-title: json()
 slug: Web/API/Response/json_static
 page-type: web-api-static-method
+browser-compat: api.Response.json_static
 ---
 
 {{APIRef("Fetch API")}}
@@ -32,6 +33,14 @@ A {{domxref("Response")}} object.
 ```js
 Response.json({ my: "data" });
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/response/redirect_static/index.md
+++ b/files/en-us/web/api/response/redirect_static/index.md
@@ -3,7 +3,7 @@ title: "Response: redirect() static method"
 short-title: redirect()
 slug: Web/API/Response/redirect_static
 page-type: web-api-static-method
-browser-compat: api.Response.redirect
+browser-compat: api.Response.redirect_static
 ---
 
 {{APIRef("Fetch API")}}

--- a/files/en-us/web/api/rtcpeerconnection/generatecertificate_static/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/generatecertificate_static/index.md
@@ -3,7 +3,7 @@ title: "RTCPeerConnection: generateCertificate() static method"
 short-title: generateCertificate()
 slug: Web/API/RTCPeerConnection/generateCertificate_static
 page-type: web-api-static-method
-browser-compat: api.RTCPeerConnection.generateCertificate
+browser-compat: api.RTCPeerConnection.generateCertificate_static
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
@@ -3,7 +3,7 @@ title: "RTCRtpReceiver: getCapabilities() static method"
 short-title: getCapabilities()
 slug: Web/API/RTCRtpReceiver/getCapabilities_static
 page-type: web-api-static-method
-browser-compat: api.RTCRtpReceiver.getCapabilities
+browser-compat: api.RTCRtpReceiver.getCapabilities_static
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
@@ -3,7 +3,7 @@ title: "RTCRtpSender: getCapabilities() static method"
 short-title: getCapabilities()
 slug: Web/API/RTCRtpSender/getCapabilities_static
 page-type: web-api-static-method
-browser-compat: api.RTCRtpSender.getCapabilities
+browser-compat: api.RTCRtpSender.getCapabilities_static
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/en-us/web/api/url/createobjecturl_static/index.md
+++ b/files/en-us/web/api/url/createobjecturl_static/index.md
@@ -3,7 +3,7 @@ title: "URL: createObjectURL() static method"
 short-title: createObjectURL()
 slug: Web/API/URL/createObjectURL_static
 page-type: web-api-static-method
-browser-compat: api.URL.createObjectURL
+browser-compat: api.URL.createObjectURL_static
 ---
 
 {{APIRef("URL API")}}

--- a/files/en-us/web/api/url/revokeobjecturl_static/index.md
+++ b/files/en-us/web/api/url/revokeobjecturl_static/index.md
@@ -3,7 +3,7 @@ title: "URL: revokeObjectURL() static method"
 short-title: revokeObjectURL()
 slug: Web/API/URL/revokeObjectURL_static
 page-type: web-api-static-method
-browser-compat: api.URL.revokeObjectURL
+browser-compat: api.URL.revokeObjectURL_static
 ---
 
 {{ApiRef("URL API")}}

--- a/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
@@ -3,7 +3,7 @@ title: "VideoDecoder: isConfigSupported() static method"
 short-title: isConfigSupported()
 slug: Web/API/VideoDecoder/isConfigSupported_static
 page-type: web-api-static-method
-browser-compat: api.VideoDecoder.isConfigSupported
+browser-compat: api.VideoDecoder.isConfigSupported_static
 ---
 
 {{APIRef("WebCodecs API")}}{{SecureContext_Header}}

--- a/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
@@ -3,7 +3,7 @@ title: "VideoEncoder: isConfigSupported() static method"
 short-title: isConfigSupported()
 slug: Web/API/VideoEncoder/isConfigSupported_static
 page-type: web-api-static-method
-browser-compat: api.VideoEncoder.isConfigSupported
+browser-compat: api.VideoEncoder.isConfigSupported_static
 ---
 
 {{APIRef("WebCodecs API")}}{{SecureContext_Header}}

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
@@ -5,7 +5,7 @@ slug: Web/API/XRWebGLLayer/getNativeFramebufferScaleFactor_static
 page-type: web-api-static-method
 status:
   - experimental
-browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor
+browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor_static
 ---
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}


### PR DESCRIPTION
PR for the BCD change https://github.com/mdn/browser-compat-data/pull/20063. Both PRs should to land together. 

Interesting is https://developer.mozilla.org/en-US/docs/Web/API/CSS which I missed on BCD. It is not an interface with static members. It is a namespace and so naturally all members are static. The spec says it should behave the same, see https://drafts.csswg.org/cssom/#namespacedef-css. So I believe we should treat it as if it was an interface with static members.