### PR TITLE
make preservesPitch example functional

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
+++ b/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
@@ -46,22 +46,17 @@ div {
 
 ```js
 const audio = document.querySelector("audio");
-// When the audio starts playing...
-audio.addEventListener(
-  "play",
-  () => {
-    // Handle page visibility change:
-    // - If the page is hidden, pause the video
-    // - If the page is shown, play the video
-    document.addEventListener("visibilitychange", () => {
-      if (document.hidden) {
-        audio.pause();
-      } else {
-        audio.play();
-      }
-    });
-  },
-  { once: true }
+document.getElementById("rate").addEventListener(
+  "change",
+  (e) => {
+    audio.playbackRate = e.target.value;
+  }
+);
+document.getElementById("pitch").addEventListener(
+  "change",
+  (e) => {
+    audio.preservesPitch = e.target.checked;
+  }
 );
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
+++ b/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
@@ -46,18 +46,12 @@ div {
 
 ```js
 const audio = document.querySelector("audio");
-document.getElementById("rate").addEventListener(
-  "change",
-  (e) => {
-    audio.playbackRate = e.target.value;
-  }
-);
-document.getElementById("pitch").addEventListener(
-  "change",
-  (e) => {
-    audio.preservesPitch = e.target.checked;
-  }
-);
+document.getElementById("rate").addEventListener("change", (e) => {
+  audio.playbackRate = e.target.value;
+});
+document.getElementById("pitch").addEventListener("change", (e) => {
+  audio.preservesPitch = e.target.checked;
+});
 ```
 
 {{EmbedLiveSample("Setting the preservesPitch property")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The code for the preservesPitch interactive example is mistaken and appears to be pasted from some unrelated example. As a result the controls have no affect on the audio. I've added the needed listeners for the controls so that they actually work now.
