### PR TITLE
Add page-types to Learn/Getting_started, HTML & CSS

### DIFF
--- a/files/en-us/learn/common_questions/design_and_accessibility/index.md
+++ b/files/en-us/learn/common_questions/design_and_accessibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: Design and accessibility
 slug: Learn/Common_questions/Design_and_accessibility
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/common_questions/index.md
+++ b/files/en-us/learn/common_questions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Common questions
 slug: Learn/Common_questions
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/common_questions/tools_and_setup/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tools and setup
 slug: Learn/Common_questions/Tools_and_setup
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/common_questions/web_mechanics/index.md
+++ b/files/en-us/learn/common_questions/web_mechanics/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web mechanics
 slug: Learn/Common_questions/Web_mechanics
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.md
+++ b/files/en-us/learn/css/building_blocks/a_cool_looking_box/index.md
@@ -1,6 +1,7 @@
 ---
 title: A cool-looking box
 slug: Learn/CSS/Building_blocks/A_cool_looking_box
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced styling effects
 slug: Learn/CSS/Building_blocks/Advanced_styling_effects
+page-type: guide
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -1,6 +1,7 @@
 ---
 title: Backgrounds and borders
 slug: Learn/CSS/Building_blocks/Backgrounds_and_borders
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/box_model_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/box_model_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: The box model"
 slug: Learn/CSS/Building_blocks/Box_Model_Tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cascade, specificity, and inheritance
 slug: Learn/CSS/Building_blocks/Cascade_and_inheritance
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Cascade_layers", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cascade layers
 slug: Learn/CSS/Building_blocks/Cascade_layers
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/cascade_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: The Cascade"
 slug: Learn/CSS/Building_blocks/Cascade_tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
+++ b/files/en-us/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating fancy letterheaded paper
 slug: Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/debugging_css/index.md
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.md
@@ -1,6 +1,7 @@
 ---
 title: Debugging CSS
 slug: Learn/CSS/Building_blocks/Debugging_CSS
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.md
+++ b/files/en-us/learn/css/building_blocks/fundamental_css_comprehension/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fundamental CSS comprehension
 slug: Learn/CSS/Building_blocks/Fundamental_CSS_comprehension
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Handling different text directions
 slug: Learn/CSS/Building_blocks/Handling_different_text_directions
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/images_media_form_elements/index.md
+++ b/files/en-us/learn/css/building_blocks/images_media_form_elements/index.md
@@ -1,6 +1,7 @@
 ---
 title: Images, media, and form elements
 slug: Learn/CSS/Building_blocks/Images_media_form_elements
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/images_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/images_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Images and form elements"
 slug: Learn/CSS/Building_blocks/Images_tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/index.md
+++ b/files/en-us/learn/css/building_blocks/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS building blocks
 slug: Learn/CSS/Building_blocks
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/organizing/index.md
+++ b/files/en-us/learn/css/building_blocks/organizing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Organizing your CSS
 slug: Learn/CSS/Building_blocks/Organizing
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/overflow_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/overflow_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Overflow"
 slug: Learn/CSS/Building_blocks/Overflow_Tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/overflowing_content/index.md
+++ b/files/en-us/learn/css/building_blocks/overflowing_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Overflowing content
 slug: Learn/CSS/Building_blocks/Overflowing_content
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attribute selectors
 slug: Learn/CSS/Building_blocks/Selectors/Attribute_selectors
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -1,6 +1,7 @@
 ---
 title: Combinators
 slug: Learn/CSS/Building_blocks/Selectors/Combinators
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS selectors
 slug: Learn/CSS/Building_blocks/Selectors
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pseudo-classes and pseudo-elements
 slug: Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/selectors/selectors_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/selectors_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Selectors"
 slug: Learn/CSS/Building_blocks/Selectors/Selectors_Tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Type, class, and ID selectors
 slug: Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sizing items in CSS
 slug: Learn/CSS/Building_blocks/Sizing_items_in_CSS
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/sizing_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/sizing_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Sizing"
 slug: Learn/CSS/Building_blocks/Sizing_tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/styling_tables/index.md
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.md
@@ -1,6 +1,7 @@
 ---
 title: Styling tables
 slug: Learn/CSS/Building_blocks/Styling_tables
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/tables_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/tables_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Tables"
 slug: Learn/CSS/Building_blocks/Tables_tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.md
