### PR TITLE
#27893: Fix Broken Browser Compatabity Link

### DIFF
--- a/files/en-us/web/api/webgl_api/index.md
+++ b/files/en-us/web/api/webgl_api/index.md
@@ -11,7 +11,7 @@ browser-compat:
 
 **WebGL** (Web Graphics Library) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics within any compatible web browser without the use of plug-ins. WebGL does so by introducing an API that closely conforms to OpenGL ES 2.0 that can be used in HTML {{HTMLElement("canvas")}} elements. This conformance makes it possible for the API to take advantage of hardware graphics acceleration provided by the user's device.
 
-Support for WebGL is present in all modern browsers (see the [compatibility tables](#browser-compatibility) below); however, the user's device must also have hardware that supports these features.
+Support for WebGL is present in all modern browsers (see the [compatibility tables](#browser_compatibility) below); however, the user's device must also have hardware that supports these features.
 
 The [WebGL 2](#webgl_2) API introduces support for much of the OpenGL ES 3.0 feature set; it's provided through the {{domxref("WebGL2RenderingContext")}} interface.
 


### PR DESCRIPTION
Fix broken link in WebGL docs

Fixes #27893 (Whoops, I found the section in the code)

