### PR TITLE
docs(css): Fx117 - new pages for basic shape functions rect() and xywh()

### DIFF
--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -33,9 +33,9 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     inset( <length-percentage>{1,4} [ round <`border-radius`> ]? )
     ```
 
-    When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or three values.
+    When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, three, or four values.
 
-    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property.
+    The optional `round <'border-radius'>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property.
 
     A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
 
@@ -47,9 +47,9 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     rect( [ <length-percentage> | auto ]{4} [ round <`border-radius`> ]? )
     ```
 
-    You specify four values to create the rectangle. Each of the four values is either a `<length>`, a `<percentage>`, or the keyword `auto`. When using the `rect()` function, you do not define the width and height of the rectangle. The dimensions of the rectangle depend on the size of the reference box, the offset values, and whether those offsets are relative or absolute.
+    You specify four values to create the rectangle. Each of the four values is either a `<length>`, a `<percentage>`, or the keyword `auto`. When using the `rect()` function, you do not define the width and height of the rectangle. The rectangles dimensions depend on the size of the reference box and the offset values.
 
-    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property.
+    The optional `round <'border-radius'>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property.
 
 - `{{cssxref("basic-shape/xywh","xywh()")}}`
 
@@ -59,7 +59,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <`border-radius`> ]? )
     ```
 
-    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
+    The optional `round <'border-radius'>` parameter defines rounded corners for the inset rectangle using the [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
 
 - `{{cssxref("basic-shape/circle","circle()")}}`
 
@@ -90,7 +90,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines a polygon using an SVG {{SVGAttr("fill-rule")}} and a set of vertices.
 
     ```css
-    polygon( <fill-rule>? [<shape-arg> <shape-arg>]# )
+    polygon( <fill-rule>? [ <shape-arg> <shape-arg> ]# )
     ```
 
     `<fill-rule>` represents the {{SVGAttr("fill-rule")}} used to determine the interior of the polygon. Possible values are `nonzero` and `evenodd`. Default value when omitted is `nonzero`.
@@ -102,7 +102,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines a shape using an SVG {{SVGAttr("fill-rule")}} and an SVG [path definition](/en-US/docs/Web/SVG/Attribute/d).
 
     ```css
-    path( [<fill-rule>,]? <string> )
+    path( [ <fill-rule>, ]? <string> )
     ```
 
     The optional `<fill-rule>` represents the {{SVGAttr("fill-rule")}} used to determine the interior of the path. Possible values are `nonzero` and `evenodd`. Default value when omitted is `nonzero`.

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -35,7 +35,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
 
     When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or four values.
 
-    The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
+    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
 
     A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
 
@@ -47,25 +47,19 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
     ```
 
-    When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.
+    All four values are specified as either a `<length>`, a `<percentage>`, or the keyword `auto`.
 
-    The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
-
-    A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
+    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
 
 - `{{cssxref("basic-shape/xywh","xywh()")}}`
 
-  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box along with the specified width and height of the rectangle.
+  - : Defines a rectangle with inset distances from the top and left edges of the reference box along with width and height of the rectangle.
 
     ```css
     xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [round <`border-radius`>]? )
     ```
 
-    When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.
-
-    The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
-
-    A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
+    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
 
 - `{{cssxref("basic-shape/circle","circle()")}}`
 

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -55,10 +55,10 @@ The following shapes are supported. All `<basic-shape>` values use functional no
 
 - `{{cssxref("basic-shape/xywh","xywh()")}}`
 
-  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box along with the specified width and height
+  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box along with the specified width and height of the rectangle.
 
     ```css
-    rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
+    xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [round <`border-radius`>]? )
     ```
 
     When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -33,30 +33,30 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     inset( <length-percentage>{1,4} [round <`border-radius`>]? )
     ```
 
-    When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or four values.
+    When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or three values.
 
-    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
+    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property.
 
     A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
 
 - `{{cssxref("basic-shape/rect","rect()")}}`
 
-  - : Defines a rectangle with specific inset distances from the top and left edges of the containing block.
+  - : Defines a rectangle using the specified distances from the top and left edges of the reference box.
 
     ```css
-    rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
+    rect( [ <length-percentage> | auto ]{4} [ round <`border-radius`> ]? )
     ```
 
-    All four values are specified as either a `<length>`, a `<percentage>`, or the keyword `auto`.
+    You specify four values to create the rectangle. Each of the four values is either a `<length>`, a `<percentage>`, or the keyword `auto`. When using the `rect()` function, you do not define the width and height of the rectangle. The dimensions of the rectangle depend on the size of the reference box, the offset values, and whether those offsets are relative or absolute.
 
-    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
+    The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property.
 
 - `{{cssxref("basic-shape/xywh","xywh()")}}`
 
-  - : Defines a rectangle with inset distances from the top and left edges of the containing block along with width and height of the rectangle.
+  - : Defines a rectangle using the specified distances from the top and left edges of the reference box and the specified width and height of the rectangle.
 
     ```css
-    xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [round <`border-radius`>]? )
+    xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <`border-radius`> ]? )
     ```
 
     The optional `round <border-radius>` parameter defines rounded corners for the inset rectangle using the [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand syntax.
@@ -220,5 +220,6 @@ div {
 ## See also
 
 - Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
+- [CSS shapes](/en-US/docs/Web/CSS/CSS_shapes) module
+- [Overview of CSS shapes](/en-US/docs/Web/CSS/CSS_shapes/Overview_of_shapes)
 - [Edit Shape Paths in CSS — Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/index.html)
-- [Overview of CSS Shapes](/en-US/docs/Web/CSS/CSS_shapes/Overview_of_shapes)

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -30,7 +30,35 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines an inset rectangle.
 
     ```css
