### PR TITLE
Better docs for fetch event

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -28,7 +28,10 @@ The `fetch` event is fired in the service worker's global scope when the main ap
 
 The event handler is passed a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
 
-The `FetchEvent` also provides a {{domxref("FetchEvent.respondWith()", "respondWith()")}} method, that takes a {{domxref("Response")}} (or a `Promise` that resolves to a `Response`) as a parameter, and this enables the event handler to return a different response to the request: for example, it enables a service worker to return:
+The `FetchEvent` also provides a {{domxref("FetchEvent.respondWith()", "respondWith()")}} method, that takes a {{domxref("Response")}} (or a `Promise` that resolves to a `Response`) as a parameter.
+This enables the service worker event handler to provide the response that is returned to the request in the main thread.
+
+For example, the service worker can return:
 
 - A locally cached response retrieved from the {{domxref("Cache")}} interface.
 - A response that the service worker synthesizes, using methods like {{domxref("Response.json()")}} or the {{domxref("Response.Response()", "Response()")}} constructor.
@@ -62,7 +65,8 @@ self.addEventListener("fetch", (event) => {
 });
 ```
 
-If `respondWith()` is not called in the handler, then the original network request is made: so in the example above, all requests that do not match `pattern1` or `pattern2` are made as if the service worker did not exist.
+If `respondWith()` is not called in the handler, then the user agent automatically makes the original network request.
+For example, in the code above, all requests that do not match `pattern1` or `pattern2` are made as if the service worker did not exist.
 
 ## Event type
 
@@ -94,7 +98,6 @@ self.addEventListener("fetch", (event) => {
 ### Cache only
 
 This `fetch` event handler implements a "cache only" policy for scripts and stylesheets. If the request's {{domxref("Request.destination", "destination")}} property is `"script"` or `"style"`, the handler only looks in the cache, returning an error if the response was not found.
-
 All other requests go through to the network.
 
 ```js

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -24,7 +24,7 @@ onfetch = (event) => {};
 
 ## Description
 
