### PR TITLE
New page: namespace combinator

### DIFF
--- a/files/en-us/web/css/namespace_prefix/index.md
+++ b/files/en-us/web/css/namespace_prefix/index.md
@@ -1,0 +1,107 @@
+---
+title: Namespace prefix
+slug: Web/CSS/Namespace_prefix
+page-type: css-combinator
+browser-compat: css.selectors.namespace
+---
+
+{{CSSRef("Selectors")}}
+
+The **namespace prefix** (`|`) identifies the namespace, or lack thereof, for a type selector.
+
+```css
+/* Links in the namespace named myNameSpace */
+myNameSpace|a {
+  font-weight: bold;
+}
+/* paragraphs in any or no namespace */
+*|p {
+  color: darkblue;
+}
+/* heading level 2 not in a namespace */
+|h2 {
+  margin-bottom: 0;
+}
+```
+
+[Type selectors](/en-US/docs/Web/CSS/Type_selectors) and the [universal selector](/en-US/docs/Web/CSS/Universal_selectors) allow an optional namespace component. When a namespace has been previously declared via {{CSSXref("@namespace")}}, these selectors can be namespaced by prepending the selector with name of the namespace separated by the namespace separator (`|`). This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
+
+- `ns|h1` - matches `<h1>` elements in namespace `ns`
+- `*|h1` - matches all `<h1>` elements
+- `|h1` - matches all `<h1>` elements outside of any declared or implied namespace
+
+## Syntax
+
+```css
+namespace|element { style properties }
+```
+
+## Examples
+
+#### CSS
+
+The CSS declares two namespaces, then assigns styles to links globally, to links in no name space, any namespace or no namespace, and than to two different named namespaces.
+
+```css
+@namespace myNamespace url("http://www.w3.org/2000/svg");
+@namespace defaultNameSpace url("http://www.w3.org/1999/xhtml");
+/* all namespaces or no namespace */
+a {
+  font-size: 1.4rem;
+}
+/* no name space */
+|a {
+  text-decoration: wavy overline lime;
+  font-weight: bold;
+}
+/* all namespaces or no namespace */
+*|a {
+  color: red;
+  fill: red;
+  font-style: italic;
+}
+/* only the myNamespace namespace */
+myNamespace|a {
+  color: green;
+  fill: green;
+}
+/* all HTML is in a namespace */
+defaultNameSpace|a {
+  text-decoration-line: line-through;
+}
+```
+
+#### HTML
+
+The HTML contains two links. One link is in an SVG with a explicitly declared namespace.
+
+```html
+<p>This paragraph <a href="#">has a link</a>.</p>
+
+<svg width="400" viewBox="0 0 400 20">
+  <a href="#">
+    <text x="0" y="15">Link created in SVG</text>
+  </a>
+</svg>
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 100)}}
+
+The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is implied.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [@namespace](/en-US/docs/Web/CSS/@namespace)
+- [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
+- [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
+- [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -14,7 +14,7 @@ The **namespace separator** (`|`) separates the selector from the namespace, ide
 myNameSpace|a {
   font-weight: bold;
 }
-/* paragraphs in any or no namespace */
+/* paragraphs in any namespace (including no namespace) */
 *|p {
   color: darkblue;
 }
@@ -38,7 +38,7 @@ namespace|element { style properties }
 
 ## Examples
 
-#### CSS
+### CSS
 
 The CSS declares two namespaces, then assigns styles to links globally, to links in no name space, any namespace or no namespace, and than to two different named namespaces.
 
@@ -49,12 +49,12 @@ The CSS declares two namespaces, then assigns styles to links globally, to links
 a {
   font-size: 1.4rem;
 }
-/* no name space */
+/* no namespace */
 |a {
   text-decoration: wavy overline lime;
   font-weight: bold;
 }
-/* all namespaces or no namespace */
+/* all namespaces (including no namespace) */
 *|a {
   color: red;
   fill: red;

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -183,7 +183,7 @@ The selector with no namespace, the `|a`, matched the JavaScript defined and app
 
 - [`@namespace`](/en-US/docs/Web/CSS/@namespace)
 - [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
-- [Element.namespaceURI](/en-US/docs/Web/API/Element/namespaceURI) property
+- [`Element.namespaceURI`](/en-US/docs/Web/API/Element/namespaceURI) property
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
 - [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.namespace
 
 {{CSSRef("Selectors")}}
 
-The **namespace prefix** (`|`) separates the selector from the namespace, identifying the namespace, or lack thereof, for a type selector.
+The **namespace separator** (`|`) separates the selector from the namespace, identifying the namespace, or lack thereof, for a type selector.
 
 ```css
 /* Links in the namespace named myNameSpace */

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -1,13 +1,13 @@
 ---
