### PR TITLE
FF117 HTMLElement.togglePopover() returns boolean

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1475,7 +1475,7 @@ The following HTML global attributes are supported:
 - [`popovertarget`](/en-US/docs/Web/HTML/Element/button#popovertarget)
 - [`popovertargetaction`](/en-US/docs/Web/HTML/Element/button#popovertargetaction)
 
-See [Firefox bug 934425](https://bugzil.la/934425) for more details.
+See [Firefox bug 1823757](https://bugzil.la/1823757) for more details.
 
 <table>
   <thead>

--- a/files/en-us/web/api/htmlelement/togglepopover/index.md
+++ b/files/en-us/web/api/htmlelement/togglepopover/index.md
@@ -33,13 +33,9 @@ togglePopover(force)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
-
-<!-- Spec requirement - from undefined to boolean. Waiting on implementation such as https://bugzilla.mozilla.org/show_bug.cgi?id=1842845
 `true` if the popup is open after the call, and `false` otherwise.
 
-{{jsxref("undefined")}} may be returned in older browsers (see [browser compatibility](#browser_compatibility)).
--->
+None ({{jsxref("undefined")}}) may be returned in older browser versions (see [browser compatibility](#browser_compatibility)).
 
 ## Examples
 
@@ -96,20 +92,17 @@ We also log whether the popup was open or closed after the call, but only if a `
 if (HTMLElement.prototype.hasOwnProperty("popover")) {
   document.addEventListener("keydown", (event) => {
     if (event.key === "h") {
-      popover.togglePopover();
+      const popupOpened = popover.togglePopover();
+
+      // Check if popover is opened or closed on supporting browsers
+      if (popupOpened !== undefined) {
+        instructions.innerText +=
+          popupOpened === true ? `\nOpened` : `\nClosed`;
+      }
     }
   });
 }
 ```
-
-<!-- modifications to code once togglePopover() returns boolean
-      const popupOpened = popover.togglePopover();
-
-      // If not undefined, you can check if popover is opened or closed.
-      console.log(`popupOpened: ${popupOpened}`)
-      if (popupOpened === true) instructions.innerText += `\nOpened`;
-      if (popupOpened === false) instructions.innerText += `\nClosed`;
--->
 
 You can test this out using the live example below.
 


### PR DESCRIPTION
FF117 changes [`HTMLElement.togglePopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover) to return a boolean indicating if the popover is opened or closed (behind a pref) in https://bugzilla.mozilla.org/show_bug.cgi?id=1842845

This updates the page/live example.

Related docs work can be tracked in #27417