### PR TITLE
fix: Fix wrong link for "function*" redirecting to /function

### DIFF
--- a/files/en-us/web/javascript/reference/operators/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.md
@@ -50,7 +50,7 @@ function* name(param0, param1, /* … ,*/ paramN) {
 
 ## Description
 
-A `function*` expression is very similar to, and has almost the same syntax as, a [`function*` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function). The main difference between a `function*` expression and a `function*` declaration is the _function name_, which can be omitted in `function*` expressions to create _anonymous_ functions. A `function*` expression can be used as an [IIFE](/en-US/docs/Glossary/IIFE) (Immediately Invoked Function Expression) which runs as soon as it is defined, allowing you to create an ad-hoc [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). See also the chapter about [functions](/en-US/docs/Web/JavaScript/Reference/Functions) for more information.
+A `function*` expression is very similar to, and has almost the same syntax as, a [`function*` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function*). The main difference between a `function*` expression and a `function*` declaration is the _function name_, which can be omitted in `function*` expressions to create _anonymous_ functions. A `function*` expression can be used as an [IIFE](/en-US/docs/Glossary/IIFE) (Immediately Invoked Function Expression) which runs as soon as it is defined, allowing you to create an ad-hoc [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). See also the chapter about [functions](/en-US/docs/Web/JavaScript/Reference/Functions) for more information.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
There is a link in the page about "`function*` expressions" that should be redirecting to the "`function*` declaration" that instead redirects to the "`function` declaration".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Just a bug fix.

### Related issues and pull requests

Fixes #28151 