### PR TITLE
Remove "default" from possible return values of Notification.requestPermission

### DIFF
--- a/files/en-us/web/api/notification/requestpermission_static/index.md
+++ b/files/en-us/web/api/notification/requestpermission_static/index.md
@@ -31,7 +31,6 @@ A {{jsxref("Promise")}} that resolves to a string with the permission picked by 
 
 - `granted`
 - `denied`
-- `default`
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

As the title says

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Per the spec: https://notifications.spec.whatwg.org/#dom-notification-requestpermission

> Let permissionState be the result of requesting permission to use "notifications".

... which is https://w3c.github.io/permissions/#dfn-request-permission-to-use:

> To request permission to use a descriptor, the user agent must perform the following steps. This algorithm returns either "granted" or "denied".

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
