### PR TITLE
Add link to preconnect hint introduced in Best Practices section

### DIFF
--- a/files/en-us/web/performance/dns-prefetch/index.md
+++ b/files/en-us/web/performance/dns-prefetch/index.md
@@ -49,7 +49,7 @@ There are 3 main things to keep in mind:
 Link: <https://fonts.googleapis.com/>; rel=dns-prefetch
 ```
 
-**Third**, consider pairing `dns-prefetch` with the `preconnect` hint. While `dns-prefetch` only performs a DNS lookup, `preconnect` establishes a connection to a server. This process includes DNS resolution, as well as establishing the TCP connection, and performing the [TLS](/en-US/docs/Glossary/TLS) handshake—if a site is served over HTTPS. Combining the two provides an opportunity to further reduce the perceived latency of [cross-origin requests](/en-US/docs/Web/HTTP/CORS). You can safely use them together like so:
+**Third**, consider pairing `dns-prefetch` with the [`preconnect` hint](/en-US/docs/Web/HTML/Attributes/rel/preconnect). While `dns-prefetch` only performs a DNS lookup, `preconnect` establishes a connection to a server. This process includes DNS resolution, as well as establishing the TCP connection, and performing the [TLS](/en-US/docs/Glossary/TLS) handshake—if a site is served over HTTPS. Combining the two provides an opportunity to further reduce the perceived latency of [cross-origin requests](/en-US/docs/Web/HTTP/CORS). You can safely use them together like so:
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com/" crossorigin />


### PR DESCRIPTION
### Description

Where the preconnect hint is first mentioned, I add a link.

### Motivation

As a reader of this page, I expected to see a hyperlink.
