### PR TITLE
docs(api): Add details on pointer getPredictedEvents()

### DIFF
--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -58,7 +58,7 @@ function drawCircle(x, y, color) {
 
   for (const pointerEvent of pointerEvents) {
     ctx.beginPath();
-    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 4 * Math.PI);
+    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 2 * Math.PI);
     ctx.strokeStyle = pointerEvent.color;
     ctx.stroke();
   }

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -8,10 +8,14 @@ browser-compat: api.PointerEvent.getCoalescedEvents
 
 {{APIRef("Pointer Events")}}
 
-The **`getCoalescedEvents()`** method of the
-{{domxref("PointerEvent")}} interface returns a sequence of all
-`PointerEvent` instances that were coalesced into the dispatched
-{{domxref('Element/pointermove_event', 'pointermove')}} event.
+The **`getCoalescedEvents()`** method of the {{domxref("PointerEvent")}} interface returns a sequence of `PointerEvent` instances that were coalesced (merged) into a single {{domxref('Element/pointermove_event', 'pointermove')}} event.
+Instead of a stream of many {{domxref('Element/pointermove_event', 'pointermove')}} events, user agents coalesce multiple updates into a single event.
+This helps with performance as the user agent has less event handling to perform, but there is a reduction in the granularity and accuracy when tracking, especially with fast and large movements.
+
+The **`getCoalescedEvents()`** method lets applications access all un-coalesced position changes for precise handling of pointer movement data where necessary.
+Un-coalesced position changes are desirable in drawing applications, for instance, where having access to all events helps to build smoother curves that better match the movement of a pointer.
+
+For an illustration of coalesced events, see [Figure 7 in the specification](https://w3c.github.io/pointerevents/#figure_coalesced).
 
 ## Syntax
 
@@ -26,6 +30,55 @@ None.
 ### Return value
 
 A sequence of {{domxref('PointerEvent')}} instances.
+
+## Example
+
+### HTML
+
+```html
+<canvas id="target" width="600" height="300"></canvas>
+```
+
+### JavaScript
+
+```js
+const canvas = document.getElementById("target");
+const ctx = canvas.getContext("2d");
+
+const pointerEvents = [];
+
+function drawCircle(x, y, color) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // draw the last 20 events
+  if (pointerEvents.length > 20) {
+    pointerEvents.shift();
+  }
+  pointerEvents.push({ x, y, color });
+
+  for (const pointerEvent of pointerEvents) {
+    ctx.beginPath();
+    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 4 * Math.PI);
+    ctx.strokeStyle = pointerEvent.color;
+    ctx.stroke();
+  }
+}
+
+canvas.addEventListener("pointermove", (e) => {
+  // draw a circle for the current event
+  drawCircle(e.clientX, e.clientY, "black");
+
+  const coalescedEvents = e.getCoalescedEvents();
+  for (let coalescedEvent of coalescedEvents) {
+    // give it an offset so we can see the difference and color it red
+    drawCircle(coalescedEvent.clientX + 20, coalescedEvent.clientY + 20, "red");
+  }
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Example", "", "320")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PointerEvent.getCoalescedEvents
 
 {{APIRef("Pointer Events")}}
 
-The **`getCoalescedEvents()`** method of the {{domxref("PointerEvent")}} interface returns a sequence of `PointerEvent` instances that were coalesced (merged) into a single {{domxref('Element/pointermove_event', 'pointermove')}} event.
+The **`getCoalescedEvents()`** method of the {{domxref("PointerEvent")}} interface returns a sequence of `PointerEvent` instances that were coalesced (merged) into a single {{domxref('Element/pointermove_event', 'pointermove')}} or {{domxref('Element/pointerrawupdate_event', 'pointerrawupdate')}} event.
 Instead of a stream of many {{domxref('Element/pointermove_event', 'pointermove')}} events, user agents coalesce multiple updates into a single event.
 This helps with performance as the user agent has less event handling to perform, but there is a reduction in the granularity and accuracy when tracking, especially with fast and large movements.
 

--- a/files/en-us/web/api/pointerevent/getpredictedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getpredictedevents/index.md
@@ -9,7 +9,7 @@ browser-compat: api.PointerEvent.getPredictedEvents
 {{APIRef("Pointer Events")}}
 
 The **`getPredictedEvents()`** method of the {{domxref("PointerEvent")}} interface returns a sequence of `PointerEvent` instances that are estimated future pointer positions.
-How the predicted positions are calculated depends on the user agent, but they are based on past points and current velocity and trajectory.
+How the predicted positions are calculated depends on the user agent, but they are based on past points, current velocity, and trajectory.
 
 Applications can use the predicted events to "draw ahead" to a predicted position which may reduce perceived latency depending on the application's interpretation of the predicted events and the use case.
 
@@ -56,7 +56,7 @@ function drawCircle(x, y, color) {
 
   for (const pointerEvent of pointerEvents) {
     ctx.beginPath();
-    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 4 * Math.PI);
+    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 2 * Math.PI);
     ctx.strokeStyle = pointerEvent.color;
     ctx.stroke();
   }

--- a/files/en-us/web/api/pointerevent/getpredictedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getpredictedevents/index.md
@@ -1,0 +1,87 @@
+---
+title: "PointerEvent: getPredictedEvents() method"
+short-title: getPredictedEvents()
+slug: Web/API/PointerEvent/getPredictedEvents
+page-type: web-api-instance-method
+browser-compat: api.PointerEvent.getPredictedEvents
+---
+
+{{APIRef("Pointer Events")}}
+
+The **`getPredictedEvents()`** method of the {{domxref("PointerEvent")}} interface returns a sequence of `PointerEvent` instances that are estimated future pointer positions.
+How the predicted positions are calculated depends on the user agent, but they are based on past points and current velocity and trajectory.
+
+Applications can use the predicted events to "draw ahead" to a predicted position which may reduce perceived latency depending on the application's interpretation of the predicted events and the use case.
+
+For an illustration of predicted events, see [Figure 8 in the specification](https://w3c.github.io/pointerevents/#figure_predicted).
+
+## Syntax
+
+```js-nolint
+getPredictedEvents()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A sequence of {{domxref('PointerEvent')}} instances.
+
+## Example
+
+### HTML
+
+```html
+<canvas id="target" width="600" height="300"></canvas>
+```
+
+### JavaScript
+
+```js
+const canvas = document.getElementById("target");
+const ctx = canvas.getContext("2d");
+
+const pointerEvents = [];
+
+function drawCircle(x, y, color) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // draw the last 20 events
+  if (pointerEvents.length > 20) {
+    pointerEvents.shift();
+  }
+  pointerEvents.push({ x, y, color });
+
+  for (const pointerEvent of pointerEvents) {
+    ctx.beginPath();
+    ctx.arc(pointerEvent.x, pointerEvent.y, 10, 0, 4 * Math.PI);
+    ctx.strokeStyle = pointerEvent.color;
+    ctx.stroke();
+  }
+}
+
+canvas.addEventListener("pointermove", (e) => {
+  // draw a circle for the current event
+  drawCircle(e.clientX, e.clientY, "black");
+
+  const predictedEvents = e.getPredictedEvents();
+  for (let predictedEvent of predictedEvents) {
+    // give it an offset so we can see the difference and color it red
+    drawCircle(predictedEvent.clientX + 20, predictedEvent.clientY + 20, "red");
+  }
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Example", "", "320")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
This PR adds details for pointer `getPredictedEvents()` and adds some info to `getCoalescedEvents()`


__Resources:__
* https://w3c.github.io/pointerevents/#coalesced-events
* https://w3c.github.io/pointerevents/#predicted-events

__WPT:__
* https://github.com/web-platform-tests/wpt/blob/master/pointerevents/pointerlock/pointerevent_getPredictedEvents_when_pointerlocked-manual.html
* https://wpt.fyi/results/pointerevents/pointerevent_constructor.html?label=experimental&label=master&aligned