### PR TITLE
Add missing semicolons to end JS statements

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -32,7 +32,7 @@ let showBtn = document.querySelector('.show');
 
 showBtn.onclick = () => {
   browser.downloads.showDefaultFolder();
-}
+};
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -55,7 +55,7 @@ function onLanguageDetected(langInfo) {
   }
 }
 
-let text = "L'homme est né libre, et partout il est dans les fers."
+let text = "L'homme est né libre, et partout il est dans les fers.";
 
 let detecting = browser.i18n.detectLanguage(text);
 detecting.then(onLanguageDetected);

--- a/files/en-us/mozilla/add-ons/webextensions/api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.md
@@ -14,27 +14,25 @@ You can access the APIs using the `browser` namespace:
 
 ```js
 function logTabs(tabs) {
-  console.log(tabs)
+  console.log(tabs);
 }
 
-browser.tabs.query({currentWindow: true}, logTabs)
+browser.tabs.query({ currentWindow: true }, logTabs);
 ```
 
 Many of the APIs are asynchronous, returning a {{JSxRef("Promise")}}:
 
 ```js
 function logCookie(c) {
-  console.log(c)
+  console.log(c);
 }
 
 function logError(e) {
-  console.error(e)
+  console.error(e);
 }
 
-let setCookie = browser.cookies.set(
-  {url: "https://developer.mozilla.org/"}
-);
-setCookie.then(logCookie, logError)
+let setCookie = browser.cookies.set({ url: "https://developer.mozilla.org/" });
+setCookie.then(logCookie, logError);
 ```
 
 ## Browser API differences

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -50,7 +50,7 @@ function logShown(itemId) {
   console.log(`shown: ${itemId}`);
   browser.notifications.getAll().then((all) => {
     console.log(all[itemId]);
-  })
+  });
 }
 
 browser.notifications.onShown.addListener(logShown);

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -43,7 +43,7 @@ Events have three functions:
 
 ```js
 browser.omnibox.onInputStarted.addListener(() => {
-  console.log("User has started interacting with me.")
+  console.log("User has started interacting with me.");
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -48,9 +48,9 @@ browser.contextMenus.create({
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "show") {
-    browser.pageAction.show(tab.id)
+    browser.pageAction.show(tab.id);
   }
-})
+});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -174,19 +174,19 @@ If you have multiple content scripts communicating at the same time, you might w
 ```js
 // background-script.js
 
-let ports = []
+let ports = [];
 
 function connected(p) {
-  ports[p.sender.tab.id]    = p
+  ports[p.sender.tab.id] = p;
   // …
 }
 
