### PR TITLE
Add "system" label for system/infrastructure files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,15 @@
+system:
+  - package.json
+  - yarn.lock
+  - .github/**/*
+  - .husky/**/*
+  - .vscode/**/*
+  - .*
+  - scripts/**/*
+  - tests/**/*
+  - jest.config.json
+  - front-matter-config.json
+
 Content:Accessibility:
   - files/en-us/web/accessibility/**/*
 Content:CSS:


### PR DESCRIPTION
This PR adds a https://github.com/mdn/content/labels/system label to auto-label all infrasturcutre files as such.
