### PR TITLE
fix(examples): fix samples in canvas api tutorial

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -88,6 +88,14 @@ Here is a minimalistic template, which we'll be using as a starting point for la
   <head>
     <meta charset="utf-8" />
     <title>Canvas tutorial</title>
+    <style>
+      canvas {
+        border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="tutorial" width="150" height="150"></canvas>
     <script>
       function draw() {
         const canvas = document.getElementById("tutorial");
@@ -95,15 +103,8 @@ Here is a minimalistic template, which we'll be using as a starting point for la
           const ctx = canvas.getContext("2d");
         }
       }
+      draw();
     </script>
-    <style>
-      canvas {
-        border: 1px solid black;
-      }
-    </style>
-  </head>
-  <body onload="draw();">
-    <canvas id="tutorial" width="150" height="150"></canvas>
   </body>
 </html>
 ```
@@ -124,6 +125,9 @@ To begin, let's take a look at a simple example that draws two intersecting rect
   <head>
     <meta charset="UTF-8" />
     <title>Canvas experiment</title>
+  </head>
+  <body>
+    <canvas id="canvas" width="150" height="150"></canvas>
     <script type="application/javascript">
       function draw() {
         const canvas = document.getElementById("canvas");
@@ -137,10 +141,8 @@ To begin, let's take a look at a simple example that draws two intersecting rect
           ctx.fillRect(30, 30, 50, 50);
         }
       }
+      draw();
     </script>
-  </head>
-  <body onload="draw();">
-    <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
 ```

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -37,7 +37,7 @@ Below is the `draw()` function from the previous page, but now it is making use 
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -54,6 +54,10 @@ function draw() {
     ctx.strokeRect(50, 50, 50, 50);
   }
 }
+```
+
+```js hidden
+draw();
 ```
 
 This example's output is shown below.
@@ -103,7 +107,7 @@ For example, the code for drawing a triangle would look something like this:
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="100" height="100"></canvas>
   </body>
 </html>
@@ -124,6 +128,10 @@ function draw() {
 }
 ```
 
+```js hidden
+draw();
+```
+
 The result looks like this:
 
 {{EmbedLiveSample("Drawing_a_triangle", 110, 110, "triangle.png")}}
@@ -141,7 +149,7 @@ To try this for yourself, you can use the code snippet below. Just paste it into
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -166,6 +174,10 @@ function draw() {
 }
 ```
 
+```js hidden
+draw();
+```
+
 The result looks like this:
 
 {{EmbedLiveSample("Moving_the_pen", 160, 160, "canvas_smiley.png")}}
@@ -187,7 +199,7 @@ The example below draws two triangles, one filled and one outlined.
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -215,6 +227,10 @@ function draw() {
     ctx.stroke();
   }
 }
+```
+
+```js hidden
+draw();
 ```
 
 This starts by calling `beginPath()` to start a new shape path. We then use the `moveTo()` method to move the starting point to the desired position. Below this, two lines are drawn which make up two sides of the triangle.
@@ -248,7 +264,7 @@ The statement for the `clockwise` parameter results in the first and third row b
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="200"></canvas>
   </body>
 </html>
@@ -283,6 +299,10 @@ function draw() {
 }
 ```
 
+```js hidden
+draw();
+```
+
 {{EmbedLiveSample("Arcs", 160, 210, "canvas_arc.png")}}
 
 ### Bezier and quadratic curves
@@ -309,7 +329,7 @@ This example uses multiple quadratic Bézier curves to render a speech balloon.
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -335,6 +355,10 @@ function draw() {
 }
 ```
 
+```js hidden
+draw();
+```
+
 {{EmbedLiveSample("Quadratic_Bezier_curves", 160, 160, "canvas_quadratic.png")}}
 
 #### Cubic Bezier curves
@@ -343,7 +367,7 @@ This example draws a heart using cubic Bézier curves.
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -369,6 +393,10 @@ function draw() {
 }
 ```
 
+```js hidden
+draw();
+```
+
 {{EmbedLiveSample("Cubic_Bezier_curves", 160, 160, "canvas_bezier.png")}}
 
 ### Rectangles
@@ -386,7 +414,7 @@ So far, each example on this page has used only one type of path function per sh
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -474,6 +502,10 @@ function roundedRect(ctx, x, y, width, height, radius) {
 }
 ```
 
+```js hidden
+draw();
+```
+
 The resulting image looks like this:
 
 {{EmbedLiveSample("Making_combinations", 160, 160, "combinations.png")}}
@@ -509,7 +541,7 @@ In this example, we are creating a rectangle and a circle. Both are stored as a 
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="130" height="100"></canvas>
   </body>
 </html>
@@ -531,6 +563,10 @@ function draw() {
     ctx.fill(circle);
   }
 }
+```
+
+```js hidden
+draw();
 ```
 
 {{EmbedLiveSample("Path2D_example", 130, 110, "path2d.png")}}

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -127,7 +127,7 @@ In the following example, we will use an external image as the backdrop for a sm
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="180" height="150"></canvas>
   </body>
 </html>
@@ -150,6 +150,10 @@ function draw() {
 }
 ```
 
+```js
+draw();
+```
+
 The resulting graph looks like this:
 
 {{EmbedLiveSample("Example_A_simple_line_graph", 220, 160, "canvas_backdrop.png")}}
@@ -169,7 +173,7 @@ In this example, we'll use an image as a wallpaper and repeat it several times o
 
 ```html hidden
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
   </body>
 </html>
@@ -188,6 +192,10 @@ function draw() {
   };
   img.src = "rhino.jpg";
 }
+```
+
+```js hidden
+draw();
 ```
 
 The resulting canvas looks like this:
@@ -215,7 +223,7 @@ In this example, we'll use the same rhino as in the previous example, but we'll 
 
 ```html
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <canvas id="canvas" width="150" height="150"></canvas>
     <div style="display:none;">
       <img id="source" src="rhino.jpg" width="300" height="227" />
@@ -246,6 +254,7 @@ function draw() {
   // Draw frame
   ctx.drawImage(document.getElementById("frame"), 0, 0);
 }
+draw();
 ```
 
 We took a different approach to loading the images this time. Instead of loading them by creating new {{domxref("HTMLImageElement")}} objects, we included them as {{HTMLElement("img")}} tags directly in our HTML source and retrieved the images from those. The images are hidden from output by setting the CSS property {{cssxref("display")}} to none for those images.
@@ -264,7 +273,7 @@ The code below should be self-explanatory. We loop through the {{domxref("docume
 
 ```html
 <html lang="en">
-  <body onload="draw();">
+  <body>
     <table>
       <tr>
         <td><img src="gallery_1.jpg" /></td>
@@ -331,6 +340,7 @@ function draw() {
     }
   }
 }
+draw();
 ```
 
 {{EmbedLiveSample("Art_gallery_example", 725, 400)}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixing live samples in the canvas api tutorial. They should not inlcude <html>/<body> tags. And we should fix that, too. For now we just stop depending ont the onload in the <body>

### Motivation

The new way of live samples is not quite as forgiving as the old one. Anyhow we used to produce html like:
```html
<html>
  <body>
    <html>
      <body>
      </body>
    </html>
  </body>
</html>
```

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
