### PR TITLE
Hint to use `addEventListener` instead of the onchange property

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9616,7 +9616,7 @@
 /en-US/docs/Web/API/Screen.unlockOrientation	/en-US/docs/Web/API/Screen/unlockOrientation
 /en-US/docs/Web/API/Screen.width	/en-US/docs/Web/API/Screen/width
 /en-US/docs/Web/API/Screen/onorientationchange	/en-US/docs/Web/API/Screen/orientationchange_event
-/en-US/docs/Web/API/ScreenOrientation/onchange	/en-US/docs/Web/API/ScreenOrientation#events
+/en-US/docs/Web/API/ScreenOrientation/onchange	/en-US/docs/Web/API/ScreenOrientation/change_event
 /en-US/docs/Web/API/ScriptProcessorNode.bufferSize	/en-US/docs/Web/API/ScriptProcessorNode/bufferSize
 /en-US/docs/Web/API/ScriptProcessorNode.onaudioprocess	/en-US/docs/Web/API/ScriptProcessorNode/audioprocess_event
 /en-US/docs/Web/API/ScriptProcessorNode/audioprocess	/en-US/docs/Web/API/ScriptProcessorNode/audioprocess_event

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9616,7 +9616,7 @@
 /en-US/docs/Web/API/Screen.unlockOrientation	/en-US/docs/Web/API/Screen/unlockOrientation
 /en-US/docs/Web/API/Screen.width	/en-US/docs/Web/API/Screen/width
 /en-US/docs/Web/API/Screen/onorientationchange	/en-US/docs/Web/API/Screen/orientationchange_event
-/en-US/docs/Web/API/ScreenOrientation/onchange	/en-US/docs/Web/API/ScreenOrientation
+/en-US/docs/Web/API/ScreenOrientation/onchange	/en-US/docs/Web/API/ScreenOrientation#events
 /en-US/docs/Web/API/ScriptProcessorNode.bufferSize	/en-US/docs/Web/API/ScriptProcessorNode/bufferSize
 /en-US/docs/Web/API/ScriptProcessorNode.onaudioprocess	/en-US/docs/Web/API/ScriptProcessorNode/audioprocess_event
 /en-US/docs/Web/API/ScriptProcessorNode/audioprocess	/en-US/docs/Web/API/ScriptProcessorNode/audioprocess_event

--- a/files/en-us/web/api/screen/orientationchange_event/index.md
+++ b/files/en-us/web/api/screen/orientationchange_event/index.md
@@ -31,7 +31,7 @@ A generic {{domxref("Event")}}.
 
 This feature is not part of any specification. It is no longer on track to becoming a standard.
 
-Use {{domxref("ScreenOrientation.change_event")}} instead.
+Use the {{domxref("ScreenOrientation.change_event", "ScreenOrientation change event")}} instead.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/screen/orientationchange_event/index.md
+++ b/files/en-us/web/api/screen/orientationchange_event/index.md
@@ -31,7 +31,7 @@ A generic {{domxref("Event")}}.
 
 This feature is not part of any specification. It is no longer on track to becoming a standard.
 
-Use {{domxref("ScreenOrientation.onchange")}} instead.
+Use {{domxref("ScreenOrientation.change_event")}} instead.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -26,7 +26,7 @@ A generic {{domxref("Event")}}.
 
 ## Example
 
-In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle")}}
+In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle", "angle")}}
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -26,7 +26,7 @@ A generic {{domxref("Event")}}.
 
 ## Example
 
