### PR TITLE
docs(html): Add section about rendered whitespace in HTML v innerHTML

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -658,22 +658,42 @@ textarea.onkeyup = () => {
 };
 ```
 
-{{ EmbedLiveSample('Active_learning_Adding_some_features_to_an_HTML_document', 700, 1075, "", "") }}
+{{ EmbedLiveSample('Active_learning_Adding_some_features_to_an_HTML_document', 700, 500) }}
 
 ### Whitespace in HTML
 
 In the examples above, you may have noticed that a lot of whitespace is included in the code. This is optional. These two code snippets are equivalent:
 
 ```html-nolint
-<p>Dogs are silly.</p>
+<p id="noWhitespace">Dogs are silly.</p>
 
-<p>Dogs        are
-         silly.</p>
+<p id="whitespace">Dogs
+    are
+        silly.</p>
 ```
 
 No matter how much whitespace you use inside HTML element content (which can include one or more space character, but also line breaks), the HTML parser reduces each sequence of whitespace to a single space when rendering the code. So why use so much whitespace? The answer is readability.
 
 It can be easier to understand what is going on in your code if you have it nicely formatted. In our HTML we've got each nested element indented by two spaces more than the one it is sitting inside. It is up to you to choose the style of formatting (how many spaces for each level of indentation, for example), but you should consider formatting it.
+
+Let's have a look at how the browser renders the two paragraphs above with and without whitespace:
+
+{{ EmbedLiveSample('Whitespace_in_HTML', 700, 100) }}
+
+> **Note:** Accessing the [innerHTML](/en-US/docs/Web/API/Element/innerHTML) of elements from JavaScript will keep all the whitespace intact.
+> This may return unexpected results if the whitespace is trimmed by the browser.
+
+```js
+const noWhitespace = document.getElementById("noWhitespace").innerHTML;
+console.log(noWhitespace);
+// "Dogs are silly."
+
+const whitespace = document.getElementById("whitespace").innerHTML;
+console.log(whitespace);
+// "Dogs
+//    are
+//        silly."
+```
 
 ## Entity references: Including special characters in HTML
 


### PR DESCRIPTION
This small PR adds a hint in "intro to HTML" about accessing HTML from JS, specifically `innerHTML` and how this can deviate from rendered HTML.


__Related issues and pull requests:__
- [x] https://github.com/mdn/content/pull/24057