### PR TITLE
Add WebGPU updates for Chrome 116

### DIFF
--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -39,6 +39,10 @@ requestDevice(descriptor)
 
 A {{jsxref("Promise")}} that fulfills with a {{domxref("GPUDevice")}} object instance.
 
+If you make a duplicate call, i.e. call `requestDevice()` on a {{domxref("GPUAdapter")}} that `requestDevice()` was already called on, the promise fulfills with a device that is immediately lost. You can then get information on how the device was lost via {{domxref("GPUDevice.lost")}}.
+
+> **Note:** On older implementations, duplicate calls result in a promise that is rejected with `null`.
+
 ### Exceptions
 
 - `OperationError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -41,8 +41,6 @@ A {{jsxref("Promise")}} that fulfills with a {{domxref("GPUDevice")}} object ins
 
 If you make a duplicate call, i.e. call `requestDevice()` on a {{domxref("GPUAdapter")}} that `requestDevice()` was already called on, the promise fulfills with a device that is immediately lost. You can then get information on how the device was lost via {{domxref("GPUDevice.lost")}}.
 
-> **Note:** On older implementations, duplicate calls result in a promise that is rejected with `null`.
-
 ### Exceptions
 
 - `OperationError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/gpudevice/importexternaltexture/index.md
+++ b/files/en-us/web/api/gpudevice/importexternaltexture/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GPUDevice.importExternalTexture
 {{APIRef("WebGPU API")}}{{SeeCompatTable}}
 
 The **`importExternalTexture()`** method of the
-{{domxref("GPUDevice")}} interface takes an {{domxref("HTMLVideoElement")}} as an input and returns a {{domxref("GPUExternalTexture")}} wrapper object containing a snapshot of the video that can be used as a frame in GPU rendering operations.
+{{domxref("GPUDevice")}} interface takes an {{domxref("HTMLVideoElement")}} or a {{domxref("VideoFrame")}} object as an input and returns a {{domxref("GPUExternalTexture")}} wrapper object containing a snapshot of the video that can be used as a frame in GPU rendering operations.
 
 ## Syntax
 
@@ -28,11 +28,16 @@ importExternalTexture(descriptor)
     - `label` {{optional_inline}}
       - : A string providing a label that can be used to identify the object, for example in {{domxref("GPUError")}} messages or console warnings.
     - `source`
-      - : The {{domxref("HTMLVideoElement")}} source of the video snapshot.
+      - : The {{domxref("HTMLVideoElement")}} or {{domxref("VideoFrame")}} source of the video snapshot.
 
 ### Return value
 
 A {{domxref("GPUExternalTexture")}} object instance.
+
+Note that the moment when the {{domxref("GPUExternalTexture")}} object expires (is destroyed) depends on what its source is:
+
+- {{domxref("GPUExternalTexture")}} objects with an {{domxref("HTMLVideoElement")}} source expire as soon as they are used (for example in a bind group).
+- {{domxref("GPUExternalTexture")}} objects with an {{domxref("VideoFrame")}} source expire only when the `VideoFrame` is closed, for example via a {{domxref("VideoFrame.close()")}} call.
 
 ### Validation
 

--- a/files/en-us/web/api/gpupipelineerror/gpupipelineerror/index.md
+++ b/files/en-us/web/api/gpupipelineerror/gpupipelineerror/index.md
@@ -21,8 +21,8 @@ new GPUPipelineError(message, options)
 
 ### Parameters
 
-- `message`
-  - : A string providing a human-readable message that explains why the error occurred.
+- `message` {{optional_inline}}
+  - : A string providing a human-readable message that explains why the error occurred. If not specified, `message` defaults to an empty string (`""`).
 - `options`
   - : An object, which can contain the following properties:
     - `reason`

--- a/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
+++ b/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
@@ -28,7 +28,7 @@ copyExternalImageToTexture(source, destination, copySize)
   - : An object representing the source to write to the destination, and its origin. This can take the following properties:
 
     - `source`
-      - : An object providing the source of the snapshot to copy. This can be an {{domxref("ImageBitmap")}}, {{domxref("HTMLVideoElement")}}, {{domxref("HTMLCanvasElement")}}, or {{domxref("OffscreenCanvas")}}. The image source data is captured at the exact moment `copyExternalImageToTexture()` is invoked.
+      - : An object providing the source of the snapshot to copy. This can be an {{domxref("ImageBitmap")}}, {{domxref("HTMLVideoElement")}}, {{domxref("VideoFrame")}}, {{domxref("HTMLCanvasElement")}}, or {{domxref("OffscreenCanvas")}}. The image source data is captured at the exact moment `copyExternalImageToTexture()` is invoked.
     - `origin` {{optional_inline}}
 
       - : An object or array specifying the origin of the copy — the top-left corner of the source sub-region to copy from. Together with `copySize`, this defines the full extent of the source sub-region. The `x` and `y` values default to 0 if any of all of `origin` is omitted.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds some content for [Chromium 116 WebGPU updates](https://pr-6763-static-dot-dcc-staging.uc.r.appspot.com/blog/new-in-webgpu-116), namely:

- `GPUDevice.importExternalTexture()` and `GPUQueue.copyExternalImageToTexture()` can now use a `VideoFrame` object as a source. Details added to the intro and source description for each. Also added information on when each type of texture is destroyed (from `HTMLVideoElement`, and from `VideoFrame`) after being created with `GPUDevice.importExternalTexture()`. See https://gpuweb.github.io/gpuweb/#gpuexternaltexture

- `GPUAdapter.requestDevice()` now returns a device that is immediately lost, if it has already been used to create a device (i.e. `requestDevice()` was already called.) rather than the promise being rejected with `null`. You can then get lost info from it via `GPUDevice.lost`. This info has been added to the return value section.

- `GPUPipelineError.GPUPipelineError()` message argument is optional. Optional label added, as well as information on the default value.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
