### PR TITLE
Update HTMLMediaElement playbackRate property

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLMediaElement.playbackRate
 
 The **`HTMLMediaElement.playbackRate`** property sets the rate at which the media is being played back. This is used to implement user controls for fast forward, slow motion, and so forth. The normal playback rate is multiplied by this value to obtain the current rate, so a value of 1.0 indicates normal speed.
 
-If `playbackRate` is negative, the media is **not** played backwards.
+If `playbackRate` is negative, the media is played backwards.
 
 The audio is muted when the fast forward or slow motion is outside a useful range (for example, Gecko mutes the sound outside the range `0.25` to `4.0`).
 


### PR DESCRIPTION
This PR updates the page for the HTMLMediaElement's `playbackRate` property to specify that a negative value _should_ play the media backwards.  This is a follow-up to https://github.com/mdn/browser-compat-data/issues/10139.