### PR TITLE
Remove all extra explanation of TypedArray methds and redirect to Array methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.copyWithin
 
 {{JSRef}}
 
-The **`copyWithin()`** method shallow copies part of an array to another location in the same array and returns it without modifying its length.
+The **`copyWithin()`** method shallow copies part of this array to another location in the same array and returns this array without modifying its length.
 
 {{EmbedInteractiveExample("pages/js/array-copywithin.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -59,7 +59,7 @@ The `every()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Ob
 
 ### Testing size of all array elements
 
-The following example tests whether all elements in the array are bigger than 10.
+The following example tests whether all elements in the array are bigger than 9.
 
 ```js
 function isBigEnough(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Array.fill
 
 {{JSRef}}
 
-The **`fill()`** method changes all elements in an array to a static value, from a start index (default `0`) to an end index (default `array.length`).
-It returns the modified array.
+The **`fill()`** method changes all elements within a range of indices in an array to a static value. It returns the modified array.
 
 {{EmbedInteractiveExample("pages/js/array-fill.html")}}
 
@@ -54,7 +53,7 @@ The `fill()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Obj
 
 ## Examples
 
-### Using fill
+### Using fill()
 
 ```js
 console.log([1, 2, 3].fill(4)); // [4, 4, 4]

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -55,7 +55,7 @@ The `filter()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_O
 
 ### Filtering out all small values
 
-The following example uses `filter()` to create a filtered array that has all elements with values less than `10` removed.
+The following example uses `filter()` to create a filtered array that has all elements with values less than 10 removed.
 
 ```js
 function isBigEnough(value) {

--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -103,9 +103,9 @@ console.log(result);
 // { name: "fish", quantity: 1 }
 ```
 
-### Find last prime number in an array
+### Find the last prime number in an array
 
-The following example finds the last element in the array that is a prime number (or returns {{jsxref("undefined")}} if there is no prime number):
+The following example returns the last element in the array that is a prime number, or {{jsxref("undefined")}} if there is no prime number.
 
 ```js
 function isPrime(element) {

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -34,7 +34,7 @@ forEach(callbackFn, thisArg)
 
 ### Return value
 
-`undefined`.
+{{jsxref("undefined")}}.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -31,7 +31,7 @@ indexOf(searchElement, fromIndex)
 
 ### Return value
 
-The first index of the element in the array; **-1** if not found.
+The first index of the element in the array; `-1` if not found.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.md
@@ -8,8 +8,7 @@ browser-compat: javascript.builtins.Array.join
 {{JSRef}}
 
 The **`join()`** method creates and
-returns a new string by concatenating all of the elements in an array
-(or an [array-like object](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects)),
+returns a new string by concatenating all of the elements in this array,
 separated by commas or a specified separator string. If the array has
 only one item, then that item will be returned without using the separator.
 
@@ -25,10 +24,7 @@ join(separator)
 ### Parameters
 
 - `separator` {{optional_inline}}
-  - : Specifies a string to separate each pair of adjacent elements of the array. The
-    separator is converted to a string if necessary. If omitted, the array elements are
-    separated with a comma (","). If `separator` is an empty string, all
-    elements are joined without any characters in between them.
+  - : A string to separate each pair of adjacent elements of the array. If omitted, the array elements are separated with a comma (",").
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -32,7 +32,7 @@ lastIndexOf(searchElement, fromIndex)
 
 ### Return value
 
-The last index of the element in the array; **-1** if not found.
+The last index of the element in the array; `-1` if not found.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -7,8 +7,8 @@ browser-compat: javascript.builtins.Array.map
 
 {{JSRef}}
 
-The **`map()`** method **creates
-a new array** populated with the results of calling a provided function on
+The **`map()`** method creates
+a new array populated with the results of calling a provided function on
 every element in the calling array.
 
 {{EmbedInteractiveExample("pages/js/array-map.html")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -8,9 +8,9 @@ browser-compat: javascript.builtins.Array.toLocaleString
 {{JSRef}}
 
 The **`toLocaleString()`** method returns a string representing
-the elements of the array. The elements are converted to Strings using their
-`toLocaleString` methods and these Strings are separated by a locale-specific
-String (such as a comma ",").
+the elements of the array. The elements are converted to strings using their
+`toLocaleString` methods and these strings are separated by a locale-specific
+string (such as a comma ",").
 
 {{EmbedInteractiveExample("pages/js/array-tolocalestring.html","shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/toreversed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/toreversed/index.md
@@ -77,6 +77,7 @@ console.log(Array.prototype.toReversed.call(arrayLike));
 ## See also
 
 - [Polyfill of `Array.prototype.toReversed` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
+- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array.prototype.reverse()")}}
 - {{jsxref("Array.prototype.toSorted()")}}
 - {{jsxref("Array.prototype.toSpliced()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/tosorted/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tosorted/index.md
@@ -12,17 +12,8 @@ The **`toSorted()`** method of {{jsxref("Array")}} instances is the [copying](/e
 ## Syntax
 
 ```js-nolint
-// Functionless
 toSorted()
-
-// Arrow function
-toSorted((a, b) => { /* … */ })
-
-// Compare function
 toSorted(compareFn)
-
-// Inline compare function
-toSorted(function compareFn(a, b) { /* … */ })
 ```
 
 ### Parameters
@@ -102,6 +93,7 @@ console.log(Array.prototype.toSorted.call(arrayLike));
 ## See also
 
 - [Polyfill of `Array.prototype.toSorted` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
+- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array.prototype.sort()")}}
 - {{jsxref("Array.prototype.toReversed()")}}
 - {{jsxref("Array.prototype.toSpliced()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/with/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/with/index.md
@@ -96,6 +96,7 @@ console.log(Array.prototype.with.call(arrayLike, 0, 1));
 ## See also
 
 - [Polyfill of `Array.prototype.with` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
+- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array.prototype.toReversed()")}}
 - {{jsxref("Array.prototype.toSorted()")}}
 - {{jsxref("Array.prototype.toSpliced()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.TypedArray.at
 
 {{JSRef}}
 
-The **`at()`** method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.
-
-This is not to suggest there is anything wrong with using the square bracket notation. For example `array[0]` would return the first item. However instead of using {{jsxref('TypedArray.prototype.length','array.length')}} for latter items; e.g. `array[array.length-1]` for the last item, you can call `array.at(-1)`. [(See the examples below)](#examples)
+The **`at()`** method of {{jsxref("TypedArray")}} instances takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.at()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-at.html")}}
 
@@ -22,11 +20,15 @@ at(index)
 ### Parameters
 
 - `index`
-  - : The index (position) of the array element to be returned. Supports relative indexing from the end of the array when passed a negative index; that is, if a negative number is used, the element returned will be found by counting back from the end of the array.
+  - : Zero-based index of the array element to be returned, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion). Negative index counts back from the end of the array — if `index < 0`, `index + array.length` is accessed.
 
 ### Return value
 
-The element in the array matching the given index. Returns {{jsxref('undefined')}} if the given index can not be found.
+The element in the typed array matching the given index. Always returns {{jsxref("undefined")}} if `index < -array.length` or `index >= array.length` without attempting to access the corresponding property.
+
+## Description
+
+See {{jsxref("Array.prototype.at()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -48,7 +50,7 @@ console.log(lastItem); // 18
 
 ### Comparing methods
 
-Here we compare different ways to select the penultimate (last but one) item of a {{jsxref('TypedArray')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the `at()` method.
+Here we compare different ways to select the penultimate (last but one) item of a {{jsxref("TypedArray")}}. Whilst all below methods are valid, it highlights the succinctness and readability of the `at()` method.
 
 ```js
 // Our typed array with values
@@ -78,7 +80,9 @@ console.log(atWay); // 11
 ## See also
 
 - [Polyfill of `TypedArray.prototype.at` in `core-js`](https://github.com/zloirock/core-js#relative-indexing-method)
-- [A polyfill for the at() method](https://github.com/tc39/proposal-relative-indexing-method#polyfill).
-- {{jsxref("TypedArray.prototype.find()")}} – return a value based on a given test.
-- {{jsxref("TypedArray.prototype.includes()")}} – test whether a value exists in the array.
-- {{jsxref("TypedArray.prototype.indexOf()")}} – return the index of a given element.
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.indexOf()")}}
+- {{jsxref("Array.prototype.at()")}}
+- {{jsxref("String.prototype.at()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -7,13 +7,7 @@ browser-compat: javascript.builtins.TypedArray.copyWithin
 
 {{JSRef}}
 
-The **`copyWithin()`** method copies the sequence of array
-elements within the array to the position starting at `target`.
-The copy is taken from the index positions of the second and third arguments
-`start` and `end`. The
-`end` argument is optional and defaults to the length of the
-array. This method has the same algorithm as {{jsxref("Array.prototype.copyWithin")}}.
-_TypedArray_ is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`copyWithin()`** method of {{jsxref("TypedArray")}} instances shallow copies part of this typed array to another location in the same typed array and returns this typed array without modifying its length. This method has the same algorithm as {{jsxref("Array.prototype.copyWithin()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-copywithin.html")}}
 
@@ -27,11 +21,11 @@ copyWithin(target, start, end)
 ### Parameters
 
 - `target`
-  - : Target start index position where to copy the elements to.
+  - : Zero-based index at which to copy the sequence to, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 - `start`
-  - : Source start index position where to start copying elements from.
+  - : Zero-based index at which to start copying elements from, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 - `end` {{optional_inline}}
-  - : Optional. Source end index position where to end copying elements from.
+  - : Zero-based index at which to end copying elements from, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion). `copyWithin()` copies up to but not including `end`.
 
 ### Return value
 
@@ -39,11 +33,11 @@ The modified array.
 
 ## Description
 
-See {{jsxref("Array.prototype.copyWithin")}} for more details.
+See {{jsxref("Array.prototype.copyWithin()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using copyWithin
+### Using copyWithin()
 
 ```js
 const buffer = new ArrayBuffer(8);
@@ -65,4 +59,6 @@ console.log(uint8); // Uint8Array [ 1, 2, 3, 1, 2, 3, 0, 0 ]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.copyWithin` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
+- {{jsxref("Array.prototype.copyWithin()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.TypedArray.entries
 
 {{JSRef}}
 
-The **`entries()`** method returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ that contains the key/value pairs for each index in the array.
+The **`entries()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the key/value pairs for each index in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.entries()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-entries.html")}}
 
@@ -20,6 +20,10 @@ entries()
 ### Return value
 
 A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
+
+## Description
+
+See {{jsxref("Array.prototype.entries()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -62,3 +66,5 @@ console.log(arrayEntries.next().value); // [4, 50]
 - {{jsxref("TypedArray.prototype.keys()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
 - [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
+- {{jsxref("Array.prototype.entries()")}}
+- [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.every
 
 {{JSRef}}
 
-The **`every()`** method tests whether all elements in the
-typed array pass the test implemented by the provided function. This method has the same
-algorithm as {{jsxref("Array.prototype.every()")}}. _TypedArray_ is one
-of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`every()`** method of {{jsxref("TypedArray")}} instances tests whether all elements in the typed array pass the test implemented by the provided function. It returns a Boolean value. This method has the same algorithm as {{jsxref("Array.prototype.every()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-every.html")}}
 
@@ -36,29 +33,11 @@ every(callbackFn, thisArg)
 
 ### Return value
 
-`true` if the callback function returns a {{Glossary("truthy")}} value for
-every array element; otherwise, `false`.
+`true` if `callbackFn` returns a {{Glossary("truthy")}} value for every array element. Otherwise, `false`.
 
 ## Description
 
-The `every` method executes the provided `callbackFn`
-function once for each element present in the typed array until it finds the one where
-`callbackFn` returns a {{Glossary("falsy")}} value. If such an
-element is found, the `every` method immediately returns `false`.
-Otherwise, if `callbackFn` returns a {{Glossary("truthy")}} value
-for all elements, `every` returns `true`.
-
-`callbackFn` is invoked with three arguments: the value of the
-element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `every`, it
-will be used as callback's `this` value. Otherwise, the value
-`undefined` will be used as its `this` value. The
-`this` value ultimately observable by `callbackFn` is
-determined according to
-[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
-
-`every` does not mutate the typed array on which it is called.
+See {{jsxref("Array.prototype.every()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -74,15 +53,6 @@ new Uint8Array([12, 5, 8, 130, 44]).every(isBigEnough); // false
 new Uint8Array([12, 54, 18, 130, 44]).every(isBigEnough); // true
 ```
 
-### Testing typed array elements using arrow functions
-
-[Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) provide a shorter syntax for the same test.
-
-```js
-new Uint8Array([12, 5, 8, 130, 44]).every((elem) => elem >= 10); // false
-new Uint8Array([12, 54, 18, 130, 44]).every((elem) => elem >= 10); // true
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -94,5 +64,9 @@ new Uint8Array([12, 54, 18, 130, 44]).every((elem) => elem >= 10); // true
 ## See also
 
 - [Polyfill of `TypedArray.prototype.every` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.forEach()")}}
 - {{jsxref("TypedArray.prototype.some()")}}
+- {{jsxref("TypedArray.prototype.find()")}}
 - {{jsxref("Array.prototype.every()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.fill
 
 {{JSRef}}
 
-The **`fill()`** method fills all the elements of a typed array
-from a start index to an end index with a static value. This method has the same
-algorithm as {{jsxref("Array.prototype.fill()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`fill()`** method of {{jsxref("TypedArray")}} instances changes all elements within a range of indices in a typed array to a static value. It returns the modified typed array. This method has the same algorithm as {{jsxref("Array.prototype.fill()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-fill.html","shorter")}}
 
@@ -27,27 +24,17 @@ fill(value, start, end)
 - `value`
   - : Value to fill the typed array with.
 - `start` {{optional_inline}}
-  - : Start index. Defaults to 0.
+  - : Zero-based index at which to start filling, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 - `end` {{optional_inline}}
-  - : End index (not included). Defaults to `this.length`.
+  - : Zero-based index at which to end filling, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion). `fill()` fills up to but not including `end`.
 
 ### Return value
 
-The modified array.
+The modified array, filled with `value`.
 
 ## Description
 
-The elements interval to fill is \[`start`,
-`end`).
-
-The **`fill()`** method takes up to three arguments
-`value`, `start` and `end`. The `start` and
-`end` arguments are optional with default values of `0`
-and the `length` of the `this` object.
-
-If `start` is negative, it is treated as
-`length+start` where `length` is the length of the array. If
-`end` is negative, it is treated as `length+end`.
+See {{jsxref("Array.prototype.fill()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -72,4 +59,6 @@ new Uint8Array([1, 2, 3]).fill(4, -3, -2); // Uint8Array [4, 2, 3]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.fill` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("Array.prototype.fill()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.filter
 
 {{JSRef}}
 
-The **`filter()`** method creates a new typed array with all
-elements that pass the test implemented by the provided function. This method has the
-same algorithm as {{jsxref("Array.prototype.filter()")}}. _TypedArray_ is one of
-the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`filter()`** method of {{jsxref("TypedArray")}} instances creates a copy of a portion of a given typed array, filtered down to just the elements from the given typed array that pass the test implemented by the provided function. This method has the same algorithm as {{jsxref("Array.prototype.filter()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-filter.html")}}
 
@@ -36,63 +33,23 @@ filter(callbackFn, thisArg)
 
 ### Return value
 
-A new typed array with the elements that pass the test.
+A new typed array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
 
 ## Description
 
-The `filter()` method calls a provided `callbackFn`
-function once for each element in a typed array, and constructs a new typed array of all
-the values for which `callbackFn` returns [a value that coerces to `true`](/en-US/docs/Glossary/Truthy).
-`callbackFn` is invoked only for indexes of the typed array which
-have assigned values; it is not invoked for indexes which have been deleted or which
-have never been assigned values. Typed array elements which do not pass the
-`callbackFn` test are skipped, and are not included in the new typed
-array.
-
-`callbackFn` is invoked with three arguments:
-
-1. the value of the element
-2. the index of the element
-3. the typed array object being traversed
-
-If a `thisArg` parameter is provided to `filter()`, it
-will be passed to `callbackFn` when invoked, for use as its
-`this` value. Otherwise, the value `undefined` will be passed for
-use as its `this` value. The `this` value ultimately observable by
-`callbackFn` is determined according to
-[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
-
-`filter()` does not mutate the typed array on which it is called.
-
-The range of elements processed by `filter()` is set before the first
-invocation of `callbackFn`. Elements which are appended to the typed
-array after the call to `filter()` begins will not be visited by
-`callbackFn`. If existing elements of the typed array are changed,
-or deleted, their value as passed to `callbackFn` will be the value
-at the time `filter()` visits them; elements that are deleted are not
-visited.
+See {{jsxref("Array.prototype.filter()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
 ### Filtering out all small values
 
-The following example uses `filter()` to create a filtered typed array that
-has all elements with values less than 10 removed.
+The following example uses `filter()` to create a filtered typed array that has all elements with values less than 10 removed.
 
 ```js
 function isBigEnough(element, index, array) {
   return element >= 10;
 }
 new Uint8Array([12, 5, 8, 130, 44]).filter(isBigEnough);
-// Uint8Array [ 12, 130, 44 ]
-```
-
-### Filtering typed array elements using arrow functions
-
-[Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) provide a shorter syntax for the same test.
-
-```js
-new Uint8Array([12, 5, 8, 130, 44]).filter((elem) => elem >= 10);
 // Uint8Array [ 12, 130, 44 ]
 ```
 
@@ -107,6 +64,11 @@ new Uint8Array([12, 5, 8, 130, 44]).filter((elem) => elem >= 10);
 ## See also
 
 - [Polyfill of `TypedArray.prototype.filter` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.forEach()")}}
 - {{jsxref("TypedArray.prototype.every()")}}
+- {{jsxref("TypedArray.prototype.map()")}}
 - {{jsxref("TypedArray.prototype.some()")}}
+- {{jsxref("TypedArray.prototype.reduce()")}}
 - {{jsxref("Array.prototype.filter()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -7,13 +7,7 @@ browser-compat: javascript.builtins.TypedArray.find
 
 {{JSRef}}
 
-The **`find()`** method returns a value of an element in the
-typed array, if it satisfies the provided testing function. Otherwise
-{{jsxref("undefined")}} is returned. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
-
-See also the {{jsxref("TypedArray.findIndex", "findIndex()")}} method, which returns
-the **index** of a found element in the typed array instead of its value.
+The **`find()`** method of {{jsxref("TypedArray")}} instances returns the first element in the provided typed array that satisfies the provided testing function. If no values satisfy the testing function, {{jsxref("undefined")}} is returned. This method has the same algorithm as {{jsxref("Array.prototype.find()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-find.html")}}
 
@@ -33,48 +27,24 @@ find(callbackFn, thisArg)
     - `index`
       - : The index of the current element being processed in the typed array.
     - `array`
-      - : The array `find()` was called upon.
+      - : The typed array `find()` was called upon.
 - `thisArg` {{optional_inline}}
   - : A value to use as `this` when executing `callbackFn`. See [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods).
 
 ### Return value
 
-A value in the array if an element passes the test; otherwise, {{jsxref("undefined")}}.
+The first element in the typed array that satisfies the provided testing function.
+Otherwise, {{jsxref("undefined")}} is returned.
 
 ## Description
 
-The `find()` method executes the `callbackFn` function
-once for each element present in the typed array until it finds one where
-`callbackFn` returns a true value. If such an element is found,
-`find()` immediately returns the value of that element. Otherwise,
-`find()` returns {{jsxref("undefined")}}. `callbackFn` is
-invoked only for indexes of the typed array which have assigned values; it is not
-invoked for indexes which have been deleted or which have never been assigned values.
-
-`callbackFn` is invoked with three arguments: the value of the
-element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `find()`, it
-will be used as the `this` for each invocation of the
-`callbackFn`. If it is not provided, then {{jsxref("undefined")}} is
-used.
-
-`find()` does not mutate the typed array on which it is called.
-
-The range of elements processed by `find()` is set before the first
-invocation of `callbackFn`. Elements that are appended to the typed
-array after the call to `find()` begins will not be visited by
-`callbackFn`. If an existing, unvisited element of the typed array
-is changed by `callbackFn`, its value passed to the visiting
-`callbackFn` will be the value at the time that `find()`
-visits that element's index; elements that are deleted are not visited.
+See {{jsxref("Array.prototype.find()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
 ### Find a prime number in a typed array
 
-The following example finds an element in the typed array that is a prime number (or
-returns {{jsxref("undefined")}} if there is no prime number).
+The following example finds an element in the typed array that is a prime number (or returns {{jsxref("undefined")}} if there is no prime number).
 
 ```js
 function isPrime(element, index, array) {
@@ -102,5 +72,13 @@ console.log(uint8.find(isPrime)); // 5
 ## See also
 
 - [Polyfill of `TypedArray.prototype.find` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.findLast()")}}
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
+- {{jsxref("TypedArray.prototype.includes()")}}
+- {{jsxref("TypedArray.prototype.filter()")}}
 - {{jsxref("TypedArray.prototype.every()")}}
+- {{jsxref("TypedArray.prototype.some()")}}
+- {{jsxref("Array.prototype.find()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -7,12 +7,7 @@ browser-compat: javascript.builtins.TypedArray.findIndex
 
 {{JSRef}}
 
-The **`findIndex()`** method returns an **index**
-in the typed array, if an element in the typed array satisfies the provided testing
-function. Otherwise -1 is returned.
-
-See also the {{jsxref("TypedArray.find", "find()")}} method, which returns the
-**value** of a found element in the typed array instead of its index.
+he **`findIndex()`** method of {{jsxref("TypedArray")}} instances returns the index of the first element in a typed array that satisfies the provided testing function. If no elements satisfy the testing function, -1 is returned. This method has the same algorithm as {{jsxref("Array.prototype.findIndex()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-findindex.html")}}
 
@@ -38,36 +33,11 @@ findIndex(callbackFn, thisArg)
 
 ### Return value
 
-An index in the array if an element passes the test; otherwise, `-1`.
+The index of the first element in the array that passes the test. Otherwise, `-1`.
 
 ## Description
 
-The `findIndex()` method executes the `callbackFn`
-function once for each element present in the typed array until it finds one where
-`callbackFn` returns a true value. If such an element is found,
-`findIndex()` immediately returns the index of that element. Otherwise,
-`findIndex()` returns -1. `callbackFn` is invoked only
-for indexes of the typed array which have assigned values; it is not invoked for indexes
-which have been deleted or which have never been assigned values.
-
-`callbackFn` is invoked with three arguments: the value of the
-element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `findIndex()`,
-it will be used as the `this` for each invocation of the
-`callback`. If it is not provided, then {{jsxref("undefined")}} is
-used.
-
-`findIndex()` does not mutate the typed array on which it is called.
-
-The range of elements processed by `findIndex()` is set before the first
-invocation of `callbackFn`. Elements that are appended to the typed
-array after the call to `findIndex()` begins will not be visited by
-`callbackFn`. If an existing, unvisited element of the typed array
-is changed by `callbackFn`, its value passed to the visiting
-`callbackFn` will be the value at the time that
-`findIndex()` visits that element's index; elements that are deleted are not
-visited.
+See {{jsxref("Array.prototype.findIndex()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -105,5 +75,11 @@ console.log(uint16.findIndex(isPrime)); // 2
 ## See also
 
 - [Polyfill of `TypedArray.prototype.findIndex` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.find()")}}
+- {{jsxref("TypedArray.prototype.findLast()")}}
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}
+- {{jsxref("TypedArray.prototype.lastIndexOf()")}}
+- {{jsxref("Array.prototype.findIndex()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.findLast
 
 {{JSRef}}
 
-The **`findLast()`** method iterates a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) in reverse order and returns the value of the first element that satisfies the provided testing function.
-If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
-
-See also the {{jsxref("TypedArray.findLastIndex()", "findLastIndex()")}} method, which returns the index of the found element instead of its value.
+The **`findLast()`** method of {{jsxref("TypedArray")}} instances iterates the typed array in reverse order and returns the value of the first element that satisfies the provided testing function. If no elements satisfy the testing function, {{jsxref("undefined")}} is returned. This method has the same algorithm as {{jsxref("Array.prototype.findLast()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-findlast.html")}}
 
@@ -36,32 +33,17 @@ findLast(callbackFn, thisArg)
 
 ### Return value
 
-The element in the typed array with the highest index value that satisfies the provided testing function; {{jsxref("undefined")}} if no matching value is found.
+The element in the typed array with the highest index value that satisfies the provided testing function; {{jsxref("undefined")}} if no matching element is found.
 
 ## Description
 
-The `findLast()` method executes the `callbackFn` function once for each index of the typed array in descending-index order until the `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value.
-`findLast()` then returns the value of that element and stops iterating through the typed array.
-If `callbackFn` never returns a truthy value, `findLast()` returns {{jsxref("undefined")}}.
-
-`callbackFn` is invoked with three arguments: the value of the element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `findLast()`, it will be used as the `this` for each invocation of the `callbackFn`.
-If it is not provided, then {{jsxref("undefined")}} is used.
-
-The `findLast()` method does not mutate the typed array on which it is called, but the function provided to `callbackFn` can.
-
-The range of elements processed by `findLast()` is set before the first invocation of `callbackFn`.
-Elements that are appended to the typed array after the call to `findLast()` begins will not be visited by `callbackFn`.
-If an existing, unvisited element of the typed array is changed by `callbackFn`, its value passed to the visiting `callbackFn` will be the value at the time that `findLast()` visits that element's index.
-
-> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+See {{jsxref("Array.prototype.findLast()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Find a prime number in a typed array
+### Find the last prime number in a typed array
 
-The following example finds the value of the last element in the typed array that is a prime number (or returns {{jsxref("undefined")}} if there is no prime number).
+The following example returns the value of the last element in the typed array that is a prime number, or {{jsxref("undefined")}} if there is no prime number.
 
 ```js
 function isPrime(element) {
@@ -135,6 +117,13 @@ uint8.findLast((value, index) => {
 ## See also
 
 - [Polyfill of `TypedArray.prototype.findLast()` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- {{jsxref("TypedArray.prototype.findLastIndex()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.find()")}}
+- {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
+- {{jsxref("TypedArray.prototype.includes()")}}
+- {{jsxref("TypedArray.prototype.filter()")}}
 - {{jsxref("TypedArray.prototype.every()")}}
+- {{jsxref("TypedArray.prototype.some()")}}
+- {{jsxref("Array.prototype.findLast()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.findLastIndex
 
 {{JSRef}}
 
-The **`findLastIndex()`** method iterates a [typed array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) in reverse order and returns the index of the first element that satisfies the provided testing function.
-If no values satisfy the testing function, -1 is returned.
-
-See also the {{jsxref("TypedArray.findLast()", "findLast()")}} method, which returns the value of the found element rather than its index.
+The **`findLastIndex()`** method of {{jsxref("TypedArray")}} instances iterates the typed array in reverse order and returns the index of the first element that satisfies the provided testing function. If no elements satisfy the testing function, -1 is returned. This method has the same algorithm as {{jsxref("Array.prototype.findLastIndex()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-findlastindex.html")}}
 
@@ -41,28 +38,13 @@ Otherwise -1 if no matching element is found.
 
 ## Description
 
-The `findLastIndex()` method executes the `callbackFn` function once for each index of the typed array in descending-index order until the `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value.
-`findLastIndex()` then returns the index of that element and stops iterating through the typed array.
-If `callbackFn` never returns a truthy value, `findLastIndex()` returns `-1`.
-
-`callbackFn` is invoked with three arguments: the value of the element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `findLastIndex()`, it will be used as the `this` for each invocation of the `callbackFn`.
-If it is not provided, then {{jsxref("undefined")}} is used.
-
-The `findLastIndex()` method does not mutate the typed array on which it is called, but the function provided to `callbackFn` can.
-
-The range of elements processed by `findLastIndex()` is set before the first invocation of `callbackFn`.
-Elements that are appended to the typed array after the call to `findLastIndex()` begins will not be visited by `callbackFn`.
-If an existing, unvisited element of the typed array is changed by `callbackFn`, its value passed to the visiting `callbackFn` will be the value at the time that `findLastIndex()` visits that element's index.
-
-> **Warning:** Concurrent modification of the kind described in the previous paragraph frequently leads to hard-to-understand code and is generally to be avoided (except in special cases).
+See {{jsxref("Array.prototype.findLastIndex()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Find the index of a prime number in a typed array
+### Find the index of the last prime number in a typed array
 
-The following example finds the index of the last element in the typed array that is a prime number (or returns `-1` if there is no prime number).
+The following example returns the index of the last element in the typed array that is a prime number, or `-1` if there is no prime number.
 
 ```js
 function isPrime(element) {
@@ -96,6 +78,11 @@ console.log(uint8.findLastIndex(isPrime));
 ## See also
 
 - [Polyfill of `TypedArray.prototype.findLastIndex` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- {{jsxref("TypedArray.prototype.findLast()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.find()")}}
 - {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.findLast()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}
+- {{jsxref("TypedArray.prototype.lastIndexOf()")}}
+- {{jsxref("Array.prototype.findLastIndex()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.forEach
 
 {{JSRef}}
 
-The **`forEach()`** method executes a provided function once
-per array element. This method has the same algorithm as
-{{jsxref("Array.prototype.forEach()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`forEach()`** method of {{jsxref("TypedArray")}} instances executes a provided function once for each typed array element. This method has the same algorithm as {{jsxref("Array.prototype.forEach()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-foreach.html")}}
 
@@ -40,37 +37,7 @@ forEach(callbackFn, thisArg)
 
 ## Description
 
-The `forEach()` method executes the provided
-`callbackFn` once for each element present in the typed array in
-ascending order. It is not invoked for indexes that have been deleted or elided.
-However, it is executed for elements that are present and have the value
-{{jsxref("undefined")}}.
-
-`callbackFn` is invoked with **three arguments**:
-
-- the **element value**
-- the **element index**
-- the **typed array being traversed**
-
-If a `thisArg` parameter is provided to `forEach()`,
-it will be passed to `callbackFn` when invoked, for use as its
-`this` value. Otherwise, the value {{jsxref("undefined")}} will be passed
-for use as its `this` value. The `this` value ultimately
-observable by `callbackFn` is determined according to
-[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
-
-The range of elements processed by `forEach()` is set before the first
-invocation of `callbackFn`. Elements that are appended to the typed array after
-the call to `forEach()` begins will not be visited by
-`callbackFn`. If the values of existing elements of the typed array
-are changed, the value passed to `callbackFn` will be the value at
-the time `forEach()` visits them; elements that are deleted before being
-visited are not visited.
-
-`forEach()` executes the `callbackFn` function once for each typed
-array element; unlike {{jsxref("TypedArray.prototype.every()", "every()")}} and
-{{jsxref("TypedArray.prototype.some()", "some()")}} it, always returns the value
-{{jsxref("undefined")}}.
+See {{jsxref("Array.prototype.forEach()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -102,7 +69,13 @@ new Uint8Array([0, 1, 2, 3]).forEach(logArrayElements);
 ## See also
 
 - [Polyfill of `TypedArray.prototype.forEach` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.find()")}}
 - {{jsxref("TypedArray.prototype.map()")}}
+- {{jsxref("TypedArray.prototype.filter()")}}
 - {{jsxref("TypedArray.prototype.every()")}}
 - {{jsxref("TypedArray.prototype.some()")}}
 - {{jsxref("Array.prototype.forEach()")}}
+- {{jsxref("Map.prototype.forEach()")}}
+- {{jsxref("Set.prototype.forEach()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -133,6 +133,8 @@ console.log(Int8Array.from.call(NotArray2, [1, 2, 3]));
 ## See also
 
 - [Polyfill of `TypedArray.from` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.of()")}}
+- {{jsxref("TypedArray.prototype.map()")}}
 - {{jsxref("Array.from()")}}
-- {{jsxref("Array.prototype.map()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.includes
 
 {{JSRef}}
 
-The **`includes()`** method determines whether a typed array
-includes a certain element, returning `true` or `false` as
-appropriate. This method has the same algorithm as
-{{jsxref("Array.prototype.includes()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`includes()`** method of {{jsxref("TypedArray")}} instances determines whether a typed array includes a certain value among its entries, returning `true` or `false` as appropriate. This method has the same algorithm as {{jsxref("Array.prototype.includes()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-includes.html")}}
 
@@ -25,18 +21,21 @@ includes(searchElement, fromIndex)
 ### Parameters
 
 - `searchElement`
-  - : The element to search for.
+  - : The value to search for.
 - `fromIndex` {{optional_inline}}
-  - : The position in this array at which to begin searching for
-    `searchElement`; defaults to 0.
+  - : Zero-based index at which to start searching, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 
 ### Return value
 
-A {{jsxref("Boolean")}}.
+A boolean value which is `true` if the value `searchElement` is found within the array (or the part of the array indicated by the index `fromIndex`, if specified).
+
+## Description
+
+See {{jsxref("Array.prototype.includes()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using includes
+### Using includes()
 
 ```js
 const uint8 = new Uint8Array([1, 2, 3]);
@@ -61,6 +60,10 @@ new Float64Array([NaN]).includes(NaN); // true;
 ## See also
 
 - [Polyfill of `TypedArray.prototype.includes` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.indexOf()")}}
+- {{jsxref("TypedArray.prototype.find()")}}
+- {{jsxref("TypedArray.prototype.findIndex()")}}
 - {{jsxref("Array.prototype.includes()")}}
 - {{jsxref("String.prototype.includes()")}}
-- {{jsxref("TypedArray.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.indexOf
 
 {{JSRef}}
 
-The **`indexOf()`** method returns the first index at which a
-given element can be found in the typed array, or -1 if it is not present. This method
-has the same algorithm as {{jsxref("Array.prototype.indexOf()")}}. _TypedArray_
-is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`indexOf()`** method of {{jsxref("TypedArray")}} instances returns the first index at which a given element can be found in the typed array, or -1 if it is not present. This method has the same algorithm as {{jsxref("Array.prototype.indexOf()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-indexof.html")}}
 
@@ -27,12 +23,7 @@ indexOf(searchElement, fromIndex)
 - `searchElement`
   - : Element to locate in the typed array.
 - `fromIndex` {{optional_inline}}
-  - : The index to start the search at. If the index is greater than or equal to the typed
-    array's length, -1 is returned, which means the typed array will not be searched. If
-    the provided index value is a negative number, it is taken as the offset from the end
-    of the typed array. Note: if the provided index is negative, the typed array is still
-    searched from front to back. If the calculated index is less than 0, then the whole
-    typed array will be searched. Default: 0 (entire typed array is searched).
+  - : Zero-based index at which to start searching, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 
 ### Return value
 
@@ -40,14 +31,11 @@ The first index of the element in the array; `-1` if not found.
 
 ## Description
 
-`indexOf` compares `searchElement` to elements of the
-typed array using
-[strict equality](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#strict_equality_using)
-(the same method used by the `===` operator).
+See {{jsxref("Array.prototype.indexOf()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using indexOf
+### Using indexOf()
 
 ```js
 const uint8 = new Uint8Array([2, 5, 9]);
@@ -69,5 +57,10 @@ uint8.indexOf(2, -3); // 0
 ## See also
 
 - [Polyfill of `TypedArray.prototype.indexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
 - {{jsxref("TypedArray.prototype.lastIndexOf()")}}
 - {{jsxref("Array.prototype.indexOf()")}}
+- {{jsxref("String.prototype.indexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.join
 
 {{JSRef}}
 
-The **`join()`** method joins all elements of an array into a
-string. This method has the same algorithm as {{jsxref("Array.prototype.join()")}}.
-_TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`join()`** method of {{jsxref("TypedArray")}} instances creates and returns a new string by concatenating all of the elements in this typed array, separated by commas or a specified separator string. If the typed array has only one item, then that item will be returned without using the separator. This method has the same algorithm as {{jsxref("Array.prototype.join()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-join.html")}}
 
@@ -24,13 +21,16 @@ join(separator)
 ### Parameters
 
 - `separator` {{optional_inline}}
-  - : Specifies a string to separate each element. The `separator`
-    is converted to a string if necessary. If omitted, the typed array elements are
-    separated with a comma (",").
+  - : A string to separate each pair of adjacent elements of the array. If omitted, the typed array elements are separated with a comma (",").
 
 ### Return value
 
-A string with all array elements joined.
+A string with all array elements joined. If `arr.length` is
+`0`, the empty string is returned.
+
+## Description
+
+See {{jsxref("Array.prototype.join()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -54,5 +54,8 @@ uint8.join(""); // '123'
 ## See also
 
 - [Polyfill of `TypedArray.prototype.join` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.toString()")}}
 - {{jsxref("Array.prototype.join()")}}
+- {{jsxref("String.prototype.split()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.TypedArray.keys
 
 {{JSRef}}
 
-The **`keys()`** method returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the keys for each index in the array.
+The **`keys()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the keys for each index in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.keys()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-keys.html")}}
 
@@ -20,6 +20,10 @@ keys()
 ### Return value
 
 A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
+
+## Description
+
+See {{jsxref("Array.prototype.keys()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -61,5 +65,5 @@ console.log(arrKeys.next().value); // 4
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
 - [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
-- [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
+- {{jsxref("Array.prototype.keys()")}}
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.lastIndexOf
 
 {{JSRef}}
 
-The **`lastIndexOf()`** method returns the last index at which
-a given element can be found in the typed array, or -1 if it is not present. The typed
-array is searched backwards, starting at `fromIndex`. This method has the
-same algorithm as {{jsxref("Array.prototype.lastIndexOf()")}}. _TypedArray_ is
-one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`lastIndexOf()`** method of {{jsxref("TypedArray")}} instances returns the last index at which a given element can be found in the typed array, or -1 if it is not present. The typed array is searched backwards, starting at `fromIndex`. This method has the same algorithm as {{jsxref("Array.prototype.lastIndexOf()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-lastindexof.html")}}
 
@@ -27,13 +23,7 @@ lastIndexOf(searchElement, fromIndex)
 - `searchElement`
   - : Element to locate in the typed array.
 - `fromIndex`
-  - : Optional. The index at which to start searching backwards. Defaults to the typed
-    array's length, i.e. the whole typed array will be searched. If the index is greater
-    than or equal to the length of the typed array, the whole typed array will be
-    searched. If negative, it is taken as the offset from the end of the typed array. Note
-    that even when the index is negative, the typed array is still searched from back to
-    front. If the calculated index is less than 0, -1 is returned, i.e. the typed array
-    will not be searched.
+  - : Zero-based index at which to start searching backwards, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 
 ### Return value
 
@@ -41,13 +31,11 @@ The last index of the element in the array; `-1` if not found.
 
 ## Description
 
-`lastIndexOf` compares `searchElement` to elements of the typed array using
-[strict equality](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#strict_equality_using)
-(the same method used by the `===` operator).
+See {{jsxref("Array.prototype.lastIndexOf()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using lastIndexOf
+### Using lastIndexOf()
 
 ```js
 const uint8 = new Uint8Array([2, 5, 9, 2]);
@@ -70,5 +58,10 @@ uint8.lastIndexOf(2, -1); // 3
 ## See also
 
 - [Polyfill of `TypedArray.prototype.lastIndexOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.findIndex()")}}
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
 - {{jsxref("TypedArray.prototype.indexOf()")}}
 - {{jsxref("Array.prototype.lastIndexOf()")}}
+- {{jsxref("String.prototype.lastIndexOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.map
 
 {{JSRef}}
 
-The **`map()`** method creates a new typed array with the
-results of calling a provided function on every element in this typed array. This method
-has the same algorithm as {{jsxref("Array.prototype.map()")}}.
-_TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`map()`** method of {{jsxref("TypedArray")}} instances creates a new typed array populated with the results of calling a provided function on every element in the calling typed array. This method has the same algorithm as {{jsxref("Array.prototype.map()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-map.html", "shorter")}}
 
@@ -37,37 +33,11 @@ map(callbackFn, thisArg)
 
 ### Return value
 
-A new typed array.
+A new typed array with each element being the result of the callback function.
 
 ## Description
 
-The `map()` method calls a provided callback function
-(`callbackFn`) once for each element in a typed array, in order, and
-constructs a new typed array from the results.
-
-`callbackFn` is invoked only for indexes of the typed array which have
-assigned values; it is not invoked for indexes that are `undefined`, those
-which have been deleted, or which have never been assigned values.
-
-`callbackFn` is invoked with three arguments: the value of the
-element, the index of the element, and the typed array object being traversed.
-
-If a `thisArg` parameter is provided to `map()`, it
-will be passed to `callbackFn` when invoked, for use as its
-`this` value. Otherwise, the value {{jsxref("undefined")}} will be passed for
-use as its `this` value. The `this` value ultimately observable by
-`callbackFn` is determined according to
-[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
-
-`map()` does not mutate the typed array on which it is called (although
-`callbackFn`, if invoked, may do so).
-
-The range of elements processed by `map()` is set before the first
-invocation of `callbackFn`. Elements which are appended to the array
-after the call to `map()` begins will not be visited by
-`callbackFn`. If existing elements of the typed array are changed, or
-deleted, their value as passed to `callbackFn` will be the value at the
-time `map()` visits them; elements that are deleted are not visited.
+See {{jsxref("Array.prototype.map()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -107,5 +77,9 @@ const doubles = numbers.map((num) => num * 2);
 ## See also
 
 - [Polyfill of `TypedArray.prototype.map` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- {{jsxref("TypedArray.prototype.filter()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.forEach()")}}
+- {{jsxref("TypedArray.from()")}}
 - {{jsxref("Array.prototype.map()")}}
+- {{jsxref("Map")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -39,7 +39,7 @@ Where `TypedArray` is one of:
 ### Parameters
 
 - `elementN`
-  - : Elements of which to create the typed array.
+  - : Elements used to create the typed array.
 
 ### Return value
 
@@ -47,14 +47,11 @@ A new {{jsxref("TypedArray")}} instance.
 
 ## Description
 
-Some subtle distinctions between {{jsxref("Array.of()")}} and
+See {{jsxref("Array.of()")}} for more details. There are some subtle distinctions between {{jsxref("Array.of()")}} and
 `TypedArray.of()`:
 
-- If the `this` value passed to `TypedArray.of()` is
-  not a constructor, `TypedArray.of()` will throw a
-  {{jsxref("TypeError")}}, where `Array.of()` defaults to creating a new
-  {{jsxref("Array")}}.
-- `TypedArray.of()` uses `[[Set]]` where `Array.of()` uses `[[DefineOwnProperty]]`. Hence, when working with {{jsxref("Proxy")}} objects, it calls [`handler.set()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set) to create new elements rather than [`handler.defineProperty()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty).
+- If the `this` value passed to `TypedArray.of()` is not a constructor, `TypedArray.from()` will throw a {{jsxref("TypeError")}}, while `Array.of()` defaults to creating a new {{jsxref("Array")}}.
+- `TypedArray.of()` uses `[[Set]]` while `Array.of()` uses `[[DefineOwnProperty]]`. Hence, when working with {{jsxref("Proxy")}} objects, it calls [`handler.set()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set) to create new elements rather than [`handler.defineProperty()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty).
 
 ## Examples
 
@@ -78,5 +75,7 @@ Int16Array.of(undefined); // Int16Array [ 0 ]
 ## See also
 
 - [Polyfill of `TypedArray.of` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.from()")}}
 - {{jsxref("Array.of()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.reduce
 
 {{JSRef}}
 
-The **`reduce()`** method applies a function against an
-accumulator and each value of the typed array (from left-to-right) has to reduce it to a
-single value. This method has the same algorithm as
-{{jsxref("Array.prototype.reduce()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`reduce()`** method of {{jsxref("TypedArray")}} instances executes a user-supplied "reducer" callback function on each element of the typed array, in order, passing in the return value from the calculation on the preceding element. The final result of running the reducer across all elements of the typed array is a single value. This method has the same algorithm as {{jsxref("Array.prototype.reduce()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-reduce.html")}}
 
@@ -41,31 +37,16 @@ reduce(callbackFn, initialValue)
 
 ### Return value
 
-The value that results from the reduction.
+The value that results from running the "reducer" callback function to completion over the entire array.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the typed array contains no elements and `initialValue` is not provided.
 
 ## Description
 
-The `reduce` method executes the `callbackFn` function
-once for each element present in the typed array, excluding holes in the typed array,
-receiving four arguments: the initial value (or value from the previous
-`callbackFn` call), the value of the current element, the current
-index, and the typed array over which iteration is occurring.
-
-The first time the callback is called, `accumulator` and
-`currentValue` can be one of two values. If
-`initialValue` is provided in the call to `reduce`,
-then `accumulator` will be equal to
-`initialValue` and `currentValue` will be
-equal to the first value in the typed array. If no `initialValue`
-was provided, then `accumulator` will be equal to the first
-value in the typed array and `currentValue` will be equal to the
-second.
-
-If the typed array is empty and no `initialValue` was provided,
-{{jsxref("TypeError")}} would be thrown. If the typed array has only one element
-(regardless of position) and no `initialValue` was provided, or if
-`initialValue` is provided but the typed array is empty, the solo
-value would be returned without calling `callbackFn`.
+See {{jsxref("Array.prototype.reduce()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -87,5 +68,12 @@ const total = new Uint8Array([0, 1, 2, 3]).reduce((a, b) => a + b);
 ## See also
 
 - [Polyfill of `TypedArray.prototype.reduce` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.group()")}}
+- {{jsxref("TypedArray.prototype.groupToMap()")}}
+- {{jsxref("TypedArray.prototype.map()")}}
+- {{jsxref("TypedArray.prototype.flat()")}}
+- {{jsxref("TypedArray.prototype.flatMap()")}}
 - {{jsxref("TypedArray.prototype.reduceRight()")}}
 - {{jsxref("Array.prototype.reduce()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -7,11 +7,7 @@ browser-compat: javascript.builtins.TypedArray.reduceRight
 
 {{JSRef}}
 
-The **`reduceRight()`** method applies a function against an
-accumulator and each value of the typed array (from right-to-left) has to reduce it to a
-single value. This method has the same algorithm as
-{{jsxref("Array.prototype.reduceRight()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`reduceRight()`** method of {{jsxref("TypedArray")}} instances applies a function against an accumulator and each value of the typed array (from right-to-left) to reduce it to a single value. This method has the same algorithm as {{jsxref("Array.prototype.reduceRight()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-reduceright.html")}}
 
@@ -27,7 +23,7 @@ reduceRight(callbackFn, initialValue)
 - `callbackFn`
   - : A function to execute for each element in the typed array. Its return value becomes the value of the `accumulator` parameter on the next invocation of `callbackFn`. For the last invocation, the return value becomes the return value of `reduceRight()`. The function is called with the following arguments:
     - `accumulator`
-      - : The value previously returned in the last invocation of the callback, or `initialValue`, if supplied. (See below.)
+      - : The value resulting from the previous call to `callbackFn`. On first call, `initialValue` if specified, otherwise the array's last element's value.
     - `currentValue`
       - : The current element being processed in the typed array.
     - `index`
@@ -35,7 +31,7 @@ reduceRight(callbackFn, initialValue)
     - `array`
       - : The typed array `reduceRight()` was called upon.
 - `initialValue` {{optional_inline}}
-  - : Value to use as accumulator to the first call of the `callbackFn`. If no initial value is supplied, the last element in the array will be used and skipped. Calling `reduceRight()` on an empty array without an initial value creates a `TypeError`.
+  - : Value to use as accumulator to the first call of the `callbackFn`. If no initial value is supplied, the last element in the typed array will be used and skipped. Calling `reduceRight()` on an empty typed array without an initial value creates a `TypeError`.
 
 ### Return value
 
@@ -43,35 +39,7 @@ The value that results from the reduction.
 
 ## Description
 
-The `reduceRight` method executes the `callbackFn`
-function once for each element present in the typed array, excluding holes in the typed
-array, receiving four arguments: the initial value (or value from the previous
-`callbackFn` call), the value of the current element, the current
-index, and the typed array over which iteration is occurring.
-
-The call to the `reduceRight` callback would look something like this:
-
-```js
-typedarray.reduceRight((accumulator, currentValue, index, typedarray) => {
-  // ...
-});
-```
-
-The first time the function is called, the `accumulator` and
-`currentValue` can be one of two values. If an
-`initialValue` was provided in the call to
-`reduceRight`, then `accumulator` will be equal to
-`initialValue` and `currentValue` will be
-equal to the last value in the typed array. If no `initialValue`
-was provided, then `accumulator` will be equal to the last value
-in the typed array and `currentValue` will be equal to the
-second-to-last value.
-
-If the typed array is empty and no `initialValue` was provided,
-{{jsxref("TypeError")}} would be thrown. If the typed array has only one element
-(regardless of position) and no `initialValue` was provided, or if
-`initialValue` is provided but the typed array is empty, the solo
-value would be returned without calling `callbackFn`.
+See {{jsxref("Array.prototype.reduceRight()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -93,5 +61,12 @@ const total = new Uint8Array([0, 1, 2, 3]).reduceRight((a, b) => a + b);
 ## See also
 
 - [Polyfill of `TypedArray.prototype.reduceRight` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.group()")}}
+- {{jsxref("TypedArray.prototype.groupToMap()")}}
+- {{jsxref("TypedArray.prototype.map()")}}
+- {{jsxref("TypedArray.prototype.flat()")}}
+- {{jsxref("TypedArray.prototype.flatMap()")}}
 - {{jsxref("TypedArray.prototype.reduce()")}}
 - {{jsxref("Array.prototype.reduceRight()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.reverse
 
 {{JSRef}}
 
-The **`reverse()`** method reverses a typed array in place. The
-first typed array element becomes the last and the last becomes the first. This method
-has the same algorithm as {{jsxref("Array.prototype.reverse()")}}. _TypedArray_
-is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`reverse()`** method of {{jsxref("TypedArray")}} instances reverses a typed array _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_ and returns the reference to the same typed array, the first typed array element now becoming the last, and the last typed array element becoming the first. In other words, elements order in the typed array will be turned towards the direction opposite to that previously stated. This method has the same algorithm as {{jsxref("Array.prototype.reverse()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-reverse.html","shorter")}}
 
@@ -22,11 +19,15 @@ reverse()
 
 ### Return value
 
-The reversed array.
+The reference to the original typed array, now reversed. Note that the typed array is reversed _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_, and no copy is made.
+
+## Description
+
+See {{jsxref("Array.prototype.reverse()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using reverse
+### Using reverse()
 
 ```js
 const uint8 = new Uint8Array([1, 2, 3]);
@@ -46,4 +47,9 @@ console.log(uint8); // Uint8Array [3, 2, 1]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.reverse` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.join()")}}
+- {{jsxref("TypedArray.prototype.sort()")}}
+- {{jsxref("TypedArray.prototype.toReversed()")}}
 - {{jsxref("Array.prototype.reverse()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.slice
 
 {{JSRef}}
 
-The **`slice()`** method returns a new typed array (with a new
-underlying buffer), that contains a copy of a portion of the original typed array. This
-method has the same algorithm as {{jsxref("Array.prototype.slice()")}}.
-_TypedArray_ is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`slice()`** method of {{jsxref("TypedArray")}} instances returns a copy of a portion of a typed array into a new typed array object selected from `start` to `end` (`end` not included) where `start` and `end` represent the index of items in that typed array. The original typed array will not be modified. This method has the same algorithm as {{jsxref("Array.prototype.slice()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-slice.html","shorter")}}
 
@@ -26,28 +23,11 @@ slice(start, end)
 
 - `start` {{optional_inline}}
 
-  - : Zero-based index at which to begin extraction.
-
-    A negative index can be used, indicating an offset from the end of the sequence.
-    `slice(-2)` extracts the last two elements in the sequence.
-
-    If `start` is undefined, `slice` begins from index
-    `0`.
+  - : Zero-based index at which to start extraction, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
 
 - `end` {{optional_inline}}
 
-  - : Zero-based index _before_ which to end extraction. `slice`
-    extracts up to but not including `end`.
-
-    For example, `slice(1,4)` extracts the second element through the fourth
-    element (elements indexed 1, 2, and 3).
-
-    A negative index can be used, indicating an offset from the end of the sequence.
-    `slice(2,-1)` extracts the third element through the second-to-last element
-    in the sequence.
-
-    If `end` is omitted, `slice` extracts through the
-    end of the sequence (`typedarray.length`).
+  - : Zero-based index at which to end extraction, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion). `slice()` extracts up to but not including `end`.
 
 ### Return value
 
@@ -55,9 +35,7 @@ A new typed array containing the extracted elements.
 
 ## Description
 
-The `slice` method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the `slice` method returns is always a [deep copy](/en-US/docs/Glossary/Deep_copy).
-
-If an element is changed in either typed array, the other typed array is not affected.
+See {{jsxref("Array.prototype.slice()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -82,4 +60,11 @@ uint8.slice(0, 1); // Uint8Array [ 1 ]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.slice` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.pop()")}}
+- {{jsxref("TypedArray.prototype.shift()")}}
+- {{jsxref("TypedArray.prototype.concat()")}}
+- {{jsxref("TypedArray.prototype.splice()")}}
 - {{jsxref("Array.prototype.slice()")}}
+- {{jsxref("String.prototype.slice()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.some
 
 {{JSRef}}
 
-The **`some()`** method tests whether some element in the typed
-array passes the test implemented by the provided function. This method has the same
-algorithm as {{jsxref("Array.prototype.some()")}}. _TypedArray_ is one
-of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`some()`** method of {{jsxref("TypedArray")}} instances tests whether at least one element in the typed array passes the test implemented by the provided function. It returns true if, in the typed array, it finds an element for which the provided function returns true; otherwise it returns false. It doesn't modify the typed array. This method has the same algorithm as {{jsxref("Array.prototype.some()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-some.html")}}
 
@@ -36,27 +33,11 @@ some(callbackFn, thisArg)
 
 ### Return value
 
-**`true`** if the callback function returns a [truthy](/en-US/docs/Glossary/Truthy) value for any array element; otherwise,
-**`false`**.
+`true` if the callback function returns a {{Glossary("truthy")}} value for at least one element in the typed array. Otherwise, `false`.
 
 ## Description
 
-The `some` method executes the `callbackFn` function once for each
-element present in the typed array until it finds one where `callbackFn`
-returns a true value. If such an element is found, `some` immediately returns
-`true`. Otherwise, `some` returns `false`.
-
-`callbackFn` is invoked with three arguments: the value of the element, the
-index of the element, and the array object being traversed.
-
-If a `thisArg` parameter is provided to `some`, it will be passed
-to `callbackFn` when invoked, for use as its `this` value.
-Otherwise, the value `undefined` will be passed for use as its
-`this` value. The `this` value ultimately observable by
-`callbackFn` is determined according to
-[the usual rules for determining the `this` seen by a function](/en-US/docs/Web/JavaScript/Reference/Operators/this).
-
-`some` does not mutate the typed array on which it is called.
+See {{jsxref("Array.prototype.some()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -72,15 +53,6 @@ new Uint8Array([2, 5, 8, 1, 4]).some(isBiggerThan10); // false
 new Uint8Array([12, 5, 8, 1, 4]).some(isBiggerThan10); // true
 ```
 
-### Testing typed array elements using arrow functions
-
-[Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) provide a shorter syntax for the same test.
-
-```js
-new Uint8Array([2, 5, 8, 1, 4]).some((elem) => elem > 10); // false
-new Uint8Array([12, 5, 8, 1, 4]).some((elem) => elem > 10); // true
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -92,5 +64,10 @@ new Uint8Array([12, 5, 8, 1, 4]).some((elem) => elem > 10); // true
 ## See also
 
 - [Polyfill of `TypedArray.prototype.some` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.every()")}}
+- {{jsxref("TypedArray.prototype.forEach()")}}
+- {{jsxref("TypedArray.prototype.find()")}}
+- {{jsxref("TypedArray.prototype.includes()")}}
 - {{jsxref("Array.prototype.some()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.sort
 
 {{JSRef}}
 
-The **`sort()`** method sorts the elements of a typed array
-numerically _in place_ and returns the typed array. This method has the same
-algorithm as {{jsxref("Array.prototype.sort()")}}, except that it sorts the values numerically instead of as strings by default. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`sort()`** method of {{jsxref("TypedArray")}} instances sorts the elements of a typed array _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_ and returns the reference to the same typed array, now sorted. This method has the same algorithm as {{jsxref("Array.prototype.sort()")}}, except that it sorts the values numerically instead of as strings by default.
 
 {{EmbedInteractiveExample("pages/js/typedarray-sort.html","shorter")}}
 
@@ -23,9 +20,9 @@ sort(compareFn)
 
 ### Parameters
 
-- `compareFunction` {{optional_inline}}
+- `compareFn` {{optional_inline}}
 
-  - : A function that defines the sort order. The return value should be a number whose positivity indicates the relative order of the two elements. The function is called with the following arguments:
+  - : A function that defines the sort order. The return value should be a number whose sign indicates the relative order of the two elements: negative if `a` is less than `b`, positive if `a` is greater than `b`, and zero if they are equal. `NaN` is treated as `0`. The function is called with the following arguments:
 
     - `a`
       - : The first element for comparison. Will never be `undefined`.
@@ -36,11 +33,15 @@ sort(compareFn)
 
 ### Return value
 
-The sorted typed array.
+The reference to the original array, now sorted. Note that the array is sorted _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_, and no copy is made.
+
+## Description
+
+See {{jsxref("Array.prototype.sort()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
-### Using sort
+### Using sort()
 
 For more examples, see also the {{jsxref("Array.prototype.sort()")}} method.
 
@@ -71,4 +72,8 @@ numbers.sort((a, b) => a - b); // compare numbers
 ## See also
 
 - [Polyfill of `TypedArray.prototype.sort` with modern behavior like stable sort in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.reverse()")}}
+- {{jsxref("TypedArray.prototype.toSorted()")}}
 - {{jsxref("Array.prototype.sort()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
@@ -7,13 +7,7 @@ browser-compat: javascript.builtins.TypedArray.toLocaleString
 
 {{JSRef}}
 
-The **`toLocaleString()`** method returns a string representing
-the elements of the typed array. The elements are converted to strings and are separated
-by a locale-specific string (such as a comma ","). This method has the same algorithm as
-{{jsxref("Array.prototype.toLocaleString()")}} and, as the typed array elements are
-numbers, the same algorithm as {{jsxref("Number.prototype.toLocaleString()")}} applies
-for each element. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`toLocaleString()`** method of {{jsxref("TypedArray")}} instances returns a string representing the elements of the typed array. The elements are converted to strings using their `toLocaleString` methods and these strings are separated by a locale-specific string (such as a comma ","). This method has the same algorithm as {{jsxref("Array.prototype.toLocaleString()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-tolocalestring.html")}}
 
@@ -27,22 +21,22 @@ toLocaleString(locales, options)
 
 ### Parameters
 
-The `locales` and `options` arguments customize the behavior of
-the function and let applications specify the language whose formatting conventions
-should be used. In implementations, which ignore the `locales` and
-`options` arguments, the locale used and the form of the string returned
-are entirely implementation dependent.
-
-See the {{jsxref("Intl/NumberFormat/NumberFormat", "Intl.NumberFormat()")}}
-constructor for details on these parameters and how to use them.
+- `locales` {{optional_inline}}
+  - : A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the `locales` argument, see [the parameter description on the `Intl` main page](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+- `options` {{optional_inline}}
+  - : An object with configuration properties. See {{jsxref("Number.prototype.toLocaleString()")}}.
 
 ### Return value
 
 A string representing the elements of the typed array.
 
+## Description
+
+See {{jsxref("Array.prototype.toLocaleString()")}} for more details. This method is not generic and can only be called on typed array instances.
+
 ## Examples
 
-### Using toLocaleString
+### Using toLocaleString()
 
 ```js
 const uint = new Uint32Array([2000, 500, 8123, 12, 4212]);
@@ -68,5 +62,10 @@ uint.toLocaleString("ja-JP", { style: "currency", currency: "JPY" });
 
 ## See also
 
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
+- {{jsxref("TypedArray.prototype.toString()")}}
 - {{jsxref("Array.prototype.toLocaleString()")}}
+- {{jsxref("Intl")}}
+- {{jsxref("Intl.ListFormat")}}
 - {{jsxref("Number.prototype.toLocaleString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/toreversed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/toreversed/index.md
@@ -7,17 +7,21 @@ browser-compat: javascript.builtins.TypedArray.toReversed
 
 {{JSRef}}
 
-The **`toReversed()`** method is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) counterpart of the {{jsxref("TypedArray/reverse", "reverse()")}} method. It returns a new array with the elements in reversed order. This method has the same algorithm as {{jsxref("Array.prototype.reverse()")}}. _TypedArray_ is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`toReversed()`** method of {{jsxref("TypedArray")}} instances is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) counterpart of the {{jsxref("TypedArray/reverse", "reverse()")}} method. It returns a new typed array with the elements in reversed order. This method has the same algorithm as {{jsxref("Array.prototype.toReversed()")}}.
 
 ## Syntax
 
 ```js-nolint
-reverse()
+toReversed()
 ```
 
 ### Return value
 
 A new typed array containing the elements in reversed order.
+
+## Description
+
+See {{jsxref("Array.prototype.toReversed()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -41,7 +45,8 @@ console.log(uint8); // Uint8Array [1, 2, 3]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.toReversed` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
-- {{jsxref("Array.prototype.toReversed()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray.prototype.reverse()")}}
 - {{jsxref("TypedArray.prototype.toSorted()")}}
 - {{jsxref("TypedArray.prototype.with()")}}
+- {{jsxref("Array.prototype.toReversed()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tosorted/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tosorted/index.md
@@ -7,32 +7,33 @@ browser-compat: javascript.builtins.TypedArray.toSorted
 
 {{JSRef}}
 
-The **`toSorted()`** method is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) version of the {{jsxref("TypedArray/sort", "sort()")}} method. It returns a new array with the elements sorted in ascending order. This method has the same algorithm as {{jsxref("Array.prototype.toSorted()")}}, except that it sorts the values numerically instead of as strings by default. _TypedArray_ is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`toSorted()`** method of {{jsxref("TypedArray")}} instances is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) version of the {{jsxref("TypedArray/sort", "sort()")}} method. It returns a new typed array with the elements sorted in ascending order. This method has the same algorithm as {{jsxref("Array.prototype.toSorted()")}}.
 
 ## Syntax
 
 ```js-nolint
-// Functionless
 toSorted()
-
-// Arrow function
-toSorted((a, b) => { /* … */ })
-
-// Compare function
 toSorted(compareFn)
-
-// Inline compare function
-toSorted(function compareFn(a, b) { /* … */ })
 ```
 
 ### Parameters
 
 - `compareFn` {{optional_inline}}
-  - : Specifies a function that defines the sort order.
+
+  - : Specifies a function that defines the sort order. If omitted, the array elements are converted to strings, then sorted according to each character's Unicode code point value.
+
+    - `a`
+      - : The first element for comparison.
+    - `b`
+      - : The second element for comparison.
 
 ### Return value
 
 A new typed array with the elements sorted in ascending order.
+
+## Description
+
+See {{jsxref("Array.prototype.toSorted()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -60,7 +61,8 @@ console.log(numbers); // Uint8Array [ 40, 1, 5, 200 ]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.toSorted` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
-- {{jsxref("Array.prototype.toSorted()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray.prototype.sort()")}}
 - {{jsxref("TypedArray.prototype.toReversed()")}}
 - {{jsxref("TypedArray.prototype.with()")}}
+- {{jsxref("Array.prototype.toSorted()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.md
@@ -7,10 +7,7 @@ browser-compat: javascript.builtins.TypedArray.toString
 
 {{JSRef}}
 
-The **`toString()`** method returns a string representing the
-specified array and its elements. This method has the same algorithm as
-{{jsxref("Array.prototype.toString()")}}. _TypedArray_ is one of the
-[typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`toString()`** method of {{jsxref("TypedArray")}} instances returns a string representing the specified typed array and its elements. This method has the same algorithm as {{jsxref("Array.prototype.toString()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-tostring.html","shorter")}}
 
@@ -24,31 +21,20 @@ toString()
 
 A string representing the elements of the typed array.
 
+## Description
+
+See {{jsxref("Array.prototype.toString()")}} for more details. This method is not generic and can only be called on typed array instances.
+
 ## Examples
 
-The {{jsxref("TypedArray")}} objects override the `toString` method of
-{{jsxref("Object")}}. For `TypedArray` objects, the `toString`
-method joins the array and returns one string containing each typed array element
-separated by commas. For example, the following code creates a typed array and uses
-`toString` to convert the array to a string.
+### Converting a typed array to a string
 
 ```js
-const numbers = new Uint8Array([2, 5, 8, 1, 4]);
-numbers.toString(); // "2,5,8,1,4"
-```
-
-JavaScript calls the `toString` method automatically when a typed array is
-to be represented as a text value or when an array is referred to in a string
-concatenation.
-
-### Compatibility
-
-If a browser doesn't support the `TypedArray.prototype.toString()` method
-yet, JavaScript will call the `toString` method of {{jsxref("Object")}}:
-
-```js
-const numbers = new Uint8Array([2, 5, 8, 1, 4]);
-numbers.toString(); // "[object Uint8Array]"
+const uint8 = new Uint8Array([1, 2, 3]);
+// Explicit conversion
+console.log(uint8.toString()); // 1,2,3
+// Implicit conversion
+console.log(`${uint8}`); // 1,2,3
 ```
 
 ## Specifications
@@ -61,4 +47,9 @@ numbers.toString(); // "[object Uint8Array]"
 
 ## See also
 
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
+- {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.join()")}}
+- {{jsxref("TypedArray.prototype.toLocaleString()")}}
+- {{jsxref("Array.prototype.toString()")}}
+- {{jsxref("String.prototype.toString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.TypedArray.values
 
 {{JSRef}}
 
-The **`values()`** method returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the values for each index in the array.
+The **`values()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that iterates the value of each item in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.values()")}}.
 
 {{EmbedInteractiveExample("pages/js/typedarray-values.html")}}
 
@@ -20,6 +20,10 @@ values()
 ### Return value
 
 A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
+
+## Description
+
+See {{jsxref("Array.prototype.values()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -61,3 +65,5 @@ console.log(values.next().value); // 50
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
 - [`TypedArray.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator)
+- {{jsxref("Array.prototype.values()")}}
+- [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/with/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/with/index.md
@@ -7,21 +7,18 @@ browser-compat: javascript.builtins.TypedArray.with
 
 {{JSRef}}
 
-The **`with()`** method is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) version of using the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation) to change the value of a given index. It returns a new array with the element at the given index replaced with the given value. This method has the same algorithm as {{jsxref("Array.prototype.with()")}}. _TypedArray_ is one of the [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
+The **`with()`** method of {{jsxref("TypedArray")}} instances is the [copying](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods) version of using the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation) to change the value of a given index. It returns a new typed array with the element at the given index replaced with the given value. This method has the same algorithm as {{jsxref("Array.prototype.with()")}}.
 
 ## Syntax
 
 ```js-nolint
-array.with(index, value)
+arrayObject.with(index, value)
 ```
 
 ### Parameters
 
 - `index`
   - : Zero-based index at which to change the array, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
-    - Negative index counts back from the end of the array — if `start < 0`, `start + array.length` is used.
-    - If `start` is omitted, `0` is used.
-    - If the index, with negative values counted backwards, is out of bounds, a {{jsxref("RangeError")}} is thrown.
 - `value`
   - : Any value to be assigned to the given index.
 
@@ -32,7 +29,11 @@ A new typed array with the element at `index` replaced with `value`.
 ### Exceptions
 
 - {{jsxref("RangeError")}}
-  - : Thrown if `index > array.length` or `index < -array.length`.
+  - : Thrown if `index >= array.length` or `index < -array.length`.
+
+## Description
+
+See {{jsxref("Array.prototype.with()")}} for more details. This method is not generic and can only be called on typed array instances.
 
 ## Examples
 
@@ -55,6 +56,7 @@ console.log(arr); // Uint8Array [1, 2, 3, 4, 5]
 ## See also
 
 - [Polyfill of `TypedArray.prototype.with` in `core-js`](https://github.com/zloirock/core-js#change-array-by-copy)
-- {{jsxref("Array.prototype.with()")}}
+- [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray.prototype.toReversed()")}}
 - {{jsxref("TypedArray.prototype.toSorted()")}}
+- {{jsxref("Array.prototype.with()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is planned in https://github.com/mdn/content/issues/26847

The TypedArray method pages have long been outdated. No one seems to care about them because we don't see any PRs fixing bugs. This means people either read Array method pages for the detailed information, or these pages are not useful at all. At any rate it would be easier for maintenance if we only keep one copy of the information.

In this PR I've made the wording as aligned between the two sections as possible.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
