### PR TITLE
Avoid h24 in examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -26,13 +26,13 @@ Below is a list of supported hour cycle types.
 ### Supported hour cycle types
 
 - `h12`
-  - : Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am.
+  - : Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am. (The 12-hour clock as used e.g. in the United States.)
 - `h23`
-  - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00.
+  - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00. (The 24-hour clock.)
 - `h11`
-  - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am.
+  - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am. (Japanese 12-hour clock.)
 - `h24`
-  - : Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00.
+  - : Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00. (Not used anywhere.)
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -30,7 +30,7 @@ Below is a list of supported hour cycle types.
 - `h23`
   - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00.
 - `h11`
-  - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am. (Japanese 12-hour clock.)
+  - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am. Mostly used in Japan.
 - `h24`
   - : Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00. (Not used anywhere.)
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -28,7 +28,7 @@ Below is a list of supported hour cycle types.
 - `h12`
   - : Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am. As used, for example, in the United States.
 - `h23`
-  - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00. (The 24-hour clock.)
+  - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00.
 - `h11`
   - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am. (Japanese 12-hour clock.)
 - `h24`

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -32,7 +32,7 @@ Below is a list of supported hour cycle types.
 - `h11`
   - : Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am. Mostly used in Japan.
 - `h24`
-  - : Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00. (Not used anywhere.)
+  - : Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00. Not used anywhere.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -26,7 +26,7 @@ Below is a list of supported hour cycle types.
 ### Supported hour cycle types
 
 - `h12`
-  - : Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am. (The 12-hour clock as used e.g. in the United States.)
+  - : Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am. As used, for example, in the United States.
 - `h23`
   - : Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00. (The 24-hour clock.)
 - `h11`

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
@@ -72,7 +72,7 @@ These properties are defined on `Intl.Locale.prototype` and shared by all `Intl.
 - {{jsxref("Intl/Locale/getCollations", "Intl.Locale.prototype.getCollations()")}}
   - : Returns an {{jsxref("Array")}} of the collation types for the `Locale`.
 - {{jsxref("Intl/Locale/getHourCycles", "Intl.Locale.prototype.getHourCycles()")}}
-  - : Returns an {{jsxref("Array")}} of hour cycle identifiers, indicating either the 12-hour format ("h11", "h12") or the 24-hour format ("h23", "h24").
+  - : Returns an {{jsxref("Array")}} of hour cycle identifiers, indicating either the 12-hour clock ("h12"), the Japanese 12-hour clock ("h11"), the 24-hour clock ("h23"), or the unused format "h24".
 - {{jsxref("Intl/Locale/getNumberingSystems", "Intl.Locale.prototype.getNumberingSystems()")}}
   - : Returns an {{jsxref("Array")}} of numbering system identifiers available according to the locale's rules.
 - {{jsxref("Intl/Locale/getTextInfo", "Intl.Locale.prototype.getTextInfo()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -41,7 +41,7 @@ new Intl.Locale(tag, options)
     - `caseFirst`
       - : The case-first sort option. Possible values are `"upper"`, `"lower"`, or `"false"`.
     - `hourCycle`
-      - : The hour cycle. Possible values are `"h11"`, `"h12"`, `"h23"`, or `"h24"`.
+      - : The hour cycle. Possible values are `"h11"` (Japanese 12-hour clock), `"h12"` (12-hour clock elsewhere), `"h23"` (24-hour clock), or `"h24"` (not used anywhere).
     - `numeric`
       - : The numeric sort option. A boolean.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -41,7 +41,7 @@ new Intl.Locale(tag, options)
     - `caseFirst`
       - : The case-first sort option. Possible values are `"upper"`, `"lower"`, or `"false"`.
     - `hourCycle`
-      - : The hour cycle. Possible values are `"h11"` (Japanese 12-hour clock), `"h12"` (12-hour clock elsewhere), `"h23"` (24-hour clock), or `"h24"` (not used anywhere).
+      - : The hour cycle. Possible values are `"h23"`, `"h12"`, `"h11"`, or the practically unused `"h24"`, which are explained in [`Intl.Locale.prototype.getHourCycles`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles#supported_hour_cycle_types)
     - `numeric`
       - : The numeric sort option. A boolean.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.md
@@ -46,18 +46,18 @@ include {{jsxref("Intl/Locale/hourCycle", "hourCycle")}},
 
 ```js
 const myLocale = new Intl.Locale("fr", {
-  hourCycle: "h24",
+  hourCycle: "h12",
   calendar: "gregory",
 });
 console.log(myLocale.baseName); // Prints "fr"
-console.log(myLocale.toString()); // Prints "fr-u-ca-gregory-hc-h24"
+console.log(myLocale.toString()); // Prints "fr-u-ca-gregory-hc-h12"
 const myLocMaximized = myLocale.maximize();
 
 // Prints "fr-Latn-FR". The "Latn" and "FR" tags are added,
 // since French is only written in the Latin script and is most likely to be spoken in France.
 console.log(myLocMaximized.baseName);
 
-// Prints "fr-Latn-FR-u-ca-gregory-hc-h24".
+// Prints "fr-Latn-FR-u-ca-gregory-hc-h12".
 // Note that the extension tags (after "-u") remain unchanged.
 console.log(myLocMaximized.toString());
 ```

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
@@ -45,11 +45,11 @@ in the locale identifier are called extension subtags and are not affected by th
 
 ```js
 const myLocale = new Intl.Locale("fr-Latn-FR", {
-  hourCycle: "h24",
+  hourCycle: "h12",
   calendar: "gregory",
 });
 console.log(myLocale.baseName); // Prints "fr-Latn-FR"
-console.log(myLocale.toString()); // Prints "fr-Latn-FR-u-ca-gregory-hc-h24"
+console.log(myLocale.toString()); // Prints "fr-Latn-FR-u-ca-gregory-hc-h12"
 
 const myLocMinimized = myLocale.minimize();
 
@@ -57,7 +57,7 @@ const myLocMinimized = myLocale.minimize();
 // and is most likely to be spoken in France.
 console.log(myLocMinimized.baseName);
 
-// Prints "fr-u-ca-gregory-hc-h24".
+// Prints "fr-u-ca-gregory-hc-h12".
 // Note that the extension tags (after "-u") remain unchanged.
 console.log(myLocMinimized.toString());
 ```

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -39,11 +39,11 @@ JSON, or any other context where an exact string representation is useful.
 
 ```js
 const myLocale = new Intl.Locale("fr-Latn-FR", {
-  hourCycle: "h24",
+  hourCycle: "h12",
   calendar: "gregory",
 });
 console.log(myLocale.baseName); // Prints "fr-Latn-FR"
-console.log(myLocale.toString()); // Prints "fr-Latn-FR-u-ca-gregory-hc-h24"
+console.log(myLocale.toString()); // Prints "fr-Latn-FR-u-ca-gregory-hc-h12"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Avoid suggesting the use of "h24" anywhere.

### Motivation

The hour cycle h24 is specified for completeness, as its existence in the mathematical sense is implied by h11, h12, and h23. However, h24 isn't used anywhere in the world (as far as CLDR is aware).

Superficially, h24 looks like the designator for "the 24-hour clock", but the correct designator for "the 24-hour clock" is h23.

### Additional details

See https://github.com/unicode-org/cldr-json/blob/80a94b0f6c3a34d6e2dc0dca8639a54babc87f94/cldr-json/cldr-core/supplemental/timeData.json (h means h12, H means h23, K means h11. h24 would be k, which doesn't appear there.)

### Related issues and pull requests

https://github.com/tc39/ecma402/issues/402
https://github.com/mdn/interactive-examples/pull/2597