### PR TITLE
Remove anti-pattern example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -428,23 +428,17 @@ const products = new Proxy(
         return obj.length;
       }
 
-      let result;
       const types = {};
 
       for (const product of obj) {
         if (product.name === prop) {
-          result = product;
+          return product;
         }
         if (types[product.type]) {
           types[product.type].push(product);
         } else {
           types[product.type] = [product];
         }
-      }
-
-      // Get a product by name
-      if (result) {
-        return result;
       }
 
       // Get products by type

--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -405,65 +405,6 @@ console.log(products.latestBrowser);
 //  'Edge'
 ```
 
-### Finding an array item object by its property
-
-This proxy extends an array with some utility features. As you see, you can flexibly "define" properties without using {{jsxref("Object.defineProperties", "Object.defineProperties()")}}. This example can be adapted to find a table row by its cell. In that case, the target will be {{domxref("HTMLTableElement/rows", "table.rows")}}.
-
-```js
-const products = new Proxy(
-  [
-    { name: "Firefox", type: "browser" },
-    { name: "SeaMonkey", type: "browser" },
-    { name: "Thunderbird", type: "mailer" },
-  ],
-  {
-    get(obj, prop) {
-      // The default behavior to return the value; prop is usually an integer
-      if (prop in obj) {
-        return obj[prop];
-      }
-
-      // Get the number of products; an alias of products.length
-      if (prop === "number") {
-        return obj.length;
-      }
-
-      const types = {};
-
-      for (const product of obj) {
-        if (product.name === prop) {
-          return product;
-        }
-        if (types[product.type]) {
-          types[product.type].push(product);
-        } else {
-          types[product.type] = [product];
-        }
-      }
-
-      // Get products by type
-      if (prop in types) {
-        return types[prop];
-      }
-
-      // Get product types
-      if (prop === "types") {
-        return Object.keys(types);
-      }
-
-      return undefined;
-    },
-  },
-);
-
-console.log(products[0]); // { name: 'Firefox', type: 'browser' }
-console.log(products["Firefox"]); // { name: 'Firefox', type: 'browser' }
-console.log(products["Chrome"]); // undefined
-console.log(products.browser); // [{ name: 'Firefox', type: 'browser' }, { name: 'SeaMonkey', type: 'browser' }]
-console.log(products.types); // ['browser', 'mailer']
-console.log(products.number); // 3
-```
-
 ### A complete traps list example
 
 Now in order to create a complete sample `traps` list, for didactic purposes, we will try to proxify a _non-native_ object that is particularly suited to this type of operation: the `docCookies` global object created by [a simple cookie framework](https://reference.codeproject.com/dom/document/cookie/simple_document.cookie_framework).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is no point to continue loop if we find the object. The more performance-effective way is early return found product object.
