### PR TITLE
Use new URL to combobox pattern in APG

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
@@ -109,7 +109,7 @@ Every `combobox` must have an accessible name. If using an {{HTMLElement('input'
 - [ARIA: `list` role](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role)
 - [ARIA: `listitem` role](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
 - [ARIA Best Practices – Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-- [ARIA Role Model – Combobox](https://www.w3.org/TR/wai-aria-1.1/#combobox)
+- [ARIA Role Model – Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 - [Accessible combobox module](https://dequelabs.github.io/combobo/demo/) examples by Deque
 
 <section id="Quick_links">

--- a/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
@@ -108,7 +108,7 @@ Every `combobox` must have an accessible name. If using an {{HTMLElement('input'
 - [ARIA: `option` role](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role)
 - [ARIA: `list` role](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role)
 - [ARIA: `listitem` role](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
-- [ARIA Best Practices – Combobox](https://www.w3.org/TR/wai-aria-practices/#Combobox)
+- [ARIA Best Practices – Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 - [ARIA Role Model – Combobox](https://www.w3.org/TR/wai-aria-1.1/#combobox)
 - [Accessible combobox module](https://dequelabs.github.io/combobo/demo/) examples by Deque
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I noticed this link to the combobox pattern was to pre-redesign APG, it's now on a different URL and the redirect doesn't adequately redirect to the right place, so I've put the new URL in.

### Motivation

Easier to find the combobox pattern on APG

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
