### PR TITLE
Markdownlint: don't format ".git" folder

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -211,5 +211,5 @@
     }
   },
   "customRules": ["markdownlint-rule-search-replace"],
-  "ignores": ["node_modules", ".github", "tests"]
+  "ignores": ["node_modules", ".git", ".github", "tests"]
 }


### PR DESCRIPTION
This PR adds `.git` as an ignore to the Markdownlint config.
