### PR TITLE
Replace "parallelize" with "run concurrently"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
@@ -51,7 +51,7 @@ A new {{jsxref("Promise")}} whose fulfillment value is a new {{jsxref("Array")}}
 
 `Array.fromAsync()` and {{jsxref("Promise.all()")}} can both turn an iterable of promises into a promise of an array. However, there are two key differences:
 
-- `Array.fromAsync()` awaits each value yielded from the object sequentially. `Promise.all()` awaits all values in parallel.
+- `Array.fromAsync()` awaits each value yielded from the object sequentially. `Promise.all()` awaits all values concurrently.
 - `Array.fromAsync()` iterates the iterable lazily, and doesn't retrieve the next value until the current one is settled. `Promise.all()` retrieves all values in advance and awaits them all.
 
 ## Examples
@@ -121,7 +121,7 @@ Array.fromAsync(
 
 ### Comparison with Promise.all()
 
-`Array.fromAsync()` awaits each value yielded from the object sequentially. `Promise.all()` awaits all values in parallel.
+`Array.fromAsync()` awaits each value yielded from the object sequentially. `Promise.all()` awaits all values concurrently.
 
 ```js
 function* makeAsyncIterable() {

--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -206,7 +206,7 @@ async function getPrice() {
 
 `Promise.all` is the best choice of [concurrency method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) here, because error handling is intuitive — if any of the promises reject, the result is no longer available, so the whole `await` expression throws.
 
-`Promise.all` accepts an iterable of promises, so if you are using it to parallelize execution of several async functions, you need to call the async functions and use the returned promises. Directly passing the functions to `Promise.all` does not work, since they are not promises.
+`Promise.all` accepts an iterable of promises, so if you are using it to run several async functions concurrently, you need to call the async functions and use the returned promises. Directly passing the functions to `Promise.all` does not work, since they are not promises.
 
 ```js example-bad
 async function getPrice() {

--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -160,7 +160,7 @@ if (typeof window === "undefined") {
 
 Dynamic imports allow any expression as the module specifier, not necessarily string literals.
 
-Here, we load 10 modules, `/modules/module-0.js`, `/modules/module-1.js`, etc., in parallel, and call the `load` functions that each one exports.
+Here, we load 10 modules, `/modules/module-0.js`, `/modules/module-1.js`, etc., concurrently, and call the `load` functions that each one exports.
 
 ```js
 Promise.all(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I replaced the word 'parallelize' with 'run ~ concurrently' because it could be misleading, suggesting it was related with parallelism rather than concurrency.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To ensure that it is clear that JavaScript cannot achieve parallelism (single-threaded) but rather concurrency. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to #23397

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
