### PR TITLE
Fix badly named async functions and order descriptions

### DIFF
--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -274,7 +274,7 @@ setTimeout(concurrentSmallWorks, 7000); // same as sequentialInvokeBeforeComplet
 setTimeout(concurrentBigWorks, 10000); // after 1 second, logs "fast", then after 1 more second, "slow"
 ```
 
-#### await and parallelism
+#### await and concurrency
 
 In `sequentialInvokeAfterCompletion`, execution suspends 2 seconds for the first
 `await`, and then another second for the second `await`. The
@@ -288,10 +288,10 @@ However, the `await` calls still run in series, which means the second
 `await` will wait for the first one to finish. In this case, the result of
 the fastest timer is processed after the slowest.
 
-If you wish to safely perform two or more jobs in parallel, you must await a call
+If you wish to safely perform other job after two or more jobs run concurrently and complete, you must await a call
 to [`Promise.all`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all),
 or
-[`Promise.allSettled`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled).
+[`Promise.allSettled`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) before that job.
 
 > **Warning:** The functions `sequentialInvokeBeforeCompletion` and `concurrentSmallWorks`
 > are not functionally equivalent.

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -254,7 +254,7 @@ async function concurrentBigWorks() {
   console.log("==concurrentBigWorks starts==");
 
   // 1. handle two big works (timer and log) concurrently
-  await Promise.allSettled([
+  await Promise.all([
     (async () => console.log(await resolveAfter2Seconds()))(),
     (async () => console.log(await resolveAfter1Second()))(),
   ]);

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -226,10 +226,10 @@ async function sequentialInvokeBeforeCompletion() {
   // 2. invoke the next timer without waiting the previous one
   const fast = resolveAfter1Second();
 
-  console.log(await slow);
   // 3. wait for the slow timer to complete, and then print the result
-  console.log(await fast);
+  console.log(await slow);
   // 4. wait for the fast timer to complete, and then print the result
+  console.log(await fast);
 
   console.log("this function is done");
 }
@@ -242,7 +242,6 @@ async function concurrentSmallWorks() {
     resolveAfter2Seconds(),
     resolveAfter1Second(),
   ]);
-
   // 2. wait for the both timers to complete, and then print the results
   console.log(results[0]); // slow
   console.log(results[1]); // fast


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I made corrections to function names and their descriptions that could be misleading, as mentioned in #27551, to clarify that PR in what happens with multiple async function callings is "Concurrency" and not "Parallelism."

In addition, I made modifications to other function names. For example, `concurrentStart` was executing async functions sequentially, suspending at the start of asynchronous API execution, and then starting the next process. To make the comparison clearer with `sequentialStart`, I renamed them to focus on whether the process waits for completion or not.

Furthermore, I adjusted the comparison between `concurrentPromise` and `parallel` since they differed in the size of the works intended for concurrency, causing misconceptions about comparing "Concurrency" and "Parallelism." I changed the function names to better reflect the points of comparison.

I also fixed other misleading descriptions that implied "Parallelism" was occurring and improved comments to make the processing order inside each async function clearer.

### Motivation

To eliminate the description that implies Parallelism occurs in async functions and to provide a more accurate representation of the actual behavior.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

#27551 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
