### PR TITLE
Swap chunk and controller parameter positions

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/signal/index.md
@@ -50,7 +50,7 @@ In this example, we use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to actual
 ```js
 const endpoint = "https://www.example.com/api"; // Fake URL for example purpose
 const writingStream = new WritableStream({
-  async write(controller, chunk) {
+  async write(chunk, controller) {
     // Write to the server using the Fetch API
     const response = await fetch(endpoint, {
       signal: controller.signal, // We use the same object for both fetch and controller


### PR DESCRIPTION
Should be `write(chunk, controller)`, is currently `write(controller, chunk)` in documentation.