### PR TITLE
Fix styleSheets order description

### DIFF
--- a/files/en-us/web/api/document/stylesheets/index.md
+++ b/files/en-us/web/api/document/stylesheets/index.md
@@ -14,7 +14,7 @@ The **`styleSheets`** read-only property of the {{domxref("Document")}} interfac
 
 The returned list is ordered as follows:
 
-- StyleSheets retrieved from {{htmlelement("link")}} headers are placed first, sorted in header order.
+- StyleSheets retrieved from {{HTTPHeader("Link")}} headers are placed first, sorted in header order.
 - StyleSheets retrieved from the DOM are placed after, sorted in [tree order](https://dom.spec.whatwg.org/#concept-tree-order).
 
 ## Examples


### PR DESCRIPTION
### Description

Updates the description of the value to link to the Link HTTPHeader, rather than the Link HTMLElement.

### Motivation

The link to the element (rendered as `<Link>` can cause one to mis-read that sentence as pertaining to link elements rather than headers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
