### PR TITLE
added link to non-deprecated resource

### DIFF
--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -87,7 +87,7 @@ self.addEventListener("install", (event) => {
 
 ## See also
 
-- [`install` event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event)
+- [`install` event](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event)
 - {{domxref("NotificationEvent")}}
 - {{jsxref("Promise")}}
 - [Fetch API](/en-US/docs/Web/API/Fetch_API)

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -16,6 +16,8 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 
 {{InheritanceDiagram}}
 
+> **Note:** Use the non-deprecated ServiceWorkerGlobalScope [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) event instead.
+
 ## Constructor
 
 - {{domxref("InstallEvent.InstallEvent", "InstallEvent()")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
@@ -85,6 +87,7 @@ self.addEventListener("install", (event) => {
 
 ## See also
 
+- [`install` event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event)
 - {{domxref("NotificationEvent")}}
 - {{jsxref("Promise")}}
 - [Fetch API](/en-US/docs/Web/API/Fetch_API)

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -16,7 +16,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 
 {{InheritanceDiagram}}
 
-> **Note:** Use the non-deprecated ServiceWorkerGlobalScope [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) event instead.
+> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) using a listener added with [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener).
 
 ## Constructor
 


### PR DESCRIPTION
the install event is not exactly deprecated, but the `oninstall` is. added note to see the valid page and added link in see also as well. 