### PR TITLE
Improve var scoping/hoisting description

### DIFF
--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -84,7 +84,9 @@ The list that follows the `var` keyword is called a _{{glossary("binding")}} lis
 
 ### Hoisting
 
-`var` declarations, wherever they occur, are processed during JavaScript compilation before any code is executed. Declaring a variable anywhere in the code is equivalent to declaring it at the top. This also means that a variable can appear to be used before it's declared. This behavior is called [_hoisting_](/en-US/docs/Glossary/Hoisting), as it appears that the variable declaration is moved to the top of the function or global code.
+`var` declarations, wherever they occur in a script, are processed before any code within the script is executed. Declaring a variable anywhere in the code is equivalent to declaring it at the top. This also means that a variable can appear to be used before it's declared. This behavior is called [_hoisting_](/en-US/docs/Glossary/Hoisting), as it appears that the variable declaration is moved to the top of the function, static initialization block, or script source in which it occurs.
+
+> **Note:** `var` declarations are only hoisted to the top of the current script. If you have two `<script>` elements within one HTML, the first script cannot access variables declared by the second one.
 
 ```js
 bla = 2;

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -40,7 +40,10 @@ The scope of a variable declared with `var` is one of the following curly-brace-
 - Function body
 - [Static initialization block](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks)
 
-Or the current module or script, if it's contained in neither of these.
+Or if neither of these apply:
+
+- [Module scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) - the scope for code running in module mode. Or
+- [Global scope] - the default scope for all code running in script mode.
 
 ```js
 function foo() {
@@ -81,7 +84,7 @@ The list that follows the `var` keyword is called a _{{glossary("binding")}} lis
 
 ### Hoisting
 
-`var` declarations, wherever they occur, are processed before any code is executed. Declaring a variable anywhere in the code is equivalent to declaring it at the top. This also means that a variable can appear to be used before it's declared. This behavior is called [_hoisting_](/en-US/docs/Glossary/Hoisting), as it appears that the variable declaration is moved to the top of the function or global code.
+`var` declarations, wherever they occur, are processed during JavaScript compilation before any code is executed. Declaring a variable anywhere in the code is equivalent to declaring it at the top. This also means that a variable can appear to be used before it's declared. This behavior is called [_hoisting_](/en-US/docs/Glossary/Hoisting), as it appears that the variable declaration is moved to the top of the function or global code.
 
 ```js
 bla = 2;

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -40,10 +40,10 @@ The scope of a variable declared with `var` is one of the following curly-brace-
 - Function body
 - [Static initialization block](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks)
 
-Or if neither of these apply:
+Or if none of the above applies:
 
-- [Module scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) - the scope for code running in module mode. Or
-- [Global scope] - the default scope for all code running in script mode.
+- The current [module](/en-US/docs/Web/JavaScript/Guide/Modules), for code running in module mode
+- The global scope, for code running in script mode.
 
 ```js
 function foo() {

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -86,7 +86,7 @@ The list that follows the `var` keyword is called a _{{glossary("binding")}} lis
 
 `var` declarations, wherever they occur in a script, are processed before any code within the script is executed. Declaring a variable anywhere in the code is equivalent to declaring it at the top. This also means that a variable can appear to be used before it's declared. This behavior is called [_hoisting_](/en-US/docs/Glossary/Hoisting), as it appears that the variable declaration is moved to the top of the function, static initialization block, or script source in which it occurs.
 
-> **Note:** `var` declarations are only hoisted to the top of the current script. If you have two `<script>` elements within one HTML, the first script cannot access variables declared by the second one.
+> **Note:** `var` declarations are only hoisted to the top of the current script. If you have two `<script>` elements within one HTML, the first script cannot access variables declared by the second before the second script has been processed and executed.
 
 ```js
 bla = 2;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Remove ambiguity in `var` [Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#description)  that can be construed to mean standard scripts have their own scope.

Expand the first sentence of`var`  [Hoisting]() to explicitly say that Hoisting occurs during JavaScript compilation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Changes to the description are aimed at preventing readers from inferring that individual scripts  have "script" scope.

The change to `var` [Hoisting]() is to explicitly indicate that  `var` declarations (and hoisting) don't take effect until the script is compiled - in words that do not touch on the semantics of host environment support for separate compilation of one or more script sources.

See [Issue 27966](https://github.com/mdn/content/issues/27966) for a case study (on Stack Overflow) involving both of these proposals. 

### Related Articles

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

* [Grammar and Types > Variable Scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variable_scope)
* [Glossary > Global Scope](https://developer.mozilla.org/en-US/docs/Glossary/Global_scope)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #27966
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
