### PR TITLE
Fix issue 28589: ResizeObserverEntry properties are arrays

### DIFF
--- a/files/en-us/web/api/resizeobserverentry/index.md
+++ b/files/en-us/web/api/resizeobserverentry/index.md
@@ -12,11 +12,11 @@ The **`ResizeObserverEntry`** interface represents the object passed to the {{do
 ## Instance properties
 
 - {{domxref('ResizeObserverEntry.borderBoxSize')}} {{ReadOnlyInline}}
-  - : An object containing the new border box size of the observed element when the callback is run.
+  - : An array of objects containing the new border box size of the observed element when the callback is run.
 - {{domxref('ResizeObserverEntry.contentBoxSize')}} {{ReadOnlyInline}}
-  - : An object containing the new content box size of the observed element when the callback is run.
+  - : An array of objects containing the new content box size of the observed element when the callback is run.
 - {{domxref('ResizeObserverEntry.devicePixelContentBoxSize')}} {{ReadOnlyInline}}
-  - : An object containing the new content box size in device pixels of the observed element when the callback is run.
+  - : An array of objects containing the new content box size in device pixels of the observed element when the callback is run.
 - {{domxref('ResizeObserverEntry.contentRect')}} {{ReadOnlyInline}}
   - : A {{domxref('DOMRectReadOnly')}} object containing the new size of the observed element when the callback is run. Note that this is better supported than the above two properties, but it is left over from an earlier implementation of the Resize Observer API, is still included in the spec for web compat reasons, and may be deprecated in future versions.
 - {{domxref('ResizeObserverEntry.target')}} {{ReadOnlyInline}}
@@ -30,28 +30,38 @@ None.
 
 ## Examples
 
-The following snippet is taken from the [resize-observer-text.html](https://mdn.github.io/dom-examples/resize-observer/resize-observer-text.html) ([see source](https://github.com/mdn/dom-examples/blob/main/resize-observer/resize-observer-text.html)) example. This uses a simple feature detection test to see if the browser supports the newer `contentBoxSize` property — if so, it uses that to get the sizing data it needs. If not, it uses the older `contentRect` property.
+The following snippet is taken from the [resize-observer-text.html](https://mdn.github.io/dom-examples/resize-observer/resize-observer-text.html) ([see source](https://github.com/mdn/dom-examples/blob/main/resize-observer/resize-observer-text.html)) example.
+
+Note that the code covers three different compatibility cases:
+
+- Some old browsers may support `contentRect` but not `contentBoxSize`.
+- Old versions of Firefox support `contentBoxSize`, but incorrectly implemented it as a single object rather than an array.
+- Modern browsers support `contentBoxSize` as an array of objects, to enable them to report box sizes for fragmented elements (for example, in a multi-column scenario).
 
 ```js
 const resizeObserver = new ResizeObserver((entries) => {
-  for (const entry of entries) {
+  for (let entry of entries) {
     if (entry.contentBoxSize) {
-      h1Elem.style.fontSize = `${Math.max(
-        1.5,
-        entry.contentBoxSize.inlineSize / 200,
-      )}rem`;
-      pElem.style.fontSize = `${Math.max(
-        1,
-        entry.contentBoxSize.inlineSize / 600,
-      )}rem`;
+      // The standard makes contentBoxSize an array...
+      if (entry.contentBoxSize[0]) {
+        h1Elem.style.fontSize =
+          Math.max(1.5, entry.contentBoxSize[0].inlineSize / 200) + "rem";
+        pElem.style.fontSize =
+          Math.max(1, entry.contentBoxSize[0].inlineSize / 600) + "rem";
+      } else {
+        // ...but old versions of Firefox treat it as a single item
+        h1Elem.style.fontSize =
+          Math.max(1.5, entry.contentBoxSize.inlineSize / 200) + "rem";
+        pElem.style.fontSize =
+          Math.max(1, entry.contentBoxSize.inlineSize / 600) + "rem";
+      }
     } else {
-      h1Elem.style.fontSize = `${Math.max(
-        1.5,
-        entry.contentRect.width / 200,
-      )}rem`;
-      pElem.style.fontSize = `${Math.max(1, entry.contentRect.width / 600)}rem`;
+      h1Elem.style.fontSize =
+        Math.max(1.5, entry.contentRect.width / 200) + "rem";
+      pElem.style.fontSize = Math.max(1, entry.contentRect.width / 600) + "rem";
     }
   }
+  console.log("Size changed");
 });
 
 resizeObserver.observe(divElem);


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28589. I also updated the code sample to match https://github.com/mdn/dom-examples/blob/main/resize-observer/resize-observer-text.html exactly.