### PR TITLE
A reminder about exitPointerLock()

### DIFF
--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -11,6 +11,8 @@ browser-compat: api.Document.exitPointerLock
 The **`exitPointerLock()`** method asynchronously releases a
 pointer lock previously requested through {{domxref("Element.requestPointerLock")}}.
 
+> **_NOTE:_** While the **`exitPointerLock()`** method is called on the document, the **`requestPointerLock()`** method is called on an element.
+
 To track the success or failure of the request, it is necessary to listen for the
 {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} and {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events.
 

--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Document.exitPointerLock
 The **`exitPointerLock()`** method asynchronously releases a
 pointer lock previously requested through {{domxref("Element.requestPointerLock")}}.
 
-> **_NOTE:_** While the **`exitPointerLock()`** method is called on the document, the **`requestPointerLock()`** method is called on an element.
+> **Note:** While the **`exitPointerLock()`** method is called on the document, the **`requestPointerLock()`** method is called on an element.
 
 To track the success or failure of the request, it is necessary to listen for the
 {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} and {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events.


### PR DESCRIPTION
Fixes : #27612 

Added a note reminding the reader that `exitPointerLock()` and `requestPointerLock()`  are called on the document and the element respectively.


