### PR TITLE
index.md fix link

### DIFF
--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -147,6 +147,6 @@ self.addEventListener("push", (event) => {
 
 ## See also
 
-- [How to create an app badge](https://web.dev/patterns/advanced-apps/badges/)
+- [How to create an app badge](https://web.dev/patterns/web-apps/badges/)
 - [Re-engage users with badges, notifications, and push messages](https://learn.microsoft.com/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges)
 - [Codelab: Build a push notification server](https://web.dev/push-notifications-server-codelab/)


### PR DESCRIPTION
Link to "How to create an app badge" was broken and point to a 404. I just googled for the title with site and found this page. So maybe it's the same one.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The link point to a 404 page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Because a link to a 404 is missliding. 
It will help new reader to get correct resources.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
🤷‍♂️

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Nop

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
