### PR TITLE
Add page-type entries to Mozilla/Firefox

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -38,14 +38,14 @@ This section lists page types that are specific to a single area of MDN.
 
 ### Accessibility page types
 
-This section lists `page-type` values for pages under [Web/Accessibility](/en-US/docs/Web/Accessibility). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/Accessibility](/en-US/docs/Web/Accessibility). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `aria-role`: an ARIA [role](/en-US/docs/Web/Accessibility/ARIA/Roles), like [`section`](/en-US/docs/Web/Accessibility/ARIA/Roles/section_role).
 - `aria-attribute`: an ARIA [attribute](eb/Accessibility/ARIA/Attributes), like [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort).
 
 ### CSS page types
 
-This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/CSS](/en-US/docs/Web/CSS). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `css-at-rule`: an [at-rule](/en-US/docs/Web/CSS/At-rule), like {{cssxref("@charset")}}.
 - `css-at-rule-descriptor`: an at-rule descriptor, like [`@counter-style/prefix`](/en-US/docs/Web/CSS/@counter-style/prefix).
@@ -70,7 +70,7 @@ This section lists `page-type` values for pages under [Glossary](/en-US/docs/Glo
 
 ### HTML page types
 
-This section lists `page-type` values for pages under [Web/HTML](/en-US/docs/Web/HTML). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/HTML](/en-US/docs/Web/HTML). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `html-attribute`: an HTML attribute, like [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete).
 - `html-attribute-value`: a single value for an HTML attribute, like [`dns-prefetch`](/en-US/docs/Web/HTML/Attributes/rel/dns-prefetch).
@@ -78,7 +78,7 @@ This section lists `page-type` values for pages under [Web/HTML](/en-US/docs/Web
 
 ### HTTP page types
 
-This section lists `page-type` values for pages under [Web/HTTP](/en-US/docs/Web/HTTP). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/HTTP](/en-US/docs/Web/HTTP). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `http-csp-directive`: a [CSP](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) directive, like [`script-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
 - `http-cors-error`: a [CORS](/en-US/docs/Web/HTTP/CORS) error, like [`CORSDidNotSucceed`](/en-US/docs/Web/HTTP/CORS/Errors/CORSDidNotSucceed).
@@ -89,7 +89,7 @@ This section lists `page-type` values for pages under [Web/HTTP](/en-US/docs/Web
 
 ### JavaScript page types
 
-This section lists `page-type` values for pages under [Web/JavaScript](/en-US/docs/Web/JavaScript). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/JavaScript](/en-US/docs/Web/JavaScript). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `javascript-class`: a definition of a built-in object, like [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 - `javascript-constructor`: an object constructor, like [`Array()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array).
@@ -109,21 +109,21 @@ This section lists `page-type` values for pages under [Web/JavaScript](/en-US/do
 
 ### MathML page types
 
-This section lists `page-type` values for pages under [Web/MathML](/en-US/docs/Web/MathML). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/MathML](/en-US/docs/Web/MathML). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `mathml-attribute`: an MathML attribute, like [`mathcolor`](/en-US/docs/Web/MathML/Global_attributes/mathcolor).
 - `mathml-element`: an HTML element, like [`<msqrt>`](/en-US/docs/Web/MathML/Element/msqrt).
 
 ### SVG page types
 
-This section lists `page-type` values for pages under [Web/SVG](/en-US/docs/Web/SVG). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/SVG](/en-US/docs/Web/SVG). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `svg-attribute`: an SVG attribute, like [`crossorigin`](/en-US/docs/Web/SVG/Attribute/crossorigin).
 - `svg-element`: an SVG element, like [`<circle>`](/en-US/docs/Web/SVG/Element/circle).
 
 ### Web API page types
 
-This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/API). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `web-api-overview`: gives an overview of a Web API, like the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 - `web-api-global-function`: a global function, like [`fetch()`](/en-US/docs/Web/API/fetch).
@@ -140,7 +140,7 @@ This section lists `page-type` values for pages under [Web/API](/en-US/docs/Web/
 
 ### WebDriver
 
-This section lists `page-type` values for pages under [Web/WebDriver](/en-US/docs/Web/WebDriver). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/WebDriver](/en-US/docs/Web/WebDriver). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `webdriver-command`: a webdriver command, like [`CloseWindow`](/en-US/docs/Web/WebDriver/Commands/CloseWindow).
 - `webdriver-capability`: a webdriver capability, like [`acceptInsecureCerts`](/en-US/docs/Web/WebDriver/Capabilities/acceptInsecureCerts).
