### PR TITLE
relnote(116): CSSPropertyRule and registerProperty() enabled in Fx nightly

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1239,6 +1239,48 @@ See [Firefox bug 1740530](https://bugzil.la/1740530) for more details.
   </tbody>
 </table>
 
+#### CSS Properties and Values API
+
+The [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API) allows developers to register custom CSS properties through JavaScript via [`registerProperty()`](/en-US/docs/Web/API/CSS/registerProperty_static) or in CSS using the [`@property`](/en-US/docs/Web/CSS/@property) at-rule.
+Registering properties using these two methods allows for type checking, default values, and properties that do or do not inherit values from their parent elements.
+See [Firefox bug 1840480](https://bugzil.la/1840480) for more details.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>116</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>116</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>116</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>116</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.property-and-value-api.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Service Workers
 
 #### Preloading of service worker resources on navigation

--- a/files/en-us/web/api/css_properties_and_values_api/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/index.md
@@ -2,7 +2,9 @@
 title: CSS Properties and Values API
 slug: Web/API/CSS_Properties_and_Values_API
 page-type: web-api-overview
-browser-compat: api.CSS.registerProperty
+browser-compat:
+  - api.CSSPropertyRule
+  - api.CSS.registerProperty_static
 ---
 
 {{DefaultAPISidebar("CSS Properties and Values API")}}

--- a/files/en-us/web/api/csspropertyrule/index.md
+++ b/files/en-us/web/api/csspropertyrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSPropertyRule
 
 {{APIRef("CSS Properties and Values API")}}
 
-The **`CSSPropertyRule`** interface of the {{domxref('CSS_Properties_and_Values_API','','',' ')}} represents a single CSS {{cssxref("@property")}} rule.
+The **`CSSPropertyRule`** interface of the [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API) represents a single CSS {{cssxref("@property")}} rule.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
The pref `layout.css.properties-and-values.enabled` is set to true (enabled) on Nightly in 116. This allows for using the following:

- [`CSSPropertyRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule)
- [`CSSPropertyRule.inherits`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/inherits)
- [`CSSPropertyRule.initialvalue`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/initialvalue)
- [`CSSPropertyRule.name`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/name)
- [`CSSPropertyRule.syntax`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/syntax)
- [`registerProperty()`](https://developer.mozilla.org/en-US/docs/Web/API/CSS/registerProperty_static) 


__pen:__
https://codepen.io/bsmth/pen/xxQpVow?editors=0111


__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/27756
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/20346

__Bugzilla:__
- [BUG-1840480](https://bugzilla.mozilla.org/show_bug.cgi?id=1840480)
