### PR TITLE
Remove obsolete text-underline-position values

### DIFF
--- a/files/en-us/web/css/text-underline-position/index.md
+++ b/files/en-us/web/css/text-underline-position/index.md
@@ -44,12 +44,6 @@ text-underline-position: unset;
   - : In vertical writing-modes, this keyword forces the line to be placed on the _left_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
 - `right`
   - : In vertical writing-modes, this keyword forces the line to be placed on the _right_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
-- `auto-pos` {{non-standard_inline}} {{Experimental_Inline}}
-  - : A synonym of `auto`, which should be used instead.
-- `above` {{non-standard_inline}}
-  - : Forces the line to be above the text. When used with East-Asian text, using the `auto` keyword will lead to a similar effect.
-- `below` {{non-standard_inline}}
-  - : Forces the line to be below the text. When used with alphabetic text, using the `auto` keyword will lead to a similar effect.
 
 ## Formal definition
 


### PR DESCRIPTION
For https://github.com/mdn/browser-compat-data/pull/20172 and https://github.com/mdn/browser-compat-data/pull/20173.

These were probably in an early spec but aren't supported (and maybe never were).