### PR TITLE
Put syntax examples in the right place

### DIFF
--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -12,6 +12,8 @@ browser-compat: css.properties.-moz-float-edge
 
 The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property specifies whether the height and width properties of the element include the margin, border, or padding thickness.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -moz-float-edge: border-box;
@@ -24,8 +26,6 @@ The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property speci
 -moz-float-edge: initial;
 -moz-float-edge: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-moz-image-region/index.md
+++ b/files/en-us/web/css/-moz-image-region/index.md
@@ -11,6 +11,12 @@ browser-compat: css.properties.-moz-image-region
 
 For certain XUL elements and pseudo-elements that use an image from the {{CSSxRef("list-style-image")}} property, this property specifies a region of the image that is used in place of the whole image. This allows elements to use different pieces of the same image to improve performance.
 
+The syntax is similar to the {{CSSxRef("clip")}} property. All four values are relative to the upper left corner of the image.
+
+> **Note:** For a system that works on any background, see {{CSSxRef("-moz-image-rect")}}.
+
+## Syntax
+
 ```css
 /* Keyword value */
 -moz-image-region: auto;
@@ -23,12 +29,6 @@ For certain XUL elements and pseudo-elements that use an image from the {{CSSxRe
 -moz-image-region: initial;
 -moz-image-region: unset;
 ```
-
-The syntax is similar to the {{CSSxRef("clip")}} property. All four values are relative to the upper left corner of the image.
-
-> **Note:** For a system that works on any background, see {{CSSxRef("-moz-image-rect")}}.
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -11,6 +11,10 @@ browser-compat: css.properties.-moz-user-focus
 
 The **`-moz-user-focus`** [CSS](/en-US/docs/Web/CSS) property is used to indicate whether an element can have the focus.
 
+By setting its value to `ignore`, you can disable focusing the element, which means that the user will not be able to activate the element. The element will be skipped in the tab sequence.
+
+## Syntax
+
 ```css
 /* Keyword values */
 -moz-user-focus: normal;
@@ -21,10 +25,6 @@ The **`-moz-user-focus`** [CSS](/en-US/docs/Web/CSS) property is used to indicat
 -moz-user-focus: initial;
 -moz-user-focus: unset;
 ```
-
-By setting its value to `ignore`, you can disable focusing the element, which means that the user will not be able to activate the element. The element will be skipped in the tab sequence.
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -12,6 +12,12 @@ browser-compat: css.properties.-moz-user-input
 
 In Mozilla applications, **`-moz-user-input`** determines if an element will accept user input.
 
