### PR TITLE
ReadableStream.from() static method

### DIFF
--- a/files/en-us/web/api/readablestream/from_static/index.md
+++ b/files/en-us/web/api/readablestream/from_static/index.md
@@ -72,7 +72,7 @@ const myReadableStream = ReadableStream.from(asyncIterator);
 ```
 
 [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams) demonstrates several ways to consume a stream.
-The code below uses a `for ... await` loop, as this method is the simplest.
+The code below uses a `for ...await` loop, as this method is the simplest.
 Each iteration of the loop logs the current chunk from the stream.
 
 ```js

--- a/files/en-us/web/api/readablestream/from_static/index.md
+++ b/files/en-us/web/api/readablestream/from_static/index.md
@@ -1,0 +1,84 @@
+---
+title: "ReadableStream: from() static method"
+short-title: from()
+slug: Web/API/ReadableStream/from_static
+page-type: web-api-static-method
+status:
+  - experimental
+browser-compat: api.ReadableStream.from_static
+---
+
+{{APIRef("Streams")}}{{SeeCompatTable}}
+
+The **`ReadableStream.from()`** static method returns a {{domxref("ReadableStream")}} from a provided iterable or async iterable object.
+
+The method can be used to wrap iterable and async iterable objects as readable streams, including arrays, sets, async generators, `ReadableStreams`, Node.js `readable` streams, and so on.
+
+## Syntax
+
+```js-nolint
+ReadableStream.from(anyIterable)
+```
+
+### Parameters
+
+- `anyIterable`
+  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [async iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) object.
+
+### Return value
+
+A {{domxref("ReadableStream")}}.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the passed parameter is not an iterable or async iterable (does not define the `@@iterator` or `@@asyncIterator` method).
+    Also thrown if, during iteration, the result of the next step is not an object or is a promise that does not resolve to an object.
+
+### Examples
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const asyncIterator = (async function* () {
+  yield 1;
+  yield 2;
+  yield 3;
+})();
+
+let myReadableStream = ReadableStream.from(asyncIterator);
+consumeStream(myReadableStream);
+
+// Iterate a ReadableStream asynchronously
+async function consumeStream(readableStream) {
+  for await (const chunk of myReadableStream) {
+    // Do something with each chunk
+    // Here we just log the values
+    log(`chunk: ${chunk}`);
+  }
+}
+```
+
+{{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ReadableStream")}}
+- [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams)

--- a/files/en-us/web/api/readablestream/from_static/index.md
+++ b/files/en-us/web/api/readablestream/from_static/index.md
@@ -12,7 +12,7 @@ browser-compat: api.ReadableStream.from_static
 
 The **`ReadableStream.from()`** static method returns a {{domxref("ReadableStream")}} from a provided iterable or async iterable object.
 
-The method can be used to wrap iterable and async iterable objects as readable streams, including arrays, sets, async generators, `ReadableStreams`, Node.js `readable` streams, and so on.
+The method can be used to wrap iterable and async iterable objects as readable streams, including arrays, sets, arrays of promises, async generators, `ReadableStreams`, Node.js `readable` streams, and so on.
 
 ## Syntax
 

--- a/files/en-us/web/api/readablestream/from_static/index.md
+++ b/files/en-us/web/api/readablestream/from_static/index.md
@@ -35,7 +35,11 @@ A {{domxref("ReadableStream")}}.
   - : Thrown if the passed parameter is not an iterable or async iterable (does not define the `@@iterator` or `@@asyncIterator` method).
     Also thrown if, during iteration, the result of the next step is not an object or is a promise that does not resolve to an object.
 
-### Examples
+## Examples
+
+### Convert an async iterator to a ReadableStream
+
+This live example demonstrates how you can convert an async iterable to a `ReadableStream`, and then how this stream might be consumed.
 
 ```html hidden
 <pre id="log"></pre>
@@ -46,16 +50,32 @@ const logElement = document.getElementById("log");
 function log(text) {
   logElement.innerText += `${text}\n`;
 }
+
+if (!ReadableStream.from) {
+  log("ReadableStream.from() is not supported");
+}
 ```
 
+The async iterable is an anonymous generator function that yields the values of 1, 2 and 3 when it is called three times.
+This is passed to `ReadableStream.from()` to create the `ReadableStream`.
+
 ```js
+// Define an asynchronous iterator
 const asyncIterator = (async function* () {
   yield 1;
   yield 2;
   yield 3;
 })();
 
-let myReadableStream = ReadableStream.from(asyncIterator);
+// Create ReadableStream from iterator
+const myReadableStream = ReadableStream.from(asyncIterator);
+```
+
+[Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams) demonstrates several ways to consume a stream.
+The code below uses a `for ... await` loop, as this method is the simplest.
+Each iteration of the loop logs the current chunk from the stream.
+
+```js
 consumeStream(myReadableStream);
 
 // Iterate a ReadableStream asynchronously
