### PR TITLE
Fix example bug

### DIFF
--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -183,6 +183,8 @@ function withDefaults(
 
 function withoutDefaults(a, b, c, d, e, f, g) {
   switch (arguments.length) {
+    case 0:
+      a = undefined;
     case 1:
       b = 5;
     case 2:

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -184,7 +184,6 @@ function withDefaults(
 function withoutDefaults(a, b, c, d, e, f, g) {
   switch (arguments.length) {
     case 0:
-      a = undefined;
     case 1:
       b = 5;
     case 2:


### PR DESCRIPTION
The function `withoutDefaults` is not in accordance with the comment after the call to the function `withoutDefaults`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add default value to the argument `a`, otherwise no case clause is executed when there is no argument passed to the function `withoutDefaults`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
