### PR TITLE
FF115Relnote: Response: json() static method supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -40,6 +40,8 @@ This article provides information about the changes in Firefox 115 that affect d
 
 ### APIs
 
+- The [`Response: json()` static method](/en-US/docs/Web/API/Response/json_static) is now supported, making it easer to construct {{domxref("Response")}} objects for returning JSON data.
+  The method will be useful for [service workers](/en-US/docs/Web/API/Service_Worker_API) and any other code that needs to respond to browser requests with JSON data ([Firefox bug 1758943](https://bugzil.la/1758943)).
 - The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
   This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
   ([Firefox bug 1823354](https://bugzil.la/1823354)).


### PR DESCRIPTION
FF115 adds support for [`Response: json()` static method](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) in https://bugzilla.mozilla.org/show_bug.cgi?id=1758943

This adds a a release note.

Related tracking doc in #27169