### PR TITLE
chore: add leading slash to internal hrefs in HTML tables

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -151,8 +151,8 @@
         {
           "name": "relative-link",
           "message": "Internal links should start with '/'",
-          "search": "(en-US/docs",
-          "replace": "(/en-US/docs",
+          "searchPattern": "/([\\(\"])en-US\\/docs/g",
+          "replace": "$1/en-US/docs",
           "skipCode": true
         },
         {

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -153,7 +153,7 @@
           "message": "Internal links should start with '/'",
           "searchPattern": "/([\\(\"])en-US\\/docs/g",
           "replace": "$1/en-US/docs",
-          "skipCode": true
+          "searchScope": "text"
         },
         {
           "name": "relative-link-path",

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -332,10 +332,10 @@ If you find yourself needing to embed plugin content, this is the kind of inform
         height and width (in CSS pixels) of the box controlled by the plugin
       </td>
       <td>
-         <a href="en-US/docs/Web/HTML/Element/embed#height"><code>height</code></a><br /><a href="en-US/docs/Web/HTML/Element/embed#width"><code>width</code></a>
+         <a href="/en-US/docs/Web/HTML/Element/embed#height"><code>height</code></a><br /><a href="/en-US/docs/Web/HTML/Element/embed#width"><code>width</code></a>
       </td>
       <td>
-         <a href="en-US/docs/Web/HTML/Element/object#height"><code>height</code></a><br /><a href="en-US/docs/Web/HTML/Element/object#width"><code>width</code></a>
+         <a href="/en-US/docs/Web/HTML/Element/object#height"><code>height</code></a><br /><a href="/en-US/docs/Web/HTML/Element/object#width"><code>width</code></a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -24,7 +24,7 @@ In this article, we'll learn about the concept of responsive images — images t
       <th scope="row">Objective:</th>
       <td>
         Learn how to use features like
-         <a href="en-US/docs/Web/HTML/Element/img#srcset"><code>srcset</code></a> and the
+         <a href="/en-US/docs/Web/HTML/Element/img#srcset"><code>srcset</code></a> and the
         {{htmlelement("picture")}} element to implement responsive
         image solutions on websites.
       </td>

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -414,10 +414,10 @@ Also consider using the [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocom
     <tr>
       <td><strong>Supported common attributes</strong></td>
       <td>
-         <a href="en-US/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>
+         <a href="/en-US/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#list"><code>list</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -259,15 +259,15 @@ ssn.oninput = (event) => {
     <tr>
       <td><strong>Supported Common Attributes</strong></td>
       <td>
-         <a href="en-US/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#inputmode"><code>inputmode</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#maxlength"><code>maxlength</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#minlength"><code>minlength</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#pattern"><code>pattern</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>,
-         <a href="en-US/docs/Web/HTML/Element/input#required"><code>required</code></a>, and
-         <a href="en-US/docs/Web/HTML/Element/input#size"><code>size</code></a>
+         <a href="/en-US/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#inputmode"><code>inputmode</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#maxlength"><code>maxlength</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#minlength"><code>minlength</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#pattern"><code>pattern</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>,
+         <a href="/en-US/docs/Web/HTML/Element/input#required"><code>required</code></a>, and
+         <a href="/en-US/docs/Web/HTML/Element/input#size"><code>size</code></a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -117,7 +117,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>depth</code></td>
       <td>{{ MathMLElement("mpadded") }}</td>
       <td>
-       A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired depth (below the baseline).
+       A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired depth (below the baseline).
       </td>
     </tr>
     <tr>
@@ -209,7 +209,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mspace") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired height (above the baseline).
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired height (above the baseline).
       </td>
     </tr>
     <tr>
@@ -225,7 +225,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>linethickness</code></td>
       <td>{{ MathMLElement("mfrac") }}</td>
-      <td>A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the thickness of the horizontal fraction line.</td>
+      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the thickness of the horizontal fraction line.</td>
     </tr>
     <tr>
       <td><code>lspace</code></td>
@@ -233,7 +233,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mo") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating amount of space before the operator.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating amount of space before the operator.
       </td>
     </tr>
     <tr>
@@ -242,7 +242,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mpadded") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the element.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the element.
       </td>
     </tr>
     <tr>
@@ -281,12 +281,12 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>maxsize</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the maximum size of the operator when it is stretchy.</td>
+      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the maximum size of the operator when it is stretchy.</td>
     </tr>
     <tr>
       <td><code>minsize</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum size of the operator when it is stretchy.</td>
+      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum size of the operator when it is stretchy.</td>
     </tr>
     <tr>
       <td><code>movablelimits</code></td>
@@ -343,7 +343,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>rspace</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the amount of space after the operator.</td>
+      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the amount of space after the operator.</td>
     </tr>
     <tr>
       <td><code>rquote</code> {{deprecated_inline}}</td>
@@ -412,7 +412,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mmultiscripts") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the subscript down.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the subscript down.
       </td>
     </tr>
     <tr>
@@ -423,7 +423,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mmultiscripts") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the superscript up.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the superscript up.
       </td>
     </tr>
     <tr>
@@ -436,7 +436,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>voffset</code></td>
       <td>{{ MathMLElement("mpadded") }}</td>
-      <td>A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the vertical location of the positioning point of the child content with respect to the positioning point of the element.
+      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the vertical location of the positioning point of the child content with respect to the positioning point of the element.
 </td>
     </tr>
     <tr>
@@ -447,7 +447,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mtable") }}
       </td>
       <td>
-        A <a href="en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired width.
+        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired width.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
We have checks for markdown links that start with `/en` : https://github.com/mdn/content/blob/324bb0a68fb8c06c7d8cd2b5b9dee0f56ada9b23/.markdownlint-cli2.jsonc#L152-L156

This doesn't catch HTML tables. This PR does a search and replace for stray internal refs that start with `en-US` instead of `/en-US`.
