### PR TITLE
Fix default value for grayscale() being 1, not 0

### DIFF
--- a/files/en-us/web/css/filter-function/grayscale/index.md
+++ b/files/en-us/web/css/filter-function/grayscale/index.md
@@ -20,7 +20,7 @@ grayscale(amount)
 ### Parameters
 
 - `amount`
-  - : Amount of the input image that is converted to grayscale. It is specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value of `100%` changes the input completely to grayscale, while a value of `0%` leaves the input unchanged. Values between `0%` and `100%` have linear multipliers on the effect. The default value when omitted is `1`. The initial value used for {{Glossary("interpolation")}} is `0`.
+  - : Amount of the input image that is converted to grayscale. It is specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value of `100%` changes the input completely to grayscale, while a value of `0%` leaves the input unchanged. Values between `0%` and `100%` have linear multipliers on the effect. If the `grayscale()` filter is present with no parameter, the default value `1`. The initial value used for {{Glossary("interpolation")}} is `0`.
 
 ## Examples
 

--- a/files/en-us/web/css/filter-function/grayscale/index.md
+++ b/files/en-us/web/css/filter-function/grayscale/index.md
@@ -20,7 +20,7 @@ grayscale(amount)
 ### Parameters
 
 - `amount`
-  - : Amount of the input image that is converted to grayscale. It is specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value of `100%` changes the input completely to grayscale, while a value of `0%` leaves the input unchanged. Values between `0%` and `100%` have linear multipliers on the effect. The default value when omitted is `0`. The initial value used for {{Glossary("interpolation")}} is `0`.
+  - : Amount of the input image that is converted to grayscale. It is specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value of `100%` changes the input completely to grayscale, while a value of `0%` leaves the input unchanged. Values between `0%` and `100%` have linear multipliers on the effect. The default value when omitted is `1`. The initial value used for {{Glossary("interpolation")}} is `0`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

The default value for the filter function grayscale is 1, not 0.

### Motivation

I am fixing incorrect information.

### Additional details

The standard says so, here: https://www.w3.org/TR/filter-effects-1/#funcdef-filter-grayscale and this is consistent with behavior in at least Firefox and Edge.