### PR TITLE
Request.integrity is specified not computed

### DIFF
--- a/files/en-us/web/api/request/integrity/index.md
+++ b/files/en-us/web/api/request/integrity/index.md
@@ -12,17 +12,26 @@ The **`integrity`** read-only property of the {{domxref("Request")}} interface c
 
 ## Value
 
-The [subresource integrity](/en-US/docs/Web/Security/Subresource_Integrity) value of the request (e.g., `sha256-BpfBw7ivV8q2jLiT13fxDYAe2tJllusRSZ273h2nFSE=`).
+The value that was passed as the `options.integrity` argument when constructing the `Request`.
 
 If an integrity has not been specified, the property returns `''`.
 
 ## Examples
 
-In the following snippet, we create a new request using the {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as the script), then save the request `integrity` value in a variable:
+In the following snippet, we create a new request using the {{domxref("Request/Request", "Request()")}} constructor (for an image file in the same directory as the script), then reads the request's integrity. Because the request was created without a specific integrity, the property returns an empty string.
 
 ```js
 const myRequest = new Request("flowers.jpg");
-const myIntegrity = myRequest.integrity;
+console.log(myRequest.integrity); // ""
+```
+
+In the example below, the request was created with a specific integrity value, so the property returns that value. Note that there's no validation of the integrity value; the property returns exactly what was passed in.
+
+```js
+const myRequest = new Request("flowers.jpg", {
+  integrity: "sha256-abc123",
+});
+console.log(myRequest.integrity); // "sha256-abc123"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The doc does not make it explicit that `integrity` does not actually compute any hash. This makes it clearer.

Fixes https://github.com/mdn/content/issues/24728

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
