### PR TITLE
fix(CSS): update syntax section on :current page

### DIFF
--- a/files/en-us/web/css/_colon_current/index.md
+++ b/files/en-us/web/css/_colon_current/index.md
@@ -3,6 +3,7 @@ title: ":current"
 slug: Web/CSS/:current
 page-type: css-pseudo-class
 browser-compat: css.selectors.current
+spec-urls: https://drafts.csswg.org/selectors/#the-current-pseudo
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/_colon_current/index.md
+++ b/files/en-us/web/css/_colon_current/index.md
@@ -17,7 +17,15 @@ The **`:current`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS
 
 ## Syntax
 
-{{csssyntax}}
+```css-nolint
+:current {
+  /* ... */
+}
+
+:current(<compound-selector-list>) {
+  /* ... */
+}
+```
 
 ## Examples
 


### PR DESCRIPTION
- Fixes: https://github.com/mdn/content/issues/27880

Syntax content inspired by `:has` page:
https://github.com/mdn/content/blob/ee3935a6e060bd1074819c0a6adaa34385a1914f/files/en-us/web/css/_colon_has/index.md?plain=1#L23-L29