### PR TITLE
Remove comment wrap from quotes css example

### DIFF
--- a/files/en-us/web/css/quotes/index.md
+++ b/files/en-us/web/css/quotes/index.md
@@ -109,9 +109,9 @@ For most browsers, the default value of `quotes` is `auto` (Firefox 70+), or the
 #### CSS
 
 ```css
-/*q {
+q {
   quotes: auto;
-}*/
+}
 ```
 
 #### Result


### PR DESCRIPTION
### Description

Remove the comment markers around the quote css example.

### Motivation

From light anecdotal evidence, I haven't seen this syntax in use on other MDN pages, and it feels like this example was done in error.

**[Current](https://developer.mozilla.org/en-US/docs/Web/CSS/quotes#css_2):**

<img width="532" alt="CleanShot 2023-08-08 at 11 12 08@2x" src="https://github.com/rijkvanzanten/content/assets/9141017/9fd07e59-a18c-4cca-b2d3-638c01b812b8">

**[Another example](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action)**, note how they're not commented out:

<img width="653" alt="CleanShot 2023-08-08 at 11 12 32@2x" src="https://github.com/rijkvanzanten/content/assets/9141017/955bf85d-14e2-4d25-8cf8-8b051e80073f">



### Additional details

Erroneous example location on live site: https://developer.mozilla.org/en-US/docs/Web/CSS/quotes#css_2

### Related issues and pull requests

n/a