### PR TITLE
Use "Note" callouts for different behaviors in Firefox

### DIFF
--- a/files/en-us/web/api/element/contextmenu_event/index.md
+++ b/files/en-us/web/api/element/contextmenu_event/index.md
@@ -12,7 +12,7 @@ The **`contextmenu`** event fires when the user attempts to open a context menu.
 
 In the latter case, the context menu is displayed at the bottom left of the focused element, unless the element is a tree, in which case the context menu is displayed at the bottom left of the current row.
 
-Any right-click event that is not disabled (by calling the click event's {{domxref("Event.preventDefault", "preventDefault()")}} method) will result in a `contextmenu` event being fired at the targeted element. 
+Any right-click event that is not disabled (by calling the click event's {{domxref("Event.preventDefault", "preventDefault()")}} method) will result in a `contextmenu` event being fired at the targeted element.
 
 > **Note:** An exception to this in Firefox: if the user holds down the <kbd>Shift</kbd> key while right-clicking, then the context menu will be shown without a `contextmenu` event being fired.
 

--- a/files/en-us/web/api/element/contextmenu_event/index.md
+++ b/files/en-us/web/api/element/contextmenu_event/index.md
@@ -12,7 +12,9 @@ The **`contextmenu`** event fires when the user attempts to open a context menu.
 
 In the latter case, the context menu is displayed at the bottom left of the focused element, unless the element is a tree, in which case the context menu is displayed at the bottom left of the current row.
 
-Any right-click event that is not disabled (by calling the click event's {{domxref("Event.preventDefault", "preventDefault()")}} method) will result in a `contextmenu` event being fired at the targeted element. One exception to this is that in Firefox, if the user holds down the <kbd>Shift</kbd> key while right-clicking, then the context menu will be shown without a `contextmenu` event being fired.
+Any right-click event that is not disabled (by calling the click event's {{domxref("Event.preventDefault", "preventDefault()")}} method) will result in a `contextmenu` event being fired at the targeted element. 
+
+> **Note:** An exception to this in Firefox: if the user holds down the <kbd>Shift</kbd> key while right-clicking, then the context menu will be shown without a `contextmenu` event being fired.
 
 ## Syntax
 
@@ -91,7 +93,7 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
 In this example, the default action of the `contextmenu` event is canceled using `preventDefault()` when the `contextmenu` event is fired at the first paragraph. As a result, the first paragraph will do nothing when right-clicked, while the second paragraph will show the standard context menu offered by your browser.
 
-Note that in Firefox, if you hold down the <kbd>Shift</kbd> key while right-clicking, then the context menu is shown without the `contextmenu` event being fired, so canceling the event does not stop the context menu from being shown.
+> **Note:** In Firefox, if you hold down the <kbd>Shift</kbd> key while right-clicking, then the context menu is shown without the `contextmenu` event being fired. Therefore, canceling the event does not stop the context menu from being shown.
 
 #### HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Use the **Note:** callout to make it easy to spot different Firefox-specific behavior. 

### Motivation

Easier “scan-ability” of page content.

