### PR TITLE
fix: Incorrect range for exception in Number.toExponential()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.md
@@ -34,7 +34,7 @@ with one digit before the decimal point, rounded to
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : Thrown if `fractionDigits` is not between `1` and `100` (inclusive).
+  - : Thrown if `fractionDigits` is not between `0` and `100` (inclusive).
 - {{jsxref("TypeError")}}
   - : Thrown if this method is invoked on an object that is not a {{jsxref("Number")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The spec defines that the RangeError should appear if the `toExponential` parameter is not between `0` and `100`. In the definition of the `toExponential` parameter the range is defined correctly but not in the `Exceptions` section.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This change will make the page consistent with the spec and avoid any confusion that a person might have when reading it.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

The page with the issue: hhttps://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
