### PR TITLE
Allow specifying a custom frontmatter linter config

### DIFF
--- a/scripts/front-matter_linter.js
+++ b/scripts/front-matter_linter.js
@@ -43,9 +43,7 @@ async function lintFrontMatter(filesAndDirectories, options) {
     await Promise.all(filesAndDirectories.map(resolveDirectory))
   ).flat();
 
-  options.config = JSON.parse(
-    await fs.readFile("./front-matter-config.json", "utf-8"),
-  );
+  options.config = JSON.parse(await fs.readFile(options.configFile, "utf-8"));
 
   options.validator = getAjvValidator(options.config.schema);
 
@@ -102,6 +100,10 @@ program
   .option("--fix", "Save corrected output", {
     validator: program.BOOLEAN,
     default: false,
+  })
+  .option("--config-file", "Custom configuration file", {
+    validator: program.STRING,
+    default: "./front-matter-config.json",
   })
   .argument("[files...]", "list of files and/or directories to check", {
     default: ["./files/en-us"],


### PR DESCRIPTION
This PR updates the frontmatter linter to allow specifying a custom configuration file in the command line.  This is part of work to lint the frontmatter in translated content.
