### PR TITLE
FF115 ApplicationCache removed from platform 

### DIFF
--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -11,7 +11,7 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 
 {{APIRef}}
 > **Warning:** Application cache has been removed from web platform.
-> Using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
+> Use [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
 
 {{Deprecated_Header}}{{SecureContext_Header}}
 

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -10,6 +10,7 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 
 {{APIRef}}
+
 > **Warning:** Application cache has been removed from web platform.
 > Use [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
 

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -9,9 +9,11 @@ status:
 browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 
-{{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{SecureContext_Header}}
+{{APIRef}}
+> **Warning:** Application cache has been removed from web platform.
+> Using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
 
-> **Warning:**: Application cache is being removed from web platform. Consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
+{{Deprecated_Header}}{{SecureContext_Header}}
 
 Returns a reference to the application cache object for the window.
 


### PR DESCRIPTION
ApplicationCache API has been removed from FF in FF115, but was actually disabled by default in FF84.

We're still inside 2 years since FF84, so not doing a purge.
So this change is to make a stronger statement about not using the API - i.e  moves the warning to top of page and says "**has** been removed from the web platform".

Other docs work tracked in #27176 