### PR TITLE
added examples to emphasize the location of the @import at-rule

### DIFF
--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -39,7 +39,29 @@ where:
 
 ## Description
 
-Imported rules must come before all other types of rules, except {{CSSxRef("@charset")}} rules and layer creating [`@layer`](/en-US/docs/Web/CSS/@layer) statements. The `@import` rule is not a [nested statement](/en-US/docs/Web/CSS/Syntax#nested_statements). Therefore, it cannot be used inside [conditional group at-rules](/en-US/docs/Web/CSS/At-rule#conditional_group_rules).
+Imported rules must come before all other types of rules, except {{CSSxRef("@charset")}} rules and layer creating [`@layer`](/en-US/docs/Web/CSS/@layer) statements.
+
+```css example-bad
+* {
+  margin: 0;
+  padding: 0;
+}
+/* more styles */
+@import url("my-imported-styles.css");
+```
+
+As the `@import` at-rule is declared after the styles it is invalid and hence ignored.
+
+```css example-good
+@import url("my-imported-styles.css");
+* {
+  margin: 0;
+  padding: 0;
+}
+/* more styles */
+```
+
+The `@import` rule is not a [nested statement](/en-US/docs/Web/CSS/Syntax#nested_statements). Therefore, it cannot be used inside [conditional group at-rules](/en-US/docs/Web/CSS/At-rule#conditional_group_rules).
 
 So that {{glossary("user agent", "user agents")}} can avoid retrieving resources for unsupported media types, authors may specify media-dependent import conditions. These conditional imports specify comma-separated [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) after the URL. In the absence of any media query, the import is not conditional on the media used. Specifying `all` for the `list-of-media-queries` has the same effect.
 


### PR DESCRIPTION
### Description

I have added a good and bad example to help emphasize the location of the @import at-rule 

### Motivation

Making sure the documentation is clearer while making sure that [27182](https://github.com/mdn/content/issues/27182) is documented.

### Related issues and pull requests

- [BCD](https://github.com/mdn/browser-compat-data/pull/20303)
- [Firefox Release](https://github.com/mdn/content/pull/27796)
- [Bugzilla Issue 1830779](https://bugzilla.mozilla.org/show_bug.cgi?id=1830779)