-    inset( <shape-arg>{1,4} [round <border-radius>]? )
+    inset( <length-percentage>{1,4} [round <`border-radius`>]? )
+    ```
+
+    When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or four values.
+
+    The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
+
+    A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
+
+- `{{cssxref("basic-shape/rect","rect()")}}`
+
+  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box.
+
+    ```css
+    rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
+    ```
+
+    When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.
+
+    The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
+
+    A pair of insets in either dimension that add up to more than the used dimension (such as left and right insets of 75% apiece) define a shape enclosing no area. For this specification, this results in an empty float area.
+
+- `{{cssxref("basic-shape/xywh","xywh()")}}`
+
+  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box along with the specified width and height
+
+    ```css
+    rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
     ```
 
     When all of the first four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -47,7 +47,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
     rect( [ <length-percentage> | auto ]{4} [ round <`border-radius`> ]? )
     ```
 
-    You specify four values to create the rectangle. Each of the four values is either a `<length>`, a `<percentage>`, or the keyword `auto`. When using the `rect()` function, you do not define the width and height of the rectangle. The rectangles dimensions depend on the size of the reference box and the offset values.
+    You specify four values to create the rectangle. Each of the four values is either a `<length>`, a `<percentage>`, or the keyword `auto`. When using the `rect()` function, you do not define the width and height of the rectangle. The rectangle's dimensions depend on the size of the reference box and the offset values.
 
     The optional `round <'border-radius'>` parameter defines rounded corners for the inset rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property.
 

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -30,7 +30,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines an inset rectangle.
 
     ```css
-    inset( <length-percentage>{1,4} [round <`border-radius`>]? )
+    inset( <length-percentage>{1,4} [ round <`border-radius`> ]? )
     ```
 
     When all of the first four arguments are supplied, they represent the top, right, bottom and left offsets from the reference box inward that define the position of the edges of the inset rectangle. These arguments follow the syntax of the {{cssxref("margin")}} shorthand, which lets you set all four insets with one, two, or three values.
@@ -66,7 +66,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines a circle using a radius and a position.
 
     ```css
-    circle( [<shape-radius>]? [at <position>]? )
+    circle( <shape-radius>? [ at <position> ]? )
     ```
 
     The `<shape-radius>` argument represents _r_, the radius of the circle. Negative values are invalid. A percentage value here is resolved from the used width and height of the reference box as `sqrt(width^2+height^2)/sqrt(2)`.
@@ -78,7 +78,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines an ellipse using two radii and a position.
 
     ```css
-    ellipse( [<shape-radius>{2}]? [at <position>]? )
+    ellipse( [ <shape-radius>{2} ]? [ at <position> ]? )
     ```
 
     The `<shape-radius>` arguments represent rx and ry, the x-axis and y-axis radii of the ellipse, in that order. Negative values for either radius are invalid. Percentage values here are resolved against the used width (for the rx value) and the used height (for the ry value) of the reference box.
@@ -90,7 +90,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines a polygon using an SVG {{SVGAttr("fill-rule")}} and a set of vertices.
 
     ```css
-    polygon( [<fill-rule>,]? [<shape-arg> <shape-arg>]# )
+    polygon( <fill-rule>? [<shape-arg> <shape-arg>]# )
     ```
 
     `<fill-rule>` represents the {{SVGAttr("fill-rule")}} used to determine the interior of the polygon. Possible values are `nonzero` and `evenodd`. Default value when omitted is `nonzero`.
@@ -102,7 +102,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
   - : Defines a shape using an SVG {{SVGAttr("fill-rule")}} and an SVG [path definition](/en-US/docs/Web/SVG/Attribute/d).
 
     ```css
-    path( [<fill-rule>,]? <string>)
+    path( [<fill-rule>,]? <string> )
     ```
 
     The optional `<fill-rule>` represents the {{SVGAttr("fill-rule")}} used to determine the interior of the path. Possible values are `nonzero` and `evenodd`. Default value when omitted is `nonzero`.

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -41,7 +41,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
 
 - `{{cssxref("basic-shape/rect","rect()")}}`
 
-  - : Defines a rectangle with specific inset distances from the top and left edges of the reference box.
+  - : Defines a rectangle with specific inset distances from the top and left edges of the containing block.
 
     ```css
     rect( [ <length-percentage> | auto]{4} [round <`border-radius`>]? )
@@ -53,7 +53,7 @@ The following shapes are supported. All `<basic-shape>` values use functional no
 
 - `{{cssxref("basic-shape/xywh","xywh()")}}`
 
-  - : Defines a rectangle with inset distances from the top and left edges of the reference box along with width and height of the rectangle.
+  - : Defines a rectangle with inset distances from the top and left edges of the containing block along with width and height of the rectangle.
 
     ```css
     xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [round <`border-radius`>]? )

