### PR TITLE
Add page types for Web/XML, Web/XPath, Web/(E)XSLT

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -173,6 +173,26 @@ This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs
 
 - `web-manifest-member`: a member of a manifest, like [`description`](/en-US/docs/Web/Manifest/description).
 
+### XPath page types
+
+This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
+
+- `xpath-function`: a function, like [`ceiling](/en-US/docs/Web/XPath/Functions/ceiling)
+
+### XSLT page types
+
+This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
+
+- `xslt-element`: an element of XSLT, like [`<xsl:message>`](/en-US/docs/WWeb/XSLT/Element/message).
+- `xslt-function`: a function of XSLT, like [`description`](/en-US/docs/Web/Manifest/description).
+- `xslt-axis`: an axis of XSLT, like [`ancestor`](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/ancestor).
+
+### EXSLT page types
+
+This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
+
+- `web-manifest-member`: a member of a manifest, like [`description`](/en-US/docs/Web/Manifest/description).
+
 ### Firefox page types
 
 This section lists `page-type` values for pages under [Mozilla/Firefox](/en-US/docs/Mozilla/Firefox). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -177,21 +177,20 @@ This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs
 
 This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
-- `xpath-function`: a function, like [`ceiling](/en-US/docs/Web/XPath/Functions/ceiling)
+- `xpath-function`: a function, like [`ceiling()`](/en-US/docs/Web/XPath/Functions/ceiling)
 
 ### XSLT page types
 
 This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
 - `xslt-element`: an element of XSLT, like [`<xsl:message>`](/en-US/docs/WWeb/XSLT/Element/message).
-- `xslt-function`: a function of XSLT, like [`description`](/en-US/docs/Web/Manifest/description).
 - `xslt-axis`: an axis of XSLT, like [`ancestor`](/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/ancestor).
 
 ### EXSLT page types
 
 This section lists `page-type` values for pages under [Web/Manifest](/en-US/docs/Web/Manifest). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
-- `web-manifest-member`: a member of a manifest, like [`description`](/en-US/docs/Web/Manifest/description).
+- `xslt-function`: a function of EXSLT, like [`exsl:node-set()`](/en-US/docs/Web/EXSLT/exsl/node-set).
 
 ### Firefox page types
 

--- a/files/en-us/web/exslt/exsl/index.md
+++ b/files/en-us/web/exslt/exsl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Common (exsl)
 slug: Web/EXSLT/exsl
+page-type: landing-page
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/exsl/node-set/index.md
+++ b/files/en-us/web/exslt/exsl/node-set/index.md
@@ -1,6 +1,7 @@
 ---
 title: exsl:node-set()
 slug: Web/EXSLT/exsl/node-set
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/exsl/object-type/index.md
+++ b/files/en-us/web/exslt/exsl/object-type/index.md
@@ -1,6 +1,7 @@
 ---
 title: exsl:object-type()
 slug: Web/EXSLT/exsl/object-type
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/index.md
+++ b/files/en-us/web/exslt/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXSLT
 slug: Web/EXSLT
+page-type: landing-page
 ---
 
 EXSLT is a set of extensions to [XSLT](/en-US/docs/Web/XSLT). There are a number of modules; those that are supported by Firefox are listed below:

--- a/files/en-us/web/exslt/math/highest/index.md
+++ b/files/en-us/web/exslt/math/highest/index.md
@@ -1,6 +1,7 @@
 ---
 title: math:highest()
 slug: Web/EXSLT/math/highest
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/index.md
+++ b/files/en-us/web/exslt/math/index.md
@@ -1,6 +1,7 @@
 ---
 title: Math (math)
 slug: Web/EXSLT/math
+page-type: landing-page
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/lowest/index.md
+++ b/files/en-us/web/exslt/math/lowest/index.md
@@ -1,6 +1,7 @@
 ---
 title: math:lowest()
 slug: Web/EXSLT/math/lowest
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/max/index.md
+++ b/files/en-us/web/exslt/math/max/index.md
@@ -1,6 +1,7 @@
 ---
 title: math:max()
 slug: Web/EXSLT/math/max
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -1,6 +1,7 @@
 ---
 title: math:min()
 slug: Web/EXSLT/math/min
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/index.md
+++ b/files/en-us/web/exslt/regexp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Regular expressions (regexp)
 slug: Web/EXSLT/regexp
