### PR TITLE
Add one missing case for string

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -61,7 +61,7 @@ Many built-in operations that expect booleans first coerce their arguments to bo
 - [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `false`.
 - `0`, `-0`, and `NaN` turn into `false`; other numbers turn into `true`.
 - `0n` turns into `false`; other [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) turn into `true`.
-- Empty [string](en-US/docs/Web/JavaScript/Reference/Global_Objects/String) values turn into `false`; other strings turn into `true`.
+- Empty [string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) values turn into `false`; other strings turn into `true`.
 - [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) turn into `true`.
 - All objects become `true`.
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -61,7 +61,7 @@ Many built-in operations that expect booleans first coerce their arguments to bo
 - [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `false`.
 - `0`, `-0`, and `NaN` turn into `false`; other numbers turn into `true`.
 - `0n` turns into `false`; other [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) turn into `true`.
-- Empty [string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) values turn into `false`; other strings turn into `true`.
+- The empty string `""` turns into `false`; other strings turn into `true`.
 - [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) turn into `true`.
 - All objects become `true`.
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -61,6 +61,7 @@ Many built-in operations that expect booleans first coerce their arguments to bo
 - [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `false`.
 - `0`, `-0`, and `NaN` turn into `false`; other numbers turn into `true`.
 - `0n` turns into `false`; other [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) turn into `true`.
+- Empty [string](en-US/docs/Web/JavaScript/Reference/Global_Objects/String) value turn into `false`; other strings turn into `true`.
 - [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) turn into `true`.
 - All objects become `true`.
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -61,7 +61,7 @@ Many built-in operations that expect booleans first coerce their arguments to bo
 - [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `false`.
 - `0`, `-0`, and `NaN` turn into `false`; other numbers turn into `true`.
 - `0n` turns into `false`; other [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) turn into `true`.
-- Empty [string](en-US/docs/Web/JavaScript/Reference/Global_Objects/String) value turn into `false`; other strings turn into `true`.
+- Empty [string](en-US/docs/Web/JavaScript/Reference/Global_Objects/String) values turn into `false`; other strings turn into `true`.
 - [Symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) turn into `true`.
 - All objects become `true`.
 


### PR DESCRIPTION
Add one missing case for the string type

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It seems that one case is missing for the string type.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

When I read the docs in MDN, I found some descriptions a little misleading, so I think it should be corrected.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

[Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
