### PR TITLE
Update examples in “URL: port” doc

### DIFF
--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -22,17 +22,18 @@ A string.
 ## Examples
 
 ```js
-const url = new URL("https://example.com:80/svn/Repos/");
-console.log(url.port); // Logs '80'
-```
-
-Port 80 + 443 in combination with http + https show empty port
-```js
-new URL("https://example.com:443/svn/Repos/").port; // shows ''
-```
-
-```js
-new URL("http://example.com:80/svn/Repos/").port; // shows ''
+// https protocol with non-default port number
+new URL("https://example.com:5443/svn/Repos/").port; // '5443'
+// http protocol with non-default port number
+new URL("http://example.com:8080/svn/Repos/").port; // '8080'
+// https protocol with default port number
+new URL("https://example.com:443/svn/Repos/").port; // '' (empty string)
+// http protocol with default port nubmer
+new URL("http://example.com:80/svn/Repos/").port; // '' (empty string)
+// https protocol with no explicit port number
+new URL("https://example.com/svn/Repos/").port; // '' (empty string)
+// http protocol with no explicit port number
+new URL("https://example.com/svn/Repos/").port; // '' (empty string)
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -26,6 +26,15 @@ const url = new URL("https://example.com:80/svn/Repos/");
 console.log(url.port); // Logs '80'
 ```
 
+Port 80 + 443 in combination with http + https show empty port
+```js
+new URL("https://example.com:443/svn/Repos/").port; // shows ''
+```
+
+```js
+new URL("http://example.com:80/svn/Repos/").port; // shows ''
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
Allthough specified, the port property returns empty string on https + 443 port, http + 80 port.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adding two examples where port property returns empty string, allthough it was specified in the construct.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Adding the examples, as it is unclear to me, if this is working as designed or a feature. Anyhow it might lead hard to discover bugs, if we rely on the port property being filled properly.

I hope that the examples will help developers to prevent bugs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
