### PR TITLE
Format some files in WebExtensions folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,7 +7,7 @@ build/
 
 # A full pass on all Markdown files is being performed.
 # The following folders still need a full pass:
-/files/en-us/mozilla/add-ons/**/*.md
+/files/en-us/mozilla/add-ons/webextensions/api/**/*.md
 
 # XXX Ignored until https://github.com/prettier/prettier/issues/15032 is fixed
 /files/en-us/web/javascript/reference/operators/exponentiation/index.md

--- a/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -116,7 +116,7 @@ We've made two changes from the original:
 So now we need to create that popup. Create a directory called "popup" then create a file called "choose_page.html" inside it. Give it the following contents:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
@@ -75,7 +75,7 @@ However, if you need certain content in the background page, you can specify one
 - background-page.html
 
   ```html
-  <!DOCTYPE html>
+  <!doctype html>
   <html lang="en">
     <head>
       <meta charset="utf-8" />
@@ -93,9 +93,9 @@ Listen to {{WebExtAPIRef("runtime.onInstalled")}} to initialize an extension on 
 ```js
 browser.runtime.onInstalled.addListener(() => {
   browser.contextMenus.create({
-    "id": "sampleContextMenu",
-    "title": "Sample Context Menu",
-    "contexts": ["selection"]
+    id: "sampleContextMenu",
+    title: "Sample Context Menu",
+    contexts: ["selection"],
   });
 });
 ```
@@ -109,9 +109,9 @@ Listeners must be registered synchronously from the start of the page.
 ```js
 browser.runtime.onInstalled.addListener(() => {
   browser.contextMenus.create({
-    "id": "sampleContextMenu",
-    "title": "Sample Context Menu",
-    "contexts": ["selection"]
+    id: "sampleContextMenu",
+    title: "Sample Context Menu",
+    contexts: ["selection"],
   });
 });
 
@@ -129,7 +129,7 @@ window.onload = () => {
   browser.bookmarks.onCreated.addListener(() => {
     // do something
   });
-}
+};
 ```
 
 Do this:
@@ -144,9 +144,11 @@ browser.tabs.onUpdated.addListener(() => {
 Extensions can remove listeners from their background scripts by calling `removeListener`, such as with {{WebExtAPIRef("runtime.onMessage")}} `removeListener`. If all listeners for an event are removed, the browser no longer loads the extension's background script for that event.
 
 ```js
-browser.runtime.onMessage.addListener(function messageListener(message, sender, reply) {
-  browser.runtime.onMessage.removeListener(messageListener);
-});
+browser.runtime.onMessage.addListener(
+  function messageListener(message, sender, reply) {
+    browser.runtime.onMessage.removeListener(messageListener);
+  },
+);
 ```
 
 ### Filter events
@@ -154,9 +156,12 @@ browser.runtime.onMessage.addListener(function messageListener(message, sender, 
 Use APIs that support event filters to restrict listeners to the cases the extension cares about. If an extension is listening for {{WebExtAPIRef("tabs.onUpdated")}}, use the {{WebExtAPIRef("webNavigation.onCompleted")}} event with filters instead, as the tabs API does not support filters.
 
 ```js
-browser.webNavigation.onCompleted.addListener(() => {
-  console.log("This is my favorite website!");
-}, { url: [{ urlMatches : 'https://www.mozilla.org/' }] });
+browser.webNavigation.onCompleted.addListener(
+  () => {
+    console.log("This is my favorite website!");
+  },
+  { url: [{ urlMatches: "https://www.mozilla.org/" }] },
+);
 ```
 
 ### React to listeners
@@ -166,13 +171,14 @@ Listeners exist to trigger functionality once an event has fired. To react to an
 ```js
 browser.runtime.onMessage.addListener((message, callback) => {
   if (message.data === "setAlarm") {
-    browser.alarms.create({delayInMinutes: 5})
+    browser.alarms.create({ delayInMinutes: 5 });
   } else if (message.data === "runLogic") {
-    browser.tabs.executeScript({file: 'logic.js'});
+    browser.tabs.executeScript({ file: "logic.js" });
   } else if (message.data === "changeColor") {
-    browser.tabs.executeScript(
-      {code: 'document.body.style.backgroundColor="orange"'});
-  };
+    browser.tabs.executeScript({
+      code: 'document.body.style.backgroundColor="orange"',
+    });
+  }
 });
 ```
 
@@ -181,16 +187,16 @@ browser.runtime.onMessage.addListener((message, callback) => {
 Data should be persisted periodically to not lose important information if an extension crashes without receiving {{WebExtAPIRef("runtime.onSuspend")}}. Use the storage API to assist with this.
 
 ```js
