### PR TITLE
Move timeoutId out of try-catch scope in Abort example

### DIFF
--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -123,9 +123,10 @@ To trigger on multiple signals they must be daisy chained.
 The code snippet below shows how you might call {{domxref("AbortController.abort()")}} in the handler for a separate timer.
 
 ```js
+let timeoutId;
 try {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  timeoutId = setTimeout(() => controller.abort(), 5000);
   const res = await fetch(url, { signal: controller.signal });
   const body = await res.json();
 } catch (e) {


### PR DESCRIPTION
### Description
- Changed timeoutId variable to let from const
- Moved the timeoutId variable declaration outside the scope of the try-catch-finally

### Motivation
I was adding a timeout based on the example and stumbled upon the scoping issue.
Just changing it so future readers save a few seconds ;).

### Additional details
Too simple a change to require any.

### Related issues and pull requests
I don't believe it would be related to any current issue or pull request.
