### PR TITLE
chore(pr-check-lint): skip setting up reviewdog if not needed

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -103,6 +103,7 @@ jobs:
           git diff
 
       - name: Setup reviewdog
+        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true'
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest


### PR DESCRIPTION
### Description

skip 'setup reviewdog' if not needed
