### PR TITLE
Improve Intl.DurationFormat.format examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -81,7 +81,9 @@ new Intl.DurationFormat("en", { style: "digital" }).format(duration);
 // "1:46:40"
 
 // With style set to "digital", locale set to "en", and hours set to "long"
-new Intl.DurationFormat("en", { style: "digital", hours: "long" }).format(duration);
+new Intl.DurationFormat("en", { style: "digital", hours: "long" }).format(
+  duration,
+);
 // "1 hour, 46:40"
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -47,7 +47,7 @@ new Intl.DurationFormat("en").format(duration);
 //  "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
 ```
 
-### Using format() with different locales and styles
+### Using format with different locales and styles
 
 ```js
 const duration = {
@@ -77,7 +77,7 @@ new Intl.DurationFormat("en", { style: "digital" }).format(duration);
 // "1 hour, 46:40"
 ```
 
-### Using the fractionalDigits option
+### Using format with the fractionalDigits option
 
 ```js
 const duration = {

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -20,11 +20,13 @@ format(duration)
 ### Parameters
 
 - `duration`
-  - : The duration object to be formatted. It should include some or all of the following properties: `"months"`, `"weeks"`, `"days"`, `"hours"`, `"minutes"`, `"seconds"`, `"milliseconds"`, `"microseconds"`, `"nanoseconds"`.
+  - : The duration object to be formatted. It should include some or all of the following properties: `months`, `weeks`, `days`, `hours`, `minutes`, `seconds`, `milliseconds`, `microseconds`, `nanoseconds`.
 
 ## Examples
 
-### Using format with an object as parameter
+### Using format
+
+The following example shows how to create a Duration formatter using the English language.
 
 ```js
 const duration = {
@@ -42,15 +44,7 @@ const duration = {
 
 // Without options, style defaults to "short"
 new Intl.DurationFormat("en").format(duration);
-// "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
-
-// With style set to "long"
-new Intl.DurationFormat("en", { style: "long" }).format(duration);
-// "1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds"
-
-// With style set to "narrow"
-new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
-// "1y 2mo 3w 3d 4h 5m 6s 7ms 8μs 9ns"
+//  "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
 ```
 
 ### Using format() with different locales and styles
@@ -64,42 +58,48 @@ const duration = {
 
 // With style set to "long" and locale "fr-FR"
 new Intl.DurationFormat("fr-FR", { style: "long" }).format(duration);
-// "1 heure, 46 minutes et 40 secondes"
+//  "1 heure, 46 minutes et 40 secondes"
 
 // With style set to "short" and locale set to "en"
 new Intl.DurationFormat("en", { style: "short" }).format(duration);
-// "1 hr, 46 min and 40 sec"
+//  "1 hr, 46 min and 40 sec"
 
 // With style set to "short" and locale set to "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
-// "1h 46min 40s"
+//  "1h 46min 40s"
 
 // With style set to "digital" and locale set to "en"
 new Intl.DurationFormat("en", { style: "digital" }).format(duration);
 // "1:46:40"
+
+// With style set to "digital", locale set to "en", and hours set to "long"
+new Intl.DurationFormat("en", { style: "digital" }).format(duration);
+// "1 hour, 46:40"
 ```
 
-### Using format with fractionalDigits option
-
-Use the `format` getter function for formatting using with fractionalDigits options and setting milliseconds display to `narrow`.
+### Using the fractionalDigits option
 
 ```js
 const duration = {
+  hours: 11,
+  minutes: 30,
   seconds: 12,
   milliseconds: 345,
   microseconds: 600,
 };
 
-// Example using fractionalDigits
-new Intl.DurationFormat("en", { fractionalDigits: 2 }).format(duration);
-// => 12 sec, 345 ms, 600 μs
+new Intl.DurationFormat("en", { style: "digital" }).format(duration);
+// "11:30:12.3456"
 
-// Example using fractionalDigits and milliseconds set to `long`
-new Intl.DurationFormat("en", {
-  milliseconds: "long",
-  fractionalDigits: 2,
-}).format(duration);
-// => 12 sec, 345 milliseconds, 600 μs
+new Intl.DurationFormat("en", { style: "digital", fractionalDigits: 5 }).format(
+  duration,
+);
+// "11:30:12.34560"
+
+new Intl.DurationFormat("en", { style: "digital", fractionalDigits: 3 }).format(
+  duration,
+);
+// "11:30:12.346"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -44,7 +44,7 @@ const duration = {
 
 // Without options, style defaults to "short"
 new Intl.DurationFormat("en").format(duration);
-//  "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
+// "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
 
 // With style set to "long"
 new Intl.DurationFormat("en", { style: "long" }).format(duration);

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -24,7 +24,7 @@ format(duration)
 
 ## Examples
 
-### Using format
+### Using format()
 
 The following example shows how to create a Duration formatter using the English language.
 
@@ -47,7 +47,7 @@ new Intl.DurationFormat("en").format(duration);
 //  "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
 ```
 
-### Using format with different locales and styles
+### Using format() with different locales and styles
 
 ```js
 const duration = {
@@ -58,15 +58,15 @@ const duration = {
 
 // With style set to "long" and locale "fr-FR"
 new Intl.DurationFormat("fr-FR", { style: "long" }).format(duration);
-//  "1 heure, 46 minutes et 40 secondes"
+// "1 heure, 46 minutes et 40 secondes"
 
 // With style set to "short" and locale set to "en"
 new Intl.DurationFormat("en", { style: "short" }).format(duration);
-//  "1 hr, 46 min and 40 sec"
+// "1 hr, 46 min and 40 sec"
 
 // With style set to "short" and locale set to "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
-//  "1h 46min 40s"
+// "1h 46min 40s"
 
 // With style set to "digital" and locale set to "en"
 new Intl.DurationFormat("en", { style: "digital" }).format(duration);
@@ -77,7 +77,7 @@ new Intl.DurationFormat("en", { style: "digital" }).format(duration);
 // "1 hour, 46:40"
 ```
 
-### Using format with the fractionalDigits option
+### Using format() with the fractionalDigits option
 
 ```js
 const duration = {

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -45,9 +45,7 @@ const duration = {
 // Without options, style defaults to "short"
 new Intl.DurationFormat("en").format(duration);
 //  "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns"
-```
 
-### Using format() with different locales and styles
 // With style set to "long"
 new Intl.DurationFormat("en", { style: "long" }).format(duration);
 // "1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds"
@@ -55,8 +53,9 @@ new Intl.DurationFormat("en", { style: "long" }).format(duration);
 // With style set to "narrow"
 new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
 // "1y 2mo 3w 3d 4h 5m 6s 7ms 8μs 9ns"
+```
 
-### Using format with different locales and styles
+### Using format() with different locales and styles
 
 ```js
 const duration = {
@@ -82,7 +81,7 @@ new Intl.DurationFormat("en", { style: "digital" }).format(duration);
 // "1:46:40"
 
 // With style set to "digital", locale set to "en", and hours set to "long"
-new Intl.DurationFormat("en", { style: "digital" }).format(duration);
+new Intl.DurationFormat("en", { style: "digital", hours: "long" }).format(duration);
 // "1 hour, 46:40"
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -48,6 +48,15 @@ new Intl.DurationFormat("en").format(duration);
 ```
 
 ### Using format() with different locales and styles
+// With style set to "long"
+new Intl.DurationFormat("en", { style: "long" }).format(duration);
+// "1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds"
+
+// With style set to "narrow"
+new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
+// "1y 2mo 3w 3d 4h 5m 6s 7ms 8μs 9ns"
+
+### Using format with different locales and styles
 
 ```js
 const duration = {


### PR DESCRIPTION
…normative changes related to fractionalDigits option, clarify usage in general

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

* Updated examples to reflect https://github.com/tc39/proposal-intl-duration-format/pull/150
* Made existing examples much more comprehensive/accurate

### Motivation

Recent normative changes have altered the behaviour of `fractionalDigits. Intl.DurationFormat.format() now defaults to displaying however many digits are necessary to display all components, rather than defaulting to 0 fractional digits displayed.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/tc39/proposal-intl-duration-format/pull/150

