### PR TITLE
fix: I removed the precomposed keyword because it's no longer needed

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -329,7 +329,7 @@ You can include links to several icons on the same page, and the browser will ch
 <!-- first- and second-generation iPad: -->
 <link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
+<link rel="apple-touch" href="favicon57.png" />
 <!-- basic favicon -->
 <link rel="icon" href="favicon32.png" />
 ```

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -30,7 +30,7 @@ There are a number of other icon `rel` values, mainly used to indicate special i
 
 ```html
 <link
-  rel="apple-touch-icon-precomposed"
+  rel="apple-touch-icon"
   sizes="114x114"
   href="apple-icon-114.png"
   type="image/png" />

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -335,7 +335,7 @@ You can include links to several icons on the same page, and the browser will ch
 <!-- first- and second-generation iPad: -->
 <link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link rel="apple-touch-icon" href="favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- basic favicon -->
 <link rel="icon" href="favicon32.png" />
 ```

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -324,18 +324,18 @@ You can include links to several icons on the same page, and the browser will ch
 ```html
 <!-- third-generation iPad with high-resolution Retina display: -->
 <link
-  rel="apple-touch-icon-precomposed"
+  rel="apple-touch-icon"
   sizes="144x144"
   href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
-  rel="apple-touch-icon-precomposed"
+  rel="apple-touch-icon"
   sizes="114x114"
   href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
+<link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
+<link rel="apple-touch-icon" href="favicon57.png" />
 <!-- basic favicon -->
 <link rel="icon" href="favicon32.png" />
 ```

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -323,15 +323,9 @@ You can include links to several icons on the same page, and the browser will ch
 
 ```html
 <!-- third-generation iPad with high-resolution Retina display: -->
-<link
-  rel="apple-touch-icon"
-  sizes="144x144"
-  href="favicon144.png" />
+<link rel="apple-touch-icon" sizes="144x144" href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
-<link
-  rel="apple-touch-icon"
-  sizes="114x114"
-  href="favicon114.png" />
+<link rel="apple-touch-icon" sizes="114x114" href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
 <link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I removed the `precomposed` keyword in Apple touch icon examples 
### Motivation
According to [this source](https://github.com/webhintio/hint/blob/main/packages/hint-apple-touch-icons/README.md#why-is-this-important), the keyword is no longer needed. By making this change, learners would gain a better understanding of how to use this line of code in their own projects or work. 
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
See link mentioned in the previous section for more context. 
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #26707

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
