### PR TITLE
Add @property "see also" links in related pages

### DIFF
--- a/files/en-us/web/css/--_star_/index.md
+++ b/files/en-us/web/css/--_star_/index.md
@@ -88,3 +88,4 @@ Custom properties are scoped to the element(s) they are declared on, and partici
 
 - [Using CSS variables](/en-US/docs/Web/CSS/Using_CSS_custom_properties)
 - The {{cssxref("var", "var()")}} function
+- {{cssxref("@property")}} at-rule

--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -311,3 +311,4 @@ element.style.setProperty("--my-var", jsVar + 4);
 
 - [Custom property syntax](/en-US/docs/Web/CSS/--*)
 - [`var()`](/en-US/docs/Web/CSS/var)
+- {{cssxref("@property")}} at-rule

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -196,3 +196,4 @@ Since `--main-bg-color` isn't set, the body's `background-color` will fall back 
 
 - {{cssxref("env","env(…)")}} – read‑only environment variables controlled by the user‑agent.
 - [Using CSS variables](/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+- {{cssxref("@property")}} at-rule


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add "see also" links about `@property` CSS at-rule in some related pages:
- https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties
- [https://developer.mozilla.org/en-US/docs/Web/CSS/--*](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)
- https://developer.mozilla.org/en-US/docs/Web/CSS/var

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

`@property` allows developers to define css variables more explicitly and with more control, but there is no mention of it in the basic css variables documentation. Adding it in the "see also" sections would help for better discoverability, and easier navigation between these related features.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
