### PR TITLE
Fix issue 24987: introduce template literals

### DIFF
--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -287,9 +287,9 @@ At this point, replace your current `checkGuess()` function with this version in
 function checkGuess() {
   const userGuess = Number(guessField.value);
   if (guessCount === 1) {
-    guesses.textContent = "Previous guesses: ";
+    guesses.textContent = "Previous guesses:";
   }
-  guesses.textContent = `${guesses.textContent}${userGuess} `;
+  guesses.textContent = `${guesses.textContent} ${userGuess}`;
 
   if (userGuess === randomNumber) {
     lastResult.textContent = "Congratulations! You got it right!";
@@ -327,7 +327,7 @@ This is a lot of code — phew! Let's go through each section and explain what i
 
   If it is, we make the guesses paragraph's text content equal to `Previous guesses:`. If not, we don't.
 
-- Next, we use a template literal to append the current `userGuess` value onto the end of the `guesses` paragraph, plus a blank space so there will be a space between each guess shown.
+- Next, we use a template literal to append the current `userGuess` value onto the end of the `guesses` paragraph, with a blank space in between.
 - The next block does a few checks:
 
   - The first `if (){ }` checks whether the user's guess is equal to the `randomNumber` set at the top of our JavaScript. If it is, the player has guessed correctly and the game is won, so we show the player a congratulations message with a nice green color, clear the contents of the Low/High guess information box, and run a function called `setGameOver()`, which we'll discuss later.

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -183,29 +183,18 @@ First let's look at arithmetic operators, for example:
 | `*`      | Multiplication | `3 * 7`   |
 | `/`      | Division       | `10 / 5`  |
 
-You can also use the `+` operator to join text strings together (in programming, this is called _concatenation_). Try entering the following lines, one at a time:
+There are also some shortcut operators available, called augmented [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators). For example, if you want to add a new number to an existing one and return the result, you could do this:
 
 ```js
-const name = "Bingo";
-name;
-const hello = " says hello!";
-hello;
-const greeting = name + hello;
-greeting;
-```
-
-There are also some shortcut operators available, called augmented [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators). For example, if you want to add a new text string to an existing one and return the result, you could do this:
-
-```js
-let name1 = "Bingo";
-name1 += " says hello!";
+let number1 = 1;
+number1 += 2;
 ```
 
 This is equivalent to
 
 ```js
-let name2 = "Bingo";
-name2 = name2 + " says hello!";
+let number2 = 1;
+number2 = number2 + 2;
 ```
 
 When we are running true/false tests (for example inside conditionals — see [below](#conditionals)) we use [comparison operators](/en-US/docs/Web/JavaScript/Reference/Operators). For example:
@@ -266,6 +255,28 @@ When we are running true/false tests (for example inside conditionals — see [b
   </thead>
 </table>
 
+### Text strings
+
+Strings are used for representing text. We've already seen a string variable. In the following code, `"I am a placeholder"` is a string:
+
+```js
+function checkGuess() {
+  alert("I am a placeholder");
+}
+```
+
+You can declare strings using double quotes (`"`) or single quotes (`'`), but you must use the same form for the start and end of a single string declaration: you can't write `"I am a placeholder'`.
+
+You can also declare strings using backticks (`` ` ``). Strings declared like this are called _template literals_ and have some special properties. In particular, you can embed other variables or even expressions in them:
+
+```js
+const name = "Mahalia";
+
+const greeting = `Hello ${name}`;
+```
+
+This gives you a mechanism to join strings together.
+
 ### Conditionals
 
 Returning to our `checkGuess()` function, I think it's safe to say that we don't want it to just spit out a placeholder message. We want it to check whether a player's guess is correct or not, and respond appropriately.
@@ -278,7 +289,7 @@ function checkGuess() {
   if (guessCount === 1) {
     guesses.textContent = "Previous guesses: ";
   }
-  guesses.textContent += `${userGuess} `;
+  guesses.textContent = `${guesses.textContent}${userGuess} `;
 
   if (userGuess === randomNumber) {
     lastResult.textContent = "Congratulations! You got it right!";
@@ -316,7 +327,7 @@ This is a lot of code — phew! Let's go through each section and explain what i
 
   If it is, we make the guesses paragraph's text content equal to `Previous guesses:`. If not, we don't.
 
-- Line 6 appends the current `userGuess` value onto the end of the `guesses` paragraph, plus a blank space so there will be a space between each guess shown.
+- Next, we use a template literal to append the current `userGuess` value onto the end of the `guesses` paragraph, plus a blank space so there will be a space between each guess shown.
 - The next block does a few checks:
 
   - The first `if (){ }` checks whether the user's guess is equal to the `randomNumber` set at the top of our JavaScript. If it is, the player has guessed correctly and the game is won, so we show the player a congratulations message with a nice green color, clear the contents of the Low/High guess information box, and run a function called `setGameOver()`, which we'll discuss later.

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -257,7 +257,7 @@ When we are running true/false tests (for example inside conditionals — see [b
 
 ### Text strings
 
-Strings are used for representing text. We've already seen a string variable. In the following code, `"I am a placeholder"` is a string:
+Strings are used for representing text. We've already seen a string variable: in the following code, `"I am a placeholder"` is a string:
 
 ```js
 function checkGuess() {

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -183,7 +183,7 @@ First let's look at arithmetic operators, for example:
 | `*`      | Multiplication | `3 * 7`   |
 | `/`      | Division       | `10 / 5`  |
 
-There are also some shortcut operators available, called augmented [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators). For example, if you want to add a new number to an existing one and return the result, you could do this:
+There are also some shortcut operators available, called [compound assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators). For example, if you want to add a new number to an existing one and return the result, you could do this:
 
 ```js
 let number1 = 1;


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/24987:

- stop talking about using `+` for string concatenation
- introduce template literals - though I never know how much to go into details in super-intro material like this
- update the code so it consistently uses template literals for concatenation

We ought to update https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html as well - it's already divergent from the code in the page 😭 .

