### PR TITLE
Fix FileSystemSyncAccessHandle read/write method return values.

### DIFF
--- a/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
@@ -30,7 +30,7 @@ read(buffer, FileSystemReadWriteOptions)
 
 ### Return value
 
-A {{jsxref('Promise')}} which resolves to a number representing the number of bytes read from the file.
+A number representing the number of bytes read from the file.
 
 ### Exceptions
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
@@ -30,7 +30,7 @@ write(buffer, FileSystemReadWriteOptions)
 
 ### Return value
 
-A {{jsxref('Promise')}} which resolves to a number representing the number of bytes written to the file.
+A number representing the number of bytes written to the file.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The FileSystemSyncAccessHandle read() and write() methods are incorrectly documented as returning Promises. This PR documents them as returning numbers instead.

### Motivation

The documented return values are incorrect.

### Additional details
FileSystemSyncAccessHandle spec:

* [FileSystemSyncAccessHandle.write()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-write)
* [FileSystemSyncAccessHandle.read()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-read)

The read() and write() methods have _always_ been synchronous, which is the reason "Sync" is in the class name. 

The spec has been changed so all the other FileSystemSyncAccess methods are synchronous as well. There is a note to that effect on every method page, but the return values for [close()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle/close), [flush()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle/flush), [getSize()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle/getSize), and [truncate()](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle/truncate) are still described as returning a Promise. This PR does not address those methods that at least used to be correct.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
