### PR TITLE
Fixed inconsistent max size of ArrayBuffer on 32-bit systems

### DIFF
--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -33,9 +33,9 @@ An invalid array length might appear in these situations:
 
 - Creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with a negative length, or setting a negative value for the {{jsxref("Array/length", "length")}} property.
 - Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2<sup>32</sup>-1.
-- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>32</sup>-1 (2GiB-1) on a 32-bit system, or 2<sup>33</sup> (8GiB) on a 64-bit system.
+- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1) on a 32-bit system, or 2<sup>33</sup> (8GiB) on a 64-bit system.
 - Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property to a floating-point number.
-- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>32</sup>-1 (2GiB-1).
+- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1).
 
 If you are creating an `Array`, using the constructor, you probably want to
 use the literal notation instead, as the first argument is interpreted as the length of
@@ -69,7 +69,7 @@ const c = new Array(2.5); // pass a floating-point number
 ```js example-good
 [Math.pow(2, 40)]; // [ 1099511627776 ]
 [-1]; // [ -1 ]
-new ArrayBuffer(Math.pow(2, 32) - 1);
+new ArrayBuffer(Math.pow(2, 31) - 1);
 new ArrayBuffer(Math.pow(2, 33)); // 64-bit systems after Firefox 89
 new ArrayBuffer(0);
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Some places said "2^32-1 (2GiB-1)" and showed that 2^32-1 was a valid size. When 2^31-1 is the correct value according to #7866.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #28404

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
