### PR TITLE
More consistent `dl` markup in reference

### DIFF
--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -17,9 +17,12 @@ As developers, we all know that reusing code as much as possible is a good idea.
 
 Web Components aims to solve such problems — it consists of three main technologies, which can be used together to create versatile custom elements with encapsulated functionality that can be reused wherever you like without fear of code collisions.
 
-- **Custom elements**: A set of JavaScript APIs that allow you to define custom elements and their behavior, which can then be used as desired in your user interface.
-- **Shadow DOM**: A set of JavaScript APIs for attaching an encapsulated "shadow" DOM tree to an element — which is rendered separately from the main document DOM — and controlling associated functionality. In this way, you can keep an element's features private, so they can be scripted and styled without the fear of collision with other parts of the document.
-- **HTML templates**: The {{HTMLElement("template")}} and {{HTMLElement("slot")}} elements enable you to write markup templates that are not displayed in the rendered page. These can then be reused multiple times as the basis of a custom element's structure.
+- **Custom elements**
+  - : A set of JavaScript APIs that allow you to define custom elements and their behavior, which can then be used as desired in your user interface.
+- **Shadow DOM**
+  - : A set of JavaScript APIs for attaching an encapsulated "shadow" DOM tree to an element — which is rendered separately from the main document DOM — and controlling associated functionality. In this way, you can keep an element's features private, so they can be scripted and styled without the fear of collision with other parts of the document.
+- **HTML templates**
+  - : The {{HTMLElement("template")}} and {{HTMLElement("slot")}} elements enable you to write markup templates that are not displayed in the rendered page. These can then be reused multiple times as the basis of a custom element's structure.
 
 The basic approach for implementing a web component generally looks something like this:
 
@@ -50,32 +53,44 @@ The basic approach for implementing a web component generally looks something li
 
   - : Special callback functions defined inside the custom element's class definition, which affect its behavior:
 
-    - `connectedCallback`: Invoked when the custom element is first connected to the document's DOM.
-    - `disconnectedCallback`: Invoked when the custom element is disconnected from the document's DOM.
-    - `adoptedCallback`: Invoked when the custom element is moved to a new document.
-    - `attributeChangedCallback`: Invoked when one of the custom element's attributes is added, removed, or changed.
+    - `connectedCallback()`
+      - : Invoked when the custom element is first connected to the document's DOM.
+    - `disconnectedCallback()`
+      - : Invoked when the custom element is disconnected from the document's DOM.
+    - `adoptedCallback()`
+      - : Invoked when the custom element is moved to a new document.
+    - `attributeChangedCallback()`
+      - : Invoked when one of the custom element's attributes is added, removed, or changed.
 
 - Extensions for creating custom built-in elements
 
   - : The following extensions are defined:
 
-    - The [`is`](/en-US/docs/Web/HTML/Global_attributes/is) global HTML attribute: Allows you to specify that a standard HTML element should behave like a registered custom built-in element.
-    - The "is" option of the {{domxref("Document.createElement()")}} method: Allows you to create an instance of a standard HTML element that behaves like a given registered custom built-in element.
+    - The [`is`](/en-US/docs/Web/HTML/Global_attributes/is) global HTML attribute
+      - : Allows you to specify that a standard HTML element should behave like a registered custom built-in element.
+    - The "is" option of the {{domxref("Document.createElement()")}} method
+      - : Allows you to create an instance of a standard HTML element that behaves like a given registered custom built-in element.
 
 - CSS pseudo-classes
 
   - : Pseudo-classes relating specifically to custom elements:
 
-    - {{cssxref(":defined")}}: Matches any element that is defined, including built in elements and custom elements defined with `CustomElementRegistry.define()`.
-    - {{cssxref(":host")}}: Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside.
-    - {{cssxref(":host", ":host()")}}: Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host.
-    - {{cssxref(":host-context", ":host-context()")}}: Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host's ancestor(s) in the place it sits inside the DOM hierarchy.
+    - {{cssxref(":defined")}}
+      - : Matches any element that is defined, including built in elements and custom elements defined with `CustomElementRegistry.define()`.
+    - {{cssxref(":host")}}
+      - : Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside.
+    - {{cssxref(":host", ":host()")}}
+      - : Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host.
+    - {{cssxref(":host-context", ":host-context()")}}
+      - : Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host's ancestor(s) in the place it sits inside the DOM hierarchy.
 
 - CSS pseudo-elements
 
   - : Pseudo-elements relating specifically to custom elements:
 
-    - {{cssxref("::part")}}: Represents any element within a [shadow tree](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) that has a matching [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
+    - {{cssxref("::part")}}
+      - : Represents any element within a [shadow tree](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) that has a matching [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
+
 
 ### Shadow DOM
 
@@ -99,8 +114,10 @@ The basic approach for implementing a web component generally looks something li
 
   - : Extensions to the `Event` interface related to shadow DOM:
 
-    - {{domxref("Event.composed")}}: Returns `true` if the event will propagate across the shadow DOM boundary into the standard DOM, otherwise `false`.
-    - {{domxref("Event.composedPath")}}: Returns the event's path (objects on which listeners will be invoked). This does not include nodes in shadow trees if the shadow root was created with {{domxref("ShadowRoot.mode")}} closed.
+    - {{domxref("Event.composed")}}
+      - : Returns `true` if the event will propagate across the shadow DOM boundary into the standard DOM, otherwise `false`.
+    - {{domxref("Event.composedPath")}}
+      - : Returns the event's path (objects on which listeners will be invoked). This does not include nodes in shadow trees if the shadow root was created with {{domxref("ShadowRoot.mode")}} closed.
 
 ### HTML templates
 
@@ -118,13 +135,15 @@ The basic approach for implementing a web component generally looks something li
 
   - : Extensions to the `Element` interface related to slots:
 
-    - {{domxref("Element.slot")}}: Returns the name of the shadow DOM slot attached to the element.
+    - {{domxref("Element.slot")}}
+      - : Returns the name of the shadow DOM slot attached to the element.
 
 - CSS pseudo-elements
 
   - : Pseudo-elements relating specifically to slots:
 
-    - {{cssxref("::slotted")}}: Matches any content that is inserted into a slot.
+    - {{cssxref("::slotted")}}
+      - : Matches any content that is inserted into a slot.
 
 - The {{domxref("HTMLSlotElement/slotchange_event", "slotchange")}} event
   - : Fired on an {{domxref("HTMLSlotElement")}} instance ({{htmlelement("slot")}} element) when the node(s) contained in that slot change.

--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -91,7 +91,6 @@ The basic approach for implementing a web component generally looks something li
     - {{cssxref("::part")}}
       - : Represents any element within a [shadow tree](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) that has a matching [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
 
-
 ### Shadow DOM
 
 - {{domxref("ShadowRoot")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

More consistent `dl` markup in reference.

### Motivation

The `dl` structure (and _thank you_ Mozilla, for adding that extension to GFM!) makes long reference lists much easier to scan visually.  They were used in some parts of this document, but not others.  This PR is a “quick, once-over” pass to use them in the Reference section for easier visual grepping.

