### PR TITLE
Further clarifications on disablePictureInPicture

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -8,15 +8,11 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 {{APIRef("HTML DOM")}}
 
-The {{domxref("HTMLVideoElement")}}
-**`disablePictureInPicture`** property reflects the HTML
-attribute indicating whether the user agent should suggest the
-picture-in-picture feature to users, or request it automatically.
+The {{domxref("HTMLVideoElement")}} **`disablePictureInPicture`** property reflects the HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
 
 ## Value
 
-A boolean value that is `true` if the user agent should not
-suggest that feature to users.
+A boolean value that is `true` if the picture-in-picture feature is disabled for this element. This means that the user agent should not suggest that feature to users, or request it automatically.
 
 ## Specifications
 


### PR DESCRIPTION
While I thought https://github.com/mdn/content/pull/28098 was good, I also thought the page was still unclear.

In particular, the start:

> The HTMLVideoElement disablePictureInPicture property reflects the HTML attribute indicating whether the user agent should suggest the picture-in-picture feature to users, or request it automatically.

...reads to me as if the property toggles between "suggest the picture-in-picture feature to users" and "request it automatically". Then the bit under "Value", that only talked about "suggest that feature to users" kind of reinforces this.

So I've reworked it to be hopefully clearer.