### PR TITLE
Update pseudo elements page

### DIFF
--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -29,7 +29,7 @@ selector::pseudo-element {
 }
 ```
 
-Double colons (`::`) are used for pseudo-elements. This distinguishes pseudo-classes from pseudo-elements where single colon (`:`) is used.
+Double colons (`::`) are used for pseudo-elements. This distinguishes pseudo-elements from [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) that use single colon (`:`) in their notation.
 
 You can use only one pseudo-element in a selector. That single pseudo-element must appear after all the other components in any [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line with `p::first-line`, but cannot select first-line's children or a hovered first line. Both `p::first-line > *` and `p::first-line:hover` are invalid. While it is not possible to style a pseudo-element based on its _state_, they can be styled based on the state of the element in which they are found: `p:hover::first-line` is valid.
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -31,7 +31,9 @@ selector::pseudo-element {
 
 Double colons (`::`) are used for pseudo-elements. This distinguishes pseudo-elements from [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) that use single colon (`:`) in their notation.
 
-You can use only one pseudo-element in a selector. That single pseudo-element must appear after all the other components in any [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line with `p::first-line`, but cannot select first-line's children or a hovered first line. Both `p::first-line > *` and `p::first-line:hover` are invalid. While it is not possible to style a pseudo-element based on its _state_, they can be styled based on the state of the element in which they are found: `p:hover::first-line` is valid.
+You can use only one pseudo-element in a selector. The pseudo-element must appear after all the other components in the [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line using `p::first-line` but not the first-line's children or a hovered first line. So both `p::first-line > *` and `p::first-line:hover` are invalid because...
+
+While it is not possible to select an element based on its _state_ by using pseudo-elements, a pseudo-element can be used to select and style a part of an element that already has a state applied to it. For example, `p:hover::first-line` selects the first line (pseudo-element) of a paragraph when the paragraph itself is being hovered (pseudo-class).
 
 It is important to note, when a selector list contains an invalid selector, the entire style block is ignored.
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -84,7 +84,7 @@ T
 
 - {{CSSxRef("::target-text")}} {{Experimental_Inline}}
 
-> **Note:** Browsers support single colon syntax for the original four pseudo-elements, `::before`, `::after`, `::first-line`, and `::first-letter`, only.
+> **Note:** Browsers support the single colon syntax only for the original four pseudo-elements: `::before`, `::after`, `::first-line`, and `::first-letter`.
 
 ## Specifications
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -2,7 +2,11 @@
 title: Pseudo-elements
 slug: Web/CSS/Pseudo-elements
 page-type: landing-page
-spec-urls: https://www.w3.org/TR/CSS22/selector.html#pseudo-element-selectors
+spec-urls:
+  - https://drafts.csswg.org/css-pseudo/
+  - https://drafts.csswg.org/css-position-4/
+  - https://drafts.csswg.org/css-shadow-parts/
+  - https://w3c.github.io/webvtt/
 ---
 
 {{CSSRef}}
@@ -17,8 +21,6 @@ p::first-line {
 }
 ```
 
-> **Note:** In contrast to pseudo-elements, {{CSSxRef("pseudo-classes")}} can be used to style an element based on its _state_.
-
 ## Syntax
 
 ```css
@@ -27,9 +29,11 @@ selector::pseudo-element {
 }
 ```
 
-You can use only one pseudo-element in a selector. It must appear after the simple selectors in the statement.
+Double colons (`::`) are used for pseudo-elements. This distinguishes pseudo-classes from pseudo-elements where single colon (`:`) is used.
 