+++ b/files/en-us/learn/css/building_blocks/test_your_skills_backgrounds_and_borders/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Backgrounds and borders"
 slug: Learn/CSS/Building_blocks/Test_your_skills_backgrounds_and_borders
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/css/building_blocks/the_box_model/index.md
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: The box model
 slug: Learn/CSS/Building_blocks/The_box_model
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_layers", "Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS values and units
 slug: Learn/CSS/Building_blocks/Values_and_units
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/values_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/values_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Values and units"
 slug: Learn/CSS/Building_blocks/Values_tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/building_blocks/writing_modes_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/writing_modes_tasks/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Writing modes and logical properties"
 slug: Learn/CSS/Building_blocks/Writing_Modes_Tasks
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/flexbox/index.md
+++ b/files/en-us/learn/css/css_layout/flexbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Flexbox
 slug: Learn/CSS/CSS_layout/Flexbox
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/flexbox_skills/index.md
+++ b/files/en-us/learn/css/css_layout/flexbox_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Flexbox"
 slug: Learn/CSS/CSS_layout/Flexbox_skills
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -1,6 +1,7 @@
 ---
 title: Floats
 slug: Learn/CSS/CSS_layout/Floats
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/floats_skills/index.md
+++ b/files/en-us/learn/css/css_layout/floats_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Floats"
 slug: Learn/CSS/CSS_layout/Floats_skills
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fundamental layout comprehension
 slug: Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/grid_skills/index.md
+++ b/files/en-us/learn/css/css_layout/grid_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Grid"
 slug: Learn/CSS/CSS_layout/Grid_skills
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -1,6 +1,7 @@
 ---
 title: Grids
 slug: Learn/CSS/CSS_layout/Grids
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/index.md
+++ b/files/en-us/learn/css/css_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS layout
 slug: Learn/CSS/CSS_layout
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to CSS layout
 slug: Learn/CSS/CSS_layout/Introduction
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/legacy_layout_methods/index.md
+++ b/files/en-us/learn/css/css_layout/legacy_layout_methods/index.md
@@ -1,6 +1,7 @@
 ---
 title: Legacy layout methods
 slug: Learn/CSS/CSS_layout/Legacy_Layout_Methods
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/media_queries/index.md
+++ b/files/en-us/learn/css/css_layout/media_queries/index.md
@@ -1,6 +1,7 @@
 ---
 title: Beginner's guide to media queries
 slug: Learn/CSS/CSS_layout/Media_queries
