### PR TITLE
Intl.NumberFormat. v3 fixes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -89,7 +89,7 @@ Intl.NumberFormat(locales, options)
         - `"auto"`: sign display for negative numbers only, including negative zero.
         - `"always"`: always display sign.
         - `"exceptZero"`: sign display for positive and negative numbers, but not zero.
-        - `"negative"`: sign display for negative numbers only, excluding negative zero. {{experimental_inline}}
+        - `"negative"`: sign display for negative numbers only, excluding negative zero.
         - `"never"`: never display sign.
 
     - `style`
@@ -116,7 +116,7 @@ Intl.NumberFormat(locales, options)
         - `"short"` (e.g., `16 l`).
         - `"narrow"` (e.g., `16l`).
 
-    - `useGrouping` {{experimental_inline}}
+    - `useGrouping`
 
       - : Whether to use grouping separators, such as thousands separators or thousand/lakh/crore separators. The default is `auto`.
 
@@ -126,7 +126,7 @@ Intl.NumberFormat(locales, options)
         - `"min2"`: display grouping separators when there are at least 2 digits in a group.
         - `true`: alias for `always`.
 
-    - `roundingMode` {{experimental_inline}}
+    - `roundingMode`
 
       - : Options for rounding modes. The default is `halfExpand`.
 
