### PR TITLE
feat(ci): cancel concurrency running workflows

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,6 +13,10 @@ on:
       - .github/workflows/markdown-lint.yml
       - .github/workflows/markdownlint-problem-matcher.json
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [synchronize]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label-rebase-needed:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

[Using concurrency](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency) to cancel long running tasks.

### Motivation

In content-related PRs, contributors sometimes apply suggestions from reviewers one by one, ~and if the content has some errors, the committer would receive multiple notifications about workflow failures~ and these tasks are time-consuming. Canceling concurrent workflows helps reduce the running time.

Append:

The committer would [receive the notification about canceling the running workflow](https://github.com/orgs/community/discussions/13015).

### Related issues and pull requests

#28553
