### PR TITLE
Use correct nomenclature to refer to author

### DIFF
--- a/files/en-us/web/css/env/index.md
+++ b/files/en-us/web/css/env/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.custom-property.env
 
 {{CSSRef}}
 
-The **`env()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) can be used to insert the value of a user-agent defined environment variable into your CSS, in a similar fashion to the {{cssxref("var", "var()")}} function and [custom properties](/en-US/docs/Web/CSS/--*). The difference is that, as well as being user-agent defined rather than user-defined, environment variables are globally scoped to a document, whereas custom properties are scoped to the element(s) on which they are declared.
+The **`env()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) can be used to insert the value of a user-agent defined environment variable into your CSS, in a similar fashion to the {{cssxref("var", "var()")}} function and [custom properties](/en-US/docs/Web/CSS/--*). The difference is that, as well as being user-agent defined rather than author-defined, environment variables are globally scoped to a document, whereas custom properties are scoped to the element(s) on which they are declared.
 
 In addition, unlike custom properties, which cannot be used outside of declarations, the `env()` function can be used in place of any part of a property value, or any part of a descriptor (e.g. in [Media query rules](/en-US/docs/Web/CSS/@media)). As the spec evolves, it may also be usable in other places such as selectors.
 


### PR DESCRIPTION
### Description

`user` in CSS means end-user but this sentence clearly means the author/developer, so name it as that.

### Motivation

Refering to the developer as `user` is incorrect in CSS.

### Additional details

<img width="308" alt="image" src="https://github.com/mdn/content/assets/115237/8642e23b-2a41-4334-807f-40e36e993b2f">

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#cascading_order

### Related issues and pull requests

-
