### PR TITLE
relnote(117): math-style, math-depth and 'font-size: math' support

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -435,46 +435,6 @@ Adds support for a [masonry-style layout](/en-US/docs/Web/CSS/CSS_grid_layout/Ma
   </tbody>
 </table>
 
-### math-style property
-
-The {{cssxref("math-style")}} property indicates whether MathML equations should render with normal or compact height. (See [Firefox bug 1665975](https://bugzil.la/1665975) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>83</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>83</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>83</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>83</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.math-style.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### fit-content() function
 
 The {{cssxref("fit-content_function", "fit-content()")}} function as it applies to {{cssxref("width")}} and other sizing properties. This function is already well-supported for CSS Grid Layout track sizing. (See [Firefox bug 1312588](https://bugzil.la/1312588) for more details.)

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -18,6 +18,8 @@ This article provides information about the changes in Firefox 117 that affect d
 
 ### CSS
 
+- The [`math-style`](/en-US/docs/Web/CSS/math-style) and [`math-depth`](/en-US/docs/Web/CSS/math-depth) properties are now supported, as well as the `math` value for the [`font-size`](/en-US/docs/Web/CSS/font-size#values) property ([Firefox bug 1845516](https://bugzil.la/1845516)).
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/web/css/font-size/index.md
+++ b/files/en-us/web/css/font-size/index.md
@@ -54,9 +54,13 @@ The `font-size` property is specified in one of the following ways:
 ### Values
 
 - `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large`, `xxx-large`
+
   - : Absolute-size keywords, based on the user's default font size (which is `medium`).
+
 - `larger`, `smaller`
+
   - : Relative-size keywords. The font will be larger or smaller relative to the parent element's font size, roughly by the ratio used to separate the absolute-size keywords above.
+
 - {{cssxref("&lt;length&gt;")}}
 
   - : A positive {{cssxref("&lt;length&gt;")}} value. For most font-relative units (such as `em` and `ex`), the font size is relative to the parent element's font size.
@@ -64,12 +68,12 @@ The `font-size` property is specified in one of the following ways:
     For font-relative units that are root-based (such as `rem`), the font size is relative to the size of the font used by the {{HTMLElement("html")}} (root) element.
 
 - {{cssxref("&lt;percentage&gt;")}}
-  - : A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.
 
-> **Note:** To maximize accessibility, it is generally best to use values that are relative to the user's default font size.
+  - : A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.
+    > **Note:** To maximize accessibility, it is generally best to use values that are relative to the user's default font size.
 
 - `math`
-  Special [mathematical scaling rules](https://w3c.github.io/mathml-core/#the-math-script-level-property) must be applied when determining the computed value of the `font-size` property.
+  - : Special [mathematical scaling rules](https://w3c.github.io/mathml-core/#the-math-script-level-property) are applied when determining the computed value of the `font-size` property.
 
 ## Description
 


### PR DESCRIPTION
The `math-style`, `math-depth` props plus `font-size: math;` supported in 117. 

Removing the note in exp features as this is landing in stable now.

__pen:__
- https://codepen.io/bsmth/pen/PoxgVPL

__Docs:__

- [`math-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/math-style)
- [`math-depth`](https://developer.mozilla.org/en-US/docs/Web/CSS/math-depth)
- [`font-size: math;`](http://localhost:5042/en-US/docs/Web/CSS/font-size#values)

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28290
- [x] BCD
  - [x] `math-depth`https://github.com/mdn/browser-compat-data/pull/20417
  - [x] `math-style`: https://github.com/mdn/browser-compat-data/pull/20425
  - [x] `font-size: math` https://github.com/mdn/browser-compat-data/pull/20417

__Bugzilla:__
- Enabled by default https://bugzilla.mozilla.org/show_bug.cgi?id=1845516
- Implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1667090