### PR TITLE
fix(css): Titles in module landing pages should follow sentence casing

### DIFF
--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Grid Layout
+title: CSS grid layout
 slug: Web/CSS/CSS_grid_layout
 page-type: css-module
 spec-urls: https://drafts.csswg.org/css-grid/

--- a/files/en-us/web/css/css_lists/index.md
+++ b/files/en-us/web/css/css_lists/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Lists
+title: CSS lists
 slug: Web/CSS/CSS_lists
 page-type: css-module
 spec-urls: https://drafts.csswg.org/css-lists/

--- a/files/en-us/web/css/css_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/index.md
@@ -1,5 +1,5 @@
 ---
-title: Media queries
+title: CSS media queries
 slug: Web/CSS/CSS_media_queries
 page-type: css-module
 spec-urls:
@@ -9,7 +9,7 @@ spec-urls:
 
 {{CSSRef}}
 
-**Media queries** are a key component of [responsive design](/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design) that allow you to apply CSS styles depending on the presence or value of device characteristics.
+**CSS media queries** are a key component of [responsive design](/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design) that allow you to apply CSS styles depending on the presence or value of device characteristics.
 
 It's common to apply a media query based on the {{Glossary("viewport")}} size so that layout choices can be made for devices with different screen sizes.
 For example, you may have a smaller font size for devices with small screens, increase the padding between paragraphs when a page is viewed in portrait mode, or increase the size of buttons on touchscreens.

--- a/files/en-us/web/css/css_paged_media/index.md
+++ b/files/en-us/web/css/css_paged_media/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Paged Media
+title: CSS paged media
 slug: Web/CSS/CSS_paged_media
 page-type: css-module
 spec-urls:
@@ -9,7 +9,7 @@ spec-urls:
 
 {{CSSRef}}
 
-**CSS Paged Media** is a module of CSS that defines how page switches are handled.
+The **CSS paged media** module defines how page switches are handled.
 
 ## Reference
 

--- a/files/en-us/web/css/css_ruby_layout/index.md
+++ b/files/en-us/web/css/css_ruby_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Ruby Layout
+title: CSS ruby layout
 slug: Web/CSS/CSS_ruby_layout
 page-type: css-module
 spec-urls: https://drafts.csswg.org/css-ruby/
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-ruby/
 
 {{CSSRef}}
 
-**CSS Ruby Layout** is a module of [CSS](/en-US/docs/Web/CSS) that provides the rendering model and formatting controls related to the display of ruby annotation. Ruby annotation is a form of interlinear annotation, consisting of short runs of text alongside the base text. They are typically used in East Asian documents to indicate pronunciation or to provide a short annotation.
+The **CSS ruby layout** module provides the rendering model and formatting controls related to the display of ruby annotation. Ruby annotation is a form of interlinear annotation, consisting of short runs of text alongside the base text. They are typically used in East Asian documents to indicate pronunciation or to provide a short annotation.
 
 ## Reference
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is a follow up to the series of PRs in https://github.com/mdn/content/pull/26939.

The slugs for the pages in the current PR are correct but titles need to be fixed to follow sentence casing.

Question for @estelle: Can we get rid of https://developer.mozilla.org/en-US/docs/Web/CSS/Paged_Media page since there is already https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_paged_media? 
