### PR TITLE
fix(ci): Concurrency issue in reviewdog

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-review-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Issue

When a contributor commits the suggestions made by reviewdog one by one instead of submitting all of them in one batch, multiple instance of reviewdog workflow spawns. All the triggered workflows except for the last commit put outdated review comments on the PR depending on when they finish their execution.\
As newbie contributors won't know how to make a batch commit, this is a valid case to be handled.

I've [reproduced this in my local fork](https://github.com/OnkarRuikar/content/pull/23).\
Steps to reproduce in your fork:
1. Submit a PR to your fork with multiple lint issues in a markdown file.
2. After reviewdog makes suggestions commit them one by one. This will spawn multiple workflow instances.
3. Wait till all of the workflows finish running.
4. Notices new review comments for each workflow run.

## Solution

Cancel pending and in progress workflow runs when a new one starts using [the GitHub concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow) feature.

## Testing

- Successfully tested in my fork https://github.com/OnkarRuikar/content/pull/25