### PR TITLE
Add BigInt64Array to Atomics.notify()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Atomics.notify
 The **`Atomics.notify()`** static
 method notifies up some agents that are sleeping in the wait queue.
 
-> **Note:** This operation only works with a shared {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}}.
+> **Note:** This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 > It will return `0` on non-shared `ArrayBuffer` objects.
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -10,8 +10,7 @@ browser-compat: javascript.builtins.Atomics.notify
 The **`Atomics.notify()`** static
 method notifies up some agents that are sleeping in the wait queue.
 
-> **Note:** This operation works with a shared {{jsxref("Int32Array")}}
-> only.
+> **Note:** This operation only works with a shared {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}}.
 > It will return `0` on non-shared `ArrayBuffer` objects.
 
 ## Syntax
@@ -23,7 +22,7 @@ Atomics.notify(typedArray, index, count)
 ### Parameters
 
 - `typedArray`
-  - : A shared {{jsxref("Int32Array")}}.
+  - : An {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 - `index`
   - : The position in the `typedArray` to wake up on.
 - `count` {{optional_inline}}
@@ -38,7 +37,7 @@ Atomics.notify(typedArray, index, count)
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if `typedArray` is not a {{jsxref("Int32Array")}}.
+  - : Thrown if `typedArray` is not an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 - {{jsxref("RangeError")}}
   - : Thrown if `index` is out of bounds in the `typedArray`.
 
@@ -83,3 +82,4 @@ Atomics.notify(int32, 0, 1);
 
 - {{jsxref("Atomics")}}
 - {{jsxref("Atomics.wait()")}}
+- {{jsxref("Atomics.waitAsync()")}}

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -11,7 +11,7 @@ The **`Atomics.waitAsync()`** static method waits asynchronously on a shared mem
 
 Unlike {{jsxref("Atomics.wait()")}}, `waitAsync` is non-blocking and usable on the main thread.
 
-> **Note:** This operation only works with a shared {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}}.
+> **Note:** This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR updates the [`Atomics.notify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify) page to note that `BigInt64Array` is accepted for the `typedArray` parameter.

I also added a link to [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) in the "See also" section.

### Motivation

According to the [ECMAScript language specification](https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.notify), the `typedArray` parameter of `Atomics.notify()` may be either `Int32Array` or `BigInt64Array`. This is the same as [`Atomics.wait()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait) and [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync).

### Additional details

Here is a minimal test I ran to confirm this in Chrome, Edge, and Safari:

```javascript
// Reproduce this test by running this code in DevTools
const sab = new SharedArrayBuffer(8);
const arr = new BigInt64Array(sab);

Atomics.store(arr, 0, 100n);
const wait = Atomics.waitAsync(arr, 0, 100n);
wait.value.then(console.log);

Atomics.notify(arr, 0);
// console output:
// ok
```

And a minimal test to confirm in Firefox (`Atomics.waitAsync()` is not implemented in Firefox):

```javascript
// Reproduce by setting up a web page to load this code

// worker.js
addEventListener('message', async e => {
  const sab = e.data;
  const arr = new BigInt64Array(sab);
  const wait = Atomics.wait(arr, 0, 100n);
  console.log(wait);
  close();
});

// main thread
const sab = new SharedArrayBuffer(8);
const arr = new BigInt64Array(sab);
Atomics.store(arr, 0, 100n);
const worker = new Worker('/worker.js');
worker.postMessage(sab);
setTimeout(() => Atomics.notify(arr, 0), 100);

// console output:
// ok
```