### PR TITLE
restore link to outdated vanilla framework

### DIFF
--- a/files/en-us/web/api/formdata/using_formdata_objects/index.md
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.md
@@ -193,7 +193,7 @@ formElem.addEventListener("formdata", (e) => {
 
 ## Submitting forms and uploading files via AJAX without `FormData` objects
 
-If you want to know how to serialize and submit a form via [AJAX](/en-US/docs/Web/Guide/AJAX) _without_ using FormData objects, please read [this paragraph](/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files).
+If you want to know how to serialize and submit a form via [AJAX](/en-US/docs/Web/Guide/AJAX) _without_ using FormData objects, please read [this paragraph](https://github.com/mdn/content/blob/92435b5f26c680a2314d392ef06f479216f0b4dd/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md#submitting-forms-and-uploading-files).
 
 ## Gotchas
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

this pr updates a broken link in the FormData docs to old github documentation link. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

back in #25383 the "vanilla framework" for xhr uploads was removed, i don't really have any context for that decision, but it left a hole in the documentation. 

that framework _is useful_ in the context of this document. i don't know how mdn would ideally extract that framework, but this at least restores the context for that link.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

fixes a bug introduced by #25383

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

thanks for any help or suggestions here, not sure what the right approach is here, but this seemed like a good stopgap until there's a better solution for what do with that outdated framework.