### PR TITLE
Update preventDefault example to properly handle keydown event

### DIFF
--- a/files/en-us/web/api/event/preventdefault/index.md
+++ b/files/en-us/web/api/event/preventdefault/index.md
@@ -117,14 +117,13 @@ whether to allow it:
 
 ```js
 function checkName(evt) {
-  const charCode = evt.charCode;
-  if (charCode !== 0) {
-    if (charCode < 97 || charCode > 122) {
-      evt.preventDefault();
-      displayWarning(
-        "Please use lowercase letters only.\n" + `charCode: ${charCode}\n`,
-      );
-    }
+  const key = evt.key;
+  const lowerCaseAlphabet = "abcdefghijklmnopqrstuvwxyz";
+  if (!lowerCaseAlphabet.includes(key)) {
+    evt.preventDefault();
+    displayWarning(
+      "Please use lowercase letters only.\n" + `Key pressed: ${key}\n`,
+    );
   }
 }
 ```


### PR DESCRIPTION
The preventDefault example contained an outdated reference to charCode and wasn't functioning as intended

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I updated the preventDefault example to properly block the keydown events on the text input.
It looks like it previously was based off the keypress event which is deprecated, but the example handler still had old charCode references in it, and as such wasn't preventing the non lowercase letter keydown events

### Motivation

The example on the page didn't work and confused me as to why exactly preventDefault didn't seem to be doing what I thought it should do.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