+page-type: landing-page
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -1,6 +1,7 @@
 ---
 title: regexp:match()
 slug: Web/EXSLT/regexp/match
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/replace/index.md
+++ b/files/en-us/web/exslt/regexp/replace/index.md
@@ -1,6 +1,7 @@
 ---
 title: regexp:replace()
 slug: Web/EXSLT/regexp/replace
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/regexp/test/index.md
+++ b/files/en-us/web/exslt/regexp/test/index.md
@@ -1,6 +1,7 @@
 ---
 title: regexp:test()
 slug: Web/EXSLT/regexp/test
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/difference/index.md
+++ b/files/en-us/web/exslt/set/difference/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:difference()
 slug: Web/EXSLT/set/difference
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/distinct/index.md
+++ b/files/en-us/web/exslt/set/distinct/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:distinct()
 slug: Web/EXSLT/set/distinct
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/has-same-node/index.md
+++ b/files/en-us/web/exslt/set/has-same-node/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:has-same-node()
 slug: Web/EXSLT/set/has-same-node
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/index.md
+++ b/files/en-us/web/exslt/set/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sets (set)
 slug: Web/EXSLT/set
+page-type: landing-page
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/intersection/index.md
+++ b/files/en-us/web/exslt/set/intersection/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:intersection()
 slug: Web/EXSLT/set/intersection
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/leading/index.md
+++ b/files/en-us/web/exslt/set/leading/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:leading()
 slug: Web/EXSLT/set/leading
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/set/trailing/index.md
+++ b/files/en-us/web/exslt/set/trailing/index.md
@@ -1,6 +1,7 @@
 ---
 title: set:trailing()
 slug: Web/EXSLT/set/trailing
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/concat/index.md
+++ b/files/en-us/web/exslt/str/concat/index.md
@@ -1,6 +1,7 @@
 ---
 title: str:concat()
 slug: Web/EXSLT/str/concat
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/index.md
+++ b/files/en-us/web/exslt/str/index.md
@@ -1,6 +1,7 @@
 ---
 title: Strings (str)
 slug: Web/EXSLT/str
+page-type: landing-page
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/split/index.md
+++ b/files/en-us/web/exslt/str/split/index.md
@@ -1,6 +1,7 @@
 ---
 title: str:split()
 slug: Web/EXSLT/str/split
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/exslt/str/tokenize/index.md
+++ b/files/en-us/web/exslt/str/tokenize/index.md
@@ -1,6 +1,7 @@
 ---
 title: str:tokenize()
 slug: Web/EXSLT/str/tokenize
+page-type: exslt-function
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}

--- a/files/en-us/web/xml/index.md
+++ b/files/en-us/web/xml/index.md
@@ -1,6 +1,7 @@
 ---
 title: "XML: Extensible Markup Language"
 slug: Web/XML
+page-type: landing-page
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}

--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: XML introduction
 slug: Web/XML/XML_introduction
+page-type: guide
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}

--- a/files/en-us/web/xpath/axes/index.md
+++ b/files/en-us/web/xpath/axes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Axes
 slug: Web/XPath/Axes
