### PR TITLE
fix(EyeDropper): promise fulfills only if "selected a color"

### DIFF
--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -10,7 +10,7 @@ browser-compat: api.EyeDropper.open
 
 {{APIRef("EyeDropper API")}}{{SeeCompatTable}}
 
-The **`EyeDropper.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has either selected a color and dismissed the eyedropper mode.
+The **`EyeDropper.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has selected a color and exited the eyedropper mode.
 
 ## Syntax
 

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -10,7 +10,7 @@ browser-compat: api.EyeDropper.open
 
 {{APIRef("EyeDropper API")}}{{SeeCompatTable}}
 
-The **`EyeDropper.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has either selected a color or dismissed the eyedropper mode.
+The **`EyeDropper.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has either selected a color and dismissed the eyedropper mode.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

The promise fulfills only if "selected a color"

### Motivation

The spec shows the steps:

1. Let colorSelectionResult be the result of the user succesfully selecting a color. If this fails, then:
   1. If the user aborts the selection, reject result with an "AbortError" DOMException, otherwise reject result with an "OperationError" DOMException.
   2. Abort these steps.
2. Exit "eyedropper mode" and dismiss UI.
3. Resolve result with colorSelectionResult.

That is, the promise would resolve the result with colorSelectionResult if and only if the user succesfully selecting a color. If the user just canceled the mode, the promise would be rejected. So if we use "or" in documation, readers may think the promise would fulfill even if it's canceled by user.

### Additional details

https://wicg.github.io/eyedropper-api/#dom-eyedropper-open
