### PR TITLE
fix: Marching Ants Effect flickering

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -445,7 +445,7 @@ The `setLineDash` method and the `lineDashOffset` property specify the dash patt
 In this example we are creating a marching ants effect. It is an animation technique often found in selection tools of computer graphics programs. It helps the user to distinguish the selection border from the image background by animating the border. In a later part of this tutorial, you can learn how to do this and other [basic animations](/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations).
 
 ```html hidden
-<canvas id="canvas" width="110" height="110" role="presentation"></canvas>
+<canvas id="canvas" width="111" height="111" role="presentation"></canvas>
 ```
 
 ```js
@@ -461,7 +461,7 @@ function draw() {
 
 function march() {
   offset++;
-  if (offset > 16) {
+  if (offset > 5) {
     offset = 0;
   }
   draw();

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
@@ -86,7 +86,7 @@ function draw() {
 
 function march() {
   offset++;
-  if (offset > 16) {
+  if (offset > 5) {
     offset = 0;
   }
   draw();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is an example of Marching Ants effect in the docs. If we slow it down we will see flickering.

Line dash pattern is [4, 2]. That is 6 pixels total. So when offset is 6 we should set it back to 0.
The original code sets offset back to 0 when it's 16! That is incorrect because we should set offset to 0 when it reaches (4+2)*n and we won't have flickering. IMO we should do it at (4+2)*1 that is 6. So when offset > 5 we should set it back to 0.

### Motivation

The bug will confuse readers that are trying to understand lineDashOffset property.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
