### PR TITLE
Add note that clip() cannot be reverted without save() and restore()

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -26,9 +26,7 @@ drawn.
 > Instead, you'd have to use {{domxref("CanvasRenderingContext2D.rect()","rect()")}} to
 > add a rectangular shape to the path before calling `clip()`.
 
-> **Note:** Clip paths cannot be reverted directly, you must save your canvas state
-> using {{domxref("CanvasRenderingContext2D.save()","save()")}} before calling `clip()`, and restore it once you have finished drawing
-> in the clipped area using {{domxref("CanvasRenderingContext2D.restore()","restore()")}}.
+> **Note:** Clip paths cannot be reverted directly. You must save your canvas state using {{domxref("CanvasRenderingContext2D/save", "save()")}} before calling `clip()`, and restore it once you have finished drawing in the clipped area using {{domxref("CanvasRenderingContext2D/restore", "restore()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -27,8 +27,8 @@ drawn.
 > add a rectangular shape to the path before calling `clip()`.
 
 > **Note:** Clip paths cannot be reverted directly, you must save your canvas state
-> using `save()` before calling `clip()`, and restore it once you have finished drawing
-> in the clipped area using `restore()`.
+> using {{domxref("CanvasRenderingContext2D.save()","save()")}} before calling `clip()`, and restore it once you have finished drawing
+> in the clipped area using {{domxref("CanvasRenderingContext2D.restore()","restore()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -26,6 +26,10 @@ drawn.
 > Instead, you'd have to use {{domxref("CanvasRenderingContext2D.rect()","rect()")}} to
 > add a rectangular shape to the path before calling `clip()`.
 
+> **Note:** Clip paths cannot be reverted directly, you must save your canvas state
+> using `save()` before calling `clip()`, and restore it once you have finished drawing
+> in the clipped area using `restore()`.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add note that `clip()` cannot be reverted without `save()` and `restore()`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Add note that `clip()` cannot be reverted without `save()` and `restore()`

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Users do not need to search elsewhere how to revert a `clip()` (only to find out it is not possible)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
