### PR TITLE
FF115 URLSearchParams.has() and delete() value arg

### DIFF
--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -100,3 +100,7 @@ Otherwise the result will be the same as in the previous example (`bar=2`).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Polyfill of `URLSearchParams` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -8,22 +8,27 @@ browser-compat: api.URLSearchParams.delete
 
 {{ApiRef("URL API")}}
 
-The **`delete()`** method of the {{domxref("URLSearchParams")}}
-interface deletes the given search parameter and all its associated values, from the
-list of all search parameters.
+The **`delete()`** method of the {{domxref("URLSearchParams")}} interface deletes specified parameters and their associated value(s) from the list of all search parameters.
 
-{{availableinworkers}}
+A parameter name and optional value are used to match parameters.
+If only a parameter name is specified, then all search parameters that match the name are deleted, along with their associated values.
+If both a parameter name and value are specified, then all search parameters that match both the parameter name and value are deleted.
+
+{{AvailableInWorkers}}
 
 ## Syntax
 
 ```js-nolint
 delete(name)
+delete(name, value)
 ```
 
 ### Parameters
 
 - `name`
-  - : The name of the parameter to be deleted.
+  - : The name of the parameters to be deleted.
+- `value` {{optional_inline}}
+  - : The value that parameters must match, along with the given name, to be deleted.
 
 ### Return value
 
@@ -31,13 +36,62 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-```js
-let url = new URL("https://example.com?foo=1&bar=2&foo=3");
-let params = new URLSearchParams(url.search);
+### Delete all parameters with specified name
 
-// Delete the foo parameter.
-params.delete("foo"); //Query string is now: 'bar=2'
+This example shows how to delete all query parameters (and values) that have a particular name.
+
+```html hidden
+<pre id="log"></pre>
 ```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const url = new URL("https://example.com?foo=1&bar=2&foo=3");
+const params = new URLSearchParams(url.search);
+log(`Query string (before):\t ${params}`);
+params.delete("foo");
+log(`Query string (after):\t ${params}`);
+```
+
+The log below shows that all parameters that have the name of `foo` are deleted.
+
+{{EmbedLiveSample('Delete all parameters with specified name', '100%', '50')}}
+
+### Delete parameters with specified name and value
+
+This example shows how to delete query parameters that match a particular name and value.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const url = new URL("https://example.com?foo=1&bar=2&foo=3&foo=1");
+const params = new URLSearchParams(url.search);
+log(`Query string (before):\t ${params}`);
+params.delete("foo", "1");
+log(`Query string (after):\t ${params}`);
+```
+
+All parameters that match both the parameter `name` and `value` should be deleted (there is no reason to specify two parameters with the same name and value as shown above).
+
+{{EmbedLiveSample('Delete parameters with specified name and value', '100%', '50')}}
+
+If your browser supports the `value` option, the "after" string should be `bar=2&foo=3`.
+Otherwise the result will be the same as in the previous example (`bar=2`).
 
 ## Specifications
 

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -103,3 +103,7 @@ If your browser does not support the `value` option the method will match on the
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Polyfill of `URLSearchParams` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -8,22 +8,27 @@ browser-compat: api.URLSearchParams.has
 
 {{ApiRef("URL API")}}
 
-The **`has()`** method of the {{domxref("URLSearchParams")}}
-interface returns a boolean value that indicates whether a parameter with the
-specified name exists.
+The **`has()`** method of the {{domxref("URLSearchParams")}} interface returns a boolean value that indicates whether the specified parameter is in the search parameters.
 
-{{availableinworkers}}
+A parameter name and optional value are used to match parameters.
+If only a parameter name is specified, then the method will return `true` if any parameters in the query string match the name, and `false` otherwise.
+If both a parameter name and value are specified, then the method will return `true` if a parameter matches both the name and value.
+
+{{AvailableInWorkers}}
 
 ## Syntax
 
 ```js-nolint
 has(name)
+has(name, value)
 ```
 
 ### Parameters
 
 - `name`
-  - : The name of the parameter to find.
+  - : The name of the parameter to match.
+- `value`
+  - : The value of the parameter, along with the given name, to match.
 
 ### Return value
 
@@ -31,12 +36,65 @@ A boolean value.
 
 ## Examples
 
-```js
-let url = new URL("https://example.com?foo=1&bar=2");
-let params = new URLSearchParams(url.search);
+### Check for parameter with specified name
 
