### PR TITLE
Remove obsolete title parameter from registerProtocolHandler

### DIFF
--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -16,10 +16,7 @@ For example, this API lets webmail sites open `mailto:` URLs, or VoIP sites open
 
 ```js-nolint
 registerProtocolHandler(scheme, url)
-registerProtocolHandler(scheme, url, title)
 ```
-
-> **Note:** The version with the deprecated `title` argument is recommended for compatibility reasons (see parameter information below).
 
 ### Parameters
 
@@ -34,15 +31,6 @@ registerProtocolHandler(scheme, url, title)
     **This URL must include `%s`**, as a placeholder that will be replaced with the [escaped](/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) URL to be handled.
 
     > **Note:** The handler URL must use the `https` scheme. Older browsers also supported `http`.
-
-- `title` {{deprecated_inline}}
-
-  - : A human-readable title string for the handler.
-    **This will be displayed to the user**, such as prompting "Allow this site to handle \[scheme] links?" or listing registered handlers in the browser's settings.
-
-    > **Note:** The title has been removed from the spec due to spoofing concerns.
-    > The `title` should still be set because some browsers **still require it** (see the [compatibility table below](#browser_compatibility)).
-    > Browsers that support the updated spec most likely will be accept but ignore the title.
 
 ### Return value
 
@@ -111,9 +99,8 @@ If your site is `burgers.example.com`, you can register a protocol handler for i
 ```js
 navigator.registerProtocolHandler(
   "web+burger",
-  "https://burgers.example.com/?burger=%s",
-  "Burger handler"
-); // last title arg included for compatibility
+  "https://burgers.example.com/?burger=%s"
+);
 ```
 
 This creates a handler that lets `web+burger:` links send the user to your site, inserting the accessed burger URL into the `%s` placeholder.


### PR DESCRIPTION
### Description

See https://github.com/mdn/browser-compat-data/issues/15357. The `title` parameter is gone from all browsers for more than two years.

### Motivation

Cleaning up information that is no longer relevant.

### Additional details

None.

### Related issues and pull requests

https://github.com/mdn/browser-compat-data/pull/20268 removes it from the compat table.

