### PR TITLE
Fix command line examples to follow guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,13 +201,13 @@ This will make it easier to submit a pull request for your changes.
 3. Check for errors by clicking `Show flaws` on each previewed page.
    You may be able to fix flaws by running:
 
-   ```sh
+   ```bash
    yarn content flaws <page_slug>
    ```
 
 4. Commit your changes to the branch (our example is using the `fix-typo` branch) and push the changes to your fork's remote:
 
-   ```sh
+   ```bash
    # Adding all files to the commit
    git add .
    # Making a commit with a message describing the changes
@@ -241,7 +241,7 @@ There are a few things to keep in mind:
 Moving one or more documents (or an entire tree of documents) is made easier with the `yarn content move` command.
 This command moves the file and fixes up redirects automatically. You can use this command as shown below:
 
-```sh
+```bash
 yarn content move <from-slug> <to-slug> [locale]
 ```
 
@@ -257,7 +257,7 @@ Let's say you want to move the entire `/en-US/Learn/Accessibility` tree to `/en-
 
 1. Starting from a fresh branch:
 
-   ```sh
+   ```bash
    cd ~/repos/content
    # Fetch the latest changes from the main branch on mdn/content
    git fetch upstream
@@ -270,13 +270,13 @@ Let's say you want to move the entire `/en-US/Learn/Accessibility` tree to `/en-
 2. Move files with `yarn content move`.
    This will delete and modify existing files, as well as create new files.
 
-   ```sh
+   ```bash
    yarn content move Learn/Accessibility Learn/A11y
    ```
 
 3. Commit all of the changes and push your branch to the remote:
 
-   ```sh
+   ```bash
    git add .
    git commit -m "Move Learn/Accessibility to Learn/A11y"
    git push
@@ -292,14 +292,14 @@ Similar to moving files, you can delete documents or a tree of documents easily 
 
 You can use this command as shown below:
 
-```sh
+```bash
 yarn content delete <document-slug> [locale] --redirect <redirect-slug-or-url>
 ```
 
 To use `yarn content delete`, provide the slug of the document you'd like to delete (e.g., `Learn/Accessibility`), and the locale as an optional second argument (this defaults to `en-US`).
 If the slug of the page you wish to delete contains special characters, include it in quotes. For example:
 
-```sh
+```bash
 yarn content delete "Glossary/Round_Trip_Time_(RTT)" --redirect Glossary/Latency
 ```
 
@@ -308,7 +308,7 @@ Say you want to delete the entire `/en-US/Learn/Accessibility` tree and redirect
 
 1. Start from a fresh branch.
 
-   ```sh
+   ```bash
    cd ~/repos/content
    # Fetch the latest changes from the main branch on mdn/content
    git fetch upstream
@@ -320,7 +320,7 @@ Say you want to delete the entire `/en-US/Learn/Accessibility` tree and redirect
 
 2. Run the `yarn content delete` command and redirect all deleted documents.
 
-   ```sh
+   ```bash
    yarn content delete Learn/Accessibility --recursive --redirect Web/Accessibility
    ```
 
@@ -330,7 +330,7 @@ Say you want to delete the entire `/en-US/Learn/Accessibility` tree and redirect
 
 3. Commit all of the changes and push your branch to the remote.
 
-   ```sh
+   ```bash
    git add .
    git commit -m "Delete Learn/Accessibility pages"
    git push
@@ -346,7 +346,7 @@ You may do this by using the `yarn content add-redirect` command.
 
 1. Start a fresh branch to work in:
 
-   ```sh
+   ```bash
    cd ~/repos/content
    # Fetch the latest changes from the main branch on mdn/content
    git fetch upstream
@@ -358,13 +358,13 @@ You may do this by using the `yarn content add-redirect` command.
 
 2. Add a redirect with `yarn content add-redirect`. The target page can be a page on MDN or an external URL:
 
