### PR TITLE
Fix anchor link for Forgiving selector lists

### DIFF
--- a/files/en-us/web/css/selector_list/index.md
+++ b/files/en-us/web/css/selector_list/index.md
@@ -66,7 +66,7 @@ h1 + p {
 
 ## Valid and invalid selector lists
 
-An invalid selector represents, and therefore matches, nothing. When a selector list contains an invalid selector, the entire style block is ignored, except for the {{CSSxRef(":is", ":is()")}} and {{CSSxRef(":where", ":where()")}} pseudo-classes that accept [forgiving selector lists](#forgiving-selector-list).
+An invalid selector represents, and therefore matches, nothing. When a selector list contains an invalid selector, the entire style block is ignored, except for the {{CSSxRef(":is", ":is()")}} and {{CSSxRef(":where", ":where()")}} pseudo-classes that accept [forgiving selector lists](#forgiving_selector_list).
 
 ### Invalid selector list
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The forgiving selectors link under [Valid and invalid selector lists](https://developer.mozilla.org/en-US/docs/Web/CSS/Selector_list#valid_and_invalid_selector_lists) pointed to 
https://developer.mozilla.org/en-US/docs/Web/CSS/Selector_list#forgiving-selector-list 
but the correct link is 
https://developer.mozilla.org/en-US/docs/Web/CSS/Selector_list#forgiving_selector_list 
(underscores instead of dashes).


### Motivation

Improve the docs

### Additional details

N/A

### Related issues and pull requests

N/A