### PR TITLE
Fix typo: insure --> ensure

### DIFF
--- a/files/en-us/glossary/hash/index.md
+++ b/files/en-us/glossary/hash/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The hash function takes a variable-length message input and produces a fixed-length hash output. It is commonly in the form of a 128-bit "fingerprint" or "message digest". Hashes are very useful for {{glossary("cryptography")}} — they insure the integrity of transmitted data, and provide the basis for {{glossary("HMAC")}}, which enables message authentication.
+The hash function takes a variable-length message input and produces a fixed-length hash output. It is commonly in the form of a 128-bit "fingerprint" or "message digest". Hashes are very useful for {{glossary("cryptography")}} — they ensure the integrity of transmitted data, and provide the basis for {{glossary("HMAC")}}, which enables message authentication.
 
 ## See also
 


### PR DESCRIPTION
I think the sentence should be: they **ensure** the integrity....

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The pull request is about fixing a typo in the Glossary article on Hash.
The sentence with the typo is: Hashes are very useful for [cryptography] — they **insure** the integrity of transmitted data, and provide the basis for [HMAC], which enables message authentication.

It should be **ensure** in place of insure.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
