### PR TITLE
Updates to the permission API

### DIFF
--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -2,31 +2,48 @@
 title: Permissions API
 slug: Web/API/Permissions_API
 page-type: web-api-overview
-browser-compat: api.Permissions
+browser-compat:
+  - api.Permissions
+  - api.Navigator.permissions
+  - api.WorkerNavigator.permissions
 ---
 
 {{DefaultAPISidebar("Permissions API")}}
 
-The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context. For example, the Permissions API can be used to determine if permission to access a particular API has been granted or denied.
+The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context. For example, the Permissions API can be used to determine if permission to access a particular API has been granted or denied, or requires specific user permission.
 
-> **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (although not current versions of Firefox, as [WorkerNavigator.permissions](/en-US/docs/Web/API/WorkerNavigator/permissions) is not implemented).
+Note that the permissions from this API effectively aggregates all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
+So, for example, if an API is restricted by permission policy, the returned permission would be `denied` and the user would not be prompted for access.
+
+> **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) on platforms that support the [WorkerNavigator.permissions](/en-US/docs/Web/API/WorkerNavigator/permissions#browser_support) property.
 
 ## Concepts and usage
 
-Historically different APIs handle their own permissions inconsistently — for example the [Notifications API](/en-US/docs/Web/API/Notifications_API) allows for explicit checking of permission status and requesting permission, whereas the [Geolocation API](/en-US/docs/Web/API/Geolocation) doesn't (which causes problems if the user denied the initial permission request). The Permissions API provides the tools to allow developers to implement a better user experience as far as permissions are concerned.
+Historically different APIs handle their own permissions inconsistently — for example the [Notifications API](/en-US/docs/Web/API/Notifications_API) provided its own methods for requesting permissions and checking permission status, whereas the [Geolocation API](/en-US/docs/Web/API/Geolocation) did not.
+The Permissions API provides the tools to allow developers to implement a consistent and better user experience for working with permissions.
 
 The `permissions` property has been made available on the {{domxref("Navigator")}} object, both in the standard browsing context and the worker context ({{domxref("WorkerNavigator")}} — so permission checks are available inside workers), and returns a {{domxref("Permissions")}} object that provides access to the Permissions API functionality.
 
 Once you have this object you can then perform permission-related tasks, for example querying a permission using the {{domxref("Permissions.query()")}} method to return a promise that resolves with the {{domxref("PermissionStatus")}} for a specific API.
 
-Not all APIs' permission statuses can be queried using the Permissions API. Notable APIs that are Permissions-aware include:
+### Permission-aware APIs
 
-- [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Notifications API](/en-US/docs/Web/API/Notifications_API)
-- [Push API](/en-US/docs/Web/API/Push_API)
-- Web MIDI API
+Not all APIs' permission statuses can be queried using the Permissions API.
+A non-exhaustive list of permission-aware APIs include:
 
-More APIs will gain Permissions API support over time.
+- [Background Synchronization API](/en-US/docs/Web/API/Background_Synchronization_API): `background-sync` (should always be granted)
+- [Clipboard API](/en-US/docs/Web/API/Clipboard_API): `clipboard-read`, `clipboard-write`
+- [Geolocation API](/en-US/docs/Web/API/Geolocation_API): `geolocation`
+- [Local Font Access API](/en-US/docs/Web/API/Local_Font_Access_API)
+- [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API): `microphone`, `camera`
+- [Notifications API](/en-US/docs/Web/API/Notifications_API): `notifications`
+- [Payment Handler API](/en-US/docs/Web/API/Payment_Handler_API): `payment-handler`
+- [Push API](/en-US/docs/Web/API/Push_API): `push`
+- [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs): `accelerometer`, `gyroscope`, `magnetometer`, `ambient-light-sensor`
+- [Storage Access API](/en-US/docs/Web/API/Storage_Access_API): `storage-access`
+- [Storage API](/en-US/docs/Web/API/Storage_API): `persistent-storage`
+- [Web Audio Output Devices API](/en-US/docs/Web/API/Audio_Output_Devices_API): `speaker-selection`
+- [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API): `midi`
 
 ## Examples
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -12,8 +12,8 @@ browser-compat:
 
 The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context. For example, the Permissions API can be used to determine if permission to access a particular API has been granted or denied, or requires specific user permission.
 
-Note that the permissions from this API effectively aggregates all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
-So, for example, if an API is restricted by permission policy, the returned permission would be `denied` and the user would not be prompted for access.
+Note that the permissions from this API effectively aggregate all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
+So, for example, if an API is restricted by permissions policy, the returned permission would be `denied` and the user would not be prompted for access.
 
 > **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) on platforms that support the [WorkerNavigator.permissions](/en-US/docs/Web/API/WorkerNavigator/permissions#browser_support) property.
 
@@ -29,7 +29,7 @@ Once you have this object you can then perform permission-related tasks, for exa
 ### Permission-aware APIs
 
 Not all APIs' permission statuses can be queried using the Permissions API.
-A non-exhaustive list of permission-aware APIs include:
+A non-exhaustive list of permission-aware APIs includes:
 
 - [Background Synchronization API](/en-US/docs/Web/API/Background_Synchronization_API): `background-sync` (should always be granted)
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API): `clipboard-read`, `clipboard-write`

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -23,7 +23,7 @@ Querying permissions in the main thread is [broadly supported](/en-US/docs/Web/A
 Many APIs now enable permission querying, such as the [Clipboard API](/en-US/docs/Web/API/Clipboard_API), [Notifications API](/en-US/docs/Web/API/Notifications_API)
 
 - [Push API](/en-US/docs/Web/API/Push_API), [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API).
-A list of many permission enabled APIs is provided in the [API Overview](/en-US/docs/Web/API/Permissions_API#permission-aware_apis), and you can get a sense of browser support in the [compatibility table here](/en-US/docs/Web/API/Permissions_API#api.permissions).
+  A list of many permission enabled APIs is provided in the [API Overview](/en-US/docs/Web/API/Permissions_API#permission-aware_apis), and you can get a sense of browser support in the [compatibility table here](/en-US/docs/Web/API/Permissions_API#api.permissions).
 
 {{domxref("Permissions")}} has other methods to specifically request permission to use an API, and to revoke permission, but these are deprecated (non-standard, and/or not broadly supported).
 

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -8,23 +8,24 @@ status:
 
 {{DefaultAPISidebar("Permissions API")}}
 
-This article provides a basic guide to using the W3C Permissions API, which provides a programmatic way to query the status of API permissions attributed to the current context.
+This article provides a basic guide to using the W3C [Permissions API](/en-US/docs/Web/API/Permissions_API), which provides a programmatic way to query the status of API permissions attributed to the current context.
 
 ## The trouble with asking for permission…
 
-Let's face it, permissions on the Web are a necessary evil, and they are not much fun to deal with as developers.
+Permissions on the Web are a necessary evil, but they are not much fun to deal with as developers.
 
-Historically, different APIs handle their own permissions inconsistently — for example the Notifications API allows for explicit checking of permission status and requesting permission, whereas the Geolocation API doesn't (which causes problems if the user denied the initial permission request, as we'll see below).
+Historically, different APIs handle their own permissions inconsistently — for example the [Notifications API](/en-US/docs/Web/API/Notifications_API) had its own methods for checking the permission status and requesting permission, whereas the [Geolocation API](/en-US/docs/Web/API/Geolocation_API) did not.
 
-The [Permissions API](/en-US/docs/Web/API/Permissions_API) provides the tools to allow developers to implement a better user experience as far as permissions are concerned. For example, it can query whether permission to use a particular API is granted or denied, and specifically request permission to use an API.
+The [Permissions API](/en-US/docs/Web/API/Permissions_API) provides a consistent approach for developers, and allows them to implement a better user experience as far as permissions are concerned.
+Specifically, developers can use {{domxref("Permissions.query()")}} to check whether permission to use a particular API in the current context is granted, denied, or requires specific user permission via a prompt.
+Querying permissions in the main thread is [broadly supported](/en-US/docs/Web/API/Permissions_API#api.navigator.permissions), and also in [Workers](/en-US/docs/Web/API/Permissions_API#api.workernavigator.permissions) (with a notable exception).
 
-At the moment, implementation of the API is at an early stage, so support in browsers is pretty spotty:
+Many APIs now enable permission querying, such as the [Clipboard API](/en-US/docs/Web/API/Clipboard_API), [Notifications API](/en-US/docs/Web/API/Notifications_API)
 
-- It can only be found in Chrome 44 and later and Firefox 43 and later.
-- The only supported method right now is {{domxref("Permissions.query()")}}, which queries permission status.
-- The only two APIs currently recognized by the Permissions API in Chrome are [Geolocation](/en-US/docs/Web/API/Geolocation) and Notification, with Firefox also recognizing [Push](/en-US/docs/Web/API/Push_API) and WebMIDI.
+- [Push API](/en-US/docs/Web/API/Push_API), [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API).
+A list of many permission enabled APIs is provided in the [API Overview](/en-US/docs/Web/API/Permissions_API#permission-aware_apis), and you can get a sense of browser support in the [compatibility table here](/en-US/docs/Web/API/Permissions_API#api.permissions).
 
-More features will be added as time progresses.
+{{domxref("Permissions")}} has other methods to specifically request permission to use an API, and to revoke permission, but these are deprecated (non-standard, and/or not broadly supported).
 
 ## A simple example
 


### PR DESCRIPTION
This updates the docs for Permission API, which were written when this was first proposed and very out of date as to status.

The main changes are to make it clear that this is mainstream now - so more exhaustive lists of supported APIs and their permissions. I couldn't find where `accessibility-events` is used though, so that isn't listed.

I've also found the fact that Permissions-Policy and Permissions API are the same to be a bit confusing, especially as they share the same permission names. I now understand that they are separate, but support each other. 
So the Permissions Policy is _one of the things_ that might restrict access to a resource on a page (context). The Permissions API is a way of working out what the aggregate permissions are, including user permission, and so on.

@Elchi3 FYI, trying to find out where those permissions are defined has highlighted that it would be great to move on adding more "Security Concerns" (or whatever we called them) sections. Mostly the information exists, but it could be aggregated, and that would be a great thing to link to in the API overviews.

This came up as I was trying to find decent info for #27748 