### PR TITLE
Update link to `URL.canParse()` in `URL` page

### DIFF
--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -49,7 +49,7 @@ If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor
 
 ## Static methods
 
-- [`canParse()`](/en-US/docs/Web/API/URL/canParse_static)
+- {{domxref("URL.canParse", "canParse()")}}
   - : Returns a boolean indicating whether or not a URL defined from a URL string and optional base URL string is parsable and valid.
 - {{domxref("URL.createObjectURL", "createObjectURL()")}}
   - : Returns a string containing a unique blob URL, that is a URL with `blob:` as its scheme, followed by an opaque string uniquely identifying the object in the browser.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Replace markdown link, to `URL.canParse()` in `URL` page, with `domxref` to match the other static methods.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Not sure if this change improves the docs, but it might (I'm not very familiar with `domxref`😅).
