### PR TITLE
Ff115 Sec-Purpose HTTP header plus some related changes in HTML

### DIFF
--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -31,3 +31,5 @@ The fetch metadata request headers are:
   - {{Glossary("HTTP_header","HTTP header")}}
   - {{Glossary("Response header")}}
   - {{Glossary("Request header")}}
+- {{HTTPHeader("Sec-Purpose")}}
+- {{HTTPHeader("Service-Worker-Navigation-Preload")}}

--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -19,6 +19,12 @@ The fetch metadata request headers are:
 - {{HTTPHeader("Sec-Fetch-User")}}
 - {{HTTPHeader("Sec-Fetch-Dest")}}
 
+The following request headers are not _strictly_ "fetch metadata request headers", as they are not in the same specification, but similarly provide information about the context of how a resource will be used.
+A server might use them to modify its caching behavior, or the information that is returned:
+
+- {{HTTPHeader("Sec-Purpose")}} {{Experimental_Inline}}
+- {{HTTPHeader("Service-Worker-Navigation-Preload")}}
+
 ## See also
 
 - [Protect your resources from web attacks with Fetch Metadata](https://web.dev/fetch-metadata/) (web.dev)
@@ -31,5 +37,3 @@ The fetch metadata request headers are:
   - {{Glossary("HTTP_header","HTTP header")}}
   - {{Glossary("Response header")}}
   - {{Glossary("Request header")}}
-- {{HTTPHeader("Sec-Purpose")}}
-- {{HTTPHeader("Service-Worker-Navigation-Preload")}}

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -60,7 +60,7 @@ Some interesting new performance and security features have been added to the `<
   crossorigin="anonymous" />
 ```
 
-A `rel` value of `preload` indicates that the browser should preload this resource (see [Preloading content with rel="preload"](/en-US/docs/Web/HTML/Attributes/rel/preload) for more details), with the `as` attribute indicating the specific class of content being fetched.
+A `rel` value of `preload` indicates that the browser should preload this resource (see [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) for more details), with the `as` attribute indicating the specific class of content being fetched.
 The `crossorigin` attribute indicates whether the resource should be fetched with a {{Glossary("CORS")}} request.
 
 Other usage notes:
@@ -80,7 +80,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - `as`
 
-  - : This attribute is only used when `rel="preload"` or `rel="prefetch"` has been set on the `<link>` element.
+  - : This attribute is only used when [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) has been set on the `<link>` element.
     It specifies the type of content being loaded by the `<link>`, which is necessary for request matching, application of correct [content security policy](/en-US/docs/Web/HTTP/CSP), and setting of correct {{HTTPHeader("Accept")}} request header.
     Furthermore, `rel="preload"` uses this as a signal for request prioritization.
     The table below lists the valid values for this attribute and the elements or resources they apply to.

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -319,13 +319,13 @@ A server can use them to make decisions about whether a request should be allowe
     It is a Structured Header whose value is a boolean so possible values are `?0` for false and `?1` for true.
 - {{HTTPHeader("Sec-Fetch-Dest")}}
   - : Indicates the request's destination.
-     It is a Structured Header whose value is a token with possible values `audio`, `audioworklet`, `document`, `embed`, `empty`, `font`, `image`, `manifest`, `object`, `paintworklet`, `report`, `script`, `serviceworker`, `sharedworker`, `style`, `track`, `video`, `worker`, and `xslt`.
+    It is a Structured Header whose value is a token with possible values `audio`, `audioworklet`, `document`, `embed`, `empty`, `font`, `image`, `manifest`, `object`, `paintworklet`, `report`, `script`, `serviceworker`, `sharedworker`, `style`, `track`, `video`, `worker`, and `xslt`.
 
 The following request headers are not _strictly_ "fetch metadata request headers", but similarly provide information about the context of how a resource will be used.
 A server might use them to modify its caching behavior, or the information that is returned:
 
-- {{HTTPHeader("Sec-Purpose")}}
-  - : Indicates the purpose of the request, if the purpose is something other than immediate use by the user-agent.
+- {{HTTPHeader("Sec-Purpose")}} {{Experimental_Inline}}
+  - : Indicates the purpose of the request, when the purpose is something other than immediate use by the user-agent.
     The header currently has one possible value, `prefetch`, which indicates that the resource is being fetched preemptively for a possible future navigation.
 - {{HTTPHeader("Service-Worker-Navigation-Preload")}}
   - : A request header sent in preemptive request to {{domxref("fetch()")}} a resource during service worker boot.

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -305,16 +305,28 @@ _Learn more about CORS [here](/en-US/docs/Glossary/CORS)._
 
 ### Fetch metadata request headers
 
-{{Glossary("Fetch metadata request header", "Fetch metadata request headers")}} provides information about the context from which the request originated. This allows a server to make decisions about whether a request should be allowed based on where the request came from and how the resource will be used.
+{{Glossary("Fetch metadata request header", "Fetch metadata request headers")}} provide information about the context from which the request originated.
+A server can use them to make decisions about whether a request should be allowed, based on where the request came from and how the resource will be used.
 
 - {{HTTPHeader("Sec-Fetch-Site")}}
-  - : It is a request header that indicates the relationship between a request initiator's origin and its target's origin. It is a Structured Header whose value is a token with possible values `cross-site`, `same-origin`, `same-site`, and `none`.
+  - : Indicates the relationship between a request initiator's origin and its target's origin.
+    It is a Structured Header whose value is a token with possible values `cross-site`, `same-origin`, `same-site`, and `none`.
 - {{HTTPHeader("Sec-Fetch-Mode")}}
-  - : It is a request header that indicates the request's mode to a server. It is a Structured Header whose value is a token with possible values `cors`, `navigate`, `no-cors`, `same-origin`, and `websocket`.
+  - : Indicates the request's mode to a server.
+    It is a Structured Header whose value is a token with possible values `cors`, `navigate`, `no-cors`, `same-origin`, and `websocket`.
 - {{HTTPHeader("Sec-Fetch-User")}}
-  - : It is a request header that indicates whether or not a navigation request was triggered by user activation. It is a Structured Header whose value is a boolean so possible values are `?0` for false and `?1` for true.
+  - : Indicates whether or not a navigation request was triggered by user activation.
+    It is a Structured Header whose value is a boolean so possible values are `?0` for false and `?1` for true.
 - {{HTTPHeader("Sec-Fetch-Dest")}}
-  - : It is a request header that indicates the request's destination to a server. It is a Structured Header whose value is a token with possible values `audio`, `audioworklet`, `document`, `embed`, `empty`, `font`, `image`, `manifest`, `object`, `paintworklet`, `report`, `script`, `serviceworker`, `sharedworker`, `style`, `track`, `video`, `worker`, and `xslt`.
+  - : Indicates the request's destination.
+     It is a Structured Header whose value is a token with possible values `audio`, `audioworklet`, `document`, `embed`, `empty`, `font`, `image`, `manifest`, `object`, `paintworklet`, `report`, `script`, `serviceworker`, `sharedworker`, `style`, `track`, `video`, `worker`, and `xslt`.
+
+The following request headers are not _strictly_ "fetch metadata request headers", but similarly provide information about the context of how a resource will be used.
+A server might use them to modify its caching behavior, or the information that is returned:
+
+- {{HTTPHeader("Sec-Purpose")}}
+  - : Indicates the purpose of the request, if the purpose is something other than immediate use by the user-agent.
+    The header currently has one possible value, `prefetch`, which indicates that the resource is being fetched preemptively for a possible future navigation.
 - {{HTTPHeader("Service-Worker-Navigation-Preload")}}
   - : A request header sent in preemptive request to {{domxref("fetch()")}} a resource during service worker boot.
     The value, which is set with {{domxref("NavigationPreloadManager.setHeaderValue()")}}, can be used to inform a server that a different resource should be returned than in a normal `fetch()` operation.

--- a/files/en-us/web/http/headers/sec-purpose/index.md
+++ b/files/en-us/web/http/headers/sec-purpose/index.md
@@ -7,10 +7,10 @@ browser-compat: http.headers.Sec-Purpose
 
 {{HTTPSidebar}}
 
-The **`Sec-Purpose`** {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the purpose for which the requested resource will be used, for some purpose other than immediate use by the user-agent.
+The **`Sec-Purpose`** {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the purpose for which the requested resource will be used, when that purpose is something other than immediate use by the user-agent.
 
-The only purpose that is currently defined is `prefetch`, which indicates that the resource is being requested in anticipation that it will be needed by a page that is likely to be navigated to in the near future.
-The server can use this knowledge to adjust the caching expiry for the request, disallow the request, or perhaps to treat it differently when counting page visits.
+The only purpose that is currently defined is `prefetch`, which indicates that the resource is being requested in anticipation that it will be needed by a page that is likely to be navigated to in the near future, such as a page linked in search results or a link that a user has hovered over.
+The server can use this knowledge to: adjust the caching expiry for the request, disallow the request, or perhaps to treat it differently when counting page visits.
 
 The header is sent when a page is loaded that has a [`<link>`](/en-US/docs/Web/HTML/Element/link) element with attribute [`rel="prefetch"`](/en-US/docs/Web/HTML/Attributes/rel/prefetch).
 Note that if this header is set then a {{HTTPHeader("Sec-Fetch-Dest")}} header in the request must be set to `empty` (any value in the [`<link>`](/en-US/docs/Web/HTML/Element/link) attribute [`as`](/en-US/docs/Web/HTML/Element/link#as) is ignored) and the {{HTTPHeader("Accept")}} header should match the value used for normal navigation requests.
@@ -45,16 +45,16 @@ Sec-Purpose: prefetch
 The allowed tokens are:
 
 - `prefetch`
-  - : The purpose is to prefetch a resource that may be needed in a probably future navigation.
+  - : The purpose is to prefetch a resource that may be needed in a probable future navigation.
 
 ## Examples
 
 ## A prefetch request
 
-A browser loads a file with a [`<link>`](/en-US/docs/Web/HTML/Element/link) element that has attribute `rel="prefetch"`, identifying an image file that is in a page that the user might navigate to next (or soon).
-The resulting `fetch()` should result in an HTTP request where `Sec-Purpose: prefetch`, `Sec-Fetch-Dest: empty` and `Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8` (the `Accept` header for page navigation).
+Consider the case where a browser loads a file with a [`<link>`](/en-US/docs/Web/HTML/Element/link) element that has the attribute `rel="prefetch"` and an `href` attribute containing the address of an image file.
+The resulting `fetch()` should result in an HTTP request where `Sec-Purpose: prefetch`, `Sec-Fetch-Dest: empty`, and an `Accept` value that is the same as the browser uses for page navigation.
 
-An example of such a header is given below:
+An example of such a header (on Firefox) is given below:
 
 ```http
 GET /images/some_image.png HTTP/1.1
@@ -72,7 +72,8 @@ Pragma: no-cache
 Cache-Control: no-cache
 ```
 
-> **Note:** At time of writing FireFox incorrectly sets the `Accept` header as `Accept: */*` for this case.
+> **Note:** At time of writing FireFox incorrectly sets the `Accept` header as `Accept: */*` for prefetches.
+> The example has been modified to show what the `Accept` value should be.
 > This issue can be tracked in [Firefox bug 1836334](https://bugzil.la/1836334).
 
 ## Specifications

--- a/files/en-us/web/http/headers/sec-purpose/index.md
+++ b/files/en-us/web/http/headers/sec-purpose/index.md
@@ -2,10 +2,12 @@
 title: Sec-Purpose
 slug: Web/HTTP/Headers/Sec-Purpose
 page-type: http-header
+status:
+  - experimental
 browser-compat: http.headers.Sec-Purpose
 ---
 
-{{HTTPSidebar}}
+{{HTTPSidebar}} {{SeeCompatTable}}
 
 The **`Sec-Purpose`** {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the purpose for which the requested resource will be used, when that purpose is something other than immediate use by the user-agent.
 

--- a/files/en-us/web/http/headers/sec-purpose/index.md
+++ b/files/en-us/web/http/headers/sec-purpose/index.md
@@ -1,0 +1,89 @@
+---
+title: Sec-Purpose
+slug: Web/HTTP/Headers/Sec-Purpose
+page-type: http-header
+browser-compat: http.headers.Sec-Purpose
+---
+
+{{HTTPSidebar}}
+
+The **`Sec-Purpose`** {{Glossary("Fetch metadata request header", "fetch metadata request header")}} indicates the purpose for which the requested resource will be used, for some purpose other than immediate use by the user-agent.
+
+The only purpose that is currently defined is `prefetch`, which indicates that the resource is being requested in anticipation that it will be needed by a page that is likely to be navigated to in the near future.
+The server can use this knowledge to adjust the caching expiry for the request, disallow the request, or perhaps to treat it differently when counting page visits.
+
+The header is sent when a page is loaded that has a [`<link>`](/en-US/docs/Web/HTML/Element/link) element with attribute [`rel="prefetch"`](/en-US/docs/Web/HTML/Attributes/rel/prefetch).
+Note that if this header is set then a {{HTTPHeader("Sec-Fetch-Dest")}} header in the request must be set to `empty` (any value in the [`<link>`](/en-US/docs/Web/HTML/Element/link) attribute [`as`](/en-US/docs/Web/HTML/Element/link#as) is ignored) and the {{HTTPHeader("Accept")}} header should match the value used for normal navigation requests.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Fetch Metadata Request Header")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>yes (prefix <code>Sec-</code>)</td>
+    </tr>
+    <tr>
+      <th scope="row">
+        {{Glossary("CORS-safelisted request header")}}
+      </th>
+      <td>no</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+Sec-Purpose: prefetch
+```
+
+## Directives
+
+The allowed tokens are:
+
+- `prefetch`
+  - : The purpose is to prefetch a resource that may be needed in a probably future navigation.
+
+## Examples
+
+## A prefetch request
+
+A browser loads a file with a [`<link>`](/en-US/docs/Web/HTML/Element/link) element that has attribute `rel="prefetch"`, identifying an image file that is in a page that the user might navigate to next (or soon).
+The resulting `fetch()` should result in an HTTP request where `Sec-Purpose: prefetch`, `Sec-Fetch-Dest: empty` and `Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8` (the `Accept` header for page navigation).
+
+An example of such a header is given below:
+
+```http
+GET /images/some_image.png HTTP/1.1
+Host: example.com
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/116.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Sec-Purpose: prefetch
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: no-cors
+Sec-Fetch-Site: same-origin
+Pragma: no-cache
+Cache-Control: no-cache
+```
+
+> **Note:** At time of writing FireFox incorrectly sets the `Accept` header as `Accept: */*` for this case.
+> This issue can be tracked in [Firefox bug 1836334](https://bugzil.la/1836334).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{Glossary("Prefetch")}} (Glossary)
+- [`<link>`](/en-US/docs/Web/HTML/Element/link) element with attribute [`rel="prefetch"`](/en-US/docs/Web/HTML/Attributes/rel/prefetch)


### PR DESCRIPTION
FF115 adds support for the `Sec-Purpose` HTTP header, replacing `X-moz: prefetch` in https://bugzilla.mozilla.org/show_bug.cgi?id=1836328. It is currently only supported by FF115, though Chrome uses `Purpose` for same reason. It has one directive `prefetch` which tells a server this is a prefetch originating from a `<link>` element with `rel="prefetch"`

The bigger picture of these docs is complicated because while prefetch has been supported forever, it has been done with different headers everywhere. The spec has now stablised and browsers are intending to move there, but none are. FF is closest. 

The small picture is complicated because this header affects other header usage. And there is no really good place to include that info. See notes inline

Other docs work can be tracked in #27171