### PR TITLE
Fix indentation and whitespace across various code examples

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -69,7 +69,8 @@ This example registers the `defaultCode` content script for all `.org` URLs:
 
 ```js
 const defaultHosts = "*://*.org/*";
-const defaultCode = "document.body.innerHTML = '<h1>This page has been eaten<h1>'";
+const defaultCode =
+  "document.body.innerHTML = '<h1>This page has been eaten<h1>'";
 
 async function register(hosts, code) {
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -49,8 +49,9 @@ function onError(e) {
   console.error(e);
 }
 
-browser.contextualIdentities.remove("firefox-container-1").
-  then(onRemoved, onError);
+browser.contextualIdentities
+  .remove("firefox-container-1")
+  .then(onRemoved, onError);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -83,12 +83,13 @@ function onError(e) {
   console.error(e);
 }
 
-browser.contextualIdentities.update(
-  "firefox-container-1", {
+browser.contextualIdentities
+  .update("firefox-container-1", {
     name: "my-thing",
     color: "purple",
-    icon: "briefcase"
-  }).then(onUpdated, onError);
+    icon: "briefcase",
+  })
+  .then(onUpdated, onError);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -21,7 +21,7 @@ Values of this type are objects, which can contain the following properties:
   - : A `string` representing the unique identifier for the cookie store.
 - `incognito` {{optional_inline}}
   - : A boolean value that indicates whether this is an incognito cookie store.
-      This property is not supported in Chrome or Safari. However, you can identify incognito cookie stores in Chrome because their `id` is always "1".
+    This property is not supported in Chrome or Safari. However, you can identify incognito cookie stores in Chrome because their `id` is always "1".
 - `tabIds`
   - : An `array` of `integers`, which identifies all of the browser tabs that share this cookie store.
 
@@ -48,7 +48,9 @@ The following code snippet gets all cookie stores and then logs the total number
 ```js
 browser.cookies.getAllCookieStores().then((stores) => {
   const incognitoStores = stores.map((store) => store.incognito);
-  console.log(`Of ${stores.length} cookie stores, ${incognitoStores.length} are incognito.`);
+  console.log(
+    `Of ${stores.length} cookie stores, ${incognitoStores.length} are incognito.`
+  );
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -64,10 +64,12 @@ This example listens for `onChanged` events and logs details from the `changeInf
 
 ```js
 browser.cookies.onChanged.addListener((changeInfo) => {
-  console.log(`Cookie changed: \n`
-    + ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n`
-    + ` * Cause: ${changeInfo.cause}\n`
-    + ` * Removed: ${changeInfo.removed}`);
+  console.log(
+    `Cookie changed: \n` +
+      ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n` +
+      ` * Cause: ${changeInfo.cause}\n` +
+      ` * Removed: ${changeInfo.removed}`
+  );
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -34,10 +34,12 @@ You can listen to the {{WebExtAPIRef("cookies.onChanged")}} event to be notified
 
 ```js
 browser.cookies.onChanged.addListener((changeInfo) => {
-  console.log(`Cookie changed: \n`
-    + ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n`
-    + ` * Cause: ${changeInfo.cause}\n`
-    + ` * Removed: ${changeInfo.removed}`);
+  console.log(
+    `Cookie changed: \n` +
+      ` * Cookie: ${JSON.stringify(changeInfo.cookie)}\n` +
+      ` * Cause: ${changeInfo.cause}\n` +
+      ` * Removed: ${changeInfo.removed}`
+  );
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -105,8 +105,7 @@ function handleResult(result) {
 const checkjQuery = "typeof jQuery !== 'undefined'";
 
 evalButton.addEventListener("click", () => {
-  browser.devtools.inspectedWindow.eval(checkjQuery)
-    .then(handleResult);
+  browser.devtools.inspectedWindow.eval(checkjQuery).then(handleResult);
 });
 ```
 
@@ -133,8 +132,7 @@ function handleResult(result) {
 }
 
 evalButton.addEventListener("click", () => {
-  browser.devtools.inspectedWindow.eval(evalString)
-    .then(handleResult);
+  browser.devtools.inspectedWindow.eval(evalString).then(handleResult);
 });
 ```
 
@@ -159,8 +157,7 @@ function handleResult(result) {
 }
 
 inspectButton.addEventListener("click", () => {
-  browser.devtools.inspectedWindow.eval(inspectString)
-    .then(handleResult);
+  browser.devtools.inspectedWindow.eval(inspectString).then(handleResult);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -51,14 +51,16 @@ function handleHidden() {
   console.log("panel is being hidden");
 }
 
-browser.devtools.panels.create(
-  "My Panel",                 // title
-  "/icons/star.png",           // icon
-  "/devtools/panel/panel.html" // content
-).then((newPanel) => {
-  newPanel.onShown.addListener(handleShown);
-  newPanel.onHidden.addListener(handleHidden);
-});
+browser.devtools.panels
+  .create(
+    "My Panel", // title
+    "/icons/star.png", // icon
+    "/devtools/panel/panel.html" // content
+  )
+  .then((newPanel) => {
+    newPanel.onShown.addListener(handleShown);
+    newPanel.onHidden.addListener(handleHidden);
+  });
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -43,13 +43,14 @@ Listen for selection changed events, and log the text content of the newly selec
 
 ```js
 function handleSelectedElement() {
-  browser.devtools.inspectedWindow.eval("$0.textContent")
-    .then((result) => {
-      console.log(result[0]);
-    });
+  browser.devtools.inspectedWindow.eval("$0.textContent").then((result) => {
+    console.log(result[0]);
+  });
 }
 
-browser.devtools.panels.elements.onSelectionChanged.addListener(handleSelectedElement);
+browser.devtools.panels.elements.onSelectionChanged.addListener(
+  handleSelectedElement
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -35,14 +35,16 @@ function handleHidden(e) {
   console.log("panel is being hidden");
 }
 
-browser.devtools.panels.create(
-  "My Panel",                 // title
-  "icons/star.png",           // icon
-  "devtools/panel/panel.html" // content
-).then((newPanel) => {
-  newPanel.onShown.addListener(handleShown);
-  newPanel.onHidden.addListener(handleHidden);
-});
+browser.devtools.panels
+  .create(
+    "My Panel", // title
+    "icons/star.png", // icon
+    "devtools/panel/panel.html" // content
+  )
+  .then((newPanel) => {
+    newPanel.onShown.addListener(handleShown);
+    newPanel.onHidden.addListener(handleHidden);
+  });
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -57,12 +57,12 @@ function onError(error) {
 }
 
 function getIcon(downloadItems) {
-    if (downloadItems.length > 0) {
-      latestDownloadId = downloadItems[0].id;
-      let gettingIcon = browser.downloads.getFileIcon(latestDownloadId);
-      gettingIcon.then(gotIcon, onError);
-    }
+  if (downloadItems.length > 0) {
+    latestDownloadId = downloadItems[0].id;
+    let gettingIcon = browser.downloads.getFileIcon(latestDownloadId);
+    gettingIcon.then(gotIcon, onError);
   }
+}
 
 let searching = browser.downloads.search({
   limit: 1,

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -48,11 +48,11 @@ function onError(error) {
 }
 
 function openDownload(downloadItems) {
-    if (downloadItems.length > 0) {
-      let opening = browser.downloads.open(downloadItems[0].id);
-      opening.then(onOpened, onError);
-    }
+  if (downloadItems.length > 0) {
+    let opening = browser.downloads.open(downloadItems[0].id);
+    opening.then(onOpened, onError);
   }
+}
 
 let searching = browser.downloads.search({
   limit: 1,

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -46,12 +46,12 @@ function onError(error) {
 }
 
 function openDownload(downloadItems) {
-    if (downloadItems.length > 0) {
-      latestDownloadId = downloadItems[0].id;
-      let showing = browser.downloads.show(latestDownloadId);
-      showing.then(onShowing, onError);
-    }
+  if (downloadItems.length > 0) {
+    latestDownloadId = downloadItems[0].id;
+    let showing = browser.downloads.show(latestDownloadId);
+    showing.then(onShowing, onError);
   }
+}
 
 let searching = browser.downloads.search({
   limit: 1,

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -76,7 +76,8 @@ function validate(redirectURL) {
 
 function authorize() {
   const redirectURL = browser.identity.getRedirectURL();
-  const clientID = "664583959686-fhvksj46jkd9j5v96vsmvs406jgndmic.apps.googleusercontent.com";
+  const clientID =
+    "664583959686-fhvksj46jkd9j5v96vsmvs406jgndmic.apps.googleusercontent.com";
   const scopes = ["openid", "email", "profile"];
   let authURL = "https://accounts.google.com/o/oauth2/auth";
   authURL += `?client_id=${clientID}`;

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -58,7 +58,8 @@ function gotError(error) {
   console.log(`Error: ${error}`);
 }
 
-let gettingWarnings = browser.management.getPermissionWarningsByManifest(manifestString);
+let gettingWarnings =
+  browser.management.getPermissionWarningsByManifest(manifestString);
 gettingWarnings.then(gotWarnings, gotError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -63,8 +63,7 @@ browser.pageAction.onClicked.addListener((tab) => {
   browser.tabs.update({url: CATGIFS});
 });
 
-browser.pageAction.onClicked.addListener(() => {
-});
+browser.pageAction.onClicked.addListener(() => {});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -67,7 +67,9 @@ async function requestPermissions() {
   console.log(`Current permissions:`, currentPermissions);
 }
 
-document.querySelector("#request").addEventListener("click", requestPermissions);
+document
+  .querySelector("#request")
+  .addEventListener("click", requestPermissions);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -63,8 +63,10 @@ browser.browserAction.onClicked.addListener(() => {
   let getting = browser.privacy.network.webRTCIPHandlingPolicy.get({});
   getting.then((got) => {
     console.log(got.value);
-    if ((got.levelOfControl === "controlled_by_this_extension") ||
-        (got.levelOfControl === "controllable_by_this_extension")) {
+    if (
+      got.levelOfControl === "controlled_by_this_extension" ||
+      got.levelOfControl === "controllable_by_this_extension"
+    ) {
       let setting = browser.privacy.network.webRTCIPHandlingPolicy.set({
         value: "default_public_interface_only"
       });

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -31,19 +31,21 @@ function onSet(result) {
   }
 }
 
-  let getting = browser.privacy.services.passwordSavingEnabled.get({});
-  getting.then((got) => {
-    console.log(got.value);
-    if ((got.levelOfControl === "controlled_by_this_extension") ||
-        (got.levelOfControl === "controllable_by_this_extension")) {
-      let setting = browser.privacy.services.passwordSavingEnabled.set({
-        value: false
-      });
-      setting.then(onSet);
-    } else {
-      console.log("Not able to set passwordSavingEnabled");
-    }
-  });
+let getting = browser.privacy.services.passwordSavingEnabled.get({});
+getting.then((got) => {
+  console.log(got.value);
+  if (
+    got.levelOfControl === "controlled_by_this_extension" ||
+    got.levelOfControl === "controllable_by_this_extension"
+  ) {
+    let setting = browser.privacy.services.passwordSavingEnabled.set({
+      value: false,
+    });
+    setting.then(onSet);
+  } else {
+    console.log("Not able to set passwordSavingEnabled");
+  }
+});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -86,10 +86,12 @@ browser.browserAction.onClicked.addListener(() => {
   let getting = browser.privacy.websites.hyperlinkAuditingEnabled.get({});
   getting.then((got) => {
     console.log(got.value);
-    if ((got.levelOfControl === "controlled_by_this_extension") ||
-        (got.levelOfControl === "controllable_by_this_extension")) {
+    if (
+      got.levelOfControl === "controlled_by_this_extension" ||
+      got.levelOfControl === "controllable_by_this_extension"
+    ) {
       let setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
-        value: true
+        value: true,
       });
       setting.then(onSet);
     } else {

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -48,7 +48,9 @@ function handleBrowserUpdateAvailable() {
   // handle event
 }
 
-browser.runtime.onBrowserUpdateAvailable.addListener(handleBrowserUpdateAvailable);
+browser.runtime.onBrowserUpdateAvailable.addListener(
+  handleBrowserUpdateAvailable
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -51,9 +51,7 @@ In this example the extension Hansel connects to the extension Gretel:
 
 ```js
 console.log("connecting to Gretel");
-let myPort = browser.runtime.connect(
-  "gretel@mozilla.org"
-);
+let myPort = browser.runtime.connect("gretel@mozilla.org");
 
 myPort.onMessage.addListener((message) => {
   console.log(`From Gretel: ${message.content}`);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -84,24 +84,22 @@ Events have three functions:
     >
     > ```js example-bad
     > // don't do this
-    > browser.runtime.onMessage.addListener(
-    >   async (data, sender) => {
-    >     if (data.type === 'handle_me') { return 'done'; }
+    > browser.runtime.onMessage.addListener(async (data, sender) => {
+    >   if (data.type === "handle_me") {
+    >     return "done";
     >   }
-    > );
+    > });
     > ```
     >
     > If you only want the listener to respond to messages of a certain type, you must define the listener as a non-`async` function, and return a Promise only for the messages the listener is meant to respond to — and otherwise return false or undefined:
     >
     > ```js example-good
-    > browser.runtime.onMessage.addListener(
-    >   (data, sender) => {
-    >     if (data.type === 'handle_me') {
-    >       return Promise.resolve('done');
-    >     }
-    >     return false;
+    > browser.runtime.onMessage.addListener((data, sender) => {
+    >   if (data.type === "handle_me") {
+    >     return Promise.resolve("done");
     >   }
-    > );
+    >   return false;
+    > });
     > ```
 
 ## Browser compatibility
@@ -226,9 +224,11 @@ function handleResponse(isBookmarked) {
   }
 }
 
-browser.runtime.sendMessage({
-  url: firstLink.href
-}).then(handleResponse);
+browser.runtime
+  .sendMessage({
+    url: firstLink.href,
+  })
+  .then(handleResponse);
 ```
 
 Here is the background script. It uses `{{WebExtAPIRef("bookmarks.search()")}}` to see if the link is bookmarked, which returns a {{jsxref("Promise")}}:
@@ -237,9 +237,11 @@ Here is the background script. It uses `{{WebExtAPIRef("bookmarks.search()")}}` 
 // background-script.js
 
 function isBookmarked(message, sender, response) {
-  return browser.bookmarks.search({
-    url: message.url
-  }).then((results) => results.length > 0);
+  return browser.bookmarks
+    .search({
+      url: message.url,
+    })
+    .then((results) => results.length > 0);
 }
 
 browser.runtime.onMessage.addListener(isBookmarked);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -72,10 +72,7 @@ In this example the extension "blue\@mozilla.org" sends a message to the extensi
 // sender: browser.runtime.id === "blue@mozilla.org"
 
 // Send a message to the extension whose ID is "red@mozilla.org"
-browser.runtime.sendMessage(
-    "red@mozilla.org",
-    "my message"
-  );
+browser.runtime.sendMessage("red@mozilla.org", "my message");
 ```
 
 ```js

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -15,16 +15,16 @@ Values of this type are strings. Possible values are:
 
 - `ISOLATED`
 
-   The default execution environment of [content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts).
-   This environment is isolated from the page's context: while they share the same document, the global scopes and available APIs differ.
+  The default execution environment of [content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts).
+  This environment is isolated from the page's context: while they share the same document, the global scopes and available APIs differ.
 
 - `MAIN`
 
-   The execution environment of the web page. This environment is shared with the web page, without isolation.
-   Scripts in this environment do not have any access to APIs that are only available to content scripts.
+  The execution environment of the web page. This environment is shared with the web page, without isolation.
+  Scripts in this environment do not have any access to APIs that are only available to content scripts.
 
-   > **Warning:** Due to the lack of isolation, the web page can detect the executed code and interfere with it.
-   > Do not use the `MAIN` world unless it is acceptable for web pages to read, access, or modify the logic or data that flows through the executed code.
+  > **Warning:** Due to the lack of isolation, the web page can detect the executed code and interfere with it.
+  > Do not use the `MAIN` world unless it is acceptable for web pages to read, access, or modify the logic or data that flows through the executed code.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -49,7 +49,10 @@ function forgetMostRecent(sessionInfos) {
   }
   let sessionInfo = sessionInfos[0];
   if (sessionInfo.tab) {
-    browser.sessions.forgetClosedTab(sessionInfo.tab.windowId, sessionInfo.tab.sessionId);
+    browser.sessions.forgetClosedTab(
+      sessionInfo.tab.windowId,
+      sessionInfo.tab.sessionId
+    );
   } else {
     browser.sessions.forgetClosedWindow(sessionInfo.window.sessionId);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -46,7 +46,10 @@ function forgetMostRecent(sessionInfos) {
   }
   let sessionInfo = sessionInfos[0];
   if (sessionInfo.tab) {
-    browser.sessions.forgetClosedTab(sessionInfo.tab.windowId, sessionInfo.tab.sessionId);
+    browser.sessions.forgetClosedTab(
+      sessionInfo.tab.windowId,
+      sessionInfo.tab.sessionId
+    );
   } else {
     browser.sessions.forgetClosedWindow(sessionInfo.window.sessionId);
   }

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -51,7 +51,9 @@ function onGetRejected(e) {
 }
 
 browser.tabs.onCreated.addListener((tab) => {
-  browser.sessions.getTabValue(tab.id, "my-key").then(onGetResolved, onGetRejected);
+  browser.sessions
+    .getTabValue(tab.id, "my-key")
+    .then(onGetResolved, onGetRejected);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -51,7 +51,9 @@ function onGetRejected(e) {
 }
 
 browser.windows.onCreated.addListener((window) => {
-  browser.sessions.getWindowValue(window.id, "my-key").then(onGetResolved, onGetRejected);
+  browser.sessions
+    .getWindowValue(window.id, "my-key")
+    .then(onGetResolved, onGetRejected);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -127,7 +127,7 @@ let gettingItem = browser.storage.local.get({
 
 ```js
 chrome.storage.local.get("kitten", (items) => {
-  console.log(items.kitten);  // -> {name:"Mog", eats:"mice"}
+  console.log(items.kitten); // -> {name:"Mog", eats:"mice"}
 });
 ```
 
@@ -142,7 +142,9 @@ chrome.storage.local.get("kitten", (items) => {
 Or using a Promise
 
 ```js
-let gettingItem = new Promise((resolve) => chrome.storage.local.get("kitten", resolve));
+let gettingItem = new Promise((resolve) =>
+  chrome.storage.local.get("kitten", resolve)
+);
 gettingItem.then(onGot); // -> Object { kitten: Object }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -79,10 +79,8 @@ let kitten = {
 browser.storage.local.set({kitten, monster})
   .then(setItem, onError);
 
-browser.storage.local.get("kitten")
-  .then(gotKitten, onError);
-browser.storage.local.get("monster")
-  .then(gotMonster, onError);
+browser.storage.local.get("kitten").then(gotKitten, onError);
+browser.storage.local.get("monster").then(gotMonster, onError);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -46,11 +46,10 @@ In this example a background script listens for a click on a [browser action](/e
 ```js
 function connectToTab(tabs) {
   if (tabs.length > 0) {
-    let examplePort = browser.tabs.connect(
-      tabs[0].id,
-      {name: "tabs-connect-example"}
-    );
-    examplePort.postMessage({greeting: "Hi from background script"});
+    let examplePort = browser.tabs.connect(tabs[0].id, {
+      name: "tabs-connect-example",
+    });
+    examplePort.postMessage({ greeting: "Hi from background script" });
   }
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -58,7 +58,9 @@ Listen for and log move events:
 
 ```js
 function handleMoved(tabId, moveInfo) {
-  console.log(`Tab ${tabId} moved from ${moveInfo.fromIndex} to ${moveInfo.toIndex}`);
+  console.log(
+    `Tab ${tabId} moved from ${moveInfo.fromIndex} to ${moveInfo.toIndex}`
+  );
 }
 
 browser.tabs.onMoved.addListener(handleMoved);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -189,9 +189,7 @@ function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log("New tab Info: ", tabInfo);
 }
 
-browser.tabs.onUpdated.addListener(
-  handleUpdated,
-  filter);
+browser.tabs.onUpdated.addListener(handleUpdated, filter);
 ```
 
 Log changes only when the `pinned` property of tabs changes for tabs whose `url` property is [matched](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) by `https://developer.mozilla.org/*` or `https://twitter.com/mozdevnet` where the tab was part of the current browser window when the update event fired:
@@ -212,9 +210,7 @@ function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log("New tab Info: ", tabInfo);
 }
 
-browser.tabs.onUpdated.addListener(
-  handleUpdated,
-  filter);
+browser.tabs.onUpdated.addListener(handleUpdated, filter);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -35,10 +35,9 @@ In this example a background script listens for a click on a [browser action](/e
 
 ```js
 browser.browserAction.onClicked.addListener(() => {
-  browser.tabs.printPreview()
-    .then(() => {
-      console.log("Entered print preview");
-    });
+  browser.tabs.printPreview().then(() => {
+    console.log("Entered print preview");
+  });
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
@@ -40,10 +40,9 @@ In this example a background script listens for a click on a [browser action](/e
 
 ```js
 browser.browserAction.onClicked.addListener(() => {
-  browser.tabs.saveAsPDF({})
-    .then((status) => {
-      console.log(status);
-    });
+  browser.tabs.saveAsPDF({}).then((status) => {
+    console.log(status);
+  });
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -63,12 +63,10 @@ function onSet(result) {
 }
 
 browser.browserAction.onClicked.addListener(() => {
-
-    let setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
-      value: false
-    });
-    setting.then(onSet);
-
+  let setting = browser.privacy.websites.hyperlinkAuditingEnabled.set({
+    value: false,
+  });
+  setting.then(onSet);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -92,7 +92,10 @@ function logOnCreatedNavigationTarget(details) {
   console.log(details.sourceFrameId);
 }
 
-browser.webNavigation.onCreatedNavigationTarget.addListener(logOnCreatedNavigationTarget, filter);
+browser.webNavigation.onCreatedNavigationTarget.addListener(
+  logOnCreatedNavigationTarget,
+  filter
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -79,7 +79,10 @@ function logOnDOMContentLoaded(details) {
   console.log(`onDOMContentLoaded: ${details.url}`);
 }
 
-browser.webNavigation.onDOMContentLoaded.addListener(logOnDOMContentLoaded, filter);
+browser.webNavigation.onDOMContentLoaded.addListener(
+  logOnDOMContentLoaded,
+  filter
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -85,7 +85,10 @@ function logOnHistoryStateUpdated(details) {
   console.log(`Transition qualifiers: ${details.transitionQualifiers}`);
 }
 
-browser.webNavigation.onHistoryStateUpdated.addListener(logOnHistoryStateUpdated, filter);
+browser.webNavigation.onHistoryStateUpdated.addListener(
+  logOnHistoryStateUpdated,
+  filter
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -85,7 +85,10 @@ function logOnReferenceFragmentUpdated(details) {
   console.log(`Transition qualifiers: ${details.transitionQualifiers}`);
 }
 
-browser.webNavigation.onReferenceFragmentUpdated.addListener(logOnReferenceFragmentUpdated, filter);
+browser.webNavigation.onReferenceFragmentUpdated.addListener(
+  logOnReferenceFragmentUpdated,
+  filter
+);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -52,13 +52,15 @@ This example listens for all HTTPS requests to "mozilla.org" or its subdomains, 
 ```js
 async function logSubject(details) {
   try {
-    let securityInfo = await browser.webRequest.getSecurityInfo(details.requestId, {});
+    let securityInfo = await browser.webRequest.getSecurityInfo(
+      details.requestId,
+      {}
+    );
     console.log(details.url);
     if (securityInfo.state === "secure" || securityInfo.state === "weak") {
       console.log(securityInfo.certificates[0].subject);
     }
-  }
-  catch (error) {
+  } catch (error) {
     console.error(error);
   }
 }
@@ -80,10 +82,11 @@ async function logRoot(details) {
     );
     console.log(details.url);
     if (securityInfo.state === "secure" || securityInfo.state === "weak") {
-      console.log(securityInfo.certificates[securityInfo.certificates.length - 1].issuer);
+      console.log(
+        securityInfo.certificates[securityInfo.certificates.length - 1].issuer
+      );
     }
-  }
-  catch (error) {
+  } catch (error) {
     console.error(error);
   }
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -199,10 +199,7 @@ function observe(requestDetails) {
   console.log(`observing: ${requestDetails.requestId}`);
 }
 
-browser.webRequest.onAuthRequired.addListener(
-  observe,
-  {urls: [target]}
-);
+browser.webRequest.onAuthRequired.addListener(observe, { urls: [target] });
 ```
 
 This code cancels authentication requests for the target URL:
@@ -212,14 +209,12 @@ const target = "https://intranet.company.com/";
 
 function cancel(requestDetails) {
   console.log(`canceling: ${requestDetails.requestId}`);
-  return {cancel: true};
+  return { cancel: true };
 }
 
-browser.webRequest.onAuthRequired.addListener(
-  cancel,
-  {urls: [target]},
-  ["blocking"]
-);
+browser.webRequest.onAuthRequired.addListener(cancel, { urls: [target] }, [
+  "blocking",
+]);
 ```
 
 This code supplies credentials synchronously. It has to keep track of outstanding requests, to ensure that it doesn't repeatedly try to submit bad credentials:
@@ -257,20 +252,14 @@ function provideCredentialsSync(requestDetails) {
 }
 
 browser.webRequest.onAuthRequired.addListener(
-    provideCredentialsSync,
-    {urls: [target]},
-    ["blocking"]
-  );
-
-browser.webRequest.onCompleted.addListener(
-  completed,
-  {urls: [target]}
+  provideCredentialsSync,
+  { urls: [target] },
+  ["blocking"]
 );
 
-browser.webRequest.onErrorOccurred.addListener(
-  completed,
-  {urls: [target]}
-);
+browser.webRequest.onCompleted.addListener(completed, { urls: [target] });
+
+browser.webRequest.onErrorOccurred.addListener(completed, { urls: [target] });
 ```
 
 This code supplies credentials asynchronously, fetching them from storage. It also has to keep track of outstanding requests, to ensure that it doesn't repeatedly try to submit bad credentials:
@@ -281,8 +270,8 @@ const target = "https://httpbin.org/basic-auth/*";
 const pendingRequests = [];
 
 /*
-* A request has completed. We can stop worrying about it.
-*/
+ * A request has completed. We can stop worrying about it.
+ */
 function completed(requestDetails) {
   console.log(`completed: ${requestDetails.requestId}`);
   let index = pendingRequests.indexOf(requestDetails.requestId);
@@ -309,20 +298,14 @@ function provideCredentialsAsync(requestDetails) {
 }
 
 browser.webRequest.onAuthRequired.addListener(
-    provideCredentialsAsync,
-    {urls: [target]},
-    ["blocking"]
-  );
-
-browser.webRequest.onCompleted.addListener(
-  completed,
-  {urls: [target]}
+  provideCredentialsAsync,
+  { urls: [target] },
+  ["blocking"]
 );
 
-browser.webRequest.onErrorOccurred.addListener(
-  completed,
-  {urls: [target]}
-);
+browser.webRequest.onCompleted.addListener(completed, { urls: [target] });
+
+browser.webRequest.onErrorOccurred.addListener(completed, { urls: [target] });
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -160,10 +160,9 @@ function logResponse(responseDetails) {
   console.log(responseDetails.redirectUrl);
 }
 
-browser.webRequest.onBeforeRedirect.addListener(
-  logResponse,
-  {urls: [target]}
-);
+browser.webRequest.onBeforeRedirect.addListener(logResponse, {
+  urls: [target],
+});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -184,10 +184,9 @@ function logURL(requestDetails) {
   console.log(`Loading: ${requestDetails.url}`);
 }
 
-browser.webRequest.onBeforeRequest.addListener(
-  logURL,
-  {urls: ["<all_urls>"]}
-);
+browser.webRequest.onBeforeRequest.addListener(logURL, {
+  urls: ["<all_urls>"],
+});
 ```
 
 This code cancels requests for images that are made to URLs under "https\://developer.mozilla.org/" (to see the effect, visit any page on MDN that contains images, such as [webRequest](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest)):
@@ -244,7 +243,8 @@ This code is exactly like the previous example, except that the listener handles
 let pattern = "https://developer.mozilla.org/*";
 
 // URL we will redirect to
-let redirectUrl = "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif";
+let redirectUrl =
+  "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif";
 
 // redirect function returns a Promise
 // which is resolved with the redirect URL when a timer expires
@@ -294,7 +294,7 @@ Here's another version:
 
 ```js
 function randomColor() {
-  return `#${Math.floor(Math.random()*16777215).toString(16)}`;
+  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
 }
 
 const pattern = "https://developer.mozilla.org/*";

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -175,7 +175,8 @@ const targetPage = "https://httpbin.org/*";
 /*
 Set UA string to Opera 12
 */
-const ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+const ua =
+  "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 /*
 Rewrite the User-Agent header to "ua".
@@ -215,7 +216,8 @@ const targetPage = "https://httpbin.org/*";
 /*
 Set UA string to Opera 12
 */
-const ua = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
+const ua =
+  "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16";
 
 /*
 Rewrite the User-Agent header to "ua".

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -163,10 +163,7 @@ function logResponse(responseDetails) {
   console.log(responseDetails.statusCode);
 }
 
-browser.webRequest.onCompleted.addListener(
-  logResponse,
-  {urls: [target]}
-);
+browser.webRequest.onCompleted.addListener(logResponse, { urls: [target] });
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -165,10 +165,7 @@ function logError(responseDetails) {
   console.log(responseDetails.error);
 }
 
-browser.webRequest.onErrorOccurred.addListener(
-  logError,
-  {urls: [target]}
-);
+browser.webRequest.onErrorOccurred.addListener(logError, { urls: [target] });
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -168,7 +168,8 @@ Events have three functions:
 This code sets an extra cookie when requesting a resource from the target URL:
 
 ```js
-let targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
+let targetPage =
+  "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
 
 // Add the new header to the original array,
 // and return it.
@@ -193,7 +194,8 @@ browser.webRequest.onHeadersReceived.addListener(
 This code does the same thing the previous example, except that the listener is asynchronous, returning a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which is resolved with the new headers:
 
 ```js
-const targetPage = "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
+const targetPage =
+  "https://developer.mozilla.org/en-US/Firefox/Developer_Edition";
 
 // Return a Promise that sets a timer.
 // When the timer fires, resolve the promise with

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -160,10 +160,9 @@ function logResponse(responseDetails) {
   console.log(responseDetails.statusLine);
 }
 
-browser.webRequest.onResponseStarted.addListener(
-  logResponse,
-  {urls: [target]}
-);
+browser.webRequest.onResponseStarted.addListener(logResponse, {
+  urls: [target],
+});
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -29,7 +29,7 @@ function listener(details) {
     let str = decoder.decode(event.data, { stream: true });
     // Just change any instance of Example in the HTTP response
     // to WebExtension Example.
-    // Note that this will maybe not work as expected because the ending of the str can also 
+    // Note that this will maybe not work as expected because the ending of the str can also
     // be "<h1>Examp" (because it is not the full response). So, it is better
     // to get the full response first and then doing the replace.
     str = str.replaceAll("Example", "WebExtension Example");

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -57,12 +57,16 @@ Close the current, e.g. popup, window when the user clicks a button on the page:
 
 ```js
 // in a script loaded by the page in the window
-document.querySelector('#close').addEventListener(async ({ button, }) => { try {
-  if (button) return; // not a left click
-  const windowId = (await browser.windows.getCurrent()).id;
-  await browser.windows.remove(windowId);
-  // this point will never be reached, since the window is gone
-} catch (error) { console.error('Closing failed:', error); } });
+document.querySelector("#close").addEventListener(async ({ button }) => {
+  try {
+    if (button) return; // not a left click
+    const windowId = (await browser.windows.getCurrent()).id;
+    await browser.windows.remove(windowId);
+    // this point will never be reached, since the window is gone
+  } catch (error) {
+    console.error("Closing failed:", error);
+  }
+});
 ```
 
 In Firefox, the same could be achieved with the `.allowScriptsToClose` window creation property and `window.close()`.


### PR DESCRIPTION
This PR fixes the indentation and whitespaces of various code examples in the WebExtensions pages, along with a bit of the Markdown.  This helps ensure uniform code styling across all of MDN: two spaces for indentation.

Note: a few other formatting changes may have been included as they were far too integrated to effectively separate.
