### PR TITLE
Remove concurrency from the event loop article's title and description

### DIFF
--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -75,8 +75,8 @@ Head over to our [Learning Area JavaScript topic](/en-US/docs/Learn/JavaScript) 
   - : Explanation of the widely misunderstood and underestimated prototype-based inheritance.
 - [Memory Management](/en-US/docs/Web/JavaScript/Memory_management)
   - : Memory life cycle and garbage collection in JavaScript.
-- [Concurrency model and Event Loop](/en-US/docs/Web/JavaScript/Event_loop)
-  - : JavaScript has a concurrency model based on an "event loop".
+- [The Event Loop](/en-US/docs/Web/JavaScript/Event_loop)
+  - : JavaScript has a runtime model based on an "event loop".
 
 ## Reference
 

--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -75,7 +75,7 @@ Head over to our [Learning Area JavaScript topic](/en-US/docs/Learn/JavaScript) 
   - : Explanation of the widely misunderstood and underestimated prototype-based inheritance.
 - [Memory Management](/en-US/docs/Web/JavaScript/Memory_management)
   - : Memory life cycle and garbage collection in JavaScript.
-- [The Event Loop](/en-US/docs/Web/JavaScript/Event_loop)
+- [The event loop](/en-US/docs/Web/JavaScript/Event_loop)
   - : JavaScript has a runtime model based on an "event loop".
 
 ## Reference


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Based on #12354, I removed "concurrency" form the event loop article's title and description.
The event loop is a runtime model.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To be consistent with terminology and content.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
