### PR TITLE
Update HTML element canvas "Maximum canvas size" section (#9379)

### DIFF
--- a/files/en-us/web/html/element/canvas/index.md
+++ b/files/en-us/web/html/element/canvas/index.md
@@ -105,26 +105,7 @@ It is better to specify your canvas dimensions by setting the `width` and `heigh
 
 ### Maximum canvas size
 
-The exact maximum size of a `<canvas>` element depends on the browser and environment. While in most cases the maximum dimensions exceed 10,000 x 10,000 pixels, notably iOS devices limit the canvas size to only 4,096 x 4,096 pixels.
-
-The following is data collected through various tests and other sources (e.g. [Stack Overflow](https://stackoverflow.com/questions/6081483/maximum-size-of-a-canvas-element)):
-
-#### Desktop
-
-| Browser            | Maximum width    | Maximum height   | Maximum area                               |
-| ------------------ | ---------------- | ---------------- | ------------------------------------------ |
-| Chrome (Win, Mac)  | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-| Firefox (Win, Mac) | 32,767 pixels    | 32,767 pixels    | 536,756,224 pixels (i.e., 23,168 x 23,168) |
-| Safari (Mac)       | 4,194,303 pixels | 8,388,607 pixels | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-| Edge (Win)         | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-
-#### Mobile
-
-| Browser           | Maximum width    | Maximum height   | Maximum area                               |
-| ----------------- | ---------------- | ---------------- | ------------------------------------------ |
-| Chrome (Android)  | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-| Firefox (Android) | 32,767 pixels    | 32,767 pixels    | 536,756,224 pixels (i.e., 23,168 x 23,168) |
-| Safari (iOS)      | 4,194,303 pixels | 6,029,311 pixels | 16,777,216 pixels (i.e., 4,096 x 4,096)    |
+The exact maximum size of a `<canvas>` element depends on the browser and environment. While in most cases the maximum dimensions exceed 10,000 x 10,000 pixels, notably iOS devices limit the canvas size to only 4,096 x 4,096 pixels. See [canvas size limits in different browsers and devices](https://github.com/jhildenbiddle/canvas-size#test-results) (2021).
 
 > **Note:** Exceeding the maximum dimensions or area renders the canvas unusable — drawing commands will not work.
 

--- a/files/en-us/web/html/element/canvas/index.md
+++ b/files/en-us/web/html/element/canvas/index.md
@@ -105,14 +105,26 @@ It is better to specify your canvas dimensions by setting the `width` and `heigh
 
 ### Maximum canvas size
 
-The maximum size of a `<canvas>` element is very large, but the exact size depends on the browser. The following is some data we've collected from various tests and other sources (e.g. [Stack Overflow](https://stackoverflow.com/questions/6081483/maximum-size-of-a-canvas-element)):
+The exact maximum size of a `<canvas>` element depends on the browser and environment. While in most cases the maximum dimensions exceed 10,000 x 10,000 pixels, notably iOS devices limit the canvas size to only 4,096 x 4,096 pixels.
 
-| Browser | Maximum height | Maximum width | Maximum area                               |
-| ------- | -------------- | ------------- | ------------------------------------------ |
-| Chrome  | 32,767 pixels  | 32,767 pixels | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-| Firefox | 32,767 pixels  | 32,767 pixels | 472,907,776 pixels (i.e., 22,528 x 20,992) |
-| Safari  | 32,767 pixels  | 32,767 pixels | 268,435,456 pixels (i.e., 16,384 x 16,384) |
-| IE      | 8,192 pixels   | 8,192 pixels  | ?                                          |
+The following is data collected through various tests and other sources (e.g. [Stack Overflow](https://stackoverflow.com/questions/6081483/maximum-size-of-a-canvas-element)):
+
+#### Desktop
+
+| Browser            | Maximum width    | Maximum height   | Maximum area                               |
+| ------------------ | ---------------- | ---------------- | ------------------------------------------ |
+| Chrome (Win, Mac)  | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
+| Firefox (Win, Mac) | 32,767 pixels    | 32,767 pixels    | 536,756,224 pixels (i.e., 23,168 x 23,168) |
+| Safari (Mac)       | 4,194,303 pixels | 8,388,607 pixels | 268,435,456 pixels (i.e., 16,384 x 16,384) |
+| Edge (Win)         | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
+
+#### Mobile
+
+| Browser           | Maximum width    | Maximum height   | Maximum area                               |
+| ----------------- | ---------------- | ---------------- | ------------------------------------------ |
+| Chrome (Android)  | 65,535 pixels    | 65,535 pixels    | 268,435,456 pixels (i.e., 16,384 x 16,384) |
+| Firefox (Android) | 32,767 pixels    | 32,767 pixels    | 536,756,224 pixels (i.e., 23,168 x 23,168) |
+| Safari (iOS)      | 4,194,303 pixels | 6,029,311 pixels | 16,777,216 pixels (i.e., 4,096 x 4,096)    |
 
 > **Note:** Exceeding the maximum dimensions or area renders the canvas unusable — drawing commands will not work.
 


### PR DESCRIPTION
### Description

This PR removes the Table with the outdated and incomplete data about [maximum canvas sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size) and replaces it with a description that highlights the most drastic difference between environments.

### Motivation

I ran into the issue that a canvas 6,000 x 4,400 pixels in size didn't work on iOS devices. It then took me a while to find accurate information about maximum canvas sizes.

### Additional details

I'm not sure if I should link to the GitHub page of the canvas-size package. On the one hand a link to a GitHub repository doesn't seem to tick all the boxes of a good external link according to the [writing guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#external_links), on the other hand this replaces a link to StackOverflow.

Instead of linking to "detailed information", the data table could also be copied to MDN.

### Related issues and pull requests

Fixes #9379