-title: Namespace prefix
-slug: Web/CSS/Namespace_prefix
+title: Namespace separator
+slug: Web/CSS/Namespace_separator
 page-type: css-combinator
 browser-compat: css.selectors.namespace
 ---
 
 {{CSSRef("Selectors")}}
 
-The **namespace prefix** (`|`) identifies the namespace, or lack thereof, for a type selector.
+The **namespace prefix** (`|`) separates the selector from the namespace, identifying the namespace, or lack thereof, for a type selector.
 
 ```css
 /* Links in the namespace named myNameSpace */

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -182,7 +182,7 @@ The selector with no namespace, the `|a`, matched the JavaScript defined and app
 ## See also
 
 - [`@namespace`](/en-US/docs/Web/CSS/@namespace)
-- [`Document.createElementNS()](/en-US/docs/Web/API/Document/createElementNS) method
+- [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
 - [Element.namespaceURI](/en-US/docs/Web/API/Element/namespaceURI) property
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -40,11 +40,11 @@ namespace|element { style properties }
 
 ### CSS
 
-The CSS declares two namespaces, then assigns styles to links globally, to links in no name space, any namespace or no namespace, and than to two different named namespaces.
+The CSS declares two namespaces, then assigns styles to links globally (`a`), to links in no namespace (`|a`), to links in any namespace or no namespace (`*|a`), and then to two different named namespaces (`svgNamespace|a` and `htmlNameSpace|a`).
 
 ```css
-@namespace myNamespace url("http://www.w3.org/2000/svg");
-@namespace defaultNameSpace url("http://www.w3.org/1999/xhtml");
+@namespace svgNamespace url("http://www.w3.org/2000/svg");
+@namespace htmlNameSpace url("http://www.w3.org/1999/xhtml");
 /* all namespaces or no namespace */
 a {
   font-size: 1.4rem;
@@ -60,20 +60,20 @@ a {
   fill: red;
   font-style: italic;
 }
-/* only the myNamespace namespace */
-myNamespace|a {
+/* only the svgNamespace namespace, which is <svg> content */
+svgNamespace|a {
   color: green;
   fill: green;
 }
-/* all HTML is in a namespace */
-defaultNameSpace|a {
+/* The htmlNameSpace namespace, which is the HTML document */
+htmlNameSpace|a {
   text-decoration-line: line-through;
 }
 ```
 
 #### HTML
 
-The HTML contains two links. One link is in an SVG with a explicitly declared namespace.
+The HTML contains two links. No namespaces are explicitly declared.
 
 ```html
 <p>This paragraph <a href="#">has a link</a>.</p>
@@ -89,7 +89,7 @@ The HTML contains two links. One link is in an SVG with a explicitly declared na
 
 {{EmbedLiveSample("Examples", "100%", 100)}}
 
-The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is implied.
+The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace, even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is also implied. This means all the content is within at least one namespace.
 
 ## Specifications
 

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -108,7 +108,7 @@ In this example, we use JavaScript to create an element without a namespace and 
 No namespaces are explicitly declared in the HTML or within the SVG.
 
 ```html
-<p>In the default namespace <a href="#">has a link</a>.</p>
+<p><a href="#">A link</a> in the implied HTML namespace.</p>
 
 <svg width="400" viewBox="0 0 400 20">
   <a href="#">
@@ -132,7 +132,7 @@ document.body.appendChild(a);
 
 #### CSS
 
-We declare a namespace with {{cssxref("@namespace")}}. By ommitting the name for the namespace, the `@namespace` declaration creates a default namespace. name for the name.
+We declare a namespace with {{cssxref("@namespace")}}. By omitting the name for the namespace, the `@namespace` declaration creates a default namespace.
 
 ```css
 /* By ommitting a name, this sets SVG as the default namespace */
@@ -151,7 +151,7 @@ p {
 
 /* links outside of any namespace */
 |a {
-  text-decoration: wavy overline purple;
+  text-decoration: wavy underline purple;
   font-weight: bold;
 }
 

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -24,7 +24,7 @@ myNameSpace|a {
 }
 ```
 
-[Type selectors](/en-US/docs/Web/CSS/Type_selectors) and the [universal selector](/en-US/docs/Web/CSS/Universal_selectors) allow an optional namespace component. When a namespace has been previously declared via {{CSSXref("@namespace")}}, these selectors can be namespaced by prepending the selector with name of the namespace separated by the namespace separator (`|`). This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
+[Type selectors](/en-US/docs/Web/CSS/Type_selectors) and the [universal selector](/en-US/docs/Web/CSS/Universal_selectors) allow an optional namespace component. When a namespace has been previously declared via {{CSSXref("@namespace")}}, these selectors can be namespaced by prepending the selector with the name of the namespace separated by the namespace separator (`|`). This is useful when dealing with documents containing multiple namespaces such as HTML with inline SVG or MathML, or XML that mixes multiple vocabularies.
 
 - `ns|h1` - matches `<h1>` elements in namespace `ns`
 - `*|h1` - matches all `<h1>` elements
@@ -38,14 +38,20 @@ namespace|element { style properties }
 
 ## Examples
 
-### CSS
+By default, all elements in an HTML or SVG element have a namespace as the `http://www.w3.org/1999/xhtml` and   `http://www.w3.org/2000/svg` namespace are implied. The {{domxref("document.createElementNS")}} method, with an empty string for the namespace parameter, can be used to create elements with no namespace.
+
+### Named namespace example
+
+In this example, all elements are in a namespace.
+
+#### CSS
 
 The CSS declares two namespaces, then assigns styles to links globally (`a`), to links in no namespace (`|a`), to links in any namespace or no namespace (`*|a`), and then to two different named namespaces (`svgNamespace|a` and `htmlNameSpace|a`).
 
 ```css
 @namespace svgNamespace url("http://www.w3.org/2000/svg");
 @namespace htmlNameSpace url("http://www.w3.org/1999/xhtml");
-/* all namespaces or no namespace */
+/* all links (see next example for exceptions) */
 a {
   font-size: 1.4rem;
 }
@@ -85,11 +91,15 @@ The HTML contains two links. No namespaces are explicitly declared.
 </svg>
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples", "100%", 100)}}
+{{EmbedLiveSample("Named namespace example", "100%", 100)}}
 
 The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace, even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is also implied. This means all the content is within at least one namespace.
+
+### Unnamed namedspace and elements with no namespace
+
+In this example, we use JavaScript to create an element without a namespace and append it to the 
 
 ## Specifications
 

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -38,7 +38,7 @@ namespace|element { style properties }
 
 ## Examples
 
-By default, all elements in an HTML or SVG element have a namespace as the `http://www.w3.org/1999/xhtml` and   `http://www.w3.org/2000/svg` namespace are implied. The {{domxref("document.createElementNS")}} method, with an empty string for the namespace parameter, can be used to create elements with no namespace.
+By default, all elements in an HTML or SVG element have a namespace as the `http://www.w3.org/1999/xhtml` and `http://www.w3.org/2000/svg` namespace are implied. The {{domxref("document.createElementNS")}} method, with an empty string for the namespace parameter, can be used to create elements with no namespace.
 
 ### Named namespace example
 
@@ -101,7 +101,7 @@ The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, 
 
 In this example, we use JavaScript to create an element without a namespace and append it to the document. We set the SVG namespace to be the default namespace by defining the unnamed namespace with `@namespace`.
 
->**Note:** If a default, or unnamed, namespace is defined, universal and type selectors apply only to elements in that namespace.
+> **Note:** If a default, or unnamed, namespace is defined, universal and type selectors apply only to elements in that namespace.
 
 #### HTML
 
@@ -123,9 +123,9 @@ With JavaScript, with {{DOMXRef("document.createElementNS")}}, we create an anch
 
 ```js
 // create 'no namespace' anchor
-const a = document.createElementNS('', 'a');
-a.href='#';
-a.appendChild(document.createTextNode('Link created without a namespace'));
+const a = document.createElementNS("", "a");
+a.href = "#";
+a.appendChild(document.createTextNode("Link created without a namespace"));
 
 document.body.appendChild(a);
 ```
@@ -143,7 +143,7 @@ a {
   font-size: 1.4rem;
 }
 
-/* `<svg>` and `<p>` in the default (set to SVG) namespace */ 
+/* `<svg>` and `<p>` in the default (set to SVG) namespace */
 svg,
 p {
   border: 5px solid gold;

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.namespace
 
 {{CSSRef("Selectors")}}
 
-The **namespace separator** (`|`) separates the selector from the namespace, identifying the namespace, or lack thereof, for a type selector.
+The **namespace separator** (`|`) separates the selector from the namespace, identifying the {{glossary("namespace")}}, or lack thereof, for a type selector.
 
 ```css
 /* Links in the namespace named myNameSpace */
@@ -44,6 +44,20 @@ By default, all elements in an HTML or SVG element have a namespace as the `http
 
 In this example, all elements are in a namespace.
 
+#### HTML
+
+No namespaces are explicitly declared in the HTML or within the SVG.
+
+```html
+<p>This paragraph <a href="#">has a link</a>.</p>
+
+<svg width="400" viewBox="0 0 400 20">
+  <a href="#">
+    <text x="0" y="15">Link created in SVG</text>
+  </a>
+</svg>
+```
+
 #### CSS
 
 The CSS declares two namespaces, then assigns styles to links globally (`a`), to links in no namespace (`|a`), to links in any namespace or no namespace (`*|a`), and then to two different named namespaces (`svgNamespace|a` and `htmlNameSpace|a`).
@@ -51,7 +65,7 @@ The CSS declares two namespaces, then assigns styles to links globally (`a`), to
 ```css
 @namespace svgNamespace url("http://www.w3.org/2000/svg");
 @namespace htmlNameSpace url("http://www.w3.org/1999/xhtml");
-/* all links (see next example for exceptions) */
+/* All `<a>`s in the default namespace, in this case, all `<a>`s */
 a {
   font-size: 1.4rem;
 }
@@ -77,29 +91,85 @@ htmlNameSpace|a {
 }
 ```
 
-#### HTML
-
-The HTML contains two links. No namespaces are explicitly declared.
-
-```html
-<p>This paragraph <a href="#">has a link</a>.</p>
-
-<svg width="400" viewBox="0 0 400 20">
-  <a href="#">
-    <text x="0" y="15">Link created in SVG</text>
-  </a>
-</svg>
-```
-
 #### Result
 
 {{EmbedLiveSample("Named namespace example", "100%", 100)}}
 
 The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace, even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is also implied. This means all the content is within at least one namespace.
 
-### Unnamed namedspace and elements with no namespace
+### Unnamed namespace and elements with no namespace
 
-In this example, we use JavaScript to create an element without a namespace and append it to the 
+In this example, we use JavaScript to create an element without a namespace and append it to the document. We set the SVG namespace to be the default namespace by defining the unnamed namespace with `@namespace`.
+
+>**Note:** If a default, or unnamed, namespace is defined, universal and type selectors apply only to elements in that namespace.
+
+#### HTML
+
+No namespaces are explicitly declared in the HTML or within the SVG.
+
+```html
+<p>In the default namespace <a href="#">has a link</a>.</p>
+
+<svg width="400" viewBox="0 0 400 20">
+  <a href="#">
+    <text x="0" y="15">Link created in SVG namespace</text>
+  </a>
+</svg>
+```
+
+#### JavaScript
+
+With JavaScript, with {{DOMXRef("document.createElementNS")}}, we create an anchor link without a namespace, then append the link.
+
+```js
+// create 'no namespace' anchor
+const a = document.createElementNS('', 'a');
+a.href='#';
+a.appendChild(document.createTextNode('Link created without a namespace'));
+
+document.body.appendChild(a);
+```
+
+#### CSS
+
+We declare a namespace with {{cssxref("@namespace")}}. By ommitting the name for the namespace, the `@namespace` declaration creates a default namespace. name for the name.
+
+```css
+/* By ommitting a name, this sets SVG as the default namespace */
+@namespace url("http://www.w3.org/2000/svg");
+
+/* `<a>` in the default (set to SVG) namespace */
+a {
+  font-size: 1.4rem;
+}
+
+/* `<svg>` and `<p>` in the default (set to SVG) namespace */ 
+svg,
+p {
+  border: 5px solid gold;
+}
+
+/* links outside of any namespace */
+|a {
+  text-decoration: wavy overline purple;
+  font-weight: bold;
+}
+
+/* links with any namespace or no namespace */
+*|a {
+  font-style: italic;
+  color: magenta;
+  fill: magenta;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Unnamed namespace and elements with no namespace", "100%", 100)}}
+
+The selector with no namespace separator, the `a`, matched only the SVG `<a>` elements, as SVG was set as the default namespace.
+
+The selector with no namespace, the `|a`, matched the JavaScript defined and appended `<a>`, as that node is the only node that doesn't have a default namespace.
 
 ## Specifications
 
@@ -112,6 +182,8 @@ In this example, we use JavaScript to create an element without a namespace and 
 ## See also
 
 - [`@namespace`](/en-US/docs/Web/CSS/@namespace)
+- [`Document.createElementNS()](/en-US/docs/Web/API/Document/createElementNS) method
+- [Element.namespaceURI](/en-US/docs/Web/API/Element/namespaceURI) property
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
 - [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -93,11 +93,11 @@ htmlNameSpace|a {
 
 #### Result
 
-{{EmbedLiveSample("Named namespace example", "100%", 100)}}
+{{EmbedLiveSample("Named_namespace_example", "100%", 100)}}
 
 The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, the `http://www.w3.org/1999/xhtml` is implied, meaning all HTML is in a namespace, even if none is explicitly declared. In SVG, even if not explicitly set, the `http://www.w3.org/2000/svg` namespace is also implied. This means all the content is within at least one namespace.
 
-### Unnamed namespace and elements with no namespace
+### Default namespace and no namespace
 
 In this example, we use JavaScript to create an element without a namespace and append it to the document. We set the SVG namespace to be the default namespace by defining the unnamed namespace with `@namespace`.
 
@@ -165,7 +165,7 @@ p {
 
 #### Result
 
-{{EmbedLiveSample("Unnamed namespace and elements with no namespace", "100%", 100)}}
+{{EmbedLiveSample("Default_namespace_and_no_namespace", "100%", 100)}}
 
 The selector with no namespace separator, the `a`, matched only the SVG `<a>` elements, as SVG was set as the default namespace.
 

--- a/files/en-us/web/css/namespace_separator/index.md
+++ b/files/en-us/web/css/namespace_separator/index.md
@@ -101,7 +101,7 @@ The selector `|a`, a link not in a namespace, doesn't match any links. In HTML, 
 
 ## See also
 
-- [@namespace](/en-US/docs/Web/CSS/@namespace)
+- [`@namespace`](/en-US/docs/Web/CSS/@namespace)
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
 - [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)


### PR DESCRIPTION
While mentioned on the universal selector page and type selector pages, there was no documentation for this namespace separator, which is a type of CSS combinator.