### PR TITLE
Auto-add more content labels; make PR/issue label consistent

### DIFF
--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -4,8 +4,14 @@ Content:CSS:
   - '\/docs\/Web\/CSS'
 Content:Events:
   - '\/docs\/Web\/Events'
+Content:Firefox:
+  - '\/docs\/Mozilla/Firefox'
+Content:Games:
+  - '\/docs\/Games'
 Content:Glossary:
   - '\/docs\/Glossary'
+Content:Guide:
+  - '\/docs\/Web/Guide'
 Content:HTML:
   - '\/docs\/Web\/HTML'
 Content:HTTP:
@@ -24,6 +30,8 @@ Content:Learn:CSS:
   - '\/docs\/Learn\/CSS'
 Content:Learn:Django:
   - '\/docs\/Learn\/Server-side\/Django'
+Content:Learn:Express:
+  - '\/docs\/Learn\/Server-side\/Express_Nodejs'
 Content:Learn:Forms:
   - '\/docs\/Learn\/Forms'
 Content:Learn:GitHub:
@@ -34,8 +42,16 @@ Content:Learn:JavaScript:
   - '\/docs\/Learn\/JavaScript'
 Content:Manifest:
   - '\/docs\/Web\/Manifest'
+Content:MathML:
+  - '\/docs\/Web\/MathML'
+Content:Media:
+  - '\/docs\/Web\/Media'
+Content:Meta:
+  - '\/docs\/MDN'
 Content:Performance:
   - '\/docs\/Web\/Performance'
+Content:PWA:
+  - '\/docs\/Web\/Progressive_web_apps'
 Content:Security:
   - '\/docs\/Web\/Security'
 Content:SVG:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,20 +2,72 @@ Content:Accessibility:
   - files/en-us/web/accessibility/**/*
 Content:CSS:
   - files/en-us/web/css/**/*
-Content:DevTools:
-  - files/en-us/tools/**/*
+Content:Events:
+  - files/en-us/web/events/**/*
+Content:Firefox:
+  - files/en-us/mozilla/firefox/**/*
+Content:Games:
+  - files/en-us/games/**/*
 Content:Glossary:
   - files/en-us/glossary/**/*
+Content:Guide:
+  - files/en-us/web/guide/**/*
 Content:HTML:
   - files/en-us/web/html/**/*
 Content:HTTP:
   - files/en-us/web/http/**/*
 Content:JS:
   - files/en-us/web/javascript/**/*
+Content:Learn:
+  - any:
+      - files/en-us/learn/**/*
+      - "!files/en-us/learn/accessibility/**/*"
+      - "!files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/**/*"
+      - "!files/en-us/learn/tools_and_testing/understanding_client-side_tools/**/*"
+      - "!files/en-us/learn/tools_and_testing/cross_browser_testing/**/*"
+      - "!files/en-us/learn/css/**/*"
+      - "!files/en-us/learn/server-side/django/**/*"
+      - "!files/en-us/learn/server-side/express_nodejs/**/*"
+      - "!files/en-us/learn/forms/**/*"
+      - "!files/en-us/learn/tools_and_testing/github/**/*"
+      - "!files/en-us/learn/html/**/*"
+      - "!files/en-us/learn/javascript/**/*"
+  - files/en-us/web/tutorials/**/*
+Content:Learn:Accessibility:
+  - files/en-us/learn/accessibility/**/*
+Content:Learn:Client-side:
+  - files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/**/*
+  - files/en-us/learn/tools_and_testing/understanding_client-side_tools/**/*
+Content:Learn:Cross-Browser-Testing:
+  - files/en-us/learn/tools_and_testing/cross_browser_testing/**/*
+Content:Learn:CSS:
+  - files/en-us/learn/css
+Content:Learn:Django:
+  - files/en-us/learn/server-side/django/**/*
+Content:Learn:Express:
+  - files/en-us/learn/server-side/express_nodejs/**/*
+Content:Learn:Forms:
+  - files/en-us/learn/forms/**/*
+Content:Learn:GitHub:
+  - files/en-us/learn/tools_and_testing/github/**/*
+Content:Learn:HTML:
+  - files/en-us/learn/html/**/*
+Content:Learn:JavaScript:
+  - files/en-us/learn/javascript/**/*
+Content:Manifest:
+  - files/en-us/web/manifest/**/*
 Content:MathML:
   - files/en-us/web/mathml/**/*
 Content:Media:
   - files/en-us/web/media/**/*
+Content:Meta:
+  - files/en-us/mdn/**/*
+Content:Performance:
+  - files/en-us/web/performance/**/*
+Content:PWA:
+  - files/en-us/web/progressive_web_apps/**/*
+Content:Security:
+  - files/en-us/web/security/**/*
 Content:SVG:
   - files/en-us/web/svg/**/*
 Content:wasm:
@@ -26,27 +78,17 @@ Content:WebDriver:
   - files/en-us/web/webdriver/**/*
 Content:WebExt:
   - files/en-us/mozilla/add-ons/webextensions/**/*
-Content:Learn:
-  - files/en-us/learn/**/*
-  - files/en-us/web/guide/**/*
-  - files/en-us/web/tutorials/**/*
 Content:Other:
-  - files/en-us/games/**/*
-  - files/en-us/mdn/**/*
-  - files/en-us/mozilla/**/*
-  - files/en-us/plugins/**/*
+  - any:
+      - files/en-us/mozilla/**/*
+      - "!files/en-us/mozilla/add-ons/webextensions/**/*"
+      - "!files/en-us/mozilla/firefox/**/*"
   - files/en-us/related/**/*
-  - files/en-us/tools/**/*
   - files/en-us/web/demos/**/*
-  - files/en-us/web/events/**/*
   - files/en-us/web/exslt/**/*
-  - files/en-us/web/manifest/**/*
   - files/en-us/web/opensearch/**/*
-  - files/en-us/web/performance/**/*
   - files/en-us/web/privacy/**/*
-  - files/en-us/web/progressive_web_apps/**/*
-  - files/en-us/web/security/**/*
-  - files/en-us/web/web_components/**/*
+  - files/en-us/web/text_fragments/**/*
   - files/en-us/web/xml/**/*
   - files/en-us/web/xpath/**/*
   - files/en-us/web/xslt/**/*


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

We use two sets of categorization for issues and PRs, which is confusing. This PR makes them perfectly consistent.

In addition, I've added some labels that are present in the repo but don't get auto-added.

cc @sideshowbarker 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
