### PR TITLE
Fix typo in String.toLocaleUpperCase

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -45,7 +45,7 @@ characters might result in two (or even more) characters when transformed to upp
 Therefore the length of the result string can differ from the input length. This also
 implies that the conversion is not stable, so i.E. the following can return
 `false`:
-`x.toLocaleUpperCase() === x.toLocaleUpperCase().toLocaleUpperCase()`
+`x. toLocaleLowerCase() === x.toLocaleUpperCase(). toLocaleLowerCase()`
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -45,7 +45,7 @@ characters might result in two (or even more) characters when transformed to upp
 Therefore the length of the result string can differ from the input length. This also
 implies that the conversion is not stable, so i.E. the following can return
 `false`:
-`x. toLocaleLowerCase() === x.toLocaleUpperCase(). toLocaleLowerCase()`
+`x.toLocaleLowerCase() === x.toLocaleUpperCase().toLocaleLowerCase()`
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -24,7 +24,7 @@ toLocaleUpperCase(locales)
 
   - : A string with a BCP 47 language tag, or an array of such strings. Indicates the locale to be used to convert to upper case according to any locale-specific case mappings. For the general form and interpretation of the `locales` argument, see [the parameter description on the `Intl` main page](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
 
-    Unlike other methods that use the `locales` argument, `toLocaleLowerCase()` does not allow locale matching. Therefore, after checking the validity of the `locales` argument, `toLocaleLowerCase()` always uses the first locale in the list (or the default locale if the list is empty), even if this locale is not supported by the implementation.
+    Unlike other methods that use the `locales` argument, `toLocaleUpperCase()` does not allow locale matching. Therefore, after checking the validity of the `locales` argument, `toLocaleUpperCase()` always uses the first locale in the list (or the default locale if the list is empty), even if this locale is not supported by the implementation.
 
 ### Return value
 
@@ -45,7 +45,7 @@ characters might result in two (or even more) characters when transformed to upp
 Therefore the length of the result string can differ from the input length. This also
 implies that the conversion is not stable, so i.E. the following can return
 `false`:
-`x.toLocaleLowerCase() === x.toLocaleUpperCase().toLocaleLowerCase()`
+`x.toLocaleUpperCase() === x.toLocaleUpperCase().toLocaleUpperCase()`
 
 ## Examples
 


### PR DESCRIPTION
### Description

Same as the title

### Motivation

Ditto.

### Additional details

None.

### Related issues and pull requests

None.