### PR TITLE
Fix a typo in `devtools.network.onRequestFinished` docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -21,7 +21,7 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 - [`devtools.network.onNavigated`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated)
   - : Fired when the user navigates the inspected window to a new page.
 - [`devtools.network.onRequestFinished`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onRequestFinished)
-  - : Fired when the a network request has finished and its details are available to the extension.
+  - : Fired when the network request has finished and its details are available to the extension.
 
 ## Browser compatibility
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The repetition of the article "the" before "a network request" is incorrect and creates a grammatical error. It should be corrected to: "Fired when the network request has finished and its details are available to the extension."
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I appreciate the detailed design of MDN docs, and as a responsible reader of those docs, I am motivated to make this change.
<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
