### PR TITLE
Fix issue 12744: pass correct arguments to EncodedVideoChunk

### DIFF
--- a/files/en-us/web/api/videodecoder/decode/index.md
+++ b/files/en-us/web/api/videodecoder/decode/index.md
@@ -41,6 +41,7 @@ const responses = await downloadVideoChunksFromServer(timestamp);
 for (const response of responses) {
   const chunk = new EncodedVideoChunk({
     timestamp: response.timestamp,
+    type: response.key ? "key" : "delta",
     data: new Uint8Array(response.body),
   });
   decoder.decode(chunk);


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/12744.

I've copied the relevant bit of https://developer.chrome.com/articles/webcodecs/#decoding for this. I don't know what `response` is here because I can't see an implementation of `downloadVideoChunksFromServer`. But at least this is formally correct now AFAICT.