### PR TITLE
Update index.md FIXED: #25636 

### DIFF
--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -33,7 +33,7 @@ new SharedWorker(aURL, options)
 - `name` {{optional_inline}}
   - : A string specifying an identifying name for the
     {{domxref("SharedWorkerGlobalScope")}} representing the scope of the worker, which is
-    mainly useful for debugging purposes.
+    mainly useful for debugging purposes. The name allows multiple instances of a particular shared worker to be started.
 - `options` {{optional_inline}}
 
   - : An object containing option properties that can set when creating the object
@@ -52,7 +52,7 @@ new SharedWorker(aURL, options)
     - `name`
       - : A string specifying an
         identifying name for the {{domxref("SharedWorkerGlobalScope")}} representing the
-        scope of the worker, which is mainly useful for debugging purposes.
+        scope of the worker, which is mainly useful for debugging purposes. The name allows multiple instances of a particular shared worker to be started.
 
 ### Exceptions
 


### PR DESCRIPTION
The SharedWorker() constructor creates a SharedWorker object that executes a script at a specified URL, adhering to the same-origin policy. It has three possible syntaxes and takes parameters such as the URL and optional name and options. The name parameter allows multiple instances of a shared worker to be started, providing an identifying name for the worker's scope. The options parameter can specify the worker type, credentials, and name. Exceptions like SecurityError, NetworkError, and SyntaxError may be thrown based on certain conditions. The example demonstrates how to create and use a SharedWorker object, including message posting and handling. Additional examples and a full shared worker example are available on the MDN website.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
 #25636

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
