### PR TITLE
Add page-types to remaining pages

### DIFF
--- a/files/en-us/games/techniques/tilemaps/square_tilemaps_implementation_colon__scrolling_maps/index.md
+++ b/files/en-us/games/techniques/tilemaps/square_tilemaps_implementation_colon__scrolling_maps/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Square tilemaps implementation: Scrolling maps"
 slug: Games/Techniques/Tilemaps/Square_tilemaps_implementation:_Scrolling_maps
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/games/techniques/tilemaps/square_tilemaps_implementation_colon__static_maps/index.md
+++ b/files/en-us/games/techniques/tilemaps/square_tilemaps_implementation_colon__static_maps/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Square tilemaps implementation: Static maps"
 slug: Games/Techniques/Tilemaps/Square_tilemaps_implementation:_Static_maps
+page-type: guide
 ---
 
 {{GamesSidebar}}

--- a/files/en-us/glossary/adobe_flash/index.md
+++ b/files/en-us/glossary/adobe_flash/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adobe Flash
 slug: Glossary/Adobe_Flash
+page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}

--- a/files/en-us/glossary/baseline/compatibility/index.md
+++ b/files/en-us/glossary/baseline/compatibility/index.md
@@ -1,6 +1,7 @@
 ---
 title: Baseline (compatibility)
 slug: Glossary/Baseline/Compatibility
+page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}

--- a/files/en-us/glossary/plugin/index.md
+++ b/files/en-us/glossary/plugin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Plugin
 slug: Glossary/Plugin
+page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}

--- a/files/en-us/glossary/replay_attack/index.md
+++ b/files/en-us/glossary/replay_attack/index.md
@@ -1,6 +1,7 @@
 ---
 title: Replay attack
 slug: Glossary/Replay_attack
+page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}

--- a/files/en-us/glossary/rsync/index.md
+++ b/files/en-us/glossary/rsync/index.md
@@ -1,6 +1,7 @@
 ---
 title: Rsync
 slug: Glossary/Rsync
+page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -1,7 +1,6 @@
 ---
 title: How to build custom form controls
 slug: Learn/Forms/How_to_build_custom_form_controls
-page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to build custom form controls
 slug: Learn/Forms/How_to_build_custom_form_controls
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/learn/html/tables/advanced/index.md
+++ b/files/en-us/learn/html/tables/advanced/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML table advanced features and accessibility
 slug: Learn/HTML/Tables/Advanced
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Tables/Basics", "Learn/HTML/Tables/Structuring_planet_data", "Learn/HTML/Tables")}}

--- a/files/en-us/learn/html/tables/basics/index.md
+++ b/files/en-us/learn/html/tables/basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML table basics
 slug: Learn/HTML/Tables/Basics
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}

--- a/files/en-us/learn/html/tables/structuring_planet_data/index.md
+++ b/files/en-us/learn/html/tables/structuring_planet_data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Structuring planet data
 slug: Learn/HTML/Tables/Structuring_planet_data
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}

--- a/files/en-us/mdn/at_ten/history_of_mdn/index.md
+++ b/files/en-us/mdn/at_ten/history_of_mdn/index.md
@@ -1,6 +1,7 @@
 ---
 title: The history of MDN
 slug: MDN/At_ten/History_of_MDN
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/at_ten/index.md
+++ b/files/en-us/mdn/at_ten/index.md
@@ -1,6 +1,7 @@
 ---
 title: MDN at 10
 slug: MDN/At_ten
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/changelog/index.md
+++ b/files/en-us/mdn/changelog/index.md
@@ -1,6 +1,7 @@
 ---
 title: MDN Web Docs changelog
 slug: MDN/Changelog
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/contribute/processes/index.md
+++ b/files/en-us/mdn/contribute/processes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Documentation processes
 slug: MDN/Contribute/Processes
+page-type: landing-page
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/contribute/processes/workstream_assessment_project/index.md
+++ b/files/en-us/mdn/contribute/processes/workstream_assessment_project/index.md
@@ -1,6 +1,7 @@
 ---
 title: MDN Workstream assessment and project setup process
 slug: MDN/Contribute/Processes/Workstream_assessment_project
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/index.md
+++ b/files/en-us/mdn/index.md
@@ -1,6 +1,7 @@
 ---
 title: The MDN Web Docs project
 slug: MDN
+page-type: landing-page
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -1,6 +1,7 @@
 ---
 title: The MDN Content Kitchensink
 slug: MDN/Kitchensink
+page-type: guide
 browser-compat: html.elements.video
 ---
 

--- a/files/en-us/mdn/mdn_product_advisory_board/index.md
+++ b/files/en-us/mdn/mdn_product_advisory_board/index.md
@@ -1,6 +1,7 @@
 ---
 title: MDN Product Advisory Board
 slug: MDN/MDN_Product_Advisory_Board
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/mdn_product_advisory_board/membership/index.md
+++ b/files/en-us/mdn/mdn_product_advisory_board/membership/index.md
@@ -1,6 +1,7 @@
 ---
 title: Product Advisory Board Charter & Membership
 slug: MDN/MDN_Product_Advisory_Board/Membership
+page-type: guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to use structured data
 slug: MDN/Writing_guidelines/Howto/JSON_Structured_data
+page-type: mdn-writing-guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to write in Markdown
 slug: MDN/Writing_guidelines/Howto/Markdown_in_MDN
+page-type: mdn-writing-guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -1,6 +1,7 @@
 ---
 title: Information contained in a WebIDL file
 slug: MDN/Writing_guidelines/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
+page-type: mdn-writing-guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
@@ -1,6 +1,7 @@
 ---
 title: API reference sidebars
 slug: MDN/Writing_guidelines/Howto/Write_an_API_reference/Sidebars
