### PR TITLE
Fix typo in “WebAssembly numeric instructions” doc

### DIFF
--- a/files/en-us/webassembly/reference/numeric/index.md
+++ b/files/en-us/webassembly/reference/numeric/index.md
@@ -91,7 +91,7 @@ WebAssembly numeric instructions.
 - [`Left shift`](/en-US/docs/WebAssembly/Reference/Numeric/Left_shift)
   - : Used for performing a bitwise left-shift.
 - [`Right shift`](/en-US/docs/WebAssembly/Reference/Numeric/Right_shift)
-  - : Used for performing a bitwise left-shift.
+  - : Used for performing a bitwise right-shift.
 - [`Left rotate`](/en-US/docs/WebAssembly/Reference/Numeric/Left_rotate)
   - : Used for performing a bitwise left-rotate.
 - [`Right rotate`](/en-US/docs/WebAssembly/Reference/Numeric/Right_rotate)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28176