### PR TITLE
chore(api): Minor improvements to lastModified regex

### DIFF
--- a/files/en-us/web/api/document/lastmodified/index.md
+++ b/files/en-us/web/api/document/lastmodified/index.md
@@ -74,7 +74,7 @@ const pattern = /last_modif\s*=\s*([^;]*)/;
 const lastVisit = parseFloat(document.cookie.replace(pattern, "$1"));
 const lastModif = Date.parse(document.lastModified);
 
-if (isNaN(lastVisit) || lastModif > lastVisit) {
+if (Number.isNaN(lastVisit) || lastModif > lastVisit) {
   document.cookie = `last_modif=${Date.now()}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=${
     location.pathname
   }`;

--- a/files/en-us/web/api/document/lastmodified/index.md
+++ b/files/en-us/web/api/document/lastmodified/index.md
@@ -51,14 +51,13 @@ comparing the modification dates of documents. Here is a possible example of how
 an alert message when the page changes (see also: [JavaScript cookies API](/en-US/docs/Web/API/Document/cookie)):
 
 ```js
+// Match 'timestamp' in 'last_modif=timestamp'
+// e.g. '1687964614822' in 'last_modif=1687964614822'
+const pattern = /last_modif\s*=\s*([^;]*)/;
+
 if (
   Date.parse(document.lastModified) >
-  parseFloat(
-    document.cookie.replace(
-      /(?:(?:^|.*;)\s*last_modif\s*=\s*([^;]*).*$)|^.*$/,
-      "$1"
-    ) || "0"
-  )
+  (parseFloat(document.cookie.match(pattern)?.[1]) || 0)
 ) {
   document.cookie = `last_modif=${Date.now()}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=${
     location.pathname
@@ -70,12 +69,9 @@ if (
 …the same example, but skipping the first visit:
 
 ```js
-const lastVisit = parseFloat(
-  document.cookie.replace(
-    /(?:(?:^|.*;)\s*last_modif\s*=\s*([^;]*).*$)|^.*$/,
-    "$1"
-  )
-);
+const pattern = /last_modif\s*=\s*([^;]*)/;
+
+const lastVisit = parseFloat(document.cookie.replace(pattern, "$1"));
 const lastModif = Date.parse(document.lastModified);
 
 if (isNaN(lastVisit) || lastModif > lastVisit) {


### PR DESCRIPTION
This PR improves the regex used in the example as I found it a bit hard to read. Thanks to a suggestion from @Josh-Cena, this should simplify along with some comments that explain what is happening. Comparing the following:

```js
// before
const pattern = /(?:(?:^|.*;)\s*last_modif\s*=\s*([^;]*).*$)|^.*$/
// after
const pattern = /last_modif\s*=\s*([^;]*)/
```

pen: https://regexr.com/7g746



## Related issues and pull requests

Fixes #24513 
