### PR TITLE
FF115 Relnote: URL.canParse() supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -40,6 +40,10 @@ This article provides information about the changes in Firefox 115 that affect d
 
 ### APIs
 
+- The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
+  This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
+  ([Firefox bug 1823354](https://bugzil.la/1823354)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF115 adds support for `URL.canParse()`. This just adds the release note.

Other docs work can be tracked in #27170