### PR TITLE
Use modern Blob.text()  method in file reading example.

### DIFF
--- a/files/en-us/web/api/file_api/index.md
+++ b/files/en-us/web/api/file_api/index.md
@@ -66,15 +66,13 @@ In this example, we provide a [file `<input>` element](/en-US/docs/Web/HTML/Elem
 const fileInput = document.querySelector("input[type=file]");
 const output = document.querySelector(".output");
 
-fileInput.addEventListener("change", () => {
+fileInput.addEventListener("change", async () => {
   const [file] = fileInput.files;
+
   if (file) {
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      output.innerText = reader.result;
-    });
-    reader.readAsText(file);
+      output.innerText = await file.text()
   }
+
 });
 ```
 
@@ -89,4 +87,5 @@ fileInput.addEventListener("change", () => {
 ## See also
 
 - [`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file): the file input element
+- [`text() method`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text): .text()
 - The {{domxref("DataTransfer")}} interface

--- a/files/en-us/web/api/file_api/index.md
+++ b/files/en-us/web/api/file_api/index.md
@@ -87,5 +87,5 @@ fileInput.addEventListener("change", async () => {
 ## See also
 
 - [`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file): the file input element
-- [`text() method`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text): .text()
+- [`text() method`](/en-US/docs/Web/API/Blob/text): .text()
 - The {{domxref("DataTransfer")}} interface

--- a/files/en-us/web/api/file_api/index.md
+++ b/files/en-us/web/api/file_api/index.md
@@ -70,9 +70,8 @@ fileInput.addEventListener("change", async () => {
   const [file] = fileInput.files;
 
   if (file) {
-      output.innerText = await file.text()
+    output.innerText = await file.text();
   }
-
 });
 ```
 


### PR DESCRIPTION
Updated the file reading example to use the simpler, Promise-based Blob.text() instead of the older, less-convenient FileReader() API.

Examples should provide the most current, easiest-to-implement solutions for beginners to follow.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the example used for file reading to use the newer, simpler, Promise-based Blob API.

### Motivation

Encourage best-practices.

### Additional details

- https://developer.mozilla.org/en-US/docs/Web/API/File_API#examples
- https://developer.mozilla.org/en-US/docs/Web/API/FileReader
- https://developer.mozilla.org/en-US/docs/Web/API/File
- https://developer.mozilla.org/en-US/docs/Web/API/Blob/text

Code using .text() was successfully tested for file reading on Firefox 114.0.2 and Chrome 114.0.5735.199

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
