### PR TITLE
add NGINX and remove duplicated label

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -91,7 +91,6 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `yaml` - YAML
   - `toml` - TOML
   - `sql` - SQL Database
-  - `diff` - Diff file
   - `ignore` - Gitignore file
   - `apacheconf` - Apache configuration
   - `nginx` - NGINX configuration
@@ -102,6 +101,7 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `pug` - [Pug templates](https://pugjs.org/api/getting-started.html) (which may be used by [Express](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer))
 - Other
   - `plain` - Plain text
+  - `diff` - Diff file
   - `http` - HTTP headers
   - `regex` - Regex
   - `uri` - URIs and URLs

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -94,6 +94,7 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `diff` - Diff file
   - `ignore` - Gitignore file
   - `apacheconf` - Apache configuration
+  - `nginx` - NGINX configuration
 - Templates
   - `django` - Django templates
   - `svelte` - Svelte templates
@@ -101,7 +102,6 @@ On MDN, writers will use code fences for example code blocks. They must specify 
   - `pug` - [Pug templates](https://pugjs.org/api/getting-started.html) (which may be used by [Express](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer))
 - Other
   - `plain` - Plain text
-  - `diff` - Git diff
   - `http` - HTTP headers
   - `regex` - Regex
   - `uri` - URIs and URLs


### PR DESCRIPTION
### Description

add NGINX and remove duplicated label

### Motivation

We've added `nginx` label in [Yari](https://github.com/mdn/yari/blob/886b2c8090af69467d31caef77fb446831f6acdd/build/syntax-highlight.ts#L19-L63).
And the `diff` label is duplicated here.
