### PR TITLE
CSS Module: shadow parts

### DIFF
--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -110,4 +110,4 @@ globalThis.customElements.define(
 
 - The [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute - Used to define parts which can be selected by the `::part()` selector
 - The [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) attribute - Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
-- [Explainer: CSS Shadow ::part and ::theme](https://github.com/fergald/docs/blob/master/explainers/css-shadow-parts-1.md)
+- [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -40,10 +40,10 @@ By default, elements in a shadow tree are only styleable from within that shadow
 
 - HTML {{HTMLElement("template")}} element
 - HTML {{HTMLElement("slot")}} element
-- {{domxref("Element.part")}}
-- {{domxref("Element.shadowRoot")}}
-- {{domxref("Element.attachShadow()")}}
-- {{domxref("ShadowRoot")}}
+- {{domxref("Element.part")}} property
+- {{domxref("Element.shadowRoot")}} property
+- {{domxref("Element.attachShadow()")}} method
+- {{domxref("ShadowRoot")}} interface
 - CSS scoping module
   - {{CSSXref(":host")}}
   - {{CSSXref(":host_function", ":host()")}}

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -9,7 +9,7 @@ spec-urls: https://drafts.csswg.org/css-shadow-parts/
 
 The **CSS shadow parts** module defines the {{CSSXref("::part", "::part()")}} pseudo-element that can be set on a [shadow host](/en-US/docs/Glossary/Shadow_tree). Using this pseudo-element, you can enable shadow hosts to expose the selected element in the shadow tree to the outside page for styling purposes.
 
-By default, elements in a shadow tree are only styleable from within that shadow root. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
+By default, elements in a shadow tree can be styled only within their respective shadow roots. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
 
 ## Reference
 

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -9,7 +9,7 @@ spec-urls: https://drafts.csswg.org/css-shadow-parts/
 
 The **CSS shadow parts** module defines the {{CSSXref("::part", "::part()")}} pseudo-element that can be set on a [shadow host](/en-US/docs/Glossary/Shadow_tree). Using this pseudo-element, you can enable shadow hosts to expose the selected element in the shadow tree to the outside page for styling purposes.
 
-By default, elements in a shadow tree can be styled only within their respective shadow roots. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
+By default, elements in a shadow tree can be styled only within their respective shadow roots. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants that make up the custom element, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
 
 ## Reference
 

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -1,0 +1,62 @@
+---
+title: CSS shadow parts module
+slug: Web/CSS/CSS_shadow_parts
+page-type: css-module
+spec-urls: https://drafts.csswg.org/css-shadow-parts/
+---
+
+{{CSSRef}}
+
+The **CSS shadow parts** module defines the {{CSSXref("::part", "::part()")}} pseudo-element on shadow hosts, allowing shadow hosts to expose selected shadow tree elements to the outside page for styling purposes.
+
+By default, elements in a shadow tree are only styleable from within that shadow root. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
+
+## Reference
+
+### Selectors
+
+- {{CSSXref("::part", "::part()")}}
+
+### HTML Attributes
+
+- [`part`](/en-US/docs/Web/HTML/Global_attributes#part)
+- [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts)
+
+### Definitions
+
+- {{glossary("Shadow tree")}}
+
+## Guides
+
+- [CSS pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements)
+
+  - : Alphabetical list of pseudo-elements defined by all the CSS specifications and WebVTT
+
+- [Web components](/en-US/docs/Web/API/Web_components)
+
+  - : Overview of the different APIs that make enable creating reusable custom elements, or web components.
+
+## Related concepts
+
+- HTML {{HTMLElement("template")}} element
+- HTML {{HTMLElement("slot")}} element
+- {{domxref("Element.part")}}
+- {{domxref("Element.shadowRoot")}}
+- {{domxref("Element.attachShadow()")}}
+- {{domxref("ShadowRoot")}}
+- CSS scoping module
+  - {{CSSXref(":host")}}
+  - {{CSSXref(":host_function", ":host()")}}
+  - {{CSSXref(":host-context", ":host-context()")}}
+  - {{CSSXref("::slotted")}}
+
+## Specifications
+
+{{Specifications}}
+
+## See also
+
+- [CSS pseudo elements](/en-US/docs/Web/CSS/CSS_pseudo) module
+- [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
+- [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
+- [Templates: styling outside of the current scope](https://web.dev/learn/html/template/#styling-outside-of-the-current-scope) on web.dev (2023)

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS shadow parts module
+title: CSS shadow parts
 slug: Web/CSS/CSS_shadow_parts
 page-type: css-module
 spec-urls: https://drafts.csswg.org/css-shadow-parts/
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-shadow-parts/
 
 {{CSSRef}}
 
-The **CSS shadow parts** module defines the {{CSSXref("::part", "::part()")}} pseudo-element on shadow hosts, allowing shadow hosts to expose selected shadow tree elements to the outside page for styling purposes.
+The **CSS shadow parts** module defines the {{CSSXref("::part", "::part()")}} pseudo-element that can be set on a [shadow host](/en-US/docs/Glossary/Shadow_tree). Using this pseudo-element, you can enable shadow hosts to expose the selected element in the shadow tree to the outside page for styling purposes.
 
 By default, elements in a shadow tree are only styleable from within that shadow root. The CSS shadow parts module enables including a [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute on {{HTMLElement("template")}} descendants, exposing the shadow tree node to external styling via the `::part()` pseudo-element.
 
@@ -17,7 +17,7 @@ By default, elements in a shadow tree are only styleable from within that shadow
 
 - {{CSSXref("::part", "::part()")}}
 
-### HTML Attributes
+### HTML attributes
 
 - [`part`](/en-US/docs/Web/HTML/Global_attributes#part)
 - [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts)
@@ -34,7 +34,7 @@ By default, elements in a shadow tree are only styleable from within that shadow
 
 - [Web components](/en-US/docs/Web/API/Web_components)
 
-  - : Overview of the different APIs that make enable creating reusable custom elements, or web components.
+  - : Overview of the different APIs that enable creating reusable custom elements or web components.
 
 ## Related concepts
 
@@ -59,4 +59,4 @@ By default, elements in a shadow tree are only styleable from within that shadow
 - [CSS pseudo elements](/en-US/docs/Web/CSS/CSS_pseudo) module
 - [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
 - [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
-- [Templates: styling outside of the current scope](https://web.dev/learn/html/template/#styling-outside-of-the-current-scope) on web.dev (2023)
+- [Templates: Styling outside of the current scope](https://web.dev/learn/html/template/#styling-outside-of-the-current-scope) on web.dev (2023)


### PR DESCRIPTION
New css module: shadow parts.
Pseudo elements links to this and this links to pseudo-elements, both new, so link will be red.
I wrote an "in action" but don't know how to make it interactive and fun, so not included yet (https://codepen.io/estelle/pen/rNQpELX)

remove the link to :theme b/c that is no longer in the spec