### PR TITLE
firefox-115: update `canParse()` method name to follow the current convention

### DIFF
--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -49,9 +49,9 @@ This article provides information about the changes in Firefox 115 that affect d
 
 ### APIs
 
-- The [`Response: json()` static method](/en-US/docs/Web/API/Response/json_static) is now supported, making it easier to construct {{domxref("Response")}} objects for returning JSON data.
+- The [`Response.json()`](/en-US/docs/Web/API/Response/json_static) static method is now supported, making it easier to construct {{domxref("Response")}} objects for returning JSON data.
   The method will be useful for [service workers](/en-US/docs/Web/API/Service_Worker_API) and any other code that needs to respond to browser requests with JSON data ([Firefox bug 1758943](https://bugzil.la/1758943)).
-- The [`URL: canParse()` static method](/en-US/docs/Web/API/URL/canParse_static) can now be used to parse and validate an absolute URL, or a relative URL and base URL.
+- The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static)  static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
   This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
   ([Firefox bug 1823354](https://bugzil.la/1823354)).
 - The [`URLSearchParams.has()`](/en-US/docs/Web/API/URLSearchParams/has) and [`URLSearchParams.delete()`](/en-US/docs/Web/API/URLSearchParams/delete) methods now support the optional `value` argument.

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -51,7 +51,7 @@ This article provides information about the changes in Firefox 115 that affect d
 
 - The [`Response.json()`](/en-US/docs/Web/API/Response/json_static) static method is now supported, making it easier to construct {{domxref("Response")}} objects for returning JSON data.
   The method will be useful for [service workers](/en-US/docs/Web/API/Service_Worker_API) and any other code that needs to respond to browser requests with JSON data ([Firefox bug 1758943](https://bugzil.la/1758943)).
-- The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static)  static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
+- The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
   This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
   ([Firefox bug 1823354](https://bugzil.la/1823354)).
 - The [`URLSearchParams.has()`](/en-US/docs/Web/API/URLSearchParams/has) and [`URLSearchParams.delete()`](/en-US/docs/Web/API/URLSearchParams/delete) methods now support the optional `value` argument.

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -51,7 +51,7 @@ This article provides information about the changes in Firefox 115 that affect d
 
 - The [`Response: json()` static method](/en-US/docs/Web/API/Response/json_static) is now supported, making it easier to construct {{domxref("Response")}} objects for returning JSON data.
   The method will be useful for [service workers](/en-US/docs/Web/API/Service_Worker_API) and any other code that needs to respond to browser requests with JSON data ([Firefox bug 1758943](https://bugzil.la/1758943)).
-- The [`URL.canParse()`](/en-US/docs/Web/API/URL/canParse_static) static method can now be used to parse and validate an absolute URL, or a relative URL and base URL.
+- The [`URL: canParse()` static method](/en-US/docs/Web/API/URL/canParse_static) can now be used to parse and validate an absolute URL, or a relative URL and base URL.
   This provides a fast and easy way to check if URLs are valid, instead of constructing them within a `try...catch` block and handling exceptions.
   ([Firefox bug 1823354](https://bugzil.la/1823354)).
 - The [`URLSearchParams.has()`](/en-US/docs/Web/API/URLSearchParams/has) and [`URLSearchParams.delete()`](/en-US/docs/Web/API/URLSearchParams/delete) methods now support the optional `value` argument.


### PR DESCRIPTION
### Description

change `URL.canParse()` to `URL: canParse()`.

### Motivation

to make it clear the method is a static method, not an instant method

### Additional details

this also aligns with the `Response: json()` item listed above

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
