### PR TITLE
Fix broken links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/25/index.md
+++ b/files/en-us/mozilla/firefox/releases/25/index.md
@@ -47,7 +47,7 @@ page-type: firefox-release-notes
 - The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) is now supported. An incomplete implementation was previously available behind a preference ([Firefox bug 779297](https://bugzil.la/779297)).
 - Some IME related keys on Windows are supported by `KeyboardEvent.key` ([Firefox bug 865565](https://bugzil.la/865565)), see [the key name table](/en-US/docs/Web/API/KeyboardEvent#keyname_table_win) for the detail.
 - Firefox for Metro now dispatches key events in the same way as the desktop version ([Firefox bug 843236](https://bugzil.la/843236)).
-- `keypress` event is no longer dispatched if `preventDefault()` of preceding `keydown` event is called ([Firefox bug 501496](https://bugzil.la/501496)), see [the document of `keydown` event](</en-US/docs/Web/API/Document/keydown_event#preventdefault()_of_keydown_event>) for the detail.
+- `keypress` event is no longer dispatched if `preventDefault()` of preceding `keydown` event is called ([Firefox bug 501496](https://bugzil.la/501496)), see [the document of `keydown` event](</en-US/docs/Web/API/Element/keydown_event#preventdefault()_of_keydown_event>) for the detail.
 - Renamed the `Future` interface to `Promise` ([Firefox bug 884279](https://bugzil.la/884279)).
 - The `srcDoc` property on the {{domxref("HTMLIFrameElement")}} interface, allowing the inline specification of the content of an {{HTMLElement("iframe")}}, is now supported ([Firefox bug 802895](https://bugzil.la/802895)).
 - The `createTBody()` method on the {{domxref("HTMLTableElement")}} interface, allowing to get its {{HTMLElement("tbody")}}, is now supported ([Firefox bug 813034](https://bugzil.la/813034)).

--- a/files/en-us/mozilla/firefox/releases/7/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/index.md
@@ -45,7 +45,7 @@ Firefox 7 shipped on September 27, 2011. This article provides information about
 - The top-level {{ MathMLElement("math") }} element now accepts any attributes of the {{ MathMLElement("mstyle") }} element.
 - Support for [Asana Math](https://www.ctan.org/tex-archive/fonts/Asana-Math/) fonts has been added.
 - The `medium` line thickness of fraction bars in {{ MathMLElement("mfrac") }} elements has been corrected to match the default thickness.
-- [Names for negative spaces](</en-US/docs/Web/MathML/Attribute/Values#constants_(namedspaces)>) are now supported.
+- [Names for negative spaces](</en-US/docs/Web/MathML/Values#constants_(namedspaces)>) are now supported.
 
 ### DOM
 

--- a/files/en-us/mozilla/firefox/releases/83/index.md
+++ b/files/en-us/mozilla/firefox/releases/83/index.md
@@ -29,7 +29,7 @@ This article provides information about the changes in Firefox 83 that will affe
 
 ### JavaScript
 
-- [`Intl[@@toStringTag]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag) has been added, returning a default value of `Intl` (recent addition to the ECMA spec). ([Firefox bug 1670053](https://bugzil.la/1670053))
+- [`Intl[@@toStringTag]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) has been added, returning a default value of `Intl` (recent addition to the ECMA spec). ([Firefox bug 1670053](https://bugzil.la/1670053))
 
 ### HTTP
 

--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -11,7 +11,7 @@ The **`FileReader`** object lets web applications asynchronously read the conten
 
 File objects may be obtained from a {{domxref("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, or from a drag and drop operation's {{domxref("DataTransfer")}} object.
 
-`FileReader` can only access the contents of files that the user has explicitly selected, either using an HTML `<input type="file">` element or by drag and drop. It cannot be used to read a file by pathname from the user's file system. To read files on the client's file system by pathname, use the [File System Access API](/en-US/docs/Web/API/File_System_Access_API). To read server-side files, use standard Ajax solutions, with CORS permission if reading cross-domain.
+`FileReader` can only access the contents of files that the user has explicitly selected, either using an HTML `<input type="file">` element or by drag and drop. It cannot be used to read a file by pathname from the user's file system. To read files on the client's file system by pathname, use the [File System Access API](/en-US/docs/Web/API/File_System_API). To read server-side files, use standard Ajax solutions, with CORS permission if reading cross-domain.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
@@ -51,6 +51,6 @@ For more examples, see <https://resourcepolicy.fyi/>.
 
 ## See also
 
-- [Cross-Origin Resource Policy (CORP) explainer](</en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)>)
+- [Cross-Origin Resource Policy (CORP) explainer](/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy)
 - [Consider deploying Cross-Origin Resource Policy](https://resourcepolicy.fyi/)
 - {{httpheader("Access-Control-Allow-Origin")}}


### PR DESCRIPTION
This PR fixes a few broken links using the `fix-flaws` command, followed by manual tweaks where needed.
