### PR TITLE
fix(flaws): use an absolute URL as a workaround for blog links displayed as broken

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -184,8 +184,8 @@
         },
         {
           "name": "fqdn-moz-links",
-          "message": "Don't use developer.mozilla.org for links",
-          "search": "](https://developer.mozilla.org/",
+          "message": "Don't use developer.mozilla.org for links, except for blog posts",
+          "search": "/](https://developer.mozilla.org/",
           "replace": "](/",
           "skipCode": true
         },

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -185,7 +185,7 @@
         {
           "name": "fqdn-moz-links",
           "message": "Don't use developer.mozilla.org for links, except for blog posts",
-          "search": "/](https://developer.mozilla.org/",
+          "searchPattern": "/\\]\\(https:\\/\\/developer.mozilla.org\\/(?!en-US\\/blog\\/)/g",
           "replace": "](/",
           "skipCode": true
         },

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -96,7 +96,7 @@ The `aria-label` attribute is **NOT** supported in:
 
 - {{HTMLElement('label')}} element
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
-- [Using HTML landmark roles to improve accessibility](/en-US/blog/aria-accessibility-html-landmark-roles/) on MDN blog (May 15, 2023)
+- [Using HTML landmark roles to improve accessibility](https://developer.mozilla.org/en-US/blog/aria-accessibility-html-landmark-roles/) on MDN blog (May 15, 2023)
 
 <section id="Quick_links">
 <strong><a href="/en-US/docs/Web/Accessibility/ARIA/Attributes">WAI-ARIA states and properties</a></strong>

--- a/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
@@ -40,7 +40,7 @@ Landmarks ensure content is in navigable regions. Use {{HTMLElement('main')}} fo
 - [ARIA: `navigation` role](/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role)
 - [ARIA: `region` role](/en-US/docs/Web/Accessibility/ARIA/Roles/region_role)
 - [ARIA: `search` role](/en-US/docs/Web/Accessibility/ARIA/Roles/search_role)
-- [Using HTML landmark roles to improve accessibility](/en-US/blog/aria-accessibility-html-landmark-roles/) on MDN blog (May 15, 2023)
+- [Using HTML landmark roles to improve accessibility](https://developer.mozilla.org/en-US/blog/aria-accessibility-html-landmark-roles/) on MDN blog (May 15, 2023)
 
 <section id="Quick_links">
 

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -158,4 +158,4 @@ If `:invalid-pseudo-class` was a valid selector, the first two rules above would
   - {{cssxref(":is", ":is()")}}
   - {{cssxref(":where", ":where()")}}
 
-- [How :not() chains multiple selectors](/en-US/blog/css-not-pseudo-multiple-selectors/) on MDN blog (May 5, 2023)
+- [How :not() chains multiple selectors](https://developer.mozilla.org/en-US/blog/css-not-pseudo-multiple-selectors/) on MDN blog (May 5, 2023)

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -346,4 +346,4 @@ div:nth-child(6) {
 - {{CSSXref("&lt;hue&gt;")}}: the data type representing the hue angle of a color
 - {{CSSXref("color")}}, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
-- [New functions, gradients, and hues in CSS colors (Level 4)](/en-US/blog/css-color-module-level-4/) on MDN blog (May 3, 2023)
+- [New functions, gradients, and hues in CSS colors (Level 4)](https://developer.mozilla.org/en-US/blog/css-color-module-level-4/) on MDN blog (May 3, 2023)

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -196,4 +196,4 @@ Please see [Using CSS gradients](/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradie
 - {{cssxref("image/image","image()")}}
 - {{cssxref("image/image-set","image-set()")}}
 - {{cssxref("cross-fade", "cross-fade()")}}
-- [New functions, gradients, and hues in CSS colors (Level 4)](/en-US/blog/css-color-module-level-4/) on MDN blog (May 3, 2023)
+- [New functions, gradients, and hues in CSS colors (Level 4)](https://developer.mozilla.org/en-US/blog/css-color-module-level-4/) on MDN blog (May 3, 2023)


### PR DESCRIPTION
__Problem:__

Links to blog posts are flagged as broken due to flaw checker not having the blog repo files.

__Changes:__

This PR contains the following changes:

* Use absolute URLs for links to MDN blog posts
* Update markdownlint rule to ignore fqdn links if they are followed by blog path:

```js
// match developer.mozilla.org              except if followed by 'en-US/blog/'
/\\]\\(https:\\/\\/developer.mozilla.org\\/(?!en-US\\/blog\\/)/g
```

__Tests:__ 
* [regexr.com/7fcd0](https://regexr.com/7fcd0)
* ran locally with `yarn run fix:md`


Fixes https://github.com/mdn/yari/issues/8954