### PR TITLE
Remove redundant Markdown language headers

### DIFF
--- a/files/en-us/glossary/xhtml/index.md
+++ b/files/en-us/glossary/xhtml/index.md
@@ -10,8 +10,6 @@ page-type: glossary-definition
 
 The following example shows an HTML document and corresponding "XHTML" document, and the accompanying {{Glossary("HTTP")}} {{HTTPHeader("Content-Type")}} headers they should be served with.
 
-### HTML document
-
 ```html
 <!-- Content-Type: text/html -->
 
@@ -26,8 +24,6 @@ The following example shows an HTML document and corresponding "XHTML" document,
   </body>
 </html>
 ```
-
-### XHTML document
 
 ```xml
 <!-- Content-Type: application/xhtml+xml -->

--- a/files/en-us/learn/css/howto/generated_content/index.md
+++ b/files/en-us/learn/css/howto/generated_content/index.md
@@ -21,13 +21,9 @@ This issue does not arise if the content you specify consists of symbols or imag
 
 CSS can insert text content before or after an element, or change the content of a list item marker (such as a bullet symbol or number) before a {{HTMLElement('li')}} or other element with {{ cssxref("display", "display: list-item;") }}. To specify this, make a rule and add {{ cssxref("::before") }}, {{ cssxref("::after") }}, or {{cssxref("::marker")}} to the selector. In the declaration, specify the {{ cssxref("content") }} property with the text content as its value.
 
-#### HTML
-
 ```html
 A text where I need to <span class="ref">something</span>
 ```
-
-#### CSS
 
 ```css
 .ref::before {
@@ -36,8 +32,6 @@ A text where I need to <span class="ref">something</span>
   content: "Reference ";
 }
 ```
-
-#### Output
 
 {{ EmbedLiveSample('Text_content', 600, 30) }}
 
@@ -51,13 +45,9 @@ To add an image before or after an element, you can specify the URL of an image 
 
 This rule adds a space and an icon after every link that has the class `glossary`:
 
-#### HTML
-
 ```html
 <a href="developer.mozilla.org" class="glossary">developer.mozilla.org</a>
 ```
-
-#### CSS
 
 ```css
 a.glossary::after {

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
@@ -7,8 +7,6 @@ This is the first example of code that explains [how to build a custom form widg
 
 ## Basic state
 
-### HTML
-
 ```html
 <div class="select">
   <span class="value">Cherry</span>
@@ -21,8 +19,6 @@ This is the first example of code that explains [how to build a custom form widg
   </ul>
 </div>
 ```
-
-### CSS
 
 ```css
 /* --------------- */
@@ -136,8 +132,6 @@ This is the first example of code that explains [how to build a custom form widg
   color: #ffffff;
 }
 ```
-
-### Result for basic state
 
 {{ EmbedLiveSample('Basic_state', 120, 130) }}
 
@@ -158,8 +152,6 @@ This is the first example of code that explains [how to build a custom form widg
 </div>
 ```
 
-### CSS
-
 ```css
 /* --------------- */
 /* Required Styles */
@@ -273,13 +265,9 @@ This is the first example of code that explains [how to build a custom form widg
 }
 ```
 
-### Result for active state
-
 {{ EmbedLiveSample('Active_state', 120, 130) }}
 
 ## Open state
-
-### HTML
 
 ```html
 <div class="select active">
@@ -293,8 +281,6 @@ This is the first example of code that explains [how to build a custom form widg
   </ul>
 </div>
 ```
-
-### CSS
 
 ```css
 /* --------------- */
@@ -408,7 +394,5 @@ This is the first example of code that explains [how to build a custom form widg
   color: #fff;
 }
 ```
-
-### Result for open state
 
 {{ EmbedLiveSample('Open_state', 120, 130) }}

--- a/files/en-us/web/api/attr/name/index.md
+++ b/files/en-us/web/api/attr/name/index.md
@@ -20,8 +20,6 @@ A string representing the attribute's qualified name.
 
 The following example displays the qualified name of the first attribute of the two first elements, when we click on the appropriate button.
 
-### HTML
-
 ```html
 <svg xml:lang="en-US" class="struct" height="1" width="1">Click me</svg>
 <label xml:lang="en-US" class="struct"></label>
@@ -36,8 +34,6 @@ The following example displays the qualified name of the first attribute of the 
   <output id="result">None.</output>
 </p>
 ```
-
-### JavaScript
 
 ```js
 const elements = document.querySelectorAll(".struct");

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -57,8 +57,6 @@ None ({{jsxref("undefined")}}).
 In the following example, `setAttribute()` is used to set attributes on a
 {{HTMLElement("button")}}.
 
-### HTML
-
 ```html
 <button>Hello World</button>
 ```
@@ -70,8 +68,6 @@ button {
   margin: 1em;
 }
 ```
-
-### JavaScript
 
 ```js
 const button = document.querySelector("button");

--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
@@ -25,13 +25,9 @@ The **`:-moz-only-whitespace`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US
 
 ### Simple :-moz-only-whitespace example
 
-#### HTML
-
 ```html-nolint
 <div> </div>
 ```
-
-#### CSS
 
 ```css
 div {

--- a/files/en-us/web/guide/audio_and_video_delivery/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/index.md
@@ -30,8 +30,6 @@ To deliver video and audio, the general workflow is usually something like this:
 3. Identify how you want to play/instantiate the media (e.g. a {{ htmlelement("video") }} element, or `document.createElement('video')` perhaps?)
 4. Deliver the media file to the player.
 
-### HTML Audio
-
 ```html
 <audio controls preload="auto">
   <source src="audiofile.mp3" type="audio/mpeg" />
@@ -49,8 +47,6 @@ The code above will create an audio player that attempts to preload as much audi
 > **Note:** The `preload` attribute may be ignored by some mobile browsers.
 
 For further info see [Cross Browser Audio Basics (HTML Audio In Detail)](/en-US/docs/Web/Guide/Audio_and_video_delivery/Cross-browser_audio_basics#html5_audio_in_detail)
-
-### HTML Video
 
 ```html
 <video

--- a/files/en-us/web/guide/audio_and_video_delivery/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/index.md
@@ -30,6 +30,8 @@ To deliver video and audio, the general workflow is usually something like this:
 3. Identify how you want to play/instantiate the media (e.g. a {{ htmlelement("video") }} element, or `document.createElement('video')` perhaps?)
 4. Deliver the media file to the player.
 
+### HTML Audio
+
 ```html
 <audio controls preload="auto">
   <source src="audiofile.mp3" type="audio/mpeg" />
@@ -47,6 +49,8 @@ The code above will create an audio player that attempts to preload as much audi
 > **Note:** The `preload` attribute may be ignored by some mobile browsers.
 
 For further info see [Cross Browser Audio Basics (HTML Audio In Detail)](/en-US/docs/Web/Guide/Audio_and_video_delivery/Cross-browser_audio_basics#html5_audio_in_detail)
+
+### HTML Video
 
 ```html
 <video

--- a/files/en-us/web/html/microformats/index.md
+++ b/files/en-us/web/html/microformats/index.md
@@ -21,8 +21,6 @@ There are [open source parsing libraries for most languages](https://microformat
 
 An author of a webpage can add microformats to their HTML. For example if they wanted to identify themselves they could use an [h-card](https://microformats.org/wiki/h-card) such as:
 
-### HTML Example
-
 ```html
 <a class="h-card" href="https://alice.example.com">Alice Blogger</a>
 ```

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -67,8 +67,6 @@ In the example below, the function contains a `for` statement that counts
 the number of selected options in a scrolling list (a [`<select>`](/en-US/docs/Web/HTML/Element/select)
 element that allows multiple selections).
 
-#### HTML
-
 ```html
 <form name="selectForm">
   <label for="musicTypes"
@@ -85,8 +83,6 @@ element that allows multiple selections).
   <button id="btn" type="button">How many are selected?</button>
 </form>
 ```
-
-#### JavaScript
 
 Here, the `for` statement declares the variable `i` and initializes it to `0`. It checks that `i` is less than the number of options in the `<select>` element, performs the succeeding `if` statement, and increments `i` by 1 after each pass through the loop.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -413,8 +413,6 @@ The regular expression looks for:
 6. followed by four digits `\d{4}`
 7. followed by the end of the line of data: `$`
 
-#### HTML
-
 ```html
 <p>
   Enter your phone number (with area code) and then click "Check".
@@ -427,8 +425,6 @@ The regular expression looks for:
 </form>
 <p id="output"></p>
 ```
-
-#### JavaScript
 
 ```js
 const form = document.querySelector("#form");
@@ -450,8 +446,6 @@ form.addEventListener("submit", (event) => {
   testInfo(input);
 });
 ```
-
-#### Result
 
 {{ EmbedLiveSample('Using_special_characters_to_verify_input') }}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -27,13 +27,9 @@ The same return value as {{jsxref("Array.prototype.values()")}}: a new [iterable
 
 Note that you seldom need to call this method directly. The existence of the `@@iterator` method makes arrays [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), and iterating syntaxes like the `for...of` loop automatically calls this method to obtain the iterator to loop over.
 
-#### HTML
-
 ```html
 <ul id="letterResult"></ul>
 ```
-
-#### JavaScript
 
 ```js
 const arr = ["a", "b", "c"];
@@ -44,8 +40,6 @@ for (const letter of arr) {
   letterResult.appendChild(li);
 }
 ```
-
-#### Result
 
 {{EmbedLiveSample('Iteration_using_for...of_loop', '', '')}}
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -309,14 +309,10 @@ The fulfillment of the promise is logged, via a fulfill callback set using {{jsx
 
 By clicking the button several times in a short amount of time, you'll even see the different promises being fulfilled one after another.
 
-#### HTML
-
 ```html
 <button id="make-promise">Make a promise!</button>
 <div id="log"></div>
 ```
-
-#### JavaScript
 
 ```js
 "use strict";
@@ -360,8 +356,6 @@ function testPromise() {
 const btn = document.getElementById("make-promise");
 btn.addEventListener("click", testPromise);
 ```
-
-#### Result
 
 {{EmbedLiveSample("Advanced_Example", "500", "200")}}
 


### PR DESCRIPTION
- The PR https://github.com/mdn/yari/pull/9081 added language headers to the fenced code blocks.

So the Markdown content no longer need language headers like `### HTML` and  `#### CSS`.
Along with language headers, the PR also removes `### Result` headers as these can be added to the `{{EmbedLiveSample}}` macro.