### PR TITLE
Fix Typo: Change "internalization API" to "internationalization API"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
@@ -63,7 +63,7 @@ console.log(bigint.toLocaleString());
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internationalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
 
 ```js
 function toLocaleStringSupportsLocales() {

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -64,7 +64,7 @@ console.log(date.toLocaleDateString());
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleDateString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internationalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleDateString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
 
 ```js
 function toLocaleDateStringSupportsLocales() {

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -65,7 +65,7 @@ console.log(date.toLocaleString());
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internationalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
 
 ```js
 function toLocaleStringSupportsLocales() {

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -65,7 +65,7 @@ console.log(date.toLocaleTimeString());
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleTimeString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internationalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleTimeString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
 
 ```js
 function toLocaleTimeStringSupportsLocales() {

--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -62,7 +62,7 @@ console.log(number.toLocaleString()); // "3,500" if in U.S. English locale
 
 ### Checking for support for locales and options parameters
 
-The `locales` and `options` parameters may not be supported in all implementations, because support for the internalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
+The `locales` and `options` parameters may not be supported in all implementations, because support for the internationalization API is optional, and some systems may not have the necessary data. For implementations without internationalization support, `toLocaleString()` always uses the system's locale, which may not be what you want. Because any implementation that supports the `locales` and `options` parameters must support the {{jsxref("Intl")}} API, you can check the existence of the latter for support:
 
 ```js
 function toLocaleStringSupportsLocales() {


### PR DESCRIPTION
### Description

Fixes a few typos in the `toLocaleString` documentation across a few methods - `internationalization` was incorrectly spelled as `internalization`.

### Motivation

Wanted to help clarify that this was actually referring to i18n and not something else. Definitely confused me for a second while I was reading through the section - hoping this solves the issue for anyone else.

### Additional details

- [Link to the Intl API documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
- [Internalization meaning in the Cambridge English dictionary](https://dictionary.cambridge.org/dictionary/english/internalization)
- [Internationalization meaning in the Cambridge English dictionary](https://dictionary.cambridge.org/dictionary/english/internationalization)

Even though I would prefer to use the undeniably superior word "internationalisation", this corrects the misspelling to the American version of the word, as seems to be standard across the docs.
