### PR TITLE
Rewrite: CSS namespace module and add CSS & HTML to glossary

### DIFF
--- a/files/en-us/glossary/namespace/index.md
+++ b/files/en-us/glossary/namespace/index.md
@@ -10,9 +10,12 @@ Namespace is a context for identifiers, a logical grouping of names used in a pr
 
 In an operating system, a directory is a namespace. Each file or subdirectory has a unique name, but one file may use the same name multiple times.
 
+In HTML, CSS, and XML-based languages, a namespace is the explicitly declared or implied dialect to which an element (or attribute) belongs.
+
 ## See also
 
 - [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
+- [CSS namespaces module](/en-US/docs/Web/CSS/CSS_namespaces)
 - CSS {{CSSXref("@namespace")}}
 - [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
 - [Namespace](https://en.wikipedia.org/wiki/Namespace) on Wikipedia

--- a/files/en-us/glossary/namespace/index.md
+++ b/files/en-us/glossary/namespace/index.md
@@ -8,14 +8,14 @@ page-type: glossary-definition
 
 Namespace is a context for identifiers, a logical grouping of names used in a program. Within the same context and same scope, an identifier must uniquely identify an entity.
 
-In an operating system, a directory is a namespace. Each file or subdirectory has a unique name, but one file may use the same name multiple times.
+In an operating system, a directory is a namespace. Each file or subdirectory within a directory has a unique name; the same name can be used multiple times across subdirectories."
 
 In HTML, CSS, and XML-based languages, a namespace is the explicitly declared or implied dialect to which an element (or attribute) belongs.
 
 ## See also
 
 - [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
-- [CSS namespaces module](/en-US/docs/Web/CSS/CSS_namespaces)
+- [CSS namespaces](/en-US/docs/Web/CSS/CSS_namespaces) module
 - CSS {{CSSXref("@namespace")}}
 - [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
 - [Namespace](https://en.wikipedia.org/wiki/Namespace) on Wikipedia

--- a/files/en-us/glossary/namespace/index.md
+++ b/files/en-us/glossary/namespace/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 Namespace is a context for identifiers, a logical grouping of names used in a program. Within the same context and same scope, an identifier must uniquely identify an entity.
 
-In an operating system, a directory is a namespace. Each file or subdirectory within a directory has a unique name; the same name can be used multiple times across subdirectories."
+In an operating system, a directory is a namespace. Each file or subdirectory within a directory has a unique name; the same name can be used multiple times across subdirectories.
 
 In HTML, CSS, and XML-based languages, a namespace is the explicitly declared or implied dialect to which an element (or attribute) belongs.
 

--- a/files/en-us/glossary/namespace/index.md
+++ b/files/en-us/glossary/namespace/index.md
@@ -8,8 +8,11 @@ page-type: glossary-definition
 
 Namespace is a context for identifiers, a logical grouping of names used in a program. Within the same context and same scope, an identifier must uniquely identify an entity.
 
-In an operating system a directory is a namespace. Each file or subdirectory has a unique name, but one file may use the same name multiple times.
+In an operating system, a directory is a namespace. Each file or subdirectory has a unique name, but one file may use the same name multiple times.
 
 ## See also
 
+- [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
+- CSS {{CSSXref("@namespace")}}
+- [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
 - [Namespace](https://en.wikipedia.org/wiki/Namespace) on Wikipedia

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -31,6 +31,8 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
 - {{DOMXRef("CSSNamespaceRule")}} interface
+  - {{DOMXRef("CSSNamespaceRule.namespaceURI")}} property
+  - {{DOMXRef("CSSNamespaceRule.prefix")}} property
 - [`Document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) method
 - [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
 - [`Document.getElementsByTagNameNS()`](/en-US/docs/Web/API/Document/getElementsByTagNameNS) method
@@ -57,5 +59,8 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 
 ## See also
 
-- [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)
 - [CSS Namespace example in SVG](/en-US/docs/Web/SVG/Element/a#example)
+- [CSS `url()` functions](/en-US/docs/Web/CSS/url)
+- [CSS at-rules](/en-US/docs/Web/CSS/At-rule)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/At-rule-functions)
+- [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -7,7 +7,11 @@ browser-compat: css.at-rules.namespace
 
 {{CSSRef}}
 
-The **CSS namespaces** allows authors to specify [XML namespaces](/en-US/docs/Web/SVG/Namespaces_Crash_Course) in CSS.
+The **CSS namespaces** module defines the syntax for using {{glossary("namespace", "namespaces")}} in CSS.
+
+CSS isn't just for HTML. A single stylesheet may be used to style SVG, MathML, XML, HTML, each of which has a different namespace, or a document containing multiple namespaces. Element tag names are not all unique to a single language. For example, The `<a>` element isn't limited to HTML. You may want to use different CSS style for your SVG differently than for your HTML links, or ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. [The `@namespace` rule](/en-US/docs/Web/CSS/@namespace), defined in this module, enable distinguishing between same-named elements in different namespaces.
+
+The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means, or if the name is even valid, depends on the context and host language.
 
 ## Reference
 
@@ -16,6 +20,10 @@ The **CSS namespaces** allows authors to specify [XML namespaces](/en-US/docs/We
 - {{cssxref("@namespace")}}
 
 ## Guides
+
+- [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
+
+  - :
 
 ## Related concepts
 
@@ -38,3 +46,4 @@ The **CSS namespaces** allows authors to specify [XML namespaces](/en-US/docs/We
 ## See also
 
 - [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)
+- [SVG nameps](/en-US/docs/Web/SVG/Element/a#example)

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -9,7 +9,9 @@ browser-compat: css.at-rules.namespace
 
 The **CSS namespaces** module defines the syntax for using {{glossary("namespace", "namespaces")}} in CSS.
 
-CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to use different CSS style for your SVG differently than for your HTML links or ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces.
+CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces. 
+
+The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to style the `<a>`s  within your SVGs differently than links in your HTML. You also likely want to ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. Namespacing can help.
 
 The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means or if the name is even valid depends on the context and host language.
 

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -11,7 +11,7 @@ The **CSS namespaces** module defines the syntax for using {{glossary("namespace
 
 CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces.
 
-The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to style the `<a>`s within your SVGs differently than links in your HTML. You also likely want to ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. Namespacing can help.
+The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to style the `<a>`s within your SVGs differently from the links in your HTML. You also will likely want to ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. Namespacing can help.
 
 The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means or if the name is even valid depends on the context and host language.
 

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -15,6 +15,18 @@ The **CSS namespaces** allows authors to specify [XML namespaces](/en-US/docs/We
 
 - {{cssxref("@namespace")}}
 
+## Guides
+
+## Related concepts
+
+- CSS [namespace separator (`|`)](/en-US/docs/Web/CSS/Namespace_separator) combinator
+- {{DOMXRef("CSSNamespaceRule")}} interface
+- [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
+- [`Element.namespaceURI`](/en-US/docs/Web/API/Element/namespaceURI) property
+- [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
+- [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
+- {{glossary("namespace")}} glossary term
+
 ## Specifications
 
 {{Specifications}}
@@ -22,3 +34,7 @@ The **CSS namespaces** allows authors to specify [XML namespaces](/en-US/docs/We
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -9,9 +9,9 @@ browser-compat: css.at-rules.namespace
 
 The **CSS namespaces** module defines the syntax for using {{glossary("namespace", "namespaces")}} in CSS.
 
-CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces. 
+CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces.
 
-The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to style the `<a>`s  within your SVGs differently than links in your HTML. You also likely want to ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. Namespacing can help.
+The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to style the `<a>`s within your SVGs differently than links in your HTML. You also likely want to ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. Namespacing can help.
 
 The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means or if the name is even valid depends on the context and host language.
 

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -9,9 +9,9 @@ browser-compat: css.at-rules.namespace
 
 The **CSS namespaces** module defines the syntax for using {{glossary("namespace", "namespaces")}} in CSS.
 
-CSS isn't just for HTML. A single stylesheet may be used to style SVG, MathML, XML, HTML, each of which has a different namespace, or a document containing multiple namespaces. Element tag names are not all unique to a single language. For example, The `<a>` element isn't limited to HTML. You may want to use different CSS style for your SVG differently than for your HTML links, or ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. [The `@namespace` rule](/en-US/docs/Web/CSS/@namespace), defined in this module, enable distinguishing between same-named elements in different namespaces.
+CSS isn't just for styling HTML. A stylesheet may be used to style SVG, MathML, XML, or HTML, each of which has a different namespace or a document containing multiple namespaces. Element tag names are not unique to a single language. For example, the `<a>` element isn't limited to HTML. You may want to use different CSS style for your SVG differently than for your HTML links or ensure that {{domxref("Document.querySelectorAll", "querySelectorAll(\"a\")")}} selects the right kind of element. The [`@namespace`](/en-US/docs/Web/CSS/@namespace) at-rule defined in this module enables distinguishing between same-named elements in different namespaces.
 
-The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means, or if the name is even valid, depends on the context and host language.
+The `@namespace` rule is used for declaring a default namespace and for binding namespaces to namespace prefixes. The namespaces module also defines the syntax for using these prefixes to represent namespace-qualified names. That's it. What a name means or if the name is even valid depends on the context and host language.
 
 ## Reference
 
@@ -28,8 +28,8 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 ## Related concepts
 
 - CSS [namespace separator (`|`)](/en-US/docs/Web/CSS/Namespace_separator) combinator
-- [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
-- [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
+- CSS [type selectors](/en-US/docs/Web/CSS/Type_selectors)
+- CSS [universal selector](/en-US/docs/Web/CSS/Universal_selectors)
 - {{DOMXRef("CSSNamespaceRule")}} interface
   - {{DOMXRef("CSSNamespaceRule.namespaceURI")}} property
   - {{DOMXRef("CSSNamespaceRule.prefix")}} property
@@ -47,7 +47,7 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 - [`NamedNodeMap.getNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/getNamedItemNS) method
 - [`NamedNodeMap.removeNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/removeNamedItemNS) method
 - [`NamedNodeMap.setNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/setNamedItemNS) method
-- {{glossary("namespace")}} glossary term
+- {{glossary("Namespace")}} glossary term
 
 ## Specifications
 
@@ -59,8 +59,8 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 
 ## See also
 
-- [CSS Namespace example in SVG](/en-US/docs/Web/SVG/Element/a#example)
-- [CSS `url()` functions](/en-US/docs/Web/CSS/url)
+- [`<a>`](/en-US/docs/Web/SVG/Element/a#example) SVG element
+- [CSS `url()` function](/en-US/docs/Web/CSS/url)
 - [CSS at-rules](/en-US/docs/Web/CSS/At-rule)
 - [CSS at-rule functions](/en-US/docs/Web/CSS/At-rule-functions)
-- [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)
+- [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -23,16 +23,28 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 
 - [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
 
-  - :
+  - : Deep dive into what a namespace is and how they are used in XML and XML-based markup languages.
 
 ## Related concepts
 
 - CSS [namespace separator (`|`)](/en-US/docs/Web/CSS/Namespace_separator) combinator
-- {{DOMXRef("CSSNamespaceRule")}} interface
-- [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
-- [`Element.namespaceURI`](/en-US/docs/Web/API/Element/namespaceURI) property
 - [CSS type selector](/en-US/docs/Web/CSS/Type_selectors)
 - [CSS universal selector](/en-US/docs/Web/CSS/Universal_selectors)
+- {{DOMXRef("CSSNamespaceRule")}} interface
+- [`Document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) method
+- [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method
+- [`Document.getElementsByTagNameNS()`](/en-US/docs/Web/API/Document/getElementsByTagNameNS) method
+- [`Element.getAttributeNodeNS()`](/en-US/docs/Web/API/Element/getAttributeNodeNS) method
+- [`Element.getAttributeNS()`](/en-US/docs/Web/API/Element/getAttributeNS) method
+- [`Element.getElementsByTagNameNS()`](/en-US/docs/Web/API/Element/getElementsByTagNameNS) method
+- [`Element.hasAttributeNS()`](/en-US/docs/Web/API/Element/hasAttributeNS) method
+- [`Element.namespaceURI`](/en-US/docs/Web/API/Element/namespaceURI) property
+- [`Element.removeAttributeNS()`](/en-US/docs/Web/API/Element/removeAttributeNS) method
+- [`Element.setAttributeNS()`](/en-US/docs/Web/API/Element/setAttributeNS) method
+- [`Element.setAttributeNodeNS()`](/en-US/docs/Web/API/Element/setAttributeNodeNS) method
+- [`NamedNodeMap.getNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/getNamedItemNS) method
+- [`NamedNodeMap.removeNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/removeNamedItemNS) method
+- [`NamedNodeMap.setNamedItemNS()`](/en-US/docs/Web/API/NamedNodeMap/setNamedItemNS) method
 - {{glossary("namespace")}} glossary term
 
 ## Specifications
@@ -46,4 +58,4 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 ## See also
 
 - [CSS selector module](/en-US/docs/Web/CSS/CSS_selectors)
-- [SVG nameps](/en-US/docs/Web/SVG/Element/a#example)
+- [CSS Namespace example in SVG](/en-US/docs/Web/SVG/Element/a#example)


### PR DESCRIPTION
Part of the CSS modules project

* add explanation, related concepts, guides, and see also to CSS module page
* add html/xml/css/svg to namespace glossary