### PR TITLE
Fix 28545: decribe template literals more explicitly

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -211,7 +211,7 @@ const goodQuotes1 = 'She said "I think so!"';
 const goodQuotes2 = `She said "I'm not going in there!"`;
 ```
 
-Another option is to _escape_ the problem quoteation mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:
+Another option is to _escape_ the problem quotation mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:
 
 ```js-nolint
 const bigmouth = 'I\'ve got no right to take my place…';

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -82,9 +82,9 @@ You must use the same character for the start and end of a string, or you will g
 const badQuotes = 'This is not allowed!";
 ```
 
-Strings declared using single quotes and strings declared using double quotes are the same, and which you use is down to personal preference — although it is good practice to choose one method and use it consistently in your code.
+Strings declared using single quotes and strings declared using double quotes are the same, and which you use is down to personal preference — although it is good practice to choose one style and use it consistently in your code.
 
-Strings declared using backticks are a special kind of string called a _template literal_. In most ways, template literals are like normal strings, but they have some special properties:
+Strings declared using backticks are a special kind of string called a [_template literal_](/en-US/docs/Web/JavaScript/Reference/Template_literals). In most ways, template literals are like normal strings, but they have some special properties:
 
 - you can [embed JavaScript](#embedding_javascript) in them
 - you can declare template literals over [multiple lines](#multiline_strings)
@@ -230,7 +230,7 @@ const number = 242;
 console.log(`${name}${number}`); // "Front 242"
 ```
 
-You might expect this to return an error, but it works just fine. Trying to represent a string as a number doesn't really make sense, but representing a number as a string does, so the browser converts the number to a string and concatenates the two strings.
+You might expect this to return an error, but it works just fine. How numbers should be displayed as strings is fairly well-defined, so the browser automatically converts the number to a string and concatenates the two strings.
 
 If you have a numeric variable that you want to convert to a string but not change otherwise, or a string variable that you want to convert to a number but not change otherwise, you can use the following two constructs:
 

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -232,7 +232,7 @@ console.log(`${name}${number}`); // "Front 242"
 
 You might expect this to return an error, but it works just fine. How numbers should be displayed as strings is fairly well-defined, so the browser automatically converts the number to a string and concatenates the two strings.
 
-If you have a numeric variable that you want to convert to a string but not change otherwise, or a string variable that you want to convert to a number but not change otherwise, you can use the following two constructs:
+If you have a numeric variable that you want to convert to a string, or a string variable that you want to convert to a number, you can use the following two constructs:
 
 - The {{jsxref("Number/Number", "Number()")}} function converts anything passed to it into a number, if it can. Try the following:
 
@@ -240,14 +240,16 @@ If you have a numeric variable that you want to convert to a string but not chan
   const myString = "123";
   const myNum = Number(myString);
   console.log(typeof myNum);
+  // number
   ```
 
-- Conversely, every number has a method called [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) that converts it to the equivalent string. Try this:
+- Conversely, the {{jsxref("String/String", "String()")}} function converts its argument to a string. Try this:
 
   ```js
   const myNum2 = 123;
-  const myString2 = myNum2.toString();
+  const myString2 = String(myNum2);
   console.log(typeof myString2);
