### PR TITLE
docs: update preventDefault() example to keydown

### DIFF
--- a/files/en-us/web/api/event/preventdefault/index.md
+++ b/files/en-us/web/api/event/preventdefault/index.md
@@ -105,11 +105,11 @@ invalid key:
 #### JavaScript
 
 And here's the JavaScript code that does the job. First, listen for
-{{domxref("Element/keypress_event", "keypress")}} events:
+{{domxref("Element/keydown_event", "keydown")}} events:
 
 ```js
 const myTextbox = document.getElementById("my-textbox");
-myTextbox.addEventListener("keypress", checkName, false);
+myTextbox.addEventListener("keydown", checkName, false);
 ```
 
 The `checkName()` function, which looks at the pressed key and decides


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault#stopping_keystrokes_from_reaching_an_edit_field) example for intercepting keystrokes is using the deprecated `keypress` event. This PR replaces it with the `keydown` event to achieve the same thing.

### Motivation

To provide an up-to-date example that doesn't rely on deprecated events.

### Additional details

- [keypress event](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event)
- [keydown event](https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event)

### Related issues and pull requests

N/A