### PR TITLE
Fix formatting of JS/JSON objects in WebExtensions pages

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -42,14 +42,13 @@ This is an example rule that blocks all script requests originating from `"foo.c
 
 ```json
 {
-  "id" : 1,
+  "id": 1,
   "priority": 1,
-  "action" : { "type" : "block" },
-  "condition" : 
-  {
-    "urlFilter" : "abc",
-    "initiatorDomains" : ["foo.com"],
-    "resourceTypes" : ["script"]
+  "action": { "type": "block" },
+  "condition": {
+    "urlFilter": "abc",
+    "initiatorDomains": ["foo.com"],
+    "resourceTypes": ["script"]
   }
 }
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -90,9 +90,9 @@ function onFailed(error) {
 let downloadUrl = "https://example.org/image.png";
 
 let downloading = browser.downloads.download({
-  url : downloadUrl,
-  filename : 'my-image-again.png',
-  conflictAction : 'uniquify'
+  url: downloadUrl,
+  filename: "my-image-again.png",
+  conflictAction: "uniquify",
 });
 
 downloading.then(onStartedDownload, onFailed);

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -60,9 +60,9 @@ This would work with a \_locales/en/messages.json file containing:
     "message": "You clicked $URL$.",
     "description": "Tells the user which link they clicked.",
     "placeholders": {
-      "url" : {
-        "content" : "$1",
-        "example" : "https://developer.mozilla.org"
+      "url": {
+        "content": "$1",
+        "example": "https://developer.mozilla.org"
       }
     }
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
@@ -35,9 +35,9 @@ The following code shows an example `messages.json file`, taken from our [notify
     "message": "You clicked $URL$.",
     "description": "Tells the user which link they clicked.",
     "placeholders": {
-      "url" : {
-        "content" : "$1",
-        "example" : "https://developer.mozilla.org"
+      "url": {
+        "content": "$1",
+        "example": "https://developer.mozilla.org"
       }
     }
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -42,11 +42,11 @@ Log the permission warnings for the given manifest file:
 
 ```js
 let manifest = {
-  "manifest_version": 2,
-  "name": "test",
-  "version": "1.0",
-  "permissions": ["management", "<all_urls>"]
-}
+  manifest_version: 2,
+  name: "test",
+  version: "1.0",
+  permissions: ["management", "<all_urls>"],
+};
 
 let manifestString = JSON.stringify(manifest);
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -44,10 +44,10 @@ function toggleAlarm(all) {
     browser.notifications.clear(myNotification);
   } else {
     browser.notifications.create(myNotification, {
-      "type": "basic",
-      "iconUrl": browser.runtime.getURL("icons/cake-48.png"),
-      "title": "Am imposing title",
-      "message": "Some interesting content"
+      type: "basic",
+      iconUrl: browser.runtime.getURL("icons/cake-48.png"),
+      title: "Am imposing title",
+      message: "Some interesting content",
     });
   }
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -136,10 +136,10 @@ browser.runtime.onMessage.addListener(notify);
 
 function notify(message) {
   browser.notifications.create({
-    "type": "basic",
-    "iconUrl": browser.extension.getURL("link.png"),
-    "title": "You clicked a link!",
-    "message": message.url
+    type: "basic",
+    iconUrl: browser.extension.getURL("link.png"),
+    title: "You clicked a link!",
+    message: message.url,
   });
 }
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -52,8 +52,8 @@ Suppose storage contains two items:
 // storage contains two items,
 // "kitten" and "monster"
 browser.storage.local.set({
-  kitten:  {name:"Mog", eats:"mice"},
-  monster: {name:"Kraken", eats:"people"}
+  kitten: { name: "Mog", eats: "mice" },
+  monster: { name: "Kraken", eats: "people" },
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -35,13 +35,13 @@ Sets the browser theme to use a sun graphic with complementary background color:
 
 ```js
 const suntheme = {
- images: {
-   theme_frame: 'sun.jpg',
- },
- colors: {
-   frame: '#CF723F',
-   tab_background_text: '#111',
- }
+  images: {
+    theme_frame: "sun.jpg",
+  },
+  colors: {
+    frame: "#CF723F",
+    tab_background_text: "#111",
+  },
 };
 
 browser.theme.update(suntheme);
@@ -51,13 +51,13 @@ Set the theme for just the currently focused window:
 
 ```js
 const day = {
-    images: {
-      theme_frame: 'sun.jpg',
-    },
-    colors: {
-      frame: '#CF723F',
-      tab_background_text: '#111',
-    }
+  images: {
+    theme_frame: "sun.jpg",
+  },
+  colors: {
+    frame: "#CF723F",
+    tab_background_text: "#111",
+  },
 };
 
 browser.menus.create({

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -70,12 +70,8 @@ Logs the target URLs for `onBeforeNavigate`, if the target's hostname contains "
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnBefore(details) {
   console.log(`onBeforeNavigate to: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -74,12 +74,8 @@ Logs the target URLs and extra transition information for `onCommitted`, if the 
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnCommitted(details) {
   console.log(`target URL: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -68,12 +68,8 @@ Logs the target URLs for `onCompleted`, if the target URL's hostname contains "e
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnCompleted(details) {
   console.log(`onCompleted: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -79,12 +79,8 @@ Logs the target URL, source Tab ID, and source frame ID for `onCreatedNavigation
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnCreatedNavigationTarget(details) {
   console.log(`onCreatedNavigationTarget: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -68,12 +68,8 @@ Logs the target URLs for `onDOMContentLoaded`, if the target URL's hostname cont
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnDOMContentLoaded(details) {
   console.log(`onDOMContentLoaded: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -86,12 +86,8 @@ Logs the target URLs for `onErrorOccurred`, if the target URL's `hostname` conta
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnErrorOccurred(details) {
   console.log(`onErrorOccurred: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -72,12 +72,8 @@ Logs the target URLs and extra transition information for `onHistoryStateUpdated
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnHistoryStateUpdated(details) {
   console.log(`onHistoryStateUpdated: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -72,12 +72,8 @@ Logs the target URLs and extra transition information for `onReferenceFragmentUp
 
 ```js
 const filter = {
-  url:
-  [
-    {hostContains: "example.com"},
-    {hostPrefix: "developer"}
-  ]
-}
+  url: [{ hostContains: "example.com" }, { hostPrefix: "developer" }],
+};
 
 function logOnReferenceFragmentUpdated(details) {
   console.log(`onReferenceFragmentUpdated: ${details.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -76,7 +76,7 @@ async function logRoot(details) {
   try {
     let securityInfo = await browser.webRequest.getSecurityInfo(
       details.requestId,
-      {"certificateChain": true}
+      { certificateChain: true }
     );
     console.log(details.url);
     if (securityInfo.state === "secure" || securityInfo.state === "weak") {


### PR DESCRIPTION
This PR fixes the formatting of various objects described in JavaScript and JSON code in the WebExtensions pages.  In a lot of objects, there was odd spacing before the colons, or redundant quotes added to the keys when defining the objects in JavaScript.  This PR aims to fix such instances.

Note: other small formatting changes may have been included in this PR as well.
