### PR TITLE
Bump @mdn/yari from 2.28.1 to 2.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
     "@caporal/core": "^2.0.2",
-    "@mdn/yari": "2.28.1",
+    "@mdn/yari": "2.28.2",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "async": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,15 +747,15 @@
   resolved "https://registry.npmjs.org/@mdn/bcd-utils-api/-/bcd-utils-api-0.0.4.tgz"
   integrity sha512-X9Qs+Um1EyFiQVZ8wEGPMEwN53VePTpZGMt2S0glKjVxwpF1kMQfKtPoaTcWmRl7kmNpCVYjvB5c3MdMTyxrxQ==
 
-"@mdn/browser-compat-data@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.3.0.tgz#a71994a571ee3801b277e54f6d4022738ea0ecc4"
-  integrity sha512-TrVSwoxpNKImgvHdAUDRleHJXWjBOgrri+C1OogMSwOPeIPZ0gEdym4cRQWv7VGHnkHCZ/PwR01XQaWlD00KFA==
+"@mdn/browser-compat-data@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.3.3.tgz#7d80203095ea6e865043794cd6ffeed589674d1b"
+  integrity sha512-89Ikx/aME3DwslhFWr4ZLhVtc7EDAuwhu5uwdwXKFIzJT1r6/9jJI2jD0ycESzVOf+0pPZq9vHe9LCE3NE7EuA==
 
-"@mdn/yari@2.28.1":
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/@mdn/yari/-/yari-2.28.1.tgz#1682be14249844f0cf918d617d2e3edc926109a9"
-  integrity sha512-6geSXGOVGzE6SiSc7p79333CMcXwrzuUq8WukzOPXCzz0mRIG+ctIPcR3nuKuXwMmKWz9vPHV9aiMQO/7elXKA==
+"@mdn/yari@2.28.2":
+  version "2.28.2"
+  resolved "https://registry.yarnpkg.com/@mdn/yari/-/yari-2.28.2.tgz#2a438101eb3e15783cb2341707fa5ca9a13e8e9c"
+  integrity sha512-NhOzpwTuuO1l8ckePUo/tYGqNnSsJ75sGDZom7cIYPB3tGKjzQ1tHAUYmAKuXT0z1I2YGPai5E+eJUixYi3ijA==
   dependencies:
     "@caporal/core" "^2.0.2"
     "@codemirror/lang-css" "^6.2.0"
@@ -765,7 +765,7 @@
     "@codemirror/theme-one-dark" "^6.1.2"
     "@fast-csv/parse" "^4.3.6"
     "@mdn/bcd-utils-api" "^0.0.4"
-    "@mdn/browser-compat-data" "^5.3.0"
+    "@mdn/browser-compat-data" "^5.3.3"
     "@mozilla/glean" "1.4.0"
     "@sentry/integrations" "^7.57.0"
     "@sentry/node" "^7.57.0"
@@ -830,7 +830,7 @@
     send "^0.18.0"
     source-map-support "^0.5.21"
     sse.js "^0.6.1"
-    tempy "^3.0.0"
+    tempy "^3.1.0"
     unified "^10.1.2"
     unist-builder "^3.0.1"
     unist-util-visit "^4.1.2"
@@ -7631,10 +7631,10 @@ temp-dir@^1.0.0:
   resolved "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
-temp-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz"
-  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+temp-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-3.0.0.tgz#7f147b42ee41234cc6ba3138cd8e8aa2302acffa"
+  integrity sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==
 
 tempfile@^2.0.0:
   version "2.0.0"
@@ -7644,13 +7644,13 @@ tempfile@^2.0.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-tempy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/tempy/-/tempy-3.0.0.tgz"
-  integrity sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==
+tempy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-3.1.0.tgz#00958b6df85db8589cb595465e691852aac038e9"
+  integrity sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==
   dependencies:
     is-stream "^3.0.0"
-    temp-dir "^2.0.0"
+    temp-dir "^3.0.0"
     type-fest "^2.12.2"
     unique-string "^3.0.0"
 


### PR DESCRIPTION
This PR bumps Yari to 2.28.2, which fixes a critical bug with content commands.

(I have no idea why Dependabot is not creating a PR for this...)