### PR TITLE
Access-Control-Expose-Headers - wildcarded authorization header info incorrect

### DIFF
--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -36,7 +36,8 @@ Access-Control-Expose-Headers: *
 - \<header-name>
   - : A list of zero or more comma-separated [header names](/en-US/docs/Web/HTTP/Headers) that clients are allowed to access from a response. These are _in addition_ to the {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}}.
 - `*` (wildcard)
-  - : The value "`*`" only counts as a special wildcard value for requests without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information). In requests with credentials, it is treated as the literal header name "`*`" without special semantics.
+  - : The value "`*`" only counts as a special wildcard value for requests without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information).
+    In requests with credentials, it is treated as the literal header name "`*`" without special semantics.
 
 ## Examples
 
@@ -58,11 +59,7 @@ For requests without credentials, a server can also respond with a wildcard valu
 Access-Control-Expose-Headers: *
 ```
 
-However, this won't wildcard the {{HTTPHeader("Authorization")}} header, so if you need to expose that, you will need to list it explicitly:
-
-```http
-Access-Control-Expose-Headers: *, Authorization
-```
+A server can also respond with the `*` value for requests with credentials, but in this case it would refer to a header named `*`.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -37,7 +37,7 @@ Access-Control-Expose-Headers: *
   - : A list of zero or more comma-separated [header names](/en-US/docs/Web/HTTP/Headers) that clients are allowed to access from a response. These are _in addition_ to the {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}}.
 - `*` (wildcard)
   - : The value "`*`" only counts as a special wildcard value for requests without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information).
-    In requests with credentials, it is treated as the literal header name "`*`" without special semantics.
+    In requests with credentials, it is treated as the literal header name "`*`".
 
 ## Examples
 


### PR DESCRIPTION
[Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers#directives) has an example of setting an `Authorization` request header if `Access-Control-Expose-Headers` is set as a wildcard.

That is incorrect because  `Access-Control-Expose-Headers` lists _response_ headers that can be shared with clients (as set by the server). It should never list `Authorization` under any circumstances.

From https://github.com/whatwg/fetch/issues/1671#issuecomment-1586937296 the situation with wildcarding pretty clear, and matches the existing docs.

> We only allow wildcarding for non-credentialed requests. To prevent responses from accidentally sharing too much information. So the note is accurate. * is a wildcard, but only if the request is non-credentialed. And when it functions as a wildcard, you cannot match a header whose name is *.

So all this does is remove the offending example.

This is part of #27230