### PR TITLE
fix: aspect-ratio example not loading in iframe

### DIFF
--- a/files/en-us/web/css/@media/aspect-ratio/index.md
+++ b/files/en-us/web/css/@media/aspect-ratio/index.md
@@ -62,7 +62,7 @@ Note that, when none of the media query conditions are true, the background will
 
 <iframe
   id="outer"
-  src="data:text/html,<style> @media (min-aspect-ratio: 8/5) { div { background: %239af; } } @media (max-aspect-ratio: 3/2) { div { background: %239ff; } } @media (aspect-ratio: 1/1) { div { background: %23f9a; } }</style><div id='inner'> Watch this element as you resize your viewport's width and height.</div>">
+  srcdoc="<style> @media (min-aspect-ratio: 8/5) { div { background: #9af; } } @media (max-aspect-ratio: 3/2) { div { background: #9ff; } } @media (aspect-ratio: 1/1) { div { background: #f9a; } }</style><div id='inner'> Watch this element as you resize your viewport's width and height.</div>">
 </iframe>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Move iframe content in the https://developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio article from a data-uri in a `src` attribute, to the well-supported `srcdoc` attribute.

### Motivation

Fixes the linked issue below, where the example doesn't load due to CSP.
Also makes this more maintainable, as there's no need to urlencode anything.

### Related issues and pull requests

Fixes https://github.com/mdn/yari/issues/9444, see: https://developer.mozilla.org/en-US/play?id=Hexi1LnKtGpALECtpZnhqz81CmZoS5znZQBu%2Fq5QOIEJbt6yvEvPzFPorvOH4Lc%2BvigQPqujTgaa5%2Bh3
