### PR TITLE
fix: remove typo

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -247,7 +247,7 @@ After following the instructions above, try playing with the values in other way
 
 `em` and `rem` are the two relative lengths you are likely to encounter most frequently when sizing anything from boxes to text. It's worth understanding how these work, and the differences between them, especially when you start getting on to more complex subjects like [styling text](/en-US/docs/Learn/CSS/Styling_text) or [CSS layout](/en-US/docs/Learn/CSS/CSS_layout). The below example provides a demonstration.
 
-The HTML illustrated below is a set of nested lists — we have three lists in total and both examples have the same HTML. The only difference is that the first has a class of _ems_ and the second a class of _rems_.
+The HTML illustrated below is a set of nested lists — we have two lists in total and both examples have the same HTML. The only difference is that the first has a class of _ems_ and the second a class of _rems_.
 
 To start with, we set 16px as the font size on the `<html>` element.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixed a typo in CSS values and units > [ems and rems](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#:~:text=The%20HTML%20illustrated%20below%20is%20a%20set%20of%20nested%20lists%20%E2%80%94%20we%20have%20three%20lists%20in%20total%20and%20both%20examples%20have%20the%20same%20HTML.%20The%20only%20difference%20is%20that%20the%20first%20has%20a%20class%20of%20ems%20and%20the%20second%20a%20class%20of%20rems.) The nested list example has only two lists but the text says as three.

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
I use the MDN web docs frequently and I wanna help wherever I can. These changes will fix a typo and prevent confusion among readers.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
