### PR TITLE
fix(lint-staged): markdownlint and prettier can race on md files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,8 @@
 {
-  "*": "prettier --ignore-unknown --write",
+  "!*.md": "prettier --ignore-unknown --write",
   "*.md": [
     "markdownlint-cli2-fix",
+    "prettier --write",
     "node scripts/front-matter_linter.js --fix true"
   ],
   "tests/**/*.*": "yarn test:front-matter-linter",

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,9 +1,9 @@
 {
   "!*.md": "prettier --ignore-unknown --write",
   "*.md": [
-    "markdownlint-cli2-fix",
-    "prettier --write",
-    "node scripts/front-matter_linter.js --fix true"
+    "markdownlint-cli2 --fix",
+    "node scripts/front-matter_linter.js --fix true",
+    "prettier --write"
   ],
   "tests/**/*.*": "yarn test:front-matter-linter",
   "*.{svg,png,jpeg,jpg,gif}": "yarn filecheck"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fix:fm": "node scripts/front-matter_linter.js --fix true",
     "fix:js": "prettier -w \"**/*.(m)?js\"",
     "fix:json": "prettier -w \"**/*.json(c)?\"",
-    "fix:md": "markdownlint-cli2-fix \"**/*.md\" && prettier -w \"**/*.md\"",
+    "fix:md": "markdownlint-cli2 --fix \"**/*.md\" && prettier -w \"**/*.md\"",
     "fix:yml": "prettier -w \"**/*.yml\"",
     "lint:fm": "node scripts/front-matter_linter.js",
     "lint:js": "prettier -c \"**/*.(m)?js\"",


### PR DESCRIPTION
### Description

Prevent possible race condition between prettier and markdownlint in lint-staged, changed to use the order defined already in the package.json fix:md and lint:md commands.

I don't believe the other rules will race, since:
- `yarn test:front-matter-linter` doesn't appear to change the files, just runs jest on them
- prettier wouldn't run anyway on `*.{svg,png,jpeg,jpg,gif}`

@OnkarRuikar I don't seem to be able to assign you as a reviewer, but it would be great if you can take a look :)

### Additional details

https://github.com/okonet/lint-staged#task-concurrency

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/27936
