### PR TITLE
relnote(117): Inline SVG allow for defer, async and module

### DIFF
--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -26,6 +26,9 @@ This article provides information about the changes in Firefox 117 that affect d
 
 ### SVG
 
+- Inline SVGs now support `<script>` elements with `type="module"`, `defer`, and `async` attributes.
+  This allows SVGs to use modern JavaScript features, including ES modules, and to load scripts asynchronously ([Firefox bug 1839954](https://bugzil.la/1839954)).
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
Small release note about SVGs with `defer`, `async` and `module` support


```html
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg"
     xmlns:h="http://www.w3.org/1999/xhtml">
  <script href="otherscript.js" async"></script>
  <script>
        /* Something else */
  </script>
</svg>

<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg"
     xmlns:h="http://www.w3.org/1999/xhtml">
  <script>
    console.log("Defer runs later")
  </script>
  <script type="text/javascript" href="defer.js" defer></script>
</svg>

<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg"
     xmlns:h="http://www.w3.org/1999/xhtml">
  <script type="module">
      /* JavaScript module code here */
  </script>
</svg>
```


__Related issues and pull requests:__
- [ ] Parent issue: https://github.com/mdn/content/issues/28294