### PR TITLE
update term of "timing function"

### DIFF
--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -301,7 +301,7 @@ CSS font functions are used with the {{CSSxRef("font-variant-alternates")}} prop
 - {{CSSxRef("font-variant-alternates#annotation", "annotation()")}}
   - : Enables annotations such as circled digits or inverted characters. The parameter is a font-specific name mapped to a number. It corresponds to the OpenType value `nalt`, such as `nalt 2`.
 
-## Timing functions
+## Easing functions
 
 The following functions are used as a value in transition and animation properties.
 


### PR DESCRIPTION
### Description

use "Easing function" instead of "Timing function".

### Motivation

See <https://www.w3.org/TR/2017/WD-css-timing-1-20170221/>, w3c is now using "Easing function" instead of "timing function"
