### PR TITLE
fix: correct example of usage of Object.groupBy function

### DIFF
--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -517,12 +517,12 @@ const inventory = [
 ];
 ```
 
-To use `group()`, you supply a callback function that is called with the current element, and optionally the current index and array, and returns a string indicating the group of the element.
+To use `Object.groupBy()`, you supply a callback function that is called with the current element, and optionally the current index and array, and returns a string indicating the group of the element.
 
 The code below uses an arrow function to return the `type` of each array element (this uses [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter) to unpack the `type` element from the passed object). The result is an object that has properties named after the unique strings returned by the callback. Each property is assigned an array containing the elements in the group.
 
 ```js
-const result = inventory.group(({ type }) => type);
+const result = Object.groupBy(inventory, ({ type }) => type);
 console.log(result.vegetables);
 // [{ name: "asparagus", type: "vegetables" }]
 ```


### PR DESCRIPTION
### Description

This PR fixes the example provided for the `Object.groupBy` function in the Indexed Collections Javascript page. The example and its caption referenced a different, nonexistent function instead of `Object.groupBy`.

### Motivation

The example was incorrect and made the reader believe there was an `Array.prototype.group` function, which does not exist.

### Additional details

Related page: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections

### Related issues and pull requests


