### PR TITLE
docs(css): Add pages for font-synthesis longhand properties

### DIFF
--- a/files/en-us/web/css/font-synthesis-small-caps/index.md
+++ b/files/en-us/web/css/font-synthesis-small-caps/index.md
@@ -51,21 +51,23 @@ This example shows turning off synthesis of the small-caps typeface by the brows
 
 ```html
 <p class="english">
-  These are the default <span class="small-caps">small-caps</span>, <strong>bold</strong>, and <em>oblique</em> typefaces.
+  These are the default <span class="small-caps">small-caps</span>,
+  <strong>bold</strong>, and <em>oblique</em> typefaces.
 </p>
 
 <p class="english no-syn">
-  The <span class="small-caps">small-caps</span> typeface is turned off here but not the <strong>bold</strong> and <em>oblique</em> typefaces.
+  The <span class="small-caps">small-caps</span> typeface is turned off here but
+  not the <strong>bold</strong> and <em>oblique</em> typefaces.
 </p>
 ```
 
 #### CSS
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
 
 .english {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 .small-caps {
   font-variant: small-caps;

--- a/files/en-us/web/css/font-synthesis-small-caps/index.md
+++ b/files/en-us/web/css/font-synthesis-small-caps/index.md
@@ -7,9 +7,9 @@ browser-compat: css.properties.font-synthesis-small-caps
 
 {{CSSRef}}
 
-The **`font-synthesis-small-caps`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize small-caps typeface when it is missing in a font family.
+The **`font-synthesis-small-caps`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize small-caps typeface when it is missing in a font family. Small-caps glyphs typically use the form of uppercase letters but are reduced to the size of lowercase letters.
 
-It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis values.
 
 ## Syntax
 
@@ -92,4 +92,5 @@ This example shows turning off synthesis of the small-caps typeface by the brows
 ## See also
 
 - [font-synthesis](/en-US/docs/Web/CSS/font-synthesis) shorthand, [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style), [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight)
-- {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-weight")}}
+- {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-weight")}}
+- [CanvasRenderingContext2D: fontVariantCaps property](/en-US/docs/Web/API/CanvasRenderingContext2D/fontVariantCaps)

--- a/files/en-us/web/css/font-synthesis-small-caps/index.md
+++ b/files/en-us/web/css/font-synthesis-small-caps/index.md
@@ -1,0 +1,89 @@
+---
+title: font-synthesis-small-caps
+slug: Web/CSS/font-synthesis-small-caps
+page-type: css-property
+browser-compat: css.properties.font-synthesis-small-caps
+---
+
+{{CSSRef}}
+
+The **`font-synthesis-small-caps`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize small-caps typeface when it is missing in a font family.
+
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+
+## Syntax
+
+```css
+/* Keyword values */
+font-synthesis-small-caps: auto;
+font-synthesis-small-caps: none;
+
+/* Global values */
+font-synthesis-small-caps: inherit;
+font-synthesis-small-caps: initial;
+font-synthesis-small-caps: revert;
+font-synthesis-small-caps: revert-layer;
+font-synthesis-small-caps: unset;
+```
+
+### Values
+
+- `auto`
+  - : Indicates that the missing small-caps typeface may be synthesized by the browser if needed.
+- `none`
+  - : Indicates that the synthesis of the missing small-caps typeface by the browser is not allowed.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Disabling synthesis of small-caps typeface
+
+This example shows turning off synthesis of the small-caps typeface by the browser in the `Montserrat` font.
+
+#### HTML
+
+```html
+<p class="english">These are the default <span class="small-caps">small-caps</span>, <strong>bold</strong>, and <em>oblique</em> typefaces.</p>
+
+<p class="english no-syn">The <span class="small-caps">small-caps</span> typeface is turned off here but not the <strong>bold</strong> and <em>oblique</em> typefaces.</p>
+```
+
+#### CSS
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
+.english {
+  font-family: 'Montserrat', sans-serif;
+}
+.small-caps {
+  font-variant: small-caps;
+}
+.no-syn {
+  font-synthesis-small-caps: none;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Disabling synthesis of small-caps typeface', '', '100')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [font-synthesis](/en-US/docs/Web/CSS/font-synthesis) shorthand, [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style), [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight)
+- {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-weight")}}

--- a/files/en-us/web/css/font-synthesis-small-caps/index.md
+++ b/files/en-us/web/css/font-synthesis-small-caps/index.md
@@ -50,9 +50,13 @@ This example shows turning off synthesis of the small-caps typeface by the brows
 #### HTML
 
 ```html
-<p class="english">These are the default <span class="small-caps">small-caps</span>, <strong>bold</strong>, and <em>oblique</em> typefaces.</p>
+<p class="english">
+  These are the default <span class="small-caps">small-caps</span>, <strong>bold</strong>, and <em>oblique</em> typefaces.
+</p>
 
-<p class="english no-syn">The <span class="small-caps">small-caps</span> typeface is turned off here but not the <strong>bold</strong> and <em>oblique</em> typefaces.</p>
+<p class="english no-syn">
+  The <span class="small-caps">small-caps</span> typeface is turned off here but not the <strong>bold</strong> and <em>oblique</em> typefaces.
+</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/font-synthesis-style/index.md
+++ b/files/en-us/web/css/font-synthesis-style/index.md
@@ -1,0 +1,86 @@
+---
+title: font-synthesis-style
+slug: Web/CSS/font-synthesis-style
+page-type: css-property
+browser-compat: css.properties.font-synthesis-style
+---
+
+{{CSSRef}}
+
+The **`font-synthesis-style`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the oblique typeface when it is missing in a font family.
+
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+
+## Syntax
+
+```css
+/* Keyword values */
+font-synthesis-style: auto;
+font-synthesis-style: none;
+
+/* Global values */
+font-synthesis-style: inherit;
+font-synthesis-style: initial;
+font-synthesis-style: revert;
+font-synthesis-style: revert-layer;
+font-synthesis-style: unset;
+```
+
+### Values
+
+- `auto`
+  - : Indicates that the missing oblique typeface may be synthesized by the browser if needed.
+- `none`
+  - : Indicates that the synthesis of the missing oblique typeface by the browser is not allowed.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Disabling synthesis of oblique typeface
+
+This example shows turning off synthesis of the oblique typeface by the browser in the `Montserrat` font.
+
+#### HTML
+
+```html
+<p class="english">This is the default <em>oblique typeface</em> and <strong>bold typeface</strong>.</p>
+
+<p class="english no-syn">The  <em>oblique typeface</em> is turned off here but not the <strong>bold typeface</strong>.</p>
+```
+
+#### CSS
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
+.english {
+  font-family: 'Montserrat', sans-serif;
+}
+.no-syn {
+  font-synthesis-style: none;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Disabling synthesis of bold typeface', '', '100')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [font-synthesis](/en-US/docs/Web/CSS/font-synthesis) shorthand, [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps), [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight)
+- {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-weight")}}

--- a/files/en-us/web/css/font-synthesis-style/index.md
+++ b/files/en-us/web/css/font-synthesis-style/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.font-synthesis-style
 
 The **`font-synthesis-style`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the oblique typeface when it is missing in a font family.
 
-It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis values.
 
 ## Syntax
 

--- a/files/en-us/web/css/font-synthesis-style/index.md
+++ b/files/en-us/web/css/font-synthesis-style/index.md
@@ -50,9 +50,13 @@ This example shows turning off synthesis of the oblique typeface by the browser 
 #### HTML
 
 ```html
-<p class="english">This is the default <em>oblique typeface</em> and <strong>bold typeface</strong>.</p>
+<p class="english">
+  This is the default <em>oblique typeface</em> and <strong>bold typeface</strong>.
+</p>
 
-<p class="english no-syn">The  <em>oblique typeface</em> is turned off here but not the <strong>bold typeface</strong>.</p>
+<p class="english no-syn">
+  The  <em>oblique typeface</em> is turned off here but not the <strong>bold typeface</strong>.
+</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/font-synthesis-style/index.md
+++ b/files/en-us/web/css/font-synthesis-style/index.md
@@ -51,21 +51,23 @@ This example shows turning off synthesis of the oblique typeface by the browser 
 
 ```html
 <p class="english">
-  This is the default <em>oblique typeface</em> and <strong>bold typeface</strong>.
+  This is the default <em>oblique typeface</em> and
+  <strong>bold typeface</strong>.
 </p>
 
 <p class="english no-syn">
-  The  <em>oblique typeface</em> is turned off here but not the <strong>bold typeface</strong>.
+  The <em>oblique typeface</em> is turned off here but not the
+  <strong>bold typeface</strong>.
 </p>
 ```
 
 #### CSS
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
 
 .english {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 .no-syn {
   font-synthesis-style: none;

--- a/files/en-us/web/css/font-synthesis-weight/index.md
+++ b/files/en-us/web/css/font-synthesis-weight/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.font-synthesis-weight
 
 The **`font-synthesis-weight`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the bold typeface when it is missing in a font family.
 
-It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis values.
 
 ## Syntax
 

--- a/files/en-us/web/css/font-synthesis-weight/index.md
+++ b/files/en-us/web/css/font-synthesis-weight/index.md
@@ -50,9 +50,13 @@ This example shows turning off synthesis of the bold typeface by the browser in 
 #### HTML
 
 ```html
-<p class="english">This is the default <strong>bold typeface</strong> and <em>oblique typeface</em>.</p>
+<p class="english">
+  This is the default <strong>bold typeface</strong> and <em>oblique typeface</em>.
+</p>
 
-<p class="english no-syn">The <strong>bold typeface</strong> is turned off here but not the <em>oblique typeface</em>.</p>
+<p class="english no-syn">
+  The <strong>bold typeface</strong> is turned off here but not the <em>oblique typeface</em>.
+</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/font-synthesis-weight/index.md
+++ b/files/en-us/web/css/font-synthesis-weight/index.md
@@ -51,21 +51,23 @@ This example shows turning off synthesis of the bold typeface by the browser in 
 
 ```html
 <p class="english">
-  This is the default <strong>bold typeface</strong> and <em>oblique typeface</em>.
+  This is the default <strong>bold typeface</strong> and
+  <em>oblique typeface</em>.
 </p>
 
 <p class="english no-syn">
-  The <strong>bold typeface</strong> is turned off here but not the <em>oblique typeface</em>.
+  The <strong>bold typeface</strong> is turned off here but not the
+  <em>oblique typeface</em>.
 </p>
 ```
 
 #### CSS
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
 
 .english {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 .no-syn {
   font-synthesis-weight: none;

--- a/files/en-us/web/css/font-synthesis-weight/index.md
+++ b/files/en-us/web/css/font-synthesis-weight/index.md
@@ -1,0 +1,86 @@
+---
+title: font-synthesis-weight
+slug: Web/CSS/font-synthesis-weight
+page-type: css-property
+browser-compat: css.properties.font-synthesis-weight
+---
+
+{{CSSRef}}
+
+The **`font-synthesis-weight`** [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the bold typeface when it is missing in a font family.
+
+It is often convenient to use the shorthand property {{cssxref("font-synthesis")}} to control all typeface synthesis in one go.
+
+## Syntax
+
+```css
+/* Keyword values */
+font-synthesis-weight: auto;
+font-synthesis-weight: none;
+
+/* Global values */
+font-synthesis-weight: inherit;
+font-synthesis-weight: initial;
+font-synthesis-weight: revert;
+font-synthesis-weight: revert-layer;
+font-synthesis-weight: unset;
+```
+
+### Values
+
+- `auto`
+  - : Indicates that the missing bold typeface may be synthesized by the browser if needed.
+- `none`
+  - : Indicates that the synthesis of the missing bold typeface by the browser is not allowed.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Disabling synthesis of bold typeface
+
+This example shows turning off synthesis of the bold typeface by the browser in the `Montserrat` font.
+
+#### HTML
+
+```html
+<p class="english">This is the default <strong>bold typeface</strong> and <em>oblique typeface</em>.</p>
+
+<p class="english no-syn">The <strong>bold typeface</strong> is turned off here but not the <em>oblique typeface</em>.</p>
+```
+
+#### CSS
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
+.english {
+  font-family: 'Montserrat', sans-serif;
+}
+.no-syn {
+  font-synthesis-weight: none;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Disabling synthesis of bold typeface', '', '100')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [font-synthesis](/en-US/docs/Web/CSS/font-synthesis) shorthand, [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps), [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style)
+- {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-weight")}}

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -91,17 +91,30 @@ This example shows the browser's default font-synthesis behavior and compares it
 
 ```html
 <pre> DEFAULT </pre>
-<p class="english">This font supports <strong>bold</strong> and <em>italic</em>.</p>
-<p class="chinese">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p><br>
+<p class="english">
+  This font supports <strong>bold</strong> and <em>italic</em>.
+</p>
+<p class="chinese">
+  这个字体支持<strong>加粗</strong>和<em>斜体</em>
+</p>
+<br />
 
 <pre> SYNTHESIS IS DISABLED </pre>
-<p class="english no-syn">This font supports <strong>bold</strong> and <em>italic.</em></p>
-<p class="chinese no-syn">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p><br>
+<p class="english no-syn">
+  This font supports <strong>bold</strong> and <em>italic.</em>
+</p>
+<p class="chinese no-syn">
+  这个字体支持<strong>加粗</strong>和<em>斜体</em>
+</p>
+<br />
 
 <pre> SYNTHESIS IS ENABLED </pre>
-<p class="english">This font supports <strong>bold</strong> and <em>italic</em>.</p>
-<p class="chinese syn">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p>
-
+<p class="english">
+  This font supports <strong>bold</strong> and <em>italic</em>.
+</p>
+<p class="chinese syn">
+  这个字体支持<strong>加粗</strong>和<em>斜体</em>
+</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -7,18 +7,27 @@ browser-compat: css.properties.font-synthesis
 
 {{CSSRef}}
 
-The **`font-synthesis`** [CSS](/en-US/docs/Web/CSS) property controls which missing typefaces, bold, italic, or small-caps, may be synthesized by the browser.
+The **`font-synthesis`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the missing typefaces – bold, italic, or small-caps.
 
 {{EmbedInteractiveExample("pages/css/font-synthesis.html")}}
+
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight)
+- [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style)
+- [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps)
 
 ## Syntax
 
 ```css
+/* none or one or more of the other keyword values */
 font-synthesis: none;
 font-synthesis: weight;
 font-synthesis: style;
-font-synthesis: small-caps;
-font-synthesis: weight style small-caps;
+font-synthesis: small-caps style; /* can be specified in any order */
+font-synthesis: style small-caps weight; /* can be specified in any order */
 
 /* Global values */
 font-synthesis: inherit;
@@ -31,17 +40,38 @@ font-synthesis: unset;
 ### Values
 
 - `none`
-  - : Indicates that no bold, italic, nor small-caps typeface may be synthesized.
+  - : Indicates that no bold, italic, or small-caps typeface may be synthesized by the browser.
 - `weight`
-  - : Indicates that a bold typeface may be synthesized if needed.
+  - : Indicates that the missing bold typeface may be synthesized by the browser if needed.
 - `style`
-  - : Indicates that an italic typeface may be synthesized if needed.
+  - : Indicates that the missing italic typeface may be synthesized by the browser if needed.
 - `small-caps`
-  - : Indicates that a small-caps typeface may be synthesized if needed.
+  - : Indicates that the missing small-caps typeface may be synthesized by the browser if needed.
 
 ## Description
 
-Most standard Western fonts include italic and bold variants, and some fonts include a small-caps variant. However, many fonts do not. Fonts used for Chinese, Japanese, Korean and other logographic scripts tend not to include these variants, and synthesizing them may impede the legibility of the text. In these cases, it may be desirable to switch off the browser's default font-synthesis.
+Most standard Western fonts include italic and bold variants, and some fonts include a small-caps variant. However, many fonts do not. Fonts used for Chinese, Japanese, Korean and other logographic scripts tend not to include these variants and synthesizing them might impede the legibility or change the meaning of the text. In these cases, it may be desirable to switch off the browser's default font-synthesis.
+
+For example, using the [:lang()](/en-US/docs/Web/CSS/:lang) pseudo-class, you can disable the browser from synthesizing bold and oblique characters for a language, in this case Arabic:
+
+```css
+*:lang(ar) {
+  font-synthesis: none;
+}
+```
+
+The table below shows how a value of the shorthand `font-synthesis` property maps to the constituent longhand properties.
+
+| font-synthesis value | [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight) value | [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style) value | [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps) value |
+| :------------------- | :-------------------------- | :------------------------- | :------------------------------ |
+| `none` | `none` | `none` | `none` |
+| `weight` | `auto` | `none` | `none` |
+| `style` | `none` | `auto` | `none` |
+| `small-caps` | `none` | `none` | `auto` |
+| `weight style` | `auto` | `auto` | `none` |
+| `weight small-caps` | `auto` | `none` | `auto` |
+| `style small-caps` | `none` | `auto` | `auto` |
+| `weight style small-caps` | `auto` | `auto` | `auto` |
 
 ## Formal definition
 
@@ -55,31 +85,49 @@ Most standard Western fonts include italic and bold variants, and some fonts inc
 
 ### Disabling font synthesis
 
+This example shows the browser's default font-synthesis behavior and compares it with when the synthesis behavior is turned off. Notice that the example uses two imported fonts to demonstrate this behavior. You might not be able to replicate turning off of font-synthesis on fonts available on your operating system by default.
+
 #### HTML
 
 ```html
-<em class="syn">Synthesize me! 站直。</em>
-<br />
-<em class="no-syn">Don't synthesize me! 站直。</em>
+<pre> DEFAULT </pre>
+<p class="english">This font supports <strong>bold</strong> and <em>italic</em>.</p>
+<p class="chinese">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p><br>
+
+<pre> SYNTHESIS IS DISABLED </pre>
+<p class="english no-syn">This font supports <strong>bold</strong> and <em>italic.</em></p>
+<p class="chinese no-syn">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p><br>
+
+<pre> SYNTHESIS IS ENABLED </pre>
+<p class="english">This font supports <strong>bold</strong> and <em>italic</em>.</p>
+<p class="chinese syn">这个字体支持<strong>加粗</strong>和<em>斜体</em>。</p>
+
 ```
 
 #### CSS
 
 ```css
-em {
-  font-weight: bold;
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ma+Shan+Zheng&display=swap');
+
+
+.english {
+  font-family: 'Montserrat', sans-serif;
 }
-.syn {
-  font-synthesis: style weight small-caps;
+.chinese {
+  font-family: 'Ma Shan Zheng';
 }
 .no-syn {
   font-synthesis: none;
+}
+.syn {
+  font-synthesis: style weight;
 }
 ```
 
 #### Result
 
-{{ EmbedLiveSample('Disabling_font_synthesis', '', '75') }}
+{{EmbedLiveSample('Disabling font synthesis', '', '400')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -62,16 +62,16 @@ For example, using the [:lang()](/en-US/docs/Web/CSS/:lang) pseudo-class, you ca
 
 The table below shows how a value of the shorthand `font-synthesis` property maps to the constituent longhand properties.
 
-| font-synthesis value | [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight) value | [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style) value | [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps) value |
-| :------------------- | :-------------------------- | :------------------------- | :------------------------------ |
-| `none` | `none` | `none` | `none` |
-| `weight` | `auto` | `none` | `none` |
-| `style` | `none` | `auto` | `none` |
-| `small-caps` | `none` | `none` | `auto` |
-| `weight style` | `auto` | `auto` | `none` |
-| `weight small-caps` | `auto` | `none` | `auto` |
-| `style small-caps` | `none` | `auto` | `auto` |
-| `weight style small-caps` | `auto` | `auto` | `auto` |
+| font-synthesis value      | [font-synthesis-weight](/en-US/docs/Web/CSS/font-synthesis-weight) value | [font-synthesis-style](/en-US/docs/Web/CSS/font-synthesis-style) value | [font-synthesis-small-caps](/en-US/docs/Web/CSS/font-synthesis-small-caps) value |
+| :------------------------ | :----------------------------------------------------------------------- | :--------------------------------------------------------------------- | :------------------------------------------------------------------------------- |
+| `none`                    | `none`                                                                   | `none`                                                                 | `none`                                                                           |
+| `weight`                  | `auto`                                                                   | `none`                                                                 | `none`                                                                           |
+| `style`                   | `none`                                                                   | `auto`                                                                 | `none`                                                                           |
+| `small-caps`              | `none`                                                                   | `none`                                                                 | `auto`                                                                           |
+| `weight style`            | `auto`                                                                   | `auto`                                                                 | `none`                                                                           |
+| `weight small-caps`       | `auto`                                                                   | `none`                                                                 | `auto`                                                                           |
+| `style small-caps`        | `none`                                                                   | `auto`                                                                 | `auto`                                                                           |
+| `weight style small-caps` | `auto`                                                                   | `auto`                                                                 | `auto`                                                                           |
 
 ## Formal definition
 
@@ -94,41 +94,34 @@ This example shows the browser's default font-synthesis behavior and compares it
 <p class="english">
   This font supports <strong>bold</strong> and <em>italic</em>.
 </p>
-<p class="chinese">
-  这个字体支持<strong>加粗</strong>和<em>斜体</em>
-</p>
+<p class="chinese">这个字体支持<strong>加粗</strong>和<em>斜体</em></p>
 <br />
 
 <pre> SYNTHESIS IS DISABLED </pre>
 <p class="english no-syn">
   This font supports <strong>bold</strong> and <em>italic.</em>
 </p>
-<p class="chinese no-syn">
-  这个字体支持<strong>加粗</strong>和<em>斜体</em>
-</p>
+<p class="chinese no-syn">这个字体支持<strong>加粗</strong>和<em>斜体</em></p>
 <br />
 
 <pre> SYNTHESIS IS ENABLED </pre>
 <p class="english">
   This font supports <strong>bold</strong> and <em>italic</em>.
 </p>
-<p class="chinese syn">
-  这个字体支持<strong>加粗</strong>和<em>斜体</em>
-</p>
+<p class="chinese syn">这个字体支持<strong>加粗</strong>和<em>斜体</em></p>
 ```
 
 #### CSS
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Ma+Shan+Zheng&display=swap');
-
+@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Ma+Shan+Zheng&display=swap");
 
 .english {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 .chinese {
-  font-family: 'Ma Shan Zheng';
+  font-family: "Ma Shan Zheng";
 }
 .no-syn {
   font-synthesis: none;

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.font-synthesis
 
 {{CSSRef}}
 
-The **`font-synthesis`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the missing typefaces – bold, italic, or small-caps.
+The **`font-synthesis`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property lets you specify whether or not the browser may synthesize the bold, italic, and/or small-caps typefaces when they are missing in the specified font-family.
 
 {{EmbedInteractiveExample("pages/css/font-synthesis.html")}}
 

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -26,8 +26,8 @@ This property is a shorthand for the following CSS properties:
 font-synthesis: none;
 font-synthesis: weight;
 font-synthesis: style;
-font-synthesis: small-caps style; /* can be specified in any order */
-font-synthesis: style small-caps weight; /* can be specified in any order */
+font-synthesis: small-caps style; /* property values can be in any order */
+font-synthesis: style small-caps weight; /* property values can be in any order */
 
 /* Global values */
 font-synthesis: inherit;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The shorthand [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property is documented on MDN.

- This PR adds pages for the following `font-synthesis` longhand properties:
   - `font-synthesis-weight` ([spec](https://drafts.csswg.org/css-fonts/#propdef-font-synthesis-weight))
   - `font-synthesis-style` ([spec](https://drafts.csswg.org/css-fonts/#propdef-font-synthesis-style))
   - `font-synthesis-small-caps` ([spec](https://drafts.csswg.org/css-fonts/#propdef-font-synthesis-small-caps))

- This PR also updates the existing [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) page:
  - Table from the [spec](https://drafts.csswg.org/css-fonts/#propdef-font-synthesis) is added to the "Description" section.
  - Example is updated

### Motivation

Interop coverage (https://github.com/mdn/mdn/issues/416)

### Additional details

The longhand properties are supported across browsers: [font-synthesis-weight](https://github.com/mdn/browser-compat-data/blob/main/css/properties/font-synthesis-weight.json), [font-synthesis-style](https://github.com/mdn/browser-compat-data/blob/main/css/properties/font-synthesis-style.json), [font-synthesis-small-caps](https://github.com/mdn/browser-compat-data/blob/main/css/properties/font-synthesis-small-caps.json)

### To dos

- [x] Update BCD: https://github.com/mdn/browser-compat-data/pull/20161
- [ ] Update mdn/data: https://github.com/mdn/data/pull/672
