### PR TITLE
Fix variable name (  ReferenceError  )

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
@@ -114,7 +114,7 @@ exports.book_update_post = [
 
       // Mark our selected genres as checked.
       for (const genre of allGenres) {
-        if (book.genre.indexOf(genres._id) > -1) {
+        if (book.genre.indexOf(genre._id) > -1) {
           genre.checked = "true";
         }
       }


### PR DESCRIPTION
book.genre.indexOf(`genres._id`)

will be 

book.genre.indexOf(`genre._id`)

`genres` is undefined.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
