### PR TITLE
FF115 Relnote: URLSearchParams.has/delete value arg

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -45,6 +45,9 @@ This article provides information about the changes in Firefox 115 that affect d
 - The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
   This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
   ([Firefox bug 1823354](https://bugzil.la/1823354)).
+- The [`URLSearchParams.has()`](/en-US/docs/Web/API/URLSearchParams/has) and [`URLSearchParams.delete()`](/en-US/docs/Web/API/URLSearchParams/delete) methods now support the optional `value` argument.
+  This allows matching a search parameter on both the `name` and `value`, making it possible to work with query strings that contain multiple search parameters that have the same name.
+  ([Firefox bug 1831587](https://bugzil.la/1831587)).
 
 #### DOM
 


### PR DESCRIPTION
FF115 `URLSearchParams.has()` and `URLSearchParams.delete()` have a new optional `value` argument to go with the parameter name.
Without the value the methods match on all/any parameter that has the specified name. With the `value` argument they methods match on a parameter that has both the matching name and value.

This updates the release note.

Other docs work for this can be tracked in #27172