-   ```sh
+   ```bash
    yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
    ```
 
 3. Commit all of the changed files and pushing your branch to your fork:
 
-   ```sh
+   ```bash
    git add .
    git commit -m "Adding redirect after deleting Learn/Accessibility pages"
    git push

--- a/files/en-us/glossary/round_trip_time/index.md
+++ b/files/en-us/glossary/round_trip_time/index.md
@@ -9,7 +9,12 @@ page-type: glossary-definition
 **Round Trip Time (RTT)** is the length time it takes for a data packet to be sent to a destination plus the time it takes for an acknowledgment of that packet to be received back at the origin. The RTT between a network and server can be determined by using the `ping` command.
 
 ```bash
-$ ping example.com
+ping example.com
+```
+
+This will output something like:
+
+```plain
 PING example.com (216.58.194.174): 56 data bytes
 64 bytes from 216.58.194.174: icmp_seq=0 ttl=55 time=25.050 ms
 64 bytes from 216.58.194.174: icmp_seq=1 ttl=55 time=23.781 ms

--- a/files/en-us/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
+++ b/files/en-us/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
@@ -90,7 +90,12 @@ To find out whether a given domain name is available,
 - Alternatively, if you use a system with a built-in shell, type a `whois` command into it, as shown here for `mozilla.org`:
 
   ```bash
-  $ whois mozilla.org
+  whois mozilla.org
+  ```
+
+  This will output the following:
+
+  ```plain
   Domain Name:MOZILLA.ORG
   Domain ID: D1409563-LROR
   Creation Date: 1998-01-24T05:00:00Z
@@ -119,11 +124,16 @@ As you can see, I can't register `mozilla.org` because the Mozilla Foundation ha
 On the other hand, let's see if I could register `afunkydomainname.org`:
 
 ```bash
-$ whois afunkydomainname.org
+whois afunkydomainname.org
+```
+
+This will output the following (at the time of writing):
+
+```plain
 NOT FOUND
 ```
 
-As you can see, the domain does not exist in the `whois` database (at the time of writing), so we could ask to register it. Good to know!
+As you can see, the domain does not exist in the `whois` database, so we could ask to register it. Good to know!
 
 #### Getting a domain name
 

--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -110,7 +110,6 @@ You can confirm this by running the following command in the bash terminal:
 
 ```bash
 python3 -V
- Python 3.8.10
 ```
 
 However, the Python Package Index tool (_pip3_) you'll need to install packages for Python 3 (including Django) is **not** available by default.
@@ -127,12 +126,13 @@ sudo apt install python3-pip
 ### macOS
 
 macOS does not include Python 3 by default (Python 2 is included on older versions).
-You can confirm this by running the following commands in the zsh or bash terminal:
+You can confirm this by running the following command in the terminal:
 
 ```bash
-$ python3 -V
-  python3: command not found
+python3 -V
 ```
+
+This will either display the Python version number, which indicates that Python 3 is installed, or `python3: command not found`, which indicates Python 3 was not found.
 
 You can easily install Python 3 (along with the _pip3_ tool) from [python.org](https://www.python.org/):
 
@@ -144,12 +144,7 @@ You can easily install Python 3 (along with the _pip3_ tool) from [python.org](h
 
 2. Locate the file using _Finder_, and double-click the package file. Following the installation prompts.
 
-You can now confirm successful installation by checking for the _Python 3_ version as shown below:
-
-```bash
-python3 -V
- Python 3.10.2
-```
+You can now confirm successful installation by running `python3 -V` again and checking for the Python version number.
 
 You can similarly check that _pip3_ is installed by listing the available packages:
 
@@ -174,7 +169,6 @@ You can then verify that Python 3 was installed by entering the following text i
 
 ```bash
 py -3 -V
