### PR TITLE
Update Response.redirect with more info about status codes

### DIFF
--- a/files/en-us/web/api/response/redirect_static/index.md
+++ b/files/en-us/web/api/response/redirect_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Response.redirect_static
 
 The **`redirect()`** static method of the {{domxref("Response")}} interface returns a `Response` resulting in a redirect to the specified URL.
 
-> **Note:** This is mainly relevant to the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API).
+> **Note:** This can be used alongside the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API).
 > A controlling service worker could intercept a page's request and redirect it as desired.
 > This will actually lead to a real redirect if a service worker sends it upstream.
 
@@ -26,7 +26,7 @@ Response.redirect(url, status)
 - `url`
   - : The URL that the new response is to originate from.
 - `status` {{optional_inline}}
-  - : An optional status code for the response (e.g., `302`.)
+  - : An optional number indicating the status code for the response: one of {{HTTPStatus("301", "301")}}, {{HTTPStatus("302", "302")}}, {{HTTPStatus("303", "303")}}, {{HTTPStatus("307", "307")}}, or {{HTTPStatus("308", "308")}}. If omitted, {{HTTPStatus("302", "302 (Found)")}} is used by default.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Update Response.redirect with more info about status codes

### Motivation

Current page doesn't make it clear that 302 is used by default, nor the other possible allowed values.

### Additional details

https://fetch.spec.whatwg.org/#dom-response-redirect-url-status-status
> ```idl
> [NewObject] static Response redirect(USVString url, optional unsigned short status = 302);
> ```

https://fetch.spec.whatwg.org/#dom-response-redirect
> If status is not a [redirect status](https://fetch.spec.whatwg.org/#redirect-status), then [throw](https://webidl.spec.whatwg.org/#dfn-throw) a [RangeError](https://webidl.spec.whatwg.org/#exceptiondef-rangeerror).

https://fetch.spec.whatwg.org/#redirect-status
> A redirect status is a [status](https://fetch.spec.whatwg.org/#concept-status) that is 301, 302, 303, 307, or 308.

### Related issues and pull requests

N/A