### PR TITLE
Advise structuredClone instead of JSON.parse(JSON.stringify()) to clone an object

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -72,7 +72,7 @@ console.log(copy); // { a: 1 }
 
 ### Warning for Deep Clone
 
-For [deep cloning](/en-US/docs/Glossary/Deep_copy), we need to use alternatives, because `Object.assign()`
+For [deep cloning](/en-US/docs/Glossary/Deep_copy), we need to use alternatives like [`structuredClone()`](/en-US/docs/Web/API/structuredClone), because `Object.assign()`
 copies property values.
 
 If the source value is a reference to an object, it only copies the reference value.
@@ -96,7 +96,7 @@ console.log(obj2); // { a: 2, b: { c: 3 } }
 
 // Deep Clone
 const obj3 = { a: 0, b: { c: 0 } };
-const obj4 = JSON.parse(JSON.stringify(obj3));
+const obj4 = structuredClone(obj3);
 obj3.a = 4;
 obj3.b.c = 4;
 console.log(obj4); // { a: 0, b: { c: 0 } }


### PR DESCRIPTION
### Description

The `Object.assign()` docs mention that it shouldn't be used to clone objects. Instead, the old `JSON.parse(JSON.stringify())` hack is shown there. This PR changes that to use the newer and better [`structuredClone()`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) function.

### Motivation

`JSON.parse(JSON.stringify(object))` is very limited, and `structuredClone()` copies everything 1:1.
