### PR TITLE
Add missing brackets to `:not([hidden])` in discussion of zebra-striping

### DIFF
--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -408,7 +408,7 @@ td {
 
 In the first table this is just using `:nth-child(even)` the third row has the `hidden` attribute applied to it. So in this instance the 3rd row is not visible and the 2nd & 4th rows are counted as even, which technically they are but visually they are not.
 
-In the second table the _of syntax_ is used to target only the `tr`s that are **not** hidden using `:nth-child(even of :not(hidden))`.
+In the second table the _of syntax_ is used to target only the `tr`s that are **not** hidden using `:nth-child(even of :not([hidden]))`.
 
 {{EmbedLiveSample('Using_of_selector_to_fix_striped_tables', 550, 180)}}
 


### PR DESCRIPTION
### Description

while the example is correct, the text explaining zebra-striping lists `:nth-child(even of :not(hidden))` as the format used, but that won't exclude hidden elements in the selection. `:nth-child(even of :not([hidden]))` (with brackets around `hidden`) is the correct syntax as noted elsewhere in the example.

### Motivation

it corrects a syntax error in the documentation.

