### PR TITLE
Fix page name in "See also" section

### DIFF
--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -71,7 +71,7 @@ Number(2n) / 2; // 1
 - [Addition (`+`)](/en-US/docs/Web/JavaScript/Reference/Operators/Addition)
 - [Subtraction (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction)
 - [Multiplication (`*`)](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication)
-- [Remainder (`/`)](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
+- [Remainder (`%`)](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)
 - [Exponentiation (`**`)](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation)
 - [Increment (`++`)](/en-US/docs/Web/JavaScript/Reference/Operators/Increment)
 - [Decrement (`--`)](/en-US/docs/Web/JavaScript/Reference/Operators/Decrement)


### PR DESCRIPTION
The "See also" section of a page is linking to the page "Remainder (%)" but mistakenly shows the division `/` operator instead of `%`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Replaces the wrong operators (`/`) with the correct one (`%`) in the link to the "Remainder (%)" page.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fix minor inconsistency.
### Additional details
None.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
None
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
