### PR TITLE
Clarify how referrer policy on scripts works

### DIFF
--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
@@ -10,8 +10,7 @@ browser-compat: api.HTMLScriptElement.referrerPolicy
 
 The **`referrerPolicy`** property of the
 {{domxref("HTMLScriptElement")}} interface reflects the HTML
-[`referrerpolicy`](/en-US/docs/Web/HTML/Element/script#referrerpolicy) of the {{HTMLElement("script")}} element and
-fetches made by that script, defining which referrer is sent when fetching the resource.
+[`referrerpolicy`](/en-US/docs/Web/HTML/Element/script#referrerpolicy) of the {{HTMLElement("script")}} element, which defines how the referrer is set when fetching the script and any scripts it imports.
 
 ## Value
 


### PR DESCRIPTION
The page for [referrerpolicy on `script` elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/referrerPolicy) claims it affects "fetches made by the script", but as you can see from the description and example [in the specification](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-referrerpolicy), it only affects specifically _imports_ made by the script, not all fetches.

This PR fixes the wording to describe what it actually does, per spec.
