### PR TITLE
Docs additions for WebGPU updates up to Chrome 115

### DIFF
--- a/files/en-us/web/api/gpu/requestadapter/index.md
+++ b/files/en-us/web/api/gpu/requestadapter/index.md
@@ -38,7 +38,7 @@ requestAdapter(options)
 
         This hint's primary purpose is to influence which GPU is used in a multi-GPU system. For instance, some laptops have a low-power integrated GPU and a high-performance discrete GPU. Different factors may affect which adapter is returned including battery status, attached displays, or removable GPUs.
 
-        > **Note:** On dual-GPU macOS devices, if `requestAdapter()` is called without a `powerPreference` option, the high-performance discrete GPU is returned when the user's device is on AC power. Otherwise, the low-power integrated GPU is returned.
+        > **Note:** On Chrome running on dual-GPU macOS devices, if `requestAdapter()` is called without a `powerPreference` option, the high-performance discrete GPU is returned when the user's device is on AC power. Otherwise, the low-power integrated GPU is returned.
 
 ### Fallback adapters
 

--- a/files/en-us/web/api/gpu/requestadapter/index.md
+++ b/files/en-us/web/api/gpu/requestadapter/index.md
@@ -38,6 +38,8 @@ requestAdapter(options)
 
         This hint's primary purpose is to influence which GPU is used in a multi-GPU system. For instance, some laptops have a low-power integrated GPU and a high-performance discrete GPU. Different factors may affect which adapter is returned including battery status, attached displays, or removable GPUs.
 
+        > **Note:** On dual-GPU macOS devices, if `requestAdapter()` is called without a `powerPreference` option, the high-performance discrete GPU is returned when the user's device is on AC power. Otherwise, the low-power integrated GPU is returned.
+
 ### Fallback adapters
 
 The adapter provided by the user agent may be a **fallback adapter**, if it determines it to be the most appropriate option available. A fallback adapter generally has significant performance caveats in exchange for some combination of wider compatibility, more predictable behavior, or improved privacy. For example, some browsers may offer a software-based implementation of the API via a fallback adapter. A fallback adapter will not be available on every system.

