### PR TITLE
fix(css): Fix easing function name (Step -> Steps)

### DIFF
--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -112,7 +112,7 @@ Consider another example of the function: `linear(0, 0.25 75%, 1)`. This produce
 
 The [`linear`](#linear) keyword is equivalent to the easing function `linear(0, 1)`.
 
-### Cubic-bezier easing function
+### Cubic Bézier easing function
 
 The `cubic-bezier()` functional notation defines a cubic [Bézier curve](/en-US/docs/Glossary/Bezier_curve). The easing functions in the cubic-bezier subset of easing functions are often called "smooth" easing functions because they can be used to smooth down the start and end of the {{Glossary("interpolation")}}. They correlate an input progress to an output progress, both expressed as {{cssxref("&lt;number&gt;")}}s. For these values, `0.0` represents the initial state, and `1.0` represents the final state.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -112,7 +112,7 @@ Consider another example of the function: `linear(0, 0.25 75%, 1)`. This produce
 
 The [`linear`](#linear) keyword is equivalent to the easing function `linear(0, 1)`.
 
-### Cubic Bézier easing function
+### Cubic-bezier easing function
 
 The `cubic-bezier()` functional notation defines a cubic [Bézier curve](/en-US/docs/Glossary/Bezier_curve). The easing functions in the cubic-bezier subset of easing functions are often called "smooth" easing functions because they can be used to smooth down the start and end of the {{Glossary("interpolation")}}. They correlate an input progress to an output progress, both expressed as {{cssxref("&lt;number&gt;")}}s. For these values, `0.0` represents the initial state, and `1.0` represents the final state.
 
@@ -132,7 +132,7 @@ When you specify an invalid cubic Bézier curve, CSS ignores the whole property.
 
 Each of the keywords [`ease`](#ease), [`ease-in`](#ease-in), [`ease-out`](#ease-out), and [`ease-in-out`](#ease-in-out) is equivalent to a specific `cubic-bezier()` value.
 
-### Step easing function
+### Steps easing function
 
 The `steps()` functional notation defines a [step function](https://en.wikipedia.org/wiki/Step_function) that divides the domain of output values in equidistant steps. This subclass of step functions are sometimes also called _staircase functions_.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The correct function name is "steps". This PR corrects the name in the section title.
While here, this PR also fixes the name of the "Cubic-bezier" function in the title (adds hyphen and removes accent)
