### PR TITLE
describe Access-Control-Request-Headers as optional part of preflight

### DIFF
--- a/files/en-us/glossary/preflight_request/index.md
+++ b/files/en-us/glossary/preflight_request/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 A CORS preflight request is a {{Glossary("CORS")}} request that checks to see if the CORS protocol is understood and a server is aware using specific methods and headers.
 
-It is an {{HTTPMethod("OPTIONS")}} request, using three HTTP request headers: {{HTTPHeader("Access-Control-Request-Method")}}, {{HTTPHeader("Access-Control-Request-Headers")}}, and the {{HTTPHeader("Origin")}} header.
+It is an {{HTTPMethod("OPTIONS")}} request, using two or three HTTP request headers: {{HTTPHeader("Access-Control-Request-Method")}}, {{HTTPHeader("Origin")}}, and optionally {{HTTPHeader("Access-Control-Request-Headers")}}.
 
 A preflight request is automatically issued by a browser and in normal cases, front-end developers don't need to craft such requests themselves. It appears when request is qualified as ["to be preflighted"](/en-US/docs/Web/HTTP/CORS#preflighted_requests) and omitted for [simple requests](/en-US/docs/Web/HTTP/CORS#simple_requests).
 


### PR DESCRIPTION
### Description

Describe `Access-Control-Request-Headers` as an optional part of a preflight request.

### Motivation

The current description of a preflight seems to indicate that the `Access-Control-Request-Headers` header will always be present. But per the fetch spec, that is not the case. 

Per
https://fetch.spec.whatwg.org/#cors-preflight-fetch ,  Access-Control-Request-Headers is an optional part of a preflight. In practice, Chrome v115 does not send Access-Control-Request-Headers when there is no restricted header in the pending outbound request.

### Additional details

https://fetch.spec.whatwg.org/#cors-preflight-fetch

specific wording is: 
> Let headers be the [CORS-unsafe request-header names](https://fetch.spec.whatwg.org/#cors-unsafe-request-header-names) with request’s [header list](https://fetch.spec.whatwg.org/#concept-request-header-list).
> 
> If headers [is not empty](https://infra.spec.whatwg.org/#list-is-empty), then:
> 
> * Let value be the items in headers separated from each other by `,`.
> 
> * [Append](https://fetch.spec.whatwg.org/#concept-header-list-append) (`[Access-Control-Request-Headers](https://fetch.spec.whatwg.org/#http-access-control-request-headers)`, value) to preflight’s [header list](https://fetch.spec.whatwg.org/#concept-request-header-list).