-In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type", "", "nocode")}} and {{DOMxRef("ScreenOrientation.angle", "angle", "", "nocode")}}
+In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type", "", "nocode")}} and {{DOMxRef("ScreenOrientation.angle", "angle", "", "nocode")}}.
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -1,0 +1,45 @@
+---
+title: "ScreenOrientation: change event"
+short-title: change
+slug: Web/API/ScreenOrientation/change_event
+page-type: web-api-event
+browser-compat: api.ScreenOrientation.change_event
+---
+
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
+
+The **`change`** event of the {{domxref("ScreenOrientation")}} fires when the orientation of the screen has changed, for example when a user rotates his mobile phone.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("change", (event) => {});
+
+onchange = (event) => {};
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
+## Example
+
+In the following example, the `change` callback prints the status of `userState` and `screenState` to the console.
+
+```js
+screen.orientation.addEventListener("change", (event) => {
+  const type = event.target.type;
+  const angle = event.target.angle;
+  console.log(`ScreenOrientation change: ${type}, ${angle} degrees.`);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ScreenOrientation.change_event
 ---
 
-{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Screen Orientation API")}}{{SeeCompatTable}}
 
 The **`change`** event of the {{domxref("ScreenOrientation")}} fires when the orientation of the screen has changed, for example when a user rotates his mobile phone.
 
@@ -26,7 +26,7 @@ A generic {{domxref("Event")}}.
 
 ## Example
 
-In the following example, the `change` callback prints the status of `userState` and `screenState` to the console.
+In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle")}}
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -26,7 +26,7 @@ A generic {{domxref("Event")}}.
 
 ## Example
 
-In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle", "angle")}}
+In the following example, the `change` callback prints the new {{DOMxRef("ScreenOrientation.type", "screen orientation type", "", "nocode")}} and {{DOMxRef("ScreenOrientation.angle", "angle", "", "nocode")}}
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ScreenOrientation.change_event
 ---
 
-{{securecontext_header}}{{APIRef("Screen Orientation API")}}{{SeeCompatTable}}
+{{APIRef("Screen Orientation API")}}
 
 The **`change`** event of the {{domxref("ScreenOrientation")}} fires when the orientation of the screen has changed, for example when a user rotates his mobile phone.
 

--- a/files/en-us/web/api/screenorientation/change_event/index.md
+++ b/files/en-us/web/api/screenorientation/change_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ScreenOrientation.change_event
 
 {{APIRef("Screen Orientation API")}}
 
-The **`change`** event of the {{domxref("ScreenOrientation")}} fires when the orientation of the screen has changed, for example when a user rotates his mobile phone.
+The **`change`** event of the {{domxref("ScreenOrientation")}} interface fires when the orientation of the screen has changed, for example when a user rotates their mobile phone.
 
 ## Syntax
 

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -36,7 +36,7 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 ## Example
 
-In the following example, we listen for an {{DOMxRef("ScreenOrientation.change_event", "orientation change event")}} and log the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle")}}.
+In the following example, we listen for an {{DOMxRef("ScreenOrientation.change_event", "orientation change event")}} and log the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle", "angle")}}.
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -24,7 +24,7 @@ A **`ScreenOrientation`** instance object can be retrieved using the {{domxref("
 
 Listen to these events using `addEventListener()` or by assigning an event listener to the `oneventname` property of this interface.
 
-- {{DOMxRef("ScreenOrientation.onchange", "change")}}
+- {{DOMxRef("ScreenOrientation.change_event", "change")}}
   - : The [event handler](/en-US/docs/Web/Events/Event_handlers) called whenever the screen changes orientation.
 
 ## Instance methods
@@ -33,6 +33,18 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Locks the orientation of the containing document to its default orientation and returns a {{JSxRef("Promise")}}.
 - {{DOMxRef("ScreenOrientation.unlock()")}}
   - : Unlocks the orientation of the containing document from its default orientation.
+
+## Example
+
+In the following example, we listen for an {{DOMxRef("ScreenOrientation.change_event", "orientation change event")}} and log the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle")}}.
+
+```js
+screen.orientation.addEventListener("change", (event) => {
+  const type = event.target.type;
+  const angle = event.target.angle;
+  console.log(`ScreenOrientation change: ${type}, ${angle} degrees.`);
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -25,7 +25,7 @@ A **`ScreenOrientation`** instance object can be retrieved using the {{domxref("
 Listen to these events using `addEventListener()` or by assigning an event listener to the `oneventname` property of this interface.
 
 - {{DOMxRef("ScreenOrientation.change_event", "change")}}
-  - : The [event handler](/en-US/docs/Web/Events/Event_handlers) called whenever the screen changes orientation.
+  - : Fired whenever the screen changes orientation.
 
 ## Instance methods
 

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -20,9 +20,11 @@ A **`ScreenOrientation`** instance object can be retrieved using the {{domxref("
 - {{DOMxRef("ScreenOrientation.angle")}} {{ReadOnlyInline}}
   - : Returns the document's current orientation angle.
 
-### Event handlers
+## Events
 
-- {{DOMxRef("ScreenOrientation.onchange")}}
+Listen to these events using `addEventListener()` or by assigning an event listener to the `oneventname` property of this interface.
+
+- {{DOMxRef("ScreenOrientation.onchange", "change")}}
   - : The [event handler](/en-US/docs/Web/Events/Event_handlers) called whenever the screen changes orientation.
 
 ## Instance methods

--- a/files/en-us/web/api/screenorientation/index.md
+++ b/files/en-us/web/api/screenorientation/index.md
@@ -36,7 +36,7 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 ## Example
 
-In the following example, we listen for an {{DOMxRef("ScreenOrientation.change_event", "orientation change event")}} and log the new {{DOMxRef("ScreenOrientation.type", "screen orientation type")}} and {{DOMxRef("ScreenOrientation.angle", "angle")}}.
+In the following example, we listen for an orientation {{DOMxRef("ScreenOrientation.change_event", "change")}} event and log the new {{DOMxRef("ScreenOrientation.type", "screen orientation type", "", "nocode")}} and {{DOMxRef("ScreenOrientation.angle", "angle", "", "nocode")}}.
 
 ```js
 screen.orientation.addEventListener("change", (event) => {

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -14,7 +14,7 @@ The `orientationchange` event is fired when the orientation of the device has ch
 
 This event is not cancelable and does not bubble.
 
-This event is deprecated. Use {{domxref("ScreenOrientation/onchange", "screen.orientation.addEventListener('change', callback)")}} instead.
+This event is deprecated. Use {{domxref("ScreenOrientation.change_event", "screen.orientation.addEventListener('change', callback)")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -14,7 +14,7 @@ The `orientationchange` event is fired when the orientation of the device has ch
 
 This event is not cancelable and does not bubble.
 
-This event is deprecated. Listen for the {{domxref("ScreenOrientation/onchange", "ScreenOrientation.onchange")}} event instead.
+This event is deprecated. Use {{domxref("ScreenOrientation/onchange", "screen.orientation.addEventListener('change', callback)")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -14,7 +14,7 @@ The `orientationchange` event is fired when the orientation of the device has ch
 
 This event is not cancelable and does not bubble.
 
-This event is deprecated. Use {{domxref("ScreenOrientation.change_event", "screen.orientation.addEventListener('change', callback)")}} instead.
+This event is deprecated. Listen for the {{domxref("ScreenOrientation.change_event", "change")}} event of the {{domxref("ScreenOrientation")}} interface instead.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

The onchange is a global and if multiple libraries use it, they will override each other's listener, it's better to recommend the use of `addEventListener` which I also documented on the linked page instead of `screen.orientation.onchange`


### Motivation

I could not find a proper replacement when looking at the deprecated event and the linked page, because it only proposes a global `onchange`, I had to google it and find [this stackoverflow answer](https://stackoverflow.com/questions/67961837/deprecated-window-orientationchange-event) to find that `ScreenOrientation` supports the use of `addEventListener`

