### PR TITLE
Improve DataTransfer.types description

### DIFF
--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -8,21 +8,15 @@ browser-compat: api.DataTransfer.types
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.types`** read-only property returns an
-array of the drag data formats (as strings) that were set in
-the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event. The order of the formats is the same order as the data
-included in the drag operation.
-
-The formats are Unicode strings giving the type or format of the data, generally given
-by a MIME type. Some values that are not MIME types are special-cased for legacy reasons
-(for example "`text`").
+The **`DataTransfer.types`** read-only property returns the available types
+that exist in the {{domxref("DataTransfer.items","items")}}.
 
 ## Value
 
-An array of the data formats used in the drag operation. Each format is a
-string. If the drag operation included no data, this list
-will be empty. If any files are included in the drag operation, then one of the types
-will be the string `Files`.
+An array of the data formats used in the drag operation. Each format is a string
+which is generally a MIME type such as `text/plain` or `text/html`. If the drag
+operation included no data, this list will be empty. If any files are included in
+the drag operation, then one of the types will be the string `Files`.
 
 ## Examples
 


### PR DESCRIPTION
Fix DataTransfer.types to remove incorrect statement "The order of the formats is the same order as the data included in the drag operation."  When a DataTransfer includes 1 or more Files, a single type "File" will be last which may be out of order with items, and may mean that types.length < items.length.

As per https://html.spec.whatwg.org/multipage/dnd.html#concept-datatransfer-types

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Improve docs to make them more accurate.

### Motivation

I am a chromium developer and I recently looked at a bug which related to DataTransfer.  The existing docs confused me since they were incorrect when describing the relationship between order of DataTransfer.types and DataTransfer.items.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
