### PR TITLE
Fix CSS 'clip' page livesample output

### DIFF
--- a/files/en-us/web/css/clip/index.md
+++ b/files/en-us/web/css/clip/index.md
@@ -53,8 +53,6 @@ clip: unset;
 
 ### Clipping an image
 
-#### HTML
-
 ```html
 <p class="dotted-border">
   <img src="macarons.png" alt="Original graphic" />
@@ -66,8 +64,6 @@ clip: unset;
     alt="Graphic clipped to bottom right" />
 </p>
 ```
-
-#### CSS
 
 ```css
 .dotted-border {
@@ -100,9 +96,7 @@ clip: unset;
 }
 ```
 
-#### Result
-
-{{EmbedLiveSample('', '', '450px')}}
+{{EmbedLiveSample('clipping_an_image', '', '450px')}}
 
 ## Specifications
 


### PR DESCRIPTION
The example output is not considering the CSS code block. Checked in Firefox.