### PR TITLE
Added a no-input flag for collectstatic in Procfile.

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.md
+++ b/files/en-us/learn/server-side/django/deployment/index.md
@@ -316,7 +316,7 @@ It lists the commands that will be executed by Railway to start your site.
 Create the file `Procfile` (with no file extension) in the root of your GitHub repo and copy/paste in the following text:
 
 ```plain
-web: python manage.py migrate && python manage.py collectstatic && gunicorn locallibrary.wsgi
+web: python manage.py migrate && python manage.py collectstatic --no-input && gunicorn locallibrary.wsgi
 ```
 
 The `web:` prefix tells Railway that this is a web process and can be sent HTTP traffic.


### PR DESCRIPTION
Added a no-input flag for collectstatic to the Procfile contents, because without it deployment to Railway fails, with logs showing that the collectstatic command is expecting a yes/no user input and causes the deployment to crash after waiting for the input.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a no-input flag for collectstatic to the Procfile contents code example in the documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I tried using the Procfile contents to deploy to Railway and my deployment crashed because the command collectstatic expects user input. Adding the --no-input flag fixes this issue. This change will help readers by making it easier for them to successfully deploy on Railway without having to troubleshoot this issue.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
