### PR TITLE
Align front-matter linter with prettier

### DIFF
--- a/scripts/front-matter_linter.js
+++ b/scripts/front-matter_linter.js
@@ -44,7 +44,7 @@ async function lintFrontMatter(filesAndDirectories, options) {
   ).flat();
 
   options.config = JSON.parse(
-    await fs.readFile("./front-matter-config.json", "utf-8")
+    await fs.readFile("./front-matter-config.json", "utf-8"),
   );
 
   options.validator = getAjvValidator(options.config.schema);
@@ -58,7 +58,7 @@ async function lintFrontMatter(filesAndDirectories, options) {
     try {
       const [error, fixableError, content] = await checkFrontMatter(
         file,
-        options
+        options,
       );
       if (content) {
         fs.writeFile(file, content);
@@ -115,7 +115,7 @@ program
         return;
       }
       return lintFrontMatter(files, options);
-    })
+    }),
   );
 
 program.run();

--- a/scripts/front-matter_utils.js
+++ b/scripts/front-matter_utils.js
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import YAML from "js-yaml";
+import * as prettier from "prettier";
 import AJV from "ajv";
 import grayMatter from "gray-matter";
 import addFormats from "ajv-formats";
@@ -53,9 +54,9 @@ export async function checkFrontMatter(filePath, options) {
 
   if (!options.fix && !isInOrder) {
     fixableError = `${getRelativePath(
-      filePath
+      filePath,
     )}\n\t Front matter attributes are not in required order: ${order.join(
-      "->"
+      "->",
     )}`;
   }
 
@@ -85,7 +86,8 @@ export async function checkFrontMatter(filePath, options) {
       quotingType: '"',
     });
     yml = yml.replace(/[\s\n]+$/g, "");
-    content = `---\n${yml}\n---\n${document.content}`;
+    yml = await prettier.format(yml, { parser: "yaml" });
+    content = `---\n${yml}---\n${document.content}`;
   } else {
     content = null;
   }

--- a/scripts/up-to-date-check.js
+++ b/scripts/up-to-date-check.js
@@ -10,6 +10,6 @@ if (installedYariVersion < availableYariVersion) {
       `the version referenced in package.json (${availableYariVersion}). ` +
       `Please make sure your main git branch is up-to-date with ` +
       `https://github.com/mdn/content/, then run yarn install to ` +
-      `install the latest Yari.`
+      `install the latest Yari.`,
   );
 }

