### PR TITLE
Fix grammar in heading_elements/index.md

### DIFF
--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -129,7 +129,7 @@ The following code shows a few headings with some content under them.
 
 ### Navigation
 
-A common navigation technique for users of screen reading software is to quickly jump from heading to heading to in order to determine the content of the page. Because of this, it is important to not skip one or more heading levels. Doing so may create confusion, as the person navigating this way may be left wondering where the missing heading is.
+A common navigation technique for users of screen reading software is to quickly jump from heading to heading in order to determine the content of the page. Because of this, it is important to not skip one or more heading levels. Doing so may create confusion, as the person navigating this way may be left wondering where the missing heading is.
 
 **Don't do this:**
 


### PR DESCRIPTION
### Description

Sorry to be a pain in the back, but the recent grammar fix/update of the wording in this paragraph has introduced a new, minor error: a duplicated word: 'to'.

This commit removes this superfluous word 'to'.

**Changed from:**
> A common navigation technique for users of screen reading software is to quickly jump 
> from heading to heading to in order to determine the content of the page.


**Changed to:**
> A common navigation technique for users of screen reading software is to quickly jump 
> from heading to heading in order to determine the content of the page.
 