### PR TITLE
relnote(116): ARIA image role now supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -20,6 +20,11 @@ This article provides information about the changes in Firefox 116 that affect d
 
 #### Removals
 
+### Accessibility (ARIA)
+
+- The [`image`](/en-US/docs/Web/Accessibility/ARIA/Roles/img_role) role is now supported as a synonym for `img`.
+  This maintains consistency with most role names which are complete words or concatenations of complete words ([Firefox bug 1829269](https://bugzil.la/1829269)).
+
 ### JavaScript
 
 #### Removals


### PR DESCRIPTION
Adding a release note for aria `image` role:

```html
<div role="image" aria-label="Table flip">
  <p>(╯°□°）╯︵ ┻━┻</p>
</div>
```

__Notes:__
Waiting on feedback from spec author before docs revisions that change `img` to `image`, adding redirects & sunsetting / deprecation notice for `img`.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/27750
- <strike>BCD: TODO</strike> looks like we don't have BCD for any roles yet

__Bugzilla:__
- [BUG-1829269](https://bugzilla.mozilla.org/show_bug.cgi?id=1829269)