### PR TITLE
[fix] `shift Tab` to previous element in menubar

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
@@ -62,7 +62,7 @@ When focus is in a `menubar` it is always on a menu item within the menu bar. Wh
   - : If arrow key wrapping is not supported, moves focus to the last item in the `menubar`.
 - <kbd>Tab</kbd>
   - : Moves focus to the next element in the tab sequence. If that makes it exit the menubar, all submenus in the menubar get closed.
-- <kbd>shift Tab</kbd>
+- <kbd>shift + Tab</kbd>
   - : Moves focus to the previous element in the tab sequence. If that makes it exit the menubar, all submenus in the menubar get closed.
 
 See [`menuitem` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role#keyboard_interactions), [`menuitemradio` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role#keyboard_interactions), and [`menuitemcheckbox` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role#keyboard_interactions) for more information on keyboard interactions when focus is on a menuitem in a menubar (which it always is).

--- a/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
@@ -62,7 +62,7 @@ When focus is in a `menubar` it is always on a menu item within the menu bar. Wh
   - : If arrow key wrapping is not supported, moves focus to the last item in the `menubar`.
 - <kbd>Tab</kbd>
   - : Moves focus to the next element in the tab sequence. If that makes it exit the menubar, all submenus in the menubar get closed.
-- <kbd>Tab</kbd>
+- <kbd>shift Tab</kbd>
   - : Moves focus to the previous element in the tab sequence. If that makes it exit the menubar, all submenus in the menubar get closed.
 
 See [`menuitem` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role#keyboard_interactions), [`menuitemradio` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role#keyboard_interactions), and [`menuitemcheckbox` keyboard interactions](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role#keyboard_interactions) for more information on keyboard interactions when focus is on a menuitem in a menubar (which it always is).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `shift Tab` is used to move backwards while tabbing. The docs for [menubar](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role) currently list `Tab` as requiring the ability to move backwards and forwards with no differentiation. This change prefixes `shift` to the keyboard mark for moving to previous elements.

### Motivation

I am working on a menubar currently and needed to implement keyboard interactions. I came across this conflicting documentation.

### Additional details

`Tab` and `shift Tab` are differentiated by w3c here: https://www.w3.org/WAI/ARIA/apg/patterns/menubar/

### Related issues and pull requests

n/a