+page-type: learn-module-chapter
 ---
 
 {{learnsidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout/Legacy_Layout_Methods", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/multicol_skills/index.md
+++ b/files/en-us/learn/css/css_layout/multicol_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Multicol"
 slug: Learn/CSS/CSS_layout/Multicol_skills
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/multicol_skills/index.md
+++ b/files/en-us/learn/css/css_layout/multicol_skills/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Test your skills: Multicol"
 slug: Learn/CSS/CSS_layout/Multicol_skills
-page-type: learn-module-chapter
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/multiple-column_layout/index.md
+++ b/files/en-us/learn/css/css_layout/multiple-column_layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: Multiple-column layout
 slug: Learn/CSS/CSS_layout/Multiple-column_Layout
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/normal_flow/index.md
+++ b/files/en-us/learn/css/css_layout/normal_flow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Normal Flow
 slug: Learn/CSS/CSS_layout/Normal_Flow
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/position_skills/index.md
+++ b/files/en-us/learn/css/css_layout/position_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Positioning"
 slug: Learn/CSS/CSS_layout/Position_skills
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/positioning/index.md
+++ b/files/en-us/learn/css/css_layout/positioning/index.md
@@ -1,6 +1,7 @@
 ---
 title: Positioning
 slug: Learn/CSS/CSS_layout/Positioning
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -1,6 +1,7 @@
 ---
 title: Practical positioning examples
 slug: Learn/CSS/CSS_layout/Practical_positioning_examples
+page-type: guide
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/responsive_design/index.md
+++ b/files/en-us/learn/css/css_layout/responsive_design/index.md
@@ -1,6 +1,7 @@
 ---
 title: Responsive design
 slug: Learn/CSS/CSS_layout/Responsive_Design
+page-type: learn-module-chapter
 ---
 
 {{learnsidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout/Media_queries", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/rwd_skills/index.md
+++ b/files/en-us/learn/css/css_layout/rwd_skills/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Responsive web design and media queries"
 slug: Learn/CSS/CSS_layout/rwd_skills
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/css_layout/supporting_older_browsers/index.md
+++ b/files/en-us/learn/css/css_layout/supporting_older_browsers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Supporting older browsers
 slug: Learn/CSS/CSS_layout/Supporting_Older_Browsers
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started with CSS
 slug: Learn/CSS/First_steps/Getting_started
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/What_is_CSS", "Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps")}}

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -1,6 +1,7 @@
 ---
 title: How CSS is structured
 slug: Learn/CSS/First_steps/How_CSS_is_structured
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}

--- a/files/en-us/learn/css/first_steps/how_css_works/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.md
@@ -1,6 +1,7 @@
 ---
 title: How CSS works
 slug: Learn/CSS/First_steps/How_CSS_works
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/first_steps/index.md
+++ b/files/en-us/learn/css/first_steps/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS first steps overview
 slug: Learn/CSS/First_steps
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/en-us/learn/css/first_steps/styling_a_biography_page/index.md
@@ -1,6 +1,7 @@
 ---
 title: Styling a biography page
 slug: Learn/CSS/First_steps/Styling_a_biography_page
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}

--- a/files/en-us/learn/css/first_steps/what_is_css/index.md
+++ b/files/en-us/learn/css/first_steps/what_is_css/index.md
@@ -1,6 +1,7 @@
 ---
 title: What is CSS?
 slug: Learn/CSS/First_steps/What_is_CSS
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps")}}

--- a/files/en-us/learn/css/howto/add_a_shadow/index.md
+++ b/files/en-us/learn/css/howto/add_a_shadow/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to add a shadow to an element
 slug: Learn/CSS/Howto/Add_a_shadow
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/add_a_text_shadow/index.md
+++ b/files/en-us/learn/css/howto/add_a_text_shadow/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to add a shadow to text
 slug: Learn/CSS/Howto/Add_a_text_shadow
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.md
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.md
@@ -1,6 +1,7 @@
 ---
-title: create fancy boxes
-slug: Learn/CSS/Howto/create_fancy_boxes
+title: Create fancy boxes
+slug: Learn/CSS/Howto/Create_fancy_boxes
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/css_faq/index.md
+++ b/files/en-us/learn/css/howto/css_faq/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS FAQ
 slug: Learn/CSS/Howto/CSS_FAQ
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/fill_a_box_with_an_image/index.md
+++ b/files/en-us/learn/css/howto/fill_a_box_with_an_image/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to fill a box with an image without distorting it
 slug: Learn/CSS/Howto/Fill_a_box_with_an_image
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/generated_content/index.md
+++ b/files/en-us/learn/css/howto/generated_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using CSS generated content
 slug: Learn/CSS/Howto/Generated_content
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/highlight_first_line/index.md
+++ b/files/en-us/learn/css/howto/highlight_first_line/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to highlight the first line of a paragraph
 slug: Learn/CSS/Howto/Highlight_first_line
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/highlight_first_para/index.md
+++ b/files/en-us/learn/css/howto/highlight_first_para/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to highlight the first paragraph
 slug: Learn/CSS/Howto/Highlight_first_para
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/highlight_para_after_h1/index.md
+++ b/files/en-us/learn/css/howto/highlight_para_after_h1/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to highlight a paragraph that comes after a heading
 slug: Learn/CSS/Howto/Highlight_para_after_h1
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/index.md
+++ b/files/en-us/learn/css/howto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Use CSS to solve common problems
 slug: Learn/CSS/Howto
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/make_box_transparent/index.md
+++ b/files/en-us/learn/css/howto/make_box_transparent/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to make a box semi-transparent
 slug: Learn/CSS/Howto/Make_box_transparent
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/howto/transition_button/index.md
+++ b/files/en-us/learn/css/howto/transition_button/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to fade a button on hover
 slug: Learn/CSS/Howto/Transition_button
+page-type: learn-faq
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/index.md
+++ b/files/en-us/learn/css/index.md
@@ -1,6 +1,7 @@
 ---
 title: Learn to style HTML using CSS
 slug: Learn/CSS
+page-type: learn-topic
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fundamental text and font styling
 slug: Learn/CSS/Styling_text/Fundamentals
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text")}}

--- a/files/en-us/learn/css/styling_text/index.md
+++ b/files/en-us/learn/css/styling_text/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS styling text
 slug: Learn/CSS/Styling_text
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -1,6 +1,7 @@
 ---
 title: Styling links
 slug: Learn/CSS/Styling_text/Styling_links
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}

--- a/files/en-us/learn/css/styling_text/styling_lists/index.md
+++ b/files/en-us/learn/css/styling_text/styling_lists/index.md
@@ -1,6 +1,7 @@
 ---
 title: Styling lists
 slug: Learn/CSS/Styling_text/Styling_lists
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Fundamentals", "Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text")}}

--- a/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.md
+++ b/files/en-us/learn/css/styling_text/typesetting_a_homepage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Typesetting a community school homepage
 slug: Learn/CSS/Styling_text/Typesetting_a_homepage
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}