- Python 3.10.2
 ```
 
 The Windows installer incorporates _pip3_ (the Python package manager) by default.
@@ -195,29 +189,21 @@ You will note that in the previous sections we use different commands to call Py
 If you only have Python 3 installed (and not Python 2), the bare commands `python` and `pip` can generally be used to run Python and pip on any operating system.
 If this is allowed on your system you will get a version "3" string when you run `-V` with the bare commands, as shown:
 
-```
-> python -V
-  Python 3.10.2
-
-> pip -V
-pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)
+```bash
+python -V
+pip -V
 ```
 
 If Python 2 is installed then to use version 3 you should prefix commands with `python3` and `pip3` on Linux/macOS, and `py -3` and `py -3 -m pip` on Windows:
 
 ```bash
+# Linux/macOS
+python3 -V
+pip3 -V
+
 # Windows
 py -3 -V
- Python 3.10.2
-
 py -3 -m pip list
-
-# Linux/macOS
-$ python3 -V
- Python 3.10.2
-
-$ pip3 -V
-  pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)
 ```
 
 The instructions below show the platform specific commands as they work on more systems.
@@ -341,8 +327,12 @@ Once you've installed _virtualenvwrapper_ or _virtualenvwrapper-win_ then workin
 Now you can create a new virtual environment with the `mkvirtualenv` command. As this command runs you'll see the environment being set up (what you see is slightly platform-specific). When the command completes the new virtual environment will be active — you can see this because the start of the prompt will be the name of the environment in brackets (below we show this for Ubuntu, but the final line is similar for Windows/macOS).
 
 ```bash
-$ mkvirtualenv my_django_environment
+mkvirtualenv my_django_environment
+```
 
+You should see output similar to the following:
+
+```plain
 Running virtualenv with interpreter /usr/bin/python3
 # …
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/t_env7/bin/get_env_details
@@ -379,11 +369,9 @@ You can test that Django is installed by running the following command (this jus
 ```bash
 # Linux/macOS
 python3 -m django --version
- 4.0.10
 
 # Windows
 py -3 -m django --version
- 4.0.10
 ```
 
 > **Note:** If the above Windows command does not show a django module present, try:
@@ -424,22 +412,14 @@ cd mytestsite
 We can run the _development web server_ from within this folder using **manage.py** and the `runserver` command, as shown.
 
 ```bash
-$ python3 manage.py runserver
-Watching for file changes with StatReloader
-Performing system checks…
+# Linux/macOS
+python3 manage.py runserver
 
-System check identified no issues (0 silenced).
-
-You have 18 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
-Run 'python manage.py migrate' to apply them.
-March 01, 2022 - 01:19:16
-Django version 4.0.10, using settings 'mytestsite.settings'
-Starting development server at http://127.0.0.1:8000/
-Quit the server with CONTROL-C.
+# Windows
+py -3 manage.py runserver
 ```
 
-> **Note:** The above command shows the Linux/macOS command.
-> You can ignore the warnings about "18 unapplied migration(s)" at this point!
+> **Note:** You can ignore the warnings about "18 unapplied migration(s)" at this point!
 
 Once the server is running you can view the site by navigating to the following URL on your local web browser: `http://127.0.0.1:8000/`. You should see a site that looks like this:
 

--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -110,6 +110,7 @@ You can confirm this by running the following command in the bash terminal:
 
 ```bash
 python3 -V
+# Output: Python 3.8.10
 ```
 
 However, the Python Package Index tool (_pip3_) you'll need to install packages for Python 3 (including Django) is **not** available by default.

--- a/files/en-us/learn/server-side/django/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/django/skeleton_website/index.md
@@ -337,16 +337,7 @@ During development, you can serve the website first using the _development web s
 Run the _development web server_ by calling the `runserver` command (in the same directory as **manage.py**):
 
 ```bash
-$ python3 manage.py runserver
-
-Watching for file changes with StatReloader
-Performing system checks...
-
-System check identified no issues (0 silenced).
-March 01, 2022 - 04:08:45
-Django version 4.0.2, using settings 'locallibrary.settings'
-Starting development server at http://127.0.0.1:8000/
-Quit the server with CONTROL-C.
+python3 manage.py runserver
 ```
 
 Once the server is running, you can view the site by navigating to `http://127.0.0.1:8000/` in your local web browser. You should see a site error page that looks like this:

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -402,7 +402,10 @@ The final step is to copy your application source files into the repo folder, an
    It should look a bit like the listing below.
 
    ```bash
-   > git status
+   git status
+   ```
+
+   ```plain
    On branch main
    Your branch is up-to-date with 'origin/main'.
    Changes to be committed:

--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
@@ -159,7 +159,12 @@ As a slightly more exciting test let's create a very basic "pure node" server th
 2. Start the server by navigating into the same directory as your `hellonode.js` file in your command prompt, and calling `node` along with the script name, like so:
 
    ```bash