+page-type: landing-page
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/comparison_with_css_selectors/index.md
+++ b/files/en-us/web/xpath/comparison_with_css_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Comparison of CSS Selectors and XPath
 slug: Web/XPath/Comparison_with_CSS_selectors
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/boolean/index.md
+++ b/files/en-us/web/xpath/functions/boolean/index.md
@@ -1,6 +1,7 @@
 ---
 title: boolean
 slug: Web/XPath/Functions/boolean
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/ceiling/index.md
+++ b/files/en-us/web/xpath/functions/ceiling/index.md
@@ -1,6 +1,7 @@
 ---
 title: ceiling
 slug: Web/XPath/Functions/ceiling
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/choose/index.md
+++ b/files/en-us/web/xpath/functions/choose/index.md
@@ -1,6 +1,7 @@
 ---
 title: choose
 slug: Web/XPath/Functions/choose
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/concat/index.md
+++ b/files/en-us/web/xpath/functions/concat/index.md
@@ -1,6 +1,7 @@
 ---
 title: concat
 slug: Web/XPath/Functions/concat
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/contains/index.md
+++ b/files/en-us/web/xpath/functions/contains/index.md
@@ -1,6 +1,7 @@
 ---
 title: contains
 slug: Web/XPath/Functions/contains
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/count/index.md
+++ b/files/en-us/web/xpath/functions/count/index.md
@@ -1,6 +1,7 @@
 ---
 title: count
 slug: Web/XPath/Functions/count
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/current/index.md
+++ b/files/en-us/web/xpath/functions/current/index.md
@@ -1,6 +1,7 @@
 ---
 title: current
 slug: Web/XPath/Functions/current
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/document/index.md
+++ b/files/en-us/web/xpath/functions/document/index.md
@@ -1,6 +1,7 @@
 ---
 title: document
 slug: Web/XPath/Functions/document
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/element-available/index.md
+++ b/files/en-us/web/xpath/functions/element-available/index.md
@@ -1,6 +1,7 @@
 ---
 title: element-available
 slug: Web/XPath/Functions/element-available
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/false/index.md
+++ b/files/en-us/web/xpath/functions/false/index.md
@@ -1,6 +1,7 @@
 ---
 title: "false"
 slug: Web/XPath/Functions/false
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/floor/index.md
+++ b/files/en-us/web/xpath/functions/floor/index.md
@@ -1,6 +1,7 @@
 ---
 title: floor
 slug: Web/XPath/Functions/floor
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/format-number/index.md
+++ b/files/en-us/web/xpath/functions/format-number/index.md
@@ -1,6 +1,7 @@
 ---
 title: format-number
 slug: Web/XPath/Functions/format-number
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/function-available/index.md
+++ b/files/en-us/web/xpath/functions/function-available/index.md
@@ -1,6 +1,7 @@
 ---
 title: function-available
 slug: Web/XPath/Functions/function-available
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/generate-id/index.md
+++ b/files/en-us/web/xpath/functions/generate-id/index.md
@@ -1,6 +1,7 @@
 ---
 title: generate-id
 slug: Web/XPath/Functions/generate-id
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/id/index.md
+++ b/files/en-us/web/xpath/functions/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: id
 slug: Web/XPath/Functions/id
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/index.md
+++ b/files/en-us/web/xpath/functions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Functions
 slug: Web/XPath/Functions
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/key/index.md
+++ b/files/en-us/web/xpath/functions/key/index.md
@@ -1,6 +1,7 @@
 ---
 title: key
 slug: Web/XPath/Functions/key
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/lang/index.md
+++ b/files/en-us/web/xpath/functions/lang/index.md
@@ -1,6 +1,7 @@
 ---
 title: lang
 slug: Web/XPath/Functions/lang
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/last/index.md
+++ b/files/en-us/web/xpath/functions/last/index.md
@@ -1,6 +1,7 @@
 ---
 title: last
 slug: Web/XPath/Functions/last
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/local-name/index.md
+++ b/files/en-us/web/xpath/functions/local-name/index.md
@@ -1,6 +1,7 @@
 ---
 title: local-name
 slug: Web/XPath/Functions/local-name
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/name/index.md
+++ b/files/en-us/web/xpath/functions/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: name
 slug: Web/XPath/Functions/name
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/namespace-uri/index.md
+++ b/files/en-us/web/xpath/functions/namespace-uri/index.md
@@ -1,6 +1,7 @@
 ---
 title: namespace-uri
 slug: Web/XPath/Functions/namespace-uri
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/normalize-space/index.md
+++ b/files/en-us/web/xpath/functions/normalize-space/index.md
@@ -1,6 +1,7 @@
 ---
 title: normalize-space
 slug: Web/XPath/Functions/normalize-space
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/not/index.md
+++ b/files/en-us/web/xpath/functions/not/index.md
@@ -1,6 +1,7 @@
 ---
 title: not
 slug: Web/XPath/Functions/not
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/number/index.md
+++ b/files/en-us/web/xpath/functions/number/index.md
@@ -1,6 +1,7 @@
 ---
 title: number
 slug: Web/XPath/Functions/number
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/position/index.md
+++ b/files/en-us/web/xpath/functions/position/index.md
@@ -1,6 +1,7 @@
 ---
 title: position
 slug: Web/XPath/Functions/position
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/round/index.md
+++ b/files/en-us/web/xpath/functions/round/index.md
@@ -1,6 +1,7 @@
 ---
 title: round
 slug: Web/XPath/Functions/round
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/starts-with/index.md
+++ b/files/en-us/web/xpath/functions/starts-with/index.md
@@ -1,6 +1,7 @@
 ---
 title: starts-with
 slug: Web/XPath/Functions/starts-with
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/string-length/index.md
+++ b/files/en-us/web/xpath/functions/string-length/index.md
@@ -1,6 +1,7 @@
 ---
 title: string-length
 slug: Web/XPath/Functions/string-length
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/string/index.md
+++ b/files/en-us/web/xpath/functions/string/index.md
@@ -1,6 +1,7 @@
 ---
 title: string
 slug: Web/XPath/Functions/string
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/substring-after/index.md
+++ b/files/en-us/web/xpath/functions/substring-after/index.md
@@ -1,6 +1,7 @@
 ---
 title: substring-after
 slug: Web/XPath/Functions/substring-after
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/substring-before/index.md
+++ b/files/en-us/web/xpath/functions/substring-before/index.md
@@ -1,6 +1,7 @@
 ---
 title: substring-before
 slug: Web/XPath/Functions/substring-before
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/substring/index.md
+++ b/files/en-us/web/xpath/functions/substring/index.md
@@ -1,6 +1,7 @@
 ---
 title: substring
 slug: Web/XPath/Functions/substring
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/sum/index.md
+++ b/files/en-us/web/xpath/functions/sum/index.md
@@ -1,6 +1,7 @@
 ---
 title: sum
 slug: Web/XPath/Functions/sum
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/system-property/index.md
+++ b/files/en-us/web/xpath/functions/system-property/index.md
@@ -1,6 +1,7 @@
 ---
 title: system-property
 slug: Web/XPath/Functions/system-property
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/translate/index.md
+++ b/files/en-us/web/xpath/functions/translate/index.md
@@ -1,6 +1,7 @@
 ---
 title: translate
 slug: Web/XPath/Functions/translate
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/true/index.md
+++ b/files/en-us/web/xpath/functions/true/index.md
@@ -1,6 +1,7 @@
 ---
 title: "true"
 slug: Web/XPath/Functions/true
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/functions/unparsed-entity-url/index.md
+++ b/files/en-us/web/xpath/functions/unparsed-entity-url/index.md
@@ -1,6 +1,7 @@
 ---
 title: unparsed-entity-url
 slug: Web/XPath/Functions/unparsed-entity-url