-browser.storage.local.set({variable: variableInformation});
+browser.storage.local.set({ variable: variableInformation });
 ```
 
 Message ports cannot prevent an event page from shutting down. If an extension uses message passing, the ports are closed when the event page idles. Listening to the {{WebExtAPIRef("runtime.Port")}} `onDisconnect` lets you discover when open ports are closing, however the listener will be under the same time constraints as {{WebExtAPIRef("runtime.onSuspend")}}.
 
 ```js
 browser.runtime.onMessage.addListener((message, callback) => {
-  if (message === 'hello') {
-    sendResponse({greeting: 'welcome!'})
-  } else if (message === 'goodbye') {
+  if (message === "hello") {
+    sendResponse({ greeting: "welcome!" });
+  } else if (message === "goodbye") {
     browser.runtime.Port.disconnect();
   }
 });
@@ -201,7 +207,7 @@ Background scripts unload after a few seconds of inactivity. However, if during 
 ```js
 browser.runtime.onSuspend.addListener(() => {
   console.log("Unloading.");
-  chrome.browserAction.setBadgeText({text: ""});
+  chrome.browserAction.setBadgeText({ text: "" });
 });
 ```
 
@@ -229,7 +235,7 @@ Listeners must be at the top-level to activate the background script if an event
 ```js
 browser.runtime.onStartup.addListener(() => {
   // run startup function
-})
+});
 ```
 
 ### Record state changes
@@ -243,7 +249,7 @@ browser.storage.local.set({ variable: variableInformation });
 Use {{WebExtAPIRef("storage.local")}} `get` to retrieve the value of that variable.
 
 ```js
-browser.storage.local.get(['variable'], (result) => {
+browser.storage.local.get(["variable"], (result) => {
   let someVariable = result.variable;
   // Do something with someVariable
 });
@@ -254,14 +260,14 @@ browser.storage.local.get(['variable'], (result) => {
 DOM-based timers do not remain active after an event page has idled. Instead, use the {{WebExtAPIRef("alarms")}} API if you need a timer to wake an event page.
 
 ```js
-browser.alarms.create({delayInMinutes: 3.0})
+browser.alarms.create({ delayInMinutes: 3.0 });
 ```
 
 Then add a listener.
 
 ```js
 browser.alarms.onAlarm.addListener(() => {
-  alert("Hello, world!")
+  alert("Hello, world!");
 });
 ```
 
@@ -270,7 +276,7 @@ browser.alarms.onAlarm.addListener(() => {
 If a content script or action must call a function, use {{WebExtAPIRef("runtime.getBackgroundPage")}} to ensure the event page is running. If the call is optional (that is, only needed if the event page is alive) then use {{WebExtAPIRef("extension.getBackgroundPage")}}, which return `null` if the page is not running.
 
 ```js
-document.getElementById('target').addEventListener('click', async () => {
+document.getElementById("target").addEventListener("click", async () => {
   let backgroundPage = await window.runtime.getBackgroundPage();
   backgroundPage.backgroundFunction();
 });

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -63,13 +63,10 @@ So, for example, this `manifest.json` code makes the polyfill available to backg
 
 ```json
 {
- // …
- "background": {
-   "scripts": [
-     "browser-polyfill.js",
-     "background.js"
-   ]
- }
+  // …
+  "background": {
+    "scripts": ["browser-polyfill.js", "background.js"]
+  }
 }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -31,13 +31,13 @@ The rest of this page summarizes these and other incompatibilities.
 - **In Firefox:** The equivalent APIs are accessed using the `browser` namespace.
 
   ```js
-  browser.browserAction.setIcon({path: "path/to/icon.png"});
+  browser.browserAction.setIcon({ path: "path/to/icon.png" });
   ```
 
 - **In Chrome:** Extensions access privileged JavaScript APIs using the `chrome` namespace.
 
   ```js
-  chrome.browserAction.setIcon({path: "path/to/icon.png"});
+  chrome.browserAction.setIcon({ path: "path/to/icon.png" });
   ```
 
 ### Callbacks and promises
@@ -53,9 +53,9 @@ The rest of this page summarizes these and other incompatibilities.
     console.error(e);
   }
 
-  let setCookie = browser.cookies.set(
-    {url: "https://developer.mozilla.org/"}
-  );
+  let setCookie = browser.cookies.set({
+    url: "https://developer.mozilla.org/",
+  });
   setCookie.then(logCookie, logError);
   ```
 
@@ -70,10 +70,7 @@ The rest of this page summarizes these and other incompatibilities.
     }
   }
 
-  chrome.cookies.set(
-    {url: "https://developer.mozilla.org/"},
-    logCookie
-  );
+  chrome.cookies.set({ url: "https://developer.mozilla.org/" }, logCookie);
   ```
 
 ### Firefox supports both the chrome and browser namespaces

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -24,12 +24,16 @@ Content scripts can only access [a small subset of the WebExtension APIs](#webex
 
 You can load a content script into a web page in one of three ways:
 
+<!-- markdownlint-disable MD005 -->
+
 1. - At install time, into pages that match URL patterns.
-     - : Using the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key in your `manifest.json`, you can ask the browser to load a content script whenever the browser loads a page whose URL [matches a given pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns).
+   - : Using the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key in your `manifest.json`, you can ask the browser to load a content script whenever the browser loads a page whose URL [matches a given pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns).
 2. - At runtime, into pages that match URL patterns.
-     - : Using {{WebExtAPIRef("scripting.registerContentScripts()")}} or (only in Manifest V2 in Firefox) {{WebExtAPIRef("contentScripts")}}, you can ask the browser to load a content script whenever the browser loads a page whose URL [matches a given pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). (This is similar to method 1, _except_ that you can add and remove content scripts at runtime.)
+   - : Using {{WebExtAPIRef("scripting.registerContentScripts()")}} or (only in Manifest V2 in Firefox) {{WebExtAPIRef("contentScripts")}}, you can ask the browser to load a content script whenever the browser loads a page whose URL [matches a given pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). (This is similar to method 1, _except_ that you can add and remove content scripts at runtime.)
 3. - At runtime, into specific tabs.
-     - : Using {{WebExtAPIRef("scripting.executeScript()")}} or (in Manifest V2 only) {{WebExtAPIRef("tabs.executeScript()")}}, you can load a content script into a specific tab whenever you want. (For example, in response to the user clicking on a [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action).)
+   - : Using {{WebExtAPIRef("scripting.executeScript()")}} or (in Manifest V2 only) {{WebExtAPIRef("tabs.executeScript()")}}, you can load a content script into a specific tab whenever you want. (For example, in response to the user clicking on a [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action).)
+
+<!-- markdownlint-enable MD005 -->
 
 There is only one global scope _per frame, per extension_. This means that variables from one content script can directly be accessed by another content script, regardless of how the content script was loaded.
 
@@ -86,7 +90,7 @@ As noted at ["Content script environment" at Chrome incompatibilities](/en-US/do
 Consider a web page like this:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -115,7 +119,7 @@ window.foo = "This global variable was added by a page script";
 // redefine the built-in window.confirm() function
 window.confirm = () => {
   alert("The page script has also redefined 'confirm'");
-}
+};
 ```
 
 Now an extension injects a content script into the page:
@@ -128,7 +132,7 @@ let pageScriptPara = document.getElementById("page-script-para");
 pageScriptPara.style.backgroundColor = "blue";
 
 // can't see properties added by page-script.js
-console.log(window.foo);  // undefined
+console.log(window.foo); // undefined
 
 // sees the original form of redefined properties
 window.confirm("Are you sure?"); // calls the original window.confirm()
@@ -286,7 +290,7 @@ function notifyExtension(e) {
   if (e.target.tagName !== "A") {
     return;
   }
-  browser.runtime.sendMessage({"url": e.target.href});
+  browser.runtime.sendMessage({ url: e.target.href });
 }
 ```
 
@@ -299,10 +303,10 @@ browser.runtime.onMessage.addListener(notify);
 
 function notify(message) {
   browser.notifications.create({
-    "type": "basic",
-    "iconUrl": browser.extension.getURL("link.png"),
-    "title": "You clicked a link!",
-    "message": message.url
+    type: "basic",
+    iconUrl: browser.extension.getURL("link.png"),
+    title: "You clicked a link!",
+    message: message.url,
   });
 }
 ```
@@ -342,8 +346,8 @@ For example, as soon as it loads, the following content script:
 ```js
 // content-script.js
 
-let myPort = browser.runtime.connect({name:"port-from-cs"});
-myPort.postMessage({greeting: "hello from content script"});
+let myPort = browser.runtime.connect({ name: "port-from-cs" });
+myPort.postMessage({ greeting: "hello from content script" });
 
 myPort.onMessage.addListener((m) => {
   console.log("In content script, received message from background script: ");
@@ -351,7 +355,7 @@ myPort.onMessage.addListener((m) => {
 });
 
 document.body.addEventListener("click", () => {
-  myPort.postMessage({greeting: "they clicked the page!"});
+  myPort.postMessage({ greeting: "they clicked the page!" });
 });
 ```
 
@@ -373,16 +377,18 @@ let portFromCS;
 
 function connected(p) {
   portFromCS = p;
-  portFromCS.postMessage({greeting: "hi there content script!"});
+  portFromCS.postMessage({ greeting: "hi there content script!" });
   portFromCS.onMessage.addListener((m) => {
-    portFromCS.postMessage({greeting: `In background script, received message from content script: ${m.greeting}`});
+    portFromCS.postMessage({
+      greeting: `In background script, received message from content script: ${m.greeting}`,
+    });
   });
 }
 
 browser.runtime.onConnect.addListener(connected);
 
 browser.browserAction.onClicked.addListener(() => {
-  portFromCS.postMessage({greeting: "they clicked the button!"});
+  portFromCS.postMessage({ greeting: "they clicked the button!" });
 });
 ```
 
@@ -393,19 +399,19 @@ If you have multiple content scripts communicating at the same time, you might w
 ```js
 // background-script.js
 
-let ports = []
+let ports = [];
 
 function connected(p) {
-  ports[p.sender.tab.id] = p
+  ports[p.sender.tab.id] = p;
   // …
 }
 
-browser.runtime.onConnect.addListener(connected)
+browser.runtime.onConnect.addListener(connected);
 
 browser.browserAction.onClicked.addListener(() => {
   ports.forEach((p) => {
-        p.postMessage({greeting: "they clicked the button!"})
-    })
+    p.postMessage({ greeting: "they clicked the button!" });
+  });
 });
 ```
 
@@ -436,10 +442,13 @@ let messenger = document.getElementById("from-page-script");
 messenger.addEventListener("click", messageContentScript);
 
 function messageContentScript() {
-  window.postMessage({
-    direction: "from-page-script",
-    message: "Message from the page"
-  }, "*");
+  window.postMessage(
+    {
+      direction: "from-page-script",
+      message: "Message from the page",
+    },
+    "*",
+  );
 }
 ```
 
