### PR TITLE
Update pull() description

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -46,11 +46,10 @@ new ReadableStream(underlyingSource, queuingStrategy)
         {{domxref("ReadableStreamDefaultController")}} or a
         {{domxref("ReadableByteStreamController")}}, depending on the value of the
         `type` property. This can be used by the developer to control the
-        stream as more chunks are fetched.
-
-        This function will not be called until `start()` successfully completes. Additionally,
-        it will only be called repeatedly if it enqueues at least one chunk or fulfills a
-        BYOB request; a no-op pull() implementation will not be continually called.
+        stream as more chunks are fetched. This function will not be called until `start()`
+        successfully completes. Additionally, it will only be called repeatedly if it
+        enqueues at least one chunk or fulfills a BYOB request; a no-op pull()
+        implementation will not be continually called.
     - `cancel` (reason) {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals
         that the stream is to be cancelled (e.g. if {{domxref("ReadableStream.cancel()")}}

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -47,6 +47,10 @@ new ReadableStream(underlyingSource, queuingStrategy)
         {{domxref("ReadableByteStreamController")}}, depending on the value of the
         `type` property. This can be used by the developer to control the
         stream as more chunks are fetched.
+
+        This function will not be called until `start()` successfully completes. Additionally,
+        it will only be called repeatedly if it enqueues at least one chunk or fulfills a
+        BYOB request; a no-op pull() implementation will not be continually called.
     - `cancel` (reason) {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals
         that the stream is to be cancelled (e.g. if {{domxref("ReadableStream.cancel()")}}

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -48,7 +48,7 @@ new ReadableStream(underlyingSource, queuingStrategy)
         `type` property. This can be used by the developer to control the
         stream as more chunks are fetched. This function will not be called until `start()`
         successfully completes. Additionally, it will only be called repeatedly if it
-        enqueues at least one chunk or fulfills a BYOB request; a no-op pull()
+        enqueues at least one chunk or fulfills a BYOB request; a no-op `pull()`
         implementation will not be continually called.
     - `cancel` (reason) {{optional_inline}}
       - : This method, also defined by the developer, will be called if the app signals


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update `pull()` details to include important requirement from the specification that chunks must be enqueued for pull() to be called more than once.

### Motivation

MDN Web Docs `pull()` description is incomplete re details in language of the specification.
### Additional details

https://streams.spec.whatwg.org/#dom-underlyingsource-pull

> This function will not be called until [start()](https://streams.spec.whatwg.org/#dom-underlyingsource-start) successfully completes. Additionally, it will only be called repeatedly if it enqueues at least one chunk or fulfills a BYOB request; a no-op [pull()](https://streams.spec.whatwg.org/#dom-underlyingsource-pull) implementation will not be continually called.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
