### PR TITLE
Remove duplicated example from WebExtensions/manifest.json/icons

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -21,17 +21,6 @@ browser-compat: webextensions.manifest.icons
       <th scope="row">Manifest version</th>
       <td>2 or higher</td>
     </tr>
-    <tr>
-      <th scope="row">Example</th>
-      <td>
-        <pre class="brush: json">
-"icons": {
-  "48": "icon.png",
-  "96": "icon@2x.png"
-}</pre
-        >
-      </td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This PR removes the duplicate example from `Mozilla/Add-ons/WebExtensions/manifest.json/icons`.
