### PR TITLE
fix: assert supported properties in @page rule

### DIFF
--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -47,7 +47,7 @@ The **`@page`** at-rule is a CSS at-rule used to modify different aspects of pri
 The `@page` at-rule can contain only [page descriptors](#page-descriptors) and [margin at-rules](#margin_at-rules). The following descriptors have been implemented by at least one browser:
 
 - [`margin`](/en-US/docs/Web/CSS/margin)
-  - : Specifies the page margins. Individual margin properties `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` can also be used.
+  - : Specifies the page margins. Individual margin properties [`margin-top`](/en-US/docs/Web/CSS/margin-top), [`margin-right`](/en-US/docs/Web/CSS/margin-right), [`margin-bottom`](/en-US/docs/Web/CSS/margin-bottom), and [`margin-left`](/en-US/docs/Web/CSS/margin-left) can also be used.
 - [`page-orientation`](/en-US/docs/Web/CSS/@page/page-orientation)
   - : Specifies the orientation of the page. This does not affect the layout of the page; the rotation is applied after the layout in the output medium.
 - [`size`](/en-US/docs/Web/CSS/@page/size)
@@ -160,7 +160,7 @@ and `<pseudo-selector>` represents these pseudo-classes:
 
 ## Margin at-rules
 
-> **Warning:** The margin at-rules have not been implemented by any user agent <small>(updated: August 2023)</small>.
+> **Warning:** The margin at-rules have not been implemented by any user agent (updated: August 2023).
 
 The margin at-rules are used inside of the `@page` at-rule. They each target a different section of the document printed page, styling the area of the printed page based on the property values set in the style block:
 
@@ -176,55 +176,23 @@ The margin at-rules are used inside of the `@page` at-rule. They each target a d
 
 Other margin-at rules include:
 
-```plain
-@top-left-corner {
-  <page-margin-properties>
-}
-@top-left {
-  <page-margin-properties>
-}
-@top-center {
-  <page-margin-properties>
-}
-@top-right {
-  <page-margin-properties>
-}
-@top-right-corner {
-  <page-margin-properties>
-}
-@bottom-left-corner {
-  <page-margin-properties>
-}
-@bottom-left {
-  <page-margin-properties>
-}
-@bottom-center {
-  <page-margin-properties>
-}
-@bottom-right {
-  <page-margin-properties>
-}
-@bottom-right-corner {
-  <page-margin-properties>
-}
-@left-top {
-  <page-margin-properties>
-}
-@left-middle {
-  <page-margin-properties>
-}
-@left-bottom {
-  <page-margin-properties>
-}
-@right-top {
-  <page-margin-properties>
-}
-@right-middle {
-  <page-margin-properties>
-}
-@right-bottom {
-  <page-margin-properties>
-}
+```css-nolint
+@top-left-corner
+@top-left
+@top-center
+@top-right
+@top-right-corner
+@bottom-left-corner
+@bottom-left
+@bottom-center
+@bottom-right
+@bottom-right-corner
+@left-top
+@left-middle
+@left-bottom
+@right-top
+@right-middle
+@right-bottom
 ```
 
 #### Page-margin properties

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.page
 
 {{CSSRef}}
 
-The **`@page`** at-rule is a CSS at-rule used to modify different aspects of a printed pages. It targets and modifies the page's dimensions, page orientation, and margins. The **`@page`** at-rule can be used to target all pages in a print-out, or even specific ones using its various pseudo-classes.
+The **`@page`** at-rule is a CSS at-rule used to modify different aspects of printed pages. It targets and modifies the page's dimensions, orientation, and margins. The `@page` at-rule can be used to target all pages in a print-out or a subset using its various pseudo-classes.
 
 ## Syntax
 
@@ -44,7 +44,7 @@ The **`@page`** at-rule is a CSS at-rule used to modify different aspects of a p
 
 ### Page properties
 
-The **`@page`** at-rule can contain only **page properties** and **margin at-rules**. Following properties have been implemented by at least one browser:
+The `@page` at-rule can contain only [page descriptors](#page-descriptors) and [margin at-rules](#margin_at-rules). The following descriptors have been implemented by at least one browser:
 
 - [`margin`](/en-US/docs/Web/CSS/margin)
   - : Specifies the page margins. Individual margin properties `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` can also be used.
@@ -160,9 +160,9 @@ and `<pseudo-selector>` represents these pseudo-classes:
 
 ## Margin at-rules
 
-> **Warning:** The margin at-rules have not been implemented by any user agent yet.
+> **Warning:** The margin at-rules have not been implemented by any user agent <small>(updated: August 2023)</small>.
 
-The margin at-rules are used inside of the `@page` at-rule. They each target a different section of the document printed page and make changes based on the properties or content set in the block of code:
+The margin at-rules are used inside of the `@page` at-rule. They each target a different section of the document printed page, styling the area of the printed page based on the property values set in the style block:
 
 ```css
 @page {
@@ -439,4 +439,5 @@ Please refer to the various [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
 - The `@page` [`size`](/en-US/docs/Web/CSS/@page/size) descriptor
 - The {{Cssxref("page")}} property
 - See the [\[META\] CSS Paged Media Module Level 3](https://bugzilla.mozilla.org/show_bug.cgi?id=286443) ticket in Bugzilla for tracking progress on the subject (page-based counters, etc.)
-- [Paged.js](https://pagedjs.org/documentation/1-the-big-picture/#what-is-paged.js): a JavaScript library/polyfill that implements W3C paged media specifications
+- [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) module
+- [Paged.js: W3C paged media polyfill](https://pagedjs.org/documentation/1-the-big-picture)

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.page
 
 {{CSSRef}}
 
-The **`@page`** at-rule is a CSS at-rule used to modify different aspects of a printed page property. It targets and modifies the page's dimensions, page orientation, and margins. The **`@page`** at-rule can be used to target all pages in a print-out, or even specific ones using its various pseudo-classes.
+The **`@page`** at-rule is a CSS at-rule used to modify different aspects of a printed pages. It targets and modifies the page's dimensions, page orientation, and margins. The **`@page`** at-rule can be used to target all pages in a print-out, or even specific ones using its various pseudo-classes.
 
 ## Syntax
 
@@ -33,51 +33,30 @@ The **`@page`** at-rule is a CSS at-rule used to modify different aspects of a p
 @page wide {
   size: a4 landscape;
 }
+
+@page {
+  /* margin box at top right showing page number */
+  @top-right {
+    content: "Page " counter(pageNumber);
+  }
+}
 ```
 
-### Descriptors
+### Page properties
 
+The **`@page`** at-rule can contain only **page properties** and **margin at-rules**. Following properties have been implemented by at least one browser:
+
+- [`margin`](/en-US/docs/Web/CSS/margin)
+  - : Specifies the page margins. Individual margin properties `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` can also be used.
 - [`page-orientation`](/en-US/docs/Web/CSS/@page/page-orientation)
   - : Specifies the orientation of the page. This does not affect the layout of the page; the rotation is applied after the layout in the output medium.
 - [`size`](/en-US/docs/Web/CSS/@page/size)
   - : Specifies the target size and orientation of the page box's containing block. In the general case, where one page box is rendered onto one page sheet, it also indicates the size of the destination page sheet.
 
-## Description
+The specification mentions following CSS properties to be applicable to page boxes via @page at-rule. But these have _not been supported_ by any user agent yet.
 
-> **Note:** This documentation lists out features yet to be implemented across UAs, but they are stated in the official documentation. At the time of this writing, the only CSS property shown to have visible on both the at-rule and its pseudo-classes is the `margin` property.
-
-You can't change all CSS properties with **`@page`**. You can only change the margin of the document. Attempts to change any other CSS properties will be ignored.
-
-The `@page` at-rule can be accessed via the CSS object model interface {{domxref("CSSPageRule")}}.
-
-> **Note:** The W3C is discussing how to handle viewport-related {{cssxref("&lt;length&gt;")}} units, `vh`, `vw`, `vmin`, and `vmax`. Meanwhile do not use them within a `@page` at-rule.
-
-### Related properties
-
-The `@page` at-rule, allows the user to assign a name to the rule, which is then called in a declaration using the `page` property.
-
-- {{Cssxref("page")}}
-  - : Allows a selector to use a user defined **named page**
-
-## Formal syntax
-
-{{csssyntax}}
-
-Where the `<page-body>` includes:
-
-- page-properties
-- page-margin properties
-
-and `<pseudo-selector>` represents these pseudo-classes:
-
-- {{Cssxref(":blank")}}
-- {{Cssxref(":first")}}
-- {{Cssxref(":left")}}
-- {{Cssxref(":right")}}
-
-> **Note:** The **`@page`** at-rule can only contain **page-properties** and **margin at-rules**, and the **margin at-rules** can only contain **page-margin properties**
-
-### page-properties
+<details>
+<summary>Remaining page properties</summary>
 
 | Feature               | CSS properties        |
 | --------------------- | --------------------- |
@@ -148,14 +127,47 @@ and `<pseudo-selector>` represents these pseudo-classes:
 |                       | min-width             |
 |                       | max-width             |
 
-### margin at-rules
+</details>
+
+## Description
+
+The @page rule defines properties of the page box. The `@page` at-rule can be accessed via the CSS object model interface {{domxref("CSSPageRule")}}.
+
+> **Note:** The W3C is discussing how to handle viewport-related {{cssxref("&lt;length&gt;")}} units, `vh`, `vw`, `vmin`, and `vmax`. Meanwhile do not use them within a `@page` at-rule.
+
+### Related properties
+
+The `@page` at-rule, allows the user to assign a name to the rule, which is then called in a declaration using the `page` property.
+
+- {{Cssxref("page")}}
+  - : Allows a selector to use a user defined **named page**
+
+## Formal syntax
+
+{{csssyntax}}
+
+Where the `<page-body>` includes:
+
+- page-properties
+- page-margin properties
+
+and `<pseudo-selector>` represents these pseudo-classes:
+
+- {{Cssxref(":blank")}}
+- {{Cssxref(":first")}}
+- {{Cssxref(":left")}}
+- {{Cssxref(":right")}}
+
+## Margin at-rules
+
+> **Warning:** The margin at-rules have not been implemented by any user agent yet.
 
 The margin at-rules are used inside of the `@page` at-rule. They each target a different section of the document printed page and make changes based on the properties or content set in the block of code:
 
 ```css
 @page {
   @top-left {
-    <page-margin-properties>
+    /* page-margin-properties */
   }
 }
 ```
@@ -215,9 +227,12 @@ Other margin-at rules include:
 }
 ```
 
-#### page-margin properties
+#### Page-margin properties
 
 The page-margin properties are the set of CSS properties can be set in any individual margin at-rule. They include:
+
+<details>
+<summary>Page-margin properties</summary>
 
 | Feature               | CSS properties        |
 | --------------------- | --------------------- |
@@ -291,6 +306,8 @@ The page-margin properties are the set of CSS properties can be set in any indiv
 |                       | max-width             |
 | z-index               | z-index               |
 
+</details>
+
 ## Named pages
 
 Named pages enable performing per-page layout and adding [page-breaks](/en-US/docs/Web/CSS/CSS_fragmentation) in a declarative manner when printing.
@@ -337,24 +354,6 @@ This example shows how to split the `<section>`s into individual pages in `lands
       velit.
     </p>
   </section>
-  <section>
-    <h2>Header</h2>
-    <p>
-      Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur
-      facilis vitae voluptatibus odio consequuntur optio placeat? Id, nam sequi
-      aut in dolorem dolores, laudantium, quasi totam ipsam aliquam quibusdam
-      velit.
-    </p>
-  </section>
-  <section>
-    <h2>Header</h2>
-    <p>
-      Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur
-      facilis vitae voluptatibus odio consequuntur optio placeat? Id, nam sequi
-      aut in dolorem dolores, laudantium, quasi totam ipsam aliquam quibusdam
-      velit.
-    </p>
-  </section>
 </article>
 ```
 
@@ -366,9 +365,22 @@ This example shows how to split the `<section>`s into individual pages in `lands
   margin: 20%;
 }
 
+section {
+  page-break-after: always;
+  break-after: page;
+}
+
+@media print {
+  button {
+    display: none;
+  }
+}
+```
+
+```css hidden
 body {
-  font-family: "Helvetica";
-  background-color: rgb(110 110 119);
+  font-family: "Helvetica", sans-serif;
+  background-color: silver;
 }
 
 article {
@@ -379,25 +391,14 @@ section {
   display: grid;
   background-color: white;
   border-radius: 0.6rem;
-  margin-block-end: 1.5rem;
   justify-items: center;
   padding: 1rem;
   width: 50%;
-  page-break-after: always;
-  break-after: page;
   print-color-adjust: exact;
   -webkit-print-color-adjust: exact;
-}
-
-section {
-  page-break-after: always;
-  break-after: page;
-}
-
-@media print {
-  button {
-    display: none;
-  }
+  margin: 0 auto;
+  margin-block-end: 1.5rem;
+  border: 1px dashed;
 }
 ```
 
@@ -438,3 +439,4 @@ Please refer to the various [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
 - The `@page` [`size`](/en-US/docs/Web/CSS/@page/size) descriptor
 - The {{Cssxref("page")}} property
 - See the [\[META\] CSS Paged Media Module Level 3](https://bugzilla.mozilla.org/show_bug.cgi?id=286443) ticket in Bugzilla for tracking progress on the subject (page-based counters, etc.)
+- [Paged.js](https://pagedjs.org/documentation/1-the-big-picture/#what-is-paged.js): a JavaScript library/polyfill that implements W3C paged media specifications


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/28423

The PR asserts the three properties that have been supported by the browsers so far. And puts others in collapsible content. Refactors the example.

Browsers haven't implemented a lot of stuff mentioned in the specifications. If we document everything in the specs then most of the document remains useless, and confuses the readers. TBH we could simply remove the long unsupported property tables and margin at-rules sections all together. And re-add them whenever browsers implement them.

Suggesting the Paged.js polyfill in see also section because it actually implements most of these W3C specs and [provides way better printing experience](https://stackoverflow.com/a/70054545/15273968) than the browser default implementations.