### PR TITLE
fix(CI): reorder workflow steps, pass in .nvmrc config

### DIFF
--- a/.github/workflows/interfacedata-updater.yml
+++ b/.github/workflows/interfacedata-updater.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-
       - name: Checkout content
         uses: actions/checkout@v3
         with:
           path: mdn-content
           ref: main
+
+      - name: Setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: "mdn-content/.nvmrc"
 
       - name: Checkout webref
         uses: actions/checkout@v3


### PR DESCRIPTION
We're trying to pick up `.nvmrc` configuration before the clone / checkout step. Reordering the steps and passing in the correct path to the config file.

Fixes #28484