### PR TITLE
docs(css): Fx116 - Update "offset-position" property syntax

### DIFF
--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -70,26 +70,26 @@ This example visually compares the initial offset starting position of an elemen
 
 ```html hidden
 <div id="wrap">
-     <div class="box">+</div>
-     <div class="box box0">+</div>
+  <div class="box">+</div>
+  <div class="box box0">+</div>
 </div>
 
 <div id="wrap">
-     <div class="box">+</div>
-     <div class="box box1">+</div>
-     <p>offset-position: normal;</p>
+  <div class="box">+</div>
+  <div class="box box1">+</div>
+  <p>offset-position: normal;</p>
 </div>
 
 <div id="wrap">
-     <div class="box">+</div>
-     <div class="box box2">+</div>
-     <p>offset-position: auto;</p>
+  <div class="box">+</div>
+  <div class="box box2">+</div>
+  <p>offset-position: auto;</p>
 </div>
 
 <div id="wrap">
-     <div class="box">+</div>
-     <div class="box box3">+</div>
-     <p>offset-position: left top;</p>
+  <div class="box">+</div>
+  <div class="box box3">+</div>
+  <p>offset-position: left top;</p>
 </div>
 ```
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -9,12 +9,13 @@ browser-compat: css.properties.offset-position
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`offset-position`** CSS property defines the [initial position](https://www.w3.org/TR/motion-1/#valdef-offsetpath-initial-position) of the {{cssxref("offset-path")}}.
+The **`offset-position`** [CSS](/en-US/docs/Web/CSS) property defines the initial position of an element on a path. It determines where the element gets placed initially for moving along an {{cssxref("offset-path")}}.
 
 ## Syntax
 
 ```css
 /* Keyword values */
+offset-position: normal;
 offset-position: auto;
 offset-position: top;
 offset-position: bottom;
@@ -46,8 +47,10 @@ offset-position: unset;
 
 ### Values
 
+- `normal`
+  - : Indicates that the element does not have an offset starting position.
 - `auto`
-  - : The initial position is the position of the box specified by the {{cssxref("position")}} property.
+  - : Indicates that the offset starting position is the top-left corner of the element box.
 - `<position>`
   - : A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.
 
@@ -61,20 +64,38 @@ offset-position: unset;
 
 ## Examples
 
-### Setting initial offset position
+### Exploring various offset starting positions
+
+### Setting initial offset position for an offset-path
+
+#### HTML
 
 ```html
-<div id="motion-demo"></div>
+<div id="wrap">
+  <div id="motion-demo"></div>
+</div>
 ```
 
+#### CSS
+
 ```css
+#wrap {
+  position: relative;
+  width: 300px;
+  height: 200px;
+  border: 1px solid black;
+}
+
 #motion-demo {
-  offset-path: path("M20,20 C20,100 200,0 200,100");
-  offset-position: left top;
+  offset-path: path("M10,10 C10,100 200,0 200,100");
+  offset-position: auto;
   animation: move 3000ms infinite alternate ease-in-out;
   width: 40px;
   height: 40px;
   background: cyan;
