### PR TITLE
Fix accessibility object term for WebDriver conformance changes in Firefox 115

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -80,7 +80,7 @@ This article provides information about the changes in Firefox 115 that affect d
 
 #### Marionette
 
-- Both the commands `WebDriver:GetComputedLabel` and `WebDriver:GetComputedRole` now correctly wait for the requested Accessible for an element to exist if it just got inserted into the DOM ([Firefox bug 1828816](https://bugzil.la/1828816)).
+- Both the commands `WebDriver:GetComputedLabel` and `WebDriver:GetComputedRole` now correctly wait for the requested accessibility object for an element to exist if it just got inserted into the DOM ([Firefox bug 1828816](https://bugzil.la/1828816)).
 - All instances of `window.setTimeout()` in our privileged code running in content processes now use a variant timer that is not affected by the throttling of the timers in case the given tab for automation is in the background.
 
 ## Changes for add-on developers


### PR DESCRIPTION
Follow-up from https://github.com/mdn/content/pull/27647.