### PR TITLE
SVG - remove deprecated xlink:href in mpath

### DIFF
--- a/files/en-us/web/api/node/baseuri/index.md
+++ b/files/en-us/web/api/node/baseuri/index.md
@@ -11,17 +11,14 @@ browser-compat: api.Node.baseURI
 The read-only **`baseURI`** property of the {{domxref("Node")}} interface
 returns the absolute base URL of the document containing the node.
 
-The base URL is used to resolve relative URLs when the browser needs to obtain an
-absolute URL, for example when processing the HTML {{HTMLElement("img")}} element's
-`src` attribute or the `xlink:href` or `href` attributes in SVG.
+The base URL is used to resolve relative URLs when the browser needs to obtain an absolute URL, for example when processing the HTML {{HTMLElement("img")}} element's `src` attribute or the `xlink:href` {{deprecated_inline}} or `href` attributes in SVG.
 
 Although this property is read-only, its value is determined by an algorithm each time
 the property is accessed, and may change if the conditions changed.
 
 The base URL is determined as follows:
 
-1. By default, the base URL is the location of the document
-   (as determined by {{domxref("window.location")}}).
+1. By default, the base URL is the location of the document (as determined by {{domxref("window.location")}}).
 2. If it is an HTML Document and there is a {{HTMLElement("Base")}} element in the document,
    the `href` value of the _first_ `Base` element with such an attribute is used instead.
 

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -18,7 +18,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.download")}}
   - : See {{domxref("HTMLAnchorElement.download")}}.
 - {{domxref("SVGAElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute.
+  - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute.
 - {{domxref("SVGAElement.hreflang")}}
   - : A string that reflects the `hreflang` attribute, indicating the language of the linked resource.
 - {{domxref("SVGAElement.ping")}}

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -38,7 +38,7 @@ svg {
 
     <rect id="r1" x="0" y="0" width="50" height="100" />
 
-    <use clip-path="url(#clip1)" xlink:href="#r1" fill="lightblue" />
+    <use clip-path="url(#clip1)" href="#r1" fill="lightblue" />
   </svg>
 </div>
 <pre id="log"></pre>

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -51,12 +51,12 @@ svg {
     <rect id="r4" x="55" y="0" width="45" height="45" />
 
     <!-- The first 3 rect are clipped with userSpaceOnUse units -->
-    <use clip-path="url(#clip1)" xlink:href="#r1" fill="red" />
-    <use clip-path="url(#clip1)" xlink:href="#r2" fill="blue" />
-    <use clip-path="url(#clip1)" xlink:href="#r3" fill="yellow" />
+    <use clip-path="url(#clip1)" href="#r1" fill="red" />
+    <use clip-path="url(#clip1)" href="#r2" fill="blue" />
+    <use clip-path="url(#clip1)" href="#r3" fill="yellow" />
 
     <!-- The last rect is clipped with objectBoundingBox units -->
-    <use clip-path="url(#clip2)" xlink:href="#r4" fill="green" />
+    <use clip-path="url(#clip2)" href="#r4" fill="green" />
   </svg>
 </div>
 <pre id="log"></pre>

--- a/files/en-us/web/api/svgclippathelement/transform/index.md
+++ b/files/en-us/web/api/svgclippathelement/transform/index.md
@@ -36,7 +36,7 @@ svg {
 
     <rect id="r1" x="0" y="0" width="100" height="100" />
 
-    <use clip-path="url(#clip1)" xlink:href="#r1" fill="lightblue" />
+    <use clip-path="url(#clip1)" href="#r1" fill="lightblue" />
   </svg>
 </div>
 <pre id="log"></pre>

--- a/files/en-us/web/api/svgfeimageelement/index.md
+++ b/files/en-us/web/api/svgfeimageelement/index.md
@@ -20,7 +20,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGFEImageElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given element.
 - {{domxref("SVGFEImageElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
+  - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given element.
 - {{domxref("SVGFEImageElement.preserveAspectRatio")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedPreserveAspectRatio")}} corresponding to the {{SVGAttr("preserveAspectRatio")}} attribute of the given element.
 - {{domxref("SVGFEImageElement.result")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgfilterelement/index.md
+++ b/files/en-us/web/api/svgfilterelement/index.md
@@ -14,7 +14,7 @@ The **`SVGFilterElement`** interface provides access to the properties of {{SVGE
 ## Instance properties
 
 - {{domxref("SVGFilterElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("filter")}} element.
+  - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("filter")}} element.
 - {{domxref("SVGFilterElement.filterUnits")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} that corresponds to the {{SVGAttr("filterUnits")}} attribute of the given {{SVGElement("filter")}} element. Takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
 - {{domxref("SVGFilterElement.primitiveUnits")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svggradientelement/index.md
+++ b/files/en-us/web/api/svggradientelement/index.md
@@ -52,7 +52,7 @@ The **`SVGGradient`** interface is a base interface used by {{domxref("SVGLinear
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGGradientElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given element.
 - {{domxref("SVGGradientElement.gradientUnits")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("gradientUnits")}} attribute on the given element. This property takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
 - {{domxref("SVGGradientElement.gradientTransform")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgimageelement/index.md
+++ b/files/en-us/web/api/svgimageelement/index.md
@@ -16,7 +16,7 @@ The **`SVGImageElement`** interface corresponds to the {{SVGElement("image")}} e
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
 - {{domxref("SVGImageElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("image")}} element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("image")}} element.
 - {{domxref("SVGImageElement.decoding")}}
   - : A string representing a hint given to the browser on how it should decode the image.
 - {{domxref("SVGImageElement.height")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
@@ -62,12 +62,12 @@ svg {
     <rect id="r4" x="55" y="0" width="45" height="45" />
 
     <!-- The first 3 rect are masked with useSpaceOnUse units -->
-    <use mask="url(#mask1)" xlink:href="#r1" fill="blue" />
-    <use mask="url(#mask1)" xlink:href="#r2" fill="yellow" />
-    <use mask="url(#mask1)" xlink:href="#r3" fill="green" />
+    <use mask="url(#mask1)" href="#r1" fill="blue" />
+    <use mask="url(#mask1)" href="#r2" fill="yellow" />
+    <use mask="url(#mask1)" href="#r3" fill="green" />
 
     <!-- The last rect is masked with objectBoundingBox units -->
-    <use mask="url(#mask2)" xlink:href="#r4" fill="lightblue" />
+    <use mask="url(#mask2)" href="#r4" fill="lightblue" />
   </svg>
 </div>
 <pre id="log"></pre>

--- a/files/en-us/web/api/svgmaskelement/maskunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskunits/index.md
@@ -74,12 +74,12 @@ svg {
     <rect id="r4" x="55" y="0" width="45" height="45" />
 
     <!-- The first 3 rect are masked with useSpaceOnUse units -->
-    <use mask="url(#mask1)" xlink:href="#r1" fill="blue" />
-    <use mask="url(#mask1)" xlink:href="#r2" fill="green" />
-    <use mask="url(#mask1)" xlink:href="#r3" fill="yellow" />
+    <use mask="url(#mask1)" href="#r1" fill="blue" />
+    <use mask="url(#mask1)" href="#r2" fill="green" />
+    <use mask="url(#mask1)" href="#r3" fill="yellow" />
 
     <!-- The last rect is masked with objectBoundingBox units -->
-    <use mask="url(#mask2)" xlink:href="#r4" fill="lightblue" />
+    <use mask="url(#mask2)" href="#r4" fill="lightblue" />
   </svg>
 </div>
 <pre id="log"></pre>

--- a/files/en-us/web/api/svgmpathelement/index.md
+++ b/files/en-us/web/api/svgmpathelement/index.md
@@ -16,7 +16,7 @@ The **`SVGMPathElement`** interface corresponds to the {{SVGElement("mpath")}} e
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGMPathElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("mpath")}} element.
+  - : An {{domxref("SVGAnimatedString")}} that corresponds to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("mpath")}} element.
 
 ## Instance methods
 

--- a/files/en-us/web/api/svgpatternelement/index.md
+++ b/files/en-us/web/api/svgpatternelement/index.md
@@ -16,7 +16,7 @@ The **`SVGPatternElement`** interface corresponds to the {{SVGElement("pattern")
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}} and implements the ones from {{domxref("SVGFitToViewBox")}}._
 
 - {{domxref("SVGPatternElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("pattern")}} element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("pattern")}} element.
 - {{domxref("SVGPatternElement.patternUnits")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("patternUnits")}} attribute of the given {{SVGElement("pattern")}} element. Takes one of the constants defined in {{domxref("SVGUnitTypes")}}.
 - {{domxref("SVGPatternElement.patternContentUnits")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgscriptelement/index.md
+++ b/files/en-us/web/api/svgscriptelement/index.md
@@ -14,7 +14,7 @@ The **`SVGScriptElement`** interface corresponds to the SVG {{SVGElement("script
 ## Instance properties
 
 - {{domxref("SVGScriptElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("script")}} element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("script")}} element.
 - {{domxref("SVGScriptElement.type")}} {{ReadOnlyInline}}
   - : A string corresponding to the {{SVGAttr("type")}} attribute of the given {{SVGElement("script")}} element. A {{domxref("DOMException")}} is raised with the code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read only attribute.
 - {{domxref("SVGScriptElement.crossOrigin")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -80,7 +80,7 @@ The **`SVGTextPathElement`** interface corresponds to the {{SVGElement("textPath
 _This interface also inherits properties from its parent interface, {{domxref("SVGTextContentElement")}}._
 
 - {{domxref("SVGTextPathElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given element.
 - {{domxref("SVGTextPathElement.startOffset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the X component of the {{SVGAttr("startOffset")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.method")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svguseelement/index.md
+++ b/files/en-us/web/api/svguseelement/index.md
@@ -18,7 +18,7 @@ The **`SVGUseElement`** interface corresponds to the {{SVGElement("use")}} eleme
 _This interface also inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}._
 
 - {{domxref("SVGUseElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given element.
 - {{domxref("SVGUseElement.x")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("x")}} attribute of the given element.
 - {{domxref("SVGUseElement.y")}} {{ReadOnlyInline}}

--- a/files/en-us/web/svg/attribute/clippathunits/index.md
+++ b/files/en-us/web/svg/attribute/clippathunits/index.md
@@ -40,12 +40,12 @@ svg {
   <rect id="r4" x="55" y="0" width="45" height="45" />
 
   <!-- The first 3 rect are clipped with userSpaceOnUse units -->
-  <use clip-path="url(#myClip1)" xlink:href="#r1" fill="red" />
-  <use clip-path="url(#myClip1)" xlink:href="#r2" fill="red" />
-  <use clip-path="url(#myClip1)" xlink:href="#r3" fill="red" />
+  <use clip-path="url(#myClip1)" href="#r1" fill="red" />
+  <use clip-path="url(#myClip1)" href="#r2" fill="red" />
+  <use clip-path="url(#myClip1)" href="#r3" fill="red" />
 
   <!-- The last rect is clipped with objectBoundingBox units -->
-  <use clip-path="url(#myClip2)" xlink:href="#r4" fill="red" />
+  <use clip-path="url(#myClip2)" href="#r4" fill="red" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/maskcontentunits/index.md
+++ b/files/en-us/web/svg/attribute/maskcontentunits/index.md
@@ -42,12 +42,12 @@ svg {
   <rect id="r4" x="55" y="0" width="45" height="45" />
 
   <!-- The first 3 rect are masked with useSpaceOnUse units -->
-  <use mask="url(#myMask1)" xlink:href="#r1" fill="red" />
-  <use mask="url(#myMask1)" xlink:href="#r2" fill="red" />
-  <use mask="url(#myMask1)" xlink:href="#r3" fill="red" />
+  <use mask="url(#myMask1)" href="#r1" fill="red" />
+  <use mask="url(#myMask1)" href="#r2" fill="red" />
+  <use mask="url(#myMask1)" href="#r3" fill="red" />
 
   <!-- The last rect is masked with objectBoundingBox units -->
-  <use mask="url(#myMask2)" xlink:href="#r4" fill="red" />
+  <use mask="url(#myMask2)" href="#r4" fill="red" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/maskunits/index.md
+++ b/files/en-us/web/svg/attribute/maskunits/index.md
@@ -54,12 +54,12 @@ svg {
   <rect id="r4" x="55" y="0" width="45" height="45" />
 
   <!-- The first 3 rect are masked with useSpaceOnUse units -->
-  <use mask="url(#myMask1)" xlink:href="#r1" fill="red" />
-  <use mask="url(#myMask1)" xlink:href="#r2" fill="red" />
-  <use mask="url(#myMask1)" xlink:href="#r3" fill="red" />
+  <use mask="url(#myMask1)" href="#r1" fill="red" />
+  <use mask="url(#myMask1)" href="#r2" fill="red" />
+  <use mask="url(#myMask1)" href="#r3" fill="red" />
 
   <!-- The last rect is masked with objectBoundingBox units -->
-  <use mask="url(#myMask2)" xlink:href="#r4" fill="red" />
+  <use mask="url(#myMask2)" href="#r4" fill="red" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/element/mpath/index.md
+++ b/files/en-us/web/svg/element/mpath/index.md
@@ -70,7 +70,7 @@ This element implements the {{domxref("SVGMPathElement")}} interface.
     stroke-width="7.06">
     <!-- Define the motion path animation -->
     <animateMotion dur="6s" repeatCount="indefinite" rotate="auto">
-      <mpath xlink:href="#path1" />
+      <mpath href="#path1" />
     </animateMotion>
   </path>
 </svg>
@@ -78,7 +78,7 @@ This element implements the {{domxref("SVGMPathElement")}} interface.
 
 ### Result
 
-{{EmbedLiveSample("Example", 250, 165)}}
+{{EmbedLiveSample("Example", 250, 400)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/element/mpath/index.md
+++ b/files/en-us/web/svg/element/mpath/index.md
@@ -22,7 +22,7 @@ The **`<mpath>`** sub-element for the {{SVGElement("animateMotion")}} element pr
 
 ### Specific attributes
 
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 


### PR DESCRIPTION
Fixes #28222 

The `xlink:href` is deprecated, and appears to break SVG. Solution is to use `href` instead. 

Also fixed all other cases in docs and added deprecated_inline macro to mentions of `xlink:href` - since it is clearly not just "deprecated" but likely to cause problems.