@@ -163,7 +163,7 @@ Intl.NumberFormat(locales, options)
         These options reflect the [ICU user guide](https://unicode-org.github.io/icu/userguide/format_parse/numbers/rounding-modes.html), where "expand" and "trunc" map to ICU "UP" and "DOWN", respectively.
         The [rounding modes](#rounding_modes) example below demonstrates how each mode works.
 
-    - `roundingPriority` {{experimental_inline}}
+    - `roundingPriority`
 
       - : Specify how rounding conflicts will be resolved if both "FractionDigits" ([`minimumFractionDigits`](#minimumfractiondigits)/[`maximumFractionDigits`](#maximumfractiondigits)) and "SignificantDigits" ([`minimumSignificantDigits`](#minimumsignificantdigits)/[`maximumSignificantDigits`](#maximumsignificantdigits)) are specified:
 
@@ -173,7 +173,7 @@ Intl.NumberFormat(locales, options)
 
         Note that for values other than `auto` the result with more precision is calculated from the [`maximumSignificantDigits`](#minimumsignificantdigits) and [`maximumFractionDigits`](#maximumfractiondigits) (minimum fractional and significant digit settings are ignored).
 
-    - `roundingIncrement` {{experimental_inline}}
+    - `roundingIncrement`
 
       - : Specifies the rounding-increment precision.
         Must be one of the following integers:
@@ -201,7 +201,7 @@ Intl.NumberFormat(locales, options)
         >
         > If you set `minimumFractionDigits` and `maximumFractionDigits`, they must set them to the same value; otherwise a `RangeError` is thrown.
 
-    - `trailingZeroDisplay` {{experimental_inline}}
+    - `trailingZeroDisplay`
 
       - : A string expressing the strategy for displaying trailing zeros on whole numbers.
         The default is `"auto"`.

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -278,6 +278,10 @@ This behavior, called `ChainNumberFormat`, does not happen when `Intl.NumberForm
       Note that depending various formatting options, these properties can have default values.
       It is therefore possible to get this error even if you only set one of the properties.
 
+- {{jsxref("TypeError")}}
+
+  - : Thrown if the `options.style` property is set to "unit" or "currency", and no value has been set for the corresponding property `options.unit` or `options.currency`.
+
 ## Examples
 
 ### Basic usage

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -267,6 +267,17 @@ Note that there's only one actual `Intl.NumberFormat` instance here: the one hid
 
 This behavior, called `ChainNumberFormat`, does not happen when `Intl.NumberFormat()` is called without `new` but with `this` set to anything else that's not an `instanceof Intl.NumberFormat`. If you call it directly as `Intl.NumberFormat()`, the `this` value is [`Intl`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl), and a new `Intl.NumberFormat` instance is created normally.
 
+### Exceptions
+
+- {{jsxref("RangeError")}}
+
+  - : Thrown in the following cases:
+
+    - A property that takes enumerated values (such as `style`, `units`, `currency`, and so on) is set to an invalid value.
+    - Both `maximumFractionDigits` and `minimumFractionDigits` are set, and they are set to different values.
+      Note that depending various formatting options, these properties can have default values.
+      It is therefore possible to get this error even if you only set one of the properties.
+
 ## Examples
 
 ### Basic usage

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -94,7 +94,7 @@ const de = new Intl.NumberFormat("de-DE", {
 const usedOptions = de.resolvedOptions();
 console.log(usedOptions.locale); // "de-DE"
 console.log(usedOptions.numberingSystem); // "latn"
-console.log(usedOptions.compactDisplay); // "undefined"
+console.log(usedOptions.compactDisplay); // undefined ("notation" not set to "compact")
 console.log(usedOptions.currency); // "USD"
 console.log(usedOptions.currencyDisplay); // "symbol"
 console.log(usedOptions.currencySign); // "standard"

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -23,23 +23,49 @@ A new object with properties reflecting the [locale and number formatting option
 
 The resulting object has the following properties:
 
-- `locale`
-  - : The BCP 47 language tag for the locale actually used.
-    If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in `locale`.
-- `numberingSystem`
-  - : The value provided for this properties in the `options` argument, if present, or the value requested using the Unicode extension key `"nu"` or filled in as a default.
-- `notation`
-  - : The value provided for this property in the `options` argument, if present, or `"standard"` filled in as a default.
 - `compactDisplay`
-  - : The value provided for this property in the `options` argument, or `"short"` filled in as a default.
-    This property is only present if the `notation` is set to "compact".
+  - : Whether to use short or long form when using compact notation.
+    This is the value provided in the [`options.compactDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#compactdisplay) argument of the constructor, or the default value: `"short"`.
+    The value is only present if `notation` is set to "compact", and otherwise is `undefined`.
+- `currency`
+  - : The currency to use in currency formatting.
+    This is the value provided in the [`options.currency`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currency) argument of the constructor.
+    The value is only present if `style` is `"currency"`, and is otherwise `undefined`.
+- `currencyDisplay`
+  - : The display format for the currency, such as a symbol, or currency code.
+    This is the value provided in the [`options.currencyDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencydisplay) argument of the constructor, or the default value: `"symbol"`.
+    The value is only present if `style` is `"currency"`, and otherwise is `undefined`.
+- `currencySign`
+  - : The method used to specify the sign of the currency value: `standard` or `accounting`.
+    This is the value provided in the [`options.currencySign`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencysign) argument of the constructor, or the default value: `"standard"`.
+    The value is only present if `style` is `"currency"`, and otherwise is `undefined`.
+- `locale`
+  - : The BCP 47 language tag for the locale that was actually used.
+    The key-value pairs that were requested in the constructor [`locale`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#local) and are supported for this locale are included.
+- `notation`
+  - : The formatting that should be applied to the number, such as `standard` or `engineering`.
+    This is the value provided in the [`options.notation`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#notation) argument of the constructor, or the default value: `"standard"`.
+- `numberingSystem`
+  - : The numbering system.
+    This is the value provided in the [`options.numberingSystem`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#numberingsystem) argument of the constructor, if present, or the value set using the Unicode extension key [`nu`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#nu), or filled in as a default.
+- `roundingMode`
+  - : The rounding mode.
+    This is the value provided for the [`options.roundingMode`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode) argument in the constructor, or the default value: `halfExpand`.
+- `roundingPriority`
+  - : The priority for resolving rounding conflicts if both "FractionDigits" and "SignificantDigits" are specified.
+    This is the value provided for the [`options.roundingPriority`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingpriority) argument in the constructor, or the default value: `auto`.
+- `roundingIncrement`
+  - : The rounding-increment precision (the increment used when rounding numbers).
+    This is the value specified in the [`options.roundingIncrement`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingincrement) argument in the constructor.
 - `signDisplay`
-  - : The value provided for this property in the `options` argument, or `"auto"` filled in as a default.
+  - : Whether or not to display the positive/negative sign.
+    This is the value specified in the [`options.signDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#signdisplay) argument in the constructor, or the default value: `"auto"`.
 - `useGrouping`
-  - : The value provided for the [useGrouping](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#usegrouping) property in the constructor `options` argument or the default value (`"auto"`).
-- `currency`, `currencyDisplay`
-  - : The values provided for these properties in the `options` argument or filled in as defaults.
-    These properties are only present if `style` is `"currency"`.
+  - : Whether or not to use grouping separators to indicate "thousands", "millions" and son on.
+    This is the value specified in the [`options.useGrouping`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#usegrouping) argument in the constructor, or the default value: `"auto"`.
+- `trailingZeroDisplay`
+  - : The strategy for displaying trailing zeros on whole numbers.
+    This is the value specified in the [`options.trailingZeroDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay) argument in the constructor, or the default value: `"auto"`.
 
 Only one of the following two groups of properties is included:
 
@@ -55,18 +81,36 @@ Only one of the following two groups of properties is included:
 ### Using the `resolvedOptions` method
 
 ```js
-const de = new Intl.NumberFormat("de-DE");
-const usedOptions = de.resolvedOptions();
+// Create a NumberFormat
+const de = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+  roundingIncrement: 5,
+  roundingMode: "halfCeil",
+});
 
-usedOptions.locale; // "de-DE"
-usedOptions.numberingSystem; // "latn"
-usedOptions.notation; // "standard"
-usedOptions.signDisplay; // "auto"
-usedOptions.style; // "decimal"
-usedOptions.minimumIntegerDigits; // 1
-usedOptions.minimumFractionDigits; // 0
-usedOptions.maximumFractionDigits; // 3
-usedOptions.useGrouping; // true
+// Resolve the options
+const usedOptions = de.resolvedOptions();
+console.log(usedOptions.locale); // "de-DE"
+console.log(usedOptions.numberingSystem); // "latn"
+console.log(usedOptions.compactDisplay); // "undefined"
+console.log(usedOptions.currency); // "USD"
+console.log(usedOptions.currencyDisplay); // "symbol"
+console.log(usedOptions.currencySign); // "standard"
+console.log(usedOptions.minimumIntegerDigits); // 1
+console.log(usedOptions.minimumFractionDigits); // 2
+console.log(usedOptions.maximumFractionDigits); // 2
+console.log(usedOptions.minimumSignificantDigits); // undefined (maximumFractionDigits is set)
+console.log(usedOptions.maximumSignificantDigits); // undefined (maximumFractionDigits is set)
+console.log(usedOptions.notation); // "standard"
+console.log(usedOptions.roundingIncrement); // 5
+console.log(usedOptions.roundingMode); // halfCeil
+console.log(usedOptions.roundingPriority); // auto
+console.log(usedOptions.signDisplay); // "auto"
+console.log(usedOptions.style); // "currency"
+console.log(usedOptions.trailingZeroDisplay); // auto
+console.log(usedOptions.useGrouping); // auto
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -29,16 +29,16 @@ The resulting object has the following properties:
     The value is only present if `notation` is set to "compact", and otherwise is `undefined`.
 - `currency`
   - : The currency to use in currency formatting.
+    The value is defined if `style` is `"currency"`, and is otherwise `undefined`.
     This is the value provided in the [`options.currency`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currency) argument of the constructor.
-    The value is only present if `style` is `"currency"`, and is otherwise `undefined`.
 - `currencyDisplay`
   - : The display format for the currency, such as a symbol, or currency code.
+    The value is defined if `style` is `"currency"`, and otherwise is `undefined`.
     This is the value provided in the [`options.currencyDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencydisplay) argument of the constructor, or the default value: `"symbol"`.
-    The value is only present if `style` is `"currency"`, and otherwise is `undefined`.
 - `currencySign`
   - : The method used to specify the sign of the currency value: `standard` or `accounting`.
+    The value is present if `style` is `"currency"`, and otherwise is `undefined`.
     This is the value provided in the [`options.currencySign`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencysign) argument of the constructor, or the default value: `"standard"`.
-    The value is only present if `style` is `"currency"`, and otherwise is `undefined`.
 - `locale`
   - : The BCP 47 language tag for the locale that was actually used.
     The key-value pairs that were requested in the constructor [`locale`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#local) and are supported for this locale are included.
@@ -60,6 +60,16 @@ The resulting object has the following properties:
 - `signDisplay`
   - : Whether or not to display the positive/negative sign.
     This is the value specified in the [`options.signDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#signdisplay) argument in the constructor, or the default value: `"auto"`.
+- `unit`
+  - : The unit to use in unit formatting.
+    The value is only present if `style` is `"unit"`, and is otherwise `undefined`.
+    This is the value specified in the [`options.unit`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#unit) argument in the constructor.
+- `unitDisplay`
+
+  - : The display format to use for units in unit formatting, such as "long", "short" or "narrow".
+    The value is only present if `style` is `"unit"`, and is otherwise `undefined`.
+    This is the value specified in the [`options.unitDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#unitDisplay) argument in the constructor, or the default value: `short`.
+
 - `useGrouping`
   - : Whether or not to use grouping separators to indicate "thousands", "millions" and son on.
     This is the value specified in the [`options.useGrouping`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#usegrouping) argument in the constructor, or the default value: `"auto"`.

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
@@ -18,7 +18,7 @@ selectRange(startRange, endRange)
 ### Return value
 
 A string representing the pluralization category of the `number`.
-This can be one of `zero`, `one`, `two`, `few`, `many` or `other`, that are relevant for the locale whose localization is specified in [LDML Language Plural Rules](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#rules).
+This can be one of `zero`, `one`, `two`, `few`, `many` or `other`, that are relevant for the locale whose localization is specified in [LDML Language Plural Rules](https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html).
 
 ## Description
 


### PR DESCRIPTION
FF116 adds support for Intl.NumberFormat v3 proposal. This has largely been documented already, but this fixes some omissions/does some tidy up. The work might happen across a number of PRs.

Fixes in this one:
- `Intl.NumberFormat` constructor 
  - remove the experimental inline markers for the new options.
  - Add some exceptions (might not be exhaustive - but is something.)
- `NumberFormat.resolvedOptions()` 
  - new options for trailing zeros and rounding might be returned (in addition to the `userGrouping` already indicated. These have been added.
  - Added missing results: `unit`, `unitDisplay`
  - Added cross links to the constructor docs, which define the values you might receive properly - i.e. this is just a summary - if you want detail you look in the constructor.
  - Improved the example to show more of these new options.

Other docs work can be tracked in https://github.com/mdn/content/issues/27746