### PR TITLE
Express - Casting ObjectID improvement

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
@@ -88,26 +88,15 @@ Run the application and open your browser to `http://localhost:3000/`. Select th
 
 ![Genre Detail Page - Express Local Library site](locallibary_express_genre_detail.png)
 
-> **Note:** You might get an error similar to this:
+> **Note:** You might get an error similar to like the one below if `req.params.id` (or any other ID) cannot be cast to a [`mongoose.Types.ObjectId()`](https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.Types).
 >
 > ```bash
 > Cast to ObjectId failed for value " 59347139895ea23f9430ecbb" at path "_id" for model "Genre"
 > ```
 >
-> This is a mongoose error coming from the `req.params.id`. To solve this problem, first you need to require mongoose on the `genreController.js` page like this:
->
-> ```js
-> const mongoose = require("mongoose");
-> ```
->
-> Then use `mongoose.Types.ObjectId()` to convert the id to a type that can be used. For example:
->
-> ```js
-> exports.genre_detail = asyncHandler(async (req, res, next) => {
->   const id = mongoose.Types.ObjectId(req.params.id);
->   // …
-> });
-> ```
+> The most likely cause is that the ID being passed into the mongoose methods is not actually an ID.
+> This could happen, for example, if your intended route had an ID, but another route without an ID was matched first.
+> [`Mongoose.prototype.isValidObjectId()`](<https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.isValidObjectId()>) can be used to check whether a particular ID is valid.
 
 ## Next steps
 

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
@@ -88,7 +88,7 @@ Run the application and open your browser to `http://localhost:3000/`. Select th
 
 ![Genre Detail Page - Express Local Library site](locallibary_express_genre_detail.png)
 
-> **Note:** You might get an error similar to like the one below if `req.params.id` (or any other ID) cannot be cast to a [`mongoose.Types.ObjectId()`](https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.Types).
+> **Note:** You might get an error similar to the one below if `req.params.id` (or any other ID) cannot be cast to a [`mongoose.Types.ObjectId()`](https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.Types).
 >
 > ```bash
 > Cast to ObjectId failed for value " 59347139895ea23f9430ecbb" at path "_id" for model "Genre"


### PR DESCRIPTION
Fixes #27196

The note was not particularly useful in that it showed how you could manually cast a value to an ObjectId.
The problem with this is that if you get the error then Express has already tried to cast the passed value, and failed. So the  id is not a valid object ID for some reason.

If you get this error it means you didn't follow the tutorial properly. Probably caused by ordering your router functions such that something without an ID is matched before a route with the ID that you intended.

What I have done is modified this to explain the cause of the problem and how you can validate the IDs. Also explained that it probably means you passed something that wasn't an ID, and that this is probably caused by your routing functions being called in the wrong order. In other words, hints to debug.