-browser.runtime.onConnect.addListener(connected)
+browser.runtime.onConnect.addListener(connected);
 
 browser.browserAction.onClicked.addListener(() => {
   ports.forEach((p) => {
-        p.postMessage({greeting: "they clicked the button!"})
-    })
+    p.postMessage({ greeting: "they clicked the button!" });
+  });
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -44,7 +44,7 @@ This code forgets the single most recently-closed session, whether it's a tab or
 ```js
 function forgetMostRecent(sessionInfos) {
   if (!sessionInfos.length) {
-    console.log("No sessions found")
+    console.log("No sessions found");
     return;
   }
   let sessionInfo = sessionInfos[0];

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -41,7 +41,7 @@ This code forgets the single most recently-closed session, whether it's a tab or
 ```js
 function forgetMostRecent(sessionInfos) {
   if (!sessionInfos.length) {
-    console.log("No sessions found")
+    console.log("No sessions found");
     return;
   }
   let sessionInfo = sessionInfos[0];

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -41,7 +41,7 @@ This code restores the single most recently-closed session, whether it's a tab o
 ```js
 function restoreMostRecent(sessionInfos) {
   if (!sessionInfos.length) {
-    console.log("No sessions found")
+    console.log("No sessions found");
     return;
   }
   let sessionInfo = sessionInfos[0];

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -44,7 +44,7 @@ This very annoying extension listens for `onChanged`, then immediately restores 
 ```js
 function restoreSession(sessionInfos) {
   if (!sessionInfos.length) {
-    console.log("No sessions found")
+    console.log("No sessions found");
     return;
   }
   let sessionInfo = sessionInfos[0];

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -39,7 +39,7 @@ This restores the single most recently-closed session, whether it's a window or 
 ```js
 function restoreMostRecent(sessionInfos) {
   if (!sessionInfos.length) {
-    console.log("No sessions found")
+    console.log("No sessions found");
     return;
   }
   let sessionInfo = sessionInfos[0];

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -59,7 +59,7 @@ function gotMonster(item) {
 }
 
 function onError(error) {
-  console.log(error)
+  console.log(error);
 }
 
 // define 2 objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -81,7 +81,7 @@ Open "https\://example.org" in a new tab:
 
 ```js
 function onCreated(tab) {
-  console.log(`Created new tab: ${tab.id}`)
+  console.log(`Created new tab: ${tab.id}`);
 }
 
 function onError(error) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -71,7 +71,7 @@ function listener(details) {
     str = str.replace(/Example/g, 'WebExtension Example');
     filter.write(encoder.encode(str));
     filter.disconnect();
-  }
+  };
 
   return {};
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -46,7 +46,7 @@ function listener(details) {
     let encoder = new TextEncoder();
     filter.write(encoder.encode("replacement content"));
     filter.close();
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -44,7 +44,7 @@ function listener(details) {
     let encoder = new TextEncoder();
     filter.write(encoder.encode("preface text"));
     filter.disconnect();
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -23,7 +23,7 @@ function listener(details) {
 
   filter.onerror = (event) => {
     console.log(`Error: ${filter.error}`);
-  }
+  };
 
   //return {}; // not needed
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -25,7 +25,7 @@ You can listen to each event by assigning a listener function to its attribute:
 ```js
 filter.onstart = (event) => {
   console.log("started");
-}
+};
 ```
 
 Note that the request is blocked during the execution of any event listeners.
@@ -83,17 +83,17 @@ function listener(details) {
 
   filter.onstart = (event) => {
     console.log("started");
-  }
+  };
 
   filter.ondata = (event) => {
     console.log(event.data);
     filter.write(event.data);
-  }
+  };
 
   filter.onstop = (event) => {
     console.log("finished");
     filter.disconnect();
-  }
+  };
 
   //return {}; // not needed
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -29,7 +29,7 @@ function listener(details) {
 
   filter.onerror = (event) => {
     console.log(`Error: ${filter.error}`);
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -47,7 +47,7 @@ function listener(details) {
 
   filter.onerror = (event) => {
     console.log(`Error: ${filter.error}`); // Error: Invalid request ID
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -26,7 +26,7 @@ function listener(details) {
     let encoder = new TextEncoder();
     filter.write(encoder.encode("replacement content"));
     filter.close();
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -44,8 +44,7 @@ function listener(details) {
       filter.resume();
       filter.disconnect();
     }, 1000);
-
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -33,23 +33,23 @@ A string that describes the current status of the request. It will be one of the
 ```js
 function listener(details) {
   let filter = browser.webRequest.filterResponseData(details.requestId);
-  console.log(filter.status);          // uninitialized
+  console.log(filter.status); // uninitialized
 
   filter.onstart = (event) => {
-    console.log(filter.status);        // transferringdata
-  }
+    console.log(filter.status); // transferringdata
+  };
 
   filter.ondata = (event) => {
-    console.log(filter.status);        // transferringdata
+    console.log(filter.status); // transferringdata
     // pass through the response data
     filter.write(event.data);
-  }
+  };
 
   filter.onstop = (event) => {
-    console.log(filter.status);        // finishedtransferringdata
+    console.log(filter.status); // finishedtransferringdata
     filter.disconnect();
-    console.log(filter.status);        // disconnected
-  }
+    console.log(filter.status); // disconnected
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -44,8 +44,7 @@ function listener(details) {
       filter.resume();
       filter.disconnect();
     }, 1000);
-
-  }
+  };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -49,7 +49,7 @@ function listener(details) {
     str = str.replace(/Example/g, 'WebExtension Example');
     filter.write(encoder.encode(str));
     filter.disconnect();
-  }
+  };
 
   //return {}; // not needed
 }


### PR DESCRIPTION
This PR adds missing semicolons throughout the JavaScript code examples in the WebExtensions documentation.

Note: this may include other formatting fixes that were too integrated to effectively separate.
