### PR TITLE
Add a missing return statement in promise chaining example

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -159,10 +159,12 @@ Nesting is a control structure to limit the scope of `catch` statements. Specifi
 
 ```js
 doSomethingCritical()
-  .then((result) =>
+  .then((result) => {
     doSomethingOptional(result)
       .then((optionalResult) => doSomethingExtraNice(optionalResult))
-      .catch((e) => {}),
+      .catch((e) => {});
+    return result;
+    }
   ) // Ignore if optional stuff fails; proceed.
   .then(() => moreCriticalStuff())
   .catch((e) => console.error(`Critical failure: ${e.message}`));


### PR DESCRIPTION
Add a missing return statement in chaining promises example

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I have encountered an issue while attempting to replicate the example provided in the MDN documentation on chaining promises. It appears that there is a missing return statement within the example. To rectify this, I have added the necessary return statement in order to ensure proper functionality and adherence to the intended behavior.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I have tried copying the example from the MDN docs, but what is stated in the example is not working as described. Upon closer inspection, I noticed that there was a missing return statement. Therefore, I decided to add it to enhance clarity.

### Additional details
- NA
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
- NA
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
