### PR TITLE
Make most code blocks parseable

### DIFF
--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -362,13 +362,13 @@ try {
 You can use a `catch` block to handle all exceptions that may be generated
 in the `try` block.
 
-```js
-catch (catchID) {
+```js-nolint
+catch (exception) {
   statements
 }
 ```
 
-The `catch` block specifies an identifier (`catchID`
+The `catch` block specifies an identifier (`exception`
 in the preceding syntax) that holds the value specified by the `throw`
 statement. You can use this identifier to get information about the exception that was
 thrown.

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -123,15 +123,19 @@ It is an error to assign values to unmodifiable properties or to properties of a
 For more complex assignments, the [destructuring assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax is a JavaScript expression that makes it possible to extract data from arrays or objects using a syntax that mirrors the construction of array and
 object literals.
 
+Without destructuring, it takes multiple statements to extract values from arrays and objects:
+
 ```js
 const foo = ["one", "two", "three"];
 
-// without destructuring
 const one = foo[0];
 const two = foo[1];
 const three = foo[2];
+```
 
-// with destructuring
+With destructuring, you can extract multiple values into distinct variables using a single statement:
+
+```js
 const [one, two, three] = foo;
 ```
 
@@ -1101,7 +1105,7 @@ a * c + b * c // 9
 You can use the [`new` operator](/en-US/docs/Web/JavaScript/Reference/Operators/new) to create an instance of a user-defined object type or of one of the built-in object types. Use `new` as follows:
 
 ```js
-const objectName = new objectType(param1, param2, /* …, */ paramN);
+const objectName = new ObjectType(param1, param2, /* …, */ paramN);
 ```
 
 ### super
@@ -1109,7 +1113,7 @@ const objectName = new objectType(param1, param2, /* …, */ paramN);
 The [`super` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/super) is used to call functions on an object's parent.
 It is useful with [classes](/en-US/docs/Web/JavaScript/Reference/Classes) to call the parent constructor, for example.
 
-```js
+```js-nolint
 super(args); // calls the parent constructor.
 super.functionOnParent(args);
 ```

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -28,11 +28,7 @@ function square(number) {
 }
 ```
 
-The function `square` takes one parameter, called `number`. The function consists of one statement that says to return the parameter of the function (that is, `number`) multiplied by itself. The statement [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) specifies the value returned by the function:
-
-```js
-return number * number;
-```
+The function `square` takes one parameter, called `number`. The function consists of one statement that says to return the parameter of the function (that is, `number`) multiplied by itself. The [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement specifies the value returned by the function, which is `number * number`.
 
 Parameters are essentially passed to functions **by value** — so if the code within the body of a function assigns a completely new value to a parameter that was passed to the function, **the change is not reflected globally or in the code which called that function**.
 

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -44,7 +44,7 @@ The syntax of **comments** is the same as in C++ and in many other languages:
 
 You can't nest block comments. This often happens when you accidentally include a `*/` sequence in your comment, which will terminate the comment.
 
-```js example-bad
+```js-nolint example-bad
 /* You can't, however, /* nest comments */ SyntaxError */
 ```
 
@@ -105,7 +105,7 @@ In essence, `let x = 42` is equivalent to `let x; x = 42`.
 
 `const` declarations always need an initializer, because they forbid any kind of assignment after declaration, and implicitly initializing it with `undefined` is likely a programmer mistake.
 
-```js example-bad
+```js-nolint example-bad
 const x; // SyntaxError: Missing initializer in const declaration
 ```
 
@@ -205,7 +205,7 @@ A constant cannot change value through assignment or be re-declared while the sc
 
 You cannot declare a constant with the same name as a function or variable in the same scope. For example:
 
-```js example-bad
+```js-nolint example-bad
 // THIS WILL CAUSE AN ERROR
 function f() {}
 const f = 5;
@@ -214,8 +214,6 @@ const f = 5;
 function f() {
   const g = 5;
   var g;
-
-  //statements
 }
 ```
 
@@ -488,7 +486,7 @@ Object property names can be any string, including the empty string. If the prop
 
 Property names that are not valid identifiers cannot be accessed as a dot (`.`) property.
 
-```js example-bad
+```js-nolint example-bad
 const unusualPropertyNames = {
   '': 'An empty string',
   '!': 'Bang!'

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -59,14 +59,21 @@ const obj = { prop: [element0, element1, /* …, */ elementN] };
 
 If you wish to initialize an array with a single element, and the element happens to be a `Number`, you must use the bracket syntax. When a single `Number` value is passed to the `Array()` constructor or function, it is interpreted as an `arrayLength`, not as a single element.
 
+This creates an array with only one element: the number 42.
+
 ```js
-// This creates an array with only one element: the number 42.
 const arr = [42];
+```
 
-// This creates an array with no elements and arr.length set to 42.
+This creates an array with no elements and `arr.length` set to 42.
+
+```js
 const arr = Array(42);
+```
 
-// This is equivalent to:
+This is equivalent to:
+
+```js
 const arr = [];
 arr.length = 42;
 ```

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -226,17 +226,7 @@ label:
 
 The value of `label` may be any JavaScript identifier that is not a
 reserved word. The `statement` that you identify with a label may be
-any statement.
-
-### Example
-
-In this example, the label `markLoop` identifies a `while` loop.
-
-```js
-markLoop: while (theMark) {
-  doSomething();
-}
-```
+any statement. For examples of using labeled statements, see the examples of `break` and `continue` below.
 
 ## break statement
 
@@ -251,7 +241,7 @@ Use the {{jsxref("statements/break","break")}} statement to terminate a loop,
 
 The syntax of the `break` statement looks like this:
 
-```js
+```js-nolint
 break;
 break label;
 ```
@@ -311,7 +301,7 @@ statement.
 
 The syntax of the `continue` statement looks like the following:
 
-```js
+```js-nolint
 continue;
 continue label;
 ```
@@ -334,7 +324,8 @@ while (i < 5) {
   n += i;
   console.log(n);
 }
-//1,3,7,12
+// Logs:
+// 1 3 7 12
 ```
 
 If you comment out the `continue;`, the loop would run till the end and you would see `1,3,6,10,15`.

--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.md
@@ -371,7 +371,7 @@ const endYear = new Date(1995, 11, 31, 23, 59, 59, 999); // Set day and month
 endYear.setFullYear(today.getFullYear()); // Set year to this year
 const msPerDay = 24 * 60 * 60 * 1000; // Number of milliseconds per day
 let daysLeft = (endYear.getTime() - today.getTime()) / msPerDay;
-daysLeft = Math.round(daysLeft); //returns days left in the year
+daysLeft = Math.round(daysLeft); // Returns days left in the year
 ```
 
 This example creates a `Date` object named `today` that contains today's date. It then creates a `Date` object named `endYear` and sets the year to the current year. Then, using the number of milliseconds per day, it computes the number of days between `today` and `endYear`, using `getTime` and rounding to a whole number of days.

--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -348,7 +348,7 @@ console.log(red.getRed()); // 255
 
 Accessing private fields outside the class is an early syntax error. The language can guard against this because `#privateField` is a special syntax, so it can do some static analysis and find all usage of private fields before even evaluating the code.
 
-```js example-bad
+```js-nolint example-bad
 console.log(red.#values); // SyntaxError: Private field '#values' must be declared in an enclosing class
 ```
 
@@ -423,7 +423,7 @@ class Color {
 
 There are some limitations in using private properties: the same name can't be declared twice in a single class, and they can't be deleted. Both lead to early syntax errors.
 
-```js example-bad
+```js-nolint example-bad
 class BadIdeas {
   #firstName;
   #firstName; // syntax error occurs here
@@ -690,7 +690,7 @@ console.log(ColorWithAlpha.isValid(255, 0, 0, -1)); // false
 
 Derived classes don't have access to the parent class's private fields — this is another key aspect to JavaScript private fields being "hard private". Private fields are scoped to the class body itself and do not grant access to _any_ outside code.
 
-```js example-bad
+```js-nolint example-bad
 class ColorWithAlpha extends Color {
   log() {
     console.log(this.#values); // SyntaxError: Private field '#values' must be declared in an enclosing class

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -167,7 +167,7 @@ console.log(Pi); // 3.14
 
 A variable declared with `const` cannot be reassigned.
 
-```js example-bad
+```js-nolint example-bad
 const Pi = 3.14;
 Pi = 1; // will throw an error because you cannot change a constant variable.
 ```

--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -50,13 +50,13 @@ otto.introduce(); // Hello, my name is Otto
 If you don't provide your own constructor, then a default constructor will be supplied for you.
 If your class is a base class, the default constructor is empty:
 
-```js
+```js-nolint
 constructor() {}
 ```
 
 If your class is a derived class, the default constructor calls the parent constructor, passing along any arguments that were provided:
 
-```js
+```js-nolint
 constructor(...args) {
   super(...args);
 }

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -55,19 +55,18 @@ Private properties are declared with **# names** (pronounced "hash names"), whic
 
 It is a syntax error to refer to `#` names from outside of the class. It is also a syntax error to refer to private properties that were not declared in the class body, or to attempt to remove declared properties with [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete).
 
-```js example-bad
+```js-nolint example-bad
 class ClassWithPrivateField {
   #privateField;
 
-  constructor() {
-    this.#privateField = 42;
+  constructor() {;
     delete this.#privateField; // Syntax error
-    this.#undeclaredField = 444; // Syntax error
+    this.#undeclaredField = 42; // Syntax error
   }
 }
 
 const instance = new ClassWithPrivateField();
-instance.#privateField === 42; // Syntax error
+instance.#privateField; // Syntax error
 ```
 
 JavaScript, being a dynamic language, is able to perform this compile-time check because of the special hash identifier syntax, making it different from normal properties on the syntax level.

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -215,7 +215,7 @@ Legacy generator function statements and legacy generator function expressions a
 
 Array comprehensions and generator comprehensions are removed.
 
-```js
+```js-nolint
 // Legacy array comprehensions
 [for (x of iterable) x]
 [for (x of iterable) if (condition) x]

--- a/files/en-us/web/javascript/reference/errors/bad_await/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_await/index.md
@@ -49,7 +49,7 @@ Instead, make the script a module:
 
 You cannot use `await` in a sync callback:
 
-```js example-bad
+```js-nolint example-bad
 urls.forEach((url) => {
   await fetch(url);
   // SyntaxError: await is only valid in async functions, async generators and modules
@@ -59,9 +59,11 @@ urls.forEach((url) => {
 Instead, make the callback async. See more explanation in the [Using promises guide](/en-US/docs/Web/JavaScript/Guide/Using_promises#composition).
 
 ```js example-good
-Promise.all(urls.map(async (url) => {
-  await fetch(url);
-});
+Promise.all(
+  urls.map(async (url) => {
+    await fetch(url);
+  }),
+);
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/errors/bad_break/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_break/index.md
@@ -30,7 +30,7 @@ SyntaxError: 'break' is only valid inside a switch or loop statement. (Safari)
 
 `break` cannot be used outside `switch` or loops.
 
-```js example-bad
+```js-nolint example-bad
 let score = 0;
 
 function increment() {
@@ -47,7 +47,7 @@ Maybe instead of `break`, you intend to use {{jsxref("Statements/return", "retur
 let score = 0;
 
 function increment() {
-  if (score === 100)
+  if (score === 100) {
     return;
   }
   score++;
@@ -58,7 +58,7 @@ function increment() {
 
 `break` cannot be used in callbacks, even if the callback is called from a loop.
 
-```js example-bad
+```js-nolint example-bad
 let containingIndex = 0;
 const matrix = [
   [1, 2, 3],
@@ -98,10 +98,14 @@ outer: while (containingIndex < matrix.length) {
 
 ```js example-good
 let containingIndex = 0;
-const matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+const matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
 
 while (containingIndex < matrix.length) {
-  if (matrix[containingIndex].includes(5))
+  if (matrix[containingIndex].includes(5)) {
     break;
   }
   containingIndex++;
@@ -110,7 +114,7 @@ while (containingIndex < matrix.length) {
 
 There's no way to early-terminate a {{jsxref("Array/forEach", "forEach()")}} loop. You can use {{jsxref("Array/some", "some()")}} instead, or convert it to a {{jsxref("Statements/for...of", "for...of")}} loop.
 
-```js example-bad
+```js-nolint example-bad
 array.forEach((value) => {
   if (value === 5) {
     break; // SyntaxError: unlabeled break must be inside loop or switch
@@ -125,6 +129,7 @@ array.some((value) => {
     return true;
   }
   // do something with value
+  return false;
 });
 ```
 

--- a/files/en-us/web/javascript/reference/errors/bad_continue/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_continue/index.md
@@ -32,7 +32,7 @@ SyntaxError: Cannot continue to the label 'label' as it is not targeting a loop.
 
 If you want to proceed with the next iteration in a {{jsxref("Array/forEach", "forEach()")}} loop, use {{jsxref("Statements/return", "return")}} instead, or convert it to a {{jsxref("Statements/for...of", "for...of")}} loop.
 
-```js example-bad
+```js-nolint example-bad
 array.forEach((value) => {
   if (value === 5) {
     continue; // SyntaxError: continue must be inside loop

--- a/files/en-us/web/javascript/reference/errors/bad_return/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_return/index.md
@@ -28,7 +28,7 @@ A [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement i
 
 ### Missing curly brackets
 
-```js example-bad
+```js-nolint example-bad
 function cheer(score) {
   if (score === 147)
     return "Maximum!";

--- a/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
@@ -49,7 +49,7 @@ a ?? (b && c);
 
 When migrating legacy code that uses `||` and `&&` for guarding against `null` or `undefined`, you may often convert it partially:
 
-```js example-bad
+```js-nolint example-bad
 function getId(user, fallback) {
   // Previously: user && user.id || fallback
   return user && user.id ?? fallback; // SyntaxError: cannot use `??` unparenthesized within `||` and `&&` expressions

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -34,9 +34,9 @@ This error only happens in [strict mode code](/en-US/docs/Web/JavaScript/Referen
 
 ### Freeing the contents of a variable
 
-Attempting to delete a plain variable, doesn't work in JavaScript and it throws an error in strict mode:
+Attempting to delete a plain variable throws an error in strict mode:
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 var x;

--- a/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_octal/index.md
@@ -37,7 +37,7 @@ letter "O" (`0o` or `0O`).
 
 ### "0"-prefixed octal literals
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 03;
@@ -47,7 +47,7 @@ letter "O" (`0o` or `0O`).
 
 ### Octal escape sequences
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 
 "\251";

--- a/files/en-us/web/javascript/reference/errors/either_be_both_static_or_non-static/index.md
+++ b/files/en-us/web/javascript/reference/errors/either_be_both_static_or_non-static/index.md
@@ -28,7 +28,7 @@ Private [getters](/en-US/docs/Web/JavaScript/Reference/Functions/get) and [sette
 
 ### Mismatched placement
 
-```js example-bad
+```js-nolint example-bad
 class Test {
   static set #foo(_) {}
   get #foo() {}

--- a/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
+++ b/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
@@ -35,7 +35,7 @@ line of a file, or accidentally forgetting the quotation marks around a DOM iden
 
 For each case, there might be something slightly wrong. For example
 
-```js example-bad
+```js-nolint example-bad
 document.querySelector(#some-element)
 ```
 
@@ -47,7 +47,7 @@ document.querySelector("#some-element");
 
 ### Outside of a class
 
-```js example-bad
+```js-nolint example-bad
 class ClassWithPrivateField {
   #privateField;
 

--- a/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
@@ -36,7 +36,7 @@ They can't start with a digit! Only subsequent characters can be digits (0-9).
 
 Variable names can't start with numbers in JavaScript. The following fails:
 
-```js example-bad
+```js-nolint example-bad
 const 1life = "foo";
 // SyntaxError: identifier starts immediately after numeric literal
 

--- a/files/en-us/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/en-us/web/javascript/reference/errors/illegal_character/index.md
@@ -36,7 +36,7 @@ Some characters look similar, but will cause the parser to fail interpreting you
 Famous examples of this are quotes, the minus or semicolon
 ([greek question mark (U+37e)](https://en.wikipedia.org/wiki/Question_mark#Greek_question_mark) looks same).
 
-```js example-bad
+```js-nolint example-bad
 “This looks like a string”; // SyntaxError: illegal character
 // “ and ” are not " but look like it
 
@@ -61,7 +61,7 @@ Some editors and IDEs will notify you or at least use a slightly different highl
 
 It's easy to forget a character here or there.
 
-```js example-bad
+```js-nolint example-bad
 const colors = ["#000", #333", "#666"];
 // SyntaxError: illegal character
 ```
@@ -77,7 +77,7 @@ const colors = ["#000", "#333", "#666"];
 When copy pasting code from external sources, there might be invalid characters. Watch
 out!
 
-```js example-bad
+```js-nolint example-bad
 const foo = "bar";​
 // SyntaxError: illegal character
 ```

--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -28,7 +28,7 @@ There was an unexpected assignment somewhere. This might be due to a mismatch of
 
 ### Typical invalid assignments
 
-```js example-bad
+```js-nolint example-bad
 if (Math.PI + 1 = 3 || Math.PI + 1 = 4) {
   console.log("no way!");
 }
@@ -56,7 +56,7 @@ const str = "Hello, "
 
 Invalid assignments don't always produce syntax errors. Sometimes the syntax is almost correct, but at runtime, the left hand side expression evaluates to a _value_ instead of a _reference_, so the assignment is still invalid. Such errors occur later in execution, when the line is actually executed.
 
-```js example-bad
+```js-nolint example-bad
 function foo() {
   return { a: 1 };
 }
@@ -78,7 +78,7 @@ foo().a = 1;
 
 [Optional chaining](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) is not a valid target of assignment.
 
-```js example-bad
+```js-nolint example-bad
 obj?.foo = 1; // SyntaxError: invalid assignment left-hand side
 ```
 

--- a/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -36,7 +36,7 @@ In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), however, a `
 
 This example throws a `SyntaxError`:
 
-```js example-bad
+```js-nolint example-bad
 const obj = { a: 1, b: 2, c: 3 };
 
 for (const i = 0 in obj) {

--- a/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -28,7 +28,7 @@ The head of a [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...o
 
 ### Invalid for-of loop
 
-```js example-bad
+```js-nolint example-bad
 const iterable = [10, 20, 30];
 
 for (const value = 50 of iterable) {

--- a/files/en-us/web/javascript/reference/errors/label_not_found/index.md
+++ b/files/en-us/web/javascript/reference/errors/label_not_found/index.md
@@ -30,7 +30,7 @@ In JavaScript, [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label) a
 
 You cannot use labels as if they are `goto`.
 
-```js example-bad
+```js-nolint example-bad
 start: console.log("Hello, world!");
 console.log("Do it again");
 break start;

--- a/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
@@ -30,7 +30,7 @@ closing bracket (`]`) or a comma (`,`) missing.
 
 ### Incomplete array initializer
 
-```js example-bad
+```js-nolint example-bad
 const list = [1, 2,
 
 const instruments = [

--- a/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -40,7 +40,7 @@ const obj = { propertyKey: "value" };
 This code fails, as the equal sign can't be used this way in this object initializer
 syntax.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { propertyKey = "value" };
 // SyntaxError: missing : after property id
 ```
@@ -50,11 +50,13 @@ after the object has been created already.
 
 ```js example-good
 const obj = { propertyKey: "value" };
+```
 
-// or alternatively
+Or alternatively:
 
+```js
 const obj = {};
-obj["propertyKey"] = "value";
+obj.propertyKey = "value";
 ```
 
 ### Computed properties
@@ -62,7 +64,7 @@ obj["propertyKey"] = "value";
 If you create a property key from an expression, you need to use square brackets.
 Otherwise the property name can't be computed:
 
-```js example-bad
+```js-nolint example-bad
 const obj = { "b"+"ar": "foo" };
 // SyntaxError: missing : after property id
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
@@ -32,32 +32,36 @@ a bit nicer might also help you to see through the jungle.
 
 Oftentimes, there is a missing curly bracket in your function code:
 
-```js example-bad
-const charge = function () {
+```js-nolint example-bad
+function charge() {
   if (sunny) {
     useSolarCells();
   } else {
     promptBikeRide();
-};
+}
 ```
 
 Correct would be:
 
 ```js example-good
-const charge = function () {
+function charge() {
   if (sunny) {
     useSolarCells();
   } else {
     promptBikeRide();
   }
-};
+}
 ```
 
-It can be more obscure when using [IIFE](/en-US/docs/Glossary/IIFE), [Closures](/en-US/docs/Web/JavaScript/Closures), or other constructs that use
+It can be more obscure when using [IIFEs](/en-US/docs/Glossary/IIFE) or other constructs that use
 a lot of different parenthesis and curly brackets, for example.
 
-```js example-bad
-(function () { if (true) { return false; } );
+```js-nolint example-bad
+(function () {
+  if (Math.random() < 0.01) {
+    doSomething();
+  }
+)();
 ```
 
 Oftentimes, indenting differently or double checking indentation helps to spot these
@@ -65,10 +69,10 @@ errors.
 
 ```js example-good
 (function () {
-  if (true) {
-    return false;
+  if (Math.random() < 0.01) {
+    doSomething();
   }
-});
+})();
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -35,7 +35,7 @@ also help you to see through the jungle.
 
 Oftentimes, there is a missing comma in your object initializer code:
 
-```js example-bad
+```js-nolint example-bad
 const obj = {
   a: 1,
   b: { myProp: 2 }

--- a/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -42,7 +42,7 @@ identifier is part of the code.
 Function parameters must be identifiers when setting up a function. All these function
 declarations fail, as they are providing values for their parameters:
 
-```js example-bad
+```js-nolint example-bad
 function square(3) {
   return number * number;
 }

--- a/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
@@ -40,7 +40,7 @@ changed later).
 Unlike `var` or `let`, you must specify a value for a
 `const` declaration. This throws:
 
-```js example-bad
+```js-nolint example-bad
 const COLUMNS;
 // SyntaxError: missing = in const declaration
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -38,7 +38,7 @@ case. Please see the examples below.
 in JavaScript use either the dot (.) or square brackets (`[]`), but not both.
 Square brackets allow computed property access.
 
-```js example-bad
+```js-nolint example-bad
 const obj = { foo: { bar: "baz", bar2: "baz2" } };
 const i = 2;
 
@@ -67,7 +67,7 @@ obj.foo[`bar${i}`]; // "baz2"
 If you are coming from another programming language (like [PHP](/en-US/docs/Glossary/PHP)), it is also easy to mix up the dot operator
 (`.`) and the concatenation operator (`+`).
 
-```js example-bad
+```js-nolint example-bad
 console.log("Hello" . "world");
 
 // SyntaxError: missing name after . operator

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -32,7 +32,7 @@ Because there is no "+" operator to concatenate the string, JavaScript expects t
 argument for the `log` function to be just `"PI: "`. In that case,
 it should be terminated by a closing parenthesis.
 
-```js example-bad
+```js-nolint example-bad
 console.log("PI: " Math.PI);
 // SyntaxError: missing ) after argument list
 ```
@@ -53,7 +53,7 @@ console.log("PI:", Math.PI);
 
 ### Unterminated strings
 
-```js example-bad
+```js-nolint example-bad
 console.log('"Java" + "Script" = \"' + "Java" + 'Script\");
 // SyntaxError: missing ) after argument list
 ```

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
@@ -43,7 +43,7 @@ if (condition) {
 
 It might just be an oversight, carefully check all you parenthesis in your code.
 
-```js example-bad
+```js-nolint example-bad
 if (Math.PI < 3 {
   console.log("wait what?");
 }
@@ -64,7 +64,7 @@ if (Math.PI < 3) {
 If you are coming from another programming language, it is also easy to add keywords
 that don't mean the same or have no meaning at all in JavaScript.
 
-```js example-bad
+```js-nolint example-bad
 if (done is true) {
  console.log("we are done!");
 }

--- a/files/en-us/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -41,7 +41,7 @@ many parenthesis somewhere. Carefully check the syntax when this error is thrown
 This error can occur easily when not escaping strings properly and the JavaScript
 engine is expecting the end of your string already. For example:
 
-```js example-bad
+```js-nolint example-bad
 const foo = 'Tom's bar';
 // SyntaxError: missing ; before statement
 ```
@@ -59,7 +59,7 @@ const foo = 'Tom\'s bar';
 You **cannot** declare properties of an object or array with a
 `let`, `const`, or `var` declaration.
 
-```js example-bad
+```js-nolint example-bad
 const obj = {};
 const obj.foo = "hi"; // SyntaxError missing ; before statement
 
@@ -82,7 +82,7 @@ array[0] = "there";
 If you come from another programming language, it is also common to use keywords that
 don't mean the same or have no meaning at all in JavaScript:
 
-```js example-bad
+```js-nolint example-bad
 def print(info) {
   console.log(info);
 } // SyntaxError missing ; before statement

--- a/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
@@ -31,7 +31,7 @@ When declaring multiple variables at the same time, make sure that the previous 
 
 ### Missing a variable name
 
-```js example-bad
+```js-nolint example-bad
 const = "foo";
 ```
 
@@ -46,7 +46,7 @@ const description = "foo";
 There are a few variable names that are [reserved keywords](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords).
 You can't use these. Sorry :(
 
-```js example-bad
+```js-nolint example-bad
 const debugger = "whoop";
 // SyntaxError: missing variable name
 ```
@@ -57,7 +57,7 @@ Pay special attention to commas when declaring multiple variables.
 Is there an excess comma, or did you use commas instead of semicolons?
 Did you remember to assign values for all your `const` variables?
 
-```js example-bad
+```js-nolint example-bad
 let x, y = "foo",
 const z, = "foo"
 
@@ -83,7 +83,7 @@ const second = document.getElementById("two");
 {{jsxref("Array")}} literals in JavaScript need square brackets around the values.
 This won't work:
 
-```js example-bad
+```js-nolint example-bad
 const arr = 1,2,3,4,5;
 // SyntaxError: missing variable name
 ```

--- a/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
@@ -35,7 +35,7 @@ allowed in JavaScript.
 
 In this case, the variable "arg" redeclares the argument.
 
-```js example-bad
+```js-nolint example-bad
 function f(arg) {
   let arg = "foo";
 }

--- a/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
+++ b/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
@@ -46,14 +46,14 @@ The following are only reserved when they are found in strict mode code:
 
 The `enum` identifier is generally reserved.
 
-```js example-bad
+```js-nolint example-bad
 const enum = { RED: 0, GREEN: 1, BLUE: 2 };
 // SyntaxError: enum is a reserved identifier
 ```
 
 In strict mode code, more identifiers are reserved.
 
-```js example-bad
+```js-nolint example-bad
 "use strict";
 const package = ["potatoes", "rice", "fries"];
 // SyntaxError: package is a reserved identifier

--- a/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -45,7 +45,7 @@ the ECMAScript specification.
 In this case, the function `sum` has default parameters `a=1` and
 `b=2`:
 
-```js example-bad
+```js-nolint example-bad
 function sum(a = 1, b = 2) {
   // SyntaxError: "use strict" not allowed in function with default parameter
   "use strict";
@@ -68,7 +68,7 @@ function sum(a = 1, b = 2) {
 
 A function expression can use yet another workaround:
 
-```js example-bad
+```js-nolint example-bad
 const sum = function sum([a, b]) {
   // SyntaxError: "use strict" not allowed in function with destructuring parameter
   "use strict";
@@ -92,7 +92,7 @@ const sum = (function () {
 If an arrow function needs to access the `this` variable, you can use the
 arrow function as the enclosing function:
 
-```js example-bad
+```js-nolint example-bad
 const callback = (...args) => {
   // SyntaxError: "use strict" not allowed in function with rest parameter
   "use strict";

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -35,7 +35,7 @@ be a simple typo.
 
 For example, when chaining expressions, trailing commas are not allowed.
 
-```js example-bad
+```js-nolint example-bad
 for (let i = 0; i < 5,; ++i) {
   console.log(i);
 }
@@ -54,7 +54,7 @@ for (let i = 0; i < 5; ++i) {
 
 Sometimes, you leave out brackets around `if` statements:
 
-```js example-bad
+```js-nolint example-bad
 function round(n, upperBound, lowerBound) {
   if (n > upperBound) || (n < lowerBound) { // Not enough brackets here!
     throw new Error(`Number ${n} is more than ${upperBound} or less than ${lowerBound}`);

--- a/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
@@ -38,20 +38,24 @@ Also, certain methods, such as {{jsxref("Object.create()")}} or
 
 ### Invalid cases
 
+You cannot invoke a method on an `undefined` or `null` variable.
+
 ```js example-bad
-// undefined and null cases on which the substring method won't work
 const foo = undefined;
 foo.substring(1); // TypeError: foo is undefined
 
-const foo = null;
-foo.substring(1); // TypeError: foo is null
+const foo2 = null;
+foo2.substring(1); // TypeError: foo is null
+```
 
-// Certain methods might require a specific type
+Certain methods might require a specific type.
+
+```js example-bad
 const foo = {};
 Symbol.keyFor(foo); // TypeError: foo is not a symbol
 
-const foo = "bar";
-Object.create(foo); // TypeError: "foo" is not an object or null
+const foo2 = "bar";
+Object.create(foo2); // TypeError: "foo" is not an object or null
 ```
 
 ### Fixing the issue

--- a/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -34,7 +34,7 @@ You'll need to check how functions are defined and if you need to provide a name
 A _[function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function)_ (or _function declaration_) requires a name.
 This won't work:
 
-```js example-bad
+```js-nolint example-bad
 function () {
   return "Hello world";
 }
@@ -59,10 +59,9 @@ If your function is intended to be an [IIFE](https://en.wikipedia.org/wiki/Immed
 
 ### Labeled functions
 
-If you are using function [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label), you will still need to provide a function name after the `function` keyword.
-This doesn't work:
+[Labels](/en-US/docs/Web/JavaScript/Reference/Statements/label) are an entirely different feature from function names. You can't use a label as a function name.
 
-```js example-bad
+```js-nolint example-bad
 function Greeter() {
   german: function () {
     return "Moin";
@@ -71,11 +70,11 @@ function Greeter() {
 // SyntaxError: function statement requires a name
 ```
 
-This would work, for example:
+In addition, labeled function declarations themselves are a deprecated feature. Use regular function declarations instead.
 
 ```js example-good
 function Greeter() {
-  german: function g() {
+  function german() {
     return "Moin";
   }
 }
@@ -92,9 +91,11 @@ const greeter = {
     return "Moin";
   },
 };
+```
 
-// or
+You can also use the [method syntax](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions).
 
+```js
 const greeter = {
   german() {
     return "Moin";
@@ -107,7 +108,7 @@ const greeter = {
 Also, check your syntax when using callbacks.
 Brackets and commas can quickly get confusing.
 
-```js example-bad
+```js-nolint example-bad
 promise.then(
   function () {
     console.log("success");

--- a/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
@@ -24,7 +24,7 @@ SyntaxError: Unexpected token '**'. Ambiguous unary expression in the left hand 
 
 You likely wrote something like this:
 
-```js example-bad
+```js-nolint example-bad
 -a ** b
 ```
 
@@ -37,7 +37,7 @@ Whether it should be evaluated as `(-a) ** b` or `-(a ** b)` is ambiguous. In ma
 
 Other unary operators cannot be the left-hand side of exponentiation either.
 
-```js example-bad
+```js-nolint example-bad
 await a ** b
 !a ** b
 +a ** b
@@ -48,7 +48,7 @@ await a ** b
 
 When writing complex math expressions involving exponentiation, you may write something like this:
 
-```js example-bad
+```js-nolint example-bad
 function taylorSin(x) {
   return (n) => (-1 ** n * x ** (2 * n + 1)) / factorial(2 * n + 1);
   // SyntaxError: unparenthesized unary expression can't appear on the left-hand side of '**'

--- a/files/en-us/web/javascript/reference/errors/unterminated_string_literal/index.md
+++ b/files/en-us/web/javascript/reference/errors/unterminated_string_literal/index.md
@@ -41,7 +41,7 @@ To fix this error, check if:
 
 You can't split a string across multiple lines like this in JavaScript:
 
-```js example-bad
+```js-nolint example-bad
 const longString = "This is a very long string which needs
                     to wrap across multiple lines because
                     otherwise my code is unreadable.";

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -194,7 +194,7 @@ console?.log`Hello`; // SyntaxError: Invalid tagged template on optional chain
 
 Note that these two expressions are still parsable. This means they would not be subject to [automatic semicolon insertion](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion), which will only insert semicolons to fix code that's otherwise unparsable.
 
-```js example-bad
+```js-nolint example-bad
 // Still a syntax error
 const a = console?.log
 `Hello`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This helps me add a linter to the JS docs (currently only run with my own mdn-checker).

I've opted to use `js-nolint` with `example-bad`. This means there are blocks that are "bad" but still lintable, and those that don't make sense to be linted at all.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
