### PR TITLE
Typo in String.lastIndexOf

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -68,7 +68,7 @@ expression returns `-1`:
 
 The following example uses {{jsxref("String.prototype.indexOf()", "indexOf()")}} and
 `lastIndexOf()` to locate values in the string
-"`Brave, Brave New World`".
+`"Brave, Brave New World"`.
 
 ```js
 const anyString = "Brave, Brave New World";

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -22,7 +22,7 @@ lastIndexOf(searchString, position)
 
 - `searchString`
 
-  - : Substring to search for. All values are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `indexOf()` to search for the string `"undefined"`, which is rarely what you want.
+  - : Substring to search for. All values are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), so omitting it or passing `undefined` causes `lastIndexOf()` to search for the string `"undefined"`, which is rarely what you want.
 
 - `position` {{optional_inline}}
 


### PR DESCRIPTION
### Description

Same as the title. Typo `indexOf` -> `lastIndexOf`

### Motivation

### Additional details

None.

### Related issues and pull requests
