### PR TITLE
update the section name for Glossary page

### DIFF
--- a/files/en-us/glossary/clickjacking/index.md
+++ b/files/en-us/glossary/clickjacking/index.md
@@ -10,7 +10,7 @@ Clickjacking is an interface-based attack that tricks website users into unwitti
 
 Clickjacking can be prevented by implementing a [Content Security Policy (frame-ancestors)](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) and implementing [Set-Cookie attributes](/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes).
 
-## Learn more
+## See also
 
 - [Web security: clickjacking protection](/en-US/docs/Web/Security#clickjacking_protection)
 - [Clickjacking](https://en.wikipedia.org/wiki/Clickjacking) on Wikipedia

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -173,7 +173,7 @@ An extended discussion of a topic might be spread across multiple conceptual pag
 
 A **glossary page** contains a brief explanation of a term, topic, or concept.
 The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences.
-This can be followed by links to further information in the **Learn more** section.
+This can be followed by links to further information in the **See also** section.
 If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) for more details.
 
 ### Examples


### PR DESCRIPTION
### Description

update the section name for Glossary page

### Motivation

We are now using "See also" instead of the "Learn more" section. After [searching through the content repo](https://github.com/search?q=repo%3Amdn%2Fcontent+%22Learn+more%22+path%3A%2F%5Efiles%5C%2Fen-us%5C%2Fglossary%5C%2F%2F&type=code).  There is only one page left.

![image](https://github.com/mdn/content/assets/15844309/9c81f46e-e81e-4afe-a088-fcb7da0a1204)
