### PR TITLE
Fix typo in speechsynthesis rate doc

### DIFF
--- a/files/en-us/web/api/speechsynthesisutterance/rate/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/rate/index.md
@@ -15,7 +15,7 @@ If unset, a default value of 1 will be used.
 ## Value
 
 A float representing the rate value.
-It can range between 0.1 (lowest) and 10 (highest), with 1 being the default pitch for the current platform or voice, which should correspond to a normal speaking rate.
+It can range between 0.1 (lowest) and 10 (highest), with 1 being the default rate for the current platform or voice, which should correspond to a normal speaking rate.
 Other values act as a percentage relative to this, so for example 2 is twice as fast, 0.5 is half as fast, etc.
 
 Some speech synthesis engines or voices may constrain the minimum and maximum rates further.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is a typo in the `rate` docs. Instead of saying `rate` it says `pitch`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Just a small fixt to make it clear to the readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
