### PR TITLE
Doc(shadow dom): type fix

### DIFF
--- a/files/en-us/web/api/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/api/web_components/using_shadow_dom/index.md
@@ -121,7 +121,7 @@ const wrapper = document.createElement("span");
 wrapper.setAttribute("class", "wrapper");
 const icon = document.createElement("span");
 icon.setAttribute("class", "icon");
-icon.setAttribute("tabindex", 0);
+icon.setAttribute("tabindex", "0");
 const info = document.createElement("span");
 info.setAttribute("class", "info");
 


### PR DESCRIPTION
name on `icon.setAttribute("tabindex", name);` requires a [stringDom type](https://developer.mozilla.org/fr/docs/Web/API/Element/setAttribute) even if it's displayed as a number. icon.setAttribute("tabindex", 0); > icon.setAttribute("tabindex", "0");

### Description

Fix type of setAttrbutes

### Motivation

Im doing this because I got some errors by following the documentation with typescript