@@ -148,7 +148,7 @@ This section lists `page-type` values for pages under [Web/WebDriver](/en-US/doc
 
 ### WebExtensions page types
 
-This section lists `page-type` values for pages under [Mozilla/Add-ons/WebExtensions](/en-US/docs/Mozilla/Add-ons/WebExtensions). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Mozilla/Add-ons/WebExtensions](/en-US/docs/Mozilla/Add-ons/WebExtensions). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `webextension-api`: a WebExtension API, like [`alarms`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms).
 - `webextension-api-event`: a WebExtension API event, like [`action.onClicked`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action/onClicked).
@@ -159,12 +159,12 @@ This section lists `page-type` values for pages under [Mozilla/Add-ons/WebExtens
 
 ### Web Manifest page types
 
-This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `web-manifest-member`: a member of a manifest, like [`description`](/en-US/docs/Web/Manifest/description).
 
 ### Firefox page types
 
-This section lists `page-type` values for pages under [Mozilla/Firefox](/en-US/docs/Mozilla/Firefox). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+This section lists `page-type` values for pages under [Mozilla/Firefox](/en-US/docs/Mozilla/Firefox). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `firefox-release-notes`: the release notes for a particular Firefox version, such as [_Firefox 115 for developers_](/en-US/docs/Mozilla/Firefox/Releases/115).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -162,3 +162,9 @@ This section lists `page-type` values for pages under [Mozilla/Add-ons/WebExtens
 This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
 - `web-manifest-member`: a member of a manifest, like [`description`](/en-US/docs/Web/Manifest/description).
+
+### Firefox page types
+
+This section lists `page-type` values for pages under [Mozilla/Firefox](/en-US/docs/Mozilla/Firefox). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
+
+- `firefox-release-notes`: the release notes for a given Firefox, like [_Firefox 115 for developers_](/en-US/docs/Mozilla/Firefox/Releases/115).

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -167,4 +167,4 @@ This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs
 
 This section lists `page-type` values for pages under [Mozilla/Firefox](/en-US/docs/Mozilla/Firefox). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the generic page type values.
 
-- `firefox-release-notes`: the release notes for a given Firefox, like [_Firefox 115 for developers_](/en-US/docs/Mozilla/Firefox/Releases/115).
+- `firefox-release-notes`: the release notes for a particular Firefox version, such as [_Firefox 115 for developers_](/en-US/docs/Mozilla/Firefox/Releases/115).

--- a/files/en-us/mozilla/firefox/index.md
+++ b/files/en-us/mozilla/firefox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox
 slug: Mozilla/Firefox
+page-type: landing-page
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/1.5/adapting_xul_applications_for_firefox_1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/adapting_xul_applications_for_firefox_1.5/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adapting XUL Applications for Firefox 1.5
 slug: Mozilla/Firefox/Releases/1.5/Adapting_XUL_Applications_for_Firefox_1.5
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: Changing the Priority of HTTP Requests (Non-Standard)
 slug: Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 1.5 for developers
 slug: Mozilla/Firefox/Releases/1.5
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Firefox 1.5 caching
 slug: Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: What's New in Deer Park Alpha
 slug: Mozilla/Firefox/Releases/1.5/What_s_new_in_1.5_alpha
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 10 for developers
 slug: Mozilla/Firefox/Releases/10
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating add-ons for Firefox 10
 slug: Mozilla/Firefox/Releases/10/Updating_add-ons
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 100 for developers
 slug: Mozilla/Firefox/Releases/100
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 101 for developers
 slug: Mozilla/Firefox/Releases/101
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 102 for developers
 slug: Mozilla/Firefox/Releases/102
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 103 for developers
 slug: Mozilla/Firefox/Releases/103
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 104 for developers
 slug: Mozilla/Firefox/Releases/104
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 105 for developers
 slug: Mozilla/Firefox/Releases/105
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 106 for developers
 slug: Mozilla/Firefox/Releases/106
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 107 for developers
 slug: Mozilla/Firefox/Releases/107
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 108 for developers
 slug: Mozilla/Firefox/Releases/108
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 109 for developers
 slug: Mozilla/Firefox/Releases/109
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 11 for developers
 slug: Mozilla/Firefox/Releases/11
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 110 for developers
 slug: Mozilla/Firefox/Releases/110
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 111 for developers
 slug: Mozilla/Firefox/Releases/111
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 112 for developers
 slug: Mozilla/Firefox/Releases/112
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 113 for developers
 slug: Mozilla/Firefox/Releases/113
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 114 for developers
 slug: Mozilla/Firefox/Releases/114
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 115 for developers
 slug: Mozilla/Firefox/Releases/115
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 116 for developers
 slug: Mozilla/Firefox/Releases/116
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 12 for developers
 slug: Mozilla/Firefox/Releases/12
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/13/index.md
+++ b/files/en-us/mozilla/firefox/releases/13/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 13 for developers
 slug: Mozilla/Firefox/Releases/13
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/14/index.md
+++ b/files/en-us/mozilla/firefox/releases/14/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 14 for developers
 slug: Mozilla/Firefox/Releases/14
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/15/index.md
+++ b/files/en-us/mozilla/firefox/releases/15/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 15 for developers
 slug: Mozilla/Firefox/Releases/15
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/16/index.md
+++ b/files/en-us/mozilla/firefox/releases/16/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 16 for developers
 slug: Mozilla/Firefox/Releases/16
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/17/index.md
+++ b/files/en-us/mozilla/firefox/releases/17/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 17 for developers
 slug: Mozilla/Firefox/Releases/17
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 18 for developers
 slug: Mozilla/Firefox/Releases/18
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 19 for developers
 slug: Mozilla/Firefox/Releases/19
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adding feed readers to Firefox
 slug: Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/2/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 2 for developers
 slug: Mozilla/Firefox/Releases/2
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/2/security_changes/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/security_changes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Security in Firefox 2
 slug: Mozilla/Firefox/Releases/2/Security_changes
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/2/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/updating_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 2
 slug: Mozilla/Firefox/Releases/2/Updating_extensions
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 20 for developers
 slug: Mozilla/Firefox/Releases/20
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 21 for developers
 slug: Mozilla/Firefox/Releases/21
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/22/index.md
+++ b/files/en-us/mozilla/firefox/releases/22/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 22 for developers
 slug: Mozilla/Firefox/Releases/22
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/23/index.md
+++ b/files/en-us/mozilla/firefox/releases/23/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 23 for developers
 slug: Mozilla/Firefox/Releases/23
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/24/index.md
+++ b/files/en-us/mozilla/firefox/releases/24/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 24 for developers
 slug: Mozilla/Firefox/Releases/24
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/25/index.md
+++ b/files/en-us/mozilla/firefox/releases/25/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 25 for developers
 slug: Mozilla/Firefox/Releases/25
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/26/index.md
+++ b/files/en-us/mozilla/firefox/releases/26/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 26 for developers
 slug: Mozilla/Firefox/Releases/26
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/27/index.md
+++ b/files/en-us/mozilla/firefox/releases/27/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 27 for developers
 slug: Mozilla/Firefox/Releases/27
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 28 for developers
 slug: Mozilla/Firefox/Releases/28
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/29/index.md
+++ b/files/en-us/mozilla/firefox/releases/29/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 29 for developers
 slug: Mozilla/Firefox/Releases/29
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
@@ -1,6 +1,7 @@
 ---
 title: ICC color correction in Firefox
 slug: Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Security changes in Firefox 3.5
 slug: Mozilla/Firefox/Releases/3.5/Security_changes
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 3.5
 slug: Mozilla/Firefox/Releases/3.5/Updating_extensions
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.6/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 3.6 for developers
 slug: Mozilla/Firefox/Releases/3.6
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
@@ -1,6 +1,7 @@
 ---
 title: Interfaces moved in Firefox 3.6
 slug: Mozilla/Firefox/Releases/3.6/Interfaces_moved
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 3.6
 slug: Mozilla/Firefox/Releases/3.6/Updating_extensions
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_plug-ins/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_plug-ins/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating plug-ins for Firefox 3.6
 slug: Mozilla/Firefox/Releases/3.6/Updating_plug-ins
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating themes for Firefox 3.6
 slug: Mozilla/Firefox/Releases/3.6/Updating_themes
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/dom_improvements/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/dom_improvements/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOM improvements in Firefox 3
 slug: Mozilla/Firefox/Releases/3/DOM_improvements
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/full_page_zoom/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/full_page_zoom/index.md
@@ -1,6 +1,7 @@
 ---
 title: Full page zoom
 slug: Mozilla/Firefox/Releases/3/Full_page_zoom
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 3 for developers
 slug: Mozilla/Firefox/Releases/3
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Notable bugs fixed in Firefox 3
 slug: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/site_compatibility/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/site_compatibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: Site compatibility for Firefox 3
 slug: Mozilla/Firefox/Releases/3/Site_compatibility
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/svg_improvements/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/svg_improvements/index.md
@@ -1,6 +1,7 @@
 ---
 title: SVG improvements in Firefox 3
 slug: Mozilla/Firefox/Releases/3/SVG_improvements
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/templates/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/templates/index.md
@@ -1,6 +1,7 @@
 ---
 title: Templates in Firefox 3
 slug: Mozilla/Firefox/Releases/3/Templates
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 3
 slug: Mozilla/Firefox/Releases/3/Updating_extensions
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating web applications for Firefox 3
 slug: Mozilla/Firefox/Releases/3/Updating_web_applications
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/using_an_external_spell_checker/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/using_an_external_spell_checker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using an external spell checker
 slug: Mozilla/Firefox/Releases/3/Using_an_external_spell_checker
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/wai_aria_live_regions_api_support/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/wai_aria_live_regions_api_support/index.md
@@ -1,6 +1,7 @@
 ---
 title: WAI ARIA Live Regions/API Support
 slug: Mozilla/Firefox/Releases/3/WAI_ARIA_Live_Regions_API_Support
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
@@ -1,6 +1,7 @@
 ---
 title: XUL improvements in Firefox 3
 slug: Mozilla/Firefox/Releases/3/XUL_improvements_in_Firefox_3
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 30 for developers
 slug: Mozilla/Firefox/Releases/30
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/31/index.md
+++ b/files/en-us/mozilla/firefox/releases/31/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 31 for developers
 slug: Mozilla/Firefox/Releases/31
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/32/index.md
+++ b/files/en-us/mozilla/firefox/releases/32/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 32 for developers
 slug: Mozilla/Firefox/Releases/32
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/33/index.md
+++ b/files/en-us/mozilla/firefox/releases/33/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 33 for developers
 slug: Mozilla/Firefox/Releases/33
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/34/index.md
+++ b/files/en-us/mozilla/firefox/releases/34/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 34 for developers
 slug: Mozilla/Firefox/Releases/34
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/35/index.md
+++ b/files/en-us/mozilla/firefox/releases/35/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 35 for developers
 slug: Mozilla/Firefox/Releases/35
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 36 for developers
 slug: Mozilla/Firefox/Releases/36
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/37/index.md
+++ b/files/en-us/mozilla/firefox/releases/37/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 37 for developers
 slug: Mozilla/Firefox/Releases/37
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 38 for developers
 slug: Mozilla/Firefox/Releases/38
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 39 for developers
 slug: Mozilla/Firefox/Releases/39
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 4 for developers
 slug: Mozilla/Firefox/Releases/4
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
@@ -1,6 +1,7 @@
 ---
 title: The add-on bar
 slug: Mozilla/Firefox/Releases/4/The_add-on_bar
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/4/updating_extensions_for_firefox_4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/updating_extensions_for_firefox_4/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 4
 slug: Mozilla/Firefox/Releases/4/Updating_extensions_for_Firefox_4
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/40/index.md
+++ b/files/en-us/mozilla/firefox/releases/40/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 40 for developers
 slug: Mozilla/Firefox/Releases/40
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/41/index.md
+++ b/files/en-us/mozilla/firefox/releases/41/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 41 for developers
 slug: Mozilla/Firefox/Releases/41
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/42/index.md
+++ b/files/en-us/mozilla/firefox/releases/42/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 42 for developers
 slug: Mozilla/Firefox/Releases/42
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/43/index.md
+++ b/files/en-us/mozilla/firefox/releases/43/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 43 for developers
 slug: Mozilla/Firefox/Releases/43
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 44 for developers
 slug: Mozilla/Firefox/Releases/44
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/45/index.md
+++ b/files/en-us/mozilla/firefox/releases/45/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 45 for developers
 slug: Mozilla/Firefox/Releases/45
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/46/index.md
+++ b/files/en-us/mozilla/firefox/releases/46/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 46 for developers
 slug: Mozilla/Firefox/Releases/46
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/47/index.md
+++ b/files/en-us/mozilla/firefox/releases/47/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 47 for developers
 slug: Mozilla/Firefox/Releases/47
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/48/index.md
+++ b/files/en-us/mozilla/firefox/releases/48/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 48 for developers
 slug: Mozilla/Firefox/Releases/48
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 49 for developers
 slug: Mozilla/Firefox/Releases/49
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 5 for developers
 slug: Mozilla/Firefox/Releases/5
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating add-ons for Firefox 5
 slug: Mozilla/Firefox/Releases/5/Updating_add-ons
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/50/index.md
+++ b/files/en-us/mozilla/firefox/releases/50/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 50 for developers
 slug: Mozilla/Firefox/Releases/50
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/51/index.md
+++ b/files/en-us/mozilla/firefox/releases/51/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 51 for developers
 slug: Mozilla/Firefox/Releases/51
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/52/index.md
+++ b/files/en-us/mozilla/firefox/releases/52/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 52 for developers
 slug: Mozilla/Firefox/Releases/52
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/53/index.md
+++ b/files/en-us/mozilla/firefox/releases/53/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 53 for developers
 slug: Mozilla/Firefox/Releases/53
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/54/index.md
+++ b/files/en-us/mozilla/firefox/releases/54/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 54 for developers
 slug: Mozilla/Firefox/Releases/54
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/55/index.md
+++ b/files/en-us/mozilla/firefox/releases/55/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 55 for developers
 slug: Mozilla/Firefox/Releases/55
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/56/index.md
+++ b/files/en-us/mozilla/firefox/releases/56/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 56 for developers
 slug: Mozilla/Firefox/Releases/56
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/57/index.md
+++ b/files/en-us/mozilla/firefox/releases/57/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 57 (Quantum) for developers
 slug: Mozilla/Firefox/Releases/57
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/58/index.md
+++ b/files/en-us/mozilla/firefox/releases/58/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 58 for developers
 slug: Mozilla/Firefox/Releases/58
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/59/index.md
+++ b/files/en-us/mozilla/firefox/releases/59/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 59 for developers
 slug: Mozilla/Firefox/Releases/59
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 6 for developers
 slug: Mozilla/Firefox/Releases/6
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating add-ons for Firefox 6
 slug: Mozilla/Firefox/Releases/6/Updating_add-ons
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/60/index.md
+++ b/files/en-us/mozilla/firefox/releases/60/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 60 for developers
 slug: Mozilla/Firefox/Releases/60
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/61/index.md
+++ b/files/en-us/mozilla/firefox/releases/61/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 61 for developers
 slug: Mozilla/Firefox/Releases/61
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/62/index.md
+++ b/files/en-us/mozilla/firefox/releases/62/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 62 for developers
 slug: Mozilla/Firefox/Releases/62
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 63 for developers
 slug: Mozilla/Firefox/Releases/63
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/64/index.md
+++ b/files/en-us/mozilla/firefox/releases/64/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 64 for developers
 slug: Mozilla/Firefox/Releases/64
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/65/index.md
+++ b/files/en-us/mozilla/firefox/releases/65/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 65 for developers
 slug: Mozilla/Firefox/Releases/65
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/66/index.md
+++ b/files/en-us/mozilla/firefox/releases/66/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 66 for developers
 slug: Mozilla/Firefox/Releases/66
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/67/index.md
+++ b/files/en-us/mozilla/firefox/releases/67/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 67 for developers
 slug: Mozilla/Firefox/Releases/67
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 68 for developers
 slug: Mozilla/Firefox/Releases/68
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/69/index.md
+++ b/files/en-us/mozilla/firefox/releases/69/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 69 for developers
 slug: Mozilla/Firefox/Releases/69
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/7/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 7 for developers
 slug: Mozilla/Firefox/Releases/7
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating extensions for Firefox 7
 slug: Mozilla/Firefox/Releases/7/Updating_extensions
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/70/index.md
+++ b/files/en-us/mozilla/firefox/releases/70/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 70 for developers
 slug: Mozilla/Firefox/Releases/70
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/71/index.md
+++ b/files/en-us/mozilla/firefox/releases/71/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 71 for Developers
 slug: Mozilla/Firefox/Releases/71
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/72/index.md
+++ b/files/en-us/mozilla/firefox/releases/72/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 72 for Developers
 slug: Mozilla/Firefox/Releases/72
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/73/index.md
+++ b/files/en-us/mozilla/firefox/releases/73/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 73 for developers
 slug: Mozilla/Firefox/Releases/73
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/74/index.md
+++ b/files/en-us/mozilla/firefox/releases/74/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 74 for developers
 slug: Mozilla/Firefox/Releases/74
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/75/index.md
+++ b/files/en-us/mozilla/firefox/releases/75/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 75 for developers
 slug: Mozilla/Firefox/Releases/75
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/76/index.md
+++ b/files/en-us/mozilla/firefox/releases/76/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 76 for developers
 slug: Mozilla/Firefox/Releases/76
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/77/index.md
+++ b/files/en-us/mozilla/firefox/releases/77/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 77 for developers
 slug: Mozilla/Firefox/Releases/77
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/78/index.md
+++ b/files/en-us/mozilla/firefox/releases/78/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 78 for developers
 slug: Mozilla/Firefox/Releases/78
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/79/index.md
+++ b/files/en-us/mozilla/firefox/releases/79/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 79 for developers
 slug: Mozilla/Firefox/Releases/79
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/8/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 8 for developers
 slug: Mozilla/Firefox/Releases/8
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating add-ons for Firefox 8
 slug: Mozilla/Firefox/Releases/8/Updating_add-ons
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/80/index.md
+++ b/files/en-us/mozilla/firefox/releases/80/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 80 for developers
 slug: Mozilla/Firefox/Releases/80
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/81/index.md
+++ b/files/en-us/mozilla/firefox/releases/81/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 81 for developers
 slug: Mozilla/Firefox/Releases/81
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/82/index.md
+++ b/files/en-us/mozilla/firefox/releases/82/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 82 for developers
 slug: Mozilla/Firefox/Releases/82
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/83/index.md
+++ b/files/en-us/mozilla/firefox/releases/83/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 83 for developers
 slug: Mozilla/Firefox/Releases/83
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/84/index.md
+++ b/files/en-us/mozilla/firefox/releases/84/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 84 for developers
 slug: Mozilla/Firefox/Releases/84
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/85/index.md
+++ b/files/en-us/mozilla/firefox/releases/85/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 85 for developers
 slug: Mozilla/Firefox/Releases/85
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/86/index.md
+++ b/files/en-us/mozilla/firefox/releases/86/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 86 for developers
 slug: Mozilla/Firefox/Releases/86
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/87/index.md
+++ b/files/en-us/mozilla/firefox/releases/87/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 87 for developers
 slug: Mozilla/Firefox/Releases/87
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/88/index.md
+++ b/files/en-us/mozilla/firefox/releases/88/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 88 for developers
 slug: Mozilla/Firefox/Releases/88
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/89/index.md
+++ b/files/en-us/mozilla/firefox/releases/89/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 89 for developers
 slug: Mozilla/Firefox/Releases/89
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/9/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 9 for developers
 slug: Mozilla/Firefox/Releases/9
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Updating add-ons for Firefox 9
 slug: Mozilla/Firefox/Releases/9/Updating_add-ons
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/90/index.md
+++ b/files/en-us/mozilla/firefox/releases/90/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 90 for developers
 slug: Mozilla/Firefox/Releases/90
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/91/index.md
+++ b/files/en-us/mozilla/firefox/releases/91/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 91 for developers
 slug: Mozilla/Firefox/Releases/91
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/92/index.md
+++ b/files/en-us/mozilla/firefox/releases/92/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 92 for developers
 slug: Mozilla/Firefox/Releases/92
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/93/index.md
+++ b/files/en-us/mozilla/firefox/releases/93/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 93 for developers
 slug: Mozilla/Firefox/Releases/93
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 94 for developers
 slug: Mozilla/Firefox/Releases/94
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 95 for developers
 slug: Mozilla/Firefox/Releases/95
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 96 for developers
 slug: Mozilla/Firefox/Releases/96
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 97 for developers
 slug: Mozilla/Firefox/Releases/97
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 98 for developers
 slug: Mozilla/Firefox/Releases/98
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 99 for developers
 slug: Mozilla/Firefox/Releases/99
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/index.md
+++ b/files/en-us/mozilla/firefox/releases/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox release notes for developers
 slug: Mozilla/Firefox/Releases
+page-type: landing-page
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/index.md
+++ b/files/en-us/mozilla/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mozilla
 slug: Mozilla
+page-type: landing-page
 ---
 
 {{FirefoxSidebar}}

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -110,6 +110,21 @@
       },
       {
         "if": {
+          "properties": {
+            "slug": { "type": "string", "pattern": "^Mozilla/Firefox" }
+          }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": ["guide", "landing-page", "firefox-release-notes"]
+            }
+          }
+        },
+        "else": false
+      },
+      {
+        "if": {
           "properties": { "slug": { "type": "string", "pattern": "^Web/SVG/" } }
         },
         "then": {


### PR DESCRIPTION
This PR adds `firefox-release-notes` to Mozilla/Firefox (and a few `guide` and `landing-page`.

This is part of openwebdocs/project#91

@bsmth When you have time, can you have a look at this?