### PR TITLE
fix the description about `1xx` warning-codes

### DIFF
--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -43,7 +43,7 @@ Warning: <warn-code> <warn-agent> <warn-text> [<warn-date>]
 
   - : A three-digit warning number. The first digit indicates whether the `Warning` is required to be deleted from a stored response after validation.
 
-    - `1xx` warn-codes describe the freshness or validation status of the response and will be deleted by a cache after deletion.
+    - `1xx` warn-codes describe the freshness or validation status of the response and will be deleted by a cache after successful validation.
     - `2xx` warn-codes describe some aspect of the representation that is not rectified by a validation and will not be deleted by a cache after validation unless a full response is sent.
 
 - \<warn-agent>


### PR DESCRIPTION
### Description

The [rfc 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-13.1.2) shows that, the `1xx` warn-code must be deleted after a successful revalidation. But the description in MDN uses 'deletion'. I think this should be a typo
