### PR TITLE
Remove autofocus in attributes page

### DIFF
--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -120,20 +120,6 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
-        <code><a href="/en-us/web/html/global_attributes/autofocus">autofocus</a></code>
-      </td>
-      <td>
-        {{ HTMLElement("button") }},
-        {{ HTMLElement("input") }},
-        {{ HTMLElement("select") }},
-        {{ HTMLElement("textarea") }}
-      </td>
-      <td>
-        The element should be automatically focused after the page loaded.
-      </td>
-    </tr>
-    <tr>
-      <td>
         <code><a href="/en-US/docs/Web/HTML/Attributes/autoplay">autoplay</a></code>
       </td>
       <td>

--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -120,7 +120,7 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
-        <code><a href="/en-US/docs/Web/HTML/Attributes/autofocus">autofocus</a></code>
+        <code><a href="/en-us/web/html/global_attributes/autofocus">autofocus</a></code>
       </td>
       <td>
         {{ HTMLElement("button") }},


### PR DESCRIPTION
Fixed link to autofocus page

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fixed link to Autofocus page on HTML attribute reference page

<!-- ✍️ Summarize your changes in one or two sentences -->
Changed link to correct reference page
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I, as a reader, had the problem when I noticed red squiggly lines which said 'Page not found'. Thus I fixed it.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
