### PR TITLE
Move `{ type: "text/javascript" }` from Array.prototype.map's thisArg to Blob's options

### DIFF
--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -647,8 +647,8 @@ There is not an "official" way to embed the code of a worker within a web page, 
         Array.prototype.map.call(
           document.querySelectorAll("script[type='text\/js-worker']"),
           (script) => script.textContent,
-          { type: "text/javascript" },
         ),
+        { type: "text/javascript" },
       );
 
       // Creating a new document.worker property containing all our "text/js-worker" scripts.


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

```js
      const blob = new Blob(
        Array.prototype.map.call(
          document.querySelectorAll("script[type='text\/js-worker']"),
          (script) => script.textContent,
          { type: "text/javascript" },
        ),
      );
```

is essentially:

```js
textContents = [script1, script2].map(script => script.textContent, { type: "text/javascript" });
blob = new Blob(textContents);
```

but should be:

```js
textContents = [script1, script2].map(script => script.textContent);
blob = new Blob(textContents, { type: "text/javascript" });
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The code works as is (`thisArg` is not used in the mapping function, and `blob.type`'s value of `''` seems to be ignored), but is not strictly correct.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
