### PR TITLE
Clarify the message to explicitly convey that it refers to an error being thrown.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -247,7 +247,7 @@ console.log(a.length); // 0
 
 #### Array-like objects
 
-The term [_array-like object_](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) refers to any object that doesn't throw during the `length` conversion process described above. In practice, such object is expected to actually have a `length` property and to have indexed elements in the range `0` to `length - 1`. (If it doesn't have all indices, it will be functionally equivalent to a [sparse array](#array_methods_and_empty_slots).) Any integer index less than zero or greater than `length - 1` is ignored when an array method operates on an array-like object.
+The term [_array-like object_](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects) refers to any object that doesn't throw an error during the `length` conversion process described above. In practice, such object is expected to actually have a `length` property and to have indexed elements in the range `0` to `length - 1`. (If it doesn't have all indices, it will be functionally equivalent to a [sparse array](#array_methods_and_empty_slots).) Any integer index less than zero or greater than `length - 1` is ignored when an array method operates on an array-like object.
 
 Many DOM objects are array-like — for example, [`NodeList`](/en-US/docs/Web/API/NodeList) and [`HTMLCollection`](/en-US/docs/Web/API/HTMLCollection). The [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object is also array-like. You can call array methods on them even if they don't have these methods themselves.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.md
@@ -750,20 +750,33 @@ const values = [];
 for (let x = 0; x < 10; x++) {
   values.push([2 ** x, 2 * x ** 2]);
 }
-console.table(values);
+
+for (let i = 0; i < values.length; i++) {
+  let val = "";
+
+  for (let j = 0; j < values[i].length; j++) {
+    if (j === 0) {
+      val += `${values[i][j]}  `;
+    } else {
+      val += `${values[i][j]}`;
+    }
+  }
+
+  console.log(`${i}  ${val}`);
+}
 ```
 
 Results in
 
 ```plain
 // The first column is the index
-0  1    0
-1  2    2
-2  4    8
-3  8    18
-4  16   32
-5  32   50
-6  64   72
+0  1  0
+1  2  2
+2  4  8
+3  8  18
+4  16  32
+5  32  50
+6  64  72
 7  128  98
 8  256  128
 9  512  162


### PR DESCRIPTION
This change makes it clear to the reader that an error thrown is what is meant and not just "throw".