### PR TITLE
removed Infinity from invalid value for subtraction comparison functi…

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -96,7 +96,7 @@ The default lexicographic comparator satisfies all constraints above.
 
 To compare numbers instead of strings, the compare function can subtract `b`
 from `a`. The following function will sort the array in ascending order (if
-it doesn't contain `Infinity` and `NaN`):
+it doesn't contain `NaN`):
 
 ```js
 function compareNumbers(a, b) {


### PR DESCRIPTION
…on for Array.prototype.sort



<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

One-line doc change: used to read in the 2nd-to-last paragraph in the Description section that compareNumbers (on MDN page https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) when passed as the comparison function to Array.prototype.sort would only work if the array did not contain Infinity and NaN; however, because it appears to work with Infinity, this commit changes this to read that it works only if the array does not contain NaN.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

More info in linked issue below.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

More info in linked issue below.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Closes #28528 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
