### PR TITLE
ExprFeat: Access-Control-Allow-Headers wildcard disallow Authorization header

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2194,7 +2194,7 @@ For more details see [Firefox bug 1813035](https://bugzil.la/1813035).
 
 ### Access-Control-Allow-Headers wildcard does not cover Authorization
 
-The [`Access-Control-Allow-Headers`](/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) is a response header to a [CORS preflight request](/en-US/docs/Glossary/Preflight_request), which indicates what request headers may be included in the final request.
+The [`Access-Control-Allow-Headers`](/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) is a response header to a [CORS preflight request](/en-US/docs/Glossary/Preflight_request), that indicates which request headers may be included in the final request.
 The response directive can contain a wildcard (`*`) indicating all headers except the `Authorization` header are allowed.
 By default Firefox does not follow the specification, and includes `Authorization` in the headers covered by the wildcard.
 Set the preference to `false` to make Firefox follow the specification.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2195,9 +2195,10 @@ For more details see [Firefox bug 1813035](https://bugzil.la/1813035).
 ### Access-Control-Allow-Headers wildcard does not cover Authorization
 
 The [`Access-Control-Allow-Headers`](/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) is a response header to a [CORS preflight request](/en-US/docs/Glossary/Preflight_request), that indicates which request headers may be included in the final request.
-The response directive can contain a wildcard (`*`) indicating all headers except the `Authorization` header are allowed.
-By default Firefox does not follow the specification, and includes `Authorization` in the headers covered by the wildcard.
-Set the preference to `false` to make Firefox follow the specification.
+The response directive can contain a wildcard (`*`), which indicates that the final request may include all headers except the `Authorization` header.
+
+By default, Firefox includes the `Authorization` header in the final request after recieving a response with `Access-Control-Allow-Headers: *`.
+Set the preference to `false` to ensure Firefox does not include the `Authorization` header.
 For more details see [Firefox bug 1687364](https://bugzil.la/1687364).
 
 <table>
@@ -2205,29 +2206,29 @@ For more details see [Firefox bug 1687364](https://bugzil.la/1687364).
     <tr>
       <th>Release channel</th>
       <th>Version added</th>
-      <th>Disabled by default?</th>
+      <th>Enabled by default?</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <th>Nightly</th>
       <td>115</td>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Developer Edition</th>
       <td>115</td>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Beta</th>
       <td>115</td>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Release</th>
       <td>115</td>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Preference name</th>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2192,6 +2192,50 @@ For more details see [Firefox bug 1813035](https://bugzil.la/1813035).
   </tbody>
 </table>
 
+### Access-Control-Allow-Headers wildcard does not cover Authorization
+
+The [`Access-Control-Allow-Headers`](/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) is a response header to a [CORS preflight request](/en-US/docs/Glossary/Preflight_request), which indicates what request headers may be included in the final request.
+The response directive can contain a wildcard (`*`) indicating all headers except the `Authorization` header are allowed.
+By default Firefox does not follow the specification, and includes `Authorization` in the headers covered by the wildcard.
+Set the preference to `false` to make Firefox follow the specification.
+For more details see [Firefox bug 1687364](https://bugzil.la/1687364).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Disabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>115</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>115</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>115</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>115</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>network.cors_preflight.authorization_covered_by_wildcard</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## Developer tools
 
 Mozilla's developer tools are constantly evolving. We experiment with new ideas, add new features, and test them on the Nightly and Developer Edition channels before letting them go through to beta and release. The features below are the current crop of experimental developer tool features.


### PR DESCRIPTION
The [`Access-Control-Allow-Headers`](/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) is a response header to a [CORS preflight request](/en-US/docs/Glossary/Preflight_request), which indicates what request headers may be included in the final request.
According to the spec, the response directive can contain a wildcard (`*`) indicating all headers except the `Authorization` header are allowed.

Browsers have been ignoring this and including the Authorization header, but FF and Chrome (at least) are now looking to deprecate the old behaviour. FF115 adds the  spec behaviour behind a preference.
Note that the preference is negative - i.e. normally you enable a feature by setting it `true`, but in this case the preference is true by default and you have to set to `false` to get the new/spec behaviour.

Other docs work for this can be tracked in #27230