### PR TITLE
js13kgames: Fix "Offline and background operation" link

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
@@ -18,7 +18,7 @@ They run on a separate thread from the main JavaScript code of our page, and don
 
 Service workers can do more than offering offline capabilities, including handling notifications or performing heavy calculations. Service workers are quite powerful as they can take control over network requests, modify them, serve custom responses retrieved from the cache, or synthesize responses completely.
 
-To learn more about service workers, see [Offline and background operation](Web/Progressive_web_apps/Guides/Offline_and_background_operation).
+To learn more about service workers, see [Offline and background operation](/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation).
 
 ## Service workers in the js13kPWA app
 


### PR DESCRIPTION
### Description

Fixed the 404 link for "Offline and background operation" at the end of https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers#service_workers_explained section

### Motivation

Easier to follow a link that works

### Additional details

none

### Related issues and pull requests

none
