### PR TITLE
Add page-types for Games/

### DIFF
--- a/files/en-us/games/anatomy/index.md
+++ b/files/en-us/games/anatomy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Anatomy of a video game
 slug: Games/Anatomy
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/index.md
+++ b/files/en-us/games/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game development
 slug: Games
+page-type: landing-page
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/introduction/index.md
+++ b/files/en-us/games/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to game development for the Web
 slug: Games/Introduction
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/introduction_to_html5_game_development/index.md
+++ b/files/en-us/games/introduction_to_html5_game_development/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to HTML Game Development
 slug: Games/Introduction_to_HTML5_Game_Development
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/publishing_games/game_distribution/index.md
+++ b/files/en-us/games/publishing_games/game_distribution/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game distribution
 slug: Games/Publishing_games/Game_distribution
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/publishing_games/game_monetization/index.md
+++ b/files/en-us/games/publishing_games/game_monetization/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game monetization
 slug: Games/Publishing_games/Game_monetization
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/publishing_games/game_promotion/index.md
+++ b/files/en-us/games/publishing_games/game_promotion/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game promotion
 slug: Games/Publishing_games/Game_promotion
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/publishing_games/index.md
+++ b/files/en-us/games/publishing_games/index.md
@@ -1,6 +1,7 @@
 ---
 title: Publishing games
 slug: Games/Publishing_games
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -1,6 +1,7 @@
 ---
 title: 2D collision detection
 slug: Games/Techniques/2D_collision_detection
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.md
@@ -1,6 +1,7 @@
 ---
 title: Bounding volume collision detection with THREE.js
 slug: Games/Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_collision_detection/index.md
+++ b/files/en-us/games/techniques/3d_collision_detection/index.md
@@ -1,6 +1,7 @@
 ---
 title: 3D collision detection
 slug: Games/Techniques/3D_collision_detection
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/basic_theory/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/basic_theory/index.md
@@ -1,6 +1,7 @@
 ---
 title: Explaining basic 3D theory
 slug: Games/Techniques/3D_on_the_web/Basic_theory
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with A-Frame
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_A-Frame
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with Babylon.js
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Babylon.js
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/editor/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/editor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with PlayCanvas editor
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas/editor
+page-type: guide
 ---
 
 Instead of coding everything from scratch you can also use the online **PlayCanvas editor**. This can be a more pleasant working environment if you are not someone who likes to code.

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with the PlayCanvas engine
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas/engine
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with PlayCanvas
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building up a basic demo with Three.js
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
@@ -1,6 +1,7 @@
 ---
 title: GLSL Shaders
 slug: Games/Techniques/3D_on_the_web/GLSL_Shaders
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/index.md
@@ -1,6 +1,7 @@
 ---
 title: 3D games on the Web
 slug: Games/Techniques/3D_on_the_web
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebVR — Virtual Reality for the Web
 slug: Games/Techniques/3D_on_the_web/WebVR
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/async_scripts/index.md
+++ b/files/en-us/games/techniques/async_scripts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Async scripts for asm.js
 slug: Games/Techniques/Async_scripts
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/audio_for_web_games/index.md
+++ b/files/en-us/games/techniques/audio_for_web_games/index.md
@@ -1,6 +1,7 @@
 ---
 title: Audio for Web games
 slug: Games/Techniques/Audio_for_Web_Games
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
@@ -1,6 +1,7 @@
 ---
 title: Desktop gamepad controls
 slug: Games/Techniques/Control_mechanisms/Desktop_with_gamepad
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
@@ -1,6 +1,7 @@
 ---
 title: Desktop mouse and keyboard controls
 slug: Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/control_mechanisms/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/index.md
@@ -1,6 +1,7 @@
 ---
 title: Implementing game control mechanisms
 slug: Games/Techniques/Control_mechanisms
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mobile touch controls
 slug: Games/Techniques/Control_mechanisms/Mobile_touch
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/control_mechanisms/other/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/other/index.md
@@ -1,6 +1,7 @@
 ---
 title: Unconventional controls
 slug: Games/Techniques/Control_mechanisms/Other
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/controls_gamepad_api/index.md
+++ b/files/en-us/games/techniques/controls_gamepad_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Implementing controls using the Gamepad API
 slug: Games/Techniques/Controls_Gamepad_API
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/crisp_pixel_art_look/index.md
+++ b/files/en-us/games/techniques/crisp_pixel_art_look/index.md
@@ -1,6 +1,7 @@
 ---
 title: Crisp pixel art look with image-rendering
 slug: Games/Techniques/Crisp_pixel_art_look
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/index.md
+++ b/files/en-us/games/techniques/index.md
@@ -1,6 +1,7 @@
 ---
 title: Techniques for game development
 slug: Games/Techniques
