### PR TITLE
Fix column-gap description.

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -179,7 +179,7 @@ In this live example, I have flex items arranged into a row with the basic flex 
 
 ## Creating gaps between items
 
-To create a gap between flex items, use the {{cssxref("gap")}}, {{cssxref("column-gap")}}, and {{cssxref("row-gap")}} properties. The {{cssxref("column-gap")}} property creates gaps between items on the main axis. The {{cssxref("row-gap")}} property creates gaps between flex lines, when you have {{cssxref("flex-wrap")}} set to `wrap`. The {{cssxref("gap")}} property is a shorthand that sets both together.
+To create a gap between flex items, use the {{cssxref("gap")}}, {{cssxref("column-gap")}}, and {{cssxref("row-gap")}} properties. The {{cssxref("column-gap")}} property creates gaps between items in a row. The {{cssxref("row-gap")}} property creates gaps between flex lines, when you have {{cssxref("flex-wrap")}} set to `wrap`. The {{cssxref("gap")}} property is a shorthand that sets both together.
 
 {{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 700)}}
 


### PR DESCRIPTION
`column-gap` does not always add spacing along the main-axis and is oblivious to the `flex-direction`.

### Description

`column-gap` does not always work along the main-axis. It is oblivious to the `flex-direction`. 

As an example:

```css
.box {
  display: flex;
  column-gap: 10px;
  flex-direction: column
}

.box > * {
  flex: 1;
}
```

```html
<div class="box">
  <div>One</div>
  <div>Two</div>
  <div>Three</div>
  <div>Four</div>
  <div>Five</div>
  <div>Six</div>
</div>
```

Here, the main axis is column, but `column-gap` is not used to add space between items because `column-gap` only adds gaps between items in a row.

### Motivation

Hopefully, this fixes an inaccuracy.

### Additional details

It might also be nice to mention that almost all flex properties work with respect to the main and cross axes determined by `flex-direction` except for `gap`, `row-gap`, and `column-gap` which ignore flex direction. However, I did not include that edit in this pull request.

Thanks! MDN is great!

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/14415