### PR TITLE
fix(css): Correct the link to the 'animation-timeline' page

### DIFF
--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -22,7 +22,7 @@ This property is a shorthand for the following CSS properties:
 - [`animation-iteration-count`](/en-US/docs/Web/CSS/animation-iteration-count)
 - [`animation-name`](/en-US/docs/Web/CSS/animation-name)
 - [`animation-play-state`](/en-US/docs/Web/CSS/animation-play-state)
-- [`animation-timeline`](/en-US/docs/Web/CSS/animation-timing-function)
+- [`animation-timeline`](/en-US/docs/Web/CSS/animation-timeline)
 - [`animation-timing-function`](/en-US/docs/Web/CSS/animation-timing-function)
 
 ## Syntax


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`animation-timeline` link in the list is incorrectly pointing to the `animation-timing-function` page. This PR fixes that.


