### PR TITLE
Remove animation frame methods from SharedWorker and ServiceWorker

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -66,8 +66,6 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Decodes a string of data which has been encoded using base-64 encoding.
 - {{domxref("btoa", "ServiceWorkerGlobalScope.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("Window.cancelAnimationFrame", "ServiceWorkerGlobalScope.cancelAnimationFrame()")}}
-  - : Cancels a callback scheduled by requestAnimationFrame.
 - {{domxref("clearInterval", "ServiceWorkerGlobalScope.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval")}}.
 - {{domxref("clearTimeout", "ServiceWorkerGlobalScope.clearTimeout()")}}
@@ -76,8 +74,6 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Writes a message to the console.
 - {{domxref("WorkerGlobalScope.importScripts", "ServiceWorkerGlobalScope.importScripts()")}}
   - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-- {{domxref("Window.requestAnimationFrame", "ServiceWorkerGlobalScope.requestAnimationFrame()")}}
-  - : Requests the browser to execute a callback function before painting the next frame.
 - {{domxref("setInterval", "ServiceWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
 - {{domxref("setTimeout", "ServiceWorkerGlobalScope.setTimeout()")}}

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -56,8 +56,6 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Decodes a string of data which has been encoded using base-64 encoding.
 - {{domxref("btoa", "SharedWorkerGlobalScope.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("Window.cancelAnimationFrame", "SharedWorkerGlobalScope.cancelAnimationFrame()")}}
-  - : Cancels a callback scheduled by requestAnimationFrame.
 - {{domxref("clearInterval", "SharedWorkerGlobalScope.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval")}}.
 - {{domxref("clearTimeout", "SharedWorkerGlobalScope.clearTimeout()")}}
@@ -66,8 +64,6 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Writes a message to the console.
 - {{domxref("WorkerGlobalScope.importScripts", "SharedWorkerGlobalScope.importScripts()")}}
   - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-- {{domxref("Window.requestAnimationFrame", "SharedWorkerGlobalScope.requestAnimationFrame()")}}
-  - : Requests the browser to execute a callback function before painting the next frame.
 - {{domxref("setInterval", "SharedWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
 - {{domxref("setTimeout", "SharedWorkerGlobalScope.setTimeout()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove AnimationFrameProvider methods `cancelAnimationFrame` and `requestAniamtionFrame` from both the `ServiceWorker` and `SharedWorker` pages.

### Motivation

`requestAnimationFrame`  and `cancelAnimationFrame` are only exposed on `Window` and `DedicatedWorkerGlobalScope` other Worker types do not inherit it.

### Additional details
https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider
> ```js
> Window includes AnimationFrameProvider;  
> DedicatedWorkerGlobalScope includes AnimationFrameProvider;
> ```

### Related issues and pull requests
–
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
