### PR TITLE
CI: Avoid path filtering in "required" workflows

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .nvmrc
-      - files/**
-      - .github/workflows/pr-check_redirects.yml
 
 jobs:
   check-redirects:
@@ -22,11 +18,26 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      # This is a "required" workflow so path filtering can not be used:
+      # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      # We have to rely on a custom filtering mechanism to run the checks only if required files are modified.
+      - uses: dorny/paths-filter@v2
+        name: See if any file needs checking
+        id: filter
+        with:
+          filters: |
+            required_files :
+              - ".nvmrc"
+              - "files/**"
+              - ".github/workflows/pr-check_redirects_file.yml"
+
       - name: Install all yarn packages
+        if: steps.filter.outputs.required_files == 'true'
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check redirects file(s)
+        if: steps.filter.outputs.required_files == 'true'
         run: yarn content validate-redirects en-us --strict

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,10 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .nvmrc
-      - ".github/workflows/pr-test.yml"
-      - "files/en-us/**"
 
 jobs:
   tests:
@@ -31,16 +27,31 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      # This is a "required" workflow so path filtering can not be used:
+      # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      # We have to rely on a custom filtering mechanism to run the checks only if required files are modified.
+      - uses: dorny/paths-filter@v2
+        name: See if any file needs checking
+        id: filter
+        with:
+          filters: |
+            required_files :
+              - ".nvmrc"
+              - ".github/workflows/pr-test.yml"
+              - "files/en-us/**"
+
       - name: Install all yarn packages
+        if: steps.filter.outputs.            required_files == 'true'
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get changed files
+        if: steps.filter.outputs.required_files == 'true'
         run: |
           # Use the GitHub API to get the list of changed files
-          # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
+          # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,7 +41,7 @@ jobs:
               - "files/en-us/**"
 
       - name: Install all yarn packages
-        if: steps.filter.outputs.            required_files == 'true'
+        if: steps.filter.outputs.required_files == 'true'
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note


### PR DESCRIPTION
~~The workflow checks only `files/en-us/_redirects.txt` file. [_It doesn't work on any other file_](https://github.com/mdn/yari/blob/65f1e4b793f5ce7fd0d4a4a0a2b623db67af336d/tool/cli.ts#L257C51-L257C65).~~

~~It is not required to run this workflow in every PR. This PR reduces the workflows scope to only the `_redirects.txt` file and the workflow file.~~

~~Also, there is no point in making this workflow "required" in settings.~~

Edit: Had to revert the original changes due to [the edge case](https://github.com/mdn/content/pull/28277#issuecomment-1659904324). Now the PR focuses only on avoiding path filtering.

/cc @bsmth 