--- a/files/en-us/learn/css/styling_text/web_fonts/index.md
+++ b/files/en-us/learn/css/styling_text/web_fonts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web fonts
 slug: Learn/CSS/Styling_text/Web_fonts
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text/Typesetting_a_homepage", "Learn/CSS/Styling_text")}}

--- a/files/en-us/learn/getting_started_with_the_web/css_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/css_basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS basics
 slug: Learn/Getting_started_with_the_web/CSS_basics
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/dealing_with_files/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/dealing_with_files/index.md
@@ -1,6 +1,7 @@
 ---
 title: Dealing with files
 slug: Learn/Getting_started_with_the_web/Dealing_with_files
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/What_will_your_website_look_like", "Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -1,6 +1,7 @@
 ---
 title: How the web works
 slug: Learn/Getting_started_with_the_web/How_the_Web_works
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/html_basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML basics
 slug: Learn/Getting_started_with_the_web/HTML_basics
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/Dealing_with_files", "Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started with the web
 slug: Learn/Getting_started_with_the_web
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -1,6 +1,7 @@
 ---
 title: Installing basic software
 slug: Learn/Getting_started_with_the_web/Installing_basic_software
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/Getting_started_with_the_web/What_will_your_website_look_like", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: JavaScript basics
 slug: Learn/Getting_started_with_the_web/JavaScript_basics
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -1,6 +1,7 @@
 ---
 title: Publishing your website
 slug: Learn/Getting_started_with_the_web/Publishing_your_website
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web/How_the_Web_works", "Learn/Getting_started_with_the_web")}}

--- a/files/en-us/learn/getting_started_with_the_web/the_web_and_web_standards/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/the_web_and_web_standards/index.md
@@ -1,6 +1,7 @@
 ---
 title: The web and web standards
 slug: Learn/Getting_started_with_the_web/The_web_and_web_standards
+page-type: guide
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
@@ -1,6 +1,7 @@
 ---
 title: What will your website look like?
 slug: Learn/Getting_started_with_the_web/What_will_your_website_look_like
+page-type: learn-module-chapter
 status:
   - deprecated
 ---

--- a/files/en-us/learn/html/cheatsheet/index.md
+++ b/files/en-us/learn/html/cheatsheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML Cheat Sheet
 slug: Learn/HTML/Cheatsheet
+page-type: guide
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -1,6 +1,7 @@
 ---
 title: Add a hitmap on top of an image
 slug: Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image
+page-type: learn-faq
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}

--- a/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tips for authoring fast-loading HTML pages
 slug: Learn/HTML/Howto/Author_fast-loading_HTML_pages
+page-type: learn-faq
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}

--- a/files/en-us/learn/html/howto/define_terms_with_html/index.md
+++ b/files/en-us/learn/html/howto/define_terms_with_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Define terms with HTML
 slug: Learn/HTML/Howto/Define_terms_with_HTML
+page-type: learn-faq
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}

--- a/files/en-us/learn/html/howto/use_data_attributes/index.md
+++ b/files/en-us/learn/html/howto/use_data_attributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using data attributes
 slug: Learn/HTML/Howto/Use_data_attributes
