### PR TITLE
Use better param name

### DIFF
--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -52,12 +52,12 @@ The gamepad's {{domxref("Gamepad.index", "index")}} property will be unique per-
 ```js
 const gamepads = {};
 
-function gamepadHandler(event, connecting) {
+function gamepadHandler(event, connected) {
   const gamepad = event.gamepad;
   // Note:
   // gamepad === navigator.getGamepads()[gamepad.index]
 
-  if (connecting) {
+  if (connected) {
     gamepads[gamepad.index] = gamepad;
   } else {
     delete gamepads[gamepad.index];


### PR DESCRIPTION
### Description

`connected` seems to be a better name for the parameter as the gamepad has already connected when the handler is triggered.

### Motivation

Propagates "more correct" information to the user about the state of connection of the gamepad.

### Additional details

None, I guess.

### Related issues and pull requests

This does not resolve any GitHub issue, also doesn't require any other PR to be merged. This is just a documentation change.