### PR TITLE
Update the `body` element content category

### DIFF
--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -18,9 +18,7 @@ The **`<body>`** [HTML](/en-US/docs/Web/HTML) element represents the content of 
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots"
-          >Sectioning root</a
-        >.
+        None.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the `body` element content category to match the current version of the HTML specification.

### Motivation

In the current version of the HTML spec, the `body` element [belongs to no content category](https://html.spec.whatwg.org/#the-body-element). The Sectioning root concept has been removed entirely from the spec in 2022.

### Additional details

The closed PR in the HTML spec repository that removed the Sectioning root concept and changed the category of the `body` element: https://github.com/whatwg/html/pull/7829

### Related issues and pull requests

None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
