### PR TITLE
relnote(117): 'auto none' allowed for 'contain-intrinsic-size' CSS prop

### DIFF
--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -21,7 +21,7 @@ This article provides information about the changes in Firefox 117 that affect d
 - The [`math-style`](/en-US/docs/Web/CSS/math-style) and [`math-depth`](/en-US/docs/Web/CSS/math-depth) properties are now supported, as well as the `math` value for the [`font-size`](/en-US/docs/Web/CSS/font-size#values) property ([Firefox bug 1845516](https://bugzil.la/1845516)).
 
 - The `contain-intrinsic-size: auto none;` syntax is now supported which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
-  This is useful in layouts using proportional sizes, such as grid or multi-column ([Firefox bug 1729228](https://bugzil.la/1729228)).
+  This is useful in layouts using proportional sizes, such as grid or multi-column ([Firefox bug 1835813](https://bugzil.la/1835813)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -20,6 +20,9 @@ This article provides information about the changes in Firefox 117 that affect d
 
 - The [`math-style`](/en-US/docs/Web/CSS/math-style) and [`math-depth`](/en-US/docs/Web/CSS/math-depth) properties are now supported, as well as the `math` value for the [`font-size`](/en-US/docs/Web/CSS/font-size#values) property ([Firefox bug 1845516](https://bugzil.la/1845516)).
 
+- The `contain-intrinsic-size: auto none;` syntax is now supported which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
+  This is useful in layouts using proportional sizes, such as grid or multi-column ([Firefox bug 1729228](https://bugzil.la/1729228)).
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -20,7 +20,7 @@ This article provides information about the changes in Firefox 117 that affect d
 
 - The [`math-style`](/en-US/docs/Web/CSS/math-style) and [`math-depth`](/en-US/docs/Web/CSS/math-depth) properties are now supported, as well as the `math` value for the [`font-size`](/en-US/docs/Web/CSS/font-size#values) property ([Firefox bug 1845516](https://bugzil.la/1845516)).
 
-- The `contain-intrinsic-size: auto none;` syntax is now supported which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
+- The `contain-intrinsic-size: auto none;` syntax is now supported, which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
   This is useful in layouts using proportional sizes, such as grid or multi-column ([Firefox bug 1835813](https://bugzil.la/1835813)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -20,7 +20,7 @@ This article provides information about the changes in Firefox 117 that affect d
 
 - The [`math-style`](/en-US/docs/Web/CSS/math-style) and [`math-depth`](/en-US/docs/Web/CSS/math-depth) properties are now supported, as well as the `math` value for the [`font-size`](/en-US/docs/Web/CSS/font-size#values) property ([Firefox bug 1845516](https://bugzil.la/1845516)).
 
-- The `contain-intrinsic-size: auto none;` syntax is now supported, which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
+- The [`contain-intrinsic-size: auto none;`](/en-US/docs/Web/CSS/contain-intrinsic-size) syntax is now supported, which allows for using the last-remembered size of an element if possible and falls back to `contain-intrinsic-size: none` otherwise.
   This is useful in layouts using proportional sizes, such as grid or multi-column ([Firefox bug 1835813](https://bugzil.la/1835813)).
 
 #### Removals


### PR DESCRIPTION
The declaration `contain-intrinsic-size: auto none` is now supported.

__Docs:__

- [`contain-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)


__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/28292
- [x] BCD - https://github.com/mdn/browser-compat-data/pull/20532

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1835813

__Resources:__
- https://phabricator.services.mozilla.com/D174583#inline-985747
- https://chromestatus.com/feature/6203168806928384
- https://wicg.github.io/display-locking/sample-code/contain-intrinsic-size-examples.html