### PR TITLE
Markdownlint config: use named rules vs. numerical rules

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,35 +1,38 @@
+// This file defines our configuration for Markdownlint. See
+// https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+// for more details on each rule.
+
 {
   "config": {
     "default": true,
-    // MD001 - Heading levels should only increment by one level at a time.
-    // -> Disabled, as some callouts include headings.
-    "MD001": false,
-    "MD004": {
+    // Disabled, as some callouts include headings.
+    "header-increment": false,
+    "ul-style": {
       "style": "dash"
     },
-    "MD007": {
+    "ul-indent": {
       "indent": 2
     },
-    "MD010": {
+    "no-hard-tabs": {
       "spaces_per_tab": 2
     },
-    "MD013": false,
-    "MD024": {
+    "line-length": false,
+    "no-duplicate-header": {
       "allow_different_nesting": true
     },
-    "MD025": {
+    "single-title": {
       "front_matter_title": "^\\s*title\\s*[:=]"
     },
-    "MD026": {
+    "no-trailing-punctuation": {
       "punctuation": ".,;:"
     },
     // Consecutive Notes/Callouts currently don't conform with this rule
-    "MD028": false,
+    "no-blanks-blockquote": false,
     // Force ordered numbering to catch accidental list ending from indenting
-    "MD029": {
+    "ol-prefix": {
       "style": "ordered"
     },
-    "MD033": {
+    "no-inline-html": {
       "allowed_elements": [
         "a",
         "abbr",
@@ -100,24 +103,25 @@
         "var"
       ]
     },
-    "MD034": false,
+    "no-bare-urls": false,
     // Produces too many false positives
-    "MD037": false,
-    "MD040": false,
+    "no-space-in-emphasis": false,
+    "fenced-code-language": false,
     // See https://github.com/mdn/content/pull/20026, as macros currently break this
-    "MD042": false,
-    "MD046": {
+    "no-empty-links": false,
+    "code-block-style": {
       "style": "fenced"
     },
-    "MD049": {
+    "emphasis-style": {
       "style": "underscore"
     },
-    "MD050": {
+    "strong-style": {
       "style": "asterisk"
     },
-    // MD051 - Link fragments should be valid.
-    // -> Disabled, as yari generates link fragments by replacing spaces with underscores, not dashes.
-    "MD051": false,
+    // Disabled, as yari generates link fragments by replacing spaces with underscores, not dashes.
+    "link-fragments": false,
+
+    // https://github.com/OnkarRuikar/markdownlint-rule-search-replace
     "search-replace": {
       "rules": [
         {


### PR DESCRIPTION
This PR updates the Markdownlint config to use named rules in place of the numerical rules like we currently have.  This makes it MUCH easier to immediately understand what each rule means without having to refer to a separate document to translate what each rule number means.

Additionally, this adds a few extra comments, one at the top to point to the Markdownlint version we're using, and a link to the repository for the custom search-replace rule we're using.
