### PR TITLE
Remove redundant "on the web" on CLI guides note

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -118,7 +118,7 @@ Enough talk — let's start looking at some terminal commands! Out of the box, h
 - View a file's contents page by page: `less`, `cat`
 - Manipulate and transform streams of text (for example changing all the instances of `<div>`s in an HTML file to `<article>`): `awk`, `tr`, `sed`
 
-> **Note:** There are a number of good tutorials on the web that go much deeper into the command line on the web — this is only a brief introduction!
+> **Note:** There are a number of good tutorials on the web that go much deeper into the command line — this is only a brief introduction!
 
 Let's move forward and look at using a few of these tools on the command line. Before you go any further, open your terminal program!
 


### PR DESCRIPTION
### Description

Remove extra `on the web` on a note's sentence.

### Motivation

Correcting a typo or phrase reformulation.
