### PR TITLE
Remove outdated reference to browser.tabs.multiselect in tabs.Tab documentation

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -39,7 +39,7 @@ Values of this type are objects. They contain the following properties:
 
   - : `boolean`. Whether the tab is highlighted, i.e. part of the current tab selection. An active tab is always highlighted, but some browsers may allow additional tabs to be highlighted, for example by clicking them while holding <kbd>Ctrl</kbd>, <kbd>Shift</kbd> or <kbd>⌘ Command</kbd> keys.
 
-    Firefox for Android doesn't support highlighting multiple tabs, and Firefox desktop requires the `browser.tabs.multiselect` preference (enabled by default).
+    Firefox for Android doesn't support highlighting multiple tabs.
 
 - `id` {{optional_inline}}
   - : `integer`. The tab's ID. Tab IDs are unique within a browser session. The tab ID may also be set to {{WebExtAPIRef('tabs.TAB_ID_NONE')}} for browser windows that don't host content tabs (for example, devtools windows).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This pref hasn't existed since bug 1634013

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://bugzilla.mozilla.org/show_bug.cgi?id=1634013
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
