### PR TITLE
Using fetch: avoid term dictionary

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -458,7 +458,7 @@ fetch("/login", {
 });
 ```
 
-Both request and response (and by extension the `fetch()` function), will try to intelligently determine the content type. A request will also automatically set a `Content-Type` header if none is set in the dictionary.
+Both request and response (and by extension the `fetch()` function), will try to intelligently determine the content type. A request will also automatically set a `Content-Type` header if none is set in the [`options`](/en-US/docs/Web/API/fetch#options) parameter.
 
 ## Feature detection
 


### PR DESCRIPTION
Fixes #28620

The term dictionary is not used in JavaScipt/MDN if it can be avoided. This makes it clear which object we're referring to the headers being set in.