### PR TITLE
fix typo in Math.ceil() description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Math.ceil
 
 {{JSRef}}
 
-The **`Math.ceil()`** static method always rounds up and returns the smaller integer greater than or equal to a given number.
+The **`Math.ceil()`** static method always rounds up and returns the smallest integer greater than or equal to a given number.
 
 {{EmbedInteractiveExample("pages/js/math-ceil.html")}}
 


### PR DESCRIPTION
### Description
a simple typo 

### Motivation
no idea what "smaller integer greater than..." means
