### PR TITLE
Update setUninstallURL to incldue notes about Safari being a noop

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.runtime.setUninstallURL
 
 {{AddonSidebar()}}
 
-Sets the URL to be visited when the extension is uninstalled. This can be used to clean up server-side data, do analytics, or implement surveys. The URL can be up to 1023 characters. This limit used to be 255, see [Browser compatibility](browser_compatibility) for more details.
+Sets the URL to be visited when the extension is uninstalled. This can be used to clean up server-side data, do analytics, or implement surveys. In Firefox and Chromium-based browsers the URL can be up to 1023 characters (previously limited to 255). Safari doesn't have any restrictions on URL length, but the related function intentionally does nothing. See [Browser compatibility](#browser_compatibility) for more details.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 


### PR DESCRIPTION
### Description

Update the `runtime.setUninstallURL` docs to mention that Safari's implementation is an intentional noop

### Motivation

I [updated setUninstallURL](https://bugzilla.mozilla.org/show_bug.cgi?id=1835723) recently, and while [discussing it](https://github.com/w3c/webextensions/pull/410) in the [WECG](https://www.w3.org/community/webextensions/), we discussed Safari's implementation being an intentional noop. This update changes the documentation to reflect that.