### PR TITLE
Update index.md - correct typo on nubmer, +1 example

### DIFF
--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -34,8 +34,10 @@ new URL("http://example.com:80/svn/Repos/").port; // '' (empty string)
 new URL("https://example.com/svn/Repos/").port; // '' (empty string)
 // http protocol with no explicit port number
 new URL("https://example.com/svn/Repos/").port; // '' (empty string)
-// sftp protocol with default port number
-new URL("sftp://example.com:21/svn/Repos/").port; // '' (empty string)
+// ftp protocol with non-default port number
+new URL("ftp://example.com:221/svn/Repos/").port; // '221'
+// ftp protocol with default port number
+new URL("ftp://example.com:21/svn/Repos/").port; // '' (empty string)
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -28,12 +28,14 @@ new URL("https://example.com:5443/svn/Repos/").port; // '5443'
 new URL("http://example.com:8080/svn/Repos/").port; // '8080'
 // https protocol with default port number
 new URL("https://example.com:443/svn/Repos/").port; // '' (empty string)
-// http protocol with default port nubmer
+// http protocol with default port number
 new URL("http://example.com:80/svn/Repos/").port; // '' (empty string)
 // https protocol with no explicit port number
 new URL("https://example.com/svn/Repos/").port; // '' (empty string)
 // http protocol with no explicit port number
 new URL("https://example.com/svn/Repos/").port; // '' (empty string)
+// sftp protocol with default port number
+new URL("sftp://example.com:21/svn/Repos/").port; // '' (empty string)
 ```
 
 ## Specifications


### PR DESCRIPTION
1.) Typo: nubmer > number
2.) Added one more example: sftp://foo.bar:21 - also returns empty

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Very small enhancement as described above 1.) and 2.)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Was asked to do so by @sideshowbarker  ;-)

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
