### PR TITLE
Fix invalid ArrayBuffer.prototype.slice() usage

### DIFF
--- a/files/en-us/web/api/gpubuffer/index.md
+++ b/files/en-us/web/api/gpubuffer/index.md
@@ -69,7 +69,7 @@ await stagingBuffer.mapAsync(
 );
 
 const copyArrayBuffer = stagingBuffer.getMappedRange(0, BUFFER_SIZE);
-const data = copyArrayBuffer.slice();
+const data = copyArrayBuffer.slice(0);
 stagingBuffer.unmap();
 console.log(new Float32Array(data));
 ```


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
