### PR TITLE
docs(API): remove list of IDB tools, point to storage APIs instead

### DIFF
--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -80,12 +80,7 @@ This specification fires events with the following custom interface:
 
 ## See also
 
-- [localForage](https://localforage.github.io/localForage/): A Polyfill providing a simple name:value syntax for client-side data storage, which uses IndexedDB in the background, but falls back to Web SQL (deprecated) and then localStorage in browsers that don't support IndexedDB.
-- [Dexie.js](https://dexie.org/): A wrapper for IndexedDB that allows much faster code development via nice, simple syntax.
-- [JsStore](https://jsstore.net/): An IndexedDB wrapper with SQL like syntax.
-- [MiniMongo](https://github.com/mWater/minimongo): A client-side in-memory mongodb backed by localstorage with server sync over http. MiniMongo is used by MeteorJS.
-- [PouchDB](https://pouchdb.com): A client-side implementation of CouchDB in the browser using IndexedDB
-- [idb](https://www.npmjs.com/package/idb): A tiny (\~1.15k) library that mostly mirrors the IndexedDB API, but with small improvements that make a big difference to usability.
-- [idb-keyval](https://www.npmjs.com/package/idb-keyval): A super-simple-small (\~600B) promise-based keyval store implemented with IndexedDB
-- [$mol_db](https://github.com/hyoo-ru/mam_mol/tree/master/db): Tiny (\~1.3kB) TypeScript facade with promise-based API and automatic migrations.
-- [RxDB](https://rxdb.info/) A NoSQL client side database that can be used on top of IndexedDB. Supports indexes, compression and replication. Also adds cross tab functionality and observability to IndexedDB.
+- [Web Storage API](/en-US/docs/Web/API/Web_Storage_API)
+- [Window: localStorage property](/en-US/docs/Web/API/Window/localStorage)
+- [Window: sessionStorage property](/en-US/docs/Web/API/Window/sessionStorage)
+- [StorageEvent](/en-US/docs/Web/API/StorageEvent)

--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -19,7 +19,6 @@ IndexedDB is a transactional database system, like an SQL-based RDBMS. However, 
 
 - Read more about [IndexedDB key characteristics and basic terminology](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology).
 - Learn to use IndexedDB asynchronously from first principles with our [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) guide.
-- Combine IndexedDB for storing data offline with Service Workers for storing assets offline, as outlined in [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers).
 
 > **Note:** Like most web storage solutions, IndexedDB follows a [same-origin policy](https://www.w3.org/Security/wiki/Same_Origin_Policy). So while you can access stored data within a domain, you cannot access data across different domains.
 

--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -19,7 +19,7 @@ IndexedDB is a transactional database system, like an SQL-based RDBMS. However, 
 
 - Read more about [IndexedDB key characteristics and basic terminology](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology).
 - Learn to use IndexedDB asynchronously from first principles with our [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) guide.
-- Combine IndexedDB for storing data offline with Service Workers for storing assets offline, as outlined in [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers).
+- Combine IndexedDB for storing data offline with Service Workers for storing assets offline, as outlined in [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers).
 
 > **Note:** Like most web storage solutions, IndexedDB follows a [same-origin policy](https://www.w3.org/Security/wiki/Same_Origin_Policy). So while you can access stored data within a domain, you cannot access data across different domains.
 

--- a/files/en-us/web/performance/fundamentals/index.md
+++ b/files/en-us/web/performance/fundamentals/index.md
@@ -101,7 +101,7 @@ Another problem that can delay startup is idle time, caused by waiting for respo
 
 > **Note:** For much more information on improving startup performance, read [Optimizing startup performance](/en-US/docs/Web/Performance/Optimizing_startup_performance).
 
-On the same note, notice that locally-cached, static resources can be loaded much faster than dynamic data fetched over high-latency, low-bandwidth mobile networks. Network requests should never be on the critical path to early application startup. Local caching/offline apps can be achieved via [Service Workers](/en-US/docs/Web/API/Service_Worker_API). See [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers) for a guide as to how.
+On the same note, notice that locally-cached, static resources can be loaded much faster than dynamic data fetched over high-latency, low-bandwidth mobile networks. Network requests should never be on the critical path to early application startup. Local caching/offline apps can be achieved via [Service Workers](/en-US/docs/Web/API/Service_Worker_API). See [Offline and background operation](/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation) for a guide about using service workers for offline and background sync capabilities.
 
 ### Frame rate
 

--- a/files/en-us/web/performance/fundamentals/index.md
+++ b/files/en-us/web/performance/fundamentals/index.md
@@ -101,7 +101,7 @@ Another problem that can delay startup is idle time, caused by waiting for respo
 
 > **Note:** For much more information on improving startup performance, read [Optimizing startup performance](/en-US/docs/Web/Performance/Optimizing_startup_performance).
 
-On the same note, notice that locally-cached, static resources can be loaded much faster than dynamic data fetched over high-latency, low-bandwidth mobile networks. Network requests should never be on the critical path to early application startup. Local caching/offline apps can be achieved via [Service Workers](/en-US/docs/Web/API/Service_Worker_API). See [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers) for a guide as to how.
+On the same note, notice that locally-cached, static resources can be loaded much faster than dynamic data fetched over high-latency, low-bandwidth mobile networks. Network requests should never be on the critical path to early application startup. Local caching/offline apps can be achieved via [Service Workers](/en-US/docs/Web/API/Service_Worker_API). See [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers) for a guide as to how.
 
 ### Frame rate
 

--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -184,6 +184,6 @@ Best Practices
 
   - [Web Workers API](/en-US/docs/Web/API/Web_Workers_API)
 
-- [PWA](/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers)
+- [PWA](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers)
 - [Caching](/en-US/docs/Web/HTTP/Caching)
 - Content Delivery Networks (CDN)

--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -184,6 +184,6 @@ Best Practices
 
   - [Web Workers API](/en-US/docs/Web/API/Web_Workers_API)
 
-- [PWA](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers)
+- [Offline and background operation](/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation)
 - [Caching](/en-US/docs/Web/HTTP/Caching)
 - Content Delivery Networks (CDN)


### PR DESCRIPTION
This PR removes a list of tools relating to IndexedDB, and prefers internal links to related concepts. The rationale for removal is that the external tools and libraries are difficult to maintain, especially when it comes to assessing and assuring quality for our readers.

__Additional fixes:__
* Flaw in [redirected URL](https://github.com/mdn/content/blob/main/files/en-us/_redirects.txt#L12684)