### PR TITLE
FF117Relnote: ReadableStream.from() static method

### DIFF
--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -41,6 +41,8 @@ This article provides information about the changes in Firefox 117 that affect d
 
 ### APIs
 
+- The {{domxref("ReadableStream/from_static", "ReadableStream.from()")}} static member is now supported, allowing developers to construct a readable stream from any iterable or async iterable object ([Firefox bug 1772772](https://bugzil.la/1772772)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF117 adds support for `ReadableStream.from()` - this is just the release note.

Related info in #28282