### PR TITLE
Replace missing "What is npm" link on Svelte Getting Started

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -94,7 +94,7 @@ If you're using Windows, you will need to install some software to give you pari
 
 Also see the following for more information:
 
-- ["What is npm"](https://nodejs.org/en/knowledge/getting-started/npm/what-is-npm/) on nodejs.org
+- ["About npm"](https://docs.npmjs.com/about-npm) on the npm documentation
 - ["Introducing npx"](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) on the npm blog
 - ["The easiest way to get started with Svelte"](https://svelte.dev/blog/the-easiest-way-to-get-started) on the Svelte blog
 


### PR DESCRIPTION
### Description

The current ["What is npm"](https://nodejs.org/en/knowledge/getting-started/npm/what-is-npm) link is dead (leads to a 404). I suggest replacing it with the official ["About npm"](https://docs.npmjs.com/about-npm) page on the npm documentation website.

### Additional details

You can take a look at the latest captured snapshot of that page on [Wayback Machine](https://web.archive.org/web/20220801000000*/https://nodejs.org/en/knowledge/getting-started/npm/what-is-npm). Looking at the content, I think the replacement suggested is a better resource in the first place.