### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ElementInternals.role
 
 {{APIRef("DOM")}}
 
-The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles) for the element. For example, a checkbox might have [`role="checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)
+The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles) for the element. For example, a checkbox might have [`role="checkbox"`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role).
 
 ## Value
 


### PR DESCRIPTION
### Description

Add missing quotation mark in inline code example and missing period add the end of the sentence.

### Motivation

Fixing typos.

### Additional details

- [ElementInternals: role property on MDN](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/role)