### PR TITLE
Web forms: Marks inputs that are required as required

### DIFF
--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -12,17 +12,13 @@ With the basics out of the way, we'll now look in more detail at the elements us
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic
-        <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
-          >understanding of HTML</a
-        >.
+        Basic computer literacy, and a basic <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">understanding of HTML</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To understand how to structure HTML forms and give them semantics so
-        they are usable and accessible.
+        To understand how to structure HTML forms and give them semantics so they are usable and accessible.
       </td>
     </tr>
   </tbody>
@@ -133,7 +129,7 @@ Let's consider this example:
 <!-- So this: -->
 <!--div>
   <label for="username">Name:</label>
-  <input id="username" type="text" name="username">
+  <input id="username" type="text" name="username" required>
   <label for="username"><span aria-label="required">*</label>
 </div-->
 
@@ -141,7 +137,7 @@ Let's consider this example:
 <!--div>
   <label for="username">
     <span>Name:</span>
-    <input id="username" type="text" name="username">
+    <input id="username" type="text" name="username" required>
     <span aria-label="required">*</span>
   </label>
 </div-->
@@ -149,7 +145,7 @@ Let's consider this example:
 <!-- But this is probably best: -->
 <div>
   <label for="username">Name: <span aria-label="required">*</span></label>
-  <input id="username" type="text" name="username" />
+  <input id="username" type="text" name="username" required/>
 </div>
 ```
 
@@ -239,21 +235,21 @@ Let's put these ideas into practice and build a slightly more involved form — 
          <span>Name: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="text" id="name" name="username" />
+       <input type="text" id="name" name="username" required/>
      </p>
      <p>
        <label for="mail">
          <span>Email: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="email" id="mail" name="usermail" />
+       <input type="email" id="mail" name="usermail" required/>
      </p>
      <p>
        <label for="pwd">
          <span>Password: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="password" id="pwd" name="password" />
+       <input type="password" id="pwd" name="password" required/>
      </p>
    </section>
    ```
@@ -285,7 +281,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
          <span>Card number:</span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="tel" id="number" name="cardnumber" />
+       <input type="tel" id="number" name="cardnumber" required/>
      </p>
      <p>
        <label for="expiration">

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -145,7 +145,7 @@ Let's consider this example:
 <!-- But this is probably best: -->
 <div>
   <label for="username">Name: <span aria-label="required">*</span></label>
-  <input id="username" type="text" name="username" required/>
+  <input id="username" type="text" name="username" required />
 </div>
 ```
 
@@ -235,21 +235,21 @@ Let's put these ideas into practice and build a slightly more involved form — 
          <span>Name: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="text" id="name" name="username" required/>
+       <input type="text" id="name" name="username" required />
      </p>
      <p>
        <label for="mail">
          <span>Email: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="email" id="mail" name="usermail" required/>
+       <input type="email" id="mail" name="usermail" required />
      </p>
      <p>
        <label for="pwd">
          <span>Password: </span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="password" id="pwd" name="password" required/>
+       <input type="password" id="pwd" name="password" required />
      </p>
    </section>
    ```
@@ -281,7 +281,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
          <span>Card number:</span>
          <strong><span aria-label="required">*</span></strong>
        </label>
-       <input type="tel" id="number" name="cardnumber" required/>
+       <input type="tel" id="number" name="cardnumber" required />
      </p>
      <p>
        <label for="expiration">


### PR DESCRIPTION
Fixes #26790

Note, should submit at same time as mdn/learning-area#628 , so please just approve this (if correct).

[How_to_structure_a_web_form](https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form) shows a bunch of fields marked up with labels that indicate that a `*` is used to indicate a required field. However the required fields themselves were not marked as such. This just adds `required` to those inputs - which are usually things like credit card info etc.