### PR TITLE
relnote(116): support dirname on textarea and input elements

### DIFF
--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -14,7 +14,7 @@ This article provides information about the changes in Firefox 116 that affect d
 
 ### HTML
 
-- The [`dirname`](/en-US/docs/Web/HTML/Element/input#htmlattrdefdirname) attribute is now supported on [`input`](/en-US/docs/Web/HTML/Element/input#dirname) and [`textarea`](/en-US/docs/Web/HTML/Element/textarea#dirname) elements.
+- The [`dirname`](/en-US/docs/Web/HTML/Element/input#dirname) attribute is now supported on [`input`](/en-US/docs/Web/HTML/Element/input#dirname) and [`textarea`](/en-US/docs/Web/HTML/Element/textarea#dirname) elements.
   This attribute allows for passing text directionality information (`ltr` or `rtl`) to the server during form submission ([Firefox bug 675943](https://bugzil.la/675943)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -14,6 +14,9 @@ This article provides information about the changes in Firefox 116 that affect d
 
 ### HTML
 
+- The [`dirname`](/en-US/docs/Web/HTML/Element/input#htmlattrdefdirname) attribute is now supported on [`input`](/en-US/docs/Web/HTML/Element/input#dirname) and [`textarea`](/en-US/docs/Web/HTML/Element/textarea#dirname) elements.
+  This attribute allows for passing text directionality information (`ltr` or `rtl`) to the server during form submission ([Firefox bug 675943](https://bugzil.la/675943)).
+
 #### Removals
 
 ### CSS

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -48,9 +48,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is `20`.
 - `dirname`
 
-  - : This attribute is used to set the text directionality of the element in a similar fashion to the [`<input>` element's `dirname` attribute](/en-US/docs/Web/HTML/Element/input#dirname).
-    The value is sent in the format `{elementName}.dir={value}` where `{value}` may be either `ltr` for left-to-right (default) or `rtl` for right-to-left.
-    The following element would send `info.dir=rtl` with form data if right-to-left text was entered into the field:
+  - : This attribute is used to set the text directionality of the element in a manner similar to the [`dirname`](/en-US/docs/Web/HTML/Element/input#dirname) attribute of the `<input>` element. Possible values include `ltr` for left-to-right and `rtl` for right-to-left. The default value is `ltr`.
+    The value of the attribute is sent in the format `{elementName}.dir={value}`, where `{elementName}` is the name of the `<input>` element and `{value}` may be `ltr` or `rtl`.
+    The following element will send `info.dir=rtl` along with form data when text is entered into the form field:
 
     ```html
     <textarea cols="90" name="info" dirname="info.dir"></textarea>

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -50,11 +50,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : This attribute is used to set the text directionality of the element in a manner similar to the [`dirname`](/en-US/docs/Web/HTML/Element/input#dirname) attribute of the `<input>` element. Possible values include `ltr` for left-to-right and `rtl` for right-to-left. The default value is `ltr`.
     The value of the attribute is sent in the format `{elementName}.dir={value}`, where `{elementName}` is the name of the `<input>` element and `{value}` may be `ltr` or `rtl`.
-    The following element will send `info.dir=rtl` along with form data when text is entered into the form field:
-
-    ```html
-    <textarea cols="90" name="info" dirname="info.dir"></textarea>
-    ```
 
 - `disabled`
   - : This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example {{ HTMLElement("fieldset") }}; if there is no containing element when the `disabled` attribute is set, the control is enabled.

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -49,7 +49,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - `dirname`
 
   - : This attribute is used to set the text directionality of the element in a manner similar to the [`dirname`](/en-US/docs/Web/HTML/Element/input#dirname) attribute of the `<input>` element. Possible values include `ltr` for left-to-right and `rtl` for right-to-left. The default value is `ltr`.
-    The value of the attribute is sent in the format `{elementName}.dir={value}`, where `{elementName}` is the name of the `<input>` element and `{value}` may be `ltr` or `rtl`.
+    The value of the attribute is sent in the format `{elementName}.dir={value}`, where `{elementName}` is the name of the `<textarea>` element and `{value}` may be `ltr` or `rtl`.
 
 - `disabled`
   - : This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example {{ HTMLElement("fieldset") }}; if there is no containing element when the `disabled` attribute is set, the control is enabled.

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -46,6 +46,16 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.
 - `cols`
   - : The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is `20`.
+- `dirname`
+
+  - : This attribute is used to set the text directionality of the element in a similar fashion to the [`<input>` element's `dirname` attribute](/en-US/docs/Web/HTML/Element/input#dirname).
+    The value is sent in the format `{elementName}.dir={value}` where `{value}` may be either `ltr` for left-to-right (default) or `rtl` for right-to-left.
+    The following element would send `info.dir=rtl` with form data if right-to-left text was entered into the field:
+
+    ```html
+    <textarea cols="90" name="info" dirname="info.dir"></textarea>
+    ```
+
 - `disabled`
   - : This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example {{ HTMLElement("fieldset") }}; if there is no containing element when the `disabled` attribute is set, the control is enabled.
 - `form`


### PR DESCRIPTION
Adding a release note for `dirname` on `<textarea>` and `<input>` elements:

```html
<form action="page.html" method="post">
  <label
    >Fruit:
    <input type="text" name="fruit" dirname="fruit.dir" value="cherry" />
  </label>
  <input type="submit" />
</form>
<!-- page.html?fruit=cherry&fruit.dir=ltr -->
```

```html
<textarea cols="90" name="info" dirname="info.dir"></textarea>
```

__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/27760
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/20109

__Bugzilla:__
- [BUG-675943](https://bugzilla.mozilla.org/show_bug.cgi?id=675943)