+  position: absolute;
+  left: 40px;
+  top: 40px;
 }
 
 @keyframes move {
@@ -86,6 +107,16 @@ offset-position: unset;
   }
 }
 ```
+
+#### Result
+
+{{EmbedLiveSample('Setting initial offset position for an offset path', '100%', 250)}}
+
+The offset-path property is used to define the path along which an element should move. In this code example, the offset-path property is set to path("M20,20 C20,100 200,0 200,100").
+
+The value of path("M20,20 C20,100 200,0 200,100") is a SVG path data that describes a curved path. The path starts at the point (20,20) and includes a cubic Bezier curve. The control points of the curve are (20,100) and (200,0), and the end point of the curve is (200,100).
+
+By setting the offset-path property to this path, the element with the #motion-demo ID will move along this curved path during the animation.
 
 ## Specifications
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -48,9 +48,9 @@ offset-position: unset;
 ### Values
 
 - `normal`
-  - : Indicates that the element does not have an offset starting position.
+  - : Indicates that the element does not have an offset starting position. This is the default value when the {{cssxref("path")}} CSS function is used to specify the value for the {{cssxref("offset-path")}} property. When the {{cssxref("ray")}} CSS function is used to specify the value for the `offset-path` property, the `normal` keyword defaults to `0px, 0px` of the containing block.
 - `auto`
-  - : Indicates that the offset starting position is the top-left corner of the element box.
+  - : Indicates that the offset starting position is the top-left corner of the element's box. This is the default value when `ray()` is used to specify the value for the {{cssxref("offset-path")}} property.
 - `<position>`
   - : A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.
 
@@ -64,9 +64,104 @@ offset-position: unset;
 
 ## Examples
 
-### Exploring various offset starting positions
+### Comparing various offset starting positions
+
+This example visually compares the initial offset starting position of an element when `ray()` is used to specify a value for the {{cssxref("offset-path")}} property. The `+` text inside the element box is used to depict the element's anchor point.
+
+```html hidden
+<div id="wrap">
+     <div class="box">+</div>
+     <div class="box box0">+</div>
+</div>
+
+<div id="wrap">
+     <div class="box">+</div>
+     <div class="box box1">+</div>
+     <p>offset-position: normal;</p>
+</div>
+
+<div id="wrap">
+     <div class="box">+</div>
+     <div class="box box2">+</div>
+     <p>offset-position: auto;</p>
+</div>
+
+<div id="wrap">
+     <div class="box">+</div>
+     <div class="box box3">+</div>
+     <p>offset-position: left top;</p>
+</div>
+```
+
+```css hidden
+#wrap {
+  position: relative;
+  width: 500px;
+  height: 100px;
+  border: 1px solid black;
+  margin: 0 2em 4em 5em;
+  text-align: center;
+  line-height: 3em;
+}
+
+p {
+  font-family: "Courier New", monospace;
+  font-size: 0.8em;
+  text-align: right;
+  padding-right: 10px;
+}
+
+.box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50px;
+  height: 50px;
+}
+```
+
+```css
+.box {
+  background-color: green;
+  border-top: 5px solid red;
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  opacity: 20%;
+}
+
+.box0 {
+  opacity: 100%;
+}
+
+.box1 {
+  offset-position: normal;
+  offset-path: ray(0deg);
+  opacity: 100%;
+}
+
+.box2 {
+  offset-position: auto;
+  offset-path: ray(0deg);
+  opacity: 100%;
+}
+
+.box3 {
+  offset-position: left top;
+  offset-path: ray(0deg);
+  opacity: 100%;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Comparing various offset starting positions', '100%', 600)}}
+
+Notice the difference between offset starting positions `auto` and `left top`. The value `auto` places the element such that its anchor point is at the top-left corner of the element box itself, whereas the value `left top` places the element such that the anchor point is the top left corner of the containing block.
 
 ### Setting initial offset position for an offset-path
+
+In this example, the {{cssxref("offset-path")}} property is used to define the path along which the `cyan` element should move. The value of the {{cssxref("path")}} CSS function is a SVG path data that describes a curved path. The element moves along this curved path during the `move` animation.
 
 #### HTML
 
@@ -78,24 +173,25 @@ offset-position: unset;
 
 #### CSS
 
-```css
+```css hidden
 #wrap {
-  position: relative;
-  width: 300px;
-  height: 200px;
-  border: 1px solid black;
+  width: 260px;
+  height: 160px;
+  border: 1px dashed black;
 }
+```
 
+```css
 #motion-demo {
-  offset-path: path("M10,10 C10,100 200,0 200,100");
-  offset-position: auto;
+  offset-path: path("M20,20 C20,100 200,0 200,100");
+  offset-position: left top;
   animation: move 3000ms infinite alternate ease-in-out;
   width: 40px;
   height: 40px;
   background: cyan;
   position: absolute;