@@ -494,15 +503,18 @@ For example, consider a content script like this:
 ```js
 // content-script.js
 
-window.eval('window.x = 1;');
-eval('window.y = 2');
+window.eval("window.x = 1;");
+eval("window.y = 2");
 
 console.log(`In content script, window.x: ${window.x}`);
 console.log(`In content script, window.y: ${window.y}`);
 
-window.postMessage({
-  message: "check"
-}, "*");
+window.postMessage(
+  {
+    message: "check",
+  },
+  "*",
+);
 ```
 
 This code just creates some variables `x` and `y` using `window.eval()` and `eval()`, logs their values, and then messages the page.
@@ -549,11 +561,11 @@ The same applies to [`setTimeout()`](/en-US/docs/Web/API/setTimeout), [`setInter
 >
 > console.log = () => {
 >   original(true);
-> }
+> };
 > ```
 >
 > ```js example-bad
 > // content-script.js calls the redefined version
 >
-> window.eval('console.log(false)');
+> window.eval("console.log(false)");
 > ```

--- a/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
@@ -13,7 +13,7 @@ Extensions developed with WebExtension APIs have a Content Security Policy (CSP)
 Like websites, extensions can load content from different sources. For example, a browser action's popup is specified as an HTML document, and it can include JavaScript and CSS from different sources, just like a normal web page:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -35,7 +35,7 @@ The devtools page doesn't have any visible DOM, but can include JavaScript sourc
 Note that the devtools page does not get access to any other WebExtension APIs, and the background page doesn't get access to the devtools APIs. Instead, the devtools page and the background page must communicate using the `runtime` messaging APIs. Here's an example:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
@@ -56,14 +56,16 @@ The devtools window hosts a number of separate tools - the JavaScript Debugger, 
 Using the `devtools.panels.create()` API, you can create your own panel in the devtools window:
 
 ```js
-browser.devtools.panels.create(
-  "My Panel",                      // title
-  "/icons/star.png",               // icon
-  "/devtools/panel/panel.html"     // content
-).then((newPanel) => {
-  newPanel.onShown.addListener(initialisePanel);
-  newPanel.onHidden.addListener(unInitialisePanel);
-});
+browser.devtools.panels
+  .create(
+    "My Panel", // title
+    "/icons/star.png", // icon
+    "/devtools/panel/panel.html", // content
+  )
+  .then((newPanel) => {
+    newPanel.onShown.addListener(initialisePanel);
+    newPanel.onHidden.addListener(unInitialisePanel);
+  });
 ```
 
 This takes three mandatory arguments: the panel's title, icon, and content. It returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which resolves to a `devtools.panels.ExtensionPanel` object representing the new panel.
@@ -96,7 +98,7 @@ const scriptToAttach = "document.body.innerHTML = 'Hi from the devtools';";
 window.addEventListener("click", () => {
   browser.runtime.sendMessage({
     tabId: browser.devtools.inspectedWindow.tabId,
-    script: scriptToAttach
+    script: scriptToAttach,
   });
 });
 ```
@@ -106,7 +108,7 @@ window.addEventListener("click", () => {
 
 function handleMessage(request, sender, sendResponse) {
   browser.tabs.executeScript(request.tabId, {
-    code: request.script
+    code: request.script,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -95,7 +95,7 @@ We've added three new manifest keys:
 Next, because we've promised to provide `options.html`, let's create it. Create a file with that name inside the `settings` directory, and give it the following contents:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -120,7 +120,7 @@ Create `options.js`, again in the `settings` directory, and give it the followin
 function saveOptions(e) {
   e.preventDefault();
   browser.storage.sync.set({
-    color: document.querySelector("#color").value
+    color: document.querySelector("#color").value,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -36,7 +36,7 @@ The Clipboard API writes arbitrary data to the clipboard from your extension. Us
 For page scripts, the `"clipboard-write"` permission needs to be requested using the Web API {{domxref("Permissions", "navigator.permissions")}}. You can check for that permission using {{domxref("Permissions.query", "navigator.permissions.query()")}}:
 
 ```js
-navigator.permissions.query({name: "clipboard-write"}).then((result) => {
+navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
   if (result.state === "granted" || result.state === "prompt") {
     /* write to the clipboard now */
   }
@@ -49,11 +49,14 @@ This function takes a string and writes it to the clipboard:
 
 ```js
 function updateClipboard(newClip) {
-  navigator.clipboard.writeText(newClip).then(() => {
-    /* clipboard successfully set */
-  }, () => {
-    /* clipboard write failed */
-  });
+  navigator.clipboard.writeText(newClip).then(
+    () => {
+      /* clipboard successfully set */
+    },
+    () => {
+      /* clipboard write failed */
+    },
+  );
 }
 ```
 
@@ -91,7 +94,7 @@ function copy() {
 }
 
 browser.alarms.create({
-  delayInMinutes: 0.1
+  delayInMinutes: 0.1,
 });
 
 browser.alarms.onAlarm.addListener(copy);
@@ -130,8 +133,9 @@ The Clipboard API's {{domxref("Clipboard.readText", "navigator.clipboard.readTex
 Once you have the `"clipboard-read"` permission from the [Permissions API](/en-US/docs/Web/API/Permissions_API), you can read from the clipboard easily. For example, this snippet of code fetches the text from the clipboard and replaces the contents of the element with the ID `"outbox"` with that text.
 
 ```js
-navigator.clipboard.readText().then((clipText) =>
-  document.getElementById("outbox").innerText = clipText);
+navigator.clipboard
+  .readText()
+  .then((clipText) => (document.getElementById("outbox").innerText = clipText));
 ```
 
 ### Using execCommand()

--- a/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -32,10 +32,7 @@ In that directory, create a file called "manifest.json" and add:
   "name": "webRequest-demo",
   "version": "1.0",
 
-  "permissions": [
-    "webRequest",
-    "<all_urls>"
-  ],
+  "permissions": ["webRequest", "<all_urls>"],
 
   "background": {
     "scripts": ["background.js"]
@@ -50,10 +47,9 @@ function logURL(requestDetails) {
   console.log(`Loading: ${requestDetails.url}`);
 }
 
-browser.webRequest.onBeforeRequest.addListener(
-  logURL,
-  {urls: ["<all_urls>"]}
-);
+browser.webRequest.onBeforeRequest.addListener(logURL, {
+  urls: ["<all_urls>"],
+});
 ```
 
 You use {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}} to call the `logURL()` function just before starting the request. The `logURL()` function grabs the URL of the request from the event object and logs it to the browser console.
@@ -82,7 +78,6 @@ Now use `webRequest` to redirect HTTP requests. First, replace "manifest.json" w
 
 ```json
 {
-
   "description": "Demonstrating webRequests",
   "manifest_version": 2,
   "name": "webRequest-demo",
@@ -97,7 +92,6 @@ Now use `webRequest` to redirect HTTP requests. First, replace "manifest.json" w
   "background": {
     "scripts": ["background.js"]
   }
-
 }
 ```
 
@@ -111,7 +105,8 @@ Next, replace "background.js" with this:
 
 ```js
 let pattern = "https://developer.mozilla.org/*";
-const targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
+const targetUrl =
+  "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
 
 function redirect(requestDetails) {
   console.log(`Redirecting: ${requestDetails.url}`);
@@ -119,14 +114,14 @@ function redirect(requestDetails) {
     return;
   }
   return {
-    redirectUrl: targetUrl
+    redirectUrl: targetUrl,
   };
 }
 
 browser.webRequest.onBeforeRequest.addListener(
   redirect,
-  {urls:[pattern], types:["image"]},
-  ["blocking"]
+  { urls: [pattern], types: ["image"] },
+  ["blocking"],
 );
 ```
 
@@ -175,7 +170,8 @@ Replace "background.js" with code like this:
 ```js
 let targetPage = "http://useragentstring.com/*";
 
-let ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+let ua =
+  "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 function rewriteUserAgentHeader(e) {
   e.requestHeaders.forEach((header) => {
@@ -183,13 +179,13 @@ function rewriteUserAgentHeader(e) {
       header.value = ua;
     }
   });
-  return {requestHeaders: e.requestHeaders};
+  return { requestHeaders: e.requestHeaders };
 }
 
 browser.webRequest.onBeforeSendHeaders.addListener(
   rewriteUserAgentHeader,
-  {urls: [targetPage]},
-  ["blocking", "requestHeaders"]
+  { urls: [targetPage] },
+  ["blocking", "requestHeaders"],
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
@@ -79,9 +79,9 @@ Let's now look at the structure of one of these files ([\_locales/en/messages.js
     "message": "You clicked $URL$.",
     "description": "Tells the user which link they clicked.",
     "placeholders": {
-      "url" : {
-        "content" : "$1",
-        "example" : "https://developer.mozilla.org"
+      "url": {
+        "content": "$1",
+        "example": "https://developer.mozilla.org"
       }
     }
   }
@@ -173,7 +173,7 @@ The first one just retrieves the `notificationTitle message` field from the avai
 }
 ```
 
-The `"placeholders"` member defines all the placeholders, and where they are retrieved from. The `"url"` placeholder specifies that its content is taken from $1, which is the first value given inside the second parameter of `getMessage()`. Since the placeholder is called `"url"`, we use `$URL$` to call it inside the actual message string (so for `"name"` you'd use `$NAME$`, etc.) If you have multiple placeholders, you can provide them inside an array that is given to {{WebExtAPIRef("i18n.getMessage()")}} as the second parameter — `[a, b, c]` will be available as `$1`, `$2`, and `$3`, and so on, inside `messages.json`.
+The `"placeholders"` member defines all the placeholders, and where they are retrieved from. The `"url"` placeholder specifies that its content is taken from `$1`, which is the first value given inside the second parameter of `getMessage()`. Since the placeholder is called `"url"`, we use `$URL$` to call it inside the actual message string (so for `"name"` you'd use `$NAME$`, etc.) If you have multiple placeholders, you can provide them inside an array that is given to {{WebExtAPIRef("i18n.getMessage()")}} as the second parameter — `[a, b, c]` will be available as `$1`, `$2`, and `$3`, and so on, inside `messages.json`.
 
 Let's run through an example: the original `notificationContent` message string in the `en/messages.json` file is
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
@@ -325,7 +325,7 @@ If Firefox can't find an exact match for the size it wants, then it will pick th
 An action with just an icon, specified in 2 sizes. The extension's background scripts can receive click events when the user clicks the icon using code like this:
 
 ```js
- browser.action.onClicked.addListener(handleClick);
+browser.action.onClicked.addListener(handleClick);
 ```
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -366,7 +366,7 @@ If Firefox can't find an exact match for the size it wants, then it will pick th
 A browser action with just an icon, specified in 2 different sizes. The extension's background scripts can receive click events when the user clicks the icon using code like this:
 
 ```js
- browser.browserAction.onClicked.addListener(handleClick);
+browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
@@ -87,6 +87,7 @@ The `"declarative_net_request"` key is an object that must contain the `"rule_re
 ```
 
 ## Example extensions
+
 <!-- Ideally we'd use the WebExtExamples template, but examples are not categorized by manifest keys yet - https://github.com/mdn/webextensions-examples/issues/524 -->
 
 - [dnr-block-only](https://github.com/mdn/webextensions-examples/tree/master/dnr-block-only)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -92,7 +92,7 @@ For complete example extensions, see [Example extensions](/en-US/docs/Mozilla/Ad
   },
 
   "background": {
-    "scripts": ["jquery.js", "my-background.js"],
+    "scripts": ["jquery.js", "my-background.js"]
   },
 
   "browser_action": {
@@ -151,7 +151,7 @@ For complete example extensions, see [Example extensions](/en-US/docs/Mozilla/Ad
   "version": "0.1",
 
   "user_scripts": {
-    "api_script": "apiscript.js",
+    "api_script": "apiscript.js"
   },
 
   "web_accessible_resources": ["images/my-image.png"]

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
@@ -272,7 +272,7 @@ The `page_action` key is an object that may have any of three properties, all op
 A page action with just an icon, specified in 2 different sizes. The extension's background scripts can receive click events when the user clicks the icon using code like this:
 
 ```js
- browser.pageAction.onClicked.addListener(handleClick);
+browser.pageAction.onClicked.addListener(handleClick);
 ```
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -67,14 +67,15 @@ In Manifest V3, the `web_accessible_resources` key is an array of objects like t
   // …
   "web_accessible_resources": [
     {
-      "resources": [ "test1.png", "test2.png" ],
-      "matches": [ "https://web-accessible-resources-1.glitch.me/*" ]
-    }, {
-      "resources": [ "test3.png", "test4.png" ],
-      "matches": [ "https://web-accessible-resources-2.glitch.me/*" ],
+      "resources": ["test1.png", "test2.png"],
+      "matches": ["https://web-accessible-resources-1.glitch.me/*"]
+    },
+    {
+      "resources": ["test3.png", "test4.png"],
+      "matches": ["https://web-accessible-resources-2.glitch.me/*"],
       "use_dynamic_url": true
     }
-  ],
+  ]
   // …
 }
 ```
@@ -219,6 +220,7 @@ For example, if the resource only needs to be accessible to web pages at example
 ```
 
 ## Example extensions
+
 <!-- Ideally we'd use the WebExtExamples template, but examples are not categorized by manifest keys yet - https://github.com/mdn/webextensions-examples/issues/524 -->
 
 - [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify)

--- a/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -27,7 +27,6 @@ First of all, create a new directory called "modify-page". In that directory, cr
 
 ```json
 {
-
   "manifest_version": 2,
   "name": "modify-page",
   "version": "1.0",
@@ -38,7 +37,6 @@ First of all, create a new directory called "modify-page". In that directory, cr
       "js": ["page-eater.js"]
     }
   ]
-
 }
 ```
 
@@ -53,7 +51,7 @@ Next, create a file called "page-eater.js" inside the "modify-page" directory, a
 ```js
 document.body.textContent = "";
 
-let header = document.createElement('h1');
+let header = document.createElement("h1");
 header.textContent = "This page has been eaten";
 document.body.appendChild(header);
 ```
@@ -70,20 +68,15 @@ First, update "manifest.json" so it has the following contents:
 
 ```json
 {
-
   "manifest_version": 2,
   "name": "modify-page",
   "version": "1.0",
 
-  "permissions": [
-    "activeTab",
-    "contextMenus"
-  ],
+  "permissions": ["activeTab", "contextMenus"],
 
   "background": {
     "scripts": ["background.js"]
   }
-
 }
 ```
 
@@ -97,13 +90,13 @@ Let's create this file. Create a new file called `background.js` in the `modify-
 ```js
 browser.contextMenus.create({
   id: "eat-page",
-  title: "Eat this page"
+  title: "Eat this page",
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "eat-page") {
     browser.tabs.executeScript({
-      file: "page-eater.js"
+      file: "page-eater.js",
     });
   }
 });
@@ -185,27 +178,27 @@ First, edit `background.js` so that it has these contents:
 ```js
 browser.contextMenus.create({
   id: "eat-page",
-  title: "Eat this page"
+  title: "Eat this page",
 });
 
 function messageTab(tabs) {
   browser.tabs.sendMessage(tabs[0].id, {
-    replacement: "Message from the extension!"
+    replacement: "Message from the extension!",
   });
 }
 
 function onExecuted(result) {
-    let querying = browser.tabs.query({
-        active: true,
-        currentWindow: true
-    });
-    querying.then(messageTab);
+  let querying = browser.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  querying.then(messageTab);
 }
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "eat-page") {
     let executing = browser.tabs.executeScript({
-      file: "page-eater.js"
+      file: "page-eater.js",
     });
     executing.then(onExecuted);
   }
@@ -219,7 +212,7 @@ Next, update `page-eater.js` like this:
 ```js
 function eatPageReceiver(request, sender, sendResponse) {
   document.body.textContent = "";
-  let header = document.createElement('h1');
+  let header = document.createElement("h1");
   header.textContent = request.replacement;
   document.body.appendChild(header);
 }
@@ -238,7 +231,7 @@ If we want send messages back from the content script to the background page, we
 
 ```js
 browser.runtime.sendMessage({
-    title: "from page-eater.js"
+  title: "from page-eater.js",
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
@@ -152,7 +152,7 @@ For example, here's a manifest for the `ping_pong` native application:
   "description": "Example host for native messaging",
   "path": "/path/to/native-messaging/app/ping_pong.py",
   "type": "stdio",
-  "allowed_extensions": [ "ping_pong@example.org" ]
+  "allowed_extensions": ["ping_pong@example.org"]
 }
 ```
 
@@ -221,8 +221,7 @@ For example:
   "name": "favourite-color-examples@mozilla.org",
   "description": "ignored",
   "type": "storage",
-  "data":
-  {
+  "data": {
     "color": "management thinks it should be blue!"
   }
 }
@@ -231,7 +230,7 @@ For example:
 Given this JSON manifest, the `favourite-color-examples@mozilla.org` extension could access the data using code like this:
 
 ```js
-let storageItem = browser.storage.managed.get('color');
+let storageItem = browser.storage.managed.get("color");
 storageItem.then((res) => {
   console.log(`Managed color is: ${res.color}`);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -36,7 +36,7 @@ In Firefox, DOM objects in content scripts get an extra property `wrappedJSObjec
 Let's take a simple example. Suppose a web page loads a script:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />
@@ -101,7 +101,7 @@ Execute content script in the active tab.
 */
 function loadContentScript() {
   browser.tabs.executeScript({
-    file: "/content_scripts/export.js"
+    file: "/content_scripts/export.js",
   });
 }
 
@@ -119,7 +119,7 @@ browser.runtime.onMessage.addListener((message) => {
   browser.notifications.create({
     type: "basic",
     title: "Message from the page",
-    message: message.content
+    message: message.content,
   });
 });
 ```
@@ -168,15 +168,14 @@ the `cloneFunctions` option.
 let messenger = {
   notify(message) {
     browser.runtime.sendMessage({
-      content: `Object method call: ${message}`
+      content: `Object method call: ${message}`,
     });
-  }
+  },
 };
 
-window.wrappedJSObject.messenger = cloneInto(
-  messenger,
-  window,
-  {cloneFunctions: true});
+window.wrappedJSObject.messenger = cloneInto(messenger, window, {
+  cloneFunctions: true,
+});
 ```
 
 Now page scripts see a new property on the window, `messenger`, which has a function `notify()`:
@@ -198,19 +197,19 @@ const objA = new Object();
 const objB = new window.Object();
 
 console.log(
-  objA instanceof Object,                        // true
-  objB instanceof Object,                        // false
-  objA instanceof window.Object,                 // false
-  objB instanceof window.Object,                 // true
-  'wrappedJSObject' in objB                      // true; xrayed
+  objA instanceof Object, // true
+  objB instanceof Object, // false
+  objA instanceof window.Object, // false
+  objB instanceof window.Object, // true
+  "wrappedJSObject" in objB, // true; xrayed
 );
 
 objA.foo = "foo";
-objB.foo = "foo";                                // xray wrappers for plain JavaScript objects pass through property assignments
-objB.wrappedJSObject.bar = "bar";                // unwrapping before assignment does not rely on this special behavior
+objB.foo = "foo"; // xray wrappers for plain JavaScript objects pass through property assignments
+objB.wrappedJSObject.bar = "bar"; // unwrapping before assignment does not rely on this special behavior
 
 window.wrappedJSObject.objA = objA;
-window.wrappedJSObject.objB = objB;              // automatically unwraps when passed to page context
+window.wrappedJSObject.objB = objB; // automatically unwraps when passed to page context
 
 window.eval(`
   console.log(objA instanceof Object);           // false
@@ -237,20 +236,24 @@ window.eval(`
 const ev = new Event("click");
 
 console.log(
-  ev instanceof Event,                           // true
-  ev instanceof window.Event,                    // true; Event constructor is actually inherited from the xrayed window
-  'wrappedJSObject' in ev                        // true; is an xrayed object
+  ev instanceof Event, // true
+  ev instanceof window.Event, // true; Event constructor is actually inherited from the xrayed window
+  "wrappedJSObject" in ev, // true; is an xrayed object
 );
 
-ev.propA = "propA"                                // xray wrappers for native objects do not pass through assignments
-ev.propB = "wrapper";                             // define property on xray wrapper
-ev.wrappedJSObject.propB = "unwrapped";           // define same property on page object
-Reflect.defineProperty(ev.wrappedJSObject,        // privileged reflection can operate on less privileged objects
-  'propC', {
-    get: exportFunction(() => {                  // getters must be exported like regular functions
-      return 'propC';
-    }, window)
-  }
+ev.propA = "propA"; // xray wrappers for native objects do not pass through assignments
+ev.propB = "wrapper"; // define property on xray wrapper
+ev.wrappedJSObject.propB = "unwrapped"; // define same property on page object
+Reflect.defineProperty(
+  // privileged reflection can operate on less privileged objects
+  ev.wrappedJSObject,
+  "propC",
+  {
+    get: exportFunction(() => {
+      // getters must be exported like regular functions
+      return "propC";
+    }, window),
+  },
 );
 
 window.eval(`

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -476,7 +476,9 @@ body {
   background: #fcfcfc;
   background-clip: padding-box;
   border: 1px solid rgba(24, 26, 27, 0.2);
-  box-shadow: 0 3px 5px rgba(24, 26, 27, 0.1), 0 0 7px rgba(24, 26, 27, 0.1);
+  box-shadow:
+    0 3px 5px rgba(24, 26, 27, 0.1),
+    0 0 7px rgba(24, 26, 27, 0.1);
   box-sizing: content-box;
   margin: 2em auto 0.5em;
   width: 384px;

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
@@ -33,7 +33,7 @@ browser.contextMenus.create(
     title: browser.i18n.getMessage("contextMenuItemSelectionLogger"),
     contexts: ["selection"],
   },
-  onCreated
+  onCreated,
 );
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
@@ -45,7 +45,7 @@ browser.devtools.panels
   .create(
     "My Panel", // title
     "icons/star.png", // icon
-    "devtools/panel/panel.html" // content
+    "devtools/panel/panel.html", // content
   )
   .then((newPanel) => {
     newPanel.onShown.addListener(handleShown);

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/omnibox/index.md
@@ -25,7 +25,7 @@ In the extension's background JavaScript file, using {{WebExtAPIRef("omnibox.set
 ```js
 browser.omnibox.setDefaultSuggestion({
   description: `Search the Firefox codebase
-    (e.g. "hello world" | "path:omnibox.js onInputChanged")`
+    (e.g. "hello world" | "path:omnibox.js onInputChanged")`,
 });
 ```
 
@@ -33,14 +33,12 @@ You can then add the code to provide the customized content by listening for {{W
 
 ```js
 browser.omnibox.onInputChanged.addListener((text, addSuggestions) => {
-  let headers = new Headers({"Accept": "application/json"});
-  let init = {method: 'GET', headers};
+  let headers = new Headers({ Accept: "application/json" });
+  let init = { method: "GET", headers };
   let url = buildSearchURL(text);
   let request = new Request(url, init);
 
-  fetch(request)
-    .then(createSuggestionsFromResponse)
-    .then(addSuggestions);
+  fetch(request).then(createSuggestionsFromResponse).then(addSuggestions);
 });
 ```
 
@@ -57,13 +55,13 @@ browser.omnibox.onInputEntered.addListener((text, disposition) => {
   }
   switch (disposition) {
     case "currentTab":
-      browser.tabs.update({url});
+      browser.tabs.update({ url });
       break;
     case "newForegroundTab":
-      browser.tabs.create({url});
+      browser.tabs.create({ url });
       break;
     case "newBackgroundTab":
-      browser.tabs.create({url, active: false});
+      browser.tabs.create({ url, active: false });
       break;
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -21,7 +21,7 @@ Options pages have a Content Security Policy that restricts the sources from whi
 To create an options page, write an HTML file defining the page. This page can include CSS and JavaScript files, like a normal web page. This page, from the [favourite-color](https://github.com/mdn/webextensions-examples/tree/master/favourite-colour) example, includes a JavaScript file:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 
 <html lang="en">
   <head>

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
@@ -115,8 +115,11 @@ Defines the background script that'll add and remove the page's bookmark and set
 As with any background script, [background.js](https://github.com/mdn/webextensions-examples/blob/master/bookmark-it/background.js) is run as soon as the extension is started. Initially the script calls `updateActiveTab()` that starts by obtaining the `Tabs` object for the current tab, using {{WebExtAPIRef("tabs.query")}}, and passing the object to `updateTab()` with this code:
 
 ```js
-  let gettingActiveTab = browser.tabs.query({active: true, currentWindow: true});
-  gettingActiveTab.then(updateTab);
+let gettingActiveTab = browser.tabs.query({
+  active: true,
+  currentWindow: true,
+});
+gettingActiveTab.then(updateTab);
 ```
 
 `updateTab()` first passes the active tab's URL to `isSupportedProtocol()`:
@@ -131,12 +134,12 @@ As with any background script, [background.js](https://github.com/mdn/webextensi
 `isSupportedProtocol()` determines if the URL displayed in the active tab is one that can be bookmarked. To extract the protocol from the tab's URL, the extension takes advantage of the [HTMLAnchorElement](/en-US/docs/Web/API/HTMLAnchorElement) by adding the tab's URL to an `<a>` element and then getting the protocol using the `protocol` property.
 
 ```js
-  function isSupportedProtocol(urlString) {
-    let supportedProtocols = ["https:", "http:", "file:"];
-    let url = document.createElement('a');
-    url.href = urlString;
-    return supportedProtocols.includes(url.protocol);
-  }
+function isSupportedProtocol(urlString) {
+  let supportedProtocols = ["https:", "http:", "file:"];
+  let url = document.createElement("a");
+  url.href = urlString;
+  return supportedProtocols.includes(url.protocol);
+}
 ```
 
 If the protocol is one supported by bookmarks, the extension determines if the tab's URL is already bookmarked and if it is, calls `updateIcon()`:
@@ -153,19 +156,21 @@ If the protocol is one supported by bookmarks, the extension determines if the t
 ```js
 function updateIcon() {
   browser.browserAction.setIcon({
-    path: currentBookmark ? {
-      19: "icons/star-filled-19.png",
-      38: "icons/star-filled-38.png"
-    } : {
-      19: "icons/star-empty-19.png",
-      38: "icons/star-empty-38.png"
-    },
-    tabId: currentTab.id
+    path: currentBookmark
+      ? {
+          19: "icons/star-filled-19.png",
+          38: "icons/star-filled-38.png",
+        }
+      : {
+          19: "icons/star-empty-19.png",
+          38: "icons/star-empty-38.png",
+        },
+    tabId: currentTab.id,
   });
   browser.browserAction.setTitle({
     // Screen readers can see the title
-    title: currentBookmark ? 'Unbookmark it!' : 'Bookmark it!',
-    tabId: currentTab.id
+    title: currentBookmark ? "Unbookmark it!" : "Bookmark it!",
+    tabId: currentTab.id,
   });
 }
 ```
@@ -183,7 +188,7 @@ function toggleBookmark() {
   if (currentBookmark) {
     browser.bookmarks.remove(currentBookmark.id);
   } else {
-    browser.bookmarks.create({title: currentTab.title, url: currentTab.url});
+    browser.bookmarks.create({ title: currentTab.title, url: currentTab.url });
   }
 }
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
@@ -87,6 +87,7 @@ Firefox provides three types of cookie store:
 
 - The default store, which stores cookies from normal browsing.
 - Private browsing mode stores, which stores cookies created during a private browsing session. These stores and any cookies they contain are removed when the related private browsing window closes.
+
   > **Note:**
   > Only visible if {{WebExtAPIRef("extension.isAllowedIncognitoAccess()")}} returns true. Safari doesn't support access to private cookies.
 
@@ -127,7 +128,7 @@ The extension's UI uses a toolbar button ({{WebExtAPIRef("browserAction")}}) imp
 To handle the icon buttons the script first gathers all the class names used for the buttons in the HTML file:
 
 ```js
-let bgBtns = document.querySelectorAll('.bg-container button');
+let bgBtns = document.querySelectorAll(".bg-container button");
 ```
 
 It then loops through all the buttons assigning them their image and creating an onclick listener for each button:
@@ -144,12 +145,12 @@ for (let i = 0; i < bgBtns.length; i++) {
 When a button is clicked, its corresponding listener function gets the button class name and then the icon path which it passes to the page's content script ([updatebg.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/content_scripts/updatebg.js)) using a message. The content script then applies the icon to the web page's background. Meanwhile, [bgpicker.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/popup/bgpicker.js) stores the details of the icon applied to the background in a cookie:
 
 ```js
-    cookieVal.image = fullURL;
-    browser.cookies.set({
-    url: tabs[0].url,
-    name: "bgpicker",
-    value: JSON.stringify(cookieVal)
-  })
+cookieVal.image = fullURL;
+browser.cookies.set({
+  url: tabs[0].url,
+  name: "bgpicker",
+  value: JSON.stringify(cookieVal),
+});
 ```
 
 The color setting is handled in a similar way, triggered by a listener on the color input field. When a color is entered the active tab is discovered and the color selection details sent, using a message, to the page's content script to be applied to the web page background. Then the color selection is added to the cookie:
@@ -165,7 +166,7 @@ The color setting is handled in a similar way, triggered by a listener on the co
 When the user clicks the reset button, which has been assigned to the variable reset:
 
 ```js
-let reset = document.querySelector('.color-reset button');
+let reset = document.querySelector(".color-reset button");
 ```
 
 `reset.onclick` first finds the active tab. Then, using the tab's ID it passes a message to the page's content script ([updatebg.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/content_scripts/updatebg.js)) to get it to remove the icon and color from the page. The function then clears the cookie values (so the old values aren't carried forward and written onto a cookie created for a new icon or color selection on the same page) before removing the cookie:
@@ -186,7 +187,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
     * Cookie: ${JSON.stringify(changeInfo.cookie)}\n
     * Cause: ${changeInfo.cause}\n
     * Removed: ${changeInfo.removed}`);
-  });
+});
 ```
 
 ### Scripts—background.js
@@ -194,22 +195,22 @@ browser.cookies.onChanged.addListener((changeInfo) => {
 A background script ([background.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/background_scripts/background.js)) provides for the possibility that the user has chosen a background icon and color for the website in an earlier session. The script listens for changes in the active tab, either the user switching between tabs or changing the URL of the page displayed in the tab. When either of these events happen, `cookieUpdate()` is called. `cookieUpdate()` in turn uses `getActiveTab()` to get the active tab ID. The function can then check whether a cookie for the extension exists, using the tab's URL:
 
 ```js
