### PR TITLE
New modue: CSS Scoping

### DIFF
--- a/files/en-us/glossary/dom/index.md
+++ b/files/en-us/glossary/dom/index.md
@@ -6,9 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The **DOM** (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}} document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a node tree, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).
+The **DOM** (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}} document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a node tree, or **DOM tree**, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).
 
-The DOM is one of the most-used {{Glossary("API")}}s on the {{glossary("World Wide Web","Web")}} because it allows code running in a browser to access and interact with every node in the document. Nodes can be created, moved and changed. Event listeners can be added to nodes and triggered on occurrence of a given event.
+The DOM is one of the most-used {{Glossary("API")}}s on the {{glossary("World Wide Web","Web")}} because it allows code running in a browser to access and interact with every node in the document. Nodes can be created, moved, and changed. Event listeners can be added to nodes and triggered on the occurrence of a given event.
 
 DOM was not originally specified—it came about when browsers began implementing {{Glossary("JavaScript")}}. This legacy DOM is sometimes called DOM 0. Today, the WHATWG maintains the DOM Living Standard.
 

--- a/files/en-us/glossary/dom/index.md
+++ b/files/en-us/glossary/dom/index.md
@@ -6,20 +6,12 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The **DOM** (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}} document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a node tree, or **DOM tree**, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).
+The **DOM** (Document Object Model) is an {{glossary("API")}} that represents and interacts with any {{glossary("HTML")}} or {{glossary("XML")}}-based markup language document. The DOM is a document model loaded in the {{glossary("browser")}} and representing the document as a {{Glossary("Node/DOM","node")}} tree, or **DOM tree**, where each node represents part of the document (e.g. an {{Glossary("element")}}, text string, or comment).
 
 The DOM is one of the most-used {{Glossary("API")}}s on the {{glossary("World Wide Web","Web")}} because it allows code running in a browser to access and interact with every node in the document. Nodes can be created, moved, and changed. Event listeners can be added to nodes and triggered on the occurrence of a given event.
 
-DOM was not originally specified—it came about when browsers began implementing {{Glossary("JavaScript")}}. This legacy DOM is sometimes called DOM 0. Today, the WHATWG maintains the DOM Living Standard.
-
 ## See also
 
-- [The Document Object Model](https://en.wikipedia.org/wiki/Document_Object_Model) on Wikipedia
 - [The DOM documentation on MDN](/en-US/docs/Web/API/Document_Object_Model)
 - [The DOM Standard](https://dom.spec.whatwg.org/)
-- [Glossary](/en-US/docs/Glossary)
-
-  - {{Glossary("API")}}
-  - {{Glossary("HTML")}}
-  - {{Glossary("XML")}}
-  - {{Glossary("World Wide Web")}}
+- [Document Object Model](https://en.wikipedia.org/wiki/Document_Object_Model) on Wikipedia

--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -10,7 +10,7 @@ A **shadow tree** is a hidden set of {{Glossary("DOM")}} nodes whose topmost [no
 
 The shadow root is attached to another node tree through a specific DOM node referred to as its **host**. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
 
-The hidden DOM nodes of a shadow tree are generally not affected by anything applied outside the shadow tree, and vice versa. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally:
+The hidden DOM nodes of a shadow tree are generally not affected by anything applied outside the shadow tree, and vice versa. The **shadow boundary**, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally:
 
 - Scripting shadow tree nodes from outside requires the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
 - Styling a shadow tree from outside can be achieved via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) and [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts).

--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -6,13 +6,14 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the root of the shadow tree is the topmost node within the **shadow DOM**, not the root element of the document.
+A **shadow tree** is a hidden set of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**. The shadow root is the topmost node of a **shadow DOM** and not part of the regular document's DOM tree.
 
-A shadow tree is a hidden set of standard DOM nodes. The shadow root is attached to another node tree through its host. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
+The shadow root is attached to another node tree through a specific DOM node referred to as its **host**. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
 
-The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
+The hidden DOM nodes of a shadow tree are generally not affected by anything applied outside the shadow tree, and vice versa. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally:
 
-By default, nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally, via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) and [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts).
+- Scripting shadow tree nodes from outside requires the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
+- Styling a shadow tree from outside can be achieved via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) and [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts).
 
 ## See also
 

--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -6,9 +6,11 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the topmost node within a **shadow DOM**. The shadow root is attached to another node tree through its host. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
+A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the root of the shadow tree is the topmost node within the **shadow DOM**, not the root element of the document.
 
-A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
+A shadow tree is a hidden set of standard DOM nodes. The shadow root is attached to another node tree through its host. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
+
+The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
 
 By default, nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally, via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) and [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts).
 

