### PR TITLE
docs(CSS): Rename '@media/update-frequency' to '@media/update'

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11284,6 +11284,7 @@
 /en-US/docs/Web/CSS/:nth-of-type()	/en-US/docs/Web/CSS/:nth-of-type
 /en-US/docs/Web/CSS/@-moz-document	/en-US/docs/Web/CSS/@document
 /en-US/docs/Web/CSS/@font-face/font-variant	/en-US/docs/Web/CSS/@font-face
+/en-US/docs/Web/CSS/@media/update-frequency	/en-US/docs/Web/CSS/@media/update
 /en-US/docs/Web/CSS/@page_rule	/en-US/docs/Web/CSS/@page
 /en-US/docs/Web/CSS/@scroll-timeline	/en-US/docs/Web/CSS/scroll-timeline
 /en-US/docs/Web/CSS/@styleset	/en-US/docs/Web/CSS/@font-feature-values

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -76836,7 +76836,7 @@
     "modified": "2020-12-14T11:01:11.157Z",
     "contributors": ["rachelandrew", "wbamberg", "mfuji09", "bershanskiy"]
   },
-  "Web/CSS/@media/update-frequency": {
+  "Web/CSS/@media/update": {
     "modified": "2020-12-14T11:01:26.322Z",
     "contributors": [
       "rachelandrew",

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -15,7 +15,7 @@ No notable changes.
 
 ### CSS
 
-The [`update`](/en-US/docs/Web/CSS/@media/update-frequency) media feature that can be used to query the ability of the output device to modify the appearance of content after it is rendered is now available by default ([Firefox bug 1422312](https://bugzil.la/1422312)).
+The [`update`](/en-US/docs/Web/CSS/@media/update) media feature that can be used to query the ability of the output device to modify the appearance of content after it is rendered is now available by default ([Firefox bug 1422312](https://bugzil.la/1422312)).
 
 ### JavaScript
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -126,7 +126,7 @@ Media feature expressions test for their presence or value, and are entirely opt
 - {{cssxref("@media/scripting", "scripting")}} {{Experimental_Inline}}
   - : Detects whether scripting (i.e. JavaScript) is available.
     Added in Media Queries Level 5.
-- {{cssxref("@media/update-frequency", "update")}}
+- {{cssxref("@media/update", "update")}}
   - : How frequently the output device can modify the appearance of content.
     Added in Media Queries Level 4.
 - {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}

--- a/files/en-us/web/css/@media/update/index.md
+++ b/files/en-us/web/css/@media/update/index.md
@@ -1,6 +1,6 @@
 ---
 title: update
-slug: Web/CSS/@media/update-frequency
+slug: Web/CSS/@media/update
 page-type: css-media-feature
 browser-compat: css.at-rules.media.update
 ---

--- a/files/en-us/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries/index.md
@@ -53,7 +53,7 @@ Media queries are case-insensitive.
   - {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}} {{experimental_inline}}
   - {{cssxref("@media/resolution", "resolution")}}
   - {{cssxref("@media/scripting", "scripting")}}
-  - {{cssxref("@media/update-frequency", "update")}}
+  - {{cssxref("@media/update", "update")}}
   - {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}
   - {{cssxref("@media/width", "width")}}.
 


### PR DESCRIPTION
It looks like we should follow this convention for naming although `frequency` adds some hints on the behavior, the suggested changes are more uniform given the syntax:

```css
@media (update: <value>) {
...
```

Renaming this page along with updating references to the old slug / name.
