### PR TITLE
use of async keyword in error handling function

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.md
@@ -198,7 +198,7 @@ In order for the framework to properly handle exceptions, they must be caught, a
 Re-imagining the simple example from the previous section with `About.find().exec()` as a database query that returns a promise, we might write the route function inside a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block like this:
 
 ```js
-exports.get("/about", async  function (req, res, next) {
+exports.get("/about", async function (req, res, next) {
   try {
     const successfulResult = await About.find({}).exec();
     res.render("about_view", { title: "About", list: successfulResult });

--- a/files/en-us/learn/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.md
@@ -198,7 +198,7 @@ In order for the framework to properly handle exceptions, they must be caught, a
 Re-imagining the simple example from the previous section with `About.find().exec()` as a database query that returns a promise, we might write the route function inside a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block like this:
 
 ```js
-exports.get("/about", function (req, res, next) {
+exports.get("/about", async  function (req, res, next) {
   try {
     const successfulResult = await About.find({}).exec();
     res.render("about_view", { title: "About", list: successfulResult });


### PR DESCRIPTION
We are using the `await` keyword but without making the callback an async function.  https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#handling_exceptions_in_route_functions

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
