### PR TITLE
Change code snippets into proper code examples

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -40,10 +40,12 @@ let settingIcon = browser.action.setIcon(
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
         ```js
-        {
-          16: image16,
-          32: image32
-        }
+        let settingIcon = browser.action.setIcon({
+          imageData: {
+            16: image16,
+            32: image32
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
@@ -55,10 +57,12 @@ let settingIcon = browser.action.setIcon(
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
         ```js
-        {
-          16: "path/to/image16.jpg",
-          32: "path/to/image32.jpg"
-        }
+        let settingIcon = browser.action.setIcon({
+          path: {
+            16: "path/to/image16.jpg",
+            32: "path/to/image32.jpg"
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -39,7 +39,7 @@ let settingIcon = browser.action.setIcon(
 
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: image16,
           32: image32
@@ -54,7 +54,7 @@ let settingIcon = browser.action.setIcon(
 
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: "path/to/image16.jpg",
           32: "path/to/image32.jpg"

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -37,7 +37,7 @@ let settingIcon = browser.browserAction.setIcon(
 
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: image16,
           32: image32
@@ -52,7 +52,7 @@ let settingIcon = browser.browserAction.setIcon(
 
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: "path/to/image16.jpg",
           32: "path/to/image32.jpg"

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -38,10 +38,12 @@ let settingIcon = browser.browserAction.setIcon(
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
         ```js
-        {
-          16: image16,
-          32: image32
-        }
+        let settingIcon = browser.action.setIcon({
+          imageData: {
+            16: image16,
+            32: image32
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
@@ -53,10 +55,12 @@ let settingIcon = browser.browserAction.setIcon(
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
         ```js
-        {
-          16: "path/to/image16.jpg",
-          32: "path/to/image32.jpg"
-        }
+        let settingIcon = browser.action.setIcon({
+          path: {
+            16: "path/to/image16.jpg",
+            32: "path/to/image32.jpg"
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -58,19 +58,23 @@ browser.menus.create(
 
       - : `object`. One or more custom icons to display next to the item. Custom icons can only be set for items appearing in submenus. This property is an object with one property for each supplied icon: the property's name should include the icon's size in pixels, and path is relative to the icon from the extension's root directory. The browser tries to choose a 16x16 pixel icon for a normal display or a 32x32 pixel icon for a high-density display. To avoid any scaling, you can specify icons like this:
 
-        ```json
-        "icons": {
-                "16": "path/to/geo-16.png",
-                "32": "path/to/geo-32.png"
-              }
+        ```js
+        browser.menus.create({
+          icons: {
+            16: "path/to/geo-16.png",
+            32: "path/to/geo-32.png",
+          },
+        });
         ```
 
         Alternatively, you can specify a single SVG icon, and it will be scaled appropriately:
 
-        ```json
-        "icons": {
-                "16": "path/to/geo.svg"
-              }
+        ```js
+        browser.menus.create({
+          icons: {
+            16: "path/to/geo.svg",
+          },
+        });
         ```
 
         > **Note:** The top-level menu item uses the [icons](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) specified in the manifest rather than what is specified with this key.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -60,19 +60,23 @@ let updating = browser.menus.update(
 
       - : `object`. One or more custom icons to display next to the item. Custom icons can only be set for items appearing in submenus. This property is an object with one property for each supplied icon: the property's name should include the icon's size in pixels, and path is relative to the icon from the extension's root directory. The browser tries to choose a 16x16 pixel icon for a normal display or a 32x32 pixel icon for a high-density display. To avoid any scaling, you can specify icons like this:
 
-        ```json
-        "icons": {
-              "16": "path/to/geo-16.png",
-              "32": "path/to/geo-32.png"
-            }
+        ```js
+        browser.menus.create({
+          icons: {
+            16: "path/to/geo-16.png",
+            32: "path/to/geo-32.png",
+          },
+        });
         ```
 
         Alternatively, you can specify a single SVG icon, and it will be scaled appropriately:
 
-        ```json
-        "icons": {
-              "16": "path/to/geo.svg"
-            }
+        ```js
+        browser.menus.create({
+          icons: {
+            16: "path/to/geo.svg",
+          },
+        });
         ```
 
         > **Note:** The top-level menu item uses the [icons](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) specified in the manifest rather than what is specified with this key.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -35,7 +35,7 @@ let settingIcon = browser.pageAction.setIcon(
 
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: image16,
           32: image32
@@ -50,7 +50,7 @@ let settingIcon = browser.pageAction.setIcon(
 
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
-        ```json
+        ```js
         {
           16: "path/to/image16.jpg",
           32: "path/to/image32.jpg"

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -36,10 +36,12 @@ let settingIcon = browser.pageAction.setIcon(
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
         ```js
-        {
-          16: image16,
-          32: image32
-        }
+        let settingIcon = browser.action.setIcon({
+          imageData: {
+            16: image16,
+            32: image32
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
@@ -51,10 +53,12 @@ let settingIcon = browser.pageAction.setIcon(
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
         ```js
-        {
-          16: "path/to/image16.jpg",
-          32: "path/to/image32.jpg"
-        }
+        let settingIcon = browser.action.setIcon({
+          path: {
+            16: "path/to/image16.jpg",
+            32: "path/to/image32.jpg"
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -47,7 +47,7 @@ let settingIcon = browser.sidebarAction.setIcon(
 
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
-        ```json
+        ```js
         {
             16: image16,
             32: image32
@@ -62,11 +62,11 @@ let settingIcon = browser.sidebarAction.setIcon(
 
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
-        ```json
+        ```js
         {
-            16: "path/to/image16.jpg",
-            32: "path/to/image32.jpg"
-          }
+          16: "path/to/image16.jpg",
+          32: "path/to/image32.jpg"
+        }
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -48,10 +48,12 @@ let settingIcon = browser.sidebarAction.setIcon(
         Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
 
         ```js
-        {
+        let settingIcon = browser.action.setIcon({
+          imageData: {
             16: image16,
             32: image32
           }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
@@ -63,10 +65,12 @@ let settingIcon = browser.sidebarAction.setIcon(
         Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
 
         ```js
-        {
-          16: "path/to/image16.jpg",
-          32: "path/to/image32.jpg"
-        }
+        let settingIcon = browser.action.setIcon({
+          path: {
+            16: "path/to/image16.jpg",
+            32: "path/to/image32.jpg"
+          }
+        });
         ```
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.


### PR DESCRIPTION
This PR fixes a few codeblocks to become proper code examples.  As they were before, they couldn't really be classified as either JSON or JavaScript, as one would reformat them undesirably and the other wouldn't be a complete example.