### PR TITLE
Update index.md - correct element property

### DIFF
--- a/files/en-us/web/api/intersectionobserverentry/target/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/target/index.md
@@ -28,7 +28,7 @@ In this simple example, each targeted element's {{cssxref("opacity")}} is set to
 ```js
 function intersectionCallback(entries) {
   entries.forEach((entry) => {
-    entry.target.opacity = entry.intersectionRatio;
+    entry.target.style.opacity = entry.intersectionRatio;
   });
 }
 ```


### PR DESCRIPTION
### Description

Use [the correct HTMLElement instance property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) to set the opacity value: `target.style.opacity` instead of `target.opacity`

### Motivation

Current example with `target.opacity` is misleading and doesn't work.
