### PR TITLE
docs(relnotes): FX117 release notes rect() and xywh()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -977,6 +977,49 @@ See [Firefox bug 1814588](https://bugzil.la/1814588) and [Firefox bug 1814589](h
   </tbody>
 </table>
 
+### rect() and xywh() basic shape functions
+
+The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) basic shape functions enable you to create rectangular shapes in CSS properties such {{cssxref("clip-path")}} and {{cssxref("offset-path")}}. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the reference box. Using the `xywh()` function, you specify the rectangle edge offsets from the top edge and left edges of the reference box, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners. Both the functions are [basic-shape](/en-US/docs/Web/CSS/basic-shape) data types.
+For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `rect()` function and [Firefox bug 1786160](https://bugzil.la/1786160) for the `xywh()` function.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>117</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>117</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>117</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>117</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preferences name</th>
+      <td colspan="2">
+      <code>layout.css.motion-path-basic-shapes.enabled</code>, <code>layout.css.basic-shape-rect.enabled</code>, <code>layout.css.basic-shape-xywh.enabled</code>
+    </td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -979,7 +979,7 @@ See [Firefox bug 1814588](https://bugzil.la/1814588) and [Firefox bug 1814589](h
 
 ### rect() and xywh() basic shape functions
 
-The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) basic shape functions enable you to create rectangular paths along which an element moves. They are used in CSS properties such as {{cssxref("offset-path")}}. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block. Using the `xywh()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners. Both these functions are [basic-shape](/en-US/docs/Web/CSS/basic-shape) data types.
+The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) [`<basic-shape>`](/en-US/docs/Web/CSS/basic-shape) data type functions enable you to define a rectangle. In CSS properties such as {{cssxref("offset-path")}}, these functions are used to define the shape of the path along which an element moves. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block. Using the `xywh()` function, you specify the rectangle edge offsets from the left and top edges of the containing block, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners.
 For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `rect()` function and [Firefox bug 1786160](https://bugzil.la/1786160) for the `xywh()` function.
 
 <table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -969,7 +969,7 @@ See [Firefox bug 1814588](https://bugzil.la/1814588) and [Firefox bug 1814589](h
       <td>No</td>
     </tr>
     <tr>
-      <th>Preferences name</th>
+      <th>Preference name</th>
       <td colspan="2">
       <code>layout.css.abs-sign.enabled</code>
     </td>
@@ -979,7 +979,7 @@ See [Firefox bug 1814588](https://bugzil.la/1814588) and [Firefox bug 1814589](h
 
 ### rect() and xywh() basic shape functions
 
-The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) [`<basic-shape>`](/en-US/docs/Web/CSS/basic-shape) data type functions enable you to define a rectangle. In CSS properties such as {{cssxref("offset-path")}}, these functions are used to define the shape of the path along which an element moves. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block. Using the `xywh()` function, you specify the rectangle edge offsets from the left and top edges of the containing block, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners.
+The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) shape functions enable you to define a rectangle using the [`<basic-shape>`](/en-US/docs/Web/CSS/basic-shape) data type. In CSS properties such as {{cssxref("offset-path")}}, these functions are used to define the shape of the path along which an element moves. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block. Using the `xywh()` function, you specify the rectangle edge offsets from the left and top edges of the containing block as well as the width and height of the rectangle. In both the functions, you can optionally round off the corners.
 For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `rect()` function and [Firefox bug 1786160](https://bugzil.la/1786160) for the `xywh()` function.
 
 <table>
@@ -1012,7 +1012,7 @@ For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `
       <td>No</td>
     </tr>
     <tr>
-      <th>Preferences name</th>
+      <th>Preference names</th>
       <td colspan="2">
       <code>layout.css.motion-path-basic-shapes.enabled</code>, <code>layout.css.basic-shape-rect.enabled</code>, <code>layout.css.basic-shape-xywh.enabled</code>
     </td>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1501,9 +1501,9 @@ See [Firefox bug 1840480](https://bugzil.la/1840480) for more details.
   </tbody>
 </table>
 
-#### CSS Custom Hightlight API
+#### CSS Custom Highlight API
 
-The [CSS Custom Highlight API](/en-US/docs/Web/API/CSS_Custom_Highlight_API) provides a mechanism for styling arbitrary text ranges in a document (generalizing the behaviour of other highlight pseudo-elements such as {{cssxref('::selection')}}, {{cssxref('::spelling-error')}}, {{cssxref('::grammar-error')}}, and {{cssxref('::target-text')}}).
+The [CSS Custom Highlight API](/en-US/docs/Web/API/CSS_Custom_Highlight_API) provides a mechanism for styling arbitrary text ranges in a document (generalizing the behavior of other highlight pseudo-elements such as {{cssxref('::selection')}}, {{cssxref('::spelling-error')}}, {{cssxref('::grammar-error')}}, and {{cssxref('::target-text')}}).
 The ranges are defined in JavaScript using [`Range`](/en-US/docs/Web/API/Range) instances grouped in a [`Highlight`](/en-US/docs/Web/API/Highlight), and then registered with a name using [`HighlightRegistry`](/en-US/docs/Web/API/HighlightRegistry).
 The CSS [`::highlight`](/en-US/docs/Web/CSS/::highlight) pseudo-element is used to apply styles to a registered highlight.
 See [Firefox bug 1703961](https://bugzil.la/1703961) for more details.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -979,7 +979,7 @@ See [Firefox bug 1814588](https://bugzil.la/1814588) and [Firefox bug 1814589](h
 
 ### rect() and xywh() basic shape functions
 
-The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) basic shape functions enable you to create rectangular shapes in CSS properties such {{cssxref("clip-path")}} and {{cssxref("offset-path")}}. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the reference box. Using the `xywh()` function, you specify the rectangle edge offsets from the top edge and left edges of the reference box, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners. Both the functions are [basic-shape](/en-US/docs/Web/CSS/basic-shape) data types.
+The CSS [`rect()`](/en-US/docs/Web/CSS/basic-shape/rect) and [`xywh()`](/en-US/docs/Web/CSS/basic-shape/xywh) basic shape functions enable you to create rectangular paths along which an element moves. They are used in CSS properties such as {{cssxref("offset-path")}}. Using the `rect()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block. Using the `xywh()` function, you specify the rectangle edge offsets from the top edge and left edges of the containing block, along with the width and height of the rectangle. In both the functions, you can optionally round off the corners. Both these functions are [basic-shape](/en-US/docs/Web/CSS/basic-shape) data types.
 For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `rect()` function and [Firefox bug 1786160](https://bugzil.la/1786160) for the `xywh()` function.
 
 <table>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Fx117 introduces support for two new basic shape functions `rect()` and `xywh()`.
- Preferences that need to enabled (on by default in Nightly):
  - `layout.css.motion-path-basic-shapes.enabled`
  - `layout.css.basic-shape-rect.enabled`
  - `layout.css.basic-shape-xywh.enabled`
- Spec: https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes

### Related issues and pull requests

Doc issues: https://github.com/mdn/content/issues/28287, https://github.com/mdn/content/issues/28286
Content PR: https://github.com/mdn/content/pull/28565