@@ -68,7 +88,55 @@ async function consumeStream(readableStream) {
 }
 ```
 
-{{EmbedLiveSample("Examples")}}
+The output of consuming the stream is shown below (if `ReadableStream.from()` is supported).
+
+{{EmbedLiveSample("Convert an async iterator to a ReadableStream","100%", "80")}}
+
+### Convert an Array to a ReadableStream
+
+This example demonstrates how you can convert an `Array`to a `ReadableStream`.
+The iterable is just an array of strings that is passed to `ReadableStream.from()` to create the `ReadableStream`.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+
+if (!ReadableStream.from) {
+  log("ReadableStream.from() is not supported");
+}
+```
+
+```js
+// An Array of vegetable names
+const vegetables = ["Carrot", "Broccoli", "Tomato", "Spinach"];
+
+// Create ReadableStream from the Array
+const myReadableStream = ReadableStream.from(vegetables);
+```
+
+```js hidden
+consumeStream(myReadableStream);
+
+// Iterate a ReadableStream asynchronously
+async function consumeStream(readableStream) {
+  for await (const chunk of myReadableStream) {
+    // Do something with each chunk
+    // Here we just log the values
+    log(`chunk: ${chunk}`);
+  }
+}
+```
+
+We use the same approach as in the previous example to consume the stream (see previous section).
+The output is shown below.
+
+{{EmbedLiveSample("Convert an Array to a ReadableStream","100%", "100")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/readablestream/from_static/index.md
+++ b/files/en-us/web/api/readablestream/from_static/index.md
@@ -41,16 +41,28 @@ A {{domxref("ReadableStream")}}.
 
 This live example demonstrates how you can convert an async iterable to a `ReadableStream`, and then how this stream might be consumed.
 
-```html hidden
+#### HTML
+
+The HTML is consists of single `<pre>` element, which is used for logging.
+
+```html
 <pre id="log"></pre>
 ```
 
-```js hidden
+#### JavaScript
+
+The example code creates a `log()` function to write to the log HTML element.
+
+```js
 const logElement = document.getElementById("log");
 function log(text) {
   logElement.innerText += `${text}\n`;
 }
+```
 
+It then checks if the static method is supported, and if not, logs the result.
+
+```js
 if (!ReadableStream.from) {
   log("ReadableStream.from() is not supported");
 }
@@ -88,14 +100,15 @@ async function consumeStream(readableStream) {
 }
 ```
 
+#### Result
+
 The output of consuming the stream is shown below (if `ReadableStream.from()` is supported).
 
 {{EmbedLiveSample("Convert an async iterator to a ReadableStream","100%", "80")}}
 
 ### Convert an Array to a ReadableStream
 
-This example demonstrates how you can convert an `Array`to a `ReadableStream`.
-The iterable is just an array of strings that is passed to `ReadableStream.from()` to create the `ReadableStream`.
+This example demonstrates how you can convert an `Array` to a `ReadableStream`.
 
 ```html hidden
 <pre id="log"></pre>
@@ -111,6 +124,10 @@ if (!ReadableStream.from) {
   log("ReadableStream.from() is not supported");
 }
 ```
+
+#### JavaScript
+
+The iterable is just an array of strings that is passed to `ReadableStream.from()` to create the `ReadableStream`.
 
 ```js
 // An Array of vegetable names
@@ -133,7 +150,10 @@ async function consumeStream(readableStream) {
 }
 ```
 
-We use the same approach as in the previous example to consume the stream (see previous section).
+We use the same approach as in the previous example log and to consume the stream, so that is not shown here.
+
+#### Result
+
 The output is shown below.
 
 {{EmbedLiveSample("Convert an Array to a ReadableStream","100%", "100")}}

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -125,7 +125,7 @@ The {{domxref("ReadableStream/from_static", "from()")}} static method can conver
 const myReadableStream = ReadableStream.from(iteratorOrAsyncIterator);
 ```
 
-On browsers that don't support the `from()` method you can instead create your own [custom readable stream](/en-US/docs/Web/API/Streams_API/Using_readable_streams#creating_your_own_custom_readable_stream) to do the achieve the same result:
+On browsers that don't support the `from()` method you can instead create your own [custom readable stream](/en-US/docs/Web/API/Streams_API/Using_readable_streams#creating_your_own_custom_readable_stream) to achieve the same result:
 
 ```js
 function iteratorToStream(iterator) {

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -117,9 +117,15 @@ fetch("https://www.example.org")
   });
 ```
 
-### Convert async iterator to stream
+### Convert an iterator or async iterator to a stream
 
-Converting an [(async) iterator](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators) to a readable stream:
+The {{domxref("ReadableStream/from_static", "from()")}} static method can convert an iterator, such as an {{jsxref("Array")}} or {{jsxref("Map")}}, or an [(async) iterator](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators) to a readable stream:
+
+```js
+const myReadableStream = ReadableStream.from(iteratorOrAsyncIterator);
+```
+
+On browsers that don't support the `from()` method you can instead create your own [custom readable stream](/en-US/docs/Web/API/Streams_API/Using_readable_streams#creating_your_own_custom_readable_stream) to do the achieve the same result:
 
 ```js
 function iteratorToStream(iterator) {
@@ -136,8 +142,6 @@ function iteratorToStream(iterator) {
   });
 }
 ```
-
-This works with both async and non-async iterators.
 
 ### Async iteration of a stream using for await...of
 

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -21,6 +21,11 @@ The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_
 - {{domxref("ReadableStream.locked")}} {{ReadOnlyInline}}
   - : Returns a boolean indicating whether or not the readable stream is locked to a reader.
 
+## Static methods
+
+- {{domxref("ReadableStream/from_static", "ReadableStream.from()")}} {{Experimental_Inline}}
+  - : Returns `ReadableStream` from a provided iterable or async iterable object, such as an array, a set, an async generator, and so on.
+
 ## Instance methods
 
 - {{domxref("ReadableStream.cancel()")}}


### PR DESCRIPTION
This adds docs for the new `ReadableStream.from()` static method, added in FF117 in https://bugzilla.mozilla.org/show_bug.cgi?id=1772772

Related docs work can be tracked in #28282