### PR TITLE
fix(http): Line number accidentally set as code block language

### DIFF
--- a/files/en-us/web/http/status/423/index.md
+++ b/files/en-us/web/http/status/423/index.md
@@ -13,7 +13,7 @@ The HTTP **`423 Locked`** error response code indicates that either the resource
 
 ## Status
 
-```16
+```plain
 423 Locked
 ```
 


### PR DESCRIPTION
This was accidentally introduced in https://github.com/mdn/content/pull/28158, and it looks like the line number was committed instead of `plain`.