+page-type: learn-faq
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}

--- a/files/en-us/learn/html/howto/use_javascript_within_a_webpage/index.md
+++ b/files/en-us/learn/html/howto/use_javascript_within_a_webpage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Use JavaScript within a webpage
 slug: Learn/HTML/Howto/Use_JavaScript_within_a_webpage
+page-type: learn-faq
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}

--- a/files/en-us/learn/html/index.md
+++ b/files/en-us/learn/html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Structuring the web with HTML
 slug: Learn/HTML
+page-type: learn-topic
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced text formatting
 slug: Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating hyperlinks
 slug: Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/debugging_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Debugging HTML
 slug: Learn/HTML/Introduction_to_HTML/Debugging_HTML
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document and website structure
 slug: Learn/HTML/Introduction_to_HTML/Document_and_website_structure
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started with HTML
 slug: Learn/HTML/Introduction_to_HTML/Getting_started
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML text fundamentals
 slug: Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to HTML
 slug: Learn/HTML/Introduction_to_HTML
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.md
+++ b/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.md
@@ -1,6 +1,7 @@
 ---
 title: Marking up a letter
 slug: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
+++ b/files/en-us/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Structuring a page of content
 slug: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Advanced HTML text"
 slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Advanced_HTML_text
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: HTML text basics"
 slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_HTML_text_basics
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Links"
 slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Links
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: What's in the head? Metadata in HTML
 slug: Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Getting_started", "Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adding vector graphics to the web
 slug: Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Images in HTML
 slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: HTML images"
 slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML/Test_your_skills:_HTML_images
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/html/multimedia_and_embedding/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Multimedia and embedding
 slug: Learn/HTML/Multimedia_and_embedding
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mozilla splash page
 slug: Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
+page-type: learn-module-assessment
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -1,6 +1,7 @@
 ---
 title: From object to iframe — other embedding technologies
 slug: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: Responsive images
 slug: Learn/HTML/Multimedia_and_embedding/Responsive_images
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Video and audio content
 slug: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Images_in_HTML", "Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Test your skills: Multimedia and embedding"
 slug: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content/Test_your_skills:_Multimedia_and_embedding
+page-type: learn-module-assessment
 ---
 
 {{learnsidebar}}

--- a/files/en-us/learn/html/tables/index.md
+++ b/files/en-us/learn/html/tables/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML tables
 slug: Learn/HTML/Tables
+page-type: learn-module
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/javascript/howto/index.md
+++ b/files/en-us/learn/javascript/howto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Solve common problems in your JavaScript code
 slug: Learn/JavaScript/Howto
+page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/javascript/index.md
+++ b/files/en-us/learn/javascript/index.md
@@ -1,6 +1,7 @@
 ---
 title: JavaScript — Dynamic client-side scripting
 slug: Learn/JavaScript
+page-type: learn-topic
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/server-side/index.md
+++ b/files/en-us/learn/server-side/index.md
@@ -1,6 +1,7 @@
 ---
 title: Server-side website programming
 slug: Learn/Server-side
+page-type: learn-topic
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/tools_and_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tools and testing
 slug: Learn/Tools_and_testing
+page-type: learn-topic
 ---
 
 {{LearnSidebar}}

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -72,6 +72,27 @@
       },
       {
         "if": {
+          "properties": { "slug": { "type": "string", "pattern": "^Learn/" } }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": [
+                "guide",
+                "landing-page",
+                "learn-topic",
+                "learn-module",
+                "learn-module-chapter",
+                "learn-module-assessment",
+                "learn-faq"
+              ]
+            }
+          }
+        },
+        "else": false
+      },
+      {
+        "if": {
           "properties": { "slug": { "type": "string", "pattern": "^MDN/" } }
         },
         "then": {


### PR DESCRIPTION
This is part of openwebdocs/project#91 and is the first piece of #27620

- Adds `page-type` to the LA topics
- Adds `page-type` to all Getting Started pages in LA
- Adds `page-type` to all HTML pages in LA (including FAQ)
- Adds `page-type` to all CSS pages in LA (including FAQ)

- Update the front-matter config files so that linting will work.