### PR TITLE
Add usage notes to OffscreenCanvas.transferToImageBitmap.

### DIFF
--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -40,6 +40,17 @@ Rendering operations can also be run inside a [worker](/en-US/docs/Web/API/Web_W
 - {{domxref("OffscreenCanvas.transferToImageBitmap()")}}
   - : Creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`.
 
+## Important Notes
+
+Calling {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} allocates a new `ImageBitmap` object, which can be passed to many web platform APIs. An `ImageBitmap` references a potentially large graphics resource, and to ensure your web application remains robust, it is important to avoid allocating too many of these resources at any point in time. For this reason it is important to ensure that the `ImageBitmap` is either _consumed_ or _closed_.
+
+As described in the examples below, passing this `ImageBitmap` to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}} _consumes_ the `ImageBitmap` object; it no longer references the underlying graphics resource, and can not be passed to any other web APIs.
+
+If your goal is to pass the `ImageBitmap` to other web APIs which do not consume it - for example, {{domxref("CanvasRenderingContext2D.drawImage()")}} - then you should _close_ it when you're done with it by calling {{domxref("ImageBitmap.close()")}}. Don't simply drop the JavaScript reference to the `ImageBitmap`; doing so will keep its graphics resource alive until the next time the garbage collector runs.
+
+If you call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} and don't intend to pass it to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}}, consider whether you need to call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} at all. Many web APIs which accept `ImageBitmap` also accept `OffscreenCanvas` as an argument.
+
+
 ## Examples
 
 ### Synchronous display of frames produced by an `OffscreenCanvas`

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -50,7 +50,6 @@ If your goal is to pass the `ImageBitmap` to other web APIs which do not consume
 
 If you call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} and don't intend to pass it to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}}, consider whether you need to call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} at all. Many web APIs which accept `ImageBitmap` also accept `OffscreenCanvas` as an argument.
 
-
 ## Examples
 
 ### Synchronous display of frames produced by an `OffscreenCanvas`

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -38,17 +38,7 @@ Rendering operations can also be run inside a [worker](/en-US/docs/Web/API/Web_W
 - {{domxref("OffscreenCanvas.convertToBlob()")}}
   - : Creates a {{domxref("Blob")}} object representing the image contained in the canvas.
 - {{domxref("OffscreenCanvas.transferToImageBitmap()")}}
-  - : Creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`.
-
-## Important Notes
-
-Calling {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} allocates a new `ImageBitmap` object, which can be passed to many web platform APIs. An `ImageBitmap` references a potentially large graphics resource, and to ensure your web application remains robust, it is important to avoid allocating too many of these resources at any point in time. For this reason it is important to ensure that the `ImageBitmap` is either _consumed_ or _closed_.
-
-As described in the examples below, passing this `ImageBitmap` to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}} _consumes_ the `ImageBitmap` object; it no longer references the underlying graphics resource, and can not be passed to any other web APIs.
-
-If your goal is to pass the `ImageBitmap` to other web APIs which do not consume it - for example, {{domxref("CanvasRenderingContext2D.drawImage()")}} - then you should _close_ it when you're done with it by calling {{domxref("ImageBitmap.close()")}}. Don't simply drop the JavaScript reference to the `ImageBitmap`; doing so will keep its graphics resource alive until the next time the garbage collector runs.
-
-If you call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} and don't intend to pass it to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}}, consider whether you need to call {{domxref("OffscreenCanvas.transferToImageBitmap", "transferToImageBitmap()")}} at all. Many web APIs which accept `ImageBitmap` also accept `OffscreenCanvas` as an argument.
+  - : Creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`. See the {{domxref("OffscreenCanvas.transferToImageBitmap()", "API description")}} for important notes on managing this {{domxref("ImageBitmap")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -8,7 +8,7 @@ browser-compat: api.OffscreenCanvas.transferToImageBitmap
 
 {{APIRef("Canvas API")}}
 
-The **`OffscreenCanvas.transferToImageBitmap()`** method creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`.
+The **`OffscreenCanvas.transferToImageBitmap()`** method creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`. The `OffscreenCanvas` allocates a new image for its subsequent rendering.
 
 ## Syntax
 
@@ -22,7 +22,15 @@ None.
 
 ### Return value
 
-An {{domxref("ImageBitmap")}}.
+A newly-allocated {{domxref("ImageBitmap")}}.
+
+This `ImageBitmap` references a potentially large graphics resource, and to ensure your web application remains robust, it is important to avoid allocating too many of these resources at any point in time. For this reason it is important to ensure that the `ImageBitmap` is either _consumed_ or _closed_.
+
+As described in the {{domxref("OffscreenCanvas")}} examples, passing this `ImageBitmap` to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}} _consumes_ the `ImageBitmap` object; it no longer references the underlying graphics resource, and can not be passed to any other web APIs.
+
+If your goal is to pass the `ImageBitmap` to other web APIs which do not consume it - for example, {{domxref("CanvasRenderingContext2D.drawImage()")}} - then you should _close_ it when you're done with it by calling {{domxref("ImageBitmap.close()")}}. Don't simply drop the JavaScript reference to the `ImageBitmap`; doing so will keep its graphics resource alive until the next time the garbage collector runs.
+
+If you call `transferToImageBitmap()` and don't intend to pass it to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}}, consider whether you need to call `transferToImageBitmap()` at all. Many web APIs which accept `ImageBitmap` also accept `OffscreenCanvas` as an argument.
 
 ## Examples
 
@@ -34,6 +42,11 @@ const gl = offscreen.getContext("webgl");
 
 offscreen.transferToImageBitmap();
 // ImageBitmap { width: 256, height: 256 }
+
+// Either:
+// Pass this ImageBitmap to ImageBitmapRenderingContext.transferFromImageBitmap
+// or:
+// Use the ImageBitmap with other web APIs, and call ImageBitmap.close()!
 ```
 
 ## Specifications

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -44,9 +44,9 @@ offscreen.transferToImageBitmap();
 // ImageBitmap { width: 256, height: 256 }
 
 // Either:
-// Pass this ImageBitmap to ImageBitmapRenderingContext.transferFromImageBitmap
+// Pass this `ImageBitmap` to `ImageBitmapRenderingContext.transferFromImageBitmap`
 // or:
-// Use the ImageBitmap with other web APIs, and call ImageBitmap.close()!
+// Use the `ImageBitmap` with other web APIs, and call `ImageBitmap.close()`!
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

Add usage notes to OffscreenCanvas.transferToImageBitmap regarding the ImageBitmap's lifetime.
Reference these notes from the top-level OffscreenCanvas documentation.

### Motivation

Some web developers have noted that transferToImageBitmap can be confusing and lead to application bugs; crbug.com/1457212 is one recent example. Add more details to the API doc describing the necessity to either
consume or close the ImageBitmap this API creates, and mention an alternative.

### Additional details

crbug.com/1457212 contains a minimized test case from a Chromium customer which was incorrect and which
led to application instability. The customer noted that they used MDN's OffscreenCanvas documentation as a
primary source of information, and requested that the documentation be expanded with this information.

### Related issues and pull requests

None

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
