### PR TITLE
chore(html): Add link to HTMLImageElement from img element See Also, spellchecker

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -1,5 +1,7 @@
 affordance
 affordances
+APNG
+Axess
 bézier
 Bhattacharya
 Brosset
@@ -25,6 +27,7 @@ mdnplay
 menclose
 mfenced
 mfrac
+mitigations
 mmultiscripts
 mozjpeg
 mphantom
@@ -43,11 +46,13 @@ mtext
 mtr
 munder
 munderover
+Navigations
 Neethling
 nolint
 okan
 Oklab
 oklch
+Paciello
 prophoto
 rgba
 ripgrep
@@ -59,6 +64,7 @@ upvotes
 Verou
 vmin
 Weyl
+WHATWG
 Willee
 worklets
 Yari

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -474,7 +474,7 @@ The value of the `title` attribute is usually presented to the user as a tooltip
 
 ## See also
 
-- {{HTMLElement("picture")}}, {{HTMLElement("object")}} and {{HTMLElement("embed")}} elements
+- {{HTMLElement("picture")}}, {{HTMLElement("object")}}, and {{HTMLElement("embed")}} elements
 - {{cssxref("object-fit")}}, {{cssxref("object-position")}}, {{cssxref("image-orientation")}}, {{cssxref("image-rendering")}}, and {{cssxref("image-resolution")}}: Image-related CSS properties.
 - {{domxref("HTMLImageElement")}} interface for this element
 - [Images in HTML](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML)

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -474,8 +474,9 @@ The value of the `title` attribute is usually presented to the user as a tooltip
 
 ## See also
 
+- {{HTMLElement("picture")}}, {{HTMLElement("object")}} and {{HTMLElement("embed")}} elements
+- {{cssxref("object-fit")}}, {{cssxref("object-position")}}, {{cssxref("image-orientation")}}, {{cssxref("image-rendering")}}, and {{cssxref("image-resolution")}}: Image-related CSS properties.
+- {{domxref("HTMLImageElement")}} interface for this element
 - [Images in HTML](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML)
 - [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types)
 - [Responsive images](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
-- {{HTMLElement("picture")}}, {{HTMLElement("object")}} and {{HTMLElement("embed")}} elements
-- Other image-related CSS properties: {{cssxref("object-fit")}}, {{cssxref("object-position")}}, {{cssxref("image-orientation")}}, {{cssxref("image-rendering")}}, and {{cssxref("image-resolution")}}.


### PR DESCRIPTION
Suggestion from Estelle to add link to HTMLImageElement from `<img>` in See Also section. Spellchecker additions in parallel. I had intended to get this into https://github.com/mdn/content/pull/28698 but I was too slow to amend the open PR.

__spellchecker:__
Allowing 'Navigations' based on https://www.w3.org/TR/referrer-policy/

>This document describes how an author can set a referrer policy for documents they create, and the impact of such a policy on the Referer HTTP header for outgoing requests and navigations.