+page-type: xpath-function
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/index.md
+++ b/files/en-us/web/xpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPath
 slug: Web/XPath
+page-type: landing-page
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to using XPath in JavaScript
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPath snippets
 slug: Web/XPath/Snippets
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/common_errors/index.md
+++ b/files/en-us/web/xslt/common_errors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Common XSLT Errors
 slug: Web/XSLT/Common_errors
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/apply-imports/index.md
+++ b/files/en-us/web/xslt/element/apply-imports/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:apply-imports>
 slug: Web/XSLT/Element/apply-imports
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/apply-templates/index.md
+++ b/files/en-us/web/xslt/element/apply-templates/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:apply-templates>
 slug: Web/XSLT/Element/apply-templates
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/attribute-set/index.md
+++ b/files/en-us/web/xslt/element/attribute-set/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:attribute-set>
 slug: Web/XSLT/Element/attribute-set
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/attribute/index.md
+++ b/files/en-us/web/xslt/element/attribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:attribute>
 slug: Web/XSLT/Element/attribute
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/call-template/index.md
+++ b/files/en-us/web/xslt/element/call-template/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:call-template>
 slug: Web/XSLT/Element/call-template
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/choose/index.md
+++ b/files/en-us/web/xslt/element/choose/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:choose>
 slug: Web/XSLT/Element/choose
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/comment/index.md
+++ b/files/en-us/web/xslt/element/comment/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:comment>
 slug: Web/XSLT/Element/comment
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/copy-of/index.md
+++ b/files/en-us/web/xslt/element/copy-of/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:copy-of>
 slug: Web/XSLT/Element/copy-of
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/copy/index.md
+++ b/files/en-us/web/xslt/element/copy/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:copy>
 slug: Web/XSLT/Element/copy
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/decimal-format/index.md
+++ b/files/en-us/web/xslt/element/decimal-format/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:decimal-format>
 slug: Web/XSLT/Element/decimal-format
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/element/index.md
+++ b/files/en-us/web/xslt/element/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:element>
 slug: Web/XSLT/Element/element
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/fallback/index.md
+++ b/files/en-us/web/xslt/element/fallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:fallback>
 slug: Web/XSLT/Element/fallback
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/for-each/index.md
+++ b/files/en-us/web/xslt/element/for-each/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:for-each>
 slug: Web/XSLT/Element/for-each
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/if/index.md
+++ b/files/en-us/web/xslt/element/if/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:if>
 slug: Web/XSLT/Element/if
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/import/index.md
+++ b/files/en-us/web/xslt/element/import/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:import>
 slug: Web/XSLT/Element/import
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/include/index.md
+++ b/files/en-us/web/xslt/element/include/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:include>
 slug: Web/XSLT/Element/include
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/index.md
+++ b/files/en-us/web/xslt/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: XSLT elements reference
 slug: Web/XSLT/Element
