### PR TITLE
Remove parentheses from text to be consistent with example code

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -255,7 +255,7 @@ console.log(doubled); // [2, 4, 6]
 
 The `map()` method takes each item in the array in turn, passing it into the given function. It then takes the value returned by that function and adds it to a new array.
 
-So in the example above, `(item) => item * 2` is the arrow function equivalent of:
+So in the example above, `item => item * 2` is the arrow function equivalent of:
 
 ```js
 function doubleItem(item) {


### PR DESCRIPTION
Removed parentheses in a sentence to match the example code

### Description

This changes one line to match the example code it is referring to. Line 251 does not use parentheses around `item`, but line 258 does. This change removes the parentheses from line 258.

### Motivation

This would make the text consistent with the code it is referring to.
