### PR TITLE
Remove duplicate list in glossary article

### DIFF
--- a/files/en-us/glossary/semantics/index.md
+++ b/files/en-us/glossary/semantics/index.md
@@ -75,18 +75,3 @@ These are _some_ of the roughly 100 semantic [elements](/en-US/docs/Web/HTML/Ele
   - {{Glossary("SEO")}}
 
 - Semantic elements in HTML:
-
-  - {{htmlelement("article")}}
-  - {{htmlelement("aside")}}
-  - {{htmlelement("details")}}
-  - {{htmlelement("figcaption")}}
-  - {{htmlelement("figure")}}
-  - {{htmlelement("footer")}}
-  - {{htmlelement("form")}}
-  - {{htmlelement("header")}}
-  - {{htmlelement("main")}}
-  - {{htmlelement("mark")}}
-  - {{htmlelement("nav")}}
-  - {{htmlelement("section")}}
-  - {{htmlelement("summary")}}
-  - {{htmlelement("time")}}

--- a/files/en-us/glossary/semantics/index.md
+++ b/files/en-us/glossary/semantics/index.md
@@ -55,8 +55,8 @@ These are _some_ of the roughly 100 semantic [elements](/en-US/docs/Web/HTML/Ele
 - {{htmlelement("details")}}
 - {{htmlelement("figcaption")}}
 - {{htmlelement("figure")}}
-- {{htmlelement("form")}}
 - {{htmlelement("footer")}}
+- {{htmlelement("form")}}
 - {{htmlelement("header")}}
 - {{htmlelement("main")}}
 - {{htmlelement("mark")}}
@@ -73,5 +73,3 @@ These are _some_ of the roughly 100 semantic [elements](/en-US/docs/Web/HTML/Ele
 - [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("SEO")}}
-
-- Semantic elements in HTML:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicate list of some semantic HTML elements within the ["See also" section](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#see_also).

### Motivation

I don't think that the list is needed a second time.
There's already the [same listing in a separate section](https://developer.mozilla.org/en-US/docs/Glossary/Semantics#semantic_elements) right before and linking to the [HTML element reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#inline_text_semantics) within "See also" should be sufficient.

### Additional details

/

### Related issues and pull requests

/


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