-console.log(params.has("bar")); //true
+This example shows how to check if the query string has any parameters with a particular name.
+
+```html hidden
+<pre id="log"></pre>
 ```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const url = new URL("https://example.com?foo=1&bar=2&foo=3");
+const params = new URLSearchParams(url.search);
+
+// has() returns true if the parameter is in the query string
+log(`bar?:\t${params.has("bar")}`);
+log(`bark?:\t${params.has("bark")}`);
+log(`foo?:\t${params.has("foo")}`);
+```
+
+The log below shows whether the parameters `bar`, `bark`, and `foo`, are present in the query string.
+
+{{EmbedLiveSample('Check for parameter with specified name', '100%', '80')}}
+
+### Check for parameter with specified name and value
+
+This example shows how to check whether the query string has a parameter that matches both a particular name and value.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const url = new URL("https://example.com?foo=1&bar=2&foo=3");
+const params = new URLSearchParams(url.search);
+
+// has() returns true if a parameter with the matching name and value is in the query string
+log(`bar=1?:\t${params.has("bar","1")}`);
+log(`bar=2?:\t${params.has("bar","2")}`);
+log(`foo=4?:\t${params.has("foo","4")}`);
+```
+
+Only the second value above should be `true`, as only the parameter name `bar` with value `2` is matched.
+
+{{EmbedLiveSample('Check for parameter with specified name and value', '100%', '80')}}
+
+If your browser does not support the `value` option the method will match on the name, and all the results should be `true`.
 
 ## Specifications
 

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -85,9 +85,9 @@ const url = new URL("https://example.com?foo=1&bar=2&foo=3");
 const params = new URLSearchParams(url.search);
 
 // has() returns true if a parameter with the matching name and value is in the query string
-log(`bar=1?:\t${params.has("bar","1")}`);
-log(`bar=2?:\t${params.has("bar","2")}`);
-log(`foo=4?:\t${params.has("foo","4")}`);
+log(`bar=1?:\t${params.has("bar", "1")}`);
+log(`bar=2?:\t${params.has("bar", "2")}`);
+log(`foo=4?:\t${params.has("foo", "4")}`);
 ```
 
 Only the second value above should be `true`, as only the parameter name `bar` with value `2` is matched.

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -35,7 +35,7 @@ for (const [key, value] of mySearchParams.entries()) {
 - {{domxref("URLSearchParams.append()")}}
   - : Appends a specified key/value pair as a new search parameter.
 - {{domxref("URLSearchParams.delete()")}}
-  - : Deletes the given search parameter, and its associated value, from the list of all search parameters.
+  - : Deletes search parameters that match a name, and optional value, from the list of all search parameters.
 - {{domxref("URLSearchParams.entries()")}}
   - : Returns an {{jsxref("Iteration_protocols","iterator")}} allowing iteration through all key/value pairs contained in this object in the same order as they appear in the query string.
 - {{domxref("URLSearchParams.forEach()")}}
@@ -45,7 +45,7 @@ for (const [key, value] of mySearchParams.entries()) {
 - {{domxref("URLSearchParams.getAll()")}}
   - : Returns all the values associated with a given search parameter.
 - {{domxref("URLSearchParams.has()")}}
-  - : Returns a boolean value indicating if such a given parameter exists.
+  - : Returns a boolean value indicating if a given parameter, or parameter and value pair, exists.
 - {{domxref("URLSearchParams.keys()")}}
   - : Returns an {{jsxref("Iteration_protocols", "iterator")}} allowing iteration through all keys of the key/value pairs contained in this object.
 - {{domxref("URLSearchParams.set()")}}
@@ -69,6 +69,7 @@ for (const p of searchParams) {
 }
 
 console.log(searchParams.has("topic")); // true
+console.log(searchParams.has("topic", "fish")); // false
 console.log(searchParams.get("topic") === "api"); // true
 console.log(searchParams.getAll("topic")); // ["api"]
 console.log(searchParams.get("foo") === null); // true


### PR DESCRIPTION
FF115 `URLSearchParams.has()` and `URLSearchParams.delete()` have a new optional `value` argument to go with the parameter name.
Without the value the methods match on all/any parameter that has the specified name. With the `value` argument they methods match on a parameter that has both the matching name and value.

This updates the documentation for the two methods.

Other docs work for this can be tracked in #27172

Fix #26604