### PR TITLE
fix link to HTMLElement.value

### DIFF
--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -13,7 +13,7 @@ browser-compat: html.elements.input.type_search
 
 ## Value
 
-The [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string representing the value contained in the search field. You can retrieve this using the {{domxref("HTMLInputElement.value")}} property in JavaScript.
+The [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string representing the value contained in the search field. You can retrieve this using the {{domxref("HTMLInputElement")}} `value` property in JavaScript.
 
 ```js
 searchTerms = mySearch.value;

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -13,7 +13,7 @@ browser-compat: html.elements.input.type_search
 
 ## Value
 
-The [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string representing the value contained in the search field. You can retrieve this using the {{domxref("HTMLInputElement")}} `value` property in JavaScript.
+The [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string representing the value contained in the search field. You can retrieve this using the [`HTMLInputElement.value`](/en-US/docs/Web/API/HTMLInputElement#value) property in JavaScript.
 
 ```js
 searchTerms = mySearch.value;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The link to `HTMLInputElement.value` was broken for `<input type="search">`.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Simple to fix and I happened to notice it.
<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
