### PR TITLE
Add alt-used HTTP Header

### DIFF
--- a/files/en-us/web/http/headers/alt-used/index.md
+++ b/files/en-us/web/http/headers/alt-used/index.md
@@ -43,3 +43,4 @@ Alt-Used: alternate.example.net
 ## See also
 
 - {{HTTPHeader("Alt-Svc")}}
+- {{HTTPHeader("Host")}}

--- a/files/en-us/web/http/headers/alt-used/index.md
+++ b/files/en-us/web/http/headers/alt-used/index.md
@@ -1,0 +1,45 @@
+---
+title: Alt-Used
+slug: Web/HTTP/Headers/Alt-Used
+page-type: http-header
+browser-compat: http.headers.Alt-Used
+---
+
+{{HTTPSidebar}}
+
+The {{HTTPHeader("Alt-Used")}} HTTP header is used in requests to identify the alternative service in use, just as the {{HTTPHeader("Host")}} HTTP header field identifies the host and port of the origin.
+
+The is intended to allow alternative services to detect loops, differentiate traffic for purposes of load balancing, and generally to ensure that it is possible to identify the intended destination of traffic, since introducing this information after a protocol is in use has proven to be problematic.
+
+When a client uses an alternative service for a request, it can indicate this to the server using the {{HTTPHeader("Alt-Used")}} HTTP header.
+
+## Syntax
+
+```http
+Alt-Used: <host>:<port>
+```
+
+## Directives
+
+- \<host>
+  - : the domain name of the server.
+- \<port> {{optional_inline}}
+  - : TCP port number on which the server is listening.
+
+## Examples
+
+```http
+Alt-Used: alternate.example.net
+```
+
+<!-- ## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}} -->
+
+## See also
+
+- {{HTTPHeader("Alt-Svc")}}

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -374,6 +374,8 @@ A server might use them to modify its caching behavior, or the information that 
   - : A client can send the [`Accept-Signature`](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#rfc.section.3.7) header field to indicate intention to take advantage of any available signatures and to indicate what kinds of signatures it supports.
 - {{HTTPHeader("Alt-Svc")}}
   - : Used to list alternate ways to reach this service.
+- {{HTTPHeader("Alt-Used")}}
+  - : Used to identify the alternative service in use.
 - {{HTTPHeader("Date")}}
   - : Contains the date and time at which the message was originated.
 - {{HTTPHeader("Early-Data")}} {{experimental_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add alt-used HTTP Headers to the list of conventional http headers.

### Motivation

alt-svc is already present in the documentation but alt-used despite being a conventional and widely used http header is missing.

### Additional details

- https://datatracker.ietf.org/doc/html/rfc7838#section-5
- Note that the specification and browser compatibility of alt-used is left out and needs to be added to https://github.com/mdn/browser-compat-data/

