### PR TITLE
docs(CSS): Minor updates to hue color wheel on bottom text (180deg)

### DIFF
--- a/files/en-us/web/css/hue/color_wheel.svg
+++ b/files/en-us/web/css/hue/color_wheel.svg
@@ -1,1 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"><style>text{font:20px sans-serif}</style><path fill="#fff" d="M0 0h400v400H0z"/><foreignObject width="320" height="320" x="40" y="40"><div xmlns="http://www.w3.org/1999/xhtml" style="background:conic-gradient(red,#ff0,#0f0,#0ff,#00f,#f0f,red);background:conic-gradient(in hsl longer hue,red,red);border-radius:50%;height:100%;width:100%"/></foreignObject><text x="200" y="30" text-anchor="middle">0°</text><text x="347" y="115" dominant-baseline="middle">60°</text><text x="347" y="285" dominant-baseline="middle">120°</text><text x="200" y="360" dominant-baseline="hanging" text-anchor="middle">180°</text><text x="53" y="285" dominant-baseline="middle" text-anchor="end">240°</text><text x="53" y="115" dominant-baseline="middle" text-anchor="end">300°</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
+  <style>
+    text {
+      font: 20px sans-serif
+    }
+  </style>
+  <path fill="#fff" d="M0 0h400v400H0z" />
+  <foreignObject width="320" height="320" x="40" y="40">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="background:conic-gradient(red,#ff0,#0f0,#0ff,#00f,#f0f,red);background:conic-gradient(in hsl longer hue,red,red);border-radius:50%;height:100%;width:100%" />
+  </foreignObject><text x="200" y="30" text-anchor="middle">0°</text><text x="347" y="115" dominant-baseline="middle">60°</text><text x="347" y="285" dominant-baseline="middle">120°</text><text x="200" y="370" dominant-baseline="hanging" text-anchor="middle">180°</text><text x="53" y="285" dominant-baseline="middle" text-anchor="end">240°</text><text x="53" y="115" dominant-baseline="middle" text-anchor="end">300°</text>
+</svg>


### PR DESCRIPTION
After using this resource for the [MDN blog](https://developer.mozilla.org/en-US/blog/learn-css-hues-colors-hsl/#what_is_a_hue) there were some suggested updates to the image to make the label text more legible. This is a minor edit based on feedback that I'm also reflecting on the reference page.

CC @yarusome ;)