-  left: 40px;
-  top: 40px;
+  left: 20px;
+  top: 20px;
 }
 
 @keyframes move {
@@ -110,13 +206,7 @@ offset-position: unset;
 
 #### Result
 
-{{EmbedLiveSample('Setting initial offset position for an offset path', '100%', 250)}}
-
-The offset-path property is used to define the path along which an element should move. In this code example, the offset-path property is set to path("M20,20 C20,100 200,0 200,100").
-
-The value of path("M20,20 C20,100 200,0 200,100") is a SVG path data that describes a curved path. The path starts at the point (20,20) and includes a cubic Bezier curve. The control points of the curve are (20,100) and (200,0), and the end point of the curve is (200,100).
-
-By setting the offset-path property to this path, the element with the #motion-demo ID will move along this curved path during the animation.
+{{EmbedLiveSample('Setting_initial_offset_position_for_an_offset-path', '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -9,7 +9,9 @@ browser-compat: css.properties.offset-position
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`offset-position`** [CSS](/en-US/docs/Web/CSS) property defines the initial position of an element on a path. It determines where the element gets placed initially for moving along an {{cssxref("offset-path")}}.
+The **`offset-position`** [CSS](/en-US/docs/Web/CSS) property defines the initial position of an element along a path. This property is typically used in combination with the {{cssxref("offset-path")}} property to create a motion effect. The value of `offset-position` determines where the element gets placed initially for moving along an `offset-path` if the offset-path function does not specify its own starting position.
+
+The `offset-position` property is part of a motion system based on {{cssxref("offset")}} constituent properties, including {{cssxref("offset-anchor")}}, {{cssxref("offset-distance")}}, and `offset-path`. These properties work together to create various motion effects along a path.
 
 ## Syntax
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -54,7 +54,7 @@ offset-position: unset;
 - `auto`
   - : Indicates that the offset starting position is the top-left corner of the element's box. This is the default value.
 - `<position>`
-  - : A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.
+  - : A {{cssxref("&lt;position&gt;")}}. The position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the {{cssxref("length-percentage")}} values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.
 
 ## Formal definition
 
@@ -99,10 +99,12 @@ In this example, the {{cssxref("offset-path")}} property is used to define the p
 }
 
 @keyframes move {
-  0%,20% {
+  0%,
+  20% {
     offset-distance: 0%;
   }
-  80%,100% {
+  80%,
+  100% {
     offset-distance: 100%;
   }
 }
@@ -114,7 +116,7 @@ In this example, the {{cssxref("offset-path")}} property is used to define the p
 
 ### Comparing various offset starting positions
 
-This example visually compares the initial offset starting position of an element when `ray()` is used to specify a value for the {{cssxref("offset-path")}} property. The `+` text inside the element box is used to depict the element's anchor point.
+This example visually compares various initial offset starting position of an element when `ray()` is used to specify a value for the {{cssxref("offset-path")}} property. The number inside the element box indicates the element to which CSS is applied as well as the element's anchor point.
 
 ```html hidden
 <div class="wrap">
@@ -173,7 +175,7 @@ This example visually compares the initial offset starting position of an elemen
 }
 
 pre {
-  font-size: 1.0em;
+  font-size: 1em;
   text-align: right;
   padding-right: 10px;
   line-height: 1em;

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -68,7 +68,7 @@ offset-position: unset;
 
 ### Setting initial offset-position for an offset-path
 
-In this example, the {{cssxref("offset-path")}} property is used to define the path along which the `cyan` element should move. The value of the {{cssxref("path")}} CSS function is a SVG path data that describes a curved path. The element moves along this curved path during the `move` animation.
+In this example, the {{cssxref("offset-path")}} property is used to define the path along which the `cyan` element should move. The value of the {{cssxref("path")}} CSS function is an [SVG data path](/en-US/docs/Web/SVG/Attribute/d) that describes a curved path. The element moves along this curved path during the `move` animation.
 
 #### HTML
 
@@ -96,16 +96,13 @@ In this example, the {{cssxref("offset-path")}} property is used to define the p
   width: 40px;
   height: 40px;
   background: cyan;
-  position: absolute;
-  left: 20px;
-  top: 20px;
 }
 
 @keyframes move {
-  0% {
+  0%,20% {
     offset-distance: 0%;
   }
-  100% {
+  80%,100% {
     offset-distance: 100%;
   }
 }
@@ -121,51 +118,65 @@ This example visually compares the initial offset starting position of an elemen
 
 ```html hidden
 <div class="wrap">
-  <div class="box">+</div>
-  <div class="box box0">+</div>
+  <div class="box">0</div>
+  <div class="box box0">0</div>
+  <pre>
+    offset-position: normal;
+  </pre>
 </div>
 
 <div class="wrap">
-  <div class="box">+</div>
-  <div class="box box1">+</div>
-  <p>offset-position: normal;</p>
+  <div class="box">0</div>
+  <div class="box box1">1</div>
+  <pre>
+    offset-position: normal;
+    offset-path: ray(0deg);
+  </pre>
 </div>
 
 <div class="wrap">
-  <div class="box">+</div>
-  <div class="box box2">+</div>
-  <p>offset-position: auto;</p>
+  <div class="box">0</div>
+  <div class="box box2">2</div>
+  <pre>
+    offset-position: auto;
+    offset-path: ray(0deg);
+  </pre>
 </div>
 
 <div class="wrap">
-  <div class="box">+</div>
-  <div class="box box3">+</div>
-  <p>offset-position: left top;</p>
+  <div class="box">0</div>
+  <div class="box box3">3</div>
+  <pre>
+    offset-position: left top;
+    offset-path: ray(0deg);
+  </pre>
 </div>
 
 <div class="wrap">
-  <div class="box">+</div>
-  <div class="box box4">+</div>
-  <p>offset-position: 30% 70%;</p>
+  <div class="box">0</div>
+  <div class="box box4">4</div>
+  <pre>
+    offset-position: 30% 70%;
+    offset-path: ray(120deg);
+  </pre>
 </div>
 ```
 
 ```css hidden
 .wrap {
   position: relative;
-  width: 500px;
-  height: 100px;
+  width: 600px;
+  height: 120px;
   border: 1px solid black;
   margin: 0 2em 4em 5em;
   text-align: center;
-  line-height: 3em;
 }
 
-p {
-  font-family: "Courier New", monospace;
-  font-size: 0.8em;
+pre {
+  font-size: 1.0em;
   text-align: right;
   padding-right: 10px;
+  line-height: 1em;
 }
 
 .box {
@@ -175,50 +186,52 @@ p {
   width: 50px;
   height: 50px;
 }
+
+.box + .box {
+  opacity: 1;
+}
 ```
 
 ```css
 .box {
   background-color: green;
-  border-top: 5px solid red;
+  border-top: 6px dashed white;
+  background-clip: border-box;
   position: absolute;
   top: 20px;
   left: 20px;
   opacity: 20%;
+  color: white;
 }
 
 .box0 {
-  opacity: 100%;
+  offset-position: normal;
 }
 
 .box1 {
   offset-position: normal;
   offset-path: ray(0deg);
-  opacity: 100%;
 }
 
 .box2 {
   offset-position: auto;
   offset-path: ray(0deg);
-  opacity: 100%;
 }
 
 .box3 {
   offset-position: left top;
   offset-path: ray(0deg);
-  opacity: 100%;
 }
 
 .box4 {
   offset-position: 30% 70%;
-  offset-path: ray(180deg);
-  opacity: 100%;
+  offset-path: ray(120deg);
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample('Comparing various offset starting positions', '100%', 830)}}
+{{EmbedLiveSample('Comparing various offset starting positions', '100%', 930)}}
 
 Notice that when `offset-position` is `normal`, the starting position of the ray is `50%, 50%` of the containing block. Also notice the difference between offset starting positions `auto` and `left top`. The value `auto` places the element such that its anchor point is at the top-left corner of the element box itself, whereas the value `left top` places the element such that the anchor point is the top-left corner of the containing block.
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -50,9 +50,9 @@ offset-position: unset;
 ### Values
 
 - `normal`
-  - : Indicates that the element does not have an offset starting position. This is the default value when the {{cssxref("path")}} CSS function is used to specify the value for the {{cssxref("offset-path")}} property. When the {{cssxref("ray")}} CSS function is used to specify the value for the `offset-path` property, the `normal` keyword defaults to `0px, 0px` of the containing block.
+  - : Indicates that the element does not have an offset starting position.
 - `auto`
-  - : Indicates that the offset starting position is the top-left corner of the element's box. This is the default value when `ray()` is used to specify the value for the {{cssxref("offset-path")}} property.
+  - : Indicates that the offset starting position is the top-left corner of the element's box. This is the default value.
 - `<position>`
   - : A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s). For more explanation of these value types, see {{cssxref("background-position")}}.
 
@@ -220,7 +220,7 @@ p {
 
 {{EmbedLiveSample('Comparing various offset starting positions', '100%', 830)}}
 
-Notice the difference between offset starting positions `auto` and `left top`. The value `auto` places the element such that its anchor point is at the top-left corner of the element box itself, whereas the value `left top` places the element such that the anchor point is the top left corner of the containing block.
+Notice that when `offset-position` is `normal`, the starting position of the ray is `50%, 50%` of the containing block. Also notice the difference between offset starting positions `auto` and `left top`. The value `auto` places the element such that its anchor point is at the top-left corner of the element box itself, whereas the value `left top` places the element such that the anchor point is the top-left corner of the containing block.
 
 ## Specifications
 

--- a/files/en-us/web/css/offset-position/index.md
+++ b/files/en-us/web/css/offset-position/index.md
@@ -64,37 +64,92 @@ offset-position: unset;
 
 ## Examples
 
+### Setting initial offset-position for an offset-path
+
+In this example, the {{cssxref("offset-path")}} property is used to define the path along which the `cyan` element should move. The value of the {{cssxref("path")}} CSS function is a SVG path data that describes a curved path. The element moves along this curved path during the `move` animation.
+
+#### HTML
+
+```html
+<div id="wrap">
+  <div id="motion-demo"></div>
+</div>
+```
+
+#### CSS
+
+```css hidden
+#wrap {
+  width: 260px;
+  height: 160px;
+  border: 1px dashed black;
+}
+```
+
+```css
+#motion-demo {
+  offset-path: path("M20,20 C20,100 200,0 200,100");
+  offset-position: left top;
+  animation: move 3000ms infinite alternate ease-in-out;
+  width: 40px;
+  height: 40px;
+  background: cyan;
+  position: absolute;
+  left: 20px;
+  top: 20px;
+}
+
+@keyframes move {
+  0% {
+    offset-distance: 0%;
+  }
+  100% {
+    offset-distance: 100%;
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Setting_initial_offset_position_for_an_offset-path', '100%', 200)}}
+
 ### Comparing various offset starting positions
 
 This example visually compares the initial offset starting position of an element when `ray()` is used to specify a value for the {{cssxref("offset-path")}} property. The `+` text inside the element box is used to depict the element's anchor point.
 
 ```html hidden
-<div id="wrap">
+<div class="wrap">
   <div class="box">+</div>
   <div class="box box0">+</div>
 </div>
 
-<div id="wrap">
+<div class="wrap">
   <div class="box">+</div>
   <div class="box box1">+</div>
   <p>offset-position: normal;</p>
 </div>
 
-<div id="wrap">
+<div class="wrap">
   <div class="box">+</div>
   <div class="box box2">+</div>
   <p>offset-position: auto;</p>
 </div>
 
-<div id="wrap">
+<div class="wrap">
   <div class="box">+</div>
   <div class="box box3">+</div>
   <p>offset-position: left top;</p>
 </div>
+
+<div class="wrap">
+  <div class="box">+</div>
+  <div class="box box4">+</div>
+  <p>offset-position: 30% 70%;</p>
+</div>
 ```
 
 ```css hidden
-#wrap {
+.wrap {
   position: relative;
   width: 500px;
   height: 100px;
@@ -151,62 +206,19 @@ p {
   offset-path: ray(0deg);
   opacity: 100%;
 }
+
+.box4 {
+  offset-position: 30% 70%;
+  offset-path: ray(180deg);
+  opacity: 100%;
+}
 ```
 
 #### Result
 
-{{EmbedLiveSample('Comparing various offset starting positions', '100%', 600)}}
+{{EmbedLiveSample('Comparing various offset starting positions', '100%', 830)}}
 
 Notice the difference between offset starting positions `auto` and `left top`. The value `auto` places the element such that its anchor point is at the top-left corner of the element box itself, whereas the value `left top` places the element such that the anchor point is the top left corner of the containing block.
-
-### Setting initial offset position for an offset-path
-
-In this example, the {{cssxref("offset-path")}} property is used to define the path along which the `cyan` element should move. The value of the {{cssxref("path")}} CSS function is a SVG path data that describes a curved path. The element moves along this curved path during the `move` animation.
-
-#### HTML
-
-```html
-<div id="wrap">
-  <div id="motion-demo"></div>
-</div>
-```
-
-#### CSS
-
-```css hidden
-#wrap {
-  width: 260px;
-  height: 160px;
-  border: 1px dashed black;
-}
-```
-
-```css
-#motion-demo {
-  offset-path: path("M20,20 C20,100 200,0 200,100");
-  offset-position: left top;
-  animation: move 3000ms infinite alternate ease-in-out;
-  width: 40px;
-  height: 40px;
-  background: cyan;
-  position: absolute;
-  left: 20px;
-  top: 20px;
-}
-
-@keyframes move {
-  0% {
-    offset-distance: 0%;
-  }
-  100% {
-    offset-distance: 100%;
-  }
-}
-```
-
-#### Result
-
-{{EmbedLiveSample('Setting_initial_offset_position_for_an_offset-path', '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -9,9 +9,11 @@ browser-compat: css.types.ray
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`ray()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) defines a line segment that begins from an [offset starting position](https://drafts.fxtf.org/motion/#offset-starting-position) and extends in the direction of the specified angle. The line segment is referred to as "ray". The length of a ray can be constrained by specifying a size and using the `contain` keyword.
+The **`ray()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) defines a line segment that begins from an {{cssxref("offset-position")}} and extends in the direction of the specified angle. The line segment is referred to as "ray". The length of a ray can be constrained by specifying a size and using the `contain` keyword.
 
-The `ray()` function is used in [CSS motion path](/en-US/docs/Web/CSS/CSS_motion_path). It is used as a value for the [`offset-path`](/en-US/docs/Web/CSS/offset-path) property to define the path that an animated element can follow. The element is initially positioned by moving the element's [`offset-anchor`](/en-US/docs/Web/CSS/offset-anchor) point to the path's offset starting position. The default offset starting position of a ray is at the top-left corner of the element box.
+The `ray()` function is used in [CSS motion path](/en-US/docs/Web/CSS/CSS_motion_path). It is used as a value for the [`offset-path`](/en-US/docs/Web/CSS/offset-path) property to define the path that an animated element can follow. The element is initially positioned by moving the element's [`offset-anchor`](/en-US/docs/Web/CSS/offset-anchor) point to the path's offset starting position.
+
+> **Note:** The default offset starting position of a ray is at the top-left corner of the element box (that is, `offset-position: auto`).
 
 ## Syntax
 

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -18,7 +18,7 @@ ray() = ray( <angle> && <ray-size>? && contain? )
 
 The `ray()` function is used in [CSS motion path](/en-US/docs/Web/CSS/CSS_motion_path). It is used as a value for the [`offset-path`](/en-US/docs/Web/CSS/offset-path) property to define the path that an animated element can follow. The element is initially positioned by moving the element's [`offset-anchor`](/en-US/docs/Web/CSS/offset-anchor) point to the path's offset starting position.
 
-> **Note:** The default offset starting position of a ray is the `left top` corner (or `0 0`) of the element box (that is, `offset-position` is `auto`). With `offset-position: normal`, the starting position of the ray is `50%, 50%` of the containing block.
+> **Note:** The default offset starting position of a ray is `auto`. If `offset-position: auto` is explicitly specified or allowed to default, the offset starting position is the `left top` corner (or `0 0`) of the element box. With `offset-position: normal`, the starting position of the ray is `50%, 50%` of the containing block.
 
 ## Syntax
 

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -11,16 +11,16 @@ browser-compat: css.types.ray
 
 The **`ray()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) defines a line segment that begins from an {{cssxref("offset-position")}} and extends in the direction of the specified angle. The line segment is referred to as "ray". The length of a ray can be constrained by specifying a size and using the `contain` keyword.
 
+```css
+ray() = ray( <angle> && <ray-size>? && contain? )
+<ray-size> = closest-side | closest-corner | farthest-side | farthest-corner | sides
+```
+
 The `ray()` function is used in [CSS motion path](/en-US/docs/Web/CSS/CSS_motion_path). It is used as a value for the [`offset-path`](/en-US/docs/Web/CSS/offset-path) property to define the path that an animated element can follow. The element is initially positioned by moving the element's [`offset-anchor`](/en-US/docs/Web/CSS/offset-anchor) point to the path's offset starting position.
 
 > **Note:** The default offset starting position of a ray is the `left top` corner (or `0 0`) of the element box (that is, `offset-position` is `auto`). With `offset-position: normal`, the starting position of the ray is `50%, 50%` of the containing block.
 
 ## Syntax
-
-```css
-ray() = ray( <angle> && <ray-size>? && contain? )
-<ray-size> = closest-side | closest-corner | farthest-side | farthest-corner | sides
-```
 
 ```css
 /* property: ray(expression) */

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -13,7 +13,7 @@ The **`ray()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Fu
 
 The `ray()` function is used in [CSS motion path](/en-US/docs/Web/CSS/CSS_motion_path). It is used as a value for the [`offset-path`](/en-US/docs/Web/CSS/offset-path) property to define the path that an animated element can follow. The element is initially positioned by moving the element's [`offset-anchor`](/en-US/docs/Web/CSS/offset-anchor) point to the path's offset starting position.
 
-> **Note:** The default offset starting position of a ray is at the top-left corner of the element box (that is, `offset-position: auto`).
+> **Note:** The default offset starting position of a ray is the `left top` corner (or `0 0`) of the element box (that is, `offset-position` is `auto`). With `offset-position: normal`, the starting position of the ray is `50%, 50%` of the containing block.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The syntax of the [`offset-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-position) property has changed.
- A new keyword (`normal`) has been added: https://drafts.fxtf.org/motion/#offset-position-property

This PR updates the `offset-position` property page:
- Adds the new `normal` keyword
- Updates the description of the `auto` keyword
- Adds a "Result" frame for the existing example
- Adds a new example to show the difference in the values of the `offset-position` property (codepen: https://codepen.io/dipikabh/pen/oNQZyOm)

### Caveats

- Firefox has newly added support for the `offset-position` property behind the pref `layout.css.motion-path-offset-position.enabled`.
- To view the example containing the `ray()` function, the pref `layout.css.motion-path-ray.enabled` will also need to be enabled
- The code example is based on the (expected) behavior I tested in Nightly. I did not see the expected behavior of `normal` in Firefox beta 115.0b9.

### Related issues and pull requests

Doc tracker for this update: https://github.com/mdn/content/issues/27174
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1559232

### To Dos

- [x] Update BCD: https://github.com/mdn/browser-compat-data/pull/20250
- [x] Update release notes: https://github.com/mdn/content/pull/27730
    - [x] Updated release note for Fx116: https://github.com/mdn/content/pull/28036
- [x] Update mdn/data: https://github.com/mdn/data/pull/673
