### PR TITLE
Fixing two broken (on Firefox) examples within SVG documentation

### DIFF
--- a/files/en-us/web/svg/element/feblend/index.md
+++ b/files/en-us/web/svg/element/feblend/index.md
@@ -58,7 +58,7 @@ This element implements the {{domxref("SVGFEBlendElement")}} interface.
   </defs>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     x="10%"
     y="10%"
     width="80%"

--- a/files/en-us/web/svg/element/feconvolvematrix/index.md
+++ b/files/en-us/web/svg/element/feconvolvematrix/index.md
@@ -101,7 +101,7 @@ This element implements the {{domxref("SVGFEConvolveMatrixElement")}} interface.
   </defs>
 
   <image
-    xlink:href="mdn.svg"
+    href="mdn.svg"
     x="0"
     y="0"
     height="200"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed two examples of SVG filters that were broken due to deprecated xlink attributes.

### Motivation

For the two examples (feBlur and feConvolveMatrix), the examples provided do not work correctly on Firefox or Chrome. They both contain linked <Image> elements with deprecated "xlink:href" attributes, which is the source of the problem. I just switched these to plain "href" and they work.

### Additional details

See deprecation notes on "xlink:href": [https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href)

### Related issues and pull requests



<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
