### PR TITLE
Fix the link to "Routers"

### DIFF
--- a/files/en-us/glossary/modem/index.md
+++ b/files/en-us/glossary/modem/index.md
@@ -10,7 +10,7 @@ A modem ("**modulator-demodulator**") is a device that converts digital informat
 
 Different kinds are used for different networks: DSL modems for telephone wires, Wi-Fi modems for short-range wireless radio signals, 3G modems for cellular data towers, and so on.
 
-Modems are different from {{Glossary("Router","routers")}}, but many companies sell modems combined with routers.
+Modems are different from {{Glossary("Router","Routers")}}, but many companies sell modems combined with routers.
 
 ## See also
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The link is broken as the page for "Routers" has ID "Routers" and not "routers". Corrected capitalization to restore the link.

### Motivation
Broken links... aren't good, I guess? I was browsing through this and I randomly found out about it so I decided to change it.

### Additional details
N/A

### Related issues and pull requests
N/A