### PR TITLE
modify margin collapsing case dealing with adjacent siblings

### DIFF
--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -11,7 +11,7 @@ The [top](/en-US/docs/Web/CSS/margin-top) and [bottom](/en-US/docs/Web/CSS/margi
 Margin collapsing occurs in three basic cases:
 
 - Adjacent siblings
-  - : The margins of adjacent siblings are collapsed (except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats).
+  - : The margins of adjacent siblings are collapsed.
 - No content separating parent and descendants
   - : If there is no border, padding, inline part, [block formatting context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) created, or _[clearance](/en-US/docs/Web/CSS/clear)_ to separate the {{cssxref("margin-top")}} of a block from the {{cssxref("margin-top")}} of one or more of its descendant blocks; or no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate the {{cssxref("margin-bottom")}} of a block from the {{cssxref("margin-bottom")}} of one or more of its descendant blocks, then those margins collapse. The collapsed margin ends up outside the parent.
 - Empty blocks


### PR DESCRIPTION
On line 14 removed:
"(except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats)" I was unable to replicate the case where a latter sibling clearing past floats would not collapse the margin.  The only way I could force this was by floating the latter sibling, too.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
modify margin collapsing case dealing with adjacent siblings
<!-- ✍️ Summarize your changes in one or two sentences -->
 I was unable to replicate the case where a latter sibling clearing past floats would not collapse the margin.  The only way I could force this was by floating the latter sibling, too.
### Motivation
I would like for others to not get confused.
<!-- ❓ Why are you making these changes and how do they help readers? -->
The readers will not get stuck when trying to understand margin collapsing.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
