### PR TITLE
Update EXSLT website links to point to a working domain

### DIFF
--- a/files/en-us/web/exslt/exsl/node-set/index.md
+++ b/files/en-us/web/exslt/exsl/node-set/index.md
@@ -26,4 +26,4 @@ The node-set corresponding to the specified `object`.
 
 ## Specifications
 
-[EXSLT - EXSL:NODE-SET](http://exslt.org/exsl/functions/node-set/index.html)
+[EXSLT - EXSL:NODE-SET](https://exslt.github.io/exsl/functions/node-set/index.html)

--- a/files/en-us/web/exslt/exsl/object-type/index.md
+++ b/files/en-us/web/exslt/exsl/object-type/index.md
@@ -33,4 +33,4 @@ The object's type, which will be one of the following:
 
 ## Specifications
 
-[EXSLT - EXSL:OBJECT-TYPE](http://exslt.org/exsl/functions/object-type/index.html)
+[EXSLT - EXSL:OBJECT-TYPE](https://exslt.github.io/exsl/functions/object-type/index.html)

--- a/files/en-us/web/exslt/index.md
+++ b/files/en-us/web/exslt/index.md
@@ -81,7 +81,7 @@ The EXSLT Strings package provides functions that allow the manipulation of stri
 
 ## See also
 
-- [EXSLT website](http://exslt.org/)
+- [EXSLT website](https://exslt.github.io/)
 
 <section id="Quick_links">
   <ol>

--- a/files/en-us/web/exslt/math/highest/index.md
+++ b/files/en-us/web/exslt/math/highest/index.md
@@ -26,4 +26,4 @@ A result tree fragment consisting of copies of the nodes returned by [`math:max(
 
 ## Specifications
 
-[EXSLT - MATH:HIGHEST](http://exslt.org/math/functions/highest/index.html)
+[EXSLT - MATH:HIGHEST](https://exslt.github.io/math/functions/highest/index.html)

--- a/files/en-us/web/exslt/math/lowest/index.md
+++ b/files/en-us/web/exslt/math/lowest/index.md
@@ -26,4 +26,4 @@ A result tree fragment consisting of copies of the nodes returned by [`math:min(
 
 ## Specifications
 
-[EXSLT - MATH:LOWEST](http://exslt.org/math/functions/lowest/index.html)
+[EXSLT - MATH:LOWEST](https://exslt.github.io/math/functions/lowest/index.html)

--- a/files/en-us/web/exslt/math/max/index.md
+++ b/files/en-us/web/exslt/math/max/index.md
@@ -7,7 +7,7 @@ slug: Web/EXSLT/math/max
 
 `math:max()` returns the maximum value of a node-set.
 
-To compute the maximum value of the node-set, the node set is sorted into descending order as it would be using [`xsl:sort()`](/en-US/XSLT/sort) with a data type of `number`. The maximum value is then the first node in the sorted list, converted into a number.
+To compute the maximum value of the node-set, the node set is sorted into descending order as it would be using [`xsl:sort()`](/en-US/docs/Web/XSLT/Element/sort) with a data type of `number`. The maximum value is then the first node in the sorted list, converted into a number.
 
 ## Syntax
 

--- a/files/en-us/web/exslt/math/max/index.md
+++ b/files/en-us/web/exslt/math/max/index.md
@@ -26,4 +26,4 @@ A result tree fragment representing the highest valued node's numeric value as a
 
 ## Specifications
 
-[EXSLT - MATH:MAX](http://exslt.org/math/functions/max/index.html)
+[EXSLT - MATH:MAX](https://exslt.github.io/math/functions/max/index.html)

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -26,4 +26,4 @@ A result tree fragment representing the lowest valued node's numeric value as a 
 
 ## Specifications
 
-[EXSLT - MATH:MIN](http://exslt.org/math/functions/min/index.html)
+[EXSLT - MATH:MIN](https://exslt.github.io/math/functions/min/index.html)

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -7,7 +7,7 @@ slug: Web/EXSLT/math/min
 
 `math:min()` returns the minimum value of a node-set.
 
-To compute the minimum value of the node-set, the node set is sorted into ascending order as it would be using [`xsl:sort()`](/en-US/XSLT/sort) with a data type of `number`. The minimum value is then the first node in the sorted list, converted into a number.
+To compute the minimum value of the node-set, the node set is sorted into ascending order as it would be using [`xsl:sort()`](/en-US/docs/Web/XSLT/Element/sort) with a data type of `number`. The minimum value is then the first node in the sorted list, converted into a number.
 
 ## Syntax
 

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -54,4 +54,4 @@ Part 5 = /en/docs/Firefox_3_for_developers
 
 ## Specifications
 
-[EXSLT - REGEXP:MATCH](http://exslt.org/regexp/functions/match/index.html)
+[EXSLT - REGEXP:MATCH](https://exslt.github.io/regexp/functions/match/index.html)

--- a/files/en-us/web/exslt/regexp/replace/index.md
+++ b/files/en-us/web/exslt/regexp/replace/index.md
@@ -37,4 +37,4 @@ The revised version of the string.
 
 ## Specifications
 
-[EXSLT - REGEXP:REPLACE](http://exslt.org/regexp/functions/replace/index.html)
+[EXSLT - REGEXP:REPLACE](https://exslt.github.io/regexp/functions/replace/index.html)

--- a/files/en-us/web/exslt/regexp/test/index.md
+++ b/files/en-us/web/exslt/regexp/test/index.md
@@ -35,4 +35,4 @@ The character flags are:
 
 ## Specifications
 
-[EXSLT - REGEXP:TEST](http://exslt.org/regexp/functions/test/index.html)
+[EXSLT - REGEXP:TEST](https://exslt.github.io/regexp/functions/test/index.html)

--- a/files/en-us/web/exslt/set/difference/index.md
+++ b/files/en-us/web/exslt/set/difference/index.md
@@ -28,4 +28,4 @@ A node-set containing the nodes that are in `nodeSet1` but not in `nodeSet2`.
 
 ## Specifications
 
-[EXSLT - SET:DIFFERENCE](http://exslt.org/set/functions/difference/index.html)
+[EXSLT - SET:DIFFERENCE](https://exslt.github.io/set/functions/difference/index.html)

--- a/files/en-us/web/exslt/set/distinct/index.md
+++ b/files/en-us/web/exslt/set/distinct/index.md
@@ -24,4 +24,4 @@ A node-set containing the nodes that have unique string values.
 
 ## Specifications
 
-[EXSLT - SET:DISTINCT](http://exslt.org/set/functions/distinct/index.html)
+[EXSLT - SET:DISTINCT](https://exslt.github.io/set/functions/distinct/index.html)

--- a/files/en-us/web/exslt/set/has-same-node/index.md
+++ b/files/en-us/web/exslt/set/has-same-node/index.md
@@ -26,4 +26,4 @@ set:has-same-node(nodeSet1, nodeSet2)
 
 ## Specifications
 
-[EXSLT - SET:HAS-SAME-NODE](http://exslt.org/set/functions/has-same-node/index.html)
+[EXSLT - SET:HAS-SAME-NODE](https://exslt.github.io/set/functions/has-same-node/index.html)

--- a/files/en-us/web/exslt/set/intersection/index.md
+++ b/files/en-us/web/exslt/set/intersection/index.md
@@ -26,4 +26,4 @@ A node-set containing the nodes that existed in both `nodeSet1` and in `nodeSet2
 
 ## Specifications
 
-[EXSLT - SET:INTERSECTION](http://exslt.org/set/functions/intersection/index.html)
+[EXSLT - SET:INTERSECTION](https://exslt.github.io/set/functions/intersection/index.html)

--- a/files/en-us/web/exslt/set/leading/index.md
+++ b/files/en-us/web/exslt/set/leading/index.md
@@ -28,4 +28,4 @@ A node-set containing the nodes from `nodeSet1` whose values precede the first n
 
 ## Specifications
 
-[EXSLT - SET:LEADING](http://exslt.org/set/functions/leading/index.html)
+[EXSLT - SET:LEADING](https://exslt.github.io/set/functions/leading/index.html)

--- a/files/en-us/web/exslt/set/trailing/index.md
+++ b/files/en-us/web/exslt/set/trailing/index.md
@@ -28,4 +28,4 @@ A node-set containing the nodes from `nodeSet1` whose values follow the first no
 
 ## Specifications
 
-[EXSLT - SET:TRAILING](http://exslt.org/set/functions/trailing/index.html)
+[EXSLT - SET:TRAILING](https://exslt.github.io/set/functions/trailing/index.html)

--- a/files/en-us/web/exslt/str/concat/index.md
+++ b/files/en-us/web/exslt/str/concat/index.md
@@ -24,4 +24,4 @@ A string whose value is all the string values of the nodes in `nodeSet` concaten
 
 ## Specifications
 
-[EXSLT - STR:CONCAT](http://exslt.org/str/functions/concat/index.html)
+[EXSLT - STR:CONCAT](https://exslt.github.io/str/functions/concat/index.html)

--- a/files/en-us/web/exslt/str/split/index.md
+++ b/files/en-us/web/exslt/str/split/index.md
@@ -41,7 +41,7 @@ Returns a node set like:
 
 ## Specifications
 
-[EXSLT - STR:SPLIT](http://exslt.org/str/functions/split/index.html)
+[EXSLT - STR:SPLIT](https://exslt.github.io/str/functions/split/index.html)
 
 ## See also
 

--- a/files/en-us/web/exslt/str/tokenize/index.md
+++ b/files/en-us/web/exslt/str/tokenize/index.md
@@ -43,7 +43,7 @@ Returns a node set like this:
 
 ## Specifications
 
-[EXSLT - STR:TOKENIZE](http://exslt.org/str/functions/tokenize/index.html)
+[EXSLT - STR:TOKENIZE](https://exslt.github.io/str/functions/tokenize/index.html)
 
 ## See also
 


### PR DESCRIPTION
http://exslt.org is dead: last working snapshot on web.archive.org is 2023-03-10 http://web.archive.org/web/20230301094149/https://exslt.org/ . Currently it points to a parked domain page.

The site is still hosted at https://exslt.github.io. Looking at the CNAME file there (https://github.com/exslt/exslt.github.io/blob/master/CNAME) it seems like the site has been on Github Pages since 2014. So I think it’s safe to repoint MDN’s links there for the time being. If exslt.org returns to host the docs then this commit can easily be reverted.

(N.b. there are a few other occurences of http://exslt.org in the system: they’re namespace references which shouldn’t be changed.)

### Description

Update all exslt.org links to point to exslt.github.io

### Motivation

Currently exslt.org points to a domain reseller.

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/27249.