### PR TITLE
Correct the prefers-reduced-transparency page

### DIFF
--- a/files/en-us/web/css/@media/prefers-reduced-transparency/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-transparency/index.md
@@ -20,19 +20,12 @@ The **`prefers-reduced-transparency`** [CSS](/en-US/docs/Web/CSS) [media feature
 
 ## User preferences
 
-For Firefox, the `reduce` request is honored if a dedicated system-specific setting exists, otherwise it is enabled if reduced motion is also enabled:
+Various operating systems provide a preference for reducing transparency, and user agents are likely to rely on these system settings.
+They may also rely on less explicit signals on platforms which don't offer a specific setting.
 
-- In GTK/GNOME: Settings > Accessibility > Seeing > Reduced animation is turned on.
-
-  - In older versions of GNOME, GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
-  - Alternatively, add `gtk-enable-animations = false` to the `[Settings]` block of [the GTK 3 configuration file](https://wiki.archlinux.org/title/GTK#Configuration).
-
-- In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".
-- In Windows 10: Settings > Personalization > Colors > Transparency effects.
-- In Windows 11: Settings > Personalization > Colors > Transparency effects.
+- In Windows 10/11: Settings > Personalization > Colors > Transparency effects.
 - In macOS: System Preferences > Accessibility > Display > Reduce transparency.
-- In iOS: Settings > Accessibility > Motion.
-- In Android 9+: Settings > Accessibility > Remove animations.
+- In iOS: Settings > Accessibility > Display & Text Size > Reduce Transparency.
 
 ## Examples
 


### PR DESCRIPTION
No longer make an erroneous reference to reduce motion settings triggering this media query.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The page previously said that Firefox follows reduced motion preferences on operating systems that don't offer the transparency setting. This is incorrect it fallbacks to the increased contrast preference and only on GTK.

I've updated this section to simply say user agents will rely on system settings but may use other signals where this one doesn't exist. To make it generic to all browsers rather than just Firefox's specific implementation (Chrome has a flagged implementation also and WebKit has a PR for one).

Also correct the information to show that iOS does have a Reduce Transparency setting.

### Motivation

Aside from obviously wanting correct information I don't think it made sense to explicitly refer to the fallback settings for each OS because (firstly they were wrong) they could change and also aren't really relevant to consumers of the media query. Especially if they only apply in some browser and not others.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #28076

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
