### PR TITLE
FF115 Relnote: Sec-Purpose HTTP header

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -38,8 +38,7 @@ This article provides information about the changes in Firefox 115 that affect d
 ### HTTP
 
 - The [`Sec-Purpose`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose) HTTP {{Glossary("Fetch metadata request header", "fetch metadata request header")}} is now included in requests to {{Glossary("Prefetch")}} resources.
-  This allows servers to provide any special handling that might be needed, such as adjusting the caching expiry for the request.
-  ([Firefox bug 1836328](https://bugzil.la/1836328)).
+  This allows servers to provide any special handling that might be needed, such as adjusting the caching expiry for the request ([Firefox bug 1836328](https://bugzil.la/1836328)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -37,6 +37,10 @@ This article provides information about the changes in Firefox 115 that affect d
 
 ### HTTP
 
+- The [`Sec-Purpose`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose) HTTP {{Glossary("Fetch metadata request header", "fetch metadata request header")}} is now included in requests to {{Glossary("Prefetch")}} resources.
+  This allows servers to provide any special handling that might be needed, such as adjusting the caching expiry for the request.
+  ([Firefox bug 1836328](https://bugzil.la/1836328)).
+
 #### Removals
 
 ### Security


### PR DESCRIPTION
FF115 adds the `Sec-Purpose` HTTP header in https://bugzilla.mozilla.org/show_bug.cgi?id=1836328. This adds the release note.

Related docs work can be tracked in #27171