### PR TITLE
Change weakmap examples' order to make it easier to understand

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -80,7 +80,7 @@ wm2.set(wm1, wm2); // keys and values can be any objects. Even WeakMaps!
 
 wm1.get(o2); // "azerty"
 wm2.get(o2); // undefined, because that is the set value
-wm2.get(o3); // undefined, because there is no key for o2 on wm2
+wm2.get(o3); // undefined, because there is no key for o3 on wm2
 
 wm1.has(o2); // true
 wm2.has(o2); // true (even if the value itself is 'undefined')

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -75,16 +75,16 @@ const o3 = window;
 wm1.set(o1, 37);
 wm1.set(o2, "azerty");
 wm2.set(o1, o2); // a value can be anything, including an object or a function
-wm2.set(o3, undefined);
+wm2.set(o2, undefined);
 wm2.set(wm1, wm2); // keys and values can be any objects. Even WeakMaps!
 
 wm1.get(o2); // "azerty"
-wm2.get(o2); // undefined, because there is no key for o2 on wm2
-wm2.get(o3); // undefined, because that is the set value
+wm2.get(o2); // undefined, because that is the set value
+wm2.get(o3); // undefined, because there is no key for o2 on wm2
 
 wm1.has(o2); // true
-wm2.has(o2); // false
-wm2.has(o3); // true (even if the value itself is 'undefined')
+wm2.has(o2); // true (even if the value itself is 'undefined')
+wm2.has(o3); // false
 
 wm3.set(o1, 37);
 wm3.get(o1); // 37


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
In the weakmap example, the documentation shows the case, where the key doesn't exist first and then shows a case that the key exists. 

<!-- ✍️ Summarize your changes in one or two sentences -->
Changes the sequence of two different `weakmap.get()` functions that return undefined.


### Motivation
It's more intuitive and expected for the reader to see the case how weakmap behaves with an existing key first and then see how it behaves when the key isn't there. Otherwise, the reader would expect to see a less anticipated case. 

<!-- ❓ Why are you making these changes and how do they help readers? -->


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
None

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
