### PR TITLE
fix(CSS): undo a wrong fix in float document

### DIFF
--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -168,7 +168,7 @@ Add a class of `special` to the first paragraph of text, the one immediately fol
 .special {
   background-color: rgb(79, 185, 227);
   padding: 10px;
-  color: #fff;
+  color: purple;
 }
 ```
 
@@ -225,12 +225,6 @@ body {
   border-radius: 5px;
   background-color: rgb(207, 232, 220);
   padding: 1em;
-}
-
-.special {
-  background-color: rgb(79, 185, 227);
-  padding: 10px;
-  color: #fff;
 }
 ```
 
@@ -306,7 +300,7 @@ body {
 .special {
   background-color: rgb(79, 185, 227);
   padding: 10px;
-  color: #fff;
+  color: purple;
 }
 
 .cleared {
@@ -349,8 +343,7 @@ In your CSS, add the following rule for the `.wrapper` class and then reload the
 .wrapper {
   background-color: rgb(79, 185, 227);
   padding: 10px;
-  color: #fff;
-  overflow: auto;
+  color: purple;
 }
 ```
 
@@ -396,13 +389,6 @@ body {
     sans-serif;
 }
 
-.wrapper {
-  background-color: rgb(79, 185, 227);
-  padding: 10px;
-  color: #fff;
-  overflow: auto;
-}
-
 .box {
   float: left;
   margin: 15px;
@@ -411,12 +397,13 @@ body {
   border-radius: 5px;
   background-color: rgb(207, 232, 220);
   padding: 1em;
+  color: black;
 }
 ```
 
 {{EmbedLiveSample('The_problem', '100%', 600)}}
 
-Once again, this is because the float has been taken out of normal flow. You might expect that by wrapping the floated box and the text of first paragraph that wraps around the float together, the subsequent content will be cleared of the box. But this is not the case, as shown above. To deal with this, the standards method is create a [block formatting context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) (BFC) using the {{cssxref("display")}} property.
+Once again, this is because the float has been taken out of normal flow. You might expect that by wrapping the floated box and the text of first paragraph that wraps around the float together, the subsequent content will be cleared of the box. But this is not the case, as shown above. To deal with this, the standard method is to create a [block formatting context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) (BFC) using the {{cssxref("display")}} property.
 
 ### display: flow-root
 
@@ -426,7 +413,7 @@ To solve this problem is to use the value `flow-root` of the `display` property.
 .wrapper {
   background-color: rgb(79, 185, 227);
   padding: 10px;
-  color: #fff;
+  color: purple;
   display: flow-root;
 }
 ```
@@ -474,13 +461,6 @@ body {
     sans-serif;
 }
 
-.wrapper {
-  background-color: rgb(79, 185, 227);
-  padding: 10px;
-  color: #fff;
-  display: flow-root;
-}
-
 .box {
   float: left;
   margin: 15px;
@@ -489,6 +469,7 @@ body {
   border-radius: 5px;
   background-color: rgb(207, 232, 220);
   padding: 1em;
+  color: black;
 }
 ```
 

--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -407,7 +407,7 @@ Once again, this is because the float has been taken out of normal flow. You mig
 
 ### display: flow-root
 
-To solve this problem is to use the value `flow-root` of the `display` property. This exists only to create a BFC without using hacks — there will be no unintended consequences when you use it. Remove `overflow: auto` from your `.wrapper` rule and add `display: flow-root` and the box will clear.
+To solve this problem is to use the value `flow-root` of the `display` property. This exists only to create a BFC without using hacks — there will be no unintended consequences when you use it.
 
 ```css
 .wrapper {

--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -166,7 +166,7 @@ Add a class of `special` to the first paragraph of text, the one immediately fol
 
 ```css
 .special {
-  background-color: rgb(79, 185, 227);
+  background-color: rgb(148, 255, 172);
   padding: 10px;
   color: purple;
 }
@@ -298,7 +298,7 @@ body {
 }
 
 .special {
-  background-color: rgb(79, 185, 227);
+  background-color: rgb(148, 255, 172);
   padding: 10px;
   color: purple;
 }
@@ -324,9 +324,9 @@ You now know how to clear something following a floated element, but let's see w
 
 Change your document so that the first paragraph and the floated box are jointly wrapped with a {{htmlelement("div")}}, which has a class of `wrapper`.
 
-```html
+```html live-sample___the_problem
 <div class="wrapper">
-  <div class="box">Float</div>
+  <div class="box">Float1</div>
 
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla luctus
@@ -339,9 +339,9 @@ Change your document so that the first paragraph and the floated box are jointly
 
 In your CSS, add the following rule for the `.wrapper` class and then reload the page:
 
-```css
+```css live-sample___the_problem
 .wrapper {
-  background-color: rgb(79, 185, 227);
+  background-color: rgb(148, 255, 172);
   padding: 10px;
   color: purple;
 }
@@ -357,7 +357,7 @@ In addition, remove the original `.cleared` class:
 
 You'll see that, just like in the example where we put a background color on the paragraph, the background color runs behind the float.
 
-```html hidden
+```html hidden live-sample___the_problem
 <p>
   Sed auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet
   orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac ornare
@@ -378,7 +378,7 @@ You'll see that, just like in the example where we put a background color on the
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___the_problem
 body {
   width: 90%;
   max-width: 900px;
@@ -401,7 +401,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample('The_problem', '100%', 600)}}
+{{EmbedLiveSample('the_problem', '100%', 600)}}
 
 Once again, this is because the float has been taken out of normal flow. You might expect that by wrapping the floated box and the text of first paragraph that wraps around the float together, the subsequent content will be cleared of the box. But this is not the case, as shown above. To deal with this, the standard method is to create a [block formatting context](/en-US/docs/Web/Guide/CSS/Block_formatting_context) (BFC) using the {{cssxref("display")}} property.
 
@@ -411,7 +411,7 @@ To solve this problem is to use the value `flow-root` of the `display` property.
 
 ```css
 .wrapper {
-  background-color: rgb(79, 185, 227);
+  background-color: rgb(148, 255, 172);
   padding: 10px;
   color: purple;
   display: flow-root;


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/27784

The example has two sections: first the problem and second one is the solution using `display: flow-root`.

## Problem
1. The PR https://github.com/mdn/content/pull/23506 removed the old hacks and fix using `overflow: auto` sections but following statement remained, and is out of context now:
   > Remove `overflow: auto` from your `.wrapper` rule and add `display: flow-root` and the box will clear.
2. Looking at the statement other PR https://github.com/mdn/content/pull/27370 fixed the code in problem section itself using `overflow: auto`. :laughing: 
3. Now it appears that the problem section is also providing a solution to the issue. Hence the issue author is requesting to remove the solution section all together.

## Solution
This PR does following things:
- remove the `overflow: auto` fix from the problem section code
- remove the out of context statement regarding `overflow: auto`
- remove the duplicate style rules from the hidden code fences
- bring better contrast to text inside the blue box
- make "Float" word in floating box black again (current white colored is not visible)