+page-type: landing-page
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/key/index.md
+++ b/files/en-us/web/xslt/element/key/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:key>
 slug: Web/XSLT/Element/key
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/message/index.md
+++ b/files/en-us/web/xslt/element/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:message>
 slug: Web/XSLT/Element/message
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/namespace-alias/index.md
+++ b/files/en-us/web/xslt/element/namespace-alias/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:namespace-alias>
 slug: Web/XSLT/Element/namespace-alias
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/number/index.md
+++ b/files/en-us/web/xslt/element/number/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:number>
 slug: Web/XSLT/Element/number
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/otherwise/index.md
+++ b/files/en-us/web/xslt/element/otherwise/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:otherwise>
 slug: Web/XSLT/Element/otherwise
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/output/index.md
+++ b/files/en-us/web/xslt/element/output/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:output>
 slug: Web/XSLT/Element/output
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/param/index.md
+++ b/files/en-us/web/xslt/element/param/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:param>
 slug: Web/XSLT/Element/param
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/preserve-space/index.md
+++ b/files/en-us/web/xslt/element/preserve-space/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:preserve-space>
 slug: Web/XSLT/Element/preserve-space
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/processing-instruction/index.md
+++ b/files/en-us/web/xslt/element/processing-instruction/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:processing-instruction>
 slug: Web/XSLT/Element/processing-instruction
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/sort/index.md
+++ b/files/en-us/web/xslt/element/sort/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:sort>
 slug: Web/XSLT/Element/sort
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/strip-space/index.md
+++ b/files/en-us/web/xslt/element/strip-space/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:strip-space>
 slug: Web/XSLT/Element/strip-space
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/stylesheet/index.md
+++ b/files/en-us/web/xslt/element/stylesheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:stylesheet>
 slug: Web/XSLT/Element/stylesheet
+page-type: xslt-element
 spec-urls: https://www.w3.org/TR/xslt-30/#stylesheet-element
 ---
 

--- a/files/en-us/web/xslt/element/template/index.md
+++ b/files/en-us/web/xslt/element/template/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:template>
 slug: Web/XSLT/Element/template
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/text/index.md
+++ b/files/en-us/web/xslt/element/text/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:text>
 slug: Web/XSLT/Element/text
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/transform/index.md
+++ b/files/en-us/web/xslt/element/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:transform>
 slug: Web/XSLT/Element/transform
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/value-of/index.md
+++ b/files/en-us/web/xslt/element/value-of/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:value-of>
 slug: Web/XSLT/Element/value-of
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/variable/index.md
+++ b/files/en-us/web/xslt/element/variable/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:variable>
 slug: Web/XSLT/Element/variable
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/when/index.md
+++ b/files/en-us/web/xslt/element/when/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:when>
 slug: Web/XSLT/Element/when
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/element/with-param/index.md
+++ b/files/en-us/web/xslt/element/with-param/index.md
@@ -1,6 +1,7 @@
 ---
 title: <xsl:with-param>
 slug: Web/XSLT/Element/with-param
