### PR TITLE
Simplify `import.meta` example to load relative file in Node.js

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -63,7 +63,7 @@ The ES module implementation in Node.js supports resolving module specifiers con
 
 ### Resolving a file relative to the current one
 
-In Node.js CommonJS modules, there's a `__dirname` variable that contains the absolute path to the folder containing current module, which is useful for resolving relative paths. However, ES modules cannot have contextual variables except for `import.meta`. Therefore, to resolve a relative file you can use [`import.meta.resolve`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). Note that this uses URLs rather than filesystem paths.
+In Node.js CommonJS modules, there's a `__dirname` variable that contains the absolute path to the folder containing current module, which is useful for resolving relative paths. However, ES modules cannot have contextual variables except for `import.meta`. Therefore, to resolve a relative file you can use `import.meta.url`. Note that this uses URLs rather than filesystem paths.
 
 Before (CommonJS):
 
@@ -80,7 +80,7 @@ After (ES modules):
 ```js
 import fs from "node:fs/promises";
 
-const fileUrl = import.meta.resolve("./someFile.txt");
+const fileUrl = new URL("./someFile.txt", import.meta.url);
 fs.readFile(fileUrl, "utf8").then(console.log);
 ```
 

--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -80,8 +80,8 @@ After (ES modules):
 ```js
 import fs from "node:fs/promises";
 
-const fileUrl = new URL("./someFile.txt", import.meta.url);
-fs.readFile(fileUrl, "utf8").then(console.log);
+const fileURL = new URL("./someFile.txt", import.meta.url);
+fs.readFile(fileURL, "utf8").then(console.log);
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -61,9 +61,9 @@ new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 
 The ES module implementation in Node.js supports resolving module specifiers containing query parameters (or the hash), as in the latter example. However, you cannot use queries or hashes when the module is specified through the CLI command (like `node index.mjs?someURLInfo=5`), because the CLI entrypoint uses a more CommonJS-like resolution mode, treating the path as a file path rather than a URL. To pass parameters to the entrypoint module, use CLI arguments and read them through `process.argv` instead (like `node index.mjs --someURLInfo=5`).
 
-### Getting current module's file path
+### Resolving a file relative to the current one
 
-In Node.js CommonJS modules, there's a `__dirname` variable that contains the absolute path to the folder containing current module, which is useful for resolving relative paths. However, ES modules cannot have contextual variables except for `import.meta`. Therefore, to get the current module's file path, you can use `import.meta.url`.
+In Node.js CommonJS modules, there's a `__dirname` variable that contains the absolute path to the folder containing current module, which is useful for resolving relative paths. However, ES modules cannot have contextual variables except for `import.meta`. Therefore, to resolve a relative file you can use [`import.meta.resolve`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve). Note that this uses URLs rather than filesystem paths.
 
 Before (CommonJS):
 
@@ -79,10 +79,9 @@ After (ES modules):
 
 ```js
 import fs from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 
-const filePath = fileURLToPath(new URL("./someFile.txt", import.meta.url));
-fs.readFile(filePath, "utf8").then(console.log);
+const fileUrl = import.meta.resolve("./someFile.txt");
+fs.readFile(fileUrl, "utf8").then(console.log);
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR simplifies the CommonJS vs ESM example that shows how to load local files in Node.js, removing the `fileUrlToPath` call.

### Motivation

It directly passes an URL rather than a filesystem path to `fs.readFile`. Node.js supports both, and we can avoid introducing users to an extra Node.js API that isn't necessary to understand `import.meta`.

### Additional details

`readFile` docs: https://nodejs.org/dist/latest/docs/api/fs.html#fspromisesreadfilepath-options

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
