### PR TITLE
Explanation of image link

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -81,7 +81,7 @@ This turns the heading into a link:
 
 ### Image links
 
-If you have an image you want to make into a link, use the {{htmlelement("a")}} element to wrap the local image file referenced with the {{htmlelement("img")}} element. The example below references an image file saved locally.
+If you have an image you want to make into a link, use the {{htmlelement("a")}} element to wrap the image file referenced with the {{htmlelement("img")}} element. The example below uses a relative path to reference a locally stored SVG image file.
 
 ```css hidden
 img {
@@ -93,7 +93,7 @@ img {
 
 ```html
 <a href="https://developer.mozilla.org/en-US/">
-  <img src="mdn_logo.svg" alt="MDN Web Docs homepage" />
+  <img src="mdn_logo.svg" alt="MDN Web Docs" />
 </a>
 ```
 


### PR DESCRIPTION
Clarify that images don't have to be local.
Clarify that since local, referencing with a relative path.
Removing "homepage" from the alt.