### PR TITLE
Add missed CSSRef

### DIFF
--- a/files/en-us/web/css/css_media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries_for_accessibility/index.md
@@ -4,6 +4,8 @@ slug: Web/CSS/CSS_media_queries/Using_media_queries_for_accessibility
 page-type: guide
 ---
 
+{{CSSRef}}
+
 [**CSS media queries**](/en-US/docs/Web/CSS/CSS_media_queries) can be used to help users with disabilities better experience your website.
 
 ## Reduced Motion


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

CSS ref is missed in `Using media queries for accessibility` article. This pr fixes the issue.

<details>
<summary>Before</summary>

<img width="1170" alt="Screenshot 2023-06-25 at 00 54 10" src="https://github.com/mdn/content/assets/3923527/64c89ac9-4078-412d-b1a1-2be2dcb75a6c">
</details>

<details>
<summary>After</summary>

<img width="1440" alt="image" src="https://github.com/mdn/content/assets/3923527/78917a22-d77a-469f-a8be-fcff81f44065">
</details>