-   >node hellonode.js
+   node hellonode.js
+   ```
+
+   Once the server starts, you will see console output indicating the IP address the server is running on:
+
+   ```plain
    Server running at http://127.0.0.1:3000/
    ```
 
@@ -260,7 +265,12 @@ The following steps show how you can use npm to download a package, save it into
 5. You can start the server by calling node with the script in your command prompt:
 
    ```bash
-   >node index.js
+   node index.js
+   ```
+
+   You will see the following console output:
+
+   ```plain
    Example app listening on port 3000
    ```
 

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -189,13 +189,13 @@ At this point, we have a complete skeleton project. The website doesn't actually
 
    - On the Windows CMD prompt, use this command:
 
-     ```bash
+     ```batch
      SET DEBUG=express-locallibrary-tutorial:* & npm start
      ```
 
    - On Windows Powershell, use this command:
 
-     ```bash
+     ```powershell
      ENV:DEBUG = "express-locallibrary-tutorial:*"; npm start
      ```
 

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -134,7 +134,7 @@ express express-locallibrary-tutorial --view=pug
 
 The generator will create (and list) the project's files.
 
-```bash
+```plain
    create : express-locallibrary-tutorial\
    create : express-locallibrary-tutorial\public\
    create : express-locallibrary-tutorial\public\javascripts\
@@ -196,10 +196,10 @@ At this point, we have a complete skeleton project. The website doesn't actually
    - On Windows Powershell, use this command:
 
      ```bash
-     $ENV:DEBUG = "express-locallibrary-tutorial:*"; npm start
+     ENV:DEBUG = "express-locallibrary-tutorial:*"; npm start
      ```
 
-     > **Note:** Powershell commands are not covered further in this tutorial (The provided "Windows" commands assume you're using the Windows CMD prompt.)
+     > **Note:** Powershell commands are not covered in this tutorial (The provided "Windows" commands assume you're using the Windows CMD prompt.)
 
    - On macOS or Linux, use this command:
 
@@ -218,8 +218,10 @@ Congratulations! You now have a working Express application that can be accessed
 > **Note:** You could also start the app just using the `npm start` command. Specifying the DEBUG variable as shown enables console logging/debugging. For example, when you visit the above page you'll see debug output like this:
 >
 > ```bash
-> >SET DEBUG=express-locallibrary-tutorial:* & npm start
+> SET DEBUG=express-locallibrary-tutorial:* & npm start
+> ```
 >
+> ```plain
 > > express-locallibrary-tutorial@0.0.0 start D:\github\mdn\test\exprgen\express-locallibrary-tutorial
 > > node ./bin/www
 >

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_deployment_next/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_deployment_next/index.md
@@ -171,7 +171,10 @@ To deploy our app, follow these steps.
 3. Run `npx vercel` again, and you'll be prompted to answer a few questions, like this:
 
    ```bash
-   > npx vercel
+   npx vercel
+   ```
+
+   ```plain
    Vercel CLI 19.1.2
    ? Set up and deploy "./mdn-svelte-tutorial"? [Y/n] y
    ? Which scope do you want to deploy to? opensas
@@ -231,7 +234,7 @@ Let's have a go at doing this now.
 
 1. Create a `.gitlab-ci.yml` file inside your project's root and give it the following content:
 
-   ```
+   ```yaml
    image: node:latest
    pages:
      stage: deploy
@@ -264,17 +267,10 @@ Let's have a go at doing this now.
 3. Now we just have to commit and push our changes to GitLab. Do this by running the following commands:
 
    ```bash
