### PR TITLE
Normalize headings for CSS properties

### DIFF
--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -46,7 +46,7 @@ The `column-fill` property is specified as one of the keyword values listed belo
 
 {{csssyntax}}
 
-## Example
+## Examples
 
 ### Balancing column content
 

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -50,7 +50,9 @@ container-type: unset;
 
 {{CSSSyntax}}
 
-## Example
+## Examples
+
+### Establishing inline size containment
 
 Given the following HTML example which is a card component with an image, a title, and some text:
 
@@ -83,8 +85,6 @@ Writing a container query via the {{Cssxref("@container")}} at-rule will apply s
   }
 }
 ```
-
-For more information on container queries, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_container_queries) page.
 
 ## Specifications
 

--- a/files/en-us/web/css/container/index.md
+++ b/files/en-us/web/css/container/index.md
@@ -50,7 +50,9 @@ container: unset;
 
 {{CSSSyntax}}
 
-## Example
+## Examples
+
+### Establishing inline size containment
 
 Given the following HTML example which is a card component with an image, a title, and some text:
 
@@ -87,8 +89,6 @@ You can then target that container by name using the {{cssxref("@container")}} a
   /* <stylesheet> */
 }
 ```
-
-For more information on container queries, see the [CSS Container Queries](/en-US/docs/Web/CSS/CSS_container_queries) page.
 
 ## Specifications
 

--- a/files/en-us/web/css/empty-cells/index.md
+++ b/files/en-us/web/css/empty-cells/index.md
@@ -45,7 +45,7 @@ The `empty-cells` property is specified as one of the keyword values listed belo
 
 {{csssyntax}}
 
-## Example
+## Examples
 
 ### Showing and hiding empty table cells
 

--- a/files/en-us/web/css/font-weight/index.md
+++ b/files/en-us/web/css/font-weight/index.md
@@ -231,7 +231,7 @@ span {
 
 {{Compat}}
 
-## See Also
+## See also
 
 - {{cssxref("font-family")}}
 - {{cssxref("font-style")}}

--- a/files/en-us/web/css/margin-trim/index.md
+++ b/files/en-us/web/css/margin-trim/index.md
@@ -30,7 +30,7 @@ margin-trim: revert-layer;
 margin-trim: unset;
 ```
 
-## Values
+### Values
 
 - `none`
 

--- a/files/en-us/web/css/math-depth/index.md
+++ b/files/en-us/web/css/math-depth/index.md
@@ -32,7 +32,7 @@ math-depth: revert-layer;
 math-depth: unset;
 ```
 
-## Values
+### Values
 
 - `auto-add`
   - : Set to the inherited `math-depth` plus 1 when inherited [math-style](/en-US/docs/Web/CSS/math-style) is `compact`.


### PR DESCRIPTION
A few of the CSS property pages had wrong headings:
- "Examples" H2 should always be plural, and individual examples should have their own H3
- "Values" is not an H2, but an is H3 under "Syntax"
- "See also" should use sentence case

I also removed a link to the CSS container queries page from the example, since it's already linked from See also and twice in the intro paragraph.