### PR TITLE
WebExtensions action: fix browser_action links

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -17,7 +17,7 @@ You can associate a popup with the button. The popup is specified using HTML, CS
 
 If you specify a popup, it will be shown — and the content will be loaded — when the user clicks the icon. If you do not specify a popup, then when the user clicks the icon an event is dispatched to your extension.
 
-You can define most of a browser action's properties declaratively using the [`browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) key in the manifest.json.
+You can define most of a browser action's properties declaratively using the [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) key in the manifest.json.
 
 With the `action` API, you can:
 
@@ -75,7 +75,7 @@ With the `action` API, you can:
 
 {{Compat}}
 
-> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/) API. This documentation is derived from [`action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -9,7 +9,7 @@ browser-compat: webextensions.api.action
 
 Adds a button to the browser's toolbar.
 
-> **Note:** This API is available in Manifest V3 or higher.
+> **Note:** This API is available in Manifest V3 or higher. It replaces {{WebExtAPIRef("browserAction")}} and {{WebExtAPIRef("pageAction")}} Manifest V2 API.
 
 A [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action) is a button in the browser's toolbar.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -9,7 +9,7 @@ browser-compat: webextensions.api.action
 
 Adds a button to the browser's toolbar.
 
-> **Note:** This API is available in Manifest V3 or higher. It replaces {{WebExtAPIRef("browserAction")}} and {{WebExtAPIRef("pageAction")}} Manifest V2 API.
+> **Note:** This API is available in Manifest V3 or higher. It replaces the Manifest V2 APIs {{WebExtAPIRef("browserAction")}} and, in Chrome and Safari, {{WebExtAPIRef("pageAction")}}.
 
 A [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action) is a button in the browser's toolbar.
 


### PR DESCRIPTION
### Description

`action` WebExtensions API should not reference `browser_action` in [`manifest.json`](../blob/main/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md) and Chromium sources since dedicated `action` entries exist in both cases. Mention `browserAction` and `pageAction` API in the compatibility note instead.

### Motivation

- Fix incorrect links.
- Inform developers about related API in Manifest V3 and Manifest V2