-    let gettingCookies = browser.cookies.get({
-      url: tabs[0].url,
-      name: "bgpicker"
-    });
+let gettingCookies = browser.cookies.get({
+  url: tabs[0].url,
+  name: "bgpicker",
+});
 ```
 
 If the `"bgpicker"` cookie exists for the website, the details of the icon and color selected earlier are retrieved and passed to the content script [updatebg.js](https://github.com/mdn/webextensions-examples/blob/master/cookie-bg-picker/content_scripts/updatebg.js) using messages:
 
 ```js
-    gettingCookies.then((cookie) => {
-      if (cookie) {
-        let cookieVal = JSON.parse(cookie.value);
-        browser.tabs.sendMessage(tabs[0].id, {image: cookieVal.image});
-        browser.tabs.sendMessage(tabs[0].id, {color: cookieVal.color});
-      }
-    });
+gettingCookies.then((cookie) => {
+  if (cookie) {
+    let cookieVal = JSON.parse(cookie.value);
+    browser.tabs.sendMessage(tabs[0].id, { image: cookieVal.image });
+    browser.tabs.sendMessage(tabs[0].id, { color: cookieVal.color });
+  }
+});
 ```
 
 ## Other features

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_files/index.md
@@ -21,7 +21,7 @@ For each of these mechanisms, we introduce their use with references to the rele
 This mechanism enables you to get a file from your website (or any location you can define as a URL) to the user's computer. The key method is {{WebExtAPIRef("downloads.download()")}}, which in its simplest form accepts a URL and downloads the file from that URL to the user's default downloads folder:
 
 ```js
