### PR TITLE
Add ellipse to offset-path Syntax

### DIFF
--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -26,6 +26,7 @@ offset-path: url(#path);
 
 /* Shape */
 offset-path: circle(50% at 25% 25%);
+offset-path: ellipse(50% 50% at 25% 25%);
 offset-path: inset(50% 50% 50% 50%);
 offset-path: polygon(30% 0%, 70% 0%, 100% 50%, 30% 100%, 0% 70%, 0% 30%);
 offset-path: path("M 0,200 Q 200,200 260,80 Q 290,20 400,0 Q 300,100 400,200");


### PR DESCRIPTION
As per mdn#28157 (comment), Ellipse is missing from the Syntax part of offset-path, but is found in Values and in https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape. I've added an example that matches the other shapes.