### PR TITLE
Getting started with React: Remove parenthesis from note

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -83,11 +83,10 @@ const header = (
 > **Note:** The parentheses in the previous snippet aren't unique to JSX, and don't have any effect on your application. They're a signal to you (and your computer) that the multiple lines of code inside are part of the same expression. You could just as well write the header expression like this:
 >
 > ```jsx
-> const header = (
+> const header = 
 >   <header>
 >     <h1>Mozilla Developer Network</h1>
 >   </header>
-> );
 > ```
 >
 > However, this looks kind of awkward, because the [`<header>`](/en-US/docs/Web/HTML/Element/header) tag that starts the expression is not indented to the same position as its corresponding closing tag.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -82,11 +82,10 @@ const header = (
 
 > **Note:** The parentheses in the previous snippet aren't unique to JSX, and don't have any effect on your application. They're a signal to you (and your computer) that the multiple lines of code inside are part of the same expression. You could just as well write the header expression like this:
 >
-> ```jsx
-> const header = 
->   <header>
->     <h1>Mozilla Developer Network</h1>
->   </header>
+> ```jsx-nolint
+> const header = <header>
+>   <h1>Mozilla Developer Network</h1>
+> </header>;
 > ```
 >
 > However, this looks kind of awkward, because the [`<header>`](/en-US/docs/Web/HTML/Element/header) tag that starts the expression is not indented to the same position as its corresponding closing tag.


### PR DESCRIPTION

### Description

Removed parenthesis from header expression so that it coincide with text description.

### Motivation

Make the code as per the text description.



### Related issues and pull requests

Fixes #27344 

