### PR TITLE
update name of the error

### DIFF
--- a/files/en-us/web/api/mediadevices/index.md
+++ b/files/en-us/web/api/mediadevices/index.md
@@ -57,7 +57,7 @@ navigator.mediaDevices
     video.srcObject = stream;
   })
   .catch((error) => {
-    if (error.name === "ConstraintNotSatisfiedError") {
+    if (error.name === "OverconstrainedError") {
       console.error(
         `The resolution ${constraints.video.width.exact}x${constraints.video.height.exact} px is not supported by your device.`
       );


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`ConstraintNotSatisfiedError` does not seems to be in MDN also `MediaDevices` describes `OverconstrainedError` as the error that matches with the description

### Motivation

Fixed the example to be helpfull, otherwise the error never is going to be catched

### Additional details

Provoked the error to see the name of it
![Captura de Pantalla 2023-06-20 a la(s) 13 05 07](https://github.com/mdn/content/assets/13079269/24b07faa-774d-4cb9-a7b9-47e47d4f52a2)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
