### PR TITLE
Remove strange third-party links that mirror old MDN pages

### DIFF
--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -93,7 +93,7 @@ _No change._
 
 #### NetUtil.jsm
 
-- [`readInputStreamToString()`](https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/NetUtil.html) has a new, optional, parameter to configure the character set interpretation while reading the input stream.
+- `readInputStreamToString()` has a new, optional, parameter to configure the character set interpretation while reading the input stream.
 
 #### New JavaScript code modules
 

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -80,7 +80,7 @@ Mozilla has been working on integrating its own Web developer tools that complem
 #### source-editor.jsm
 
 - The [`resetUndo()`](/en-US/docs/JavaScript_code_modules/source-editor.jsm#resetUndo%28%29) method was added; this lets you clear the undo stack.
-- The source editor now offers methods for providing search capability: `find()`], `findNext()`, and `findPrevious()`.
+- The source editor now offers methods for providing search capability: `find()`, `findNext()`, and `findPrevious()`.
 
 ### XUL
 

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -80,7 +80,7 @@ Mozilla has been working on integrating its own Web developer tools that complem
 #### source-editor.jsm
 
 - The [`resetUndo()`](/en-US/docs/JavaScript_code_modules/source-editor.jsm#resetUndo%28%29) method was added; this lets you clear the undo stack.
-- The source editor now offers methods for providing search capability: [`find()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.html#find()>), [`findNext()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.html#findNext()>), and [`findPrevious()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.html#findPrevious()>).
+- The source editor now offers methods for providing search capability: `find()`], `findNext()`, and `findPrevious()`.
 
 ### XUL
 

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -47,7 +47,7 @@ Support for [XForms](/en-US/docs/XForms) has been [**removed**](https://www.phil
 > **Note:** A key change in Firefox 19 is that `nsresult` is now strongly typed. This will help make it easier to detect bugs that are caused by mishandling of return values, but may cause existing code to break if it's making incorrect assumptions in this regard.
 
 - `getBrowserSelection()` now returns the selected text in a text input field. As a result, `gContextMenu.isTextSelected` will be `true` when the user selects text in a text input field that is not a password field. ([Firefox bug 565717](https://bugzil.la/565717))
-- [Dict.jsm](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm): [`Dict()`](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm#creating_a_dictionary) now takes a JSON String. [`Dict.toJSON()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Dict.html#toJSON()>) was added, and it returns a JSON String. ([Firefox bug 727967](https://bugzil.la/727967))
+- [Dict.jsm](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm): [`Dict()`](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm#creating_a_dictionary) now takes a JSON String. `Dict.toJSON()` was added, and it returns a JSON String. ([Firefox bug 727967](https://bugzil.la/727967))
 
 ### Interface changes
 

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -47,7 +47,7 @@ Support for [XForms](/en-US/docs/XForms) has been [**removed**](https://www.phil
 > **Note:** A key change in Firefox 19 is that `nsresult` is now strongly typed. This will help make it easier to detect bugs that are caused by mishandling of return values, but may cause existing code to break if it's making incorrect assumptions in this regard.
 
 - `getBrowserSelection()` now returns the selected text in a text input field. As a result, `gContextMenu.isTextSelected` will be `true` when the user selects text in a text input field that is not a password field. ([Firefox bug 565717](https://bugzil.la/565717))
-- [Dict.jsm](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm): [`Dict()`](/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm#creating_a_dictionary) now takes a JSON String. `Dict.toJSON()` was added, and it returns a JSON String. ([Firefox bug 727967](https://bugzil.la/727967))
+- Dict.jsm: `Dict()` now takes a JSON String. `Dict.toJSON()` was added, and it returns a JSON String. ([Firefox bug 727967](https://bugzil.la/727967))
 
 ### Interface changes
 

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -138,7 +138,7 @@ _No change._
 ### JavaScript code modules
 
 - `PromiseUtils.resolveOrTimeout` is implemented ([Firefox bug 1080466](https://bugzil.la/1080466)).
-- [PromiseUtils.defer](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/PromiseUtils.html#defer()>) (a replacement for `Promise.defer()`) is implemented ([Firefox bug 1093021](https://bugzil.la/1093021)).
+- `PromiseUtils.defer` (a replacement for `Promise.defer()`) is implemented ([Firefox bug 1093021](https://bugzil.la/1093021)).
 
 ### Interfaces
 

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -346,8 +346,8 @@ If you're a theme developer, you should read [Theme changes in Firefox 4](/en-US
 
 #### Miscellaneous changes to code modules
 
-- The `NetUtil.jsm` code module now offers the [`readInputStreamToString()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/NetUtil.html#readInputStreamToString()>) method, which lets you read arbitrary bytes from a stream into a string, even if the stream includes zeroes.
-- The XPCOMUtils.jsm code module now offers [IterSimpleEnumerator()](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/XPCOMUtils.html#IterSimpleEnumerator()>) and [IterStringEnumerator()](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/XPCOMUtils.html#IterStringEnumerator()>) helpers to iterate over XPCOM enumerators.
+- The `NetUtil.jsm` code module now offers the `readInputStreamToString()` method, which lets you read arbitrary bytes from a stream into a string, even if the stream includes zeroes.
+- The XPCOMUtils.jsm code module now offers IterSimpleEnumerator() and IterStringEnumerator() helpers to iterate over XPCOM enumerators.
 - You can now [use workers in JavaScript code modules](/en-US/docs/JavaScript_code_modules/Using_workers_in_JavaScript_code_modules).
 
 ### DOM changes

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -91,7 +91,7 @@ For a guide to updating your add-on for Firefox 5, please see [Updating add-ons 
 
 #### NetUtil.jsm
 
-- The [`asyncFetch()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/NetUtil.html#asyncFetch()>) method now supports specifying the input source as an `nsIInputStream`.
+- The `asyncFetch()` method now supports specifying the input source as an `nsIInputStream`.
 
 ### Interface changes
 

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -127,7 +127,7 @@ For an overview of the changes you may need to make in order to make your add-on
 
 #### XPCOMUtils.jsm
 
-- The new [`importRelative()`](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/XPCOMUtils.html#importRelative()>) method lets you load one JavaScript code module from a path relative to the path of another JavaScript code module. This makes it easier to build modules that depend on each other.
+- The new `importRelative()`] method lets you load one JavaScript code module from a path relative to the path of another JavaScript code module. This makes it easier to build modules that depend on each other.
 
 ### XPCOM
 

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -127,7 +127,7 @@ For an overview of the changes you may need to make in order to make your add-on
 
 #### XPCOMUtils.jsm
 
-- The new `importRelative()`] method lets you load one JavaScript code module from a path relative to the path of another JavaScript code module. This makes it easier to build modules that depend on each other.
+- The new `importRelative()` method lets you load one JavaScript code module from a path relative to the path of another JavaScript code module. This makes it easier to build modules that depend on each other.
 
 ### XPCOM
 


### PR DESCRIPTION
This PR removes a bunch of strange third-party links for `contest-server.cs.uchicago.edu` that mirror old MDN articles.  It seems that this domain has entire copies of language references, including one for JavaScript which is a copy of pre-Yari MDN.  It seems strange that we'd be linking to a mirror of our own pages, even though the pages linked are long gone from MDN.
