### PR TITLE
Remove idleCallback/animationFrame polyfills

### DIFF
--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -68,4 +68,3 @@ cancelAnimationFrame(myReq);
 ## See also
 
 - {{domxref("window.requestAnimationFrame()")}}
-- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/window.polyfill.js)

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -41,7 +41,3 @@ in the article [Cooperative Scheduling of Background Tasks API](/en-US/docs/Web/
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/window.polyfill.js)

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -117,4 +117,3 @@ window.requestAnimationFrame(step);
 - [Animating with JavaScript: from setInterval to requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/) - Blog post
 - [TestUFO: Test your web browser for requestAnimationFrame() Timing Deviations](https://www.testufo.com/#test=animation-time-graph)
 - Paul Irish: [requestAnimationFrame API: now with sub-millisecond precision](https://developer.chrome.com/blog/requestanimationframe-api-now-with-sub-millisecond-precision/)
-- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/window.polyfill.js)

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -69,4 +69,3 @@ in the article [Cooperative Scheduling of Background Tasks API](/en-US/docs/Web/
 - {{domxref("setTimeout()")}}
 - {{domxref("setInterval()")}}
 - {{domxref("window.requestAnimationFrame")}}
-- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/window.polyfill.js)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The polyfill's implementation is somewhat naïve—for example, it doesn't deal with mutated built-ins like `performance.now = () => "Nope"`. Furthermore it adds these properties as _enumerable_ properties on `window`, which is a big no-no for faithful polyfills.

In addition there are possible conformance issues (fixes https://github.com/mdn/content/issues/25804), therefore I think it's in our best interest to remove this polyfill source.

cc @behnammodi 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
