### PR TITLE
fix: improve grammar in Animation performance and frame rate page

### DIFF
--- a/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
+++ b/files/en-us/web/performance/animation_performance_and_frame_rate/index.md
@@ -7,13 +7,13 @@ slug: Web/Performance/Animation_performance_and_frame_rate
 
 Animation on the web can be done via {{domxref('SVGAnimationElement', 'SVG')}}, {{domxref('window.requestAnimationFrame','JavaScript')}}, including {{htmlelement('canvas')}} and {{domxref('WebGL_API', 'WebGL')}}, CSS {{cssxref('animation')}}, {{htmlelement('video')}}, animated gifs and even animated PNGs and other image types. The performance cost of animating a CSS property can vary from one property to another, and animating expensive CSS properties can result in {{glossary('jank')}} as the browser struggles to hit a smooth {{glossary("FPS", "frame rate")}}.
 
-For animated media, such as video and animated gifs, the main performance concern is file size - downloading the file fast enough to not negatively impact performance is the greatest issue. Code based animations, be it CSS, SVG, \<canvas>, webGL or other JavaScript animations, can cause performance issues even if the bandwidth footprint is small. These animations can consume CPU and/or cause jank.
+For animated media, such as video and animated gifs, the main performance concern is file size - downloading the file fast enough to not negatively impact performance is the greatest issue. Code-based animations, be it CSS, SVG, \<canvas>, webGL, or other JavaScript animations, can cause performance issues even if the bandwidth footprint is small. These animations can consume CPU and/or cause jank.
 
-Users expect all interface interactions to be smooth and all user interfaces to be responsive. Animation can help make a site feel faster and responsive, but animations can also make a site feel slower and janky if not done correctly. Responsive user interfaces have a frame rate of 60 frames per second (fps). While it is not always possible to maintain 60fps, it is important to maintain a high and steady frame rate for all animations.
+Users expect all interface interactions to be smooth and all user interfaces to be responsive. Animation can help make a site feel faster and more responsive, but animations can also make a site feel slower and janky if not done correctly. Responsive user interfaces have a frame rate of 60 frames per second (fps). While it is not always possible to maintain 60fps, it is important to maintain a high and steady frame rate for all animations.
 
 With [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) you specify a number of [keyframes](/en-US/docs/Web/CSS/@keyframes), each of which uses CSS to define the appearance of the element at a particular stage of the animation. The browser creates the animation as a transition from each keyframe to the next.
 
-Compared with animating elements using JavaScript, CSS animations can be easier to create. They can also give better performance, as they give the browser more control over when to render frames, and to drop frames if necessary.
+Compared with animating elements using JavaScript, CSS animations can be easier to create. They can also give better performance, as they give the browser more control over when to render and drop frames if necessary.
 
 However, the performance cost of modifying a CSS property can vary from one property to another. It's commonly accepted that 60 frames per second is the rate at which animations will appear smooth. For a rate of 60 frames per second, the browser has 16.7 milliseconds to execute scripts, recalculate styles and layout if needed, and repaint the area being updated. Slow scripts and animating expensive CSS properties can result in [jank](/en-US/docs/Glossary/Jank) as the browser struggles to hit a smooth frame rate.
 
@@ -21,13 +21,13 @@ However, the performance cost of modifying a CSS property can vary from one prop
 
 The process a browser uses to paint changes to a page when an element is animating CSS properties can be described as a waterfall consisting of the following steps:
 
-![Flowchart of the CSS rendering waterfall. In order, the steps are recalculate style, layout, and paint.](css-rendering-waterfall.png)
+![Flowchart of the CSS rendering waterfall. In order, the steps are to recalculate style, layout, and paint.](css-rendering-waterfall.png)
 
 1. **Recalculate Style**: when a property for an element changes, the browser must recalculate computed styles.
-2. **Layout**: next, the browser uses the computed styles to figure out the position and geometry for the elements. This operation is labeled "layout" but is also sometimes called "reflow".
-3. **Paint**: finally, the browser needs to repaint the elements to the screen. One last step is not shown in this sequence: the page may be split into layers, which are painted independently and then combined in a process called "Composition".
+2. **Layout**: next, the browser uses the computed styles to figure out the position and geometry of the elements. This operation is labeled "layout" but is also sometimes called "reflow".
+3. **Paint**: finally, the browser needs to repaint the elements of the screen. One last step is not shown in this sequence: the page may be split into layers, which are painted independently and then combined in a process called "Composition".
 
-This sequence needs to fit into a single frame, since the screen isn't updated until it is complete.
+This sequence needs to fit into a single frame since the screen isn't updated until it is complete.
 
 ## CSS property cost
 
@@ -45,7 +45,7 @@ In the context of the rendering waterfall, some properties are more expensive th
     <tr>
       <td>
         Properties that affect an element's <em>geometry</em> or
-        <em>position</em> trigger a style recalculation, a layout and a repaint.
+        <em>position</em> triggers a style recalculation, a layout, and a repaint.
       </td>
       <td>
         <img alt="Recalculate: Yes" src="recalculate-style.png" />


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This pull request addresses an accessibility issue. However, I found some grammatical errors in this entry, so I made a commit for that first. Next, I'm going to add commits that address the accessibility problem.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Changing the dark-mode assigned background colors of the images would make the lesson more accessible for readers with low vision. Additionally, revising the grammatical errors in the lesson would make the steps clearer for readers.  
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[This](https://developer.mozilla.org/en-US/docs/Web/Performance/Animation_performance_and_frame_rate) is where the issue occurs. 
Also as I previously stated in the Description section, I will make commits that address the accessibility problem.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes mdn/content#123" -->
<!-- 👉 Highlight related pull requests using "Relates to mdn/content#123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** mdn/content#123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
