### PR TITLE
Clarification on interactions between hourCycle and dayPeriod

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -106,7 +106,7 @@ Intl.DateTimeFormat(locales, options)
 
         > **Note:**
         >
-        > - This option only has an effect if a 12-hour clock is used.
+        > - This option only has an effect if a 12-hour clock (`hourCycle: 'h12'` or `hourCycle: 'h11'`) is used.
         > - Many locales use the same string irrespective of the width specified.
 
     - `numberingSystem`
@@ -316,7 +316,7 @@ console.log(mediumTime.format(Date.now())); // "07/07/20, 1:31:55 PM"
 
 ### Using dayPeriod
 
-Use the `dayPeriod` option to output a string for the times of day ("in the morning", "at night", "noon", etc.). Note, that this only works when formatting for a 12 hour clock (`hourCycle: 'h12'`) and that for many locales the strings are the same irrespective of the value passed for the `dayPeriod`.
+Use the `dayPeriod` option to output a string for the times of day ("in the morning", "at night", "noon", etc.). Note, that this only works when formatting for a 12 hour clock (`hourCycle: 'h12'` or `hourCycle: 'h11'`) and that for many locales the strings are the same irrespective of the value passed for the `dayPeriod`.
 
 ```js
 const date = Date.UTC(2012, 11, 17, 4, 0, 42);


### PR DESCRIPTION
### Description

Current wording implies that dayPeriod is only used if `hourCycle: 'h12'` option is set, updated to reflect that `dayPeriod` is displayed if either `hourCycle: 'h12'` or `hourCycle: 'h11'` are set, i.e. both of the below

```js 

const date = new Date(Date.UTC(2020, 11, 20, 3, 23, 16, 738));

console.log(new Intl.DateTimeFormat('en', {hourCycle:'h11', hour: 'numeric', minute: '2-digit', second: '2-digit', dayPeriod: 'long'}).format(date))
console.log(new Intl.DateTimeFormat('en', {hourCycle:'h12', hour: 'numeric', minute: '2-digit', second: '2-digit', dayPeriod: 'long'}).format(date))
```

produce output containing the long form of the day period.

### Motivation

prevents confusions related to `'h11'` and `'h12'` `hourCycle` options

