### PR TITLE
ended double use of color to prevent misunderstanding

### DIFF
--- a/files/en-us/web/svg/element/mask/index.md
+++ b/files/en-us/web/svg/element/mask/index.md
@@ -21,6 +21,7 @@ svg {
 
 ```html
 <svg viewBox="-10 -10 120 120">
+<rect x="-10" y="-10" width="120" height="120" fill="blue"/>
   <mask id="myMask">
     <!-- Everything under a white pixel will be visible -->
     <rect x="0" y="0" width="100" height="100" fill="white" />
@@ -34,7 +35,7 @@ svg {
   <polygon points="-10,110 110,110 110,-10" fill="orange" />
 
   <!-- with this mask applied, we "punch" a heart shape hole into the circle -->
-  <circle cx="50" cy="50" r="50" mask="url(#myMask)" />
+  <circle cx="50" cy="50" r="50" fill="purple" mask="url(#myMask)" />
 </svg>
 ```
 


### PR DESCRIPTION
background is usually white in the browser
fill of the circle is default black

Black and white are also used in defining the mask, that's why I propose different colors for 'background' and the circle's fill

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
