### PR TITLE
run prettier on .md files in precommit hook

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "!*.md": "prettier --ignore-unknown --write",
+  "*": "prettier --ignore-unknown --write",
   "*.md": [
     "markdownlint-cli2-fix",
     "node scripts/front-matter_linter.js --fix true"


### PR DESCRIPTION
- Following up on https://github.com/mdn/content/pull/24050

Now we won't have to manually run prettier on .md files!

Tested the PR by running: `prettier --ignore-unknown -w *` command on the repo.


**Note:** If you do not want any file to be formatted by Prettier then add the exception to the [.prettierignore](https://github.com/mdn/content/blob/main/.prettierignore) file.