--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -6,16 +6,16 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the topmost node within a **shadow DOM**. A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
+A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the topmost node within a **shadow DOM**. The shadow root is attached to another node tree through its host. This host may be part of another shadow tree or part of the regular DOM tree. The node tree of a shadow root's host is sometimes referred to as the **light tree**.
 
-By default, nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally, via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping).
+A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
+
+By default, nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally, via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) and [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts).
 
 ## See also
 
-- {{Glossary("accessibility_tree", "Accessibility tree")}}
 - [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
 - {{domxref("Element.shadowRoot")}} and {{domxref("Element.attachShadow()")}}
 - {{domxref("ShadowRoot")}}
 - {{HTMLElement("slot")}}
-- [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module
-- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
+- {{Glossary("accessibility_tree", "Accessibility tree")}}

--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -6,14 +6,16 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **shadow tree** is a tree of DOM [nodes](/en-US/docs/Glossary/Node/DOM) whose topmost node is a **shadow root**; that is, the topmost node within a **shadow DOM**. A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality, but require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to access.
+A **shadow tree** is a tree of {{Glossary("DOM")}} nodes whose topmost [node](/en-US/docs/Glossary/Node/DOM) is a **shadow root**; that is, the topmost node within a **shadow DOM**. A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality. They require the use of a special [Shadow DOM API](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to be accessed.
 
-Nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms.
+By default, nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms. The shadow boundary, where the shadow DOM ends and the regular DOM begins, can be traversed, but only very intentionally, via [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping).
 
 ## See also
 
+- {{Glossary("accessibility_tree", "Accessibility tree")}}
 - [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
 - {{domxref("Element.shadowRoot")}} and {{domxref("Element.attachShadow()")}}
 - {{domxref("ShadowRoot")}}
 - {{HTMLElement("slot")}}
 - [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -89,5 +89,8 @@ The `:host-context(h1) { font-style: italic; }` and `:host-context(h1):after { c
 ## See also
 
 - [Web components](/en-US/docs/Web/API/Web_components)
-- {{cssxref(":host")}}
-- {{cssxref(":host_function", ":host()")}}
+- CSS {{cssxref(":host")}} pseudo-class
+- CSS {{cssxref(":host_function", ":host()")}} pseudo-class
+- CSS {{CSSXref("::slotted")}} pseudo-element
+- HTML {{HTMLElement("template")}} element
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -77,3 +77,5 @@ The `:host { background: rgba(0,0,0,0.1); padding: 2px 5px; }` rule styles all i
 - [Web components](/en-US/docs/Web/API/Web_components)
 - {{cssxref(":host_function", ":host()")}}
 - {{cssxref(":host-context", ":host-context()")}}
+- {{CSSXref("::slotted")}}
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/css/_doublecolon_slotted/index.md
+++ b/files/en-us/web/css/_doublecolon_slotted/index.md
@@ -119,4 +119,11 @@ Our markup includes three custom elements, including a custom element with an in
 
 ## See also
 
+- {{cssxref(":host")}}
+- {{cssxref(":host_function", ":host()")}}
+- {{cssxref(":host-context", ":host-context()")}}
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
+- HTML [`slot`](/en-US/docs/Web/HTML/Global_attributes/slot) attribute
+- HTML {{HTMLElement("slot")}} element
+- HTML {{HTMLElement("template")}} element
 - [Web components](/en-US/docs/Web/API/Web_components)

--- a/files/en-us/web/css/css_pseudo-elements/index.md
+++ b/files/en-us/web/css/css_pseudo-elements/index.md
@@ -63,7 +63,7 @@ Pseudo-elements enable targeting entities not included in HTML and sections of c
   - {{cssxref("::cue", "::cue()")}}
   - {{cssxref("::cue-region")}}
 
-- CSS scoping module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
 
   - {{CSSXref(":host")}}
   - {{CSSXref(":host_function", ":host()")}}

--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -11,7 +11,12 @@ The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms,
 
 CSS styles are either global in scope or scoped to a {{Glossary("shadow tree")}}. Globally scoped styles apply to all the elements in the node tree, including custom elements in that tree, but do not apply to the shadow trees of which each custom element is composed. Selectors and their associated style definitions don't bleed between scopes.
 
-Within the CSS of a shadow tree, selectors can't see elements outside the tree and selectors outside of a shadow tree don't apply within. Custom elements have their own shadow trees. Each shadow tree contains all the components that make up the custom element, but not the custom element, or "host", itself. Sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible by defining selectors that enable a shadow tree to style its host and a selector that enables external CSS to style elements within the shadow DOM if the custom element is set up to accept external styles.
+Within the CSS of a shadow tree, selectors don't select elements outside the tree, either in the global scope or in other shadow trees. Each custom element has its own shadow tree, which contains all the components that make up the custom element (but not the custom element, or "host", itself).
+
+Sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible by defining selectors that:
+
+- Enable a shadow tree to style its host.
+- Enable external CSS to style elements within a shadow DOM (but only if the associated custom element is set up to accept external styles).
 
 ## Reference
 
@@ -26,7 +31,7 @@ Within the CSS of a shadow tree, selectors can't see elements outside the tree a
 
 - [Web components](/en-US/docs/Web/API/Web_components)
 
-  - : Web components concepts and usage, with an introduction to the different technologies used to create reusable custom elements whose functionality is encapsulated away from the rest of the code.
+  - : An introduction to the different technologies used to create reusable web components — custom elements whose functionality is encapsulated away from the rest of your code.
 
 - [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
 
@@ -64,7 +69,7 @@ Within the CSS of a shadow tree, selectors can't see elements outside the tree a
   - {{DOMxRef("HTMLTemplateElement")}} interface
   - {{DOMxRef("ShadowRoot")}} interface
 
-> **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point, or scope, for selectors to match against, is defined in the [CSS pseudo-classes](/en-US/docs/Web/CSS/CSS_pseudo-classes) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
+> **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point (or scope) for selectors to match against, is defined in the [CSS pseudo-classes](/en-US/docs/Web/CSS/CSS_pseudo-classes) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
 
 ## Specifications
 

--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -9,7 +9,7 @@ spec-urls: https://drafts.csswg.org/css-scoping/
 
 The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms, focusing on the [Shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) [scoping](https://css.oddbird.net/scope/) mechanism.
 
-CSS styles are either global in scope or scoped to a {{Glossary("shadow tree")}}. Globally scoped styles apply to all the elements in the node tree, including custom elements in that tree, but do not apply to the shadow trees of which each custom element is composed. Selectors and their associated style definitions don't bleed between scopes.
+CSS styles are either global in scope or scoped to a {{Glossary("shadow tree")}}. Globally scoped styles apply to all the elements in the node tree that match the selector, including custom elements in that tree, but not to the shadow trees composing each custom element. Selectors and their associated style definitions don't bleed between scopes.
 
 Within the CSS of a shadow tree, selectors don't select elements outside the tree, either in the global scope or in other shadow trees. Each custom element has its own shadow tree, which contains all the components that make up the custom element (but not the custom element, or "host", itself).
 

--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -9,9 +9,9 @@ spec-urls: https://drafts.csswg.org/css-scoping/
 
 The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms, focusing on the [Shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) [scoping](https://css.oddbird.net/scope/) mechanism.
 
-CSS styles are scoped to their own DOM or {{Glossary("shadow tree")}}. Styles applied to an HTML document are considered global in scope as they apply to the entire document. While they apply to all the elements in the node tree, including any custom elements, they do not apply to the shadow trees of which each custom element is comprised. Selectors and their associated style definitions are scoped; they don't bleed between trees. Within the CSS of a shadow tree, selectors can't see elements outside the tree and selectors outside of a shadow tree don't apply within. But sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible. The pseudo-classes defined in the CSS scoping module enable styling a host from within the shadow tree it hosts.
+CSS styles are either global in scope or scoped to a {{Glossary("shadow tree")}}. Globally scoped styles apply to all the elements in the node tree, including custom elements in that tree, but do not apply to the shadow trees of which each custom element is composed. Selectors and their associated style definitions don't bleed between scopes.
 
-Custom elements have their own shadow trees. Each shadow tree contains all the components that make up the custom element, but not the custom element, or "host", itself. Because the host is in a different tree than its components, the styles within the shadow tree don't apply styles to its host. The CSS scoping module defines three pseudo-classes to enable a shadow tree to style its own host and provides one pseudo-element to enable external CSS to style elements within the shadow DOM if the custom element is set up to accept external styles.
+Within the CSS of a shadow tree, selectors can't see elements outside the tree and selectors outside of a shadow tree don't apply within. Custom elements have their own shadow trees. Each shadow tree contains all the components that make up the custom element, but not the custom element, or "host", itself. Sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible by defining selectors that enable a shadow tree to style its host and a selector that enables external CSS to style elements within the shadow DOM if the custom element is set up to accept external styles.
 
 ## Reference
 
@@ -42,7 +42,6 @@ Custom elements have their own shadow trees. Each shadow tree contains all the c
 
 ## Related concepts
 
-- CSS {{cssxref("user-select")}} property
 - CSS {{CSSXref(":defined")}} pseudo-class
 - CSS {{CSSXref("::part")}} pseudo-element
 

--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -7,13 +7,11 @@ spec-urls: https://drafts.csswg.org/css-scoping/
 
 {{CSSRef}}
 
-The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms, focusing on the Shadow DOM scoping mechanism.
+The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms, focusing on the [Shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) [scoping](https://css.oddbird.net/scope/) mechanism.
 
-Custom elements have their own shadow tree. This means the custom element is the shadow host of the shadow tree it contains. The host is outside of the shadow tree it hosts. Normally, the host of a shadow tree is not targettable by selectors from within its tree. But sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible. The pseudo-classes defined in the CSS scoping module enable styling a host from within the shadow tree it hosts.
+CSS styles are scoped to their own DOM or {{Glossary("shadow tree")}}. Styles applied to an HTML document are considered global in scope as they apply to the entire document. While they apply to all the elements in the node tree, including any custom elements, they do not apply to the shadow trees of which each custom element is comprised. Selectors and their associated style definitions are scoped; they don't bleed between trees. Within the CSS of a shadow tree, selectors can't see elements outside the tree and selectors outside of a shadow tree don't apply within. But sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible. The pseudo-classes defined in the CSS scoping module enable styling a host from within the shadow tree it hosts.
 
-Within the CSS of a shadow tree, selectors can't see elements outside the tree; by default, CSS in the shadow tree can't be used to apply styles to its host.
-
-CSS selectors outside of a shadow tree can't see within a shadow tree, and Sometimes, however, it's useful for the CSS within a shadow to select an ancestor that lies somewhere outside the shadow tree, above it in the document.
+Custom elements have their own shadow trees. Each shadow tree contains all the components that make up the custom element, but not the custom element, or "host", itself. Because the host is in a different tree than its components, the styles within the shadow tree don't apply styles to its host. The CSS scoping module defines three pseudo-classes to enable a shadow tree to style its own host and provides one pseudo-element to enable external CSS to style elements within the shadow DOM if the custom element is set up to accept external styles.
 
 ## Reference
 
@@ -23,14 +21,6 @@ CSS selectors outside of a shadow tree can't see within a shadow tree, and Somet
 - {{CSSXref(":host_function", ":host()")}}
 - {{CSSXref(":host-context", ":host-context()")}}
 - {{CSSXref("::slotted")}}
-
-### Definitions
-
-- {{glossary("scope")}}
-- {{Glossary("Shadow tree")}}
-- {{Glossary("Flat tree")}}
-- [Compound selector](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector)
-- [Selector list](/en-US/docs/Web/CSS/Selector_list)
 
 ## Guides
 
@@ -52,37 +42,28 @@ CSS selectors outside of a shadow tree can't see within a shadow tree, and Somet
 
 ## Related concepts
 
-- {{cssxref("user-select")}} property
-- [CSS pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
-  - {{CSSXref(":defined")}}
-- [CSS pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements)
+- CSS {{cssxref("user-select")}} property
+- CSS {{CSSXref(":defined")}} pseudo-class
+- CSS {{CSSXref("::part")}} pseudo-element
 
-  - {{CSSXref("::part")}}
+- HTML {{HTMLElement("template")}} element
+- HTML {{HTMLElement("slot")}} element
+- HTML [`slot`](/en-US/docs/Web/HTML/Global_attributes/slot) attribute
 
-- HTML elements and attributes:
+- {{Glossary("Shadow tree")}} glossary term
+- {{Glossary("DOM")}} glossary term
+- [Compound selector](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector) term
+- [Selector list](/en-US/docs/Web/CSS/Selector_list) term
 
-  - {{HTMLElement("template")}}
-  - {{HTMLElement("slot")}}
-  - [`slot`](/en-US/docs/Web/HTML/Global_attributes/slot) attribute
-
-- [Web component](/en-US/docs/Web/API/Web_components) interfaces, properties, and methods
-
+- [Web components](/en-US/docs/Web/API/Web_components) interfaces, properties, and methods
   - {{DOMxRef("CustomElementRegistry")}} interface
+  - {{DOMxRef("Element")}} API
+    - {{DOMxRef("Element.slot")}} property
+    - {{DOMxRef("Element.assignedSlot")}} property
+    - {{DOMxRef("Element.attachShadow()")}} method
   - {{DOMxRef("HTMLSlotElement")}} interface
   - {{DOMxRef("HTMLTemplateElement")}} interface
   - {{DOMxRef("ShadowRoot")}} interface
-    - {{domxref("ShadowRoot.delegatesFocus")}} property
-    - {{domxref("ShadowRoot.adoptedStyleSheets")}}
-    - {{domxref("ShadowRoot.pictureInPictureElement")}} property
-  - {{DOMxRef("Element")}} API
-    - {{DOMxRef("Element.slot")}} property
-    - {{DOMxRef("Element.assigedSlot")}} property
-    - {{DOMxRef("Element.attachShadow()")}} method
-
-- {{DOMxRef("CSSStyleSheet")}}
-- {{DOMxRef("CSSPseudoElement")}} interface
-  - {{DOMxRef("CSSPseudoElement.element")}} property
-  - {{DOMxRef("CSSPseudoElement.type")}} property
 
 > **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point, or scope, for selectors to match against, is defined in the [CSS pseudo-classes](/en-US/docs/Web/CSS/CSS_pseudo-classes) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
 

--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -1,0 +1,100 @@
+---
+title: CSS scoping
+slug: Web/CSS/CSS_scoping
+page-type: css-module
+spec-urls: https://drafts.csswg.org/css-scoping/
+---
+
+{{CSSRef}}
+
+The **CSS scoping** module defines the CSS scoping and encapsulation mechanisms, focusing on the Shadow DOM scoping mechanism.
+
+Custom elements have their own shadow tree. This means the custom element is the shadow host of the shadow tree it contains. The host is outside of the shadow tree it hosts. Normally, the host of a shadow tree is not targettable by selectors from within its tree. But sometimes it's useful to be able to style a host from inside the shadow tree context. The CSS scoping module makes this possible. The pseudo-classes defined in the CSS scoping module enable styling a host from within the shadow tree it hosts.
+
+Within the CSS of a shadow tree, selectors can't see elements outside the tree; by default, CSS in the shadow tree can't be used to apply styles to its host.
+
+CSS selectors outside of a shadow tree can't see within a shadow tree, and Sometimes, however, it's useful for the CSS within a shadow to select an ancestor that lies somewhere outside the shadow tree, above it in the document.
+
+## Reference
+
+### Selectors
+
+- {{CSSXref(":host")}}
+- {{CSSXref(":host_function", ":host()")}}
+- {{CSSXref(":host-context", ":host-context()")}}
+- {{CSSXref("::slotted")}}
+
+### Definitions
+
+- {{glossary("scope")}}
+- {{Glossary("Shadow tree")}}
+- {{Glossary("Flat tree")}}
+- [Compound selector](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector)
+- [Selector list](/en-US/docs/Web/CSS/Selector_list)
+
+## Guides
+
+- [Web components](/en-US/docs/Web/API/Web_components)
+
+  - : Web components concepts and usage, with an introduction to the different technologies used to create reusable custom elements whose functionality is encapsulated away from the rest of the code.
+
+- [Using shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM)
+
+  - : Shadow DOM fundamentals, including attaching a shadow DOM to an element, adding to the shadow DOM tree, and styling.
+
+- [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
+
+  - : Defining reusable HTML structure using {{htmlelement("template")}} and {{htmlelement("slot")}} elements, and using that structure inside web components.
+
+- [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements)
+
+  - : Introduction to the Custom Elements API, the JavaScript API used to create custom elements that encapsulate functionality.
+
+## Related concepts
+
+- {{cssxref("user-select")}} property
+- [CSS pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
+  - {{CSSXref(":defined")}}
+- [CSS pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements)
+
+  - {{CSSXref("::part")}}
+
+- HTML elements and attributes:
+
+  - {{HTMLElement("template")}}
+  - {{HTMLElement("slot")}}
+  - [`slot`](/en-US/docs/Web/HTML/Global_attributes/slot) attribute
+
+- [Web component](/en-US/docs/Web/API/Web_components) interfaces, properties, and methods
+
+  - {{DOMxRef("CustomElementRegistry")}} interface
+  - {{DOMxRef("HTMLSlotElement")}} interface
+  - {{DOMxRef("HTMLTemplateElement")}} interface
+  - {{DOMxRef("ShadowRoot")}} interface
+    - {{domxref("ShadowRoot.delegatesFocus")}} property
+    - {{domxref("ShadowRoot.adoptedStyleSheets")}}
+    - {{domxref("ShadowRoot.pictureInPictureElement")}} property
+  - {{DOMxRef("Element")}} API
+    - {{DOMxRef("Element.slot")}} property
+    - {{DOMxRef("Element.assigedSlot")}} property
+    - {{DOMxRef("Element.attachShadow()")}} method
+
+- {{DOMxRef("CSSStyleSheet")}}
+- {{DOMxRef("CSSPseudoElement")}} interface
+  - {{DOMxRef("CSSPseudoElement.element")}} property
+  - {{DOMxRef("CSSPseudoElement.type")}} property
+
+> **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point, or scope, for selectors to match against, is defined in the [CSS pseudo-classes](/en-US/docs/Web/CSS/CSS_pseudo-classes) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
+
+## Specifications
+
+{{Specifications}}
+
+## See also
+
+- [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
+- [CSS pseudo elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
+- [CSS namespaces](/en-US/docs/Web/CSS/CSS_namespaces) module
+- [CSS shadow-parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module
+- [Template, slot, and shadow](https://web.dev/learn/html/template/) on web.dev (2023)
+- [Custom element best practices](https://web.dev/custom-elements-best-practices/) on web.dev (2019)

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -145,7 +145,7 @@ Selectors, whether used in CSS or JavaScript, enable targeting HTML elements bas
 
 - {{CSSXref(":popover-open")}} pseudo-class
 
-- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping)module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
 
   - {{CSSXref(":host")}} pseudo-class
   - {{CSSXref(":host_function", ":host()")}} pseudo-class

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -145,7 +145,7 @@ Selectors, whether used in CSS or JavaScript, enable targeting HTML elements bas
 
 - {{CSSXref(":popover-open")}} pseudo-class
 
-- CSS scoping module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping)module
 
   - {{CSSXref(":host")}} pseudo-class
   - {{CSSXref(":host_function", ":host()")}} pseudo-class

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -44,7 +44,7 @@ By default, elements in a shadow tree can be styled only within their respective
 - {{domxref("Element.shadowRoot")}} property
 - {{domxref("Element.attachShadow()")}} method
 - {{domxref("ShadowRoot")}} interface
-- CSS scoping module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping)module
   - {{CSSXref(":host")}}
   - {{CSSXref(":host_function", ":host()")}}
   - {{CSSXref(":host-context", ":host-context()")}}

--- a/files/en-us/web/css/css_shadow_parts/index.md
+++ b/files/en-us/web/css/css_shadow_parts/index.md
@@ -44,7 +44,7 @@ By default, elements in a shadow tree can be styled only within their respective
 - {{domxref("Element.shadowRoot")}} property
 - {{domxref("Element.attachShadow()")}} method
 - {{domxref("ShadowRoot")}} interface
-- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping)module
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
   - {{CSSXref(":host")}}
   - {{CSSXref(":host_function", ":host()")}}
   - {{CSSXref(":host-context", ":host-context()")}}

--- a/files/en-us/web/html/element/slot/index.md
+++ b/files/en-us/web/html/element/slot/index.md
@@ -138,3 +138,10 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- HTML {{HTMLElement("template")}} element
+- HTML [`slot`](/en-US/docs/Web/HTML/Global_attributes/slot) attribute
+- CSS {{CSSXref("::slotted")}} pseudo-element
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -215,3 +215,4 @@ container.appendChild(secondClone);
 
 - Web components: {{HTMLElement("slot")}} (and historical: `<shadow>`)
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/html/global_attributes/slot/index.md
+++ b/files/en-us/web/html/global_attributes/slot/index.md
@@ -21,4 +21,9 @@ For examples, see our [Using templates and slots](/en-US/docs/Web/API/Web_compon
 
 ## See also
 
-- All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+- HTML [global attributes](/en-US/docs/Web/HTML/Global_attributes)
+- HTML {{HTMLElement("slot")}} element
+- HTML {{HTMLElement("template")}} element
+- CSS {{CSSXref("::slotted")}} pseudo-element
+- [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
+- [Web components](/en-US/docs/Web/API/Web_components)


### PR DESCRIPTION
* add new CSS scoping module page
* Rewrite glossary "shadow tree"
* Add links from the other modules to this new page.
* Add links to this module from related selectors, attributes, and elements
Fixes https://github.com/openwebdocs/project/issues/166