### PR TITLE
docs(css): remove `-moz` vendor-prefixed :user-valid and :user-invalid pseudos

### DIFF
--- a/files/en-us/web/css/_colon_user-invalid/index.md
+++ b/files/en-us/web/css/_colon_user-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":user-invalid (:-moz-ui-invalid)"
+title: ":user-invalid"
 slug: Web/CSS/:user-invalid
 page-type: css-pseudo-class
 browser-compat: css.selectors.user-invalid
@@ -10,8 +10,6 @@ browser-compat: css.selectors.user-invalid
 The **`:user-invalid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any validated form element whose value isn't valid based on their [validation constraints](/en-US/docs/Learn/Forms#constraint_validation), after the user has interacted with it.
 
 The `:user-invalid` pseudo-class must match an {{CSSxRef(":invalid")}}, {{CSSxRef(":out-of-range")}}, or blank-but {{CSSxRef(":required")}} element between the time the user has attempted to submit the form and before the user has interacted again with the form element.
-
-> **Note:** The pseudo-class behaves in the same way as the non-standard `:-moz-ui-invalid` pseudo-class.
 
 ## Syntax
 

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":user-valid (:-moz-ui-valid)"
+title: ":user-valid"
 slug: Web/CSS/:user-valid
 page-type: css-pseudo-class
 browser-compat: css.selectors.user-valid
@@ -8,8 +8,6 @@ browser-compat: css.selectors.user-valid
 {{CSSRef}}
 
 The **`:user-valid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any validated form element whose value validates correctly based on its [validation constraints](/en-US/docs/Learn/Forms#constraint_validation). However, unlike {{cssxref(":valid")}} it only matches once the user has interacted with it.
-
-> **Note:** The pseudo-class behaves in the same way as the non-standard `:-moz-ui-valid` pseudo-class.
 
 This pseudo-class is applied according to the following rules:
 

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -499,8 +499,8 @@ Properties: {{CSSxRef("width")}}, {{CSSxRef("min-width")}}, and {{CSSxRef("max-w
 
 ### U – X
 
-- {{CSSxRef(":user-invalid", ":-moz-ui-invalid")}}
-- {{CSSxRef(":-moz-ui-valid")}}
+- {{CSSxRef(":user-invalid", ":-moz-ui-invalid")}} {{deprecated_inline}}
+- {{CSSxRef(":user-valid", ":-moz-ui-valid")}} {{deprecated_inline}}
 - {{CSSxRef(":-moz-user-disabled")}}
 - {{CSSxRef("::-moz-viewport")}}
 - {{CSSxRef("::-moz-viewport-scroll")}}


### PR DESCRIPTION
These CSS pseudo-classes have been supported for a while in Fx, this PR removes references to the deprecated and non-standard `-moz` prefixes.

__Bugzilla:__
- Implementation ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1694141

__Related issues and pull requests:__
- [x] https://github.com/mdn/browser-compat-data/pull/7431
- [x] https://github.com/mdn/content/issues/3455