### PR TITLE
Fix grammatical error on en-us URL page

### DIFF
--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -73,7 +73,7 @@ console.log(url.hostname); // "www.example.com"
 console.log(url.pathname); // "/cats"
 ```
 
-The constructor with raise an exception if the URL cannot be parsed to a valid URL.
+The constructor will raise an exception if the URL cannot be parsed to a valid URL.
 You can either call the above code in a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block or use the [`canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method to first check the URL is valid:
 
 ```js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a grammatical error

### Motivation

Good english = good docs

### Additional details

- https://dictionary.cambridge.org/grammar/british-grammar/with
- https://dictionary.cambridge.org/grammar/british-grammar/will

### Related issues and pull requests

🌚
