### PR TITLE
`toISOString()` is wrong for `datetime-local`

### DIFF
--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -47,8 +47,6 @@ const dateControl = document.querySelector('input[type="datetime-local"]');
 dateControl.value = "2017-06-01T08:30";
 ```
 
-There are several methods provided by JavaScript's {{jsxref("Date")}} that can be used to convert numeric date information into a properly-formatted string. For example, the {{jsxref("Date.toISOString()")}} method returns the date/time in UTC with the suffix "`Z`" denoting that timezone; removing the "`Z`" would provide a value in the format expected by a `datetime-local` input.
-
 ## Additional attributes
 
 In addition to the attributes common to all {{HTMLElement("input")}} elements, datetime-local inputs offer the following attributes.


### PR DESCRIPTION

### Description

Removed incorrect information about formatting Date objects for the datetime-local input. 

There aren't several methods to format a Date object for the datetime-local input. Either the user manually constructs a string in the correct format or they use a 3rd party library, and the example of using `toISOString()` is wrong. It will produce the wrong time in any timezone other than GMT.

### Motivation

To remove misleading and incorrect statement from the docs. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
