### PR TITLE
column gap (versus row gap)

### DIFF
--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -104,8 +104,6 @@ div:nth-of-type(3n) {
 
 {{EmbedLiveSample("Flex_layout", "auto", "220px")}}
 
-The `column-gap` property defines the width of horizontal space between adjacent flex items.
-
 > **Note:** While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, you can specify a non-zero value for the {{cssxref("row-gap")}} property. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
 
 ### Grid layout

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -106,7 +106,7 @@ div:nth-of-type(3n) {
 
 The `column-gap` property defines the width of horizontal space between adjacent flex items.
 
-While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, you can specify a non-zero value for the {{cssxref("row-gap")}} property. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
+> **Note:** While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, you can specify a non-zero value for the {{cssxref("row-gap")}} property. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
 
 ### Grid layout
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -59,7 +59,7 @@ The `column-gap` property is specified as one of the values listed below.
 
 ### Flex layout
 
-In this example, a flex container contains six flex items of two different widths, creating flex items that are not laid out as a grid. The horizontal space between adjacent flex items is set using the `column-gap` property.
+In this example, a flex container contains six flex items of two different widths (`200px` and `300px`), creating flex items that are not laid out as a grid. The `column-gap` property is used to add horizontal space between the adjacent flex items.
 
 #### HTML
 
@@ -76,11 +76,11 @@ In this example, a flex container contains six flex items of two different width
 
 #### CSS
 
-To create a flex container, we set its {{cssxref("display")}} property value to `flex`. We then use the {{cssxref("flex-flow")}} shorthand property to set the {{cssxref("flex-direction")}} to row (the default) and the {{cssxref("flex-wrap")}} to `wrap`, allowing the flex items to flow onto new lines if needed. By default, flex items stretch to be as tall as their container. By setting a {{cssxref("height")}}, even our empty flex items will be 100% tall.
+To create a flex container, we set its {{cssxref("display")}} property value to `flex`. We then use the {{cssxref("flex-flow")}} shorthand property to set the {{cssxref("flex-direction")}} to row (the default) and {{cssxref("flex-wrap")}} to `wrap`, allowing the flex items to flow onto new lines if needed. By default, flex items stretch to be as tall as their container. By setting a {{cssxref("height")}}, even the empty flex items will be `100px` tall.
 
-We define the widths of the flex items on the flex items themselves; setting different widths better demonstrates the `column-gap` property. We use the {{cssxref("flex-basis")}} component of the {{cssxref("flex")}} shorthand property to make all the flex items `200px` wide. We then target every third flex item with the {{cssxref(":nth-of-type", ":nth-of-type(3n)")}} selector, widening them to `300px`.
+To better demonstrate the `column-gap` property, the flex items in this example have two different width values. The width of the flex items is set within the `<div>` flex items. We use the {{cssxref("flex-basis")}} component of the {{cssxref("flex")}} shorthand property to make all the flex items `200px` wide. We then target every third flex item by using the {{cssxref(":nth-of-type", ":nth-of-type(3n)")}} selector, widening them to `300px`.
 
-We set `column-gap: 20px;` on the flex container to create 20px of horizontal space — a 20px gap — between adjacent flex items in each row.
+The `column-gap` value is set as `20px` on the flex container to create a `20px` gap between the adjacent flex items in each row.
 
 ```css
 .flexbox {

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -62,7 +62,10 @@ The `column-gap` property is specified as one of the values listed below.
 #### HTML
 
 ```html
-<div id="flexbox">
+<div class="flexbox">
+  <div></div>
+  <div></div>
+  <div></div>
   <div></div>
   <div></div>
   <div></div>
@@ -72,22 +75,26 @@ The `column-gap` property is specified as one of the values listed below.
 #### CSS
 
 ```css
-#flexbox {
+.flexbox {
   display: flex;
+  flex-flow: row wrap;
   height: 100px;
   column-gap: 20px;
 }
 
-#flexbox > div {
+.flexbox > div {
   border: 1px solid green;
   background-color: lime;
-  flex: auto;
+  flex: 200px;
+}
+div:nth-of-type(3n) {
+  flex: 300px;
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("Flex_layout", "auto", "120px")}}
+{{EmbedLiveSample("Flex_layout", "auto", "220px")}}
 
 ### Grid layout
 
@@ -95,6 +102,9 @@ The `column-gap` property is specified as one of the values listed below.
 
 ```html
 <div id="grid">
+  <div></div>
+  <div></div>
+  <div></div>
   <div></div>
   <div></div>
   <div></div>
@@ -120,7 +130,7 @@ The `column-gap` property is specified as one of the values listed below.
 
 #### Result
 
-{{EmbedLiveSample("Grid_layout", "auto", "120px")}}
+{{EmbedLiveSample("Grid_layout", "auto", "220px")}}
 
 ### Multi-column layout
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -80,7 +80,7 @@ To create a flex container, we set its {{cssxref("display")}} property value to 
 
 We define the widths of the flex items on the flex items themselves; setting different widths better demonstrates the `column-gap` property. We use the {{cssxref("flex-basis")}} component of the {{cssxref("flex")}} shorthand property to make all the flex items `200px` wide. We then target every third flex item with the {{cssxref(":nth-of-type", ":nth-of-type(3n)")}} selector, widening them to `300px`.
 
-We set `column-gap: 20px;` on the flex container to create 20px of horizontal space -- a 20px gap -- between adjacent flex items in each row.
+We set `column-gap: 20px;` on the flex container to create 20px of horizontal space — a 20px gap — between adjacent flex items in each row.
 
 ```css
 .flexbox {

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -104,7 +104,7 @@ div:nth-of-type(3n) {
 
 {{EmbedLiveSample("Flex_layout", "auto", "220px")}}
 
-The `column-gap` property defines the width of horizontal space between adjacent flex items. 
+The `column-gap` property defines the width of horizontal space between adjacent flex items.
 
 While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, a non-zero value for the {{cssxref("row-gap")}} property is used. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -106,7 +106,7 @@ div:nth-of-type(3n) {
 
 The `column-gap` property defines the width of horizontal space between adjacent flex items.
 
-While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, a non-zero value for the {{cssxref("row-gap")}} property is used. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
+While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, you can specify a non-zero value for the {{cssxref("row-gap")}} property. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
 
 ### Grid layout
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -59,6 +59,8 @@ The `column-gap` property is specified as one of the values listed below.
 
 ### Flex layout
 
+In this example, a flex container contains six flex items of two different widths, creating flex items that are not laid out as a grid. The horizontal space between adjacent flex items is set using the `column-gap` property.
+
 #### HTML
 
 ```html
@@ -73,6 +75,12 @@ The `column-gap` property is specified as one of the values listed below.
 ```
 
 #### CSS
+
+To create a flex container, we set its {{cssxref("display")}} property value to `flex`. We then use the {{cssxref("flex-flow")}} shorthand property to set the {{cssxref("flex-direction")}} to row (the default) and the {{cssxref("flex-wrap")}} to `wrap`, allowing the flex items to flow onto new lines if needed. By default, flex items stretch to be as tall as their container. By setting a {{cssxref("height")}}, even our empty flex items will be 100% tall.
+
+We define the widths of the flex items on the flex items themselves; setting different widths better demonstrates the `column-gap` property. We use the {{cssxref("flex-basis")}} component of the {{cssxref("flex")}} shorthand property to make all the flex items `200px` wide. We then target every third flex item with the {{cssxref(":nth-of-type", ":nth-of-type(3n)")}} selector, widening them to `300px`.
+
+We set `column-gap: 20px;` on the flex container to create 20px of horizontal space -- a 20px gap -- between adjacent flex items in each row.
 
 ```css
 .flexbox {
@@ -95,6 +103,10 @@ div:nth-of-type(3n) {
 #### Result
 
 {{EmbedLiveSample("Flex_layout", "auto", "220px")}}
+
+The `column-gap` property defines the width of horizontal space between adjacent flex items. 
+
+While there is horizontal space between adjacent flex items in each flex row, there is no space between the rows. To set vertical space between flex rows, a non-zero value for the {{cssxref("row-gap")}} property is used. The {{cssxref("gap")}} shorthand property is also available to set both the `row-gap` and `column-gap` in one declaration, in that order.
 
 ### Grid layout
 

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -95,6 +95,9 @@ Note that `grid-row-gap` is an alias for this property.
   <div></div>
   <div></div>
   <div></div>
+  <div></div>
+  <div></div>
+  <div></div>
 </div>
 ```
 
@@ -104,7 +107,7 @@ Note that `grid-row-gap` is an alias for this property.
 #grid {
   display: grid;
   height: 200px;
-  grid-template-columns: 200px;
+  grid-template-columns: 150px 1fr;
   grid-template-rows: repeat(3, 1fr);
   row-gap: 20px;
 }


### PR DESCRIPTION
the example only had one row, so wasn't really obvious what the property was limited to.