### PR TITLE
sandbox is not supported in Content-Security-Policy-Report-Only

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -37,7 +37,7 @@ Content-Security-Policy-Report-Only: <policy-directive>; <policy-directive>
 
 ## Directives
 
-The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only`.
+The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only` except for sandbox directive which is unsupported in `Content-Security-Policy-Report-Only`.
 
 The CSP {{CSP("report-to")}} directive should be used with this header, otherwise this header will be an expensive no-op machine.
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -37,7 +37,7 @@ Content-Security-Policy-Report-Only: <policy-directive>; <policy-directive>
 
 ## Directives
 
-The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only`, except for the `sandbox` directive, which is unsupported in `Content-Security-Policy-Report-Only`.
+The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only`, except for the `sandbox` directive, which is ignored when used with `Content-Security-Policy-Report-Only`.
 
 The CSP {{CSP("report-to")}} directive should be used with this header, otherwise this header will be an expensive no-op machine.
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -37,7 +37,7 @@ Content-Security-Policy-Report-Only: <policy-directive>; <policy-directive>
 
 ## Directives
 
-The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only` except for sandbox directive which is unsupported in `Content-Security-Policy-Report-Only`.
+The directives of the {{HTTPHeader("Content-Security-Policy")}} header can also be applied to `Content-Security-Policy-Report-Only`, except for the `sandbox` directive, which is unsupported in `Content-Security-Policy-Report-Only`.
 
 The CSP {{CSP("report-to")}} directive should be used with this header, otherwise this header will be an expensive no-op machine.
 


### PR DESCRIPTION
### Description

Made changes to Content-Security-Policy-Report-Only directives to show it does not support sandbox even if applied from content security policy header

### Motivation

It will give clarification that sandbox is not supported in Content-Security-Policy-Report-Only


### Related issues and pull requests

Fixes #24318 

