### PR TITLE
Remove redundant -nolint

### DIFF
--- a/files/en-us/webassembly/javascript_interface/compile/index.md
+++ b/files/en-us/webassembly/javascript_interface/compile/index.md
@@ -14,8 +14,8 @@ This function is useful if it is necessary to compile a module before it can be 
 
 ## Syntax
 
-```js-nolint
-WebAssembly.compile(bufferSource)
+```js
+WebAssembly.compile(bufferSource);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/en-us/webassembly/javascript_interface/compilestreaming/index.md
@@ -14,8 +14,8 @@ This function is useful if it is necessary to compile a module before it can be 
 
 ## Syntax
 
-```js-nolint
-WebAssembly.compileStreaming(source)
+```js
+WebAssembly.compileStreaming(source);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/instantiatestreaming/index.md
+++ b/files/en-us/webassembly/javascript_interface/instantiatestreaming/index.md
@@ -15,8 +15,8 @@ is the most efficient, optimized way to load Wasm code.
 
 ## Syntax
 
-```js-nolint
-WebAssembly.instantiateStreaming(source, importObject)
+```js
+WebAssembly.instantiateStreaming(source, importObject);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/module/customsections/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/customsections/index.md
@@ -11,8 +11,8 @@ of the contents of all custom sections in the given module with the given string
 
 ## Syntax
 
-```js-nolint
-WebAssembly.Module.customSections(module, sectionName)
+```js
+WebAssembly.Module.customSections(module, sectionName);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/module/exports/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/exports/index.md
@@ -12,8 +12,8 @@ array containing descriptions of all the declared exports of the given
 
 ## Syntax
 
-```js-nolint
-WebAssembly.Module.exports(module)
+```js
+WebAssembly.Module.exports(module);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/module/imports/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/imports/index.md
@@ -11,8 +11,8 @@ containing descriptions of all the declared imports of the given `Module`.
 
 ## Syntax
 
-```js-nolint
-WebAssembly.Module.imports(module)
+```js
+WebAssembly.Module.imports(module);
 ```
 
 ### Parameters

--- a/files/en-us/webassembly/javascript_interface/validate/index.md
+++ b/files/en-us/webassembly/javascript_interface/validate/index.md
@@ -12,8 +12,8 @@ code, returning whether the bytes form a valid Wasm module (`true`) or not
 
 ## Syntax
 
-```js-nolint
-WebAssembly.validate(bufferSource)
+```js
+WebAssembly.validate(bufferSource);
 ```
 
 ### Parameters


### PR DESCRIPTION
This PR removes the redundant `-nolint` from various documents in the WebAssembly JavaScript interface documentation.