-browser.downloads.download({url: "https://example.org/image.png"})
+browser.downloads.download({ url: "https://example.org/image.png" });
 ```
 
 You can let the user download to a location of their choice by specifying the `saveAs` parameter.
@@ -80,11 +80,11 @@ The workings of the library can be understood by viewing [image-store.js](https:
 
 ```js
 async function saveCollectedBlobs(collectionName, collectedBlobs) {
- const storedImages = await getFileStorage({name: "stored-images"});
+  const storedImages = await getFileStorage({ name: "stored-images" });
 
- for (const item of collectedBlobs) {
+  for (const item of collectedBlobs) {
     await storedImages.put(`${collectionName}/${item.uuid}`, item.blob);
- }
+  }
 }
 ```
 
@@ -98,15 +98,15 @@ If the image being stored has the same name as one already in the database, it i
 
 ```js
 export async function loadStoredImages(filter) {
- const imagesStore = await getFileStorage({name: "stored-images"});
- let listOptions = filter ? {includes: filter} : undefined;
- const imagesList = await imagesStore.list(listOptions);
- let storedImages = [];
- for (const storedName of imagesList) {
+  const imagesStore = await getFileStorage({ name: "stored-images" });
+  let listOptions = filter ? { includes: filter } : undefined;
+  const imagesList = await imagesStore.list(listOptions);
+  let storedImages = [];
+  for (const storedName of imagesList) {
     const blob = await imagesStore.get(storedName);
-    storedImages.push({storedName, blobUrl: URL.createObjectURL(blob)});
- }
- return storedImages;
+    storedImages.push({ storedName, blobUrl: URL.createObjectURL(blob) });
+  }
+  return storedImages;
 }
 ```
 
@@ -118,11 +118,11 @@ Note the use of [`URL.createObjectURL(blob)`](/en-US/docs/Web/API/URL/createObje
 
 ```js
 async function removeStoredImages(storedImages) {
- const imagesStore = await getFileStorage({name: "stored-images"});
- for (const storedImage of storedImages) {
+  const imagesStore = await getFileStorage({ name: "stored-images" });
+  for (const storedImage of storedImages) {
     URL.revokeObjectURL(storedImage.blobUrl);
     await imagesStore.remove(storedImage.storedName);
- }
+  }
 }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -71,9 +71,7 @@ To see how {{WebExtAPIRef("tabs.query()")}} and {{WebExtAPIRef("tabs.Tab")}} are
       "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs",
       "manifest_version": 2,
       "name": "Tabs, tabs, tabs",
