### PR TITLE
Font-weight: page update and <font-weight-absolute>

### DIFF
--- a/files/en-us/web/css/font-weight/index.md
+++ b/files/en-us/web/css/font-weight/index.md
@@ -14,15 +14,11 @@ The **`font-weight`** [CSS](/en-US/docs/Web/CSS) property sets the weight (or bo
 ## Syntax
 
 ```css
-/* Keyword values */
+/* <font-weight-absolute> keyword values */
 font-weight: normal;
 font-weight: bold;
 
-/* Keyword values relative to the parent */
-font-weight: lighter;
-font-weight: bolder;
-
-/* Numeric keyword values */
+/* <font-weight-absolute> numeric values [1,1000] */
 font-weight: 100;
 font-weight: 200;
 font-weight: 300;
@@ -33,6 +29,10 @@ font-weight: 700; /* bold */
 font-weight: 800;
 font-weight: 900;
 
+/* Keyword values relative to the parent */
+font-weight: lighter;
+font-weight: bolder;
+
 /* Global values */
 font-weight: inherit;
 font-weight: initial;
@@ -41,24 +41,28 @@ font-weight: revert-layer;
 font-weight: unset;
 ```
 
-The `font-weight` property is specified using any one of the values listed below.
+The `font-weight` property is specified using any one of the `<font-weight-absolute>` or relative weight values, listed below.
 
 ### Values
 
 - `normal`
+
   - : Normal font weight. Same as `400`.
+
 - `bold`
+
   - : Bold font weight. Same as `700`.
+
+- `<number>`
+
+  - : A {{cssxref("&lt;number&gt;")}} value between 1 and 1000, inclusive. Higher numbers represent weights that are bolder than (or as bold as) lower numbers. This allows fine-grain control for [variable fonts](#variable_fonts). For non-variable fonts, if the exact weight given is unavailable, a [fallback weight](#fallback-weights) algorithm is used with numeric values divisible by 100 corresponding to common weight names as described in the [Common weight name mapping](#common_weight_name_mapping) section below.
+
 - `lighter`
+
   - : One relative font weight lighter than the parent element. Note that only four font weights are considered for relative weight calculation; see the [Meaning of relative weights](#meaning_of_relative_weights) section below.
+
 - `bolder`
   - : One relative font weight heavier than the parent element. Note that only four font weights are considered for relative weight calculation; see the [Meaning of relative weights](#meaning_of_relative_weights) section below.
-- `<number>`
-  - : A {{cssxref("&lt;number&gt;")}} value between 1 and 1000, inclusive. Higher numbers represent weights that are bolder than (or as bold as) lower numbers. Certain commonly used values correspond to common weight names, as described in the [Common weight name mapping](#common_weight_name_mapping) section below.
-
-In earlier versions of the `font-weight` specification, the property accepts only keyword values and the numeric values 100, 200, 300, 400, 500, 600, 700, 800, and 900; non-variable fonts can only really make use of these set values, although fine-grained values (e.g. 451) will be translated to one of these values for non-variable fonts using the [Fallback weights](#fallback_weights) system.
-
-CSS Fonts Level 4 extends the syntax to accept any number between 1 and 1000 and introduces [Variable fonts](#variable_fonts), which can make use of this much finer-grained range of font weights.
 
 ### Fallback weights
 
@@ -71,13 +75,14 @@ If the exact weight given is unavailable, then the following rule is used to det
   - If no match is found, look for available weights greater than `500`, in ascending order.
 
 - If a weight less than `400` is given, look for available weights less than the target, in descending order. If no match is found, look for available weights greater than the target, in ascending order.
+
 - If a weight greater than `500` is given, look for available weights greater than the target, in ascending order. If no match is found, look for available weights less than the target, in descending order.
 
 ### Meaning of relative weights
 
 When `lighter` or `bolder` is specified, the below chart shows how the absolute font weight of the element is determined.
 
-Note that when using relative weights, only four font weights are considered — thin (100), normal (400), bold (700), and heavy (900). If a font-family has more weights available, they are ignored for the purposes of relative weight calculation.
+Note that when using relative weights, only four font weights are considered — thin (100), normal (400), bold (700), and heavy (900). If a font family has more weights available, they are ignored for the purposes of relative weight calculation.
 
 <table class="standard-table">
   <thead>
@@ -155,11 +160,11 @@ The numerical values `100` to `900` roughly correspond to the following common w
 
 ### Variable fonts
 
-Most fonts have a particular weight which corresponds to one of the numbers in [Common weight name mapping](#common_weight_name_mapping). However some fonts, called variable fonts, can support a range of weights with a more or less fine granularity, and this can give the designer a much closer degree of control over the chosen weight.
+While many fonts have a particular weight corresponding to one of the numbers in [Common weight name mapping](#common_weight_name_mapping), most variable fonts support a range of weights providing much finer granularity, giving designers and developers more control over the chosen weight.
 
 For TrueType or OpenType variable fonts, the "wght" variation is used to implement varying widths.
 
-> **Note:** For the example below to work, you'll need a browser that supports the CSS Fonts Level 4 syntax in which `font-weight` can be any number between `1` and `1000`. The demo loads with `font-weight: 500;`. Change the value to see the weight of the text change.
+This demo loads with `font-weight: 500;` set. Change the value of the `font-weight` property to see the weight of the text change.
 
 {{EmbedGHLiveSample("css-examples/variable-fonts/font-weight.html", '100%', 860)}}
 
@@ -236,3 +241,4 @@ span {
 - {{cssxref("font-family")}}
 - {{cssxref("font-style")}}
 - [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
+- [CSS fonts module](/en-US/docs/Learn/CSS/CSS_fonts)

--- a/files/en-us/web/css/font-weight/index.md
+++ b/files/en-us/web/css/font-weight/index.md
@@ -241,4 +241,4 @@ span {
 - {{cssxref("font-family")}}
 - {{cssxref("font-style")}}
 - [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
-- [CSS fonts](/en-US/docs/Learn/CSS/CSS_fonts) module
+- [CSS fonts](/en-US/docs/Web/CSS/CSS_fonts) module

--- a/files/en-us/web/css/font-weight/index.md
+++ b/files/en-us/web/css/font-weight/index.md
@@ -41,7 +41,7 @@ font-weight: revert-layer;
 font-weight: unset;
 ```
 
-The `font-weight` property is specified using any one of the `<font-weight-absolute>` or relative weight values, listed below.
+The `font-weight` property is specified using either a `<font-weight-absolute>` value or a relative weight value, as listed below.
 
 ### Values
 
@@ -55,7 +55,7 @@ The `font-weight` property is specified using any one of the `<font-weight-absol
 
 - `<number>`
 
-  - : A {{cssxref("&lt;number&gt;")}} value between 1 and 1000, inclusive. Higher numbers represent weights that are bolder than (or as bold as) lower numbers. This allows fine-grain control for [variable fonts](#variable_fonts). For non-variable fonts, if the exact weight given is unavailable, a [fallback weight](#fallback-weights) algorithm is used with numeric values divisible by 100 corresponding to common weight names as described in the [Common weight name mapping](#common_weight_name_mapping) section below.
+  - : A {{cssxref("&lt;number&gt;")}} value between 1 and 1000, both values included. Higher numbers represent weights that are bolder than (or as bold as) lower numbers. This allows fine-grain control for [variable fonts](#variable_fonts). For non-variable fonts, if the exact specified weight is unavailable, a [fallback weight](#fallback-weights) algorithm is used — numeric values that are divisible by 100 correspond to common weight names, as described in the [Common weight name mapping](#common_weight_name_mapping) section below.
 
 - `lighter`
 
@@ -241,4 +241,4 @@ span {
 - {{cssxref("font-family")}}
 - {{cssxref("font-style")}}
 - [Fundamental text and font styling](/en-US/docs/Learn/CSS/Styling_text/Fundamentals)
-- [CSS fonts module](/en-US/docs/Learn/CSS/CSS_fonts)
+- [CSS fonts](/en-US/docs/Learn/CSS/CSS_fonts) module


### PR DESCRIPTION
add the `<font-weight-absolute>` data type language to the page in case someone searches for this data type defined in CSS-fonts-4, but not worthy of it's own data type page.

Update the content of the page as variable fonts are supported everywhere, and have been for a bit.

part of https://github.com/openwebdocs/project/issues/176