### PR TITLE
Remove incorrect macro

### DIFF
--- a/files/en-us/web/css/@media/prefers-contrast/index.md
+++ b/files/en-us/web/css/@media/prefers-contrast/index.md
@@ -65,5 +65,3 @@ This example has an annoying low contrast by default.
 ## See also
 
 - CSS [forced-colors](/en-US/docs/Web/CSS/@media/forced-colors) media query
-
-{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/@media/")}}


### PR DESCRIPTION
This tries to add a kind of generic sidebar, listing subpages of the current page. But the page already has a sidebar.