### PR TITLE
fix(ci): use git add command in the reviewdog workflow

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -38,7 +38,8 @@ jobs:
           # To avoid contents of PR getting into the diff that we are going to generate
           # after running the linters, here we make a dummy commit.
           # Note, this commit is not getting pushed.
-          git commit -am "Code from PR head"
+          git add .
+          git commit -m "Code from PR head"
 
       - name: Get changed files
         env:


### PR DESCRIPTION
Fixes https://github.com/mdn/content/actions/runs/5793903831/job/15702484911#step:4:22

> On branch main
> Your branch is up to date with 'origin/main'.
>
> Untracked files:
>  (use "git add <file>..." to include in what will be committed)
>	files/en-us/web/api/rtcencodedvideoframe/
>
> nothing added to commit but untracked files present (use "git add" to track)
> Error: Process completed with exit code 1.

Problem is `git -am` considers only modified files. We need to use `git add` separately.