### PR TITLE
Add trailing commas to WebExtensions pages

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -140,7 +140,8 @@ The following snippet updates the icon when the user clicks it, but only for the
 ```js
 browser.action.onClicked.addListener((tab) => {
   browser.action.setIcon({
-    tabId: tab.id, path: "icons/updated-48.png"
+    tabId: tab.id,
+    path: "icons/updated-48.png",
   });
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -76,7 +76,7 @@ async function register(hosts, code) {
   return await browser.contentScripts.register({
     matches: [hosts],
     js: [{code}],
-    runAt: "document_idle"
+    runAt: "document_idle",
   });
 
 }
@@ -88,10 +88,10 @@ This code registers the JS file at content_scripts/example.js:
 
 ```js
 const scriptObj = await browser.contentScripts.register({
-  "js": [{file: "/content_scripts/example.js"}],
-  "matches": ["<all_urls>"],
-  "allFrames": true,
-  "runAt": "document_start"
+  js: [{ file: "/content_scripts/example.js" }],
+  matches: ["<all_urls>"],
+  allFrames: true,
+  runAt: "document_start",
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -33,12 +33,13 @@ async function register() {
 
   registered = await browser.contentScripts.register({
     matches: ["*://*.org/*"],
-    js: [{
-      code: "document.body.innerHTML = '<h1>This page has been eaten<h1>'"
-    }],
-    runAt: "document_idle"
+    js: [
+      {
+        code: "document.body.innerHTML = '<h1>This page has been eaten<h1>'",
+      },
+    ],
+    runAt: "document_idle",
   });
-
 }
 
 function toggle() {

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -38,10 +38,12 @@ async function register() {
 
   registered = await browser.contentScripts.register({
     matches: ["*://*.org/*"],
-    js: [{
-      code: "document.body.innerHTML = '<h1>This page has been eaten<h1>'"
-    }],
-    runAt: "document_idle"
+    js: [
+      {
+        code: "document.body.innerHTML = '<h1>This page has been eaten<h1>'",
+      },
+    ],
+    runAt: "document_idle",
   });
 
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -80,11 +80,13 @@ function onError(e) {
   console.error(e);
 }
 
-browser.contextualIdentities.create({
-  name: "my-thing",
-  color: "purple",
-  icon: "briefcase"
-}).then(onCreated, onError);
+browser.contextualIdentities
+  .create({
+    name: "my-thing",
+    color: "purple",
+    icon: "briefcase",
+  })
+  .then(onCreated, onError);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -65,14 +65,14 @@ function logCookie(cookie) {
 function getCookie(tabs) {
   let getting = browser.cookies.get({
     url: tabs[0].url,
-    name: "favorite-color"
+    name: "favorite-color",
   });
   getting.then(logCookie);
 }
 
 let getActive = browser.tabs.query({
   active: true,
-  currentWindow: true
+  currentWindow: true,
 });
 getActive.then(getCookie);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -67,7 +67,7 @@ function onError(error) {
 function removeCookie(tabs) {
   let removing = browser.cookies.remove({
     url: tabs[0].url,
-    name: "favorite-color"
+    name: "favorite-color",
   });
   removing.then(onRemoved, onError);
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -77,7 +77,7 @@ function setCookie(tabs) {
   browser.cookies.set({
     url: tabs[0].url,
     name: "favorite-color",
-    value: "red"
+    value: "red",
   });
 }
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -43,8 +43,8 @@ const reloadButton = document.querySelector("#reload-button");
 
 reloadButton.addEventListener("click", () => {
   browser.devtools.inspectedWindow.reload({
-    injectedScript:"alert(navigator.userAgent);",
-    userAgent: "Not a real UA"
+    injectedScript: "alert(navigator.userAgent);",
+    userAgent: "Not a real UA",
   });
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -19,7 +19,7 @@ const scriptToAttach = "document.body.innerHTML = 'Hi from the devtools';";
 attachContentScriptButton.addEventListener("click", () => {
   browser.runtime.sendMessage({
     tabId: browser.devtools.inspectedWindow.tabId,
-    script: scriptToAttach
+    script: scriptToAttach,
   });
 });
 ```
@@ -29,7 +29,7 @@ attachContentScriptButton.addEventListener("click", () => {
 
 function handleMessage(request, sender, sendResponse) {
   browser.tabs.executeScript(request.tabId, {
-    code: request.script
+    code: request.script,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -49,8 +49,8 @@ function onCreated(sidebarPane) {
     someString: "hello there",
     someObject: {
       someNumber: 42,
-      someOtherString: "this is my pane's content"
-    }
+      someOtherString: "this is my pane's content",
+    },
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -48,8 +48,8 @@ function onCreated(sidebarPane) {
     someString: "hello there",
     someObject: {
       someNumber: 42,
-      someOtherString: "this is my pane's content"
-    }
+      someOtherString: "this is my pane's content",
+    },
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -75,8 +75,10 @@ function resolved(record) {
   console.log(record.addresses);
 }
 
-let resolving = browser.dns.resolve("developer.mozilla.org",
-                                   ["bypass_cache", "canonical_name"]);
+let resolving = browser.dns.resolve("developer.mozilla.org", [
+  "bypass_cache",
+  "canonical_name",
+]);
 resolving.then(resolved);
 
 // > e.g. xyz.us-west-2.elb.amazonaws.com

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -51,7 +51,7 @@ function onError(error) {
 
 let erasing = browser.downloads.erase({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 
 erasing.then(onErased, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -66,7 +66,7 @@ function getIcon(downloadItems) {
 
 let searching = browser.downloads.search({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 
 searching.then(getIcon, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -56,7 +56,7 @@ browser.downloads.onErased.addListener(handleErased);
 
 let erasing = browser.downloads.erase({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -56,7 +56,7 @@ function openDownload(downloadItems) {
 
 let searching = browser.downloads.search({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 
 searching.then(openDownload, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -60,7 +60,7 @@ function remove(downloadItems) {
 
 let searching = browser.downloads.search({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 
 searching.then(remove, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -55,7 +55,7 @@ function openDownload(downloadItems) {
 
 let searching = browser.downloads.search({
   limit: 1,
-  orderBy: ["-startTime"]
+  orderBy: ["-startTime"],
 });
 
 searching.then(openDownload, onError);

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -51,7 +51,7 @@ function oneMinuteAgo() {
 
 browser.history.deleteRange({
   startTime: oneMinuteAgo(),
-  endTime: Date.now()
+  endTime: Date.now(),
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -54,7 +54,7 @@ function onGot(results) {
 function onRemoved() {
   let searching = browser.history.search({
     text: urlToRemove,
-    startTime: 0
+    startTime: 0,
   });
 
   searching.then(onGot);
@@ -86,7 +86,7 @@ function onGot(results) {
 let searching = browser.history.search({
   text: "",
   startTime: 0,
-  maxResults: 1
+  maxResults: 1,
 });
 
 searching.then(onGot);

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -52,7 +52,7 @@ function listVisits(historyItems) {
   if (historyItems.length) {
     console.log(`URL ${historyItems[0].url}`);
     const gettingVisits = browser.history.getVisits({
-      url: historyItems[0].url
+      url: historyItems[0].url,
     });
     gettingVisits.then(gotVisits);
   }
@@ -61,7 +61,7 @@ function listVisits(historyItems) {
 let searching = browser.history.search({
   text: "",
   startTime: 0,
-  maxResults: 1
+  maxResults: 1,
 });
 
 searching.then(listVisits);

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -86,7 +86,7 @@ function authorize() {
 
   return browser.identity.launchWebAuthFlow({
     interactive: true,
-    url: authURL
+    url: authURL,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -52,7 +52,7 @@ function onCanceled(error) {
 }
 
 let uninstalling = browser.management.uninstallSelf({
-  showConfirmDialog: true
+  showConfirmDialog: true,
 });
 
 uninstalling.then(null, onCanceled);
@@ -67,7 +67,7 @@ function onCanceled(error) {
 
 let uninstalling = browser.management.uninstallSelf({
   showConfirmDialog: true,
-  dialogMessage: "Testing self-uninstall"
+  dialogMessage: "Testing self-uninstall",
 });
 
 uninstalling.then(null, onCanceled);

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -121,7 +121,7 @@ This example creates a context menu item that's shown when the user has selected
 browser.menus.create({
   id: "log-selection",
   title: "Log '%s' to the console",
-  contexts: ["selection"]
+  contexts: ["selection"],
 });
 
 browser.menus.onClicked.addListener((info, tab) => {
@@ -164,11 +164,11 @@ let makeItGreen = 'document.body.style.border = "5px solid green"';
 browser.menus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "radio-blue") {
     browser.tabs.executeScript(tab.id, {
-      code: makeItBlue
+      code: makeItBlue,
     });
   } else if (info.menuItemId === "radio-green") {
     browser.tabs.executeScript(tab.id, {
-      code: makeItGreen
+      code: makeItGreen,
     });
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -126,13 +126,13 @@ function onError() {
 browser.menus.create({
   id: "do-not-click-me",
   title: "Do not click this button",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "do-not-click-me") {
     let updating = browser.menus.update(info.menuItemId, {
-      title: "Do not click this button again"
+      title: "Do not click this button again",
     });
     updating.then(onUpdated, onError);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -54,7 +54,7 @@ The example also listens to {{WebExtAPIRef("omnibox.onInputEntered")}}, and open
 
 ```js
 browser.omnibox.setDefaultSuggestion({
-  description: "Type the name of a CSS property"
+  description: "Type the name of a CSS property",
 });
 
 /*
@@ -78,7 +78,7 @@ const props = [
   "padding",
   "position",
   "transform",
-  "transition"
+  "transition",
 ];
 
 const baseURL = "https://developer.mozilla.org/en-US/docs/Web/CSS/";
@@ -94,8 +94,8 @@ function getMatchingProperties(input) {
       console.log(prop);
       const suggestion = {
         content: `${baseURL}${prop}`,
-        description: prop
-      }
+        description: prop,
+      };
       result.push(suggestion);
     } else if (result.length !== 0) {
       return result;

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -54,7 +54,7 @@ The example also listens to {{WebExtAPIRef("omnibox.onInputEntered")}}, and open
 
 ```js
 browser.omnibox.setDefaultSuggestion({
-  description: "Type the name of a CSS property"
+  description: "Type the name of a CSS property",
 });
 
 /*
@@ -78,7 +78,7 @@ const props = [
   "padding",
   "position",
   "transform",
-  "transition"
+  "transition",
 ];
 
 const baseURL = "https://developer.mozilla.org/en-US/docs/Web/CSS/";
@@ -94,8 +94,8 @@ function getMatchingProperties(input) {
       console.log(prop);
       const suggestion = {
         content: `${baseURL}${prop}`,
-        description: prop
-      }
+        description: prop,
+      };
       result.push(suggestion);
     } else if (result.length !== 0) {
       return result;

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -36,7 +36,7 @@ None.
 
 ```js
 browser.omnibox.setDefaultSuggestion({
-  description: "Type the name of a CSS property"
+  description: "Type the name of a CSS property",
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -47,7 +47,7 @@ function gotPopup(popupURL) {
 
 browser.contextMenus.create({
   id: "get-popup",
-  title: "Get popup URL"
+  title: "Get popup URL",
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -47,7 +47,7 @@ function gotTitle(title) {
 
 browser.pageAction.onClicked.addListener((tab) => {
   let gettingTitle = browser.pageAction.getTitle({
-    tabId: tab.id
+    tabId: tab.id,
   });
   gettingTitle.then(gotTitle);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
@@ -43,11 +43,11 @@ Check the state of the currently active tab:
 ```js
 async function shownInActiveTab() {
   let tabs = await browser.tabs.query({
-    currentWindow:true,
-    active: true
+    currentWindow: true,
+    active: true,
   });
   let shown = await browser.pageAction.isShown({
-    tabId: tabs[0].id
+    tabId: tabs[0].id,
   });
   console.log(shown);
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -37,7 +37,7 @@ Open the popup when the user selects a context menu item:
 browser.menus.create({
   id: "open-popup",
   title: "open popup",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(() => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -83,7 +83,8 @@ Set the icon for the page action when the user clicks it:
 ```js
 browser.pageAction.onClicked.addListener((tab) => {
   browser.pageAction.setIcon({
-    tabId: tab.id, path: "icons/icon-48.png"
+    tabId: tab.id,
+    path: "icons/icon-48.png",
   });
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -48,12 +48,12 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
     if (changeInfo.status === "loading") {
       browser.pageAction.setPopup({
         tabId,
-        popup: "/popup/loading.html"
+        popup: "/popup/loading.html",
       });
     } else {
       browser.pageAction.setPopup({
         tabId,
-        popup: "/popup/complete.html"
+        popup: "/popup/complete.html",
       });
     }
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -43,8 +43,8 @@ This example shows the {{WebExtAPIRef("pageAction")}} for the active tab when th
 ```js
 browser.contextMenus.create({
   id: "show",
-  title: "Show page action"
-})
+  title: "Show page action",
+});
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "show") {

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -40,8 +40,8 @@ This code adds a click handler that removes a given permission.
 
 ```js
 const permissionToRemove = {
-  permissions: ["history"]
-}
+  permissions: ["history"],
+};
 
 async function remove() {
   console.log("removing");

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -47,8 +47,8 @@ This code adds a click handler that asks for various permissions, then logs the 
 ```js
 const permissionsToRequest = {
   permissions: ["bookmarks", "history"],
-  origins: ["https://developer.mozilla.org/"]
-}
+  origins: ["https://developer.mozilla.org/"],
+};
 
 async function requestPermissions() {
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -66,7 +66,7 @@ browser.browserAction.onClicked.addListener(() => {
     if ((got.levelOfControl === "controlled_by_this_extension") ||
         (got.levelOfControl === "controllable_by_this_extension")) {
       let setting = browser.privacy.network.webRTCIPHandlingPolicy.set({
-        value: "default_public_interface_only"
+        value: "default_public_interface_only",
       });
       setting.then(onSet);
     } else {

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
@@ -87,7 +87,9 @@ function handleProxyRequest(requestInfo) {
   return {type: "direct"};
 }
 
-browser.proxy.onRequest.addListener(handleProxyRequest, {urls: ["<all_urls>"]});
+browser.proxy.onRequest.addListener(handleProxyRequest, {
+  urls: ["<all_urls>"],
+});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.md
@@ -41,7 +41,7 @@ browser.runtime.onMessage.addListener((message, sender) => {
 let messageToProxy = {
   enabled: true,
   foo: "A string",
-  bar: 1234
+  bar: 1234,
 };
 
 browser.runtime.sendMessage(messageToProxy, {toProxyScript: true});
@@ -78,13 +78,13 @@ const proxySpecification = [
     host: "foo.com",
     port: 1080,
     proxyDNS: true,
-    failoverTimeout: 5
+    failoverTimeout: 5,
   },
   {
     type: "socks",
     host: "bar.com",
     port: 1060,
-  }
+  },
 ];
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -45,7 +45,7 @@ let proxySettings = {
   proxyType: "manual",
   http: "http://proxy.org:8080",
   socksVersion: 4,
-  passthrough: ".example.org"
+  passthrough: ".example.org",
 };
 
 browser.proxy.settings.set({value: proxySettings});

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -60,9 +60,9 @@ function logError(e) {
   console.error(e);
 }
 
-const setCookie = browser.cookies.set(
-  {url: "https://developer.mozilla.org/"}
-);
+const setCookie = browser.cookies.set({
+  url: "https://developer.mozilla.org/",
+});
 
 setCookie.then(logCookie, logError);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -61,7 +61,7 @@ When the extension is installed, log the install reason and open <https://exampl
 function handleInstalled(details) {
   console.log(details.reason);
   browser.tabs.create({
-    url: "https://example.com"
+    url: "https://example.com",
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -160,7 +160,9 @@ function handleError(error) {
 }
 
 function sendMessage(e) {
-  const sending = browser.runtime.sendMessage({content: "message from the content script"});
+  const sending = browser.runtime.sendMessage({
+    content: "message from the content script",
+  });
   sending.then(handleResponse, handleError);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -45,7 +45,7 @@ Open <https://giphy.com/explore/cat> when the browser starts up:
 ```js
 function handleStartup() {
   browser.tabs.create({
-    url: "https://giphy.com/explore/cat"
+    url: "https://giphy.com/explore/cat",
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/query/index.md
@@ -44,7 +44,7 @@ A search with the results shown in the current tab (default):
 ```js
 function search() {
   browser.search.query({
-    text: "styracosaurus"
+    text: "styracosaurus",
   });
 }
 
@@ -57,7 +57,7 @@ A search with the results shown in a new window:
 function search() {
   browser.search.query({
     text: "styracosaurus",
-    disposition: "NEW_WINDOW"
+    disposition: "NEW_WINDOW",
   });
 }
 
@@ -70,7 +70,7 @@ A search with the results shown in a specific tab:
 function search(tab) {
   browser.search.query({
     query: "styracosaurus",
-    tabId: tab.id
+    tabId: tab.id,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -49,7 +49,7 @@ A search using the default search engine with the results shown in the current t
 ```js
 function search() {
   browser.search.search({
-    query: "styracosaurus"
+    query: "styracosaurus",
   });
 }
 
@@ -62,8 +62,8 @@ A search using Wikipedia with the results shown in a new window:
 function search() {
   browser.search.search({
     query: "styracosaurus",
-    engine: "Wikipedia (en)"
-    disposition: "NEW_WINDOW"
+    engine: "Wikipedia (en)",
+    disposition: "NEW_WINDOW",
   });
 }
 
@@ -77,7 +77,7 @@ function search(tab) {
   browser.search.search({
     query: "styracosaurus",
     engine: "Wikipedia (en)",
-    tabId: tab.id
+    tabId: tab.id,
   });
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -58,7 +58,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener(() => {
   let gettingSessions = browser.sessions.getRecentlyClosed({
-    maxResults: 1
+    maxResults: 1,
   });
   gettingSessions.then(restoreMostRecent, onError);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -61,7 +61,7 @@ function onError(error) {
 
 function restoreMostRecent() {
   let gettingSessions = browser.sessions.getRecentlyClosed({
-    maxResults: 1
+    maxResults: 1,
   });
   gettingSessions.then(restoreSession, onError);
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -41,13 +41,19 @@ This code adds two context menu items: one stores a value associated with the cu
 
 ```js
 async function setOnActiveTab() {
-  let tabArray = await browser.tabs.query({currentWindow: true, active: true});
+  let tabArray = await browser.tabs.query({
+    currentWindow: true,
+    active: true,
+  });
   let tabId = tabArray[0].id;
   await browser.sessions.setTabValue(tabId, "my-key", "my-value");
 }
 
 async function removeFromActiveTab() {
-  let tabArray = await browser.tabs.query({currentWindow: true, active: true});
+  let tabArray = await browser.tabs.query({
+    currentWindow: true,
+    active: true,
+  });
   let tabId = tabArray[0].id;
   await browser.sessions.removeTabValue(tabId, "my-key");
 }
@@ -55,13 +61,13 @@ async function removeFromActiveTab() {
 browser.menus.create({
   id: "add-my-item",
   title: "add item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.create({
   id: "remove-my-item",
   title: "remove item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener((info) => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -53,13 +53,13 @@ async function removeFromActiveWindow() {
 browser.menus.create({
   id: "add-my-item",
   title: "add item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.create({
   id: "remove-my-item",
   title: "remove item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener((info) => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -56,7 +56,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener(() => {
   let gettingSessions = browser.sessions.getRecentlyClosed({
-    maxResults: 1
+    maxResults: 1,
   });
   gettingSessions.then(restoreMostRecent, onError);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -46,7 +46,10 @@ Set a value on the active tab when the user selects a menu item. Note that you'l
 
 ```js
 async function setOnActiveTab() {
-  let tabArray = await browser.tabs.query({currentWindow: true, active: true});
+  let tabArray = await browser.tabs.query({
+    currentWindow: true,
+    active: true,
+  });
   let tabId = tabArray[0].id;
   await browser.sessions.setTabValue(tabId, "my-key", "my-value");
 }
@@ -54,7 +57,7 @@ async function setOnActiveTab() {
 browser.menus.create({
   id: "my-item",
   title: "my item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(setOnActiveTab);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -53,7 +53,7 @@ async function setOnActiveWindow() {
 browser.menus.create({
   id: "my-item",
   title: "my item",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(setOnActiveWindow);

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
@@ -39,7 +39,7 @@ Close the sidebar when the user selects a context menu item:
 browser.menus.create({
   id: "close-sidebar",
   title: "close sidebar",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(() => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -39,7 +39,7 @@ Open the sidebar when the user selects a context menu item:
 browser.menus.create({
   id: "open-sidebar",
   title: "open sidebar",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(() => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -108,13 +108,13 @@ function toggle(tab) {
   if (on) {
     browser.sidebarAction.setIcon({
       path: "off.svg",
-      tabId: tab.id
+      tabId: tab.id,
     });
     on = false;
   } else {
     browser.sidebarAction.setIcon({
       path: "on.svg",
-      tabId: tab.id
+      tabId: tab.id,
     });
     on = true;
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
@@ -39,7 +39,7 @@ Toggles the sidebar when the user selects an item from the context menu:
 browser.menus.create({
   id: "toggle-sidebar",
   title: "Toggle sidebar",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 browser.menus.onClicked.addListener(() => {

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -100,7 +100,11 @@ gettingItem.then(onGot, onError);
 With an array of object names, retrieve all matches:
 
 ```js
-let gettingItem = browser.storage.local.get(["kitten", "monster", "grapefruit"]);
+let gettingItem = browser.storage.local.get([
+  "kitten",
+  "monster",
+  "grapefruit",
+]);
 gettingItem.then(onGot, onError);
 
 // -> Object { kitten: Object, monster: Object }
@@ -114,8 +118,8 @@ let gettingItem = browser.storage.local.get({
   monster: "no monster",
   grapefruit: {
     name: "Grape Fruit",
-    eats: "Water"
-  }
+    eats: "Water",
+  },
 });
 
 // -> Object { kitten: Object, monster: Object, grapefruit: Object }

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -66,14 +66,14 @@ function onError(error) {
 let monster = {
   name: "Kraken",
   tentacles: true,
-  eyeCount: 10
-}
+  eyeCount: 10,
+};
 
 let kitten = {
   name: "Moggy",
   tentacles: false,
-  eyeCount: 2
-}
+  eyeCount: 2,
+};
 
 // store the objects
 browser.storage.local.set({kitten, monster})

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -60,7 +60,8 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener(() => {
   let gettingActive = browser.tabs.query({
-    currentWindow: true, active: true
+    currentWindow: true,
+    active: true,
   });
   gettingActive.then(connectToTab, onError);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -90,7 +90,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener(() => {
   let creating = browser.tabs.create({
-    url:"https://example.org"
+    url: "https://example.org",
   });
   creating.then(onCreated, onError);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -18,9 +18,9 @@ You must have the permission for the page's URL—either explicitly, as a [host 
 You can also inject code into pages packaged with your own extension:
 
 ```js
-browser.tabs.create({url: "/my-page.html"}).then(() => {
+browser.tabs.create({ url: "/my-page.html" }).then(() => {
   browser.tabs.executeScript({
-    code: `console.log('location:', window.location.href);`
+    code: `console.log('location:', window.location.href);`,
   });
 });
 ```
@@ -133,7 +133,7 @@ function onError(error) {
 const makeItGreen = 'document.body.style.border = "5px solid green"';
 
 const executing = browser.tabs.executeScript({
-  code: makeItGreen
+  code: makeItGreen,
 });
 executing.then(onExecuted, onError);
 ```
@@ -151,7 +151,7 @@ function onError(error) {
 
 const executing = browser.tabs.executeScript({
   file: "/content-script.js",
-  allFrames: true
+  allFrames: true,
 });
 executing.then(onExecuted, onError);
 ```
@@ -167,9 +167,8 @@ function onError(error) {
   console.log(`Error: ${error}`);
 }
 
-const executing = browser.tabs.executeScript(
-  2, {
-    file: "/content-script.js"
+const executing = browser.tabs.executeScript(2, {
+  file: "/content-script.js",
 });
 executing.then(onExecuted, onError);
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -144,8 +144,8 @@ const pattern1 = "https://developer.mozilla.org/*";
 const pattern2 = "https://twitter.com/mozdevnet";
 
 const filter = {
-  urls: [pattern1, pattern2]
-}
+  urls: [pattern1, pattern2],
+};
 
 function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log(`Updated tab: ${tabId}`);
@@ -160,8 +160,8 @@ Log changes only to the `pinned` property of tabs (that is, pin and unpin action
 
 ```js
 const filter = {
-  properties: ["pinned"]
-}
+  properties: ["pinned"],
+};
 
 function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log(`Updated tab: ${tabId}`);
@@ -180,8 +180,8 @@ const pattern2 = "https://twitter.com/mozdevnet";
 
 const filter = {
   urls: [pattern1, pattern2],
-  properties: ["pinned"]
-}
+  properties: ["pinned"],
+};
 
 function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log(`Updated tab: ${tabId}`);
@@ -203,8 +203,8 @@ const pattern2 = "https://twitter.com/mozdevnet";
 const filter = {
   urls: [pattern1, pattern2],
   properties: ["pinned"],
-  windowId: browser.windows.WINDOW_ID_CURRENT
-}
+  windowId: browser.windows.WINDOW_ID_CURRENT,
+};
 
 function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log(`Updated tab: ${tabId}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -107,7 +107,7 @@ function onError(error) {
 function updateFirstTab(tabs) {
   let updating = browser.tabs.update(tabs[0].id, {
     active: true,
-    url: "https://developer.mozilla.org"
+    url: "https://developer.mozilla.org",
   });
   updating.then(onUpdated, onError);
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.md
@@ -52,7 +52,7 @@ async function warmupMDN() {
 
   const mdnTabs = await browser.tabs.query({
     currentWindow: true,
-    url: "https://developer.mozilla.org/*"
+    url: "https://developer.mozilla.org/*",
   });
 
   if (mdnTabs.length > 0) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -63,7 +63,7 @@ const day = {
 browser.menus.create({
   id: "set-theme",
   title: "set theme",
-  contexts: ["all"]
+  contexts: ["all"],
 });
 
 async function updateThemeForCurrentWindow() {

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -62,7 +62,7 @@ function onError(error) {
 
 let gettingFrame = browser.webNavigation.getFrame({
   tabId: 19,
-  frameId: 1537
+  frameId: 1537,
 });
 
 // Edge specific - processId is required not optional, must be integer not null

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -229,8 +229,8 @@ const target = "https://intranet.company.com/";
 
 const myCredentials = {
   username: "me@company.com",
-  password: "zDR$ERHGDFy"
-}
+  password: "zDR$ERHGDFy",
+};
 
 const pendingRequests = [];
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -224,7 +224,8 @@ let pattern = "https://developer.mozilla.org/*";
 function redirect(requestDetails) {
   console.log(`Redirecting: ${requestDetails.url}`);
   return {
-    redirectUrl: "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif"
+    redirectUrl:
+      "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif",
   };
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -175,7 +175,7 @@ let targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition"
 function setCookie(e) {
   const setMyCookie = {
     name: "Set-Cookie",
-    value: "my-cookie1=my-cookie-value1"
+    value: "my-cookie1=my-cookie-value1",
   };
   e.responseHeaders.push(setMyCookie);
   return { responseHeaders: e.responseHeaders };
@@ -203,7 +203,7 @@ function setCookieAsync(e) {
     setTimeout(() => {
       const setMyCookie = {
         name: "Set-Cookie",
-        value: "my-cookie1=my-cookie-value1"
+        value: "my-cookie1=my-cookie-value1",
       };
       e.responseHeaders.push(setMyCookie);
       resolve({ responseHeaders: e.responseHeaders });

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -104,7 +104,7 @@ function onError(error) {
 
 browser.browserAction.onClicked.addListener((tab) => {
   let creating = browser.windows.create({
-    tabId: tab.id
+    tabId: tab.id,
   });
   creating.then(onCreated, onError);
 });
@@ -129,7 +129,7 @@ browser.browserAction.onClicked.addListener((tab) => {
     url: popupURL,
     type: "popup",
     height: 200,
-    width: 200
+    width: 200,
   });
   creating.then(onCreated, onError);
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -70,7 +70,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
   let updating = browser.windows.update(tab.windowId, {
     left: 0,
-    top: 0
+    top: 0,
   });
   updating.then(onUpdated, onError);
 


### PR DESCRIPTION
This PR adds trailing commas to various code examples throughout the WebExtensions documentation.  We have recently adapted trailing commas as a part of MDN's code styling, namely as it helps prevent merge conflicts in Git.

Note: some other formatting updates may be included as they were too close to effectively separate without producing merge conflicts.  This PR is purely made of formatting changes, however.
