### PR TITLE
clarify sharedWorker name usage

### DIFF
--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -32,8 +32,7 @@ new SharedWorker(aURL, options)
     execute. It must obey the same-origin policy.
 - `name` {{optional_inline}}
   - : A string specifying an identifying name for the
-    {{domxref("SharedWorkerGlobalScope")}} representing the scope of the worker, which is
-    mainly useful for debugging purposes.
+    {{domxref("SharedWorkerGlobalScope")}} representing the scope of the worker, which is useful for creating new instances of the same SharedWorker and debugging.
 - `options` {{optional_inline}}
 
   - : An object containing option properties that can set when creating the object


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Change the description of the `name` of the SharedWorker to clarify that it allows to start multiple instances.
<!-- ✍️ Summarize your changes in one or two sentences -->
Changed the text to reflect this.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #25636
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
