### PR TITLE
fix: mention no space around case

### DIFF
--- a/files/en-us/web/css/adjacent_sibling_combinator/index.md
+++ b/files/en-us/web/css/adjacent_sibling_combinator/index.md
@@ -18,7 +18,8 @@ img + p {
 
 ## Syntax
 
-```css
+```css-nolint
+/* The white space around the + combinator is optional but recommended. */
 former_element + target_element { style properties }
 ```
 

--- a/files/en-us/web/css/child_combinator/index.md
+++ b/files/en-us/web/css/child_combinator/index.md
@@ -20,8 +20,9 @@ Elements matched by the second selector must be the immediate children of the el
 
 ## Syntax
 
-```css
-selector1 > selector2 { style properties }
+```css-nolint
+/* The white space around the > combinator is optional but recommended. */
+selector1 > selector2 { /* style properties */ }
 ```
 
 ## Examples

--- a/files/en-us/web/css/column_combinator/index.md
+++ b/files/en-us/web/css/column_combinator/index.md
@@ -20,8 +20,9 @@ col.selected||td {
 
 ## Syntax
 
-```css
-column-selector||cell-selector {
+```css-nolint
+/* The white space around the || combinator is optional but recommended. */
+column-selector || cell-selector {
   /* style properties */
 }
 ```

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -19,7 +19,8 @@ img ~ p {
 
 ## Syntax
 
-```css
+```css-nolint
+/* The white space around the ~ combinator is optional but recommended. */
 former_element ~ target_element { style properties }
 ```
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/28460

The PR fixes the
> The CSS Standards mix examples using spaces and omitting spaces, for clarity.

...part