### PR TITLE
fix: add multiple specs to CSS `caption-side` page to cover all values mentioned in specs

### DIFF
--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -3,6 +3,9 @@ title: caption-side
 slug: Web/CSS/caption-side
 page-type: css-property
 browser-compat: css.properties.caption-side
+spec-urls: 
+  - https://drafts.csswg.org/css2/#propdef-caption-side
+  - https://drafts.csswg.org/css-logical/#caption-side
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -3,7 +3,7 @@ title: caption-side
 slug: Web/CSS/caption-side
 page-type: css-property
 browser-compat: css.properties.caption-side
-spec-urls: 
+spec-urls:
   - https://drafts.csswg.org/css2/#propdef-caption-side
   - https://drafts.csswg.org/css-logical/#caption-side
 ---


### PR DESCRIPTION
Fixes #22271

