### PR TITLE
Point out behavior of documents.fonts.ready promise

### DIFF
--- a/files/en-us/web/api/document/fonts/index.md
+++ b/files/en-us/web/api/document/fonts/index.md
@@ -28,7 +28,7 @@ document.fonts.ready.then((fontFaceSet) => {
   const fontFaces = [...fontFaceSet];
   console.log(fontFaces);
   // some fonts may still be unloaded if they aren't used on the site
-  console.log(fontFaces.map(f => f.status));
+  console.log(fontFaces.map((f) => f.status));
 });
 ```
 

--- a/files/en-us/web/api/document/fonts/index.md
+++ b/files/en-us/web/api/document/fonts/index.md
@@ -19,14 +19,20 @@ The `FontFaceSet` interface is useful for loading new fonts, checking the status
 
 ## Examples
 
-### Doing operation after all fonts are loaded
+### Doing operation after fonts are loaded
 
 ```js
-document.fonts.ready.then(() => {
-  // Any operation that needs to be done only after all the fonts
+document.fonts.ready.then((fontFaceSet) => {
+  // Any operation that needs to be done only after all used fonts
   // have finished loading can go here.
+  const fontFaces = [...fontFaceSet];
+  console.log(fontFaces);
+  // some fonts may still be unloaded if they aren't used on the site
+  console.log(fontFaces.map(f => f.status));
 });
 ```
+
+The promise fulfils when loading and layout operations of all used fonts are done. The set of used fonts can be different from the set of _declared_ fonts, e.g. if optional fonts (i.e. fonts declared via `font-display: optional`) were not able to load in time.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Currently, the page describes the `ready` promise as if it fulfills after _all_ fonts are loaded. More precisely, it fulfills after all **used** fonts are loaded (and layout is done), i.e. the FontFaceSet might contain still unloaded fonts.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
see above

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- https://drafts.csswg.org/css-font-loading/#font-face-set-ready
- https://mastodon.social/@simevidas/110554881609639806

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

none

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
