### PR TITLE
FF116 Relnote: Support for CSP script-src with hashes to allow external files

### DIFF
--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -30,7 +30,7 @@ This article provides information about the changes in Firefox 116 that affect d
 
 ### HTTP
 
-- The [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) now allows specifying [external JavaScript files to be whitelisted using hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#whitelisting_external_scripts_using_hashes), where previously only inline scripts could be whitelisted using a hash ([Firefox bug 1409200](https://bugzil.la/1409200)).
+- Configuring a [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) now supports specifying [external JavaScript files to be whitelisted using hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#whitelisting_external_scripts_using_hashes), where previously only inline scripts could be whitelisted using a hash ([Firefox bug 1409200](https://bugzil.la/1409200)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -30,6 +30,8 @@ This article provides information about the changes in Firefox 116 that affect d
 
 ### HTTP
 
+- The [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) now allows specifying [external JavaScript files to be whitelisted using hashes](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#whitelisting_external_scripts_using_hashes), where previously only inline scripts could be whitelisted using a hash ([Firefox bug 1409200](https://bugzil.la/1409200)).
+
 #### Removals
 
 ### Security


### PR DESCRIPTION
This is release note for supporting CSP script-src using allow list of hashes for external files. It links to heading that will be added by https://github.com/mdn/content/pull/27876

Other docs work can be tracked in #27749