### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -306,7 +306,7 @@ function importRsaKey(pem) {
   const pemFooter = "-----END PUBLIC KEY-----";
   const pemContents = pem.substring(
     pemHeader.length,
-    pem.length - pemFooter.length
+    pem.length - pemFooter.length - 1
   );
   // base64 decode the string to get the binary data
   const binaryDerString = window.atob(pemContents);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the example for the import of the public part of the rsa key there is a small error which prevents the proper base64 decoding. When the part of the pem string is fetched from between the header and the footer, the length of the string is one character too long, a '-' is still trailing. So I added '- 1', then the pem string can be decoded. 
I didn' try the importPrivateKey() function for importing the private key, maybe there is the same issue.

### Motivation

I use the importRSAKey import in my webview to convert the pem string representation of a public key into a working CryptoKey which I use to encrypt data and send the data to our backend. When I tried to use it I got an error from the atob() function 'Cannot convert base64'. So I tried to fix it and found the solution above. I want to help others who consider using the importRSAKey() function and prevent them from running into the same issue.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
