### PR TITLE
fix(SVG): Minor rewrite of example to avoid line wrapping

### DIFF
--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.md
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.md
@@ -37,35 +37,28 @@ svg {
 
 ```html
 <svg viewBox="0 0 30 12" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    line {
+      stroke: black;
+    }
+  </style>
   <!-- No dashes nor gaps -->
-  <line x1="0" y1="1" x2="30" y2="1" stroke="black" />
+  <line x1="0" y1="1" x2="30" y2="1" />
 
   <!-- Dashes and gaps of the same size -->
-  <line x1="0" y1="3" x2="30" y2="3" stroke="black" stroke-dasharray="4" />
+  <line x1="0" y1="3" x2="30" y2="3" stroke-dasharray="4" />
 
   <!-- Dashes and gaps of different sizes -->
-  <line x1="0" y1="5" x2="30" y2="5" stroke="black" stroke-dasharray="4 1" />
+  <line x1="0" y1="5" x2="30" y2="5" stroke-dasharray="4 1" />
 
   <!-- Dashes and gaps of various sizes with an odd number of values -->
-  <line x1="0" y1="7" x2="30" y2="7" stroke="black" stroke-dasharray="4 1 2" />
+  <line x1="0" y1="7" x2="30" y2="7" stroke-dasharray="4 1 2" />
 
   <!-- Dashes and gaps of various sizes with an even number of values -->
-  <line
-    x1="0"
-    y1="9"
-    x2="30"
-    y2="9"
-    stroke="black"
-    stroke-dasharray="4 1 2 3" />
+  <line x1="0" y1="9" x2="30" y2="9" stroke-dasharray="4 1 2 3" />
 
   <!-- Dashes starting with a gap -->
-  <line
-    x1="0"
-    y1="11"
-    x2="30"
-    y2="11"
-    stroke="black"
-    stroke-dasharray="0 4 0" />
+  <line x1="0" y1="11" x2="30" y2="11" stroke-dasharray="0 4 0" />
 </svg>
 ```
 


### PR DESCRIPTION
Extracting out the style for strokes in this SVG to avoid line wrapping and lines can be compared visually (vertically) as we move line-by-line through the example code:

__Before:__

```html
<svg viewBox="0 0 30 12" xmlns="http://www.w3.org/2000/svg">
  <!-- No dashes nor gaps -->
  <line x1="0" y1="1" x2="30" y2="1" stroke="black" />

  <!-- Dashes and gaps of the same size -->
  <line x1="0" y1="3" x2="30" y2="3" stroke="black" stroke-dasharray="4" />

  <!-- Dashes and gaps of different sizes -->
  <line x1="0" y1="5" x2="30" y2="5" stroke="black" stroke-dasharray="4 1" />

  <!-- Dashes and gaps of various sizes with an odd number of values -->
  <line x1="0" y1="7" x2="30" y2="7" stroke="black" stroke-dasharray="4 1 2" />

  <!-- Dashes and gaps of various sizes with an even number of values -->
  <line
    x1="0"
    y1="9"
    x2="30"
    y2="9"
    stroke="black"
    stroke-dasharray="4 1 2 3" />

  <!-- Dashes starting with a gap -->
  <line
    x1="0"
    y1="11"
    x2="30"
    y2="11"
    stroke="black"
    stroke-dasharray="0 4 0" />
</svg>
```

__After:__

```html
<svg viewBox="0 0 30 12" xmlns="http://www.w3.org/2000/svg">
  <style>
    line {
      stroke: black;
    }
  </style>
  <!-- No dashes nor gaps -->
  <line x1="0" y1="1" x2="30" y2="1" />

  <!-- Dashes and gaps of the same size -->
  <line x1="0" y1="3" x2="30" y2="3" stroke-dasharray="4" />

  <!-- Dashes and gaps of different sizes -->
  <line x1="0" y1="5" x2="30" y2="5" stroke-dasharray="4 1" />

  <!-- Dashes and gaps of various sizes with an odd number of values -->
  <line x1="0" y1="7" x2="30" y2="7" stroke-dasharray="4 1 2" />

  <!-- Dashes and gaps of various sizes with an even number of values -->
  <line x1="0" y1="9" x2="30" y2="9" stroke-dasharray="4 1 2 3" />

  <!-- Dashes starting with a gap -->
  <line x1="0" y1="11" x2="30" y2="11" stroke-dasharray="0 4 0" />
</svg>
```


Fixes https://github.com/mdn/content/issues/28490