+page-type: landing-page
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/tilemaps/index.md
+++ b/files/en-us/games/techniques/tilemaps/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tiles and tilemaps overview
 slug: Games/Techniques/Tilemaps
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/webrtc_data_channels/index.md
+++ b/files/en-us/games/techniques/webrtc_data_channels/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebRTC data channels
 slug: Games/Techniques/WebRTC_data_channels
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tools/asm.js/index.md
+++ b/files/en-us/games/tools/asm.js/index.md
@@ -1,6 +1,7 @@
 ---
 title: asm.js
 slug: Games/Tools/asm.js
+page-type: guide
 status:
   - deprecated
 ---

--- a/files/en-us/games/tools/index.md
+++ b/files/en-us/games/tools/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tools for game development
 slug: Games/Tools
+page-type: landing-page
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animations and tweens
 slug: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Bounce off the walls
 slug: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.md
@@ -1,6 +1,7 @@
 ---
 title: Build the brick field
 slug: Games/Tutorials/2D_breakout_game_Phaser/Build_the_brick_field
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/buttons/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/buttons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Buttons
 slug: Games/Tutorials/2D_breakout_game_Phaser/Buttons
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Collision detection
 slug: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
@@ -1,6 +1,7 @@
 ---
 title: Extra lives
 slug: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/game_over/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game over
 slug: Games/Tutorials/2D_breakout_game_Phaser/Game_over
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/index.md
@@ -1,6 +1,7 @@
 ---
 title: 2D breakout game using Phaser
 slug: Games/Tutorials/2D_breakout_game_Phaser
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
@@ -1,6 +1,7 @@
 ---
 title: Initialize the framework
 slug: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Load the assets and print them on screen
 slug: Games/Tutorials/2D_breakout_game_Phaser/Load_the_assets_and_print_them_on_screen
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
@@ -1,6 +1,7 @@
 ---
 title: Move the ball
 slug: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.md
@@ -1,6 +1,7 @@
 ---
 title: Physics
 slug: Games/Tutorials/2D_breakout_game_Phaser/Physics
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Player paddle and controls
 slug: Games/Tutorials/2D_breakout_game_Phaser/Player_paddle_and_controls
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.md
@@ -1,6 +1,7 @@
 ---
 title: Randomizing gameplay
 slug: Games/Tutorials/2D_breakout_game_Phaser/Randomizing_gameplay
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/scaling/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/scaling/index.md
@@ -1,6 +1,7 @@
 ---
 title: Scaling
 slug: Games/Tutorials/2D_breakout_game_Phaser/Scaling
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/the_score/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/the_score/index.md
@@ -1,6 +1,7 @@
 ---
 title: The score
 slug: Games/Tutorials/2D_breakout_game_Phaser/The_score
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
@@ -1,6 +1,7 @@
 ---
 title: Win the game
 slug: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Bounce off the walls
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -1,6 +1,7 @@
 ---
 title: Build the brick field
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Collision detection
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -1,6 +1,7 @@
 ---
 title: Create the Canvas and draw on it
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -1,6 +1,7 @@
 ---
 title: Finishing up
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -1,6 +1,7 @@
 ---
 title: Game over
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -1,6 +1,7 @@
 ---
 title: 2D breakout game using pure JavaScript
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mouse controls
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -1,6 +1,7 @@
 ---
 title: Move the ball
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: Paddle and keyboard controls
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -1,6 +1,7 @@
 ---
 title: Track the score and win
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: 2D maze game with device orientation
 slug: Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/tutorials/index.md
+++ b/files/en-us/games/tutorials/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tutorials
 slug: Games/Tutorials
+page-type: landing-page
 ---
 
 {{GamesSidebar}}


### PR DESCRIPTION
Add page-types for Games/

There are no new page types: only `guide` and `landing-page` are used.

Part of openwebdocs/project/issues/91