-   > git add public/index.html
-   > git add .gitlab-ci.yml
-   > git commit -m "Added .gitlab-ci.yml file and fixed index.html absolute paths"
-   > git push
-   Counting objects: 5, done.
-   Delta compression using up to 8 threads.
-   Compressing objects: 100% (5/5), done.
-   Writing objects: 100% (5/5), 541 bytes | 541.00 KiB/s, done.
-   Total 5 (delta 3), reused 0 (delta 0)
-   To gitlab.com:opensas/mdn-svelte-todo.git
-      7dac9f3..5725f46  main -> main
+   git add public/index.html
+   git add .gitlab-ci.yml
+   git commit -m "Added .gitlab-ci.yml file and fixed index.html absolute paths"
+   git push
    ```
 
 Whenever there's a job running GitLab will display an icon showing the process of the job. Clicking on it will let you inspect the output of the job.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -207,7 +207,7 @@ In this case, if you run `npm run check` (either in the VS Code console or termi
 
 ![Check command being run inside VS Code showing type error, ms variable should be assigned a number](07-vscode-svelte-check.png)
 
-Even better, if you run it from the VS Code integrated terminal (you can open it with the <kbd>Ctrl</kbd> + <kbd>`</kbd> keyboard shortcut), <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> clicking on the file name will take you to the line containing the error.
+Even better, if you run it from the VS Code integrated terminal (you can open it with the <kbd>Ctrl</kbd> + <kbd>\`</kbd> keyboard shortcut), <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> clicking on the file name will take you to the line containing the error.
 
 You can also run the `check` script in watch mode with `npm run check -- --watch`. In this case, the script will execute whenever you change any file. If you are running this in your regular terminal, keep it running in the background in a separate terminal window so that it can keep reporting errors but won't interfere with other terminal usage.
 
@@ -300,7 +300,10 @@ Let's start with our `Alert.svelte` component.
 1. Add `lang="ts"` into your `Alert.svelte` component's `<script>` tag. You'll see some warnings in the output of the `check` script:
 
    ```bash
-   $ npm run check -- --watch
+   npm run check -- --watch
+   ```
+
+   ```plain
    > svelte-check "--watch"
 
    ./svelte-todo-typescript

--- a/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -22,7 +22,7 @@ The general step-by-step process for creating a page would be:
 
 1. Start a fresh, up-to-date branch to work in.
 
-   ```sh
+   ```bash
    cd ~/repos/mdn/content
    git checkout main
    git pull mdn main
@@ -36,7 +36,7 @@ The general step-by-step process for creating a page would be:
 
 3. Add and commit your new files as well as push your new branch to your fork.
 
-   ```sh
+   ```bash
    git add files/en-us/folder/you/created
    git commit -m "appropriate message about your changes"
    git push -u origin my-add
@@ -49,7 +49,7 @@ The general step-by-step process for creating a page would be:
 Moving one or more documents or an entire tree of documents is easy
 because we've created a special command that takes care of the details for you:
 
-```sh
+```bash
 yarn content move <from-slug> <to-slug> [locale]
 ```
 
@@ -67,7 +67,7 @@ For example, let's say you want to move the entire
 
 1. You'll start a fresh branch to work in.
 
-   ```sh
+   ```bash
    cd ~/repos/mdn/content
    git checkout main
    git pull mdn main
@@ -79,13 +79,13 @@ For example, let's say you want to move the entire
 
 2. Perform the move (which will delete and modify existing files as well as create new files).
 
-   ```sh
+   ```bash
    yarn content move Learn/Accessibility Learn/A11y
    ```
 
 3. Add and commit all of the deleted, created, and modified files as well as push your branch to your fork.
 
-   ```sh
+   ```bash
    git commit -a
    git push -u origin my-move
    ```
@@ -101,7 +101,7 @@ Documents should only be removed from MDN Web Docs under special circumstances. 
 Deleting one or more documents or an entire tree of documents is easy, just like moving pages, because we've created a special command that takes care of the
 details for you:
 
-```sh
+```bash
 yarn content delete <document-slug> [locale]
 ```
 
@@ -120,7 +120,7 @@ entire `/en-US/Learn/Accessibility` tree, you'd perform the following steps:
 
 1. You'll start a fresh branch to work in.
 
-   ```sh
+   ```bash
    cd ~/repos/mdn/content
    git checkout main
    git pull mdn main
@@ -132,19 +132,19 @@ entire `/en-US/Learn/Accessibility` tree, you'd perform the following steps:
 
 2. Perform the delete.
 
-   ```sh
+   ```bash
    yarn content delete Learn/Accessibility --recursive
    ```
 
 3. Add a redirect. The target page can be an external URL or another page on MDN Web Docs.
 
-   ```sh
+   ```bash
    yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
    ```
 
 4. Add and commit all of the deleted files as well as push your branch to your fork.
 
-   ```sh
+   ```bash
    git commit -a
    git push -u origin my-delete
    ```
@@ -153,7 +153,7 @@ entire `/en-US/Learn/Accessibility` tree, you'd perform the following steps:
 
 > **Note:** If the slug of the page you wish to delete contains special characters, include it in quotes, like so:
 >
-> ```sh
+> ```bash
 > yarn content delete "Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)"
 > ```
 

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -14,7 +14,7 @@ Let's walk through an example:
 
 1. Start with a fresh working branch with the latest content from the `main` branch of the `mdn` remote.
 
-   ```sh
+   ```bash
    cd ~/path/to/mdn/content
    git checkout main
    git pull mdn main
@@ -27,7 +27,7 @@ Let's walk through an example:
 2. Add your image to the document folder. For this example, let's assume
    we're adding a new image to the `files/en-us/web/css` document.
 
-   ```sh
+   ```bash
    cd ~/path/to/mdn/content
    cp ../some/path/my-cool-image.png files/en-us/web/css/
    ```
@@ -35,7 +35,7 @@ Let's walk through an example:
 3. Run `filecheck` on each image, which might complain if something's wrong.
    For more details, see the [Compressing images](#compressing-images) section.
 
-   ```sh
+   ```bash
    yarn filecheck files/en-us/web/css/my-cool-image.png
    ```
 
@@ -48,7 +48,7 @@ Let's walk through an example:
 5. Add and commit all of the deleted, created, and modified files, as well as
    push your branch to your fork:
 
-   ```sh
+   ```bash
    git add files/en-us/web/css/my-cool-image.png files/en-us/web/css/index.html
    git commit
    git push -u origin my-images
@@ -101,7 +101,7 @@ You can compress an image appropriately by using the `filecheck` command with th
 This option compresses the image as much as possible and replaces the original with the compressed version.
 For example:
 
-```sh
+```bash
 yarn filecheck files/en-us/web/css/my-cool-image.png --save-compression
 ```
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -82,7 +82,7 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `md` - Markdown
   - `latex` - LaTeX
 - Command Prompts
-  - `sh` - Bash/Shell
+  - `bash` - Bash/Shell
   - `batch` - Batch (Windows Shell)
   - `powershell` - PowerShell
 - Configuration/Data Files

--- a/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
@@ -92,44 +92,12 @@ Having a properly fragmented MP4 file is all you need to get started. If you wis
 
 Given that you have ffmpeg and Bento4's utilities accessible through your $PATH, you can run Bento4's `mp4-dash-encode.py` Python script to generate multiple encodings of your content at various resolutions. Bento4's `mp4-dash.py` Python script can then be used to generate the corresponding MPD file needed by clients.
 
-Run the following commands (shown with sample output):
+Run the following commands:
 
 ```bash
-$ python mp4-dash-encode.py -b 5 -v bunny_fragmented.mp4
-Encoding 5 bitrates, min bitrate = 500.0 max bitrate = 2000.0
-Media Source: Video: resolution=640x360
-ENCODING bitrate: 500, resolution: 256x144
-ENCODING bitrate: 875, resolution: 384x216
-ENCODING bitrate: 1250, resolution: 480x270
-ENCODING bitrate: 1625, resolution: 560x316
-ENCODING bitrate: 2000, resolution: 640x360
-
-$ python mp4-dash.py video_0*
-Parsing media file 1: video_00500.mp4
-Parsing media file 2: video_00875.mp4
-Parsing media file 3: video_01250.mp4
-Parsing media file 4: video_01625.mp4
-Parsing media file 5: video_02000.mp4
-Splitting media file (audio) video_00500.mp4
-Splitting media file (video) video_00500.mp4
-Splitting media file (video) video_00875.mp4
-Splitting media file (video) video_01250.mp4
-Splitting media file (video) video_01625.mp4
-Splitting media file (video) video_02000.mp4
-
-$ tree -L 2 output
-output
-├── audio
-│   └── und
-├── stream.mpd
-└── video
-    ├── 1
-    ├── 2
-    ├── 3
-    ├── 4
-    └── 5
-
-8 directories, 1 file
+python mp4-dash-encode.py -b 5 -v bunny_fragmented.mp4
+python mp4-dash.py video_0*
+tree -L 2 output
 ```
 
 > **Note:** `mp4-dash-encode.py` does not display ffmpeg error messages. You can see it by specifying the `-d` option.

--- a/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
@@ -52,10 +52,8 @@ Currently, MP4 containers with H.264 video and AAC audio codecs have support acr
 
 To convert our sample media from a QuickTime MOV container to an MP4 container, we can use ffmpeg. Because the audio codec in the MOV container is already AAC and the video codec is h.264, we can instruct ffmpeg not to perform transcoding. Instead, it will just copy the audio and video tracks over without performing any transcoding, which is relatively faster than having to transcode.
 
-```
-$ ffmpeg -i trailer_1080p.mov -c:v copy -c:a copy bunny.mp4
-$ ls
-bunny.mp4         trailer_1080p.mov
+```bash
+ffmpeg -i trailer_1080p.mov -c:v copy -c:a copy bunny.mp4
 ```
 
 ### Checking Fragmentation
@@ -97,7 +95,21 @@ Run the following commands:
 ```bash
 python mp4-dash-encode.py -b 5 -v bunny_fragmented.mp4
 python mp4-dash.py video_0*
-tree -L 2 output
+```
+
+This should output the following files:
+
+```plain
+output
+├── audio
+│   └── und
+├── stream.mpd
+└── video
+    ├── 1
+    ├── 2
+    ├── 3
+    ├── 4
+    └── 5
 ```
 
 > **Note:** `mp4-dash-encode.py` does not display ffmpeg error messages. You can see it by specifying the `-d` option.

--- a/files/en-us/webassembly/existing_c_to_wasm/index.md
+++ b/files/en-us/webassembly/existing_c_to_wasm/index.md
@@ -32,7 +32,7 @@ This is a good simple program to test whether you can get the source code of lib
 To compile this program, you need to tell the compiler where it can find libwebp's header files using the `-I` flag and also pass it all the C files of libwebp that it needs. A useful strategy is to just give it **all** the C files and rely on the compiler to strip out everything that is unnecessary. It seems to work brilliantly for this library:
 
 ```bash
-$ emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
+emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
     -I libwebp \
     webp.c \
     libwebp/src/{dec,dsp,demux,enc,mux,utils}/*.c \

--- a/files/en-us/webassembly/rust_to_wasm/index.md
+++ b/files/en-us/webassembly/rust_to_wasm/index.md
@@ -41,8 +41,7 @@ cargo install wasm-pack
 Enough setup; let's create a new package in Rust. Navigate to wherever you keep your personal projects, and type this:
 
 ```bash
-$ cargo new --lib hello-wasm
-     Created library `hello-wasm` project
+cargo new --lib hello-wasm
 ```
 
 This creates a new library in a subdirectory named `hello-wasm` with everything you need to get going:


### PR DESCRIPTION
This PR fixes the command line examples to follow our guidelines not to include prompt symbols (`$`, `>`, etc.) and not to include the output directly in bash code examples.  This also changes all codeblocks set to `sh` to use `bash` instead, which is what is more commonly used in MDN docs.
