### PR TITLE
IndexedDB API - remove link to now removed libraries

### DIFF
--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -11,8 +11,6 @@ IndexedDB is a low-level API for client-side storage of significant amounts of s
 
 {{AvailableInWorkers}}
 
-> **Note:** IndexedDB API is powerful, but may seem too complicated for simple cases. If you'd prefer a simple API, try libraries in [See also](#see_also) section that make IndexedDB more programmer-friendly.
-
 ## Key concepts and usage
 
 IndexedDB is a transactional database system, like an SQL-based RDBMS. However, unlike SQL-based RDBMSes, which use fixed-column tables, IndexedDB is a JavaScript-based object-oriented database. IndexedDB lets you store and retrieve objects that are indexed with a **key**; any objects supported by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) can be stored. You need to specify the database schema, open a connection to your database, and then retrieve and update data within a series of **transactions**.


### PR DESCRIPTION
Fixes #27788

As the author stated, the links that this note points to have been removed. So I am removing the note.