### PR TITLE
Add LaTeX syntax highlighting

### DIFF
--- a/files/en-us/learn/mathml/first_steps/three_famous_mathematical_formulas/index.md
+++ b/files/en-us/learn/mathml/first_steps/three_famous_mathematical_formulas/index.md
@@ -35,7 +35,7 @@ The goal is to rewrite the following math article using HTML and MathML:
 
 Although you don't need to be familiar with [LaTeX](https://en.wikipedia.org/wiki/LaTeX), it might be useful to know the LaTeX source from which it was generated:
 
-```
+```latex
 \documentclass{article}
 
 \usepackage{amsmath}

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -80,6 +80,7 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `xml` - XML
   - `mathml` - MathML
   - `md` - Markdown
+  - `latex` - LaTeX
 - Command Prompts
   - `sh` - Bash/Shell
   - `batch` - Batch (Windows Shell)


### PR DESCRIPTION
This PR adds LaTeX to the list of available syntax languages for highlighting, as well as assigns it to the appropriate block in https://developer.mozilla.org/en-US/docs/Learn/MathML/First_steps/Three_famous_mathematical_formulas.

Depends on https://github.com/mdn/yari/pull/9366.
