### PR TITLE
FF117 Expr.Features - updated array grouping

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1022,9 +1022,9 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ### Array grouping methods
 
-The {{jsxref("Array.prototype.group()")}} and {{jsxref("Array.prototype.groupToMap()")}} methods are used to group the elements of an array using a string or value, respectively, returned by a test function.
-The `groupBy` method should be used when strings can be used to represent element groups, while `groupByToMap()` should be used in cases where it makes sense to use a value as the key.
-(See [Firefox bug 1739648](https://bugzil.la/1739648) for more details.)
+The {{jsxref("Object.groupBy()")}} and {{jsxref("Map.groupBy()")}} static methods are used to group the elements of an iterable using a string or value returned by a test function (respectively).
+The first method should be used when strings can be used to represent element groups, while the method in `Map` might be used when elements are associated with a particular object.
+(See [Firefox bug 1841518](https://bugzil.la/1841518) for more details.)
 
 <table>
   <thead>
@@ -1037,27 +1037,27 @@ The `groupBy` method should be used when strings can be used to represent elemen
   <tbody>
     <tr>
       <th>Nightly</th>
-      <td>98</td>
-      <td>Yes</td>
+      <td>117</td>
+      <td>No</td>
     </tr>
     <tr>
       <th>Developer Edition</th>
-      <td>98</td>
+      <td>NA</td>
       <td>No</td>
     </tr>
     <tr>
       <th>Beta</th>
-      <td>98</td>
+      <td>NA</td>
       <td>No</td>
     </tr>
     <tr>
       <th>Release</th>
-      <td>98</td>
+      <td>NA</td>
       <td>No</td>
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2">None</td>
+      <td colspan="2"><code>javascript.options.experimental.array_grouping</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1020,7 +1020,7 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
-### Array grouping methods
+### Array (iterable) grouping methods
 
 The {{jsxref("Object.groupBy()")}} and {{jsxref("Map.groupBy()")}} static methods are used to group the elements of an iterable using a string or value returned by a test function (respectively).
 The first method should be used when strings can be used to represent element groups, while the method in `Map` might be used when elements are associated with a particular object.


### PR DESCRIPTION
FF117 reimplements the array grouping proposal methods (behind a preference that is only defined in nightly) in https://bugzilla.mozilla.org/show_bug.cgi?id=1841518.

This updates the experimental feature info to refer to the new methods. The methods are added to docs in #28424

Related docs work can be tracked in #28279