### PR TITLE
Unlink PR from MD037

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -101,7 +101,7 @@
       ]
     },
     "MD034": false,
-    // Pending https://github.com/mdn/content/pull/20115
+    // Produces too many false positives
     "MD037": false,
     "MD040": false,
     // See https://github.com/mdn/content/pull/20026, as macros currently break this


### PR DESCRIPTION
This PR replaces the comment above Markdownlint rule MD037 with a statement saying that it's disabled due to too many false positives.