+page-type: xslt-element
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/pi_parameters/index.md
+++ b/files/en-us/web/xslt/pi_parameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: PI Parameters
 slug: Web/XSLT/PI_Parameters
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/an_overview/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/an_overview/index.md
@@ -1,6 +1,7 @@
 ---
 title: An overview
 slug: Web/XSLT/Transforming_XML_with_XSLT/An_Overview
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/for_further_reading/index.md
@@ -1,6 +1,7 @@
 ---
 title: For further reading
 slug: Web/XSLT/Transforming_XML_with_XSLT/For_Further_Reading
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/index.md
@@ -1,6 +1,7 @@
 ---
 title: Transforming XML with XSLT
 slug: Web/XSLT/Transforming_XML_with_XSLT
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/ancestor-or-self/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/ancestor-or-self/index.md
@@ -1,6 +1,7 @@
 ---
 title: ancestor-or-self
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/ancestor-or-self
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/ancestor/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/ancestor/index.md
@@ -1,6 +1,7 @@
 ---
 title: ancestor
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/ancestor
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/attribute/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/attribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: attribute
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/attribute
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/child/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/child/index.md
@@ -1,6 +1,7 @@
 ---
 title: child
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/child
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/descendant-or-self/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/descendant-or-self/index.md
@@ -1,6 +1,7 @@
 ---
 title: descendant-or-self
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/descendant-or-self
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/descendant/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/descendant/index.md
@@ -1,6 +1,7 @@
 ---
 title: descendant
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/descendant
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/following-sibling/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/following-sibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: following-sibling
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/following-sibling
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/following/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/following/index.md
@@ -1,6 +1,7 @@
 ---
 title: following
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/following
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/namespace/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/namespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: namespace
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/namespace
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/parent/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/parent/index.md
@@ -1,6 +1,7 @@
 ---
 title: parent
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/parent
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/preceding-sibling/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/preceding-sibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: preceding-sibling
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/preceding-sibling
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/preceding/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/preceding/index.md
@@ -1,6 +1,7 @@
 ---
 title: preceding
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/preceding
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/self/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/axes/self/index.md
@@ -1,6 +1,7 @@
 ---
 title: self
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference/Axes/self
+page-type: xslt-axis
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/index.md
+++ b/files/en-us/web/xslt/transforming_xml_with_xslt/the_netscape_xslt_xpath_reference/index.md
@@ -1,6 +1,7 @@
 ---
 title: The Netscape XSLT/XPath Reference
 slug: Web/XSLT/Transforming_XML_with_XSLT/The_Netscape_XSLT_XPath_Reference
+page-type: landing-page
 ---
 
 {{XsltSidebar}}

--- a/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.md
+++ b/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Mozilla JavaScript interface to XSL Transformations
 slug: Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations
+page-type: guide
 ---
 
 {{XsltSidebar}}

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -455,6 +455,57 @@
           }
         },
         "else": false
+      },
+      {
+        "if": {
+          "properties": {
+            "slug": { "type": "string", "pattern": "^Web/XPath" }
+          }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": ["guide", "landing-page", "xpath-axis", "xpath-function"]
+            }
+          }
+        },
+        "else": false
+      },
+      {
+        "if": {
+          "properties": {
+            "slug": { "type": "string", "pattern": "^Web/EXSLT" }
+          }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": ["guide", "landing-page", "exslt-function"]
+            }
+          }
+        },
+        "else": false
+      },
+      {
+        "if": {
+          "properties": {
+            "slug": { "type": "string", "pattern": "^Web/XSLT" }
+          }
+        },
+        "then": {
+          "properties": {
+            "page-type": {
+              "enum": [
+                "guide",
+                "landing-page",
+                "xslt-element",
+                "xslt-function",
+                "xslt-axis"
+              ]
+            }
+          }
+        },
+        "else": false
       }
     ]
   },

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -465,7 +465,7 @@
         "then": {
           "properties": {
             "page-type": {
-              "enum": ["guide", "landing-page", "xpath-axis", "xpath-function"]
+              "enum": ["guide", "landing-page", "xpath-function"]
             }
           }
         },
@@ -495,13 +495,7 @@
         "then": {
           "properties": {
             "page-type": {
-              "enum": [
-                "guide",
-                "landing-page",
-                "xslt-element",
-                "xslt-function",
-                "xslt-axis"
-              ]
+              "enum": ["guide", "landing-page", "xslt-element", "xslt-axis"]
             }
           }
         },


### PR DESCRIPTION
Add the following page types:

### XPath page types
- `xpath-function`: a function, like `ceiling()`.

### XSLT page types

- `xslt-element`: an element of XSLT, like `<xsl:message>`.
- `xslt-axis`: an axis of XSLT, like `ancestor`.

### EXSLT page types

- `xslt-function`: a function of EXSLT, like `exsl:node-set()`.


This is part of openwebdocs/project#91