### PR TITLE
Use more recent media file formats

### DIFF
--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -17,8 +17,8 @@ See [Codecs used by WebRTC](/en-US/docs/Web/Media/Formats/WebRTC_codecs) for inf
 
 While there are a vast number of media container formats, the ones listed below are the ones you are most likely to encounter.
 Some support only audio while others support both audio and video.
-The MIME types and extensions for each are listed. The most commonly used containers for media on the web are probably MPEG-4 (MP4), QuickTime Movie (MOV), and the Wavefile Audio File Format (WAV).
-However, you may also encounter MP3, Ogg, WebM, AVI, and other formats.
+The MIME types and extensions for each are listed. The most commonly used containers for media on the web are probably MPEG-4 (MP4), Web Media File (WEBM), and MPEG Audio Layer III (MP3).
+However, you may also encounter MP3, Ogg, WAV, AVI, MOV, and other formats.
 Not all of these are broadly supported by browsers, however; some combinations of container and codec are sometimes given their own file extensions and MIME types as a matter of convenience, or because of their ubiquity.
 For example, an Ogg file with only an Opus audio track is sometimes referred to as an Opus file, and might even have the extension `.opus`.
 But it's still actually just an Ogg file.


### PR DESCRIPTION
### Description

Update "Common container formats" paragraph to use more common file formats according to linked issue.

### Motivation

Using file formats that are more common nowadays makes the documentation feel more up-to-date.

### Related issues and pull requests

Fixes #28488

