### PR TITLE
Added explanatory note on search vs. sort collations in Intl.Collator.compare

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
@@ -62,6 +62,8 @@ const matches = a.filter((v) => collator.compare(v, s) === 0);
 console.log(matches.join(", ")); // "Congrès, congres"
 ```
 
+> **Note:** The collation activated by the `search` value for the `usage` option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order.
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
The search collation (activated by the `search` value for the `usage` option) should not be used for anything but search. Added note to this effect. 