### PR TITLE
fix: .nvmrc version error

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+v18.17

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
->=18.16.0
+lts/hydrogen


### PR DESCRIPTION
The current version string is producing following error in fnm tool:
> Can't find an installed Node version matching >=18.16.0.
Do you want to install it? answer [y/n]: y
error: The requested version is not installable: >=18.16.0

Looks like nvm and fmn tools need a version string that will lead to exact version to install. So conditions like `>=` can't be used.

After fix it will look like this:
>Can't find an installed Node version matching lts-hydrogen.
Do you want to install it? answer [y/n]: y
Installing Node v18.17.1 (x64)
Using Node for alias lts-hydrogen

**Note:** this will nag contributors install latest LTS of Hydrogen whenever they are available. Which may be good.

/cc @bsmth @Josh-Cena @sideshowbarker @caugner 