### PR TITLE
fix: add aria-label to the form example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "fieldsets"
+    ]
+}

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -55,16 +55,16 @@ Here is a little example:
   <fieldset>
     <legend>Fruit juice size</legend>
     <p>
-      <input type="radio" name="size" id="size_1" value="small" />
-      <label for="size_1">Small</label>
+      <input type="radio" name="size" id="size_1" value="small" required />
+      <label for="size_1" aria-label="required">Small</label>
     </p>
     <p>
-      <input type="radio" name="size" id="size_2" value="medium" />
-      <label for="size_2">Medium</label>
+      <input type="radio" name="size" id="size_2" value="medium" required/>
+      <label for="size_2" aria-label="required">Medium</label>
     </p>
     <p>
-      <input type="radio" name="size" id="size_3" value="large" />
-      <label for="size_3">Large</label>
+      <input type="radio" name="size" id="size_3" value="large" required />
+      <label for="size_3" aria-label="required">Large</label>
     </p>
   </fieldset>
 </form>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I added the `aria-label="required" attribute to the form example. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This makes the form easier for screen readers to decipher. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Here's [the example](https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form#active_learning_building_a_form_structure) I'm referring to. 
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- Relates to #26790

- Fixes [#629](https://github.com/mdn/learning-area/issues/629) 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
