### PR TITLE
Add a page on SDK

### DIFF
--- a/files/en-us/glossary/sdk/index.md
+++ b/files/en-us/glossary/sdk/index.md
@@ -6,12 +6,12 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **SDK** (**Software Development Kit**) is an integrated collection of tools that a developer can use to create software for a specific platform. An SDK can include:
+An **SDK** (**Software Development Kit**) is an integrated collection of tools that a developer can use to create software for a specific framework, operating system, or other platform. An SDK can include:
 
 - An editor
 - A compiler
 - A debugger
-- An emulator, if the target platform is different from the platform used to create the program.
+- An emulator or simulator, if the target platform is different from the platform used to create the program.
 - Tools to help test and package the program for distribution.
 
 SDKs are usually provided by the owner of a software platform, to support developers targeting the platform. For example, Google provides an [Android SDK](https://developer.android.com/studio) for developers writing Android apps.

--- a/files/en-us/glossary/sdk/index.md
+++ b/files/en-us/glossary/sdk/index.md
@@ -1,0 +1,19 @@
+---
+title: SDK (Software Development Kit)
+slug: Glossary/SDK
+page-type: glossary-definition
+---
+
+{{GlossarySidebar}}
+
+An **SDK** (**Software Development Kit**) is an integrated collection of tools that a developer can use to create software for a specific platform. An SDK can include:
+
+- An editor
+- A compiler
+- A debugger
+- An emulator, if the target platform is different from the platform used to create the program.
+- Tools to help test and package the program for distribution.
+
+SDKs are usually provided by the owner of a software platform, to support developers targeting the platform. For example, Google provides an [Android SDK](https://developer.android.com/studio) for developers writing Android apps.
+
+In many respects, the {{Glossary("developer tools")}} built into modern web browsers provide a similar function for web developers.


### PR DESCRIPTION
The PWA tutorial contains a link to a glossary entry on "SDK" but we didn't have one. So here is one.

I couldn't think of anything to put for "See also".
