### PR TITLE
 font-variant css2 and numeric data types

### DIFF
--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -41,26 +41,32 @@ This property can take one of two forms:
 ### Values
 
 - `normal`
+
   - : This keyword leads to the deactivation of the use of such alternate glyphs.
+
 - `ordinal`
+
   - : This keyword forces the use of special glyphs for the ordinal markers, like 1st, 2nd, 3rd, 4th in English or a 1a in Italian. It corresponds to the OpenType values `ordn`.
+
 - `slashed-zero`
+
   - : This keyword forces the use of a 0 with a slash; this is useful when a clear distinction between O and 0 is needed. It corresponds to the OpenType values `zero`.
-- _\<numeric-figure-values_>
+
+- _`<numeric-figure-values`>_
 
   - : These values control the figures used for numbers. Two values are possible:
 
     - `lining-nums` activating the set of figures where numbers are all lying on the baseline. It corresponds to the OpenType values `lnum`.
     - `oldstyle-nums` activating the set of figures where some numbers, like 3, 4, 7, 9 have descenders. It corresponds to the OpenType values `onum`.
 
-- _\<numeric-spacing-values_>
+- _`<numeric-spacing-values>`_
 
   - : These values controls the sizing of figures used for numbers. Two values are possible:
 
     - `proportional-nums` activating the set of figures where numbers are not all of the same size. It corresponds to the OpenType values `pnum`.
     - `tabular-nums` activating the set of figures where numbers are all of the same size, allowing them to be easily aligned like in tables. It corresponds to the OpenType values `tnum`.
 
-- _\<numeric-fraction-values_>
+- _`<numeric-fraction-values>`_
 
   - : These values controls the glyphs used to display fractions. Two values are possible:
 

--- a/files/en-us/web/css/font-variant/index.md
+++ b/files/en-us/web/css/font-variant/index.md
@@ -42,21 +42,37 @@ font-variant: unset;
 ### Values
 
 - `normal`
+
   - : Specifies a normal font face. Each longhand property has an initial value of `normal`.
+
 - `none`
+
   - : Sets the value of the [`font-variant-ligatures`](/en-US/docs/Web/CSS/font-variant-ligatures) as `none` and the values of the other longhand properties as `normal`, their initial value.
+
 - `<common-lig-values>`, `<discretionary-lig-values>`, `<historical-lig-values>`, `<contextual-alt-values>`
+
   - : Specifies the keywords related to the [`font-variant-ligatures`](/en-US/docs/Web/CSS/font-variant-ligatures) longhand property. The possible values are `common-ligatures`, `no-common-ligatures`, `discretionary-ligatures`, `no-discretionary-ligatures`, `historical-ligatures`, `no-historical-ligatures`, `contextual`, and `no-contextual`.
+
 - `stylistic()`, `historical-forms`, `styleset()`, `character-variant()`, `swash()`, `ornaments()`, `annotation()`
+
   - : Specifies the keywords and functions related to the [`font-variant-ligatures`](/en-US/docs/Web/CSS/font-variant-ligatures) longhand property.
+
 - `small-caps`, `all-small-caps`, `petite-caps`, `all-petite-caps`, `unicase`, `titling-caps`
-  - : Specifies the keywords and functions related to the [`font-variant-caps`](/en-US/docs/Web/CSS/font-variant-caps) longhand property.
+
+  - : Specifies the keywords and functions related to the [`font-variant-caps`](/en-US/docs/Web/CSS/font-variant-caps) longhand property. The `small-caps` value is the only non-`normal` font variant valid within the {{cssxref("font")}} shorthand property.
+
 - `<numeric-figure-values>`, `<numeric-spacing-values>`, `<numeric-fraction-values>`, `ordinal`, `slashed-zero`
+
   - : Specifies the keywords related to the [`font-variant-numeric`](/en-US/docs/Web/CSS/font-variant-numeric) longhand property. The possible values are `lining-nums`, `oldstyle-nums`, `proportional-nums`, `tabular-nums`, `diagonal-fractions`, `stacked-fractions`, `ordinal`, and `slashed-zero`.
+
 - `<east-asian-variant-values>`, `<east-asian-width-values>`, `ruby`
+
   - : Specifies the keywords related to the [`font-variant-east-asian`](/en-US/docs/Web/CSS/font-variant-east-asian) longhand property. The possible values are `jis78`, `jis83`, `jis90`, `jis04`, `simplified`, `traditional`, `full-width`, `proportional-width`, and `ruby`.
+
 - `sub`, `super`
+
   - : Specifies the keywords and functions related to the [`font-variant-position`](/en-US/docs/Web/CSS/font-variant-position) longhand property.
+
 - `text`, `emoji`, `unicode`
   - : Specifies the keywords and functions related to the [`font-variant-emoji`](/en-US/docs/Web/CSS/font-variant-emoji) longhand property.
 

--- a/files/en-us/web/css/font-variant/index.md
+++ b/files/en-us/web/css/font-variant/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.font-variant
 
 The **`font-variant`** CSS [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) allows you to set all the font variants for a font.
 
-You can also set the CSS Level 2 (Revision 1) values of `font-variant`, (that is, `normal` or `small-caps`), by using the [`font`](/en-US/docs/Web/CSS/font) shorthand.
+You can also set the `<font-variant-css2>` values of `font-variant` defined in CSS Level 2.1, (that is, `normal` or `small-caps`), by using the [`font`](/en-US/docs/Web/CSS/font) shorthand.
 
 {{EmbedInteractiveExample("pages/css/font-variant.html")}}
 


### PR DESCRIPTION
part of https://github.com/openwebdocs/project/issues/176

adding the name of group of keywords to the one place they were introduced. Not worth a page, but need to be on MDN in case someone searches for it.

also added space between each definition b/c without white space this was difficult to decipher in markdown