+For elements that normally take user input, such as a {{HTMLElement("textarea")}}, the initial value of `-moz-user-input` is `enabled`.
+
+> **Note:** `-moz-user-input` was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, `user-focus`, was proposed in [early drafts of a predecessor of the User Interface for CSS3 specification](https://www.w3.org/TR/2000/WD-css3-userint-20000216), but was rejected by the working group.
+
+## Syntax
+
 ```css
 /* Keyword values */
 -moz-user-input: none;
@@ -23,12 +29,6 @@ In Mozilla applications, **`-moz-user-input`** determines if an element will acc
 -moz-user-input: initial;
 -moz-user-input: unset;
 ```
-
-For elements that normally take user input, such as a {{HTMLElement("textarea")}}, the initial value of `-moz-user-input` is `enabled`.
-
-> **Note:** `-moz-user-input` was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, `user-focus`, was proposed in [early drafts of a predecessor of the User Interface for CSS3 specification](https://www.w3.org/TR/2000/WD-css3-userint-20000216), but was rejected by the working group.
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-box-reflect/index.md
+++ b/files/en-us/web/css/-webkit-box-reflect/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-box-reflect
 
 The **`-webkit-box-reflect`** [CSS](/en-US/docs/Web/CSS) property lets you reflect the content of an element in one specific direction.
 
+## Syntax
+
 ```css
 /* Direction values */
 -webkit-box-reflect: above;
@@ -31,8 +33,6 @@ The **`-webkit-box-reflect`** [CSS](/en-US/docs/Web/CSS) property lets you refle
 -webkit-box-reflect: revert-layer;
 -webkit-box-reflect: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-attachment/index.md
+++ b/files/en-us/web/css/-webkit-mask-attachment/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-mask-attachment
 
 If a {{CSSxRef("mask-image")}} is specified, `-webkit-mask-attachment` determines whether the mask image's position is fixed within the viewport, or scrolls along with its containing block.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-attachment: scroll;
@@ -28,8 +30,6 @@ If a {{CSSxRef("mask-image")}} is specified, `-webkit-mask-attachment` determine
 -webkit-mask-attachment: revert-layer;
 -webkit-mask-attachment: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-composite/index.md
+++ b/files/en-us/web/css/-webkit-mask-composite/index.md
@@ -11,6 +11,10 @@ browser-compat: css.properties.-webkit-mask-composite
 
 The **`-webkit-mask-composite`** property specifies the manner in which multiple mask images applied to the same element are composited with one another. Mask images are composited in the opposite order that they are declared with the {{CSSxRef("mask-image", "-webkit-mask-image")}} property.
 
+> **Note:** There is a standardized {{CSSxRef("mask-composite")}} property covering parts of this non-standard property using different keywords.
+
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-composite: clear;
@@ -32,10 +36,6 @@ The **`-webkit-mask-composite`** property specifies the manner in which multiple
 -webkit-mask-composite: revert-layer;
 -webkit-mask-composite: unset;
 ```
-
-> **Note:** There is a standardized {{CSSxRef("mask-composite")}} property covering parts of this non-standard property using different keywords.
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -28,7 +28,10 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 -webkit-mask-position-x: -1cm;
 
 /* Multiple values */
--webkit-mask-position-x: 50px, 25%, -3em;
+-webkit-mask-position-x:
+  50px,
+  25%,
+  -3em;
 
 /* Global values */
 -webkit-mask-position-x: inherit;

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-mask-position-x
 
 The `-webkit-mask-position-x` CSS property sets the initial horizontal position of a mask image.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-position-x: left;
@@ -26,10 +28,7 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 -webkit-mask-position-x: -1cm;
 
 /* Multiple values */
--webkit-mask-position-x:
-  50px,
-  25%,
-  -3em;
+-webkit-mask-position-x: 50px, 25%, -3em;
 
 /* Global values */
 -webkit-mask-position-x: inherit;
@@ -38,8 +37,6 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 -webkit-mask-position-x: revert-layer;
 -webkit-mask-position-x: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-mask-position-y
 
 The `-webkit-mask-position-y` CSS property sets the initial vertical position of a mask image.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-position-y: top;
@@ -26,10 +28,7 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 -webkit-mask-position-y: -1cm;
 
 /* Multiple values */
--webkit-mask-position-y:
-  50px,
-  25%,
-  -3em;
+-webkit-mask-position-y: 50px, 25%, -3em;
 
 /* Global values */
 -webkit-mask-position-y: inherit;
@@ -38,8 +37,6 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 -webkit-mask-position-y: revert-layer;
 -webkit-mask-position-y: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -28,7 +28,10 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 -webkit-mask-position-y: -1cm;
 
 /* Multiple values */
--webkit-mask-position-y: 50px, 25%, -3em;
+-webkit-mask-position-y:
+  50px,
+  25%,
+  -3em;
 
 /* Global values */
 -webkit-mask-position-y: inherit;

--- a/files/en-us/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-x/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-mask-repeat-x
 
 The `-webkit-mask-repeat-x` property specifies whether and how a mask image is repeated (tiled) horizontally.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-repeat-x: repeat;
@@ -28,8 +30,6 @@ The `-webkit-mask-repeat-x` property specifies whether and how a mask image is r
 -webkit-mask-repeat-x: revert-layer;
 -webkit-mask-repeat-x: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-y/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-mask-repeat-y
 
 The `-webkit-mask-repeat-y` property sets whether and how a mask image is repeated (tiled) vertically.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-mask-repeat-y: repeat;
@@ -28,8 +30,6 @@ The `-webkit-mask-repeat-y` property sets whether and how a mask image is repeat
 -webkit-mask-repeat-y: revert-layer;
 -webkit-mask-repeat-y: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/en-us/web/css/-webkit-tap-highlight-color/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.-webkit-tap-highlight-color
 
 **`-webkit-tap-highlight-color`** is a non-standard CSS property that sets the color of the highlight that appears over a link while it's being tapped. The highlighting indicates to the user that their tap is being successfully recognized, and indicates which element they're tapping on.
 
+## Syntax
+
 ```css
 -webkit-tap-highlight-color: red;
 -webkit-tap-highlight-color: transparent; /* for removing the highlight */
@@ -22,8 +24,6 @@ browser-compat: css.properties.-webkit-tap-highlight-color
 -webkit-tap-highlight-color: revert-layer;
 -webkit-tap-highlight-color: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-text-stroke-color/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke-color/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.-webkit-text-stroke-color
 
 The **`-webkit-text-stroke-color`** CSS property specifies the stroke [color](/en-US/docs/Web/CSS/color_value) of characters of text. If this property is not set, the value of the {{cssxref("color")}} property is used.
 
+## Syntax
+
 ```css
 /* <color> values */
 -webkit-text-stroke-color: red;
@@ -22,8 +24,6 @@ The **`-webkit-text-stroke-color`** CSS property specifies the stroke [color](/e
 -webkit-text-stroke-color: revert-layer;
 -webkit-text-stroke-color: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/-webkit-touch-callout/index.md
+++ b/files/en-us/web/css/-webkit-touch-callout/index.md
@@ -13,6 +13,8 @@ The `-webkit-touch-callout` [CSS](/en-US/docs/Web/CSS) property controls the dis
 
 When a target is touched and held on iOS, Safari displays a callout information about the link. This property allows disabling that behavior.
 
+## Syntax
+
 ```css
 /* Keyword values */
 -webkit-touch-callout: default;
@@ -25,8 +27,6 @@ When a target is touched and held on iOS, Safari displays a callout information 
 -webkit-touch-callout: revert-layer;
 -webkit-touch-callout: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/background-image/index.md
+++ b/files/en-us/web/css/background-image/index.md
@@ -21,10 +21,6 @@ If a specified image cannot be drawn (for example, when the file denoted by the 
 
 ## Syntax
 
-Each background image is specified either as the keyword `none` or as an {{cssxref("&lt;image&gt;")}} value.
-
-To specify multiple background images, supply multiple values, separated by a comma:
-
 ```css
 background-image: linear-gradient(
     to bottom,
@@ -39,6 +35,10 @@ background-image: revert;
 background-image: revert-layer;
 background-image: unset;
 ```
+
+Each background image is specified either as the keyword `none` or as an {{cssxref("&lt;image&gt;")}} value.
+
+To specify multiple background images, supply multiple values, separated by a comma.
 
 ### Values
 

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -76,7 +76,7 @@ box-align =
 ### Setting box alignment
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -16,6 +16,10 @@ The **`box-align`** [CSS](/en-US/docs/Web/CSS) property specifies how an element
 
 See [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox) for information about the current standard.
 
+The direction of layout depends on the element's orientation: horizontal or vertical.
+
+## Syntax
+
 ```css
 /* Keyword values */
 box-align: start;
@@ -29,10 +33,6 @@ box-lines: inherit;
 box-lines: initial;
 box-lines: unset;
 ```
-
-The direction of layout depends on the element's orientation: horizontal or vertical.
-
-## Syntax
 
 The `box-align` property is specified as one of the keyword values listed below.
 
@@ -76,7 +76,7 @@ box-align =
 ### Setting box alignment
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />

--- a/files/en-us/web/css/box-direction/index.md
+++ b/files/en-us/web/css/box-direction/index.md
@@ -14,6 +14,8 @@ browser-compat: css.properties.box-direction
 
 The **`box-direction`** [CSS](/en-US/docs/Web/CSS) property specifies whether a box lays out its contents normally (from the top or left edge), or in reverse (from the bottom or right edge).
 
+## Syntax
+
 ```css
 /* Keyword values */
 box-direction: normal;
@@ -26,8 +28,6 @@ box-direction: revert;
 box-direction: revert-layer;
 box-direction: unset;
 ```
-
-## Syntax
 
 The `box-direction` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/box-flex-group/index.md
+++ b/files/en-us/web/css/box-flex-group/index.md
@@ -14,6 +14,12 @@ browser-compat: css.properties.box-flex-group
 
 The **`box-flex-group`** [CSS](/en-US/docs/Web/CSS) property assigns the flexbox's child elements to a flex group.
 
+For flexible elements assigned to flex groups, the first flex group is 1 and higher values specify subsequent flex groups. The initial value is 1. When dividing up the box's extra space, the browser first considers all elements within the first flex group. Each element within that group is given extra space based on the ratio of that element's flexibility compared to the flexibility of other elements within the same flex group. If the space of all flexible children within the group has been increased to the maximum, the process repeats for the children within the next flex group, using any space left over from the previous flex group. Once there are no more flex groups, and there is still space remaining, the extra space is divided within the containing box according to the {{cssxref("box-pack")}} property.
+
+If the box would overflow after the preferred space of the children has been computed, then space is removed from flexible elements in a manner similar to that used when adding extra space. Each flex group is examined in turn and space is removed according to the ratio of the flexibility of each element. Elements do not shrink below their minimum widths.
+
+## Syntax
+
 ```css
 /* <integer> values */
 box-flex-group: 1;
@@ -24,12 +30,6 @@ box-flex-group: inherit;
 box-flex-group: initial;
 box-flex-group: unset;
 ```
-
-For flexible elements assigned to flex groups, the first flex group is 1 and higher values specify subsequent flex groups. The initial value is 1. When dividing up the box's extra space, the browser first considers all elements within the first flex group. Each element within that group is given extra space based on the ratio of that element's flexibility compared to the flexibility of other elements within the same flex group. If the space of all flexible children within the group has been increased to the maximum, the process repeats for the children within the next flex group, using any space left over from the previous flex group. Once there are no more flex groups, and there is still space remaining, the extra space is divided within the containing box according to the {{cssxref("box-pack")}} property.
-
-If the box would overflow after the preferred space of the children has been computed, then space is removed from flexible elements in a manner similar to that used when adding extra space. Each flex group is examined in turn and space is removed according to the ratio of the flexibility of each element. Elements do not shrink below their minimum widths.
-
-## Syntax
 
 The `box-flex-group` property is specified as any positive {{CSSxRef("&lt;integer&gt;")}}.
 

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -72,7 +72,7 @@ box-flex =
 ### Setting box-flex
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -14,6 +14,8 @@ browser-compat: css.properties.box-flex
 
 The **`-moz-box-flex`** and **`-webkit-box-flex`** [CSS](/en-US/docs/Web/CSS) properties specify how a `-moz-box` or `-webkit-box` grows to fill the box that contains it, in the direction of the containing box's layout.
 
+## Syntax
+
 ```css
 /* <number> values */
 -moz-box-flex: 0;
@@ -35,8 +37,6 @@ The **`-moz-box-flex`** and **`-webkit-box-flex`** [CSS](/en-US/docs/Web/CSS) pr
 -webkit-box-flex: revert-layer;
 -webkit-box-flex: unset;
 ```
-
-## Syntax
 
 The `box-flex` property is specified as a {{CSSxRef("&lt;number&gt;")}}. If the value is 0, the box does not grow. If it is greater than 0, the box grows to fill a proportion of the available space.
 
@@ -72,7 +72,7 @@ box-flex =
 ### Setting box-flex
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />

--- a/files/en-us/web/css/box-lines/index.md
+++ b/files/en-us/web/css/box-lines/index.md
@@ -14,17 +14,6 @@ browser-compat: css.properties.box-lines
 
 The **`box-lines`** [CSS](/en-US/docs/Web/CSS) property determines whether the box may have a single or multiple lines (rows for horizontally oriented boxes, columns for vertically oriented boxes).
 
-```css
-/* Keyword values */
-box-lines: single;
-box-lines: multiple;
-
-/* Global values */
-box-lines: inherit;
-box-lines: initial;
-box-lines: unset;
-```
-
 By default a horizontal box will lay out its children in a single row, and a vertical box will lay out its children in a single column. This behavior can be changed using the `box-lines` property. The default value is `single`, which means that all elements will be placed in a single row or column, and any elements that don't fit will be considered overflow.
 
 If a value of `multiple` is specified, however, then the box is allowed to expand to multiple lines (that is, multiple rows or columns) in order to accommodate all of its children. The box must attempt to fit its children on as few lines as possible by shrinking all elements down to their minimum widths or heights if necessary.
@@ -36,6 +25,17 @@ A similar process occurs for children in a vertical box. Later lines in normal d
 Once the number of lines has been determined, elements with a computed value for {{CSSxRef("box-flex")}} other than `0` stretch as necessary in an attempt to fill the remaining space on the lines. Each line computes flexes independently, so only elements on that line are considered when evaluating {{CSSxRef("box-flex")}} and {{CSSxRef("box-flex-groups")}}. The packing of elements in a line, as specified by the {{CSSxRef("box-pack")}} property, is also computed independently for each line.
 
 ## Syntax
+
+```css
+/* Keyword values */
+box-lines: single;
+box-lines: multiple;
+
+/* Global values */
+box-lines: inherit;
+box-lines: initial;
+box-lines: unset;
+```
 
 The `box-lines` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/box-ordinal-group/index.md
+++ b/files/en-us/web/css/box-ordinal-group/index.md
@@ -14,6 +14,10 @@ browser-compat: css.properties.box-ordinal-group
 
 The **`box-ordinal-group`** [CSS](/en-US/docs/Web/CSS) property assigns the flexbox's child elements to an ordinal group.
 
+Ordinal groups may be used in conjunction with the {{CSSxRef("box-direction")}} property to control the order in which the direct children of a box appear. When the computed `box-direction` is normal, a box will display its elements starting from the lowest numbered ordinal group and ensure that those elements appear to the left (for horizontal boxes) or at the top (for vertical boxes) of the container. Elements with the same ordinal group are flowed in the order they appear in the source document tree. In the reverse direction, the ordinal groups are examined in the same order, except the elements appear reversed.
+
+## Syntax
+
 ```css
 /* <integer> values */
 box-ordinal-group: 1;
@@ -24,10 +28,6 @@ box-ordinal-group: inherit;
 box-ordinal-group: initial;
 box-ordinal-group: unset;
 ```
-
-Ordinal groups may be used in conjunction with the {{CSSxRef("box-direction")}} property to control the order in which the direct children of a box appear. When the computed `box-direction` is normal, a box will display its elements starting from the lowest numbered ordinal group and ensure that those elements appear to the left (for horizontal boxes) or at the top (for vertical boxes) of the container. Elements with the same ordinal group are flowed in the order they appear in the source document tree. In the reverse direction, the ordinal groups are examined in the same order, except the elements appear reversed.
-
-## Syntax
 
 The `box-ordinal-group` property is specified as any positive {{CSSxRef("&lt;integer&gt;")}}.
 

--- a/files/en-us/web/css/box-orient/index.md
+++ b/files/en-us/web/css/box-orient/index.md
@@ -14,6 +14,8 @@ browser-compat: css.properties.box-orient
 
 The **`box-orient`** [CSS](/en-US/docs/Web/CSS) property sets whether an element lays out its contents horizontally or vertically.
 
+## Syntax
+
 ```css
 /* Keyword values */
 box-orient: horizontal;
@@ -26,8 +28,6 @@ box-orient: inherit;
 box-orient: initial;
 box-orient: unset;
 ```
-
-## Syntax
 
 The `box-orient` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/box-pack/index.md
+++ b/files/en-us/web/css/box-pack/index.md
@@ -14,6 +14,10 @@ browser-compat: css.properties.box-pack
 
 The **`-moz-box-pack`** and **`-webkit-box-pack`** [CSS](/en-US/docs/Web/CSS) properties specify how a `-moz-box` or `-webkit-box` packs its contents in the direction of its layout. The effect of this is only visible if there is extra space in the box.
 
+The direction of layout depends on the element's orientation: horizontal or vertical.
+
+## Syntax
+
 ```css
 /* Keyword values */
 box-pack: start;
@@ -26,10 +30,6 @@ box-pack: inherit;
 box-pack: initial;
 box-pack: unset;
 ```
-
-The direction of layout depends on the element's orientation: horizontal or vertical.
-
-## Syntax
 
 The `box-pack` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/column-span/index.md
+++ b/files/en-us/web/css/column-span/index.md
@@ -11,6 +11,10 @@ The **`column-span`** [CSS](/en-US/docs/Web/CSS) property makes it possible for 
 
 {{EmbedInteractiveExample("pages/css/column-span.html")}}
 
+An element that spans more than one column is called a **spanning element**.
+
+## Syntax
+
 ```css
 /* Keyword values */
 column-span: none;
@@ -23,10 +27,6 @@ column-span: revert;
 column-span: revert-layer;
 column-span: unset;
 ```
-
-An element that spans more than one column is called a **spanning element**.
-
-## Syntax
 
 The `column-span` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -15,8 +15,6 @@ Formally, the **`display`** property sets an element's inner and outer _display 
 
 ## Syntax
 
-The CSS `display` property is specified using keyword values.
-
 ```css
 /* precomposed values */
 display: block;
@@ -54,6 +52,8 @@ display: revert;
 display: revert-layer;
 display: unset;
 ```
+
+The CSS `display` property is specified using keyword values.
 
 ## Grouped values
 

--- a/files/en-us/web/css/font-language-override/index.md
+++ b/files/en-us/web/css/font-language-override/index.md
@@ -9,6 +9,12 @@ browser-compat: css.properties.font-language-override
 
 The **`font-language-override`** CSS property controls the use of language-specific glyphs in a typeface.
 
+By default, HTML's `lang` attribute tells browsers to display glyphs designed specifically for that language. For example, a lot of fonts have a special character for the digraph `fi` that merge the dot on the "i" with the "f." However, if the language is set to Turkish the typeface will likely know not to use the merged glyph; Turkish has two versions of the "i," one with a dot (`i`) and one without (`ı`), and using the ligature would incorrectly transform a dotted "i" into a dotless "i."
+
+The `font-language-override` property lets you override the typeface behavior for a specific language. This is useful, for example, when the typeface you're using lacks proper support for the language. For instance, if a typeface doesn't have proper rules for the Azeri language, you can force the font to use Turkish glyphs, which follow similar rules.
+
+## Syntax
+
 ```css
 /* Keyword value */
 font-language-override: normal;
@@ -24,12 +30,6 @@ font-language-override: revert;
 font-language-override: revert-layer;
 font-language-override: unset;
 ```
-
-By default, HTML's `lang` attribute tells browsers to display glyphs designed specifically for that language. For example, a lot of fonts have a special character for the digraph `fi` that merge the dot on the "i" with the "f." However, if the language is set to Turkish the typeface will likely know not to use the merged glyph; Turkish has two versions of the "i," one with a dot (`i`) and one without (`ı`), and using the ligature would incorrectly transform a dotted "i" into a dotless "i."
-
-The `font-language-override` property lets you override the typeface behavior for a specific language. This is useful, for example, when the typeface you're using lacks proper support for the language. For instance, if a typeface doesn't have proper rules for the Azeri language, you can force the font to use Turkish glyphs, which follow similar rules.
-
-## Syntax
 
 The `font-language-override` property is specified as the keyword `normal` or a `<string>`.
 

--- a/files/en-us/web/css/font-size-adjust/index.md
+++ b/files/en-us/web/css/font-size-adjust/index.md
@@ -9,6 +9,19 @@ browser-compat: css.properties.font-size-adjust
 
 The **`font-size-adjust`** [CSS](/en-US/docs/Web/CSS) property sets the size of lower-case letters relative to the current font size (which defines the size of upper-case letters).
 
+The property is useful since the legibility of fonts, especially at small sizes, is determined more by the size of lowercase letters than by the size of capital letters. Legibility can become an issue when the first-choice {{ Cssxref("font-family") }} is unavailable and its replacement has a significantly different aspect ratio (the ratio of the size of lowercase letters to the size of the font).
+
+To use this property in a way that is compatible with browsers that do not support `font-size-adjust`, it is specified as a number that the {{ Cssxref("font-size") }} property is multiplied by. This means the value specified for the property should generally be the aspect ratio of the first choice font. For example, consider this style sheet:
+
+```css
+font-size: 14px;
+font-size-adjust: 0.5;
+```
+
+It is really specifying that the lowercase letters of the font should be `7px` high (0.5 × 14px). This will still produce reasonable results in browsers that do not support `font-size-adjust`, where a `14px` font will be used.
+
+## Syntax
+
 ```css
 /* Use the specified font size */
 font-size-adjust: none;
@@ -27,19 +40,6 @@ font-size-adjust: revert;
 font-size-adjust: revert-layer;
 font-size-adjust: unset;
 ```
-
-The property is useful since the legibility of fonts, especially at small sizes, is determined more by the size of lowercase letters than by the size of capital letters. Legibility can become an issue when the first-choice {{ Cssxref("font-family") }} is unavailable and its replacement has a significantly different aspect ratio (the ratio of the size of lowercase letters to the size of the font).
-
-To use this property in a way that is compatible with browsers that do not support `font-size-adjust`, it is specified as a number that the {{ Cssxref("font-size") }} property is multiplied by. This means the value specified for the property should generally be the aspect ratio of the first choice font. For example, consider this style sheet:
-
-```css
-font-size: 14px;
-font-size-adjust: 0.5;
-```
-
-It is really specifying that the lowercase letters of the font should be `7px` high (0.5 × 14px). This will still produce reasonable results in browsers that do not support `font-size-adjust`, where a `14px` font will be used.
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/font-variant-alternates/index.md
+++ b/files/en-us/web/css/font-variant-alternates/index.md
@@ -9,6 +9,12 @@ browser-compat: css.properties.font-variant-alternates
 
 The **`font-variant-alternates`** CSS property controls the usage of alternate glyphs. These alternate glyphs may be referenced by alternative names defined in {{cssxref("@font-feature-values")}}.
 
+The {{cssxref("@font-feature-values")}} at-rule can be used to associate, for a given font face, a human-readable name with a numeric index that controls a particular OpenType font feature. For features that select alternative glyphs (`stylistic`, `styleset`, `character-variant`, `swash`, `ornament` or `annotation`), the `font-variant-alternates` property can then reference the human-readable name in order to apply the associated feature.
+
+This allows CSS rules to enable alternative glyphs without needing to know the specific index values that a particular font uses to control them.
+
+## Syntax
+
 ```css
 /* Keyword values */
 font-variant-alternates: normal;
@@ -30,12 +36,6 @@ font-variant-alternates: revert;
 font-variant-alternates: revert-layer;
 font-variant-alternates: unset;
 ```
-
-The {{cssxref("@font-feature-values")}} at-rule can be used to associate, for a given font face, a human-readable name with a numeric index that controls a particular OpenType font feature. For features that select alternative glyphs (`stylistic`, `styleset`, `character-variant`, `swash`, `ornament` or `annotation`), the `font-variant-alternates` property can then reference the human-readable name in order to apply the associated feature.
-
-This allows CSS rules to enable alternative glyphs without needing to know the specific index values that a particular font uses to control them.
-
-## Syntax
 
 This property may take one of two forms:
 

--- a/files/en-us/web/css/font-variant-position/index.md
+++ b/files/en-us/web/css/font-variant-position/index.md
@@ -11,6 +11,12 @@ The **`font-variant-position`** CSS property controls the use of alternate, smal
 
 The glyphs are positioned relative to the baseline of the font, which remains unchanged. These glyphs are typically used in {{HTMLElement("sub")}} and {{HTMLElement("sup")}} elements.
 
+When the usage of these alternate glyphs is activated, if one character in the run doesn't have such a typographically-enhanced glyph, the whole set of characters of the run is rendered using a fallback method, synthesizing these glyphs.
+
+These alternate glyphs share the same em-box and the same baseline as the rest of the font. They are merely graphically enhanced, and have no effect on the line-height and other box characteristics.
+
+## Syntax
+
 ```css
 /* Keyword values */
 font-variant-position: normal;
@@ -24,12 +30,6 @@ font-variant-position: revert;
 font-variant-position: revert-layer;
 font-variant-position: unset;
 ```
-
-When the usage of these alternate glyphs is activated, if one character in the run doesn't have such a typographically-enhanced glyph, the whole set of characters of the run is rendered using a fallback method, synthesizing these glyphs.
-
-These alternate glyphs share the same em-box and the same baseline as the rest of the font. They are merely graphically enhanced, and have no effect on the line-height and other box characteristics.
-
-## Syntax
 
 The `font-variant-position` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.hanging-punctuation
 
 The **`hanging-punctuation`** [CSS](/en-US/docs/Web/CSS) property specifies whether a punctuation mark should hang at the start or end of a line of text. Hanging punctuation may be placed outside the line box.
 
+## Syntax
+
 ```css
 /* Keyword values */
 hanging-punctuation: none;
@@ -35,8 +37,6 @@ hanging-punctuation: revert;
 hanging-punctuation: revert-layer;
 hanging-punctuation: unset;
 ```
-
-## Syntax
 
 The `hanging-punctuation` property may be specified with one, two, or three space-separated values.
 

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -15,12 +15,12 @@ Both automatic and soft hyphens are displayed according to the specified hyphena
 
 ## Syntax
 
-The value either sets the string to use instead of a hyphen, or indicates that the user agent should select an appropriate string based on the current typographic conventions (default).
-
 ```css
 hyphenate-character: <string>;
 hyphenate-character: auto;
 ```
+
+The value either sets the string to use instead of a hyphen, or indicates that the user agent should select an appropriate string based on the current typographic conventions (default).
 
 ### Values
 

--- a/files/en-us/web/css/initial-letter-align/index.md
+++ b/files/en-us/web/css/initial-letter-align/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.initial-letter-align
 
 The **`initial-letter-align`** CSS property specifies the alignment of initial letters within a paragraph.
 
+## Syntax
+
 ```css
 /* Keyword values */
 initial-letter-align: auto;
@@ -25,8 +27,6 @@ initial-letter-align: revert;
 initial-letter-align: revert-layer;
 initial-letter-align: unset;
 ```
-
-## Syntax
 
 One of the keyword values listed below.
 

--- a/files/en-us/web/css/initial-letter/index.md
+++ b/files/en-us/web/css/initial-letter/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.initial-letter
 
 The `initial-letter` CSS property sets styling for dropped, raised, and sunken initial letters.
 
+## Syntax
+
 ```css
 /* Keyword values */
 initial-letter: normal;
@@ -28,8 +30,6 @@ initial-letter: revert;
 initial-letter: revert-layer;
 initial-letter: unset;
 ```
-
-## Syntax
 
 The keyword value `normal`, or a `<number>` optionally followed by an `<integer>`.
 

--- a/files/en-us/web/css/line-height-step/index.md
+++ b/files/en-us/web/css/line-height-step/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.line-height-step
 
 The **`line-height-step`** CSS property sets the step unit for line box heights. When the property is set, line box heights are rounded up to the closest multiple of the unit.
 
+## Syntax
+
 ```css
 /* Point values */
 line-height-step: 18pt;
@@ -22,8 +24,6 @@ line-height-step: revert;
 line-height-step: revert-layer;
 line-height-step: unset;
 ```
-
-## Syntax
 
 The `line-height-step` property is specified as any one of the following:
 

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.mask-clip
 
 The **`mask-clip`** [CSS](/en-US/docs/Web/CSS) property determines the area which is affected by a mask. The painted content of an element must be restricted to this area.
 
+## Syntax
+
 ```css
 /* <geometry-box> values */
 mask-clip: content-box;
@@ -39,8 +41,6 @@ mask-clip: revert;
 mask-clip: revert-layer;
 mask-clip: unset;
 ```
-
-## Syntax
 
 One or more of the keyword values listed below, separated by commas.
 

--- a/files/en-us/web/css/mask-composite/index.md
+++ b/files/en-us/web/css/mask-composite/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.mask-composite
 
 The **`mask-composite`** [CSS](/en-US/docs/Web/CSS) property represents a compositing operation used on the current mask layer with the mask layers below it.
 
+## Syntax
+
 ```css
 /* Keyword values */
 mask-composite: add;
@@ -23,8 +25,6 @@ mask-composite: revert;
 mask-composite: revert-layer;
 mask-composite: unset;
 ```
-
-## Syntax
 
 One or more of the keyword values listed below, separated by commas.
 

--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -10,6 +10,8 @@ browser-compat: css.properties.mask-image
 The **`mask-image`** [CSS](/en-US/docs/Web/CSS) property sets the image that is used as mask layer for an element.
 By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the {{cssxref("mask-mode")}} property.
 
+## Syntax
+
 ```css
 /* Keyword value */
 mask-image: none;
@@ -31,8 +33,6 @@ mask-image: revert;
 mask-image: revert-layer;
 mask-image: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/mask-mode/index.md
+++ b/files/en-us/web/css/mask-mode/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.mask-mode
 
 The **`mask-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether the mask reference defined by {{cssxref("mask-image")}} is treated as a luminance or alpha mask.
 
+## Syntax
+
 ```css
 /* Keyword values */
 mask-mode: alpha;
@@ -25,8 +27,6 @@ mask-mode: revert;
 mask-mode: revert-layer;
 mask-mode: unset;
 ```
-
-## Syntax
 
 The `mask-mode` property is specified as one or more of the keyword values listed below, separated by commas.
 

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.mask-origin
 
 The **`mask-origin`** [CSS](/en-US/docs/Web/CSS) property sets the origin of a mask.
 
+For elements rendered as a single box, this property specifies the mask positioning area. In other words, this property specifies the origin position of an image specified by the {{cssxref("mask-image")}} CSS property. For elements rendered as multiple boxes, such as inline boxes on several lines or boxes on several pages, it specifies which boxes {{cssxref("box-decoration-break")}} operates upon to determine the mask positioning area.
+
+## Syntax
+
 ```css
 /* Keyword values */
 mask-origin: content-box;
@@ -35,10 +39,6 @@ mask-origin: revert;
 mask-origin: revert-layer;
 mask-origin: unset;
 ```
-
-For elements rendered as a single box, this property specifies the mask positioning area. In other words, this property specifies the origin position of an image specified by the {{cssxref("mask-image")}} CSS property. For elements rendered as multiple boxes, such as inline boxes on several lines or boxes on several pages, it specifies which boxes {{cssxref("box-decoration-break")}} operates upon to determine the mask positioning area.
-
-## Syntax
 
 One or more of the keyword values listed below, separated by commas.
 

--- a/files/en-us/web/css/mask-position/index.md
+++ b/files/en-us/web/css/mask-position/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.mask-position
 
 The **`mask-position`** [CSS](/en-US/docs/Web/CSS) property sets the initial position, relative to the mask position layer set by {{cssxref("mask-origin")}}, for each defined mask image.
 
+## Syntax
+
 ```css
 /* Keyword values */
 mask-position: top;
@@ -24,9 +26,7 @@ mask-position: 10% 8em;
 
 /* Multiple values */
 mask-position: top right;
-mask-position:
-  1rem 1rem,
-  center;
+mask-position: 1rem 1rem, center;
 
 /* Global values */
 mask-position: inherit;
@@ -35,8 +35,6 @@ mask-position: revert;
 mask-position: revert-layer;
 mask-position: unset;
 ```
-
-## Syntax
 
 One or more `<position>` values, separated by commas.
 

--- a/files/en-us/web/css/mask-position/index.md
+++ b/files/en-us/web/css/mask-position/index.md
@@ -26,7 +26,9 @@ mask-position: 10% 8em;
 
 /* Multiple values */
 mask-position: top right;
-mask-position: 1rem 1rem, center;
+mask-position:
+  1rem 1rem,
+  center;
 
 /* Global values */
 mask-position: inherit;

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -29,8 +29,13 @@ mask-repeat: round space;
 mask-repeat: no-repeat round;
 
 /* Multiple values */
-mask-repeat: space round, no-repeat;
-mask-repeat: round repeat, space, repeat-x;
+mask-repeat:
+  space round,
+  no-repeat;
+mask-repeat:
+  round repeat,
+  space,
+  repeat-x;
 
 /* Global values */
 mask-repeat: inherit;

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.mask-repeat
 
 The **`mask-repeat`** [CSS](/en-US/docs/Web/CSS) property sets how mask images are repeated. A mask image can be repeated along the horizontal axis, the vertical axis, both axes, or not repeated at all.
 
+By default, the repeated images are clipped to the size of the element, but they can be scaled to fit (using `round`) or evenly distributed from end to end (using `space`).
+
+## Syntax
+
 ```css
 /* One-value syntax */
 mask-repeat: repeat-x;
@@ -25,13 +29,8 @@ mask-repeat: round space;
 mask-repeat: no-repeat round;
 
 /* Multiple values */
-mask-repeat:
-  space round,
-  no-repeat;
-mask-repeat:
-  round repeat,
-  space,
-  repeat-x;
+mask-repeat: space round, no-repeat;
+mask-repeat: round repeat, space, repeat-x;
 
 /* Global values */
 mask-repeat: inherit;
@@ -40,10 +39,6 @@ mask-repeat: revert;
 mask-repeat: revert-layer;
 mask-repeat: unset;
 ```
-
-By default, the repeated images are clipped to the size of the element, but they can be scaled to fit (using `round`) or evenly distributed from end to end (using `space`).
-
-## Syntax
 
 One or more `<repeat-style>` values, separated by commas.
 

--- a/files/en-us/web/css/mask-size/index.md
+++ b/files/en-us/web/css/mask-size/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.mask-size
 
 The **`mask-size`** [CSS](/en-US/docs/Web/CSS) property specifies the sizes of the mask images. The size of the image can be fully or partially constrained in order to preserve its intrinsic ratio.
 
+> **Note:** If the value of this property is not set in a {{cssxref("mask")}} shorthand property that is applied to the element after the `mask-size` CSS property, the value of this property is then reset to its initial value by the shorthand property.
+
+## Syntax
+
 ```css
 /* Keywords syntax */
 mask-size: cover;
@@ -41,10 +45,6 @@ mask-size: revert;
 mask-size: revert-layer;
 mask-size: unset;
 ```
-
-> **Note:** If the value of this property is not set in a {{cssxref("mask")}} shorthand property that is applied to the element after the `mask-size` CSS property, the value of this property is then reset to its initial value by the shorthand property.
-
-## Syntax
 
 One or more `<bg-size>` values, separated by commas.
 

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.mask-type
 
 The **`mask-type`** [CSS](/en-US/docs/Web/CSS) property sets whether an SVG {{svgElement("mask")}} element is used as a _luminance_ or an _alpha_ mask. It applies to the `<mask>` element itself.
 
+This property may be overridden by the {{cssxref("mask-mode")}} property, which has the same effect but applies to the element where the mask is used. Alpha masks will generally be faster to render.
+
+## Syntax
+
 ```css
 /* Keyword values */
 mask-type: luminance;
@@ -21,10 +25,6 @@ mask-type: revert;
 mask-type: revert-layer;
 mask-type: unset;
 ```
-
-This property may be overridden by the {{cssxref("mask-mode")}} property, which has the same effect but applies to the element where the mask is used. Alpha masks will generally be faster to render.
-
-## Syntax
 
 The `mask-type` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/orphans/index.md
+++ b/files/en-us/web/css/orphans/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.orphans
 
 The **`orphans`** [CSS](/en-US/docs/Web/CSS) property sets the minimum number of lines in a block container that must be shown at the _bottom_ of a [page](/en-US/docs/Web/CSS/CSS_paged_media), region, or [column](/en-US/docs/Web/CSS/CSS_multicol_layout).
 
+In typography, an _orphan_ is the first line of a paragraph that appears alone at the bottom of a page. (The paragraph continues on a following page.)
+
+## Syntax
+
 ```css
 /* <integer> values */
 orphans: 2;
@@ -21,10 +25,6 @@ orphans: revert;
 orphans: revert-layer;
 orphans: unset;
 ```
-
-In typography, an _orphan_ is the first line of a paragraph that appears alone at the bottom of a page. (The paragraph continues on a following page.)
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -11,6 +11,8 @@ The **`overscroll-behavior-block`** CSS property sets the browser's behavior whe
 
 See {{cssxref("overscroll-behavior")}} for a full explanation.
 
+## Syntax
+
 ```css
 /* Keyword values */
 overscroll-behavior-block: auto; /* default */
@@ -24,8 +26,6 @@ overscroll-behavior-block: revert;
 overscroll-behavior-block: revert-layer;
 overscroll-behavior-block: unset;
 ```
-
-## Syntax
 
 The `overscroll-behavior-block` property is specified as a keyword chosen from the list of values below.
 

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -11,6 +11,8 @@ The **`overscroll-behavior-inline`** CSS property sets the browser's behavior wh
 
 See {{cssxref("overscroll-behavior")}} for a full explanation.
 
+## Syntax
+
 ```css
 /* Keyword values */
 overscroll-behavior-inline: auto; /* default */
@@ -24,8 +26,6 @@ overscroll-behavior-inline: revert;
 overscroll-behavior-inline: revert-layer;
 overscroll-behavior-inline: unset;
 ```
-
-## Syntax
 
 The `overscroll-behavior-inline` property is specified as a keyword chosen from the list of values below.
 

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -11,6 +11,8 @@ The **`overscroll-behavior-x`** CSS property sets the browser's behavior when th
 
 See {{cssxref("overscroll-behavior")}} for a full explanation.
 
+## Syntax
+
 ```css
 /* Keyword values */
 overscroll-behavior-x: auto; /* default */
@@ -24,8 +26,6 @@ overscroll-behavior-x: revert;
 overscroll-behavior-x: revert-layer;
 overscroll-behavior-x: unset;
 ```
-
-## Syntax
 
 The `overscroll-behavior-x` property is specified as a keyword chosen from the list of values below.
 

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -11,6 +11,8 @@ The **`overscroll-behavior-y`** CSS property sets the browser's behavior when th
 
 See {{cssxref("overscroll-behavior")}} for a full explanation.
 
+## Syntax
+
 ```css
 /* Keyword values */
 overscroll-behavior-y: auto; /* default */
@@ -24,8 +26,6 @@ overscroll-behavior-y: revert;
 overscroll-behavior-y: revert-layer;
 overscroll-behavior-y: unset;
 ```
-
-## Syntax
 
 The `overscroll-behavior-y` property is specified as a keyword chosen from the list of values below.
 

--- a/files/en-us/web/css/ruby-align/index.md
+++ b/files/en-us/web/css/ruby-align/index.md
@@ -11,6 +11,8 @@ browser-compat: css.properties.ruby-align
 
 The **`ruby-align`** CSS property defines the distribution of the different ruby elements over the base.
 
+## Syntax
+
 ```css
 /* Keyword values */
 ruby-align: start;
@@ -25,8 +27,6 @@ ruby-align: revert;
 ruby-align: revert-layer;
 ruby-align: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -13,6 +13,8 @@ The **`scroll-snap-type`** [CSS](/en-US/docs/Web/CSS) property sets how strictly
 
 Specifying any precise animations or physics used to enforce those snap points is not covered by this property but instead left up to the user agent.
 
+## Syntax
+
 ```css
 /* Keyword values */
 scroll-snap-type: none;
@@ -36,8 +38,6 @@ scroll-snap-type: revert;
 scroll-snap-type: revert-layer;
 scroll-snap-type: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/text-decoration-skip/index.md
+++ b/files/en-us/web/css/text-decoration-skip/index.md
@@ -13,6 +13,8 @@ The **`text-decoration-skip`** [CSS](/en-US/docs/Web/CSS) property sets what par
 
 > **Note:** Most other browsers are converging on supporting the simpler {{cssxref("text-decoration-skip-ink")}} property.
 
+## Syntax
+
 ```css
 /* Keyword values */
 text-decoration-skip: none;
@@ -33,8 +35,6 @@ text-decoration-skip: revert;
 text-decoration-skip: revert-layer;
 text-decoration-skip: unset;
 ```
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/text-overflow/index.md
+++ b/files/en-us/web/css/text-overflow/index.md
@@ -22,8 +22,6 @@ The `text-overflow` property only affects content that is overflowing a block co
 
 ## Syntax
 
-The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line.
-
 ```css
 text-overflow: clip;
 text-overflow: ellipsis ellipsis;
@@ -36,6 +34,8 @@ text-overflow: revert;
 text-overflow: revert-layer;
 text-overflow: unset;
 ```
+
+The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line.
 
 - one of the keyword values: `clip`, `ellipsis`, `fade`
 - the function `fade()`, which is passed a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} to control the fade distance

--- a/files/en-us/web/css/text-rendering/index.md
+++ b/files/en-us/web/css/text-rendering/index.md
@@ -75,10 +75,20 @@ This demonstrates how `optimizeLegibility` is used by browsers automatically whe
 
 ```css
 .small {
-  font: 19.9px "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
+  font:
+    19.9px "Constantia",
+    "Times New Roman",
+    "Georgia",
+    "Palatino",
+    serif;
 }
 .big {
-  font: 20px "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
+  font:
+    20px "Constantia",
+    "Times New Roman",
+    "Georgia",
+    "Palatino",
+    serif;
 }
 ```
 
@@ -101,7 +111,12 @@ This example shows the difference between the appearance of `optimizeSpeed` and 
 
 ```css
 p {
-  font: 1.5em "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
+  font:
+    1.5em "Constantia",
+    "Times New Roman",
+    "Georgia",
+    "Palatino",
+    serif;
 }
 
 .speed {

--- a/files/en-us/web/css/text-rendering/index.md
+++ b/files/en-us/web/css/text-rendering/index.md
@@ -11,6 +11,12 @@ The **`text-rendering`** CSS property provides information to the rendering engi
 
 The browser makes trade-offs among speed, legibility, and geometric precision.
 
+> **Note:** The `text-rendering` property is an SVG property that is not defined in any CSS standard. However, Gecko and WebKit browsers let you apply this property to HTML and XML content on Windows, macOS, and Linux.
+
+One very visible effect is `optimizeLegibility`, which enables ligatures (ff, fi, fl, etc.) in text smaller than 20px for some fonts (for example, Microsoft's _Calibri_, _Candara_, _Constantia_, and _Corbel_, or the _DejaVu_ font family).
+
+## Syntax
+
 ```css
 /* Keyword values */
 text-rendering: auto;
@@ -25,12 +31,6 @@ text-rendering: revert;
 text-rendering: revert-layer;
 text-rendering: unset;
 ```
-
-> **Note:** The `text-rendering` property is an SVG property that is not defined in any CSS standard. However, Gecko and WebKit browsers let you apply this property to HTML and XML content on Windows, macOS, and Linux.
-
-One very visible effect is `optimizeLegibility`, which enables ligatures (ff, fi, fl, etc.) in text smaller than 20px for some fonts (for example, Microsoft's _Calibri_, _Candara_, _Constantia_, and _Corbel_, or the _DejaVu_ font family).
-
-## Syntax
 
 ### Values
 
@@ -75,20 +75,10 @@ This demonstrates how `optimizeLegibility` is used by browsers automatically whe
 
 ```css
 .small {
-  font:
-    19.9px "Constantia",
-    "Times New Roman",
-    "Georgia",
-    "Palatino",
-    serif;
+  font: 19.9px "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
 }
 .big {
-  font:
-    20px "Constantia",
-    "Times New Roman",
-    "Georgia",
-    "Palatino",
-    serif;
+  font: 20px "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
 }
 ```
 
@@ -111,12 +101,7 @@ This example shows the difference between the appearance of `optimizeSpeed` and 
 
 ```css
 p {
-  font:
-    1.5em "Constantia",
-    "Times New Roman",
-    "Georgia",
-    "Palatino",
-    serif;
+  font: 1.5em "Constantia", "Times New Roman", "Georgia", "Palatino", serif;
 }
 
 .speed {

--- a/files/en-us/web/css/text-size-adjust/index.md
+++ b/files/en-us/web/css/text-size-adjust/index.md
@@ -11,6 +11,12 @@ browser-compat: css.properties.text-size-adjust
 
 The **`text-size-adjust`** [CSS](/en-US/docs/Web/API/CSS) property controls the text inflation algorithm used on some smartphones and tablets. Other browsers will ignore this property.
 
+Because many websites have not been developed with small devices in mind, mobile browsers differ from desktop browsers in the way they render web pages. Instead of laying out pages at the width of the device screen, they lay them out using a {{glossary("viewport")}} that is much wider, usually 800 or 1000 pixels. To map the extra-wide layout back to the original device size, they either show only part of the whole render or scale the viewport down to fit.
+
+Since text that has been scaled down to fit a mobile screen may be very small, many mobile browsers apply a text inflation algorithm to enlarge the text to make it more readable. When an element containing text uses 100% of the screen's width, the algorithm increases its text size, but without modifying the layout. The `text-size-adjust` property allows web authors to disable or modify this behavior, as web pages designed with small screens in mind do not need it.
+
+## Syntax
+
 ```css
 /* Keyword values */
 text-size-adjust: none;
@@ -26,12 +32,6 @@ text-size-adjust: revert;
 text-size-adjust: revert-layer;
 text-size-adjust: unset;
 ```
-
-Because many websites have not been developed with small devices in mind, mobile browsers differ from desktop browsers in the way they render web pages. Instead of laying out pages at the width of the device screen, they lay them out using a {{glossary("viewport")}} that is much wider, usually 800 or 1000 pixels. To map the extra-wide layout back to the original device size, they either show only part of the whole render or scale the viewport down to fit.
-
-Since text that has been scaled down to fit a mobile screen may be very small, many mobile browsers apply a text inflation algorithm to enlarge the text to make it more readable. When an element containing text uses 100% of the screen's width, the algorithm increases its text size, but without modifying the layout. The `text-size-adjust` property allows web authors to disable or modify this behavior, as web pages designed with small screens in mind do not need it.
-
-## Syntax
 
 The `text-size-adjust` property is specified as `none`, `auto`, or a `<percentage>`.
 

--- a/files/en-us/web/css/touch-action/index.md
+++ b/files/en-us/web/css/touch-action/index.md
@@ -9,6 +9,14 @@ browser-compat: css.properties.touch-action
 
 The **`touch-action`** CSS property sets how an element's region can be manipulated by a touchscreen user (for example, by zooming features built into the browser).
 
+By default, panning (scrolling) and pinching gestures are handled exclusively by the browser. An application using {{domxref("Pointer_events", "Pointer events", "", 1)}} will receive a {{domxref("Element/pointercancel_event", "pointercancel")}} event when the browser starts handling a touch gesture. By explicitly specifying which gestures should be handled by the browser, an application can supply its own behavior in {{domxref("Element/pointermove_event", "pointermove")}} and {{domxref("Element/pointerup_event", "pointerup")}} listeners for the remaining gestures. Applications using {{domxref("Touch_events", "Touch events", "", 1)}} disable the browser handling of gestures by calling {{domxref("Event.preventDefault","preventDefault()")}}, but should also use `touch-action` to ensure the browser knows the intent of the application before any event listeners have been invoked.
+
+When a gesture is started, the browser intersects the `touch-action` values of the touched element and its ancestors, up to the one that implements the gesture (in other words, the first containing scrolling element). This means that in practice, `touch-action` is typically applied only to top-level elements which have some custom behavior, without needing to specify `touch-action` explicitly on any of that element's descendants.
+
+> **Note:** After a gesture starts, changes to `touch-action` will not have any impact on the behavior of the current gesture.
+
+## Syntax
+
 ```css
 /* Keyword values */
 touch-action: auto;
@@ -29,14 +37,6 @@ touch-action: revert;
 touch-action: revert-layer;
 touch-action: unset;
 ```
-
-By default, panning (scrolling) and pinching gestures are handled exclusively by the browser. An application using {{domxref("Pointer_events", "Pointer events", "", 1)}} will receive a {{domxref("Element/pointercancel_event", "pointercancel")}} event when the browser starts handling a touch gesture. By explicitly specifying which gestures should be handled by the browser, an application can supply its own behavior in {{domxref("Element/pointermove_event", "pointermove")}} and {{domxref("Element/pointerup_event", "pointerup")}} listeners for the remaining gestures. Applications using {{domxref("Touch_events", "Touch events", "", 1)}} disable the browser handling of gestures by calling {{domxref("Event.preventDefault","preventDefault()")}}, but should also use `touch-action` to ensure the browser knows the intent of the application before any event listeners have been invoked.
-
-When a gesture is started, the browser intersects the `touch-action` values of the touched element and its ancestors, up to the one that implements the gesture (in other words, the first containing scrolling element). This means that in practice, `touch-action` is typically applied only to top-level elements which have some custom behavior, without needing to specify `touch-action` explicitly on any of that element's descendants.
-
-> **Note:** After a gesture starts, changes to `touch-action` will not have any impact on the behavior of the current gesture.
-
-## Syntax
 
 The `touch-action` property may be specified as either:
 

--- a/files/en-us/web/css/transform-box/index.md
+++ b/files/en-us/web/css/transform-box/index.md
@@ -9,6 +9,8 @@ browser-compat: css.properties.transform-box
 
 The **`transform-box`** CSS property defines the layout box to which the {{cssxref("transform")}}, individual transform properties {{cssxref("translate")}},{{cssxref("scale")}}, and {{cssxref("rotate")}}, and {{cssxref("transform-origin")}} properties relate.
 
+## Syntax
+
 ```css
 /* Keyword values */
 transform-box: content-box;
@@ -24,8 +26,6 @@ transform-box: revert;
 transform-box: revert-layer;
 transform-box: unset;
 ```
-
-## Syntax
 
 The `transform-box` property is specified as one of the keyword values listed below.
 

--- a/files/en-us/web/css/user-modify/index.md
+++ b/files/en-us/web/css/user-modify/index.md
@@ -12,6 +12,10 @@ browser-compat: css.properties.user-modify
 
 The **`user-modify`** property has no effect in Firefox. It was originally planned to determine whether or not the content of an element can be edited by a user.
 
+> **Warning:** This property has been replaced by the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes#contenteditable) attribute.
+
+## Syntax
+
 ```css
 /* Keyword values */
 user-modify: read-only;
@@ -24,10 +28,6 @@ user-modify: initial;
 user-modify: revert;
 user-modify: unset;
 ```
-
-> **Warning:** This property has been replaced by the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes#contenteditable) attribute.
-
-## Syntax
 
 The `-moz-user-modify` property is specified as one of the keyword values from the list below.
 

--- a/files/en-us/web/css/widows/index.md
+++ b/files/en-us/web/css/widows/index.md
@@ -9,6 +9,10 @@ browser-compat: css.properties.widows
 
 The **`widows`** [CSS](/en-US/docs/Web/CSS) property sets the minimum number of lines in a block container that must be shown at the _top_ of a [page](/en-US/docs/Web/CSS/CSS_paged_media), region, or [column](/en-US/docs/Web/CSS/CSS_multicol_layout).
 
+In typography, a _widow_ is the last line of a paragraph that appears alone at the top of a page. (The paragraph is continued from a prior page.)
+
+## Syntax
+
 ```css
 /* <integer> values */
 widows: 2;
@@ -21,10 +25,6 @@ widows: revert;
 widows: revert-layer;
 widows: unset;
 ```
-
-In typography, a _widow_ is the last line of a paragraph that appears alone at the top of a page. (The paragraph is continued from a prior page.)
-
-## Syntax
 
 ### Values
 

--- a/files/en-us/web/css/will-change/index.md
+++ b/files/en-us/web/css/will-change/index.md
@@ -11,6 +11,16 @@ The **`will-change`** [CSS](/en-US/docs/Web/CSS) property hints to browsers how 
 
 > **Warning:** `will-change` is intended to be used as a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems.
 
+Proper usage of this property can be a bit tricky:
+
+- _Don't apply will-change to too many elements._ The browser already tries as hard as it can to optimize everything. Some of the stronger optimizations that are likely to be tied to `will-change` end up using a lot of a machine's resources, and when overused like this can cause the page to slow down or consume a lot of resources.
+- _Use sparingly._ The normal behavior for optimizations that the browser make is to remove the optimizations as soon as it can and revert back to normal. But adding `will-change` directly in a stylesheet implies that the targeted elements are always a few moments away from changing and the browser will keep the optimizations for much longer time than it would have otherwise. So it is a good practice to switch `will-change` on and off using script code before and after the change occurs.
+- _Don't apply will-change to elements to perform premature optimization_. If your page is performing well, don't add the `will-change` property to elements just to wring out a little more speed. `will-change` is intended to be used as something of a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems. Excessive use of `will-change` will result in excessive memory use and will cause more complex rendering to occur as the browser attempts to prepare for the possible change. This will lead to worse performance.
+- _Give it sufficient time to work_. This property is intended as a method for authors to let the user-agent know about properties that are likely to change ahead of time. Then the browser can choose to apply any ahead-of-time optimizations required for the property change before the property change actually happens. So it is important to give the browser some time to actually do the optimizations. Find some way to predict at least slightly ahead of time that something will change, and set `will-change` then.
+- _Be aware, that will-change may actually influence the visual appearance of elements_, when used with property values, that create a [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) (e.g. will-change: opacity), as the stacking context is created up front.
+
+## Syntax
+
 ```css
 /* Keyword values */
 will-change: auto;
@@ -27,16 +37,6 @@ will-change: revert;
 will-change: revert-layer;
 will-change: unset;
 ```
-
-Proper usage of this property can be a bit tricky:
-
-- _Don't apply will-change to too many elements._ The browser already tries as hard as it can to optimize everything. Some of the stronger optimizations that are likely to be tied to `will-change` end up using a lot of a machine's resources, and when overused like this can cause the page to slow down or consume a lot of resources.
-- _Use sparingly._ The normal behavior for optimizations that the browser make is to remove the optimizations as soon as it can and revert back to normal. But adding `will-change` directly in a stylesheet implies that the targeted elements are always a few moments away from changing and the browser will keep the optimizations for much longer time than it would have otherwise. So it is a good practice to switch `will-change` on and off using script code before and after the change occurs.
-- _Don't apply will-change to elements to perform premature optimization_. If your page is performing well, don't add the `will-change` property to elements just to wring out a little more speed. `will-change` is intended to be used as something of a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems. Excessive use of `will-change` will result in excessive memory use and will cause more complex rendering to occur as the browser attempts to prepare for the possible change. This will lead to worse performance.
-- _Give it sufficient time to work_. This property is intended as a method for authors to let the user-agent know about properties that are likely to change ahead of time. Then the browser can choose to apply any ahead-of-time optimizations required for the property change before the property change actually happens. So it is important to give the browser some time to actually do the optimizations. Find some way to predict at least slightly ahead of time that something will change, and set `will-change` then.
-- _Be aware, that will-change may actually influence the visual appearance of elements_, when used with property values, that create a [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) (e.g. will-change: opacity), as the stacking context is created up front.
-
-## Syntax
 
 ### Values
 


### PR DESCRIPTION
According to our [template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template#syntax) for CSS properties the code block syntax should appear in the `## Syntax` section of the page, and is almost always the first element in that section.

This PR adjusts all pages that didn't match this pattern, to make our docs more consistently organized.