### PR TITLE
Add 'constituent properties' section to all shorthand properties

### DIFF
--- a/files/en-us/web/css/-webkit-border-before/index.md
+++ b/files/en-us/web/css/-webkit-border-before/index.md
@@ -31,6 +31,14 @@ It relates to {{cssxref("-webkit-border-after")}}, {{cssxref("-webkit-border-sta
 
 This property is on the standard track as {{cssxref("border-block-start")}}.
 
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("-webkit-border-before-color")}}
+- {{cssxref("-webkit-border-before-style")}}
+- {{cssxref("-webkit-border-before-width")}}
+
 ## Syntax
 
 ### Values

--- a/files/en-us/web/css/-webkit-border-before/index.md
+++ b/files/en-us/web/css/-webkit-border-before/index.md
@@ -11,6 +11,16 @@ browser-compat: css.properties.-webkit-border-before
 
 The **`-webkit-border-before`** [CSS](/en-US/docs/Web/CSS) property is a shorthand property for setting the individual logical block start border property values in a single place in the style sheet.
 
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("-webkit-border-before-color")}}
+- {{cssxref("-webkit-border-before-style")}}
+- {{cssxref("-webkit-border-before-width")}}
+
+## Syntax
+
 ```css
 /* Border values */
 -webkit-border-before: 1px;
@@ -25,22 +35,6 @@ The **`-webkit-border-before`** [CSS](/en-US/docs/Web/CSS) property is a shortha
 -webkit-border-before: unset;
 ```
 
-`-webkit-border-before` can be used to set the values for one or more of: {{cssxref("-webkit-border-before-width")}}, {{cssxref("-webkit-border-before-style")}}, and {{cssxref("-webkit-border-before-color")}}. It maps to a physical border depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
-
-It relates to {{cssxref("-webkit-border-after")}}, {{cssxref("-webkit-border-start")}}, and {{cssxref("-webkit-border-end")}}, which define the other borders of the element.
-
-This property is on the standard track as {{cssxref("border-block-start")}}.
-
-## Constituent properties
-
-This property is a shorthand for the following CSS properties:
-
-- {{cssxref("-webkit-border-before-color")}}
-- {{cssxref("-webkit-border-before-style")}}
-- {{cssxref("-webkit-border-before-width")}}
-
-## Syntax
-
 ### Values
 
 One or more of the following, in any order:
@@ -51,6 +45,14 @@ One or more of the following, in any order:
   - : See {{cssxref("border-style")}}
 - `<'color'>`
   - : See {{cssxref("color")}}
+
+## Description
+
+The `-webkit-border-before` property maps to a physical border depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, or {{cssxref("border-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+
+It relates to {{cssxref("-webkit-border-after")}}, {{cssxref("-webkit-border-start")}}, and {{cssxref("-webkit-border-end")}}, which define the other borders of the element.
+
+The standard-track equivalent of this property is {{cssxref("border-block-start")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -11,6 +11,10 @@ The **`all`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US
 
 {{EmbedInteractiveExample("pages/css/all.html")}}
 
+## Constituent properties
+
+This property is a shorthand for all CSS properties except for {{cssxref("unicode-bidi")}}, {{cssxref("direction")}}, and [custom properties](/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/column-rule/index.md
+++ b/files/en-us/web/css/column-rule/index.md
@@ -11,9 +11,13 @@ The **`column-rule`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS
 
 {{EmbedInteractiveExample("pages/css/column-rule.html")}}
 
-It is a [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) that sets the individual `column-rule-*` properties in a single, convenient declaration: {{Cssxref("column-rule-width")}}, {{Cssxref("column-rule-style")}}, and {{Cssxref("column-rule-color")}}.
+## Constituent properties
 
-> **Note:** As with all shorthand properties, any individual value that is not specified is set to its corresponding initial value (possibly overriding values previously set using non-shorthand properties).
+This property is a shorthand for the following CSS properties:
+
+- {{Cssxref("column-rule-color")}}
+- {{Cssxref("column-rule-style")}}
+- {{Cssxref("column-rule-width")}}
 
 ## Syntax
 

--- a/files/en-us/web/css/container/index.md
+++ b/files/en-us/web/css/container/index.md
@@ -9,6 +9,13 @@ browser-compat: css.properties.container
 
 The **container** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property establishes the element as a query container and specifies the name or name for the [containment context](/en-US/docs/Web/CSS/CSS_container_queries#naming_containment_contexts) used in a [container query](/en-US/docs/Web/CSS/CSS_container_queries).
 
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{Cssxref("container-name")}}
+- {{Cssxref("container-type")}}
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/inset/index.md
+++ b/files/en-us/web/css/inset/index.md
@@ -13,6 +13,15 @@ The **`inset`** [CSS](/en-US/docs/Web/CSS) property is a shorthand that correspo
 
 While part of the _CSS Logical Properties_ specification, it does not define _logical_ offsets. It defines _physical_ offsets, regardless of the element's writing mode, directionality, and text orientation.
 
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{Cssxref("top")}}
+- {{Cssxref("right")}}
+- {{Cssxref("bottom")}}
+- {{Cssxref("left")}}
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -52,11 +52,11 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 
 ## Description
 
-By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content on top of a page of scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called **scroll chaining**.
+By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content at the top of a page that also has scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called **scroll chaining**.
 
-In some cases these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
+In some cases, these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
 
-Note that this property only applies to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property cannot be used to stop scroll chaining for iframes.
+Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property cannot be used to stop scroll chaining for iframes.
 
 ## Formal definition
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -7,15 +7,16 @@ browser-compat: css.properties.overscroll-behavior
 
 {{CSSRef}}
 
-The **`overscroll-behavior`** CSS property sets what a browser does when reaching the boundary of a scrolling area. It's a shorthand for {{cssxref("overscroll-behavior-x")}} and {{cssxref("overscroll-behavior-y")}}.
+The **`overscroll-behavior`** CSS property sets what a browser does when reaching the boundary of a scrolling area.
 
 {{EmbedInteractiveExample("pages/css/overscroll-behavior.html")}}
 
-By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content on top of a page of scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called **scroll chaining**.
+## Constituent properties
 
-In some cases these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
+This property is a shorthand for the following CSS properties:
 
-Note that this property only applies to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property cannot be used to stop scroll chaining for iframes.
+- {{Cssxref("overscroll-behavior-x")}}
+- {{Cssxref("overscroll-behavior-y")}}
 
 ## Syntax
 
@@ -48,6 +49,14 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
   - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
+
+## Description
+
+By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content on top of a page of scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called **scroll chaining**.
+
+In some cases these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
+
+Note that this property only applies to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property cannot be used to stop scroll chaining for iframes.
 
 ## Formal definition
 


### PR DESCRIPTION
Shorthand properties should have a "Constituent properties" section. This PR adds the section for all shorthand properties that were missing one.

I also moved the description in https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior into its own section.