### PR TITLE
reference the common sidebar and page banner macros

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -583,7 +583,7 @@ This issue was resolved in <https://github.com/mdn/content/issues/4578>.
 
 ## Page summary
 
-The _page summary_ is the first "content" paragraph in a page—the first text that appears after the page front matter and any [sidebar or page banner macros](#macros).
+The _page summary_ is the first "content" paragraph in a page—the first text that appears after the page front matter and any [sidebar](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#sidebar_generation) or [page banner](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#page_or_section_header_indicators) macros.
 
 This summary is used for search engine optimization (SEO) and also automatically included alongside page listings by some macros.
 The first paragraph should therefore be both succinct and informative.


### PR DESCRIPTION
### Description

reference the common sidebar and page banner macros.

### Motivation

As a document written to help contributors get started with contributing MDN documents, the reference content should point to a clear document (or section). The previous link pointed to KumaScript below (has be broken now), but it is also difficult for readers to determine what a sidebar (or page banner) macro is.

This PR references the sections in "Commonly used macros".
