### PR TITLE
fix(learn): closing forms tag is included in embedlivesample

### DIFF
--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -189,8 +189,6 @@ Let's put these ideas into practice and build a slightly more involved form — 
 
    ```html-nolint
    <form>
-   ...
-   </form>
    ```
 
 4. Inside the `<form>` element, add a heading and paragraph to inform users how required fields are marked:


### PR DESCRIPTION
We added a closing `</form>` tag during code cleanup:

https://github.com/mdn/content/blob/004a62d2cfdeced7a4d93ffbb07a655265d76f9b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md?plain=1#L188-L194

But the existing example is then later combined into an embedlivesample call so the example is broken. Reverts changes added in https://github.com/mdn/content/pull/24101

Fixes https://github.com/mdn/content/issues/28660