### PR TITLE
fix: drop a call of 3rd-party method from MediaRecorder's example

### DIFF
--- a/files/en-us/web/api/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/index.md
@@ -80,8 +80,6 @@ if (navigator.mediaDevices) {
     .then((stream) => {
       const mediaRecorder = new MediaRecorder(stream);
 
-      visualize(stream);
-
       record.onclick = () => {
         mediaRecorder.start();
         console.log(mediaRecorder.state);


### PR DESCRIPTION
### Description

fix: drop a call of 3rd-party method from MediaRecorder's example

### Motivation

Implementation of `visualize()` method is present only in the original example, and consequently, there is it will not work "here". With its removal, we will get 1 bug less in the code of this example