### PR TITLE
fix(learn): Prefer HTTPS URLs where possible for beginner resources, refresh links

### DIFF
--- a/files/en-us/learn/common_questions/design_and_accessibility/design_for_all_types_of_users/index.md
+++ b/files/en-us/learn/common_questions/design_and_accessibility/design_for_all_types_of_users/index.md
@@ -244,5 +244,5 @@ You must also provide alternatives to multimedia content.
 
 Some users may choose to display images, but still have limited bandwidth available, especially in developing countries and on mobile devices. If you want a successful website, please compress your images. There are various tools to help you, either online or local:
 
-- **Installed software.** [ImageOptim](https://imageoptim.com/api) (Mac), [OptiPNG](http://optipng.sourceforge.net/) (all platforms), [PNGcrush](https://pmt.sourceforge.io/pngcrush/) (DOS, Unix/Linux)
+- **Installed software.** [ImageOptim](https://imageoptim.com/api) (Mac), [OptiPNG](https://optipng.sourceforge.net/) (all platforms), [PNGcrush](https://pmt.sourceforge.io/pngcrush/) (DOS, Unix/Linux)
 - **Online tools.** Dynamic drive's [Online Image Optimizer](https://tools.dynamicdrive.com/imageoptimizer/) (which can convert automatically from one format to another if it's more bandwidth-efficient)

--- a/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
@@ -236,6 +236,18 @@ Here are some popular editors:
       </td>
     </tr>
     <tr>
+      <td><a href="https://www.pspad.com/">PSPad</a></td>
+      <td>Closed source</td>
+      <td>Free</td>
+      <td>Windows</td>
+      <td>
+        <a href="https://www.pspad.com/en/faq.htm">FAQ</a>,
+        <a href="https://forum.pspad.com/" rel="external">Forum</a>
+      </td>
+      <td><a href="https://www.pspad.com/en/helpfiles.htm">Online Help</a></td>
+      <td><a href="https://www.pspad.com/en/pspad-extensions.php">Yes</a></td>
+    </tr>
+    <tr>
       <td>
         <a href="https://www.sublimetext.com/" rel="external">Sublime Text</a>
       </td>

--- a/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
@@ -62,7 +62,7 @@ Here are some popular editors:
   </thead>
   <tbody>
     <tr>
-      <td><a href="http://bluefish.openoffice.nl">Bluefish</a></td>
+      <td><a href="https://bluefish.openoffice.nl">Bluefish</a></td>
       <td>GPL 3</td>
       <td>Free</td>
       <td>Windows, Mac, Linux</td>
@@ -71,11 +71,11 @@ Here are some popular editors:
           >Mailing list</a
         >, <a href="https://bfwiki.tellefsen.net/index.php/Main_Page">wiki</a>
       </td>
-      <td><a href="http://bluefish.openoffice.nl/manual/">Online Manual</a></td>
+      <td><a href="https://bluefish.openoffice.nl/manual/">Online Manual</a></td>
       <td>Yes</td>
     </tr>
     <tr>
-      <td><a href="http://brackets.io/" rel="external">Brackets</a></td>
+      <td><a href="https://brackets.io/" rel="external">Brackets</a></td>
       <td>MIT/BSD</td>
       <td>Free</td>
       <td>Windows, Mac, Linux</td>
@@ -111,12 +111,12 @@ Here are some popular editors:
       <td><a href="https://extensions.panic.com/">Yes</a></td>
     </tr>
     <tr>
-      <td><a href="http://www.codelobster.com">CodeLobster</a></td>
+      <td><a href="https://www.codelobster.com">CodeLobster</a></td>
       <td>Closed source</td>
       <td>Free</td>
       <td>Windows, Mac, Linux</td>
       <td>
-        <a href="http://www.codelobster.com/forum/index.php" rel="external">Forum</a >, <a href="mailto:support@codelobster.com">Email</a>
+        <a href="https://www.codelobster.com/forum/index.php" rel="external">Forum</a >, <a href="mailto:support@codelobster.com">Email</a>
       </td>
       <td><a href="https://www.codelobsteride.com/help/">Online Manual</a></td>
       <td>Yes</td>
@@ -200,7 +200,7 @@ Here are some popular editors:
       <td>MPL</td>
       <td>Free</td>
       <td>Windows, Mac, Linux</td>
-      <td><a href="http://forum.komodoide.com/" rel="external">Forum</a></td>
+      <td><a href="https://community.komodoide.com/" rel="external">Forum</a></td>
       <td>
         <a href="https://docs.activestate.com/komodo" rel="external"
           >Online Manual</a
@@ -234,18 +234,6 @@ Here are some popular editors:
           >Yes</a
         >
       </td>
-    </tr>
-    <tr>
-      <td><a href="https://www.pspad.com/">PSPad</a></td>
-      <td>Closed source</td>
-      <td>Free</td>
-      <td>Windows</td>
-      <td>
-        <a href="http://gogogadgetscott.info/pspad/dotazy.htm">FAQ</a>,
-        <a href="https://forum.pspad.com/" rel="external">Forum</a>
-      </td>
-      <td><a href="http://gogogadgetscott.info/pspad/">Online Help</a></td>
-      <td><a href="https://www.pspad.com/en/pspad-extensions.php">Yes</a></td>
     </tr>
     <tr>
       <td>
@@ -324,7 +312,7 @@ Here are some popular editors:
       <td><a href="https://www.vim.org/" rel="external">Vim</a></td>
       <td>
         <a
-          href="http://vimdoc.sourceforge.net/htmldoc/uganda.html#license"
+          href="https://vimdoc.sourceforge.net/htmldoc/uganda.html#license"
           rel="external"
           >Specific open license</a
         >
@@ -336,7 +324,7 @@ Here are some popular editors:
           >Mailing list</a
         >
       </td>
-      <td><a href="http://vimdoc.sourceforge.net/">Online Manual</a></td>
+      <td><a href="https://vimdoc.sourceforge.net/">Online Manual</a></td>
       <td>
         <a
           href="https://www.vim.org/scripts/script_search_results.php?order_by=creation_date&#x26;direction=descending"
@@ -424,7 +412,6 @@ If you aren't sure which features you want, or your favorite editor lacks those 
 
 If you like _lots_ of features and your editor is slowing down because of all your plugins, try using an [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment) (integrated development environment). An IDE provides many tools in one interface and it's a bit daunting for beginners, but always an option if your text editor feels too limited. Here are some popular IDEs:
 
-- [Aptana Studio](http://www.aptana.com/)
 - [Eclipse](https://www.eclipse.org/)
 - [Komodo IDE](https://www.activestate.com/products/komodo-ide/)
 - [NetBeans IDE](https://netbeans.apache.org//)

--- a/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/available_text_editors/index.md
@@ -424,6 +424,7 @@ If you aren't sure which features you want, or your favorite editor lacks those 
 
 If you like _lots_ of features and your editor is slowing down because of all your plugins, try using an [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment) (integrated development environment). An IDE provides many tools in one interface and it's a bit daunting for beginners, but always an option if your text editor feels too limited. Here are some popular IDEs:
 
+- [Aptana Studio](https://www.axway.com/en/aptana)
 - [Eclipse](https://www.eclipse.org/)
 - [Komodo IDE](https://www.activestate.com/products/komodo-ide/)
 - [NetBeans IDE](https://netbeans.apache.org//)


### PR DESCRIPTION
This PR is a minor refresh of the resources we're pointing users to, most have HTTPS URLs that we can use, others have moved or there are alternatives we can point to instead.

__notes:__
* PSPad included self-signed cert on a page that hasn't been updated since 2007, from what I can see. Linking to alternate page for online help here.

