### PR TITLE
FF115Relnote: disable mozPreservesPitch alias

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -50,6 +50,8 @@ This article provides information about the changes in Firefox 115 that affect d
 
 #### Removals
 
+- The deprecated `mozPreservesPitch` alias of [HTMLMediaElement.preservesPitch](/en-US/docs/Web/API/HTMLMediaElement/preservesPitch) has been disabled by default, and may be fully removed in a future release ([Firefox bug 1831205](https://bugzil.la/1831205)).
+
 ### WebAssembly
 
 #### Removals


### PR DESCRIPTION
FF114 disables the `mozPreservesPitch` alias of [`HTMLMediaElement.preservesPitch`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preservesPitch) by default, behind a preference.

Normally I'd add to experimental features, but from most user's point of view this is a removal. So I have added it to the APIs removals in the release note.

This is part of #27181