### PR TITLE
cookies.SameSiteStatus update to match Chrome and Firefox plans

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
@@ -2,6 +2,7 @@
 title: cookies.SameSiteStatus
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus
 page-type: webextension-api-type
+browser-compat: webextensions.api.cookies.SameSiteStatus
 ---
 
 {{AddonSidebar()}}
@@ -13,10 +14,16 @@ The `SameSiteStatus` type of the {{WebExtAPIRef("cookies")}} API represents info
 Values of this type are strings. Possible values are:
 
 - `no_restriction`
-  - : Represents a cookie set without a `SameSite` attribute.
+  - : Corresponds to a cookie set with `SameSite=None`.
 - `lax`
-  - : Corresponds to `SameSite=Lax`
+  - : Corresponds to a cookie set with `SameSite=Lax`.
 - `strict`
-  - : Corresponds to a cookie set with `SameSite=Strict`
+  - : Corresponds to a cookie set with `SameSite=Strict`.
+- `unspecified`
+  - : Corresponds to a cookie set without the `SameSite` attribute.
 
 See [SameSite cookies](/en-US/docs/Web/HTTP/Cookies#samesite_cookies) for more information.
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are:
 - `strict`
   - : Corresponds to a cookie set with `SameSite=Strict`.
 - `unspecified`
-  - : Corresponds to a cookie set without the `SameSite` attribute.
+  - : Corresponds to a cookie set without the `SameSite` attribute. This state is not part of any SameSite standard, and is only supported by browsers that store this state internally. Other browsers map the absence of the SameSite flag to the default state (e.g. Lax). See the browser compatibility table for more details.
 
 See [SameSite cookies](/en-US/docs/Web/HTTP/Cookies#samesite_cookies) for more information.
 


### PR DESCRIPTION
### Description

Aligns the documentation for cookies.SameSiteStatus with Chrome and the Firefox functionality intended in [Bug 1550032](https://bugzilla.mozilla.org/show_bug.cgi?id=1550032) Change cookie API to explicitly support sameSite=none.

Notes on browser differences added to BCD in https://github.com/mdn/browser-compat-data/pull/20598.

### Related issues and pull requests

Fixes #6124
