### PR TITLE
Add information about whitespaces text nodes

### DIFF
--- a/files/en-us/web/api/node/childnodes/index.md
+++ b/files/en-us/web/api/node/childnodes/index.md
@@ -15,6 +15,12 @@ comments.
 
 > **Note:** The {{domxref("NodeList")}} being live means that its content is changed each time
 > new children are added or removed.
+>
+> Browsers insert text nodes into a document to represent whitespace in the source markup.
+> Therefore a node obtained, for example, using `Node.childNodes[0]`
+> may refer to a whitespace text node rather than the actual element the author intended to get.
+>
+> See [Whitespace in the DOM](/en-US/docs/Web/API/Document_Object_Model/Whitespace) for more information.
 
 The items in the collection of nodes are objects, not strings. To get data from node
 objects, use their properties. For example, to get the name of the first


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I added some information about  empty text nodes in the `Node.childNodes` documentation, with a reference to a [documentation about the subject](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace).

This was inspired by the notes in the [previousSiblings](https://developer.mozilla.org/en-US/docs/Web/API/Node/previousSibling) and [nextSiblings](https://developer.mozilla.org/en-US/docs/Web/API/Node/nextSibling) pages.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I got myself pretty confused when trying to find out why `childNodes` was returning an array full of empty text nodes, and took me a while to find a reference to [this very helpful docs](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace) that made things clearer for me. I think other people could use this reference in the future when faced with a similar problem.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
