### PR TITLE
Fixed link on "forced-colors" page

### DIFF
--- a/files/en-us/web/css/@media/forced-colors/index.md
+++ b/files/en-us/web/css/@media/forced-colors/index.md
@@ -18,7 +18,7 @@ The `forced-colors` media feature indicates whether or not the browser is curren
 - `none`
   - : Forced colors mode is not active; the page's colors are not being forced into a limited palette.
 - `active`
-  - : Indicates that forced colors mode is active. The browser provides the color palette to authors through the [CSS system color](/en-US/docs/Web/CSS/color_value#system_colors) keywords and, if appropriate, triggers the appropriate value of [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) so that authors can adapt the page. The browser selects the value for `prefers-color-scheme` based on the lightness of the `Canvas` system color (see the [color adjust spec](https://www.w3.org/TR/css-color-adjust-1/#forced) for more details).
+  - : Indicates that forced colors mode is active. The browser provides the color palette to authors through the [CSS system color](/en-US/docs/Web/CSS/system-color) keywords and, if appropriate, triggers the appropriate value of [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) so that authors can adapt the page. The browser selects the value for `prefers-color-scheme` based on the lightness of the `Canvas` system color (see the [color adjust spec](https://www.w3.org/TR/css-color-adjust-1/#forced) for more details).
 
 ## Usage notes
 


### PR DESCRIPTION
Fixed dead link to missing section which has been moved to new page

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The link in the phrase _"The browser provides the color palette to authors through the [CSS system color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#system_colors) keywords_" links to a section of that page which appears to have been removed. Changed to link to the [dedicated System Colors page](/en-US/docs/Web/CSS/system-color).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Minor technical fix, link led to wrong page

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
None

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