-      "permissions": [
-        "tabs"
-      ],
+      "permissions": ["tabs"],
       "version": "1.0"
     }
     ```
@@ -88,7 +86,7 @@ To see how {{WebExtAPIRef("tabs.query()")}} and {{WebExtAPIRef("tabs.Tab")}} are
   - : `tabs.html` defines the content of the extension's popup:
 
     ```html
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         <meta charset="utf-8" />

--- a/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -27,7 +27,6 @@ Using a suitable [text editor](/en-US/docs/Learn/Common_questions/Tools_and_setu
 
 ```json
 {
-
   "manifest_version": 2,
   "name": "Borderify",
   "version": "1.0",
@@ -44,7 +43,6 @@ Using a suitable [text editor](/en-US/docs/Learn/Common_questions/Tools_and_setu
       "js": ["borderify.js"]
     }
   ]
-
 }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -63,9 +63,7 @@ Now create a new file called "manifest.json", and give it the following contents
     "48": "icons/beasts-48.png"
   },
 
-  "permissions": [
-    "activeTab"
-  ],
+  "permissions": ["activeTab"],
 
   "browser_action": {
     "default_icon": "icons/beasts-32.png",
@@ -139,7 +137,7 @@ touch choose_beast.html choose_beast.css choose_beast.js
 The HTML file looks like this:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -171,7 +169,8 @@ Note that we include the CSS and JS files from this file, just like a web page.
 The CSS fixes the size of the popup, ensures that the three choices fill the space, and gives them some basic styling. It also hides elements with `class="hidden"`: this means that our `<div id="error-content"...` element will be hidden by default.
 
 ```css
-html, body {
+html,
+body {
   width: 100px;
 }
 
@@ -187,19 +186,19 @@ button {
   text-align: center;
   font-size: 1.5em;
   cursor: pointer;
-  background-color: #E5F2F2;
+  background-color: #e5f2f2;
 }
 
 button:hover {
-  background-color: #CFF2F2;
+  background-color: #cff2f2;
 }
 
 button[type="reset"] {
-  background-color: #FBFBC9;
+  background-color: #fbfbc9;
 }
 
 button[type="reset"]:hover {
-  background-color: #EAEA9D;
+  background-color: #eaea9d;
 }
 ```
 
@@ -246,7 +245,7 @@ function listenForClicks() {
         const url = beastNameToURL(e.target.textContent);
         browser.tabs.sendMessage(tabs[0].id, {
           command: "beastify",
-          beastURL: url
+          beastURL: url,
         });
       });
     }
@@ -277,13 +276,15 @@ function listenForClicks() {
     if (e.target.tagName !== "BUTTON" || !e.target.closest("#popup-content")) {
       // Ignore when click is not on a button within <div id="popup-content">.
       return;
-    } 
+    }
     if (e.target.type === "reset") {
-      browser.tabs.query({active: true, currentWindow: true})
+      browser.tabs
+        .query({ active: true, currentWindow: true })
         .then(reset)
         .catch(reportError);
     } else {
-      browser.tabs.query({active: true, currentWindow: true})
+      browser.tabs
+        .query({ active: true, currentWindow: true })
         .then(beastify)
         .catch(reportError);
     }

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -95,7 +95,7 @@ In this example, the background color of the HTML body will be pink even though 
 #### HTML
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
This PR runs formatting on a few files within the WebExtensions documentation (purposefully excluding the `/webextensions/api` folder for now).  While this PR mainly uses Prettier to format the docs, some manual tweaks are included as needed to fix some issues.

This PR is a subset of #27833.