### PR TITLE
correct an error description of Request instance behavior

### DIFF
--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -62,7 +62,7 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
 - {{domxref("Request.text()")}}
   - : Returns a promise that resolves with a text representation of the request body.
 
-> **Note:** The request body functions can be run only once; subsequent calls will resolve with empty strings/ArrayBuffers.
+> **Note:** The request body functions can be run only once; subsequent calls will raise an error showing that the body stream has already used.
 
 ## Examples
 

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -62,7 +62,7 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
 - {{domxref("Request.text()")}}
   - : Returns a promise that resolves with a text representation of the request body.
 
-> **Note:** The request body functions can be run only once; subsequent calls will raise an error showing that the body stream has already used.
+> **Note:** The request body functions can be run only once; subsequent calls will reject with TypeError showing that the body stream has already used.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

subsequent calls of Request instance would reject with TypeError instead of resolving with empty strings/arraybuffers

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Try to run in edge(114.0.1823.67).
![image](https://github.com/mdn/content/assets/40999116/014da698-ac29-4ba9-a01a-d89c4f497610)

Try to run in chrome(114.0.5735.199).
![image](https://github.com/mdn/content/assets/40999116/10237aab-eb74-4333-b813-b2ae44f4f58f)

Try to run in Firefox(112.0.2).
![image](https://github.com/mdn/content/assets/40999116/e0738003-fe91-40e4-aec7-c7e870828a43)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
