### PR TITLE
fix: `add-redirect` command example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ You may do this by using the `yarn content add-redirect` command.
 2. Add a redirect with `yarn content add-redirect`. The target page can be a page on MDN or an external URL:
 
    ```sh
-   yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
+   yarn content add-redirect https://developer.mozilla.org/en-US/path/of/deleted/page https://developer.mozilla.org/en-US/path/of/target/page
    ```
 
 3. Commit all of the changed files and pushing your branch to your fork:


### PR DESCRIPTION
If you try to call this command as in example with only path name of article,
you will get the "Invalid URL" error.

Because yari-tool using URL constructor which can't accept path name without base.

Refs:
- https://github.com/mdn/yari/blob/main/tool/cli.ts#L314
- https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#examples