+  // string
   ```
 
 These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game, in line 59](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html#L59).

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -30,96 +30,68 @@ Words are very important to humans — they are a large part of how we communica
 
 Pretty much all of the programs we've shown you so far in the course have involved some string manipulation.
 
-## Strings — the basics
+## Declaring strings
 
 Strings are dealt with similarly to numbers at first glance, but when you dig deeper you'll start to see some notable differences. Let's start by entering some basic lines into the [browser developer console](/en-US/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools) to familiarize ourselves.
 
-### Creating a string
-
-1. To start with, enter the following lines:
-
-   ```js
-   const string = "The revolution will not be televised.";
-   console.log(string);
-   ```
-
-   Just like we did with numbers, we are declaring a variable, initializing it with a string value, and then returning the value. The only difference here is that when writing a string, you need to surround the value with quotes.
-
-2. If you don't do this, or miss one of the quotes, you'll get an error. Try entering the following lines:
-
-   ```js example-bad
-   const badString1 = This is a test;
-   const badString2 = 'This is a test;
-   const badString3 = This is a test';
-   ```
-
-   These lines don't work because any text without quotes around it is assumed to be a variable name, property name, a reserved word, or similar. If the browser can't find it, then an error is raised (e.g. "missing; before statement"). If the browser can see where a string starts, but can't find the end of the string, as indicated by the 2nd quote, it complains with an error (with "unterminated string literal"). If your program is raising such errors, then go back and check all your strings to make sure you have no missing quote marks.
-
-3. The following will work if you previously defined the variable `string` — try it now:
-
-   ```js
-   const badString = string;
-   console.log(badString);
-   ```
-
-   `badString` is now set to have the same value as `string`.
-
-### Single quotes vs. double quotes
-
-1. In JavaScript, you can choose single quotes or double quotes to wrap your strings in. Both of the following will work okay:
-
-   ```js-nolint
-   const sgl = 'Single quotes.';
-   const dbl = "Double quotes";
-   console.log(sgl);
-   console.log(dbl);
-   ```
-
-2. There is very little difference between the two, and which you use is down to personal preference. You should choose one and stick to it, however; differently quoted code can be confusing, especially if you use two different quotes on the same string! The following will return an error:
-
-   ```js-nolint example-bad
-   const badQuotes = 'What on earth?";
-   ```
-
-3. The browser will think the string has not been closed because the other type of quote you are not using to contain your strings can appear in the string. For example, both of these are okay:
-
-   ```js
-   const sglDbl = 'Would you eat a "fish supper"?';
-   const dblSgl = "I'm feeling blue.";
-   console.log(sglDbl);
-   console.log(dblSgl);
-   ```
-
-4. However, you can't include the same quote mark inside the string if it's being used to contain them. The following will error, as it confuses the browser as to where the string ends:
-
-   ```js-nolint example-bad
-   const bigmouth = 'I've got no right to take my place…';
-   ```
-
-   This leads us very nicely into our next subject.
-
-### Escaping characters in a string
-
-To fix our previous problem code line, we need to escape the problem quote mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:
-
-```js-nolint
-const bigmouth = 'I\'ve got no right to take my place…';
-console.log(bigmouth);
-```
-
-This works fine. You can escape other characters in the same way, e.g. `\"`, and there are some special codes besides. See [Escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) for more details.
-
-## Concatenating strings
-
-Concatenate just means "join together". To join together strings in JavaScript you can use a different type of string, called a _template literal_.
-
-A template literal looks just like a normal string, but instead of using single or double quote marks (`'` or `"`), you use backtick characters (`` ` ``):
+To start with, enter the following lines:
 
 ```js
-const greeting = `Hello`;
+const string = "The revolution will not be televised.";
+console.log(string);
 ```
 
-This can work just like a normal string, except you can include variables in it, wrapped inside `${ }` characters, and the variable's value will be inserted into the result:
+Just like we did with numbers, we are declaring a variable, initializing it with a string value, and then returning the value. The only difference here is that when writing a string, you need to surround the value with quotes.
+
+If you don't do this, or miss one of the quotes, you'll get an error. Try entering the following lines:
+
+```js example-bad
+const badString1 = This is a test;
+const badString2 = 'This is a test;
+const badString3 = This is a test';
+```
+
+These lines don't work because any text without quotes around it is assumed to be a variable name, property name, a reserved word, or similar. If the browser can't find it, then an error is raised (e.g. "missing; before statement"). If the browser can see where a string starts, but can't find the end of the string, as indicated by the 2nd quote, it complains with an error (with "unterminated string literal"). If your program is raising such errors, then go back and check all your strings to make sure you have no missing quote marks.
+
+The following will work if you previously defined the variable `string` — try it now:
+
+```js
+const badString = string;
+console.log(badString);
+```
+
+`badString` is now set to have the same value as `string`.
+
+### Single quotes, double quotes, and backticks
+
+In JavaScript, you can choose single quotes (`'`), double quotes (`"`), or backticks (`` ` ``) to wrap your strings in. All of the following will work:
+
+```js-nolint
+const single = 'Single quotes';
+const double = "Double quotes";
+const backtick = `Backtick`;
+
+console.log(single);
+console.log(double);
+console.log(backtick);
+```
+
+You must use the same character for the start and end of a string, or you will get an error:
+
+```js-nolint example-bad
+const badQuotes = 'This is not allowed!";
+```
+
+Strings declared using single quotes and strings declared using double quotes are the same, and which you use is down to personal preference — although it is good practice to choose one method and use it consistently in your code.
+
+Strings declared using backticks are a special kind of string called a _template literal_. In most ways, template literals are like normal strings, but they have some special properties:
+
+- you can [embed JavaScript](#embedding_javascript) in them
+- you can declare template literals over [multiple lines](#multiline_strings)
+
+## Embedding JavaScript
+
+Inside a template literal, you can wrap JavaScript variables or expressions inside `${ }`, and the result will be included in the string:
 
 ```js
 const name = "Chris";
@@ -136,12 +108,15 @@ const joined = `${one}${two}`;
 console.log(joined); // "Hello, how are you?"
 ```
 
+Joining strings together like this is called _concatenation_.
+
 ### Concatenation in context
 
 Let's have a look at concatenation being used in action:
 
 ```html
 <button>Press me</button>
+<div id="greeting"></div>
 ```
 
 ```js
@@ -149,7 +124,8 @@ const button = document.querySelector("button");
 
 function greet() {
   const name = prompt("What is your name?");
-  alert(`Hello ${name}, nice to see you!`);
+  const greeting = document.querySelector("#greeting");
+  greeting.textContent = `Hello ${name}, nice to see you!`;
 }
 
 button.addEventListener("click", greet);
@@ -157,11 +133,11 @@ button.addEventListener("click", greet);
 
 {{ EmbedLiveSample('Concatenation_in_context', '100%', 50) }}
 
-Here we're using the {{domxref("window.prompt()", "window.prompt()")}} function, which asks the user to answer a question via a popup dialog box then stores the text they enter inside a given variable — in this case `name`. We then use the {{domxref("window.alert()", "window.alert()")}} function to display another popup containing a string which inserts the name into a generic greeting message.
+Here we're using the {{domxref("window.prompt()", "window.prompt()")}} function, which asks the user to answer a question via a popup dialog box then stores the text they enter inside a given variable — in this case `name`. We then display a string which inserts the name into a generic greeting message.
 
 ### Concatenation using "+"
 
-You can also concatenate strings using the `+` operator:
+You can only use `${}` with template literals, not with normal strings. You can concatenate normal strings using the `+` operator:
 
 ```js
 const greeting = "Hello";
@@ -177,9 +153,76 @@ const name = "Chris";
 console.log(`${greeting}, ${name}`); // "Hello, Chris"
 ```
 
+### Including expressions in strings
+
+You can include JavaScript expressions in template literals, as well as just variables, and the results will be included in the result:
+
+```js
+const song = "Fight the Youth";
+const score = 9;
+const highestScore = 10;
+const output = `I like the song ${song}. I gave it a score of ${
+  (score / highestScore) * 100
+}%.`;
+console.log(output); // "I like the song Fight the Youth. I gave it a score of 90%."
+```
+
+## Multiline strings
+
+Template literals respect the line breaks in the source code, so you can write strings that span multiple lines like this:
+
+```js
+const newline = `One day you finally knew
+what you had to do, and began,`;
+console.log(newline);
+
+/*
+One day you finally knew
+what you had to do, and began,
+*/
+```
+
+To have the equivalent output using a normal string you'd have to include line break characters (`\n`) in the string:
+
+```js
+const newline = "One day you finally knew\nwhat you had to do, and began,";
+console.log(newline);
+
+/*
+One day you finally knew
+what you had to do, and began,
+*/
+```
+
+See our [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) reference page for more examples and details of advanced features.
+
+## Including quotes in strings
+
+Since we use quotes to indicate the start and end of strings, how can we include actual quotes in strings? We know that this won't work:
+
+```js-nolint example-bad
+const badQuotes = "She said "I think so!"";
+```
+
+One common option is to use one of the other characters to declare the string:
+
+```js-nolint
+const goodQuotes1 = 'She said "I think so!"';
+const goodQuotes2 = `She said "I'm not going in there!"`;
+```
+
+Another option is to _escape_ the problem quoteation mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:
+
+```js-nolint
+const bigmouth = 'I\'ve got no right to take my place…';
+console.log(bigmouth);
+```
+
+You can use the same technique to insert other special characters. See [Escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) for more details.
+
 ## Numbers vs. strings
 
-So what happens when we try to combine a string and a number? Let's try it in our console:
+What happens when we try to concatenate a string and a number? Let's try it in our console:
 
 ```js
 const name = "Front ";
@@ -208,49 +251,6 @@ If you have a numeric variable that you want to convert to a string but not chan
   ```
 
 These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game, in line 59](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html#L59).
-
-## Including expressions in strings
-
-You can include JavaScript expressions in template literals, as well as simple variables, and the results will be included in the result:
-
-```js
-const song = "Fight the Youth";
-const score = 9;
-const highestScore = 10;
-const output = `I like the song ${song}. I gave it a score of ${
-  (score / highestScore) * 100
-}%.`;
-console.log(output); // "I like the song Fight the Youth. I gave it a score of 90%."
-```
-
-## Multiline strings
-
-Template literals respect the line breaks in the source code, so you can write strings that span multiple lines like this:
-
-```js
-const output = `I like the song.
-I gave it a score of 90%.`;
-console.log(output);
-
-/*
-I like the song.
-I gave it a score of 90%.
-*/
-```
-
-To have the equivalent output using a normal string you'd have to include line break characters (`\n`) in the string:
-
-```js
-const output = "I like the song.\nI gave it a score of 90%.";
-console.log(output);
-
-/*
-I like the song.
-I gave it a score of 90%.
-*/
-```
-
-See our [Template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals) reference page for more examples and details of advanced features.
 
 ## Conclusion
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28545.

In this PR I've tried to present template literals alongside "normal" strings, rather than as an afterthought. I couldn't see a way to do it without some fairly big structural changes, although not all that much content is changed.

I guess this unfortunately means the Odin Project link in https://github.com/mdn/content/issues/28545#issuecomment-1677625718 will break... I don't want to keep the old section name or implement any hacks for this, but maybe we could [contribute a fix there](https://github.com/TheOdinProject/curriculum/blob/8e54ecd6730fb1c38d3a633f34d00f87f5b180cd/foundations/javascript_basics/fundamentals-2.md?plain=1#L67)?