### PR TITLE
relnote(117): 'strict-dynamic' CSP enforced in 'default-src' directives

### DIFF
--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -30,7 +30,7 @@ This article provides information about the changes in Firefox 117 that affect d
 
 ### HTTP
 
-- Fixed a bug where the [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) `strict-dynamic` source expression was not being enforced in `default-src` directives.
+- Fixed a bug where the [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) `'strict-dynamic'` source expression was not being enforced in `default-src` directives.
   The behavior now matches the specification where `default-src` directive values are used as a fallback when `script-src` is not provided ([Firefox bug 1313937](https://bugzil.la/1313937)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -30,6 +30,9 @@ This article provides information about the changes in Firefox 117 that affect d
 
 ### HTTP
 
+- Fixed a bug where the [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) `strict-dynamic` source expression was not being enforced in `default-src` directives.
+  The behavior now matches the specification where `default-src` directive values are used as a fallback when `script-src` is not provided ([Firefox bug 1313937](https://bugzil.la/1313937)).
+
 #### Removals
 
 ### Security


### PR DESCRIPTION
Adding a release note for `strict-dynamic` in `default-src` support.

```html
<meta
  http-equiv="Content-Security-Policy"
  content="default-src 'nonce-ABCDEF' 'strict-dynamic'"
/>
```

i.e.:

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta
      http-equiv="Content-Security-Policy"
      content="script-src 'nonce-ABCDEF' 'strict-dynamic'"
    />
  </head>
  <body>
    <script nonce="ABCDEF">
      let scriptElement = document.createElement("script");
      scriptElement.innerText = "alert(42)";
      document.body.appendChild(scriptElement);
    </script>
  </body>
</html>
```

As an implicit fallback for 

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta
      http-equiv="Content-Security-Policy"
      content="script-src 'nonce-ABCDEF' 'strict-dynamic'"
    />
  </head>
  <body>
    <script nonce="ABCDEF">
      let scriptElement = document.createElement("script");
      scriptElement.innerText = "alert(42)";
      document.body.appendChild(scriptElement);
    </script>
  </body>
</html>
```

__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/28301

__Bugzilla:__
- [BUG-1313937](https://bugzilla.mozilla.org/show_bug.cgi?id=1313937)