### PR TITLE
fix: svg script example didn't work in playground

### DIFF
--- a/files/en-us/web/svg/element/script/index.md
+++ b/files/en-us/web/svg/element/script/index.md
@@ -13,36 +13,38 @@ The SVG `script` element allows to add scripts to an SVG document.
 
 ## Example
 
-```html-nolint
+```html
 Click the circle to change colors.
-<svg viewBox="0 0 10 10" height="120px" width="120px" xmlns="http://www.w3.org/2000/svg">
+<svg
+  viewBox="0 0 10 10"
+  height="120px"
+  width="120px"
+  xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5" cy="5" r="4" />
+
   <script>
     // <![CDATA[
-    window.addEventListener("DOMContentLoaded", () => {
-      function getColor() {
-        const R = Math.round(Math.random() * 255)
-          .toString(16)
-          .padStart(2, "0");
+    function getColor() {
+      const R = Math.round(Math.random() * 255)
+        .toString(16)
+        .padStart(2, "0");
 
-        const G = Math.round(Math.random() * 255)
-          .toString(16)
-          .padStart(2, "0");
+      const G = Math.round(Math.random() * 255)
+        .toString(16)
+        .padStart(2, "0");
 
-        const B = Math.round(Math.random() * 255)
-          .toString(16)
-          .padStart(2, "0");
+      const B = Math.round(Math.random() * 255)
+        .toString(16)
+        .padStart(2, "0");
 
-        return `#${R}${G}${B}`;
-      }
+      return `#${R}${G}${B}`;
+    }
 
-      document.querySelector("circle").addEventListener("click", (e) => {
-        e.target.style.fill = getColor();
-      });
+    document.querySelector("circle").addEventListener("click", (e) => {
+      e.target.style.fill = getColor();
     });
     // ]]>
   </script>
-
-  <circle cx="5" cy="5" r="4" />
 </svg>
 ```
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Don't listen to the `DOMContentLoaded` event, which doesn't currently fire in the playground, and is unnecessary here if we move the `<script>` after the `<circle>`
- Also lint this codeblock

### Motivation

Fixes the broken example in https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script#example

### Related issues and pull requests

Relates to https://github.com/mdn/yari/issues/9409

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