--- a/scripts/update-interface-data.js
+++ b/scripts/update-interface-data.js
@@ -15,8 +15,8 @@ const idls = await Promise.all(
   Object.entries(idlnames)
     .sort(([k1], [k2]) => k1.localeCompare(k2))
     .map(([, { parsed: jsonIdlPath }]) =>
-      fs.readFile(path.join(webrefPath, jsonIdlPath), "utf-8").then(JSON.parse)
-    )
+      fs.readFile(path.join(webrefPath, jsonIdlPath), "utf-8").then(JSON.parse),
+    ),
 );
 
 const interfaceData = idls.reduce((interfaceData, idl) => {
@@ -31,5 +31,5 @@ const interfaceData = idls.reduce((interfaceData, idl) => {
 
 await fs.writeFile(
   "files/jsondata/InterfaceData.json",
-  JSON.stringify([interfaceData], null, 2) + "\n"
+  JSON.stringify([interfaceData], null, 2) + "\n",
 );

--- a/tests/front-matter_linter.test.js
+++ b/tests/front-matter_linter.test.js
@@ -14,20 +14,32 @@ const options = {};
 
 options.config = JSON.parse(
   fs.readFileSync(
-    fileURLToPath(new URL("config.json", SAMPLES_DIRECTORY), "utf-8")
-  )
+    fileURLToPath(new URL("config.json", SAMPLES_DIRECTORY), "utf-8"),
+  ),
 );
 options.validator = getAjvValidator(options.config.schema);
 
+function getPath(filePath) {
+  return fileURLToPath(new URL(filePath, SAMPLES_DIRECTORY));
+}
+
+function getContent(filePath) {
+  return fs.readFileSync(getPath(filePath), "utf-8");
+}
+
 describe("Test front-matter linter", () => {
   it("should use double quotes and remove unwanted quotes", async () => {
-    const filePath = fileURLToPath(
-      new URL("./double_quotes.md", SAMPLES_DIRECTORY)
-    );
-    const validPath = fileURLToPath(
-      new URL("./double_quotes.valid.md", SAMPLES_DIRECTORY)
-    );
-    const validContent = fs.readFileSync(validPath, "utf-8");
+    const filePath = getPath("./double_quotes.md");
+    const validContent = getContent("./double_quotes.valid.md");
+
+    options.fix = true;
+    const result = await checkFrontMatter(filePath, options);
+    await expect(result).toEqual([null, null, validContent]);
+  });
+
+  it("should use single quotes to enclose double quoted words", async () => {
+    const filePath = getPath("./single_quotes.md");
+    const validContent = getContent("./single_quotes.valid.md");
 
     options.fix = true;
     const result = await checkFrontMatter(filePath, options);
@@ -35,13 +47,8 @@ describe("Test front-matter linter", () => {
   });
 
   it("should enforce the attribute order", async () => {
-    const filePath = fileURLToPath(
-      new URL("./attribute_order.md", SAMPLES_DIRECTORY)
-    );
-    const validPath = fileURLToPath(
-      new URL("./attribute_order.valid.md", SAMPLES_DIRECTORY)
-    );
-    const validContent = fs.readFileSync(validPath, "utf-8");
+    const filePath = getPath("./attribute_order.md");
+    const validContent = getContent("./attribute_order.valid.md");
 
     options.fix = false;
     let result = await checkFrontMatter(filePath, options);
@@ -57,7 +64,7 @@ describe("Test front-matter linter", () => {
   });
 
   it("should flag invalid values", async () => {
-    const filePath = fileURLToPath(new URL("./values.md", SAMPLES_DIRECTORY));
+    const filePath = getPath("./values.md");
 
     options.fix = false;
     let result = await checkFrontMatter(filePath, options);
@@ -74,11 +81,8 @@ describe("Test front-matter linter", () => {
   });
 
   it("should prettify the front-matter", async () => {
-    const filePath = fileURLToPath(new URL("./prettify.md", SAMPLES_DIRECTORY));
-    const validPath = fileURLToPath(
-      new URL("./prettify.valid.md", SAMPLES_DIRECTORY)
-    );
-    const validContent = fs.readFileSync(validPath, "utf-8");
+    const filePath = getPath("./prettify.md");
+    const validContent = getContent("./prettify.valid.md");
 
     options.fix = true;
     const result = await checkFrontMatter(filePath, options);
@@ -89,13 +93,8 @@ describe("Test front-matter linter", () => {
   });
 
   it("should flag and remove unknown attribute", async () => {
-    const filePath = fileURLToPath(
-      new URL("./unknown_attribute.md", SAMPLES_DIRECTORY)
-    );
-    const validPath = fileURLToPath(
-      new URL("./unknown_attribute.valid.md", SAMPLES_DIRECTORY)
-    );
-    const validContent = fs.readFileSync(validPath, "utf-8");
+    const filePath = getPath("./unknown_attribute.md");
+    const validContent = getContent("./unknown_attribute.valid.md");
 
     options.fix = false;
     let result = await checkFrontMatter(filePath, options);

--- a/tests/front-matter_test_files/double_quotes.md
+++ b/tests/front-matter_test_files/double_quotes.md
@@ -1,5 +1,5 @@
 ---
-title: 'some api: method() is "cool"'
+title: 'some api: method() is ''cool'''
 short-title: "method()"
 slug: Web/api/method
 ---

--- a/tests/front-matter_test_files/double_quotes.valid.md
+++ b/tests/front-matter_test_files/double_quotes.valid.md
@@ -1,5 +1,5 @@
 ---
-title: "some api: method() is \"cool\""
+title: "some api: method() is 'cool'"
 short-title: method()
 slug: Web/api/method
 ---

--- a/tests/front-matter_test_files/single_quotes.md
+++ b/tests/front-matter_test_files/single_quotes.md
@@ -1,0 +1,6 @@
+---
+title: "some api: method() is \"cool\""
+slug: Web/api/method
+---
+
+Content

--- a/tests/front-matter_test_files/single_quotes.valid.md
+++ b/tests/front-matter_test_files/single_quotes.valid.md
@@ -1,0 +1,6 @@
+---
+title: 'some api: method() is "cool"'
+slug: Web/api/method
+---
+
+Content


### PR DESCRIPTION
## Summary

The front-matter linter and Prettier are correcting each other and are causing some friction.

## Problem

Formatters available in YAML space output exactly what is told, so the output remains same no matter the input. But Prettier is an intelligent formatter: it's output changes based on certain conditions.

In following examples YAML parser and Prettier have been told to prefer double quotes to enclose values.
```yml
# example 1
title: "TypeError: can't assign to property 'x' on 'y': not an object"

# in this case, both agree on the same thing
title: "TypeError: can't assign to property 'x' on 'y': not an object"

# example 2
title: "TypeError: can't assign to property \"x\" on \"y\": not an object"

# YAML parser yields the same string as output
title: "TypeError: can't assign to property \"x\" on \"y\": not an object"

# Prettier encloses string with double quoted words in single quotes
title: 'TypeError: can''t assign to property "x" on "y": not an object'
```

## Solution

It's easy to simply run YAML formatter's output through Prettier before writing to file, than making the YAML formatter behave like Prettier:
```js
let yml = YAML.dump(fmObject);
yml = await prettier.format(yml, { parser: "yaml" });
// write `yml` to file
```

**Note:** apart from above change following changes have been made:
- updated and added unit tests `yarn test:front-matter-linter`
- ran `fix:js` on all the `.js` files in the repo to confrom to the new Prettier v3.0.0

- The `*.md` files need to be committed before this PR are in https://github.com/mdn/content/pull/27830

## Testing

- Committed above code changes
- Commented `/files/en-us/web/javascript/**/*.md` line in `.prettierignore` file
- Ran `fix:fm` then committed the changes
- Ran 'fix:md' saw the diff
Prettier didn't contradict front-matter linter.
