### PR TITLE
Change meter optimum

### DIFF
--- a/files/en-us/learn/forms/other_form_controls/index.md
+++ b/files/en-us/learn/forms/other_form_controls/index.md
@@ -273,7 +273,7 @@ All browsers that implement the {{HTMLElement("meter")}} element use those value
 Such a bar is created by using the {{HTMLElement("meter")}} element. This is for implementing any kind of meter; for example, a bar showing the total space used on a disk, which turns red when it starts to get full.
 
 ```html
-<meter min="0" max="100" value="75" low="33" high="66" optimum="50">75</meter>
+<meter min="0" max="100" value="75" low="33" high="66" optimum="0">75</meter>
 ```
 
 {{EmbedLiveSample("Meter", 120, 120)}}


### PR DESCRIPTION
Done the testing locally and set the 'optimum value to '0' as mentioned for the meter bar component

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

changed the initial **optimum** value of **50** to **0**, following is the change which I made

`<meter min="0" max="100" value="75" low="33" high="66" optimum="0">75</meter>`

### Motivation

As mentioned in the description it is an issue, as per the given state the bar color should be Red and not Yellow but due to an incorrect optimum value it was set to Yellow, hence we have made changes to make it correct so that it will now align with the provided explanation statement for this component

### Additional details

![image](https://github.com/mdn/content/assets/18300894/490410df-3066-4186-ac92-47acdd55b40f)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
