### PR TITLE
CSS masonry - use experimental/BCD to indicate support

### DIFF
--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -2,13 +2,14 @@
 title: Masonry layout
 slug: Web/CSS/CSS_grid_layout/Masonry_layout
 page-type: guide
+browser-compat:
+  - css.properties.grid-template-columns.masonry
+  - css.properties.grid-template-rows.masonry
 ---
 
-{{CSSRef}}
+{{CSSRef}} {{SeeCompatTable}}
 
 Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) specification includes a `masonry` value for {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}. This guide details what masonry layout is and how to use it.
-
-> **Warning:** This feature is only implemented in Firefox, and can be enabled by setting the flag `layout.css.grid-template-masonry-value.enabled` to `true` in `about:config`, in order to allow testing and providing of feedback.
 
 Masonry layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other a masonry layout. On the masonry axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to completely fill the gaps.
 
@@ -73,7 +74,11 @@ The `justify-tracks` property works in the same way as align-tracks, however it 
 
 ## Fallback
 
-In browsers that do not support masonry, regular grid auto-placement will be used instead.
+In browsers [that do not support masonry](#browser_compatibility), regular grid auto-placement will be used instead.
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
Fixes #28541

The masonry layout guide page had a warning that this is only supported on FF behind a prefix, but now it is also supported in preview Safari. 

What I have done is added compat tables for the keyword and an experimental feature up the top. This is a more standard approach - certainly more scalable. When there is broad support both would be removed.