### PR TITLE
correct itemprop example

### DIFF
--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -54,8 +54,8 @@ The following example specifies the `itemtype` as "http\://schema.org/Movie", an
     </tr>
     <tr>
       <td>itemprop</td>
-      <td>https://youtu.be/0AY1XIkX7bY</td>
       <td>Trailer</td>
+      <td>https://youtu.be/0AY1XIkX7bY</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I believe the table listing itemprop's mixed the name and the value. This can be confusing, especially since it was a href-element where the value comes from the href-attribute and not the text content. 