--- a/files/en-us/web/css/basic-shape/inset/index.md
+++ b/files/en-us/web/css/basic-shape/inset/index.md
@@ -43,4 +43,4 @@ In the example below we have an `inset()` shape used to pull content over the fl
 ## See also
 
 - Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
-- [Guide to Basic Shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)
+- [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/inset/index.md
+++ b/files/en-us/web/css/basic-shape/inset/index.md
@@ -43,4 +43,5 @@ In the example below we have an `inset()` shape used to pull content over the fl
 ## See also
 
 - Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
+- [CSS shapes](/en-US/docs/Web/CSS/CSS_shapes) module
 - [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -26,29 +26,29 @@ The inset rectangle is defined by specifying four offset values, starting with t
 
 - `auto`
 
-  - : Makes the edge for which this value is used to coincide with the corresponding edge of the containing block. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is `0%`, and if used for the second (right) or third (bottom) value, the value of `auto` is `100%`.
+  - : Makes the edge for which this value is used to coincide with the corresponding edge of the containing block. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is `0`, and if used for the second (right) or third (bottom) value, the value of `auto` is `100%`.
 
-- `round <border-radius>`
-  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
+- `round <'border-radius'>`
+  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
 
 ## Examples
 
 ### Creating offset-path using rect()
 
-In this example, the {{cssxref("offset-path")}} property uses the `rect()` function to define the shape of the path on which the element, red box in this case, moves. Three different scenarios are shown, each using different values for the `rect()` function.
+In this example, the {{cssxref("offset-path")}} property uses the `rect()` function to define the shape of the path on which the element, a red box in this case, moves. Three different scenarios are shown, each using different values for the `rect()` function.
 
 ```html
 <div class="container">
   Rectangular path 1
-  <div class="path rect-path-1"></div>
+  <div class="path rect-path-1">→</div>
 </div>
 <div class="container">
   Rectangular path 2
-  <div class="path rect-path-2"></div>
+  <div class="path rect-path-2">→</div>
 </div>
 <div class="container">
   Rectangular path 3
-  <div class="path rect-path-3"></div>
+  <div class="path rect-path-3">→</div>
 </div>
 ```
 
@@ -66,22 +66,20 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 .path {
   width: 40px;
   height: 40px;
+  background-color: red;
   position: absolute;
   animation: move 10s linear infinite;
 }
 
 .rect-path-1 {
-  background-color: red;
   offset-path: rect(50px 150px 200px 50px round 20%);
 }
 
 .rect-path-2 {
-  background-color: red;
   offset-path: rect(50px auto 200px 50px round 20%);
 }
 
 .rect-path-3 {
-  background-color: red;
   offset-path: rect(50px auto 200px auto);
 }
 
@@ -101,7 +99,7 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 
 - The path 1 rectangle specifies the distances of the four edges (top, right, bottom, and left) from the containing block. The top and bottom values are distances from the top edge of the containing block. The right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded at `20%`, making the red box element follow the rounded corners as it moves along this path.
 - The path 2 rectangle is similar to the path 1 rectangle, except that the right value is `auto`, which is equal to the value `100%`. This causes the right edge of the rectangle to match the right edge of the containing block, creating a wider rectangle than path 1.
-- The path 3 rectangle specifies both the left and right edge parameters as `auto` and omits the `round <border-radius>` parameter. This creates a rectangle that has the width of the containing block and rectangular corners instead of rounded corners like in path 1 and path 2 rectangles.
+- The path 3 rectangle specifies both the left and right edge parameters as `auto` and omits the `round <'border-radius'>` parameter. This creates a rectangle that has the width of the containing block and rectangular corners instead of rounded corners like in path 1 and path 2 rectangles.
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -12,23 +12,27 @@ The **`rect()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the 
 ## Syntax
 
 ```css
-shape-outside: inset(20px 50px 10px 0 round 50px);
+clip-path: rect(0px 1% auto 3% round 0 1px);
 ```
 
 ### Values
 
-- `<length-percentage>{1,4}`
-  - : When all of the four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.
-- `<border-radius>`
-  - : The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
+The inset distances of rectangle edges from the reference box are specified using four values. Each value is a `<length>`, a `<percentage>`, or the keyword `auto`.
+
+- `<length-percentage>`
+
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the position of top, right, bottom, and left edges of the rectangle element. The first (top) and third (bottom) values are distances from the top edge of the reference box, and the second (right) and fourth (left) values are distances from the left edge of the reference box. The second (right) and third (bottom) values are limited by the fourth (left) and second (top) values, respectively, to correct the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` gets corrected to `rect(10px 20px 10px 20px)`.
+
+- `auto`
+
+  - : Makes the rectangle edge for which this value is used to coincide with the corresponding edge of the reference box. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is equivalent to 0%, and if used for the the second (right) or third (bottom) value, the value of `auto` is equivalent to 100%.
+
+- `round <border-radius>`
+  - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
 
 ## Examples
 
-### Basic inset example
-
-In the example below we have an `inset()` shape used to pull content over the floated element. Change the offset values to see how the shape changes.
-
-{{EmbedGHLiveSample("css-examples/shapes/basic-shape/inset.html", '100%', 800)}}
+### Creating a rectangle using rect()
 
 ## Specifications
 
@@ -40,5 +44,9 @@ In the example below we have an `inset()` shape used to pull content over the fl
 
 ## See also
 
-- Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
+- [`inset()`](/en-US/docs/Web/CSS/basic-shape#inset) function
+- [`xywh()`](/en-US/docs/Web/CSS/basic-shape#xywh) function
+- {{cssxref("clip-path")}} property
+- {{cssxref("offset-path")}} property
+- {{cssxref("&lt;basic-shape&gt;")}} data type
 - [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -41,4 +41,4 @@ In the example below we have an `inset()` shape used to pull content over the fl
 ## See also
 
 - Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
-- [Guide to Basic Shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)
+- [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -35,7 +35,7 @@ The inset rectangle is defined by specifying four offset values, starting with t
 
 ### Creating offset-path using rect()
 
-In this example, the {{cssxref("offset-path")}} property uses the `rect()` function to define the shape of the path on which the element, a red box in this case, moves. Three different scenarios are shown, each using different values for the `rect()` function.
+In this example, the {{cssxref("offset-path")}} property uses the `rect()` function to define the shape of the path on which the element, a red box in this case, moves. Three different scenarios are shown, each using different values for the `rect()` function. The arrow inside the boxes points to the right edge of the box.
 
 ```html
 <div class="container">
@@ -97,9 +97,9 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 
 {{EmbedLiveSample("Creating an offset-path using rect", "100%", 400)}}
 
-- The path 1 rectangle specifies the distances of the four edges (top, right, bottom, and left) from the containing block. The top and bottom values are distances from the top edge of the containing block. The right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded at `20%`, making the red box element follow the rounded corners as it moves along this path.
+- The path 1 rectangle specifies the distances of the four edges (top, right, bottom, and left) from the containing block. The top and bottom values are distances from the top edge of the containing block. The right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded at `20%`, making the red box element follow the rounded corners as it moves along this path. Notice how the arrow inside the box follows curve at the rectangular path corners.
 - The path 2 rectangle is similar to the path 1 rectangle, except that the right value is `auto`, which is equal to the value `100%`. This causes the right edge of the rectangle to match the right edge of the containing block, creating a wider rectangle than path 1.
-- The path 3 rectangle specifies both the left and right edge parameters as `auto` and omits the `round <'border-radius'>` parameter. This creates a rectangle that has the width of the containing block and rectangular corners instead of rounded corners like in path 1 and path 2 rectangles.
+- The path 3 rectangle specifies both the left and right edge parameters as `auto` and omits the `round <'border-radius'>` parameter. This creates a rectangle that has the width of the containing block and rectangular corners instead of rounded corners like in path 1 and path 2 rectangles. Notice the movement of the arrow inside this box at the corners.
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -7,28 +7,29 @@ browser-compat: css.types.basic-shape.rect
 
 {{CSSRef}}
 
-The **`rect()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified distance from the top and left edges of the containing block. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `rect()` function to create the rectangular shape path along which an element moves.
+The **`rect()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified distance from the top and left edges of the containing block. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). You can use the `rect()` function in CSS properties such as {{cssxref("offset-path")}} to create the rectangular path along which an element moves and in {{cssxref("clip-path")}} to define the shape of the clipping region.
 
 ## Syntax
 
 ```css
-offset-path: rect(0px 1% auto 3% round 0 1px);
+offset-path: rect(0 1% auto 3% round 0 1px);
+clip-path: rect(50px 70px 80% 20%);
 ```
 
 ### Values
 
-The inset rectangle is specified using four values, going clockwise starting with the top edge. Each value is a `<length>`, a `<percentage>`, or the keyword `auto`.
+The inset rectangle is defined by specifying four offset values, starting with the top edge offset and going clockwise, and an optional `round` keyword with the `border-radius` parameter to add rounded corners to the rectangle. Each offset value can be either a `<length>`, a `<percentage>`, or the keyword `auto`.
 
 - `<length-percentage>`
 
-  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} value for the distance of the top, right, bottom, and left edges of the rectangle from the containing block. The first (top) and third (bottom) values are distances from the top edge of the containing block, and the second (right) and fourth (left) values are distances from the left edge of the containing block. The second (right) and third (bottom) values are limited by the fourth (left) and second (top) values, respectively, to correct the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` gets corrected to `rect(10px 20px 10px 20px)`.
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} value of the distance of the top, right, bottom, or left edge of the rectangle from the top or left edge of the containing block. The first (top) and third (bottom) values are distances from the top edge of the containing block, and the second (right) and fourth (left) values are distances from the left edge of the containing block. The second (right) and third (bottom) values are clamped by the fourth (left) and second (top) values, respectively, to prevent the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` is clamped to `rect(10px 20px 10px 20px)`.
 
 - `auto`
 
-  - : Makes the edge for which this value is used to coincide with the corresponding edge of the containing block. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is equivalent to 0%, and if used for the the second (right) or third (bottom) value, `auto` value is equivalent to 100%.
+  - : Makes the edge for which this value is used to coincide with the corresponding edge of the containing block. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is `0%`, and if used for the second (right) or third (bottom) value, the value of `auto` is `100%`.
 
 - `round <border-radius>`
-  - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
+  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
 
 ## Examples
 
@@ -63,8 +64,8 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 }
 
 .path {
-  width: 50px;
-  height: 50px;
+  width: 40px;
+  height: 40px;
   position: absolute;
   animation: move 10s linear infinite;
 }
@@ -96,11 +97,11 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 
 #### Result
 
-{{EmbedLiveSample("Creating an offset-path using rect", "100%", 300)}}
+{{EmbedLiveSample("Creating an offset-path using rect", "100%", 400)}}
 
-- Path 1 rectangle specifies distances of all edges (top, right, bottom, and left) from the containing block. Top and bottom values are distances from the top edge of the containing block. Right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded`20%`, so the element moving on this path follows the rounded corner.
-- Path 2 is similar to path 1 except that the right value is `auto`. As a result, the right edge of the rectangle matches the right edge of the containing block.
-- Path 3 omits the corner rounding. Also, both right and left values are set to `auto`.
+- The path 1 rectangle specifies the distances of the four edges (top, right, bottom, and left) from the containing block. The top and bottom values are distances from the top edge of the containing block. The right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded at `20%`, making the red box element follow the rounded corners as it moves along this path.
+- The path 2 rectangle is similar to the path 1 rectangle, except that the right value is `auto`, which is equal to the value `100%`. This causes the right edge of the rectangle to match the right edge of the containing block, creating a wider rectangle than path 1.
+- The path 3 rectangle specifies both the left and right edge parameters as `auto` and omits the `round <border-radius>` parameter. This creates a rectangle that has the width of the containing block and rectangular corners instead of rounded corners like in path 1 and path 2 rectangles.
 
 ## Specifications
 
@@ -117,4 +118,5 @@ In this example, the {{cssxref("offset-path")}} property uses the `rect()` funct
 - {{cssxref("clip-path")}} property
 - {{cssxref("offset-path")}} property
 - {{cssxref("&lt;basic-shape&gt;")}} data type
+- [CSS shapes](/en-US/docs/Web/CSS/CSS_shapes) module
 - [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -7,32 +7,100 @@ browser-compat: css.types.basic-shape.rect
 
 {{CSSRef}}
 
-The **`rect()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from the top and left edges of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
+The **`rect()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified distance from the top and left edges of the containing block. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `rect()` function to create the rectangular shape path along which an element moves.
 
 ## Syntax
 
 ```css
-clip-path: rect(0px 1% auto 3% round 0 1px);
+offset-path: rect(0px 1% auto 3% round 0 1px);
 ```
 
 ### Values
 
-The inset distances of rectangle edges from the reference box are specified using four values. Each value is a `<length>`, a `<percentage>`, or the keyword `auto`.
+The inset rectangle is specified using four values, going clockwise starting with the top edge. Each value is a `<length>`, a `<percentage>`, or the keyword `auto`.
 
 - `<length-percentage>`
 
-  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the position of top, right, bottom, and left edges of the rectangle element. The first (top) and third (bottom) values are distances from the top edge of the reference box, and the second (right) and fourth (left) values are distances from the left edge of the reference box. The second (right) and third (bottom) values are limited by the fourth (left) and second (top) values, respectively, to correct the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` gets corrected to `rect(10px 20px 10px 20px)`.
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} value for the distance of the top, right, bottom, and left edges of the rectangle from the containing block. The first (top) and third (bottom) values are distances from the top edge of the containing block, and the second (right) and fourth (left) values are distances from the left edge of the containing block. The second (right) and third (bottom) values are limited by the fourth (left) and second (top) values, respectively, to correct the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` gets corrected to `rect(10px 20px 10px 20px)`.
 
 - `auto`
 
-  - : Makes the rectangle edge for which this value is used to coincide with the corresponding edge of the reference box. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is equivalent to 0%, and if used for the the second (right) or third (bottom) value, the value of `auto` is equivalent to 100%.
+  - : Makes the edge for which this value is used to coincide with the corresponding edge of the containing block. If `auto` is used for the first (top) or fourth (left) value, the value of `auto` is equivalent to 0%, and if used for the the second (right) or third (bottom) value, `auto` value is equivalent to 100%.
 
 - `round <border-radius>`
   - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
 
 ## Examples
 
-### Creating a rectangle using rect()
+### Creating offset-path using rect()
+
+In this example, the {{cssxref("offset-path")}} property uses the `rect()` function to define the shape of the path on which the element, red box in this case, moves. Three different scenarios are shown, each using different values for the `rect()` function.
+
+```html
+<div class="container">
+  Rectangular path 1
+  <div class="path rect-path-1"></div>
+</div>
+<div class="container">
+  Rectangular path 2
+  <div class="path rect-path-2"></div>
+</div>
+<div class="container">
+  Rectangular path 3
+  <div class="path rect-path-3"></div>
+</div>
+```
+
+```css
+.container {
+  position: relative;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  border: 1px solid black;
+  margin: 15px;
+  text-align: center;
+}
+
+.path {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  animation: move 10s linear infinite;
+}
+
+.rect-path-1 {
+  background-color: red;
+  offset-path: rect(50px 150px 200px 50px round 20%);
+}
+
+.rect-path-2 {
+  background-color: red;
+  offset-path: rect(50px auto 200px 50px round 20%);
+}
+
+.rect-path-3 {
+  background-color: red;
+  offset-path: rect(50px auto 200px auto);
+}
+
+@keyframes move {
+  0% {
+    offset-distance: 0%;
+  }
+  100% {
+    offset-distance: 100%;
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Creating an offset-path using rect", "100%", 300)}}
+
+- Path 1 rectangle specifies distances of all edges (top, right, bottom, and left) from the containing block. Top and bottom values are distances from the top edge of the containing block. Right and left values are distances from the left edge of the containing block. In addition, the corner of the rectangle is rounded`20%`, so the element moving on this path follows the rounded corner.
+- Path 2 is similar to path 1 except that the right value is `auto`. As a result, the right edge of the rectangle matches the right edge of the containing block.
+- Path 3 omits the corner rounding. Also, both right and left values are set to `auto`.
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -1,15 +1,13 @@
 ---
-title: inset()
-slug: Web/CSS/basic-shape/inset
+title: rect()
+slug: Web/CSS/basic-shape/rect
 page-type: css-function
-browser-compat: css.types.basic-shape.inset
+browser-compat: css.types.basic-shape.rect
 ---
 
 {{CSSRef}}
 
-The **`inset()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from each side of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
-
-{{EmbedInteractiveExample("pages/css/function-inset.html")}}
+The **`rect()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from the top and left edges of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
 
 ## Syntax
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -1,15 +1,13 @@
 ---
-title: inset()
-slug: Web/CSS/basic-shape/inset
+title: xywh()
+slug: Web/CSS/basic-shape/xywh
 page-type: css-function
-browser-compat: css.types.basic-shape.inset
+browser-compat: css.types.basic-shape.xywh
 ---
 
 {{CSSRef}}
 
-The **`inset()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from each side of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
-
-{{EmbedInteractiveExample("pages/css/function-inset.html")}}
+The **`rect()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle with the specified width and height values and positioned at the specified inset distances from the top and left edges of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
 
 ## Syntax
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -29,7 +29,7 @@ clip-path: xywh(1px 2% 3px 4em round 0 1% 2px 3em);
 
 ### Creating offset-path using xywh()
 
-In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, a magenta box in this case, moves. Two different scenarios are shown, each with different values for the `xywh()` function. The arrow inside the box points to the right edge of the box.
+In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, a magenta box in this case, moves. Two different scenarios are shown, each with different values for the `xywh()` function. The arrow inside the boxes points to the right edge of the box.
 
 ```html
 <div class="container">

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -13,7 +13,7 @@ The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the 
 
 ```css
 offset-path: xywh(0 1% 2px 3% round 0 1px 2% 3px);
-clip-path: xywh(1px 2% 3px 4em round 0px 1% 2px 3em);
+clip-path: xywh(1px 2% 3px 4em round 0 1% 2px 3em);
 ```
 
 ### Values
@@ -22,23 +22,23 @@ clip-path: xywh(1px 2% 3px 4em round 0px 1% 2px 3em);
   - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the `x` and `y` coordinates of the rectangle.
 - `<length-percentage [0,∞]>`
   - : Specifies non-negative {{cssxref("&lt;length-percentage&gt;")}} values for the width and height of the rectangle. The minimum value can be zero, and the maximum value has no limit.
-- `round <border-radius>`
-  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
+- `round <'border-radius'>`
+  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
 
 ## Examples
 
 ### Creating offset-path using xywh()
 
-In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, a magenta box in this case, moves. Two different scenarios are shown, each with different values for the `xywh()` function.
+In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, a magenta box in this case, moves. Two different scenarios are shown, each with different values for the `xywh()` function. The arrow inside the box points to the right edge of the box.
 
 ```html
 <div class="container">
   Rectangular path 1
-  <div class="path xywh-path-1"></div>
+  <div class="path xywh-path-1">→</div>
 </div>
 <div class="container">
   Rectangular path 2
-  <div class="path xywh-path-2"></div>
+  <div class="path xywh-path-2">→</div>
 </div>
 ```
 
@@ -49,7 +49,7 @@ In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` 
   width: 200px;
   height: 200px;
   border: 1px solid black;
-  margin: 15px;
+  margin: 30px;
   text-align: center;
 }
 
@@ -57,17 +57,16 @@ In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` 
   width: 50px;
   height: 50px;
   position: absolute;
+  background-color: magenta;
   animation: move 10s linear infinite;
 }
 
 .xywh-path-1 {
-  background-color: magenta;
-  offset-path: xywh(20% 30% 150px 100% round 20%);
+  offset-path: xywh(20px 20px 100% 100% round 10%);
 }
 
 .xywh-path-2 {
-  background-color: magenta;
-  offset-path: xywh(30px 30% 100px 80px);
+  offset-path: xywh(20px 30% 150% 200%);
 }
 
 @keyframes move {
@@ -82,7 +81,10 @@ In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` 
 
 #### Result
 
-{{EmbedLiveSample("Creating offset-path using xywh", "100%", 400)}}
+{{EmbedLiveSample("Creating offset-path using xywh", "100%", 600)}}
+
+- The path 1 rectangle is offset by `20px` from the left and top edges of the containing block. This path rectangle has the same dimension as the containing block, that is, the width is `100%` of the width of the containing block, and the height is `100%` of the height of the containing block. Notice how the arrow inside the box follows the `10%` curve (defined by `round 10%`) at the rectangular path corners.
+- Notice the dimension of the path 2 rectangle. The upper limit of both width and height is infinity. Also notice how the arrow inside the box behaves at the corners when no `round <'border-radius'>` is specified.
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.basic-shape.xywh
 
 {{CSSRef}}
 
-The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `xywh()` function to create a rectangular shape.
+The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified offsets from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `xywh()` function to create the rectangular shape path along which an element moves.
 
 ## Syntax
 
@@ -18,15 +18,70 @@ offset-path: xywh(0px 1% 2px 3% round 0px 1px 2% 3px);
 ### Values
 
 - `<length-percentage>`
-  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the `x` and `y` coordinates of the rectangle element.
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the `x` and `y` coordinates of the rectangle.
 - `<length-percentage [0,∞]>`
-  - : Specifies non-negative {{cssxref("&lt;length-percentage&gt;")}} values for the width and height of the rectangle element. The minimum value can be zero, and the maximum value has no limit.
+  - : Specifies non-negative {{cssxref("&lt;length-percentage&gt;")}} values for the width and height of the rectangle. The minimum value can be zero, and the maximum value has no limit.
 - `round <border-radius>`
   - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
 
 ## Examples
 
-### Creating a rectangle using xywh()
+### Creating offset-path using xywh()
+
+In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, red box in this case, moves. Two different scenarios are shown, each using different values for the `xywh()` function.
+
+```html
+<div class="container">
+  Rectangular path 1
+  <div class="path xywh-path-1"></div>
+</div>
+<div class="container">
+  Rectangular path 2
+  <div class="path xywh-path-2"></div>
+</div>
+```
+
+```css
+.container {
+  position: relative;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  border: 1px solid black;
+  margin: 15px;
+  text-align: center;
+}
+
+.path {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  animation: move 10s linear infinite;
+}
+
+.xywh-path-1 {
+  background-color: magenta;
+  offset-path: xywh(20% 30% 150px 100% round 20%);
+}
+
+.xywh-path-2 {
+  background-color: magenta;
+  offset-path: xywh(30px 30% 100px 80px);
+}
+
+@keyframes move {
+  0% {
+    offset-distance: 0%;
+  }
+  100% {
+    offset-distance: 100%;
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Creating offset-path using xywh", "100%", 400)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -7,12 +7,13 @@ browser-compat: css.types.basic-shape.xywh
 
 {{CSSRef}}
 
-The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified offsets from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `xywh()` function to create the rectangular shape path along which an element moves.
+The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified offsets from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). You can use the `xywh()` function in CSS properties such as {{cssxref("offset-path")}} to create the rectangular path along which an element moves and in {{cssxref("clip-path")}} to define the shape of the clipping region.
 
 ## Syntax
 
 ```css
-offset-path: xywh(0px 1% 2px 3% round 0px 1px 2% 3px);
+offset-path: xywh(0 1% 2px 3% round 0 1px 2% 3px);
+clip-path: xywh(1px 2% 3px 4em round 0px 1% 2px 3em);
 ```
 
 ### Values
@@ -22,13 +23,13 @@ offset-path: xywh(0px 1% 2px 3% round 0px 1px 2% 3px);
 - `<length-percentage [0,∞]>`
   - : Specifies non-negative {{cssxref("&lt;length-percentage&gt;")}} values for the width and height of the rectangle. The minimum value can be zero, and the maximum value has no limit.
 - `round <border-radius>`
-  - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
+  - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [border-radius](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
 
 ## Examples
 
 ### Creating offset-path using xywh()
 
-In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, red box in this case, moves. Two different scenarios are shown, each using different values for the `xywh()` function.
+In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` function to define the shape of the path on which the element, a magenta box in this case, moves. Two different scenarios are shown, each with different values for the `xywh()` function.
 
 ```html
 <div class="container">
@@ -98,4 +99,5 @@ In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` 
 - {{cssxref("clip-path")}} property
 - {{cssxref("offset-path")}} property
 - {{cssxref("&lt;basic-shape&gt;")}} data type
+- [CSS shapes](/en-US/docs/Web/CSS/CSS_shapes) module
 - [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.basic-shape.xywh
 
 {{CSSRef}}
 
-The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle at the specified offsets from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). You can use the `xywh()` function in CSS properties such as {{cssxref("offset-path")}} to create the rectangular path along which an element moves and in {{cssxref("clip-path")}} to define the shape of the clipping region.
+The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function creates a rectangle using the specified distances from the left (`x`) and top (`y`) edges of the containing block and the specified width (`w`) and height (`h`) of the rectangle. It is a basic shape function of the {{cssxref("&lt;basic-shape&gt;")}} [data type](/en-US/docs/Web/CSS/CSS_Types). You can use the `xywh()` function in CSS properties such as {{cssxref("offset-path")}} to create the rectangular path along which an element moves and in {{cssxref("clip-path")}} to define the shape of the clipping region.
 
 ## Syntax
 
@@ -84,7 +84,7 @@ In the example below, the {{cssxref("offset-path")}} property uses the `xywh()` 
 {{EmbedLiveSample("Creating offset-path using xywh", "100%", 600)}}
 
 - The path 1 rectangle is offset by `20px` from the left and top edges of the containing block. This path rectangle has the same dimension as the containing block, that is, the width is `100%` of the width of the containing block, and the height is `100%` of the height of the containing block. Notice how the arrow inside the box follows the `10%` curve (defined by `round 10%`) at the rectangular path corners.
-- Notice the dimension of the path 2 rectangle. The upper limit of both width and height is infinity. Also notice how the arrow inside the box behaves at the corners when no `round <'border-radius'>` is specified.
+- As the upper limit of both width and height in `xywh()` is infinity, setting the height to `200%` in the path 2 rectangle makes the generated rectangle twice as tall as the containing block. Notice how the arrow inside the box behaves at the corners when no `round <'border-radius'>` is specified.
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -7,28 +7,26 @@ browser-compat: css.types.basic-shape.xywh
 
 {{CSSRef}}
 
-The **`rect()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle with the specified width and height values and positioned at the specified inset distances from the top and left edges of the reference box. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
+The **`xywh()`** [CSS](/en-US/docs/Web/CSS) function defines a rectangle at the specified inset distances from the top and left edges of the reference box, with the specified width and height dimensions. It is a basic shape function used to define one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types). CSS properties such as {{cssxref("clip-path")}} and {{cssxref("offset-path")}} use the `xywh()` function to create a rectangular shape.
 
 ## Syntax
 
 ```css
-shape-outside: inset(20px 50px 10px 0 round 50px);
+offset-path: xywh(0px 1% 2px 3% round 0px 1px 2% 3px);
 ```
 
 ### Values
 
-- `<length-percentage>{1,4}`
-  - : When all of the four arguments are supplied they represent the top, right, bottom and left offsets from the reference box inward that define the positions of the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, that let you set all four insets with one, two or four values.
-- `<border-radius>`
-  - : The optional [`<border-radius>`](/en-US/docs/Web/CSS/border-radius) argument(s) define rounded corners for the inset rectangle using the border-radius shorthand syntax.
+- `<length-percentage>`
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} values for the `x` and `y` coordinates of the rectangle element.
+- `<length-percentage [0,∞]>`
+  - : Specifies non-negative {{cssxref("&lt;length-percentage&gt;")}} values for the width and height of the rectangle element. The minimum value can be zero, and the maximum value has no limit.
+- `round <border-radius>`
+  - : Specifies the radius of the rounded corners of the rectangle using the {{cssxref("border-radius")}} shorthand syntax. This parameter is optional.
 
 ## Examples
 
-### Basic inset example
-
-In the example below we have an `inset()` shape used to pull content over the floated element. Change the offset values to see how the shape changes.
-
-{{EmbedGHLiveSample("css-examples/shapes/basic-shape/inset.html", '100%', 800)}}
+### Creating a rectangle using xywh()
 
 ## Specifications
 
@@ -40,5 +38,9 @@ In the example below we have an `inset()` shape used to pull content over the fl
 
 ## See also
 
-- Properties that use this data type: {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}
-- [Guide to Basic Shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)
+- [`inset()`](/en-US/docs/Web/CSS/basic-shape#inset) function
+- [`rect()`](/en-US/docs/Web/CSS/basic-shape#rect) function
+- {{cssxref("clip-path")}} property
+- {{cssxref("offset-path")}} property
+- {{cssxref("&lt;basic-shape&gt;")}} data type
+- [Guide to basic shapes](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Fx117 adds support for two new basic shape functions `rect()` and `xywh()`.
- Preferences that need to enabled (on by default in Nightly 118.0a1):
  - `layout.css.motion-path-basic-shapes.enabled`
  - `layout.css.basic-shape-rect.enabled`
  - `layout.css.basic-shape-xywh.enabled`
- Spec: https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes
- BCD and spec macros will show as flaws. I'll be opening a separate PR to update them.

### Related issues and pull requests

Doc issues: https://github.com/mdn/content/issues/28287, https://github.com/mdn/content/issues/28286
Bug trackers:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1786161 (`rect()`)
- https://bugzilla.mozilla.org/show_bug.cgi?id=1786160 (`xywh()`)