--- a/files/en-us/web/api/gpu/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/gpu/wgsllanguagefeatures/index.md
@@ -22,24 +22,22 @@ A {{domxref("WGSLLanguageFeatures")}} object instance. This is a [setlike](/en-U
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const wgslFeatures = navigator.gpu.wgslLanguageFeatures;
-
-  // Return the size of the set
-  console.log(wgslFeatures.size);
-
-  // Iterate through all the set values using values()
-  const valueIterator = wgslFeatures.values();
-  for (const value of valueIterator) {
-    console.log(value);
-  }
-
-  // ...
+if (!navigator.gpu) {
+  throw Error("WebGPU not supported.");
 }
+
+const wgslFeatures = navigator.gpu.wgslLanguageFeatures;
+
+// Return the size of the set
+console.log(wgslFeatures.size);
+
+// Iterate through all the set values using values()
+const valueIterator = wgslFeatures.values();
+for (const value of valueIterator) {
+  console.log(value);
+}
+
+// ...
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpucanvascontext/getcurrenttexture/index.md
+++ b/files/en-us/web/api/gpucanvascontext/getcurrenttexture/index.md
@@ -27,6 +27,11 @@ None.
 
 A {{domxref("GPUTexture")}} object instance.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `getCurrentTexture()` is called on the canvas context before it is configured (i.e. before {{domxref("GPUCanvasContext.configure()")}} has been called).
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/gpurenderbundleencoder/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/index.md
@@ -65,7 +65,7 @@ A `GPURenderBundleEncoder` object instance is created via the {{domxref("GPUDevi
   - : Sets the {{domxref("GPURenderPipeline")}} to use for this render bundle.
 
 - {{domxref("GPURenderBundleEncoder.setVertexBuffer", "setVertexBuffer()")}} {{Experimental_Inline}}
-  - : Sets the current {{domxref("GPUBuffer")}} that will provide vertex data for subsequent drawing commands.
+  - : Sets or unsets the current {{domxref("GPUBuffer")}} that will provide vertex data for subsequent drawing commands.
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
@@ -79,7 +79,7 @@ The above snippet is taken from the WebGPU Samples [Animometer example](https://
 
 ```js
 // Set vertex buffer in slot 0
-passEncoder.setVertexBuffer(0, myVertexBuffer);
+passEncoder.setVertexBuffer(0, vertexBuffer);
 
 // Later, unset vertex buffer in slot 0
 passEncoder.setVertexBuffer(0, null);

--- a/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GPURenderBundleEncoder.setVertexBuffer
 {{APIRef("WebGPU API")}}{{SeeCompatTable}}
 
 The **`setVertexBuffer()`** method of the
-{{domxref("GPURenderBundleEncoder")}} interface sets the current {{domxref("GPUBuffer")}} for the given slot that will provide vertex data for subsequent drawing commands.
+{{domxref("GPURenderBundleEncoder")}} interface sets or unsets the current {{domxref("GPUBuffer")}} for the given slot that will provide vertex data for subsequent drawing commands.
 
 > **Note:** This method is functionally identical to its equivalent on {{domxref("GPURenderPassEncoder")}} — {{domxref("GPURenderPassEncoder.setVertexBuffer", "setVertexBuffer()")}}.
 
@@ -26,7 +26,7 @@ setVertexBuffer(slot, buffer, offset, size)
 - `slot`
   - : A number referencing the vertex buffer slot to set the vertex buffer for.
 - `buffer`
-  - : A {{domxref("GPUBuffer")}} representing the buffer containing the vertex data to use for subsequent drawing commands.
+  - : A {{domxref("GPUBuffer")}} representing the buffer containing the vertex data to use for subsequent drawing commands, or `null`, in which case any previously-set buffer in the given slot is unset.
 - `offset` {{optional_inline}}
   - : A number representing the offset, in bytes, into `buffer` where the vertex data begins. If omitted, `offset` defaults to 0.
 - `size` {{optional_inline}}
@@ -46,6 +46,8 @@ The following criteria must be met when calling **`setVertexBuffer()`**, otherwi
 - `offset` is a multiple of 4.
 
 ## Examples
+
+### Set vertex buffer
 
 ```js
 function recordRenderPass(
@@ -72,6 +74,16 @@ function recordRenderPass(
 ```
 
 The above snippet is taken from the WebGPU Samples [Animometer example](https://webgpu.github.io/webgpu-samples/samples/animometer).
+
+### Unset vertex buffer
+
+```js
+// Set vertex buffer in slot 0
+passEncoder.setVertexBuffer(0, myVertexBuffer);
+
+// Later, unset vertex buffer in slot 0
+passEncoder.setVertexBuffer(0, null);
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/gpurenderpassencoder/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/index.md
@@ -71,7 +71,7 @@ A `GPURenderPassEncoder` object instance is created via the {{domxref("GPUComman
   - : Sets the stencil reference value using during stencil tests with the `"replace"` stencil operation (as set in the descriptor of the {{domxref("GPUDevice.createRenderPipeline()")}} method, in the properties defining the various stencil operations).
 
 - {{domxref("GPURenderPassEncoder.setVertexBuffer", "setVertexBuffer()")}} {{Experimental_Inline}}
-  - : Sets the current {{domxref("GPUBuffer")}} that will provide vertex data for subsequent drawing commands.
+  - : Sets or unsets the current {{domxref("GPUBuffer")}} that will provide vertex data for subsequent drawing commands.
 - {{domxref("GPURenderPassEncoder.setViewport", "setViewport()")}} {{Experimental_Inline}}
   - : Sets the viewport used during the rasterization stage to linearly map from normalized device coordinates to viewport coordinates.
 

--- a/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GPURenderPassEncoder.setVertexBuffer
 {{APIRef("WebGPU API")}}{{SeeCompatTable}}
 
 The **`setVertexBuffer()`** method of the
-{{domxref("GPURenderPassEncoder")}} interface sets the current {{domxref("GPUBuffer")}} for the given slot that will provide vertex data for subsequent drawing commands.
+{{domxref("GPURenderPassEncoder")}} interface sets or unsets the current {{domxref("GPUBuffer")}} for the given slot that will provide vertex data for subsequent drawing commands.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ setVertexBuffer(slot, buffer, offset, size)
 - `slot`
   - : A number referencing the vertex buffer slot to set the vertex buffer for.
 - `buffer`
-  - : A {{domxref("GPUBuffer")}} representing the buffer containing the vertex data to use for subsequent drawing commands.
+  - : A {{domxref("GPUBuffer")}} representing the buffer containing the vertex data to use for subsequent drawing commands, or `null`, in which case any previously-set buffer in the given slot is unset.
 - `offset` {{optional_inline}}
   - : A number representing the offset, in bytes, into `buffer` where the vertex data begins. If omitted, `offset` defaults to 0.
 - `size` {{optional_inline}}
@@ -44,6 +44,8 @@ The following criteria must be met when calling **`setVertexBuffer()`**, otherwi
 - `offset` is a multiple of 4.
 
 ## Examples
+
+### Set vertex buffer
 
 In our [basic render demo](https://mdn.github.io/dom-examples/webgpu-render-demo/), several commands are recorded via a {{domxref("GPUCommandEncoder")}}. Most of these commands originate from the `GPURenderPassEncoder` created via {{domxref("GPUCommandEncoder.beginRenderPass()")}}. `setVertexBuffer()` is used as appropriate to set the source of vertex data.
 
@@ -82,6 +84,16 @@ passEncoder.end();
 device.queue.submit([commandEncoder.finish()]);
 
 // ...
+```
+
+### Unset vertex buffer
+
+```js
+// Set vertex buffer in slot 0
+passEncoder.setVertexBuffer(0, myVertexBuffer);
+
+// Later, unset vertex buffer in slot 0
+passEncoder.setVertexBuffer(0, null);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
@@ -90,7 +90,7 @@ device.queue.submit([commandEncoder.finish()]);
 
 ```js
 // Set vertex buffer in slot 0
-passEncoder.setVertexBuffer(0, myVertexBuffer);
+passEncoder.setVertexBuffer(0, vertexBuffer);
 
 // Later, unset vertex buffer in slot 0
 passEncoder.setVertexBuffer(0, null);

--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -46,24 +46,22 @@ The following methods are available to all read-only [setlike](/en-US/docs/Web/J
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const wgslFeatures = navigator.gpu.wgslLanguageFeatures;
-
-  // Return the size of the set
-  console.log(wgslFeatures.size);
-
-  // Iterate through all the set values using values()
-  const valueIterator = wgslFeatures.values();
-  for (const value of valueIterator) {
-    console.log(value);
-  }
-
-  // ...
+if (!navigator.gpu) {
+  throw Error("WebGPU not supported.");
 }
+
+const wgslFeatures = navigator.gpu.wgslLanguageFeatures;
+
+// Return the size of the set
+console.log(wgslFeatures.size);
+
+// Iterate through all the set values using values()
+const valueIterator = wgslFeatures.values();
+for (const value of valueIterator) {
+  console.log(value);
+}
+
+// ...
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There are a few changes in Chrome's WebGPU implementation between 113 and 115. See @beaufortfrancois 's update articles at https://developer.chrome.com/tags/new-in-webgpu/. This PR makes docs additions to cover the following:

- https://developer.chrome.com/blog/new-in-webgpu-115/#unset-vertex-buffer
- https://developer.chrome.com/blog/new-in-webgpu-115/#get-discrete-gpu-by-default-on-ac-power
- https://developer.chrome.com/blog/new-in-webgpu-114/#getcurrenttexture-on-unconfigured-canvas-throws-invalidstateerror
- I also removed the `async` function scaffolding from the `wgslLanguageFeatures` code snippet, as it wasn't needed.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
