### PR TITLE
Add note to 103 Early Hints about recommended to use HTTP/2

### DIFF
--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -19,6 +19,8 @@ A server might send multiple `103` responses, for example, following a redirect.
 Browsers only process the first early hint response, and this response must be discarded if the request results in a cross-origin redirect.
 Preloaded resources from the early hint are effectively pre-pended to the `Document`'s head element, and then followed by the resources loaded in the final response.
 
+> **Note:** For compatibility reasons [it is recommended](https://www.rfc-editor.org/rfc/rfc8297#section-3) to only send HTTP `103 Early Hints` responses over HTTP/2 or later, unless the client is known to handle informational responses correctly. Despite this, the examples below use HTTP/1.1-style notation as per usual convention.
+
 ## Syntax
 
 ```http

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -19,7 +19,11 @@ A server might send multiple `103` responses, for example, following a redirect.
 Browsers only process the first early hint response, and this response must be discarded if the request results in a cross-origin redirect.
 Preloaded resources from the early hint are effectively pre-pended to the `Document`'s head element, and then followed by the resources loaded in the final response.
 
-> **Note:** For compatibility reasons [it is recommended](https://www.rfc-editor.org/rfc/rfc8297#section-3) to only send HTTP `103 Early Hints` responses over HTTP/2 or later, unless the client is known to handle informational responses correctly. Despite this, the examples below use HTTP/1.1-style notation as per usual convention.
+> **Note:** For compatibility reasons [it is recommended](https://www.rfc-editor.org/rfc/rfc8297#section-3) to only send HTTP `103 Early Hints` responses over HTTP/2 or later, unless the client is known to handle informational responses correctly.
+>
+> Most browsers limit support to HTTP/2 or later for this reason. See [browser compatibility](#browser-compatibility) below.
+>
+> Despite this, the examples below use HTTP/1.1-style notation as per usual convention.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a note to say 103 Early Hints is recommended to only be used over HTTP/2 and only supported by Chrome and Safari in this mode. Firefox does support less versions but have not shipped this without a flag yet.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

More clearly explain when this will be supported

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://www.rfc-editor.org/rfc/rfc8297#section-3

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

I've also raised https://github.com/mdn/browser-compat-data/pull/20427 to update the latest support info and also link the RFC.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