-> **Note:** As a rule, double colons (`::`) should be used instead of a single colon (`:`). This distinguishes pseudo-classes from pseudo-elements. However, since this distinction was not present in older versions of the W3C spec, most browsers support both syntaxes for the original pseudo-elements.
+You can use only one pseudo-element in a selector. That single pseudo-element must appear after all the other components in any [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line with `p::first-line`, but cannot select first-line's children or a hovered first line. Both `p::first-line > *` and `p::first-line:hover` are invalid. While it is not possible to style a pseudo-element based on its _state_, they can be styled based on the state of the element in which they are found: `p:hover::first-line` is valid.
+
+It is important to note, when a selector list contains an invalid selector, the entire style block is ignored.
 
 ## Alphabetical index
 
@@ -78,45 +82,15 @@ T
 
 - {{CSSxRef("::target-text")}} {{Experimental_Inline}}
 
+> **Note:** Browsers support single colon syntax for the original four pseudo-elements, `::before`, `::after`, `::first-line`, and `::first-letter`, only.
+
 ## Specifications
 
 {{Specifications}}
 
-## Browser compatibility
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th>Browser</th>
-      <th>Lowest Version</th>
-      <th>Support of</th>
-    </tr>
-    <tr>
-      <td rowspan="2">Firefox (Gecko)</td>
-      <td>1.0 (1.0)</td>
-      <td><code>:pseudo-element</code></td>
-    </tr>
-    <tr>
-      <td>1.0 (1.5)</td>
-      <td><code>:pseudo-element ::pseudo-element</code></td>
-    </tr>
-    <tr>
-      <td rowspan="2">Opera</td>
-      <td>4.0</td>
-      <td><code>:pseudo-element</code></td>
-    </tr>
-    <tr>
-      <td>7.0</td>
-      <td><code>:pseudo-element ::pseudo-element</code></td>
-    </tr>
-    <tr>
-      <td>Safari (WebKit)</td>
-      <td>1.0 (85)</td>
-      <td><code>:pseudo-element ::pseudo-element</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## See also
 
+- [CSS pseudo-element](/en-US/docs/Web/CSS/CSS_pseudo) module
 - [Pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
+- [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
+- [Building block: pseudo-classes and pseudo-elements](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -37,7 +37,7 @@ While it is not possible to select an element based on its _state_ by using pseu
 
 It is important to note, when a selector list contains an invalid selector, the entire style block is ignored.
 
-## Alphabetical index
+## List of pseudo-elements
 
 Pseudo-elements defined by a set of CSS specifications include the following:
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -33,7 +33,7 @@ p::first-line {
 
 Double colons (`::`) are used for pseudo-elements. This distinguishes pseudo-elements from [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) that use single colon (`:`) in their notation.
 
-You can use only one pseudo-element in a selector. The pseudo-element must appear after all the other components in the [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line using `p::first-line` but not the first-line's children or a hovered first line. So both `p::first-line > *` and `p::first-line:hover` are invalid because...
+You can use only one pseudo-element in a selector. The pseudo-element must appear after all the other components in the [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector in which it appears. For example, you can select a paragraph's first line using `p::first-line` but not the first-line's children or a hovered first line. So both `p::first-line > *` and `p::first-line:hover` are invalid.
 
 While it is not possible to select an element based on its _state_ by using pseudo-elements, a pseudo-element can be used to select and style a part of an element that already has a state applied to it. For example, `p:hover::first-line` selects the first line (pseudo-element) of a paragraph when the paragraph itself is being hovered (pseudo-class).
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -37,7 +37,7 @@ You can use only one pseudo-element in a selector. The pseudo-element must appea
 
 While it is not possible to select an element based on its _state_ by using pseudo-elements, a pseudo-element can be used to select and style a part of an element that already has a state applied to it. For example, `p:hover::first-line` selects the first line (pseudo-element) of a paragraph when the paragraph itself is being hovered (pseudo-class).
 
-It is important to note, when a selector list contains an invalid selector, the entire style block is ignored.
+> **Note:** When a [selector list](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#selector_list) contains an invalid selector, the entire style block is ignored.
 
 ## List of pseudo-elements
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -11,7 +11,7 @@ spec-urls:
 
 {{CSSRef}}
 
-A CSS **pseudo-element** is a keyword added to a selector that lets you style a specific part of the selected element(s). 
+A CSS **pseudo-element** is a keyword added to a selector that lets you style a specific part of the selected element(s).
 
 ## Syntax
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -95,4 +95,4 @@ T
 - [CSS pseudo-element](/en-US/docs/Web/CSS/CSS_pseudo) module
 - [Pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
 - [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
-- [Building block: pseudo-classes and pseudo-elements](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
+- [CSS building blocks: Pseudo-classes and pseudo-elements](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -11,21 +11,23 @@ spec-urls:
 
 {{CSSRef}}
 
-A CSS **pseudo-element** is a keyword added to a selector that lets you style a specific part of the selected element(s). For example, {{CSSxRef("::first-line")}} can be used to change the font of the first line of a paragraph.
-
-```css
-/* The first line of every <p> element. */
-p::first-line {
-  color: blue;
-  text-transform: uppercase;
-}
-```
+A CSS **pseudo-element** is a keyword added to a selector that lets you style a specific part of the selected element(s). 
 
 ## Syntax
 
 ```css
 selector::pseudo-element {
   property: value;
+}
+```
+
+For example, {{CSSxRef("::first-line")}} can be used to change the font of the first line of a paragraph.
+
+```css
+/* The first line of every <p> element. */
+p::first-line {
+  color: blue;
+  text-transform: uppercase;
 }
 ```
 


### PR DESCRIPTION
- Pseudo elements are found in 4 specs
- added see also (note pseudo elements module is will be in PR this week, so that link will be blue soon)
- Alphabetical order for the letter F
- Removed table of archaic support for single colon v. double colon notation.
- moved the single colon notation down to the after the list since it's related to the list and not important anymore.
- detailed explanation with examples of how pseudo has to be the last component in a selector or the whole selector block fails.