### PR TITLE
Patch method cacheable modified to "No" to "Only if freshness information is included".

### DIFF
--- a/files/en-us/web/http/methods/patch/index.md
+++ b/files/en-us/web/http/methods/patch/index.md
@@ -41,7 +41,7 @@ Another (implicit) indication that `PATCH` is allowed, is the presence of the {{
     </tr>
     <tr>
       <th scope="row">{{Glossary("Cacheable")}}</th>
-      <td>No</td>
+      <td>Only if freshness information is included</td>
     </tr>
     <tr>
       <th scope="row">


### PR DESCRIPTION
I am Japanese and my English is not good. First of all, sorry for using Deepl translation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

We found that "cacheable" as written in the PATCH method is inconsistent with the RFC and other documents. This is the fix.

### Motivation

This was clearly inconsistent with other documents. The ["cacheable" documentation](https://developer.mozilla.org/en-US/docs/Glossary/Cacheable) clearly states that cacheability of POST and PATH is "Only if freshness information is included".

However, PATCH says NO. We checked [RFC5789](https://www.rfc-editor.org/rfc/rfc5789), which describes the PATH specification, and found this to be incorrect.

I sent this PR because we believe this will cause confusion for other developers.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
