### PR TITLE
Pseudo-elements: pendantic explaination

### DIFF
--- a/files/en-us/learn/css/howto/highlight_first_line/index.md
+++ b/files/en-us/learn/css/howto/highlight_first_line/index.md
@@ -28,7 +28,7 @@ In the example above, the pseudo-element selects the first line of every paragra
 
 {{EmbedGHLiveSample("css-examples/howto/highlight_first_line2.html", '100%', 700)}}
 
-> **Note:** When combining pseudo-elements with other selectors in a [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector, the pseudo-element must appear after all the other components in the selector in which it appears.
+> **Note:** When combining pseudo-elements with other selectors in a [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector, the pseudo-elements must appear after all the other components in the selector in which they appear.
 
 ## See also
 

--- a/files/en-us/learn/css/howto/highlight_first_line/index.md
+++ b/files/en-us/learn/css/howto/highlight_first_line/index.md
@@ -24,9 +24,11 @@ In this case we need to use the {{cssxref("::first-line")}} pseudo-element. It s
 
 ## Combining pseudo-elements with other selectors
 
-In the example above, the pseudo-element selects the first line of every paragraph. To select only the first line of the first paragraph, you can combine it with another selector. That could be a class, or in this case the {{cssxref(":first-child")}} {{cssxref("pseudo-classes", "pseudo-class")}}. This allows us to select the first line of the first-child of `.wrapper`.
+In the example above, the pseudo-element selects the first line of every paragraph. To select only the first line of the first paragraph, you can combine it with another selector. In this case, we use the {{cssxref(":first-child")}} {{cssxref("pseudo-classes", "pseudo-class")}}. This allows us to select the first line of the first child of `.wrapper` if that first child is a paragraph.
 
 {{EmbedGHLiveSample("css-examples/howto/highlight_first_line2.html", '100%', 700)}}
+
+> **Note:** When combining pseudo-elements with other selectors in a [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector, the pseudo-element must appear after all the other components in the selector in which it appears. 
 
 ## See also
 

--- a/files/en-us/learn/css/howto/highlight_first_line/index.md
+++ b/files/en-us/learn/css/howto/highlight_first_line/index.md
@@ -28,7 +28,7 @@ In the example above, the pseudo-element selects the first line of every paragra
 
 {{EmbedGHLiveSample("css-examples/howto/highlight_first_line2.html", '100%', 700)}}
 
-> **Note:** When combining pseudo-elements with other selectors in a [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector, the pseudo-element must appear after all the other components in the selector in which it appears. 
+> **Note:** When combining pseudo-elements with other selectors in a [complex](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) or [compound](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) selector, the pseudo-element must appear after all the other components in the selector in which it appears.
 
 ## See also
 


### PR DESCRIPTION
made it a little more accurate and added important info people may not know (if you view the example code, it's on a paragraph. this should be stated as they used first child and not first of type, which would not have needed this edit.