-The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but also implicit network requests made when pages and subresources such as JavaScript, CSS, and images are loaded.
+The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but also implicit network requests to load pages and subresources (such as JavaScript, CSS, and images) made by the browser following page navigation.
 
 The event handler is passed a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -129,6 +129,6 @@ self.addEventListener("fetch", (event) => {
 
 - [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
 - [Service workers basic code example](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker)
-- [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)
-- {{jsxref("Promise")}}
-- [Using web workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+- {{domxref("fetch()")}} method
+- {{domxref("Request")}} interface
+- {{domxref("Response")}} interface

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -24,7 +24,7 @@ onfetch = (event) => {};
 
 ## Description
 
-The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but implicit network requests made when pages and subresources such as JavaScript, CSS, and images are loaded.
+The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but also implicit network requests made when pages and subresources such as JavaScript, CSS, and images are loaded.
 
 The event handler is passed a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -26,7 +26,7 @@ onfetch = (event) => {};
 
 The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but implicit network requests made when pages and subresources such as JavaScript, CSS, and images are loaded.
 
-The event handler is passd a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
+The event handler is passed a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
 
 The `FetchEvent` also provides a {{domxref("FetchEvent.respondWith()", "respondWith()")}} method, that takes a {{domxref("Response")}} (or a `Promise` that resolves to a `Response`) as a parameter, and this enables the event handler to return a different response to the request: for example, it enables a service worker to return:
 
@@ -98,7 +98,7 @@ This `fetch` event handler implements a "cache only" policy for scripts and styl
 All other requests go through to the network.
 
 ```js
-async function fromCache(request) {
+async function cacheOnly(request) {
   const cachedResponse = await caches.match(request);
   if (cachedResponse) {
     console.log("Found response in cache:", cachedResponse);
@@ -112,7 +112,7 @@ self.addEventListener("fetch", (event) => {
     event.request.destination === "script" ||
     event.request.destination === "style"
   ) {
-    event.respondWith(fromCache(event.request));
+    event.respondWith(cacheOnly(event.request));
   }
 });
 ```

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ServiceWorkerGlobalScope.fetch_event
 
 {{APIRef("Service Workers API")}}
 
-The **fetch** event is fired when the {{domxref("fetch()")}} method is called.
+The **`fetch`** event is fired in the service worker's global scope when the main app thread makes a network request. It enables the service worker to intercept network requests and send customized responses (for example, from a local cache).
 
 This event is not cancelable and does not bubble.
 
@@ -22,46 +22,98 @@ addEventListener("fetch", (event) => {});
 onfetch = (event) => {};
 ```
 
+## Description
+
+The `fetch` event is fired in the service worker's global scope when the main app thread makes a network request. This includes not only explicit {{domxref("fetch()")}} calls from the main thread, but implicit network requests made when pages and subresources such as JavaScript, CSS, and images are loaded.
+
+The event handler is passd a {{domxref("FetchEvent")}} object, which provides access to the request as a {{domxref("Request")}} instance.
+
+The `FetchEvent` also provides a {{domxref("FetchEvent.respondWith()", "respondWith()")}} method, that takes a {{domxref("Response")}} (or a `Promise` that resolves to a `Response`) as a parameter, and this enables the event handler to return a different response to the request: for example, it enables a service worker to return:
+
+- A locally cached response retrieved from the {{domxref("Cache")}} interface.
+- A response that the service worker synthesizes, using methods like {{domxref("Response.json()")}} or the {{domxref("Response.Response()", "Response()")}} constructor.
+- A network error, using the {{domxref("Response.error_static()", "Response.error()")}} method. This will cause the `fetch()` call to reject.
+
+The `respondWith()` method can only be called once for a given request. If multiple `fetch` event listeners are added, they will be called in the order they were registered until one of them calls `respondWith()`.
+
+The `respondWith()` method must be called synchronously: that is, you can't call it in a `then` handler.
+
+Typically, a `fetch` event handler will execute different strategies depending on features of the request such as its URL:
+
+```js
+function strategy1() {
+  return fetch("picnic.jpg");
+}
+
+function strategy2() {
+  return Response.error();
+}
+
+const pattern1 = /^\/salamander/;
+const pattern2 = /^\/lizard/;
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (pattern1.test(url.pathname)) {
+    event.respondWith(strategy1());
+  } else if (pattern2.test(url.pathname)) {
+    event.respondWith(strategy2());
+  }
+});
+```
+
+If `respondWith()` is not called in the handler, then the original network request is made: so in the example above, all requests that do not match `pattern1` or `pattern2` are made as if the service worker did not exist.
+
 ## Event type
 
 A {{domxref("FetchEvent")}}.
 
-## Example
+## Examples
 
-This code snippet is from the [service worker prefetch sample](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/prefetch/service-worker.js) (see [prefetch example live](https://googlechrome.github.io/samples/service-worker/prefetch/).) The {{domxref("ServiceWorkerGlobalScope.fetch_event", "onfetch")}} event handler
-listens for the `fetch` event. When fired, the code returns a promise that
-resolves to the first matching request in the {{domxref("Cache")}} object. If no match
-is found, the code fetches a response from the network.
+### Cache falling back to network
 
-The code also handles exceptions thrown from the
-{{domxref("fetch()")}} operation. Note that an HTTP
-error response (e.g., 404) will not trigger an exception. It will return a normal
-response object that has the appropriate error code set.
+This `fetch` event handler first tries to find the response in the cache. If a response is found, it returns the cached response. Otherwise, it tries to fetch the resource from the network.
 
 ```js
+async function cacheThenNetwork(request) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    console.log("Found response in cache:", cachedResponse);
+    return cachedResponse;
+  }
+  console.log("Falling back to network");
+  return fetch(request);
+}
+
 self.addEventListener("fetch", (event) => {
   console.log(`Handling fetch event for ${event.request.url}`);
+  event.respondWith(cacheThenNetwork(event.request));
+});
+```
 
-  event.respondWith(
-    caches.match(event.request).then((response) => {
-      if (response) {
-        console.log("Found response in cache:", response);
-        return response;
-      }
-      console.log("No response found in cache. About to fetch from network…");
+### Cache only
 
-      return fetch(event.request)
-        .then((response) => {
-          console.log("Response from network is:", response);
+This `fetch` event handler implements a "cache only" policy for scripts and stylesheets. If the request's {{domxref("Request.destination", "destination")}} property is `"script"` or `"style"`, the handler only looks in the cache, returning an error if the response was not found.
 
-          return response;
-        })
-        .catch((error) => {
-          console.error(`Fetching failed: ${error}`);
-          throw error;
-        });
-    })
-  );
+All other requests go through to the network.
+
+```js
+async function fromCache(request) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    console.log("Found response in cache:", cachedResponse);
+    return cachedResponse;
+  }
+  return Response.error();
+}
+
+self.addEventListener("fetch", (event) => {
+  if (
+    event.request.destination === "script" ||
+    event.request.destination === "style"
+  ) {
+    event.respondWith(fromCache(event.request));
+  }
 });
 ```
 


### PR DESCRIPTION
Our page for the [service worker's `fetch` event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/fetch_event) didn't mention some useful things, such as [what happens if `respondWith()` is not called](https://github.com/mdn/content/pull/27354#discussion_r1231638998).

This PR adds a "Description" section, updates one of the examples to be more readable, and adds a second example.

cc @hamishwillee .
