### PR TITLE
Typo "controller" -> "controlled" on "Headers: set()"

### DIFF
--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -17,7 +17,7 @@ the specified header already exists and accepts multiple values, `set()`
 overwrites the existing value with the new one, whereas {{domxref("Headers.append")}}
 appends the new value to the end of the set of values.
 
-For security reasons, some headers can only be controller by the user agent. These
+For security reasons, some headers can only be controlled by the user agent. These
 headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Tiny typo fix

### Motivation
Clear and understandable language

### Additional details
None

### Related issues and pull requests

None