### PR TITLE
Fix ink trail example

### DIFF
--- a/files/en-us/web/api/ink_api/index.md
+++ b/files/en-us/web/api/ink_api/index.md
@@ -35,7 +35,9 @@ The entry point is the {{domxref("Navigator.ink")}} property, which returns an {
 - {{domxref("Navigator.ink")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an {{domxref("Ink")}} object for the current document.
 
-## Example
+## Examples
+
+### Drawing an ink trail
 
 In this example, we draw a trail onto a 2D canvas. Near the start of the code, we call {{domxref("Ink.requestPresenter()")}}, passing it the canvas as the presentation area for it to take care of and storing the promise it returns in the `presenter` variable.
 
@@ -46,11 +48,31 @@ Later on, in the `pointermove` event listener, the new position of the trailhead
 
 The result is that a delegated ink trail is drawn ahead of the default browser rendering on the app's behalf, in the specified style, until the next time it receives a `pointermove` event.
 
+#### HTML
+
+```html
+<canvas id="canvas"></canvas>
+<div id="div">Delegated ink trail should match the color of this div.</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: rgba(0, 255, 0, 1);
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+}
+```
+
+#### JavaScript
+
 ```js
 const ctx = canvas.getContext("2d");
-let presenter = navigator.ink.requestPresenter({ presentationArea: canvas });
+const presenter = navigator.ink.requestPresenter({ presentationArea: canvas });
 let move_cnt = 0;
-let style = { color: "rgba(0, 0, 255, 1)", diameter: 10 };
+let style = { color: "rgba(0, 255, 0, 1)", diameter: 10 };
 
 function getRandomInt(min, max) {
   min = Math.ceil(min);
@@ -58,27 +80,26 @@ function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-canvas.addEventListener("pointermove", (evt) => {
+canvas.addEventListener("pointermove", async (evt) => {
   const pointSize = 10;
-  ctx.fillStyle = "#000000";
+  ctx.fillStyle = style.color;
   ctx.fillRect(evt.pageX, evt.pageY, pointSize, pointSize);
-  if (move_cnt == 50) {
-    let r = getRandomInt(0, 255);
-    let g = getRandomInt(0, 255);
-    let b = getRandomInt(0, 255);
-    style = { color: "rgba(" + r + ", " + g + ", " + b + ", 1)", diameter: 10 };
+  if (move_cnt == 20) {
+    const r = getRandomInt(0, 255);
+    const g = getRandomInt(0, 255);
+    const b = getRandomInt(0, 255);
+
+    style = { color: `rgba(${r}, ${g}, ${b}, 1)`, diameter: 10 };
     move_cnt = 0;
-    document.getElementById("div").style.backgroundColor =
-      "rgba(" + r + ", " + g + ", " + b + ", 1)";
+    document.getElementById(
+      "div",
+    ).style.backgroundColor = `rgba(${r}, ${g}, ${b}, 0.6)`;
   }
   move_cnt += 1;
-  presenter.then(function (v) {
-    v.updateInkTrailStartPoint(evt, style);
-  });
+  await presenter.updateInkTrailStartPoint(evt, style);
 });
 
-window.addEventListener("pointerdown", (evt) => {
-  evt.pointerId;
+window.addEventListener("pointerdown", () => {
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 });
 
@@ -86,7 +107,9 @@ canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
 ```
 
-> **Note:** See this example running live — [Delegated ink trail](https://mabian-ms.github.io/delegated-ink-trail.html).
+#### Result
+
+{{EmbedLiveSample("Drawing an ink trail")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/inkpresenter/updateinktrailstartpoint/index.md
+++ b/files/en-us/web/api/inkpresenter/updateinktrailstartpoint/index.md
@@ -41,7 +41,9 @@ requestPresenter(event, style)
     - `diameter` property is not a number or less than 1.
     - {{domxref("InkPresenter.presentationArea", "presentationArea")}} element is removed from the document before or during rendering.
 
-## Example
+## Examples
+
+### Drawing an ink trail
 
 In this example, we draw a trail onto a 2D canvas. Near the start of the code, we call {{domxref("Ink.requestPresenter()")}}, passing it the canvas as the presentation area for it to take care of and storing the promise it returns in the `presenter` variable.
 
@@ -52,11 +54,31 @@ Later on, in the `pointermove` event listener, the new position of the trailhead
 
 The result is that a delegated ink trail is drawn ahead of the default browser rendering on the app's behalf, in the specified style, until the next time it receives a `pointermove` event.
 
+#### HTML
+
+```html
+<canvas id="canvas"></canvas>
+<div id="div">Delegated ink trail should match the color of this div.</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: rgba(0, 255, 0, 1);
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+}
+```
+
+#### JavaScript
+
 ```js
 const ctx = canvas.getContext("2d");
-let presenter = navigator.ink.requestPresenter({ presentationArea: canvas });
+const presenter = navigator.ink.requestPresenter({ presentationArea: canvas });
 let move_cnt = 0;
-let style = { color: "rgba(0, 0, 255, 1)", diameter: 10 };
+let style = { color: "rgba(0, 255, 0, 1)", diameter: 10 };
 
 function getRandomInt(min, max) {
   min = Math.ceil(min);
@@ -64,27 +86,26 @@ function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-canvas.addEventListener("pointermove", (evt) => {
+canvas.addEventListener("pointermove", async (evt) => {
   const pointSize = 10;
-  ctx.fillStyle = "#000000";
+  ctx.fillStyle = style.color;
   ctx.fillRect(evt.pageX, evt.pageY, pointSize, pointSize);
-  if (move_cnt == 50) {
-    let r = getRandomInt(0, 255);
-    let g = getRandomInt(0, 255);
-    let b = getRandomInt(0, 255);
-    style = { color: "rgba(" + r + ", " + g + ", " + b + ", 1)", diameter: 10 };
+  if (move_cnt == 20) {
+    const r = getRandomInt(0, 255);
+    const g = getRandomInt(0, 255);
+    const b = getRandomInt(0, 255);
+
+    style = { color: `rgba(${r}, ${g}, ${b}, 1)`, diameter: 10 };
     move_cnt = 0;
-    document.getElementById("div").style.backgroundColor =
-      "rgba(" + r + ", " + g + ", " + b + ", 1)";
+    document.getElementById(
+      "div",
+    ).style.backgroundColor = `rgba(${r}, ${g}, ${b}, 0.6)`;
   }
   move_cnt += 1;
-  presenter.then(function (v) {
-    v.updateInkTrailStartPoint(evt, style);
-  });
+  await presenter.updateInkTrailStartPoint(evt, style);
 });
 
-window.addEventListener("pointerdown", (evt) => {
-  evt.pointerId;
+window.addEventListener("pointerdown", () => {
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 });
 
@@ -92,7 +113,9 @@ canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
 ```
 
-> **Note:** See this example running live — [Delegated ink trail](https://mabian-ms.github.io/delegated-ink-trail.html).
+#### Result
+
+{{EmbedLiveSample("Drawing an ink trail")}}
 
 ## Specifications
 


### PR DESCRIPTION
This applies the fix in https://github.com/mdn/content/pull/27242 but also moves the example into the page as a live sample, and cleans it up in a few other ways (let->const, template literals, async/await).

Supersedes https://github.com/mdn/content/pull/27242.