### PR TITLE
Remove copypasta from X-Forwarded-Host article

### DIFF
--- a/files/en-us/web/http/headers/x-forwarded-host/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.md
@@ -16,13 +16,6 @@ Host names and ports of reverse proxies (load balancers, CDNs) may differ from t
 origin server handling the request, in that case the `X-Forwarded-Host`
 header is useful to determine which Host was originally used.
 
-This header is used for debugging, statistics, and generating location-dependent
-content and by design it exposes privacy sensitive information, such as the IP address
-of the client. Therefore the user's privacy must be kept in mind when deploying this
-header.
-
-A standardized version of this header is the HTTP {{HTTPHeader("Forwarded")}} header.
-
 <table class="properties">
   <tbody>
     <tr>
@@ -55,8 +48,7 @@ X-Forwarded-Host: id42.example-cdn.com
 
 ## Specifications
 
-Not part of any current specification. The standardized version of this header is
-{{HTTPHeader("Forwarded")}}.
+Not part of any current specification.
 
 ## See also
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28015

Some parts of this article appear to have been copied from the `X-Forwarded-For` article but don’t apply at all to the `X-Forwarded-Host` header. This change removes those parts.