### PR TITLE
Update link element docs for rel=preload modulepreload

### DIFF
--- a/files/en-us/web/api/htmllinkelement/as/index.md
+++ b/files/en-us/web/api/htmllinkelement/as/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLLinkElement.as
 
 The **`as`** property of the {{domxref("HTMLLinkElement")}} interface returns a string representing the type of content to be preloaded by a link element.
 
-The `as` property must be applied link elements where [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload), or the resource will not be fetched.
+The `as` property must have a value for link elements when [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload), or the resource will not be fetched.
 It may also be applied to link elements where [`rel="modulepreload"`](/en-US/docs/Web/HTML/Attributes/rel/preload), but if omitted, will default to `script`.
 The property should not be set for other types of link elements, such as `rel="prefetch"`.
 

--- a/files/en-us/web/api/htmllinkelement/as/index.md
+++ b/files/en-us/web/api/htmllinkelement/as/index.md
@@ -8,15 +8,17 @@ browser-compat: api.HTMLLinkElement.as
 
 {{APIRef("HTML DOM")}}
 
-The **`as`** property of the {{domxref("HTMLLinkElement")}}
-interface returns a string representing the type of content being
-loaded by the HTML link, one of `"script"`, `"style"`,
-`"image"`, `"video"`, `"audio"`, `"track"`,
-`"font"`, `"fetch"`.
+The **`as`** property of the {{domxref("HTMLLinkElement")}} interface returns a string representing the type of content to be preloaded by a link element.
+
+The `as` property must be applied link elements where [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload), or the resource will not be fetched.
+It may also be applied to link elements where [`rel="modulepreload"`](/en-US/docs/Web/HTML/Attributes/rel/preload), but if omitted, will default to `script`.
+The property should not be set for other types of link elements, such as `rel="prefetch"`.
+
+This property reflects the value of the [`as` attribute](/en-US/docs/Web/HTML/Element/link#as) of the [`<link>`](/en-US/docs/Web/HTML/Element/link) HTML element.
 
 ## Value
 
-A string.
+A string with the following allowed values: `"audio"`, `"document"`, `"embed"`, `"fetch"`, `"font"`, `"image"`, `"object"`, `"script"`, `"style"`, `"track"`, `"video"`, `"worker"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -16,7 +16,7 @@ The **`HTMLLinkElement`** interface represents reference information for externa
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLLinkElement.as")}}
-  - : A string representing the type of content being loaded by the HTML link.
+  - : A string representing the type of content being loaded by the HTML link when [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) or [`rel="modulepreload"`](/en-US/docs/Web/HTML/Attributes/rel/modulepreload).
 - {{domxref("HTMLLinkElement.crossOrigin")}}
   - : A string that corresponds to the CORS setting for this link element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for details.
 - {{domxref("HTMLLinkElement.disabled")}}

--- a/files/en-us/web/html/attributes/rel/modulepreload/index.md
+++ b/files/en-us/web/html/attributes/rel/modulepreload/index.md
@@ -7,7 +7,9 @@ browser-compat: html.elements.link.rel.modulepreload
 
 {{HTMLSidebar}}
 
-The **`modulepreload`** keyword for the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute of the {{HTMLElement("link")}} element provides a declarative way to preemptively fetch a [module script](/en-US/docs/Web/JavaScript/Guide/Modules) and its dependencies, and store them in the document's module map for later evaluation.
+The **`modulepreload`** keyword, for the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute of the {{HTMLElement("link")}} element, provides a declarative way to preemptively fetch a [module script](/en-US/docs/Web/JavaScript/Guide/Modules) and its dependencies, and store them in the document's module map for later evaluation.
+
+The type of the preloaded module may also be set to `"script"` using the [`as`](/en-US/docs/Web/HTML/Element/link#as) attribute (`as="script"`), though this is not required as it is the default.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -80,8 +80,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - `as`
 
-  - : This attribute is only used when [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) has been set on the `<link>` element.
+  - : This attribute is required when [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) has been set on the `<link>` element, optional when [`rel="modulepreload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) has been set, and otherwise should not be used.
     It specifies the type of content being loaded by the `<link>`, which is necessary for request matching, application of correct [content security policy](/en-US/docs/Web/HTTP/CSP), and setting of correct {{HTTPHeader("Accept")}} request header.
+
     Furthermore, `rel="preload"` uses this as a signal for request prioritization.
     The table below lists the valid values for this attribute and the elements or resources they apply to.
 


### PR DESCRIPTION
Some of the docs around `rel="preload"` weren't completely up to date. I also wanted to make very clear that the `as` is only set for preload and not for prefetch.

This a peripheral part of #27171