### PR TITLE
Prefer double quotes over single quotes for strings

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
@@ -39,13 +39,13 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Resets the command named "my-command" when the user clicks the "reset" button:
 
 ```js
-const commandName = 'my-command';
+const commandName = "my-command";
 
 function resetShortcut() {
   browser.commands.reset(commandName);
 }
 
-document.querySelector('#reset').addEventListener('click', resetShortcut);
+document.querySelector("#reset").addEventListener("click", resetShortcut);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -49,16 +49,16 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Updates the command named "my-command" with the given shortcut value, when the user clicks "update":
 
 ```js
-const commandName = 'my-command';
+const commandName = "my-command";
 
 function updateShortcut() {
   browser.commands.update({
     name: commandName,
-    shortcut: document.querySelector('#shortcut').value
+    shortcut: document.querySelector("#shortcut").value,
   });
 }
 
-document.querySelector('#update').addEventListener('click', updateShortcut);
+document.querySelector("#update").addEventListener("click", updateShortcut);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
@@ -36,7 +36,7 @@ Create a new pane, and populate it with an HTML page. You could run this code in
 
 ```js
 function onCreated(sidebarPane) {
-  sidebarPane.setPage('sidebar/sidebar.html');
+  sidebarPane.setPage("sidebar/sidebar.html");
 }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -28,7 +28,7 @@ None.
 The following snippet contains a show button, which when clicked invokes `showDefaultFolder()` to open the default downloads folder in the platform's file manager:
 
 ```js
-let showBtn = document.querySelector('.show');
+let showBtn = document.querySelector(".show");
 
 showBtn.onclick = () => {
   browser.downloads.showDefaultFolder();

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -82,7 +82,7 @@ function authorize() {
   authURL += `?client_id=${clientID}`;
   authURL += `&response_type=token`;
   authURL += `&redirect_uri=${encodeURIComponent(redirectURL)}`;
-  authURL += `&scope=${encodeURIComponent(scopes.join(' '))}`;
+  authURL += `&scope=${encodeURIComponent(scopes.join(" "))}`;
 
   return browser.identity.launchWebAuthFlow({
     interactive: true,

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -38,10 +38,10 @@ In this simple snippet, we call `queryState()` and then check if the returned `n
 
 ```js
 function onGot(newState) {
-  if (newState === 'idle') {
-    console.log('Please come back — we miss you!');
-  } else if (newState === 'active') {
-    console.log('Glad to still have you with us!');
+  if (newState === "idle") {
+    console.log("Please come back — we miss you!");
+  } else if (newState === "active") {
+    console.log("Glad to still have you with us!");
   }
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -66,7 +66,8 @@ Each `InjectionResult` object has these properties:
 The result of the script is the last evaluated statement, which is similar to the results seen if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) (not any `console.log()` output). For example, consider a script like this:
 
 ```js
-let foo='my result'; foo;
+let foo = "my result";
+foo;
 ```
 
 Here the results array contains the string "`my result`" as an element.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -31,7 +31,7 @@ Here's an example manifest:
 Given this manifest, the [favourite-colour](https://github.com/mdn/webextensions-examples/tree/master/favourite-colour) extension could access the data using code like this:
 
 ```js
-let storageItem = browser.storage.managed.get('colour');
+let storageItem = browser.storage.managed.get("colour");
 storageItem.then((res) => {
   console.log(`Managed colour is: ${res.colour}`);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -106,7 +106,8 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 The result of the script is the last evaluated statement, which is similar to what would be output (the results, not any `console.log()` output) if you executed the script in the [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html). For example, consider a script like this:
 
 ```js
-let foo='my result'; foo;
+let foo = "my result";
+foo;
 ```
 
 Here the results array will contain the string "`my result`" as an element.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -68,7 +68,7 @@ function listener(details) {
     let str = decoder.decode(event.data, {stream: true});
     // Just change any instance of Example in the HTTP response
     // to WebExtension Example.
-    str = str.replace(/Example/g, 'WebExtension Example');
+    str = str.replace(/Example/g, "WebExtension Example");
     filter.write(encoder.encode(str));
     filter.disconnect();
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -46,7 +46,7 @@ function listener(details) {
     let str = decoder.decode(event.data, {stream: true});
     // Just change any instance of Example in the HTTP response
     // to WebExtension Example.
-    str = str.replace(/Example/g, 'WebExtension Example');
+    str = str.replace(/Example/g, "WebExtension Example");
     filter.write(encoder.encode(str));
     filter.disconnect();
   }


### PR DESCRIPTION
This PR updates strings throughout the code to use double quotes instead of single quotes.  This helps us maintain consistent styling across all of our code examples.
