### PR TITLE
Clarify sorting for time zone IDs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -9,9 +9,7 @@ browser-compat: javascript.builtins.Intl.supportedValuesOf
 
 The **`Intl.supportedValuesOf()`** static method returns an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
 
-Duplicates are omitted and the array is sorted in the same order as using {{jsxref("Array/sort", "Array.prototype.sort()")}} with an `undefined` compare function.
-All-uppercase or all-lowercase arrays will be sorted in ascending alphabetic order.
-However, for keys like `"timeZone"` that return an array with mixed-case strings, results will be sorted with uppercase ahead of lowercase, then alphabetically.
+Duplicates are omitted and the array is sorted in ascending lexicographical order (or more precisely, using {{jsxref("Array/sort", "Array.prototype.sort()")}} with an `undefined` compare function).
 
 The method can be used to feature-test whether values are supported in a particular implementation and download a polyfill only if necessary.
 It can also be used to build UIs that allow users to select their preferred localized values, for example when the UI is created from WebGL or server-side.

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -9,7 +9,9 @@ browser-compat: javascript.builtins.Intl.supportedValuesOf
 
 The **`Intl.supportedValuesOf()`** static method returns an array containing the supported calendar, collation, currency, numbering systems, or unit values supported by the implementation.
 
-Duplicates are omitted and the array is sorted in ascending alphabetic order (or more precisely, using {{jsxref("Array/sort", "Array.prototype.sort()")}} with an `undefined` compare function)
+Duplicates are omitted and the array is sorted in the same order as using {{jsxref("Array/sort", "Array.prototype.sort()")}} with an `undefined` compare function.
+All-uppercase or all-lowercase arrays will be sorted in ascending alphabetic order.
+However, for keys like `"timeZone"` that return an array with mixed-case strings, results will be sorted with uppercase ahead of lowercase, then alphabetically.
 
 The method can be used to feature-test whether values are supported in a particular implementation and download a polyfill only if necessary.
 It can also be used to build UIs that allow users to select their preferred localized values, for example when the UI is created from WebGL or server-side.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarifies that time zone IDs are sorted in ASCII order, not alphabetically. 

### Motivation

For case-insensitive data, "alphabetic" sort usually ignores letter case, as in SQL databases with case-insensitive collation.  The default sort used in ECMAScript doesn't ignore letter case, which may result in unexpectedly sorted mixed-case data. For this API, only time zone IDs are mixed case, so it's helpful to note this exception in the docs.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Chrome, Node, and Safari currently don't produce any different output using a case-insensitive sort of time zones than a case-sensitive sort. But Firefox does display different results, as you can see with the following code:

```js
function caseInsensitiveSortFunc(s1, s2) {
  s1 = s1.toLowerCase();
  s2 = s2.toLowerCase();
  if (s1 < s2) return -1;
  if (s1 > s2) return 1;
  return 0;
}

tzs = Intl.supportedValuesOf('timeZone');
tzsInsensitive = [...Intl.supportedValuesOf('timeZone')].sort(caseInsensitiveSortFunc);

console.log(`Index of PST8PDT (case sensitive): ${tzs.indexOf('PST8PDT')}`);
// => Index of PST8PDT (case sensitive): 426 
console.log(`Index of PST8PDT (case insensitive): ${tzsInsensitive.indexOf('PST8PDT')}`);
// => Index of PST8PDT (case insensitive): 466

// Note: results above only work in Firefox. Chrome and Safari don't include `'PST8PDT'` at all.
```

Adding a warning to the docs might help developers avoid writing code that will work OK in non-FF browsers but will break in FF. 

### Related issues and pull requests

Relates to https://github.com/tc39/ecma402/issues/790

cc @sffc

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
