### PR TITLE
Improve event page documentation and examples

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -78,6 +78,8 @@ Events have three functions:
         - either keep a reference to the `sendResponse()` argument and return `true` from the listener function. You will then be able to call `sendResponse()` after the listener function has returned.
         - or return a {{jsxref("Promise")}} from the listener function and resolve the promise when the response is ready. This is a preferred way.
 
+          > **Note:** Promise as a return value is not supported in Chrome until [Chrome bug 1185241](https://crbug.com/1185241) is resolved. As an alternative, [return true and use sendResponse](#sending_an_asynchronous_response_using_sendresponse).
+
     The `listener` function can return either a Boolean or a {{jsxref("Promise")}}.
 
     > **Note:** If you pass an async function to `addListener()`, the listener will return a Promise for every message it receives, preventing other listeners from responding:
@@ -211,7 +213,11 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
+> **Warning:** Do not prepend `async` to the function. That changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
+
 ### Sending an asynchronous response using a Promise
+
+> **Note:** Promise as a return value is not supported in Chrome until [Chrome bug 1185241](https://crbug.com/1185241) is resolved. As an alternative, [return true and use `sendResponse`](#sending_an_asynchronous_response_using_sendresponse).
 
 This content script gets the first `<a>` link on the page and sends a message asking if the link's location is bookmarked. It expects to get a Boolean response (`true` if the location is bookmarked, `false` otherwise):
 

--- a/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
@@ -88,7 +88,7 @@ You cannot specify background scripts and a background page.
 
 ### Initialize the extension
 
-Listen to {{WebExtAPIRef("runtime.onInstalled")}} to initialize an extension on installation. Use this event to set a state or for one-time initialization. For extensions with event pages, this is where stateful APIs, such as a context menu created using `browser.menus.create`, should be used.
+Listen to {{WebExtAPIRef("runtime.onInstalled")}} to initialize an extension on installation. Use this event to set a state or for one-time initialization. For extensions with event pages, this is where stateful APIs, such as a context menu created using {{WebExtAPIRef("menus.create")}}, should be used.
 
 ```js
 browser.runtime.onInstalled.addListener(() => {
@@ -145,7 +145,7 @@ Extensions can remove listeners from their background scripts by calling `remove
 
 ```js
 browser.runtime.onMessage.addListener(
-  function messageListener(message, sender, reply) {
+  function messageListener(message, sender, sendResponse) {
     browser.runtime.onMessage.removeListener(messageListener);
   },
 );
@@ -167,16 +167,30 @@ browser.webNavigation.onCompleted.addListener(
 ### React to listeners
 
 Listeners exist to trigger functionality once an event has fired. To react to an event, structure the desired reaction inside of the listener event.
+When responding to events in the context of a specific tab or frame, use the `tabId` and `frameId` from the event details instead of relying on the "current tab". Specifying the target ensures your extension does not invoke an extension API on the wrong target when the "current tab" changes while waking the event page.
+For example, {{WebExtAPIRef("runtime.onMessage")}} can respond to {{WebExtAPIRef("runtime.sendMessage")}} calls as follows:
 
 ```js
-browser.runtime.onMessage.addListener((message, callback) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.data === "setAlarm") {
     browser.alarms.create({ delayInMinutes: 5 });
   } else if (message.data === "runLogic") {
-    browser.tabs.executeScript({ file: "logic.js" });
+    browser.scripting.executeScript({
+      target: {
+        tabId: sender.tab.id,
+        frameIds: [sender.frameId],
+      },
+      files: ["logic.js"],
+    });
   } else if (message.data === "changeColor") {
-    browser.tabs.executeScript({
-      code: 'document.body.style.backgroundColor="orange"',
+    browser.scripting.executeScript({
+      target: {
+        tabId: sender.tab.id,
+        frameIds: [sender.frameId],
+      },
+      func: () => {
+        document.body.style.backgroundColor = "orange";
+      },
     });
   }
 });
@@ -187,18 +201,26 @@ browser.runtime.onMessage.addListener((message, callback) => {
 Data should be persisted periodically to not lose important information if an extension crashes without receiving {{WebExtAPIRef("runtime.onSuspend")}}. Use the storage API to assist with this.
 
 ```js
+// Or storage.session if the variable does not need to persist pass browser shutdown.
 browser.storage.local.set({ variable: variableInformation });
 ```
 
 Message ports cannot prevent an event page from shutting down. If an extension uses message passing, the ports are closed when the event page idles. Listening to the {{WebExtAPIRef("runtime.Port")}} `onDisconnect` lets you discover when open ports are closing, however the listener will be under the same time constraints as {{WebExtAPIRef("runtime.onSuspend")}}.
 
 ```js
-browser.runtime.onMessage.addListener((message, callback) => {
-  if (message === "hello") {
-    sendResponse({ greeting: "welcome!" });
-  } else if (message === "goodbye") {
-    browser.runtime.Port.disconnect();
-  }
+browser.runtime.onConnect.addListener((port) => {
+  port.onMessage.addListener((message) => {
+    if (message === "hello") {
+      let response = { greeting: "welcome!" };
+      port.postMessage(response);
+    } else if (message === "goodbye") {
+      console.log("Disconnecting port from this end");
+      port.disconnect();
+    }
+  });
+  port.onDisconnect.addListener(() => {
+    console.log("Port was disconnected from the other end");
+  });
 });
 ```
 
@@ -207,7 +229,7 @@ Background scripts unload after a few seconds of inactivity. However, if during 
 ```js
 browser.runtime.onSuspend.addListener(() => {
   console.log("Unloading.");
-  chrome.browserAction.setBadgeText({ text: "" });
+  browser.browserAction.setBadgeText({ text: "" });
 });
 ```
 
@@ -240,24 +262,55 @@ browser.runtime.onStartup.addListener(() => {
 
 ### Record state changes
 
-As scripts now open and close as needed, use the storage API to set and return states and values. Use {{WebExtAPIRef("storage.local")}} `set` to update on the local machine.
+Scripts now open and close as needed. So, do not rely on global variables.
 
-```js
-browser.storage.local.set({ variable: variableInformation });
+```js bad-example
+var count = 101;
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message === "count") {
+    ++count;
+    sendResponse(count);
+  }
+});
 ```
 
-Use {{WebExtAPIRef("storage.local")}} `get` to retrieve the value of that variable.
+Instead, use the storage API to set and return states and values:
+
+- Use {{WebExtAPIRef("storage.session")}} for in-memory storage that is cleared when the extension or browser shuts down. By default, `storage.session` is only available to extension contexts and not to content scripts.
+- Use {{WebExtAPIRef("storage.local")}} for a larger storage area that persists across browser and extension restarts.
 
 ```js
-browser.storage.local.get(["variable"], (result) => {
-  let someVariable = result.variable;
-  // Do something with someVariable
+browser.runtime.onMessage.addListener(async (message, sender) => {
+  if (message === "count") {
+    let items = await browser.storage.session.get({ myStoredCount: 101 });
+    let count = items.myStoredCount;
+    ++count;
+    await browser.storage.session.set({ myStoredCount: count });
+    return count;
+  }
+});
+```
+
+The preceding example [sends an asynchronous response using a promise](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Runtime/onMessage#sending_an_asynchronous_response_using_a_promise), which is not supported in Chrome until [Chrome bug 1185241](https://crbug.com/1185241) is resolved.
+A cross-browser alternative is to [return true and use `sendResponse`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Runtime/onMessage#sending_an_asynchronous_response_using_sendresponse).
+
+```js
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message === "count") {
+    browser.storage.session.get({ myStoredCount: 101 }).then(async (items) => {
+      let count = items.myStoredCount;
+      ++count;
+      await browser.storage.session.set({ myStoredCount: count });
+      sendResponse(count);
+    });
+    return true;
+  }
 });
 ```
 
 ### Change timers into alarms
 
-DOM-based timers do not remain active after an event page has idled. Instead, use the {{WebExtAPIRef("alarms")}} API if you need a timer to wake an event page.
+DOM-based timers, such as {{domxref("setTimeout()")}}, do not remain active after an event page has idled. Instead, use the {{WebExtAPIRef("alarms")}} API if you need a timer to wake an event page.
 
 ```js
 browser.alarms.create({ delayInMinutes: 3.0 });
@@ -273,11 +326,30 @@ browser.alarms.onAlarm.addListener(() => {
 
 ### Update calls for background script functions
 
-If a content script or action must call a function, use {{WebExtAPIRef("runtime.getBackgroundPage")}} to ensure the event page is running. If the call is optional (that is, only needed if the event page is alive) then use {{WebExtAPIRef("extension.getBackgroundPage")}}, which return `null` if the page is not running.
+Extensions commonly host their primary functionality in the background script. Some extensions access functions and variables defined in the background page through the `window` returned by {{WebExtAPIRef("extension.getBackgroundPage")}}.
+The method returns `null` when:
+
+- extension pages are isolated, such as extension pages in Private Browsing mode or container tabs.
+- the background page is not running. This is uncommon with persistent background pages but very likely when using an Event Page, as an Event Page can be suspended.
+
+> **Note:** The recommended way to invoke functionality in the background script is to communicate with it through {{WebExtAPIRef("runtime.sendMessage","runtime.sendMessage()")}} or {{WebExtAPIRef("runtime.connect","runtime.connect()")}}.
+> The `getBackgroundPage()` methods discussed in this section cannot be used in a cross-browser extension, because Manifest Version 3 extensions in Chrome cannot use background or event pages.
+
+If your extension requires a reference to the `window` of the background page, use {{WebExtAPIRef("runtime.getBackgroundPage")}} to ensure the event page is running.
+If the call is optional (that is, only needed if the event page is alive) then use {{WebExtAPIRef("extension.getBackgroundPage")}}.
+
+```js example-bad
+document.getElementById("target").addEventListener("click", async () => {
+  let backgroundPage = browser.extension.getBackgroundPage();
+  // Warning: backgroundPage is likely null.
+  backgroundPage.backgroundFunction();
+});
+```
 
 ```js
 document.getElementById("target").addEventListener("click", async () => {
-  let backgroundPage = await window.runtime.getBackgroundPage();
+  // runtime.getBackgroundPage() wakes up the event page if it was not running.
+  let backgroundPage = await browser.runtime.getBackgroundPage();
   backgroundPage.backgroundFunction();
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixes broken code and inaccurate content at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This fixes several issues:

- Fix non-functional demos of `runtime.onMessage` and `runtime.Port` APIs due to incorrect method signatures.

- The `tabs.executeScript` example used a dangerous pattern prone to TOCTOU. Besides fixing this, I also replaced `tabs.executeScript` with `scripting.executeScript` because the former is MV2-only, and `scripting.executeScript` would be more future-proof.

- Expanded the state storage documentation by mentioning storage.session, and showing an actual code example to demonstrate the difference.

- The advice for `extension.getBackgroundPage()` was bad; extension messaging should be the first recommendation, followed by `runtime.getBackgroundPage()` with caveats.

- Emphasized cross-browser differences where relevant.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
