### PR TITLE
Remove "await" from yield-ed values in AsyncGenerator constructor example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -21,9 +21,9 @@ The `AsyncGenerator` constructor is not available globally. Instances of `AsyncG
 
 ```js
 async function* createAsyncGenerator() {
-  yield await Promise.resolve(1);
-  yield await Promise.resolve(2);
-  yield await Promise.resolve(3);
+  yield Promise.resolve(1);
+  yield Promise.resolve(2);
+  yield Promise.resolve(3);
 }
 const asyncGen = createAsyncGenerator();
 asyncGen.next().then((res) => console.log(res.value)); // 1


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example for AsyncGenerator in the constructor documentation has yield statements that look like this:

```javascript
  yield await Promise.resolve(1);
  ...
```

There's no reason to have "await" here; the output of the generator is expected to be a Promise. The only reasons one might add "await" is (1) if the Promise rejects (which it doesn't) _and_ (2) if the generator catches the exception (which it doesn't).

### Motivation

Removing the await provides a proper minimal example and won't lead readers to believe that await is required here.

### Additional details

Note that the live example under the Try It section also has the unnecessary awaits. I don't know how to submit a pull request for that. Note that you can remove "await" from the yield statements in the live example and it still works fine.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
