### PR TITLE
Add an example for Response.error()

### DIFF
--- a/files/en-us/web/api/response/error_static/index.md
+++ b/files/en-us/web/api/response/error_static/index.md
@@ -45,7 +45,7 @@ self.addEventListener("fetch", (event) => {
 });
 ```
 
-With this service worker, all fetch requests from the app will pass through the service worker to the network, except for requests to fetch "salamander.jpg", which will reject. This means that the following code would throw an error, and the `catch` handler will run.
+With this service worker, all fetch requests from the app will pass through the service worker to the network, except for requests to fetch "salamander.jpg", which will reject. This means that the following main thread code would throw an error, and the `catch` handler will run.
 
 ```js
 // main.js

--- a/files/en-us/web/api/response/error_static/index.md
+++ b/files/en-us/web/api/response/error_static/index.md
@@ -10,10 +10,9 @@ browser-compat: api.Response.error_static
 
 The **`error()`** static method of the {{domxref("Response")}} interface returns a new `Response` object associated with a network error.
 
-> **Note:** This is mainly relevant to [ServiceWorkers](/en-US/docs/Web/API/Service_Worker_API); the error method is used to return an error if you so wish it.
-> An error response has its {{domxref("Response.type","type")}} set to `error`.
+This is mainly useful when writing service workers: it enables a service worker to send a response from a {{domxref("ServiceWorkerGlobalScope.fetch_event", "fetch")}} event handler that will cause the {{domxref("fetch()")}} call in the main app code to reject the promise.
 
-> **Note:** An "error" `Response` never really gets exposed to script: such a response to a {{domxref("fetch()")}} would reject the promise.
+An error response has its {{domxref("Response.type","type")}} set to `error`.
 
 ## Syntax
 
@@ -31,7 +30,37 @@ A {{domxref("Response")}} object.
 
 ## Examples
 
-TBD (does not yet appear to be supported anywhere).
+### Throwing an error from a service worker
+
+Suppose a web app has a service worker, which contains the following `fetch` event handler:
+
+```js
+// service-worker.js
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname === "/salamander.jpg") {
+    event.respondWith(Response.error());
+  }
+});
+```
+
+With this service worker, all fetch requests from the app will pass through the service worker to the network, except for requests to fetch "salamander.jpg", which will reject. This means that the following code would throw an error, and the `catch` handler will run.
+
+```js
+// main.js
+
+const image = document.querySelector("#image");
+
+try {
+  const response = await fetch("salamander.jpg");
+  const blob = await response.blob();
+  const objectURL = URL.createObjectURL(blob);
+  image.src = objectURL;
+} catch (e) {
+  console.error(e);
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/response/error_static/index.md
+++ b/files/en-us/web/api/response/error_static/index.md
@@ -30,7 +30,7 @@ A {{domxref("Response")}} object.
 
 ## Examples
 
-### Throwing an error from a service worker
+### Returning a network error from a service worker
 
 Suppose a web app has a service worker, which contains the following `fetch` event handler:
 


### PR DESCRIPTION
Under "Examples", [the page for `Response.error()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/error_static) says:

> TBD (does not yet appear to be supported anywhere).

This is wrong. This PR adds an example, and a bit of clarity about what this method does.


