### PR TITLE
Fix syntax error on ServiceWorker.postMessage

### DIFF
--- a/files/en-us/web/api/serviceworker/postmessage/index.md
+++ b/files/en-us/web/api/serviceworker/postmessage/index.md
@@ -67,9 +67,9 @@ In order to receive the message, the service worker, in `service-worker.js` has 
 
 ```js
 // This must be in `service-worker.js`
-addEventListener("message", (event) =>
+addEventListener("message", (event) => {
   console.log(`Message received: ${event.data}`);
-);
+});
 ```
 
 Note that the service worker can send back messages to the main thread using the {{domxref("Client.postMessage()", "postMessage()")}} method. To receive it, the main thread needs to listen for a {{domxref("ServiceWorkerContainer.message_event", "message")}} event on the {{domxref("ServiceWorkerContainer")}} object.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The current snippet contains a syntax error: implicit return with a semicolon without curly braces.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Avoid errors when copy-pasting.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
N/A

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
