### PR TITLE
CSS :scope: grammar and example clarification

### DIFF
--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -16,7 +16,7 @@ The **`:scope`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/P
 }
 ```
 
-Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")}}, as currently, there is no way to explicitly establish a scoped element. When used from a DOM API, such as {{domxref("Element.querySelector", "querySelector()")}}, {{domxref("Element.querySelectorAll", "querySelectorAll()")}}, {{domxref("Element.matches", "matches()")}}, or {{domxref("Element.closest()")}}, `:scope` matches the element on which the method was called.
+When used in a stylesheet, `:scope` is the same as {{cssxref(":root")}}, as there is currently no way to explicitly establish a scoped element. When used from a DOM API, such as {{domxref("Element.querySelector", "querySelector()")}}, {{domxref("Element.querySelectorAll", "querySelectorAll()")}}, {{domxref("Element.matches", "matches()")}}, or {{domxref("Element.closest()")}}, `:scope` matches the element on which the method was called.
 
 ## Syntax
 

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -30,7 +30,7 @@ Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")
 
 ### Identity match
 
-This example demonstrates using the `:scope` pseudo-class with the {{domxref("Element.matches()")}} method to match the element on which it's called. In this example, if `:scope` is supported, and the paragraph is within the `:root`'s scope, text is displayed in the placeholder "output" paragraph. 
+This example demonstrates using the `:scope` pseudo-class with the {{domxref("Element.matches()")}} method to match the element on which it's called. In this example, if `:scope` is supported, and the paragraph is within the `:root`'s scope, text is displayed in the placeholder "output" paragraph.
 
 #### JavaScript
 

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.scope
 
 {{CSSRef}}
 
-The **`:scope`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents elements that are a reference point for selectors to match against.
+The **`:scope`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents elements that are a reference point, or scope, for selectors to match against.
 
 ```css
 /* Selects a scoped element */
@@ -16,7 +16,7 @@ The **`:scope`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/P
 }
 ```
 
-Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")}}, since there is not at this time a way to explicitly establish a scoped element. When used from a DOM API such as {{domxref("Element.querySelector", "querySelector()")}}, {{domxref("Element.querySelectorAll", "querySelectorAll()")}}, {{domxref("Element.matches", "matches()")}}, or {{domxref("Element.closest()")}}, `:scope` matches the element on which the method was called.
+Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")}}, as currently, there is no way to explicitly establish a scoped element. When used from a DOM API, such as {{domxref("Element.querySelector", "querySelector()")}}, {{domxref("Element.querySelectorAll", "querySelectorAll()")}}, {{domxref("Element.matches", "matches()")}}, or {{domxref("Element.closest()")}}, `:scope` matches the element on which the method was called.
 
 ## Syntax
 
@@ -30,7 +30,7 @@ Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")
 
 ### Identity match
 
-In this simple example, we demonstrate that using the `:scope` pseudo-class from the {{domxref("Element.matches()")}} method matches the element on which it's called.
+This example demonstrates using the `:scope` pseudo-class with the {{domxref("Element.matches()")}} method to match the element on which it's called. In this example, if `:scope` is supported, and the paragraph is within the `:root`'s scope, text is displayed in the placeholder "output" paragraph. 
 
 #### JavaScript
 
@@ -39,7 +39,7 @@ const paragraph = document.getElementById("para");
 const output = document.getElementById("output");
 
 if (paragraph.matches(":scope")) {
-  output.textContent = "Yep, the element is its own scope as expected!";
+  output.textContent = "The first paragraph is its own scope, as expected!";
 }
 ```
 
@@ -58,7 +58,7 @@ if (paragraph.matches(":scope")) {
 
 ### Direct children
 
-A situation where the `:scope` pseudo-class prove to be useful is when you need to get direct descendant of an already retrieved {{domxref("Element")}}.
+A situation where the `:scope` pseudo-class proves to be useful is when you need to get a direct descendant of an already retrieved {{domxref("Element")}}.
 
 #### JavaScript
 
@@ -92,6 +92,8 @@ document.getElementById("results").innerHTML = Array.prototype.map
 #### Result
 
 {{ EmbedLiveSample('Direct_children') }}
+
+The scope of `context` is the element with the [`id`](/en-US/docs/Web/HTML/Global_attributes#id) of `context`. The selected elements are the `div` elements that are direct children of that context, `element-1` and `element-2`, but not their descendants.
 
 ## Specifications
 


### PR DESCRIPTION
i went in to fix two grammar issues.
Elaborated the two examples to ensure clarity, esp. if AI explain comes back