### PR TITLE
Minor: put link to whatwg before wikipedia

### DIFF
--- a/files/en-us/glossary/whatwg/index.md
+++ b/files/en-us/glossary/whatwg/index.md
@@ -10,5 +10,5 @@ The WHATWG (_Web Hypertext Application Technology Working Group_) is a community
 
 ## See also
 
-- [WHATWG](https://en.wikipedia.org/wiki/WHATWG) on Wikipedia
 - [WHATWG website](https://whatwg.org/)
+- [WHATWG](https://en.wikipedia.org/wiki/WHATWG) on Wikipedia


### PR DESCRIPTION
The link to whatwg seems more relevant than Wikipedia
if you agree, approve.
if you don't, close without merging. i will not be offended.