### PR TITLE
Add null check before adding to WeakSet

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/index.md
@@ -35,7 +35,7 @@ function execRecursively(fn, subject, _refs = new WeakSet()) {
   }
 
   fn(subject);
-  if (typeof subject === "object") {
+  if (typeof subject === "object" && subject !== null) {
     _refs.add(subject);
     for (const key in subject) {
       execRecursively(fn, subject[key], _refs);

--- a/files/en-us/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/index.md
@@ -35,7 +35,7 @@ function execRecursively(fn, subject, _refs = new WeakSet()) {
   }
 
   fn(subject);
-  if (typeof subject === "object" && subject !== null) {
+  if (typeof subject === "object" && subject) {
     _refs.add(subject);
     for (const key in subject) {
       execRecursively(fn, subject[key], _refs);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the sample `WeakSet` code to perform a `null` check alongside `typeof subject`, because `typeof null === 'object'`.

### Motivation

Using <code>typeof <var>somevarname</var> === 'object'</code> to determine whether an arbitrary value is insertable into a `WeakSet` is fragile, because `null`s cannot be `WeakSet` members, but `typeof null` returns `object`. It's worth demonstrating in the sample code that this possibility should be accounted for and handled, to avoid teaching bad practices.

#### Be even more explicit?

The issue of `null`s not being insertable into `WeakSet`s despite ostensibly being `object`s is not currently addressed in the documentation, other than (after this PR) implicitly via the `null` check added to the sample code. 

Perhaps it should be, but I didn't see an opportunity to discuss the issue in more detail, without feeling like it was derailing the text with a digression. Perhaps the added code check is sufficient, curious readers who see the check in the code can certainly investigate for themselves and discover that `typeof null === 'object'` easily enough.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
