### PR TITLE
docs(api): Rename OSLeft and OSRight keycodes to MetaLeft and MetaRight

### DIFF
--- a/files/en-us/web/api/keyboardevent/keycode/index.md
+++ b/files/en-us/web/api/keyboardevent/keycode/index.md
@@ -1152,7 +1152,7 @@ Gecko sets `keyCode` values of punctuation keys as far as possible (when points 
       <td><code>0x11 (17)</code></td>
     </tr>
     <tr>
-      <th scope="row"><code>"OSLeft"</code></th>
+      <th scope="row"><code>"MetaLeft"</code></th>
       <td><code>0x5B (91)</code></td>
       <td><code>0x5B (91)</code></td>
       <td><code>0x5B (91)</code></td>
@@ -1163,7 +1163,7 @@ Gecko sets `keyCode` values of punctuation keys as far as possible (when points 
       <td><code>0x5B (91)</code></td>
     </tr>
     <tr>
-      <th scope="row"><code>"OSRight"</code></th>
+      <th scope="row"><code>"MetaRight"</code></th>
       <td><code>0x5C (92)</code></td>
       <td><code>0x5C (92)</code></td>
       <td><code>0x5D (93)</code>⚠️</td>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/27459

__notes:__ 
It looks like we're also missing:

* `Backspace`
* `ContextMenu`
* `Enter`
* `Space`
* `Tab`

based on https://www.w3.org/TR/uievents-code/#key-alphanumeric-functional

Although it may be intentional that these are omitted.