### PR TITLE
Update `XMLHttpRequest` API description

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/open/index.md
+++ b/files/en-us/web/api/xmlhttprequest/open/index.md
@@ -31,7 +31,7 @@ open(method, url, async, user, password)
     `"GET"`, `"POST"`, `"PUT"`, `"DELETE"`,
     etc. Ignored for non-HTTP(S) URLs.
 - `url`
-  - : A string representing the URL to send the request to.
+  - : A string or any other object with a {{Glossary("stringifier")}} — including a {{domxref("URL")}} object — that provides the URL of the resource to send the request to.
 - `async` {{optional_inline}}
 
   - : An optional Boolean parameter, defaulting to `true`, indicating whether


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added missing `URL` type  in the `xhr.open.url` description. We already have this explained in the `fetch` [docs](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters), and the API works the same for the `XHR`, but it was missing in the docs.

Also in Typescript definitions https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts#L26182

### Motivation

We have it described elsewhere, but it's missing in `mdn` docs

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
