### PR TITLE
Add page-type for Web/Manifest

### DIFF
--- a/files/en-us/web/manifest/background_color/index.md
+++ b/files/en-us/web/manifest/background_color/index.md
@@ -1,6 +1,7 @@
 ---
 title: background_color
 slug: Web/Manifest/background_color
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.background_color

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -1,6 +1,7 @@
 ---
 title: categories
 slug: Web/Manifest/categories
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.categories

--- a/files/en-us/web/manifest/description/index.md
+++ b/files/en-us/web/manifest/description/index.md
@@ -1,6 +1,7 @@
 ---
 title: description
 slug: Web/Manifest/description
+page-type: web-manifest-member
 browser-compat: html.manifest.description
 ---
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -1,6 +1,7 @@
 ---
 title: display
 slug: Web/Manifest/display
+page-type: web-manifest-member
 browser-compat: html.manifest.display
 ---
 

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -1,6 +1,7 @@
 ---
 title: display_override
 slug: Web/Manifest/display_override
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.display_override

--- a/files/en-us/web/manifest/file_handlers/index.md
+++ b/files/en-us/web/manifest/file_handlers/index.md
@@ -1,6 +1,7 @@
 ---
 title: file_handlers
 slug: Web/Manifest/file_handlers
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.file_handlers

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -1,6 +1,7 @@
 ---
 title: icons
 slug: Web/Manifest/icons
+page-type: web-manifest-member
 browser-compat: html.manifest.icons
 ---
 

--- a/files/en-us/web/manifest/id/index.md
+++ b/files/en-us/web/manifest/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: id
 slug: Web/Manifest/id
+page-type: web-manifest-member
 browser-compat: html.manifest.id
 ---
 

--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web app manifests
 slug: Web/Manifest
+page-type: landing-page
 browser-compat: html.manifest
 ---
 

--- a/files/en-us/web/manifest/launch_handler/index.md
+++ b/files/en-us/web/manifest/launch_handler/index.md
@@ -1,6 +1,7 @@
 ---
 title: launch_handler
 slug: Web/Manifest/launch_handler
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.launch_handler

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: name
 slug: Web/Manifest/name
+page-type: web-manifest-member
 browser-compat: html.manifest.name
 ---
 

--- a/files/en-us/web/manifest/orientation/index.md
+++ b/files/en-us/web/manifest/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: orientation
 slug: Web/Manifest/orientation
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.orientation

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -1,6 +1,7 @@
 ---
 title: prefer_related_applications
 slug: Web/Manifest/prefer_related_applications
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.prefer_related_applications

--- a/files/en-us/web/manifest/protocol_handlers/index.md
+++ b/files/en-us/web/manifest/protocol_handlers/index.md
@@ -1,6 +1,7 @@
 ---
 title: protocol_handlers
 slug: Web/Manifest/protocol_handlers
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.protocol_handlers

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -1,6 +1,7 @@
 ---
 title: related_applications
 slug: Web/Manifest/related_applications
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.related_applications

--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -1,6 +1,7 @@
 ---
 title: scope
 slug: Web/Manifest/scope
+page-type: web-manifest-member
 browser-compat: html.manifest.scope
 ---
 

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -1,6 +1,7 @@
 ---
 title: screenshots
 slug: Web/Manifest/screenshots
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.screenshots

--- a/files/en-us/web/manifest/serviceworker/index.md
+++ b/files/en-us/web/manifest/serviceworker/index.md
@@ -1,6 +1,7 @@
 ---
 title: serviceworker
 slug: Web/Manifest/serviceworker
+page-type: web-manifest-member
 status:
   - experimental
   - non-standard

--- a/files/en-us/web/manifest/share_target/index.md
+++ b/files/en-us/web/manifest/share_target/index.md
@@ -1,6 +1,7 @@
 ---
 title: share_target
 slug: Web/Manifest/share_target
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.share_target

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -1,6 +1,7 @@
 ---
 title: short_name
 slug: Web/Manifest/short_name
+page-type: web-manifest-member
 browser-compat: html.manifest.short_name
 ---
 

--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -1,6 +1,7 @@
 ---
 title: shortcuts
 slug: Web/Manifest/shortcuts
+page-type: web-manifest-member
 status:
   - experimental
 browser-compat: html.manifest.shortcuts

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -1,6 +1,7 @@
 ---
 title: start_url
 slug: Web/Manifest/start_url
+page-type: web-manifest-member
 browser-compat: html.manifest.start_url
 ---
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -1,6 +1,7 @@
 ---
 title: theme_color
 slug: Web/Manifest/theme_color
+page-type: web-manifest-member
 browser-compat: html.manifest.theme_color
 ---
 

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -242,6 +242,21 @@
       {
         "if": {
           "properties": {
+            "slug": { "type": "string", "pattern": "^Web/Manifest/" }
+          }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": ["guide", "landing-page", "web-manifest-member"]
+            }
+          }
+        },
+        "else": false
+      },
+      {
+        "if": {
+          "properties": {
             "slug": {
               "type": "string",
               "pattern": "^Web/HTTP/Headers/Content-Security-Policy/"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This adds the following page-type for web/manifest

`web-manifest-member`

### Motivation

Members have a specific page structure

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

This is part of openwebdocs/project#91
