### PR TITLE
docs(CSS): Clean up @container examples and reintroduce style queries section

### DIFF
--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -62,10 +62,6 @@ Logical keywords can be used to define the container condition:
 @container (width > 400px) or (height > 400px) {
   /* <stylesheet> */
 }
-
-@container (width > 400px) not (height > 400px) {
-  /* <stylesheet> */
-}
 ```
 
 ### Named containment contexts
@@ -233,6 +229,21 @@ The following query evaluates to true and applies the declared style if the cont
   }
 }
 ```
+
+### Style container queries
+
+{{CSSRef}}{{SeeCompatTable}}
+
+Container queries can also evaluate the computed style of the container element.
+The following container query checks if the {{cssxref("computed_value")}} of the container element's `--accent-color` is `blue`:
+
+```css
+@container style(--accent-color: blue) {
+  /* <stylesheet> */
+}
+```
+
+> **Note:** If a custom property has a value of `blue`, the equivalent hexidecimal code `#0000ff` will not match unless the property has been defined as a color with {{cssxref("@property")}} so the browser can properly compare computed values.
 
 ## Specifications
 

--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -51,15 +51,15 @@ Logical keywords can be used to define the container condition:
 - `not` negates the condition. Only one 'not' condition is allowed per container query and cannot be used with the `and` or `or` keywords.
 
 ```css
-@container not (width < 400px) {
-  /* <stylesheet> */
-}
-
 @container (width > 400px) and (height > 400px) {
   /* <stylesheet> */
 }
 
 @container (width > 400px) or (height > 400px) {
+  /* <stylesheet> */
+}
+
+@container not (width < 400px) {
   /* <stylesheet> */
 }
 ```


### PR DESCRIPTION
### Description

- Removed an invalid example for `@container`
- Reordered examples to match the keywords listed above
- Reintroduced a section about container style queries with a note about experimental status

### Motivation

- I'm excited to use container queries, and found the fourth example to be invalid after testing in stable Firefox and Chrome Canary. I could not find a reference to a `(condition A) not (condition B)` syntax in the CSS spec. Incorrect information cannot be helpful.
- The keywords are listed as `and`/`or`/`not`, but the examples were `not`/`and`/`or`. It is a small improvement that makes it more logical when having a quick look at this page.
- I wanted to see what information there was on style queries and could not find any, only to see that section was completely removed instead of showing an "Experimental" preamble. In order to allow for authors to experiment with the feature and provide feedback to vendors, the existence of the feature should not be obfuscated.

### Additional details

I'm not privy to internal discussions so the removal of style queries might be justified but regardless, I believe it should be shown. I'm not sure of the correct syntax in the docs to highlight experimental status, so if my contribution is incorrect, I'd welcome feedback to make it better.