+page-type: mdn-writing-guide
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/index.md
@@ -1,6 +1,7 @@
 ---
 title: Page structures
 slug: MDN/Writing_guidelines/Page_structures
+page-type: landing-page
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mozilla/add-ons/index.md
+++ b/files/en-us/mozilla/add-ons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Add-ons
 slug: Mozilla/Add-ons
+page-type: landing-page
 ---
 
 {{AddonSidebarMain}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/index.md
@@ -1,6 +1,7 @@
 ---
 title: dom
 slug: Mozilla/Add-ons/WebExtensions/API/dom
+page-type: webextension-api
 browser-compat: webextensions.api.dom
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
@@ -1,6 +1,7 @@
 ---
 title: dom.openOrClosedShadowRoot()
 slug: Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot
+page-type: webextension-api-function
 browser-compat: webextensions.api.dom.openOrClosedShadowRoot
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
@@ -1,6 +1,7 @@
 ---
 title: omnibox.onDeleteSuggestion
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onDeleteSuggestion
+page-type: webextension-api-event
 browser-compat: webextensions.api.omnibox.onDeleteSuggestion
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -1,6 +1,7 @@
 ---
 title: scripting.ExecutionWorld
 slug: Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld
+page-type: webextension-api-type
 browser-compat: webextensions.api.scripting.ExecutionWorld
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
@@ -1,6 +1,7 @@
 ---
 title: search.query()
 slug: Mozilla/Add-ons/WebExtensions/API/search/query
+page-type: webextension-api-function
 browser-compat: webextensions.api.search.query
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
@@ -1,6 +1,7 @@
 ---
 title: declarative_net_request
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request
+page-type: webextension-manifest-key
 browser-compat: webextensions.manifest.declarative_net_request
 ---
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1,6 +1,7 @@
 ---
 title: Experimental features in Firefox
 slug: Mozilla/Firefox/Experimental_features
+page-type: guide
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/mozilla/firefox/releases/3.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/index.md
@@ -1,6 +1,7 @@
 ---
 title: Firefox 3.5 for developers
 slug: Mozilla/Firefox/Releases/3.5
+page-type: firefox-release-notes
 ---
 
 {{FirefoxSidebar}}

--- a/files/en-us/web/api/domhighrestimestamp/index.md
+++ b/files/en-us/web/api/domhighrestimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMHighResTimeStamp
 slug: Web/API/DOMHighResTimeStamp
+page-type: web-api-interface
 browser-compat: api.DOMHighResTimestamp
 ---
 

--- a/files/en-us/web/demos/index.md
+++ b/files/en-us/web/demos/index.md
@@ -1,6 +1,7 @@
 ---
 title: Demos of open web technologies
 slug: Web/Demos
+page-type: landing-page
 ---
 
 Mozilla supports a wide variety of exciting open web technologies, and we encourage their use. This page offers links to interesting demonstrations of these technologies.

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating and triggering events
 slug: Web/Events/Creating_and_triggering_events
+page-type: guide
 ---
 
 This article demonstrates how to create and dispatch DOM events. Such events are commonly called **synthetic events**, as opposed to the events fired by the browser itself.

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event handling (overview)
 slug: Web/Events/Event_handlers
+page-type: guide
 ---
 
 Events are signals fired inside the browser window that notify of changes in the browser or operating system environment. Programmers can create _event handler_ code that will run when an event fires, allowing web pages to respond appropriately to change.

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event reference
 slug: Web/Events
+page-type: landing-page
 spec-urls: https://html.spec.whatwg.org/multipage/indices.html#events-2
 ---
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Permissions-Policy: publickey-credentials-create"
 slug: Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create
+page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.publickey-credentials-create

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP
 slug: Web/HTTP
+page-type: landing-page
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/index.md
+++ b/files/en-us/web/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web technology for developers
 slug: Web
+page-type: landing-page
 ---
 
 <section id="Quick_links">

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedall/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedall/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Blocked: All storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedAll
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedbypermission/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedbypermission/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Blocked: Custom cookie permission"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedByPermission
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Blocked: All third-party storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedForeign
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedtracker/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookieblockedtracker/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Blocked: Storage access requests from trackers"
 slug: Web/Privacy/Storage_access_policy/Errors/CookieBlockedTracker
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Partitioned: All third-party storage access requests"
 slug: Web/Privacy/Storage_access_policy/Errors/CookiePartitionedForeign
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy/Storage_access_policy/Errors")}}

--- a/files/en-us/web/privacy/storage_access_policy/errors/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Errors
 slug: Web/Privacy/Storage_Access_Policy/Errors
+page-type: landing-page
 ---
 
 {{QuicklinksWithSubPages}}

--- a/files/en-us/web/privacy/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Storage access policy: Block cookies from trackers"
 slug: Web/Privacy/Storage_Access_Policy
+page-type: guide
 ---
 
 {{QuicklinksWithSubPages("Web/Privacy")}}

--- a/files/en-us/web/progressive_web_apps/guides/caching/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/caching/index.md
@@ -1,6 +1,7 @@
 ---
 title: Caching
 slug: Web/Progressive_web_apps/Guides/Caching
+page-type: guide
 ---
 
 {{PWASidebar}}


### PR DESCRIPTION
While doing the page-type project, we forgot some pages here or there (or they got added right after an area was converted without having a `page-type` YAML key.

This PR adds the missing page types in the 50-or-so pages that didn't have one. After this PR (and the two others still open), all MDN pages should have a `page-type`. (A last check will be made before closing the issue).

Note: no new page type is introduced by this PR

This is part of openwebdocs/project#91 and will close #27620.