### PR TITLE
docs(contrib): Add guidelines for PRs with failing CI

### DIFF
--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -131,12 +131,11 @@ When you are reviewing a pull request, you should:
 - **Request load balancing** if your plate is full and you don't have bandwidth for the review.
   Tag the `@core-yari-content` team and ask if someone else can step in.
 - **Don't merge unless 'depends on'** pull requests are merged first.
-
-- **Don't merge pull requests that have failing tests.** 
-It is good [open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette) to keep the `main` branch stable to avoid disruption for contributors, maintainers, and for automated processes.
-An unstable `main` branch blocks all other pull requests and makes it difficult for others to review and merge contributions.
-In addition, contributors who watch repositories receive high volumes of notifications and unnecessary noise caused by failing tests can be frustrating.
-If you are not sure how to fix the failing tests, [ask for help](/en-US/docs/MDN/Community/Communication_channels) or assign the pull request to someone else.
+- **Don't merge pull requests that have failing tests.**
+  It is good [open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette) to keep the `main` branch stable to avoid disruption for contributors, maintainers, and for automated processes.
+  An unstable `main` branch blocks all other pull requests and makes it difficult for others to review and merge contributions.
+  In addition, contributors who watch repositories receive high volumes of notifications and unnecessary noise caused by failing tests can be frustrating.
+  If you are not sure how to fix the failing tests, [ask for help](/en-US/docs/MDN/Community/Communication_channels) or assign the pull request to someone else.
 
 If a pull request looks good apart from small typos or other minor issues, you may want to fix the problem directly.
 You can do this provided the pull request [has been set up to allow changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -132,7 +132,7 @@ When you are reviewing a pull request, you should:
   Tag the `@core-yari-content` team and ask if someone else can step in.
 - **Don't merge unless 'depends on'** pull requests are merged first.
 
-Don't merge pull requests that have failing tests.
+- **Don't merge pull requests that have failing tests.** 
 It is good [open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette) to keep the `main` branch stable to avoid disruption for contributors, maintainers, and for automated processes.
 An unstable `main` branch blocks all other pull requests and makes it difficult for others to review and merge contributions.
 In addition, contributors who watch repositories receive high volumes of notifications and unnecessary noise caused by failing tests can be frustrating.

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -132,6 +132,12 @@ When you are reviewing a pull request, you should:
   Tag the `@core-yari-content` team and ask if someone else can step in.
 - **Don't merge unless 'depends on'** pull requests are merged first.
 
+Don't merge pull requests that have failing tests.
+It is good [open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette) to keep the `main` branch stable to avoid disruption for contributors, maintainers, and for automated processes.
+An unstable `main` branch blocks all other pull requests and makes it difficult for others to review and merge contributions.
+In addition, contributors who watch repositories receive high volumes of notifications and unnecessary noise caused by failing tests can be frustrating.
+If you are not sure how to fix the failing tests, [ask for help](/en-US/docs/MDN/Community/Communication_channels) or assign the pull request to someone else.
+
 If a pull request looks good apart from small typos or other minor issues, you may want to fix the problem directly.
 You can do this provided the pull request [has been set up to allow changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
 It's recommended to use [comments with suggestions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) for fixing minor issues, as they can be batched and committed in one go.


### PR DESCRIPTION
This PR adds details about avoiding merging PRs if CI is red and includes links to communication channels if someone is stuck.