### PR TITLE
fix: better explain animation-timeline view() function

### DIFF
--- a/files/en-us/glossary/scroll_container/index.md
+++ b/files/en-us/glossary/scroll_container/index.md
@@ -10,4 +10,8 @@ A **scroll container** is an element box in which content can be scrolled, wheth
 
 When the content of an element box overflows its bounding box, users can use scroll bars to scroll through the clipped content that is otherwise hidden from view.
 
-A scroll container includes a scrollport and scroll bars. The scrollport is the visible part of a scroll container and coincides with the padding box of the scroll container. The scroll bars are used to move content in and out of the scrollport so that the content can be viewed.
+A scroll container includes a scrollport and scroll bars.
+
+## Scrollport
+
+The scrollport is the visible part of a scroll container and coincides with the padding box of the scroll container. The scroll bars are used to move content in and out of the scrollport so that the content can be viewed.

--- a/files/en-us/web/css/animation-timeline/view/index.md
+++ b/files/en-us/web/css/animation-timeline/view/index.md
@@ -192,6 +192,7 @@ Important point to remember is that the animation lasts as long as the `subject`
   animation-name: grow;
   animation-fill-mode: both;
   animation-duration: 1ms; /* Firefox requires this to apply the animation */
+  animation-timing-function: linear;
 }
 
 @keyframes grow {

--- a/files/en-us/web/css/animation-timeline/view/index.md
+++ b/files/en-us/web/css/animation-timeline/view/index.md
@@ -63,7 +63,7 @@ animation-timeline: view(x 200px auto);
 
 - inset
 
-  - : The inset value can be one or two values, which can be either `auto` or a {{cssxref("length-percentage")}}. It specifies an inset (positive) or outset (negative) adjustment of the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport). The inset is used to determine whether the element is in view which determines length of the animation timeline. In other words, the animation lasts as long as the element is in the inset adjusted view.
+  - : The inset value can be one or two values, which can be either `auto` or a {{cssxref("length-percentage")}}. It specifies an inset (positive) or outset (negative) adjustment of the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport). The inset is used to determine whether the element is in view which determines the length of the animation timeline. In other words, the animation lasts as long as the element is in the inset-adjusted view.
 
     - start
       - : Inward offset from beginning of the scrollport.
@@ -126,7 +126,7 @@ The HTML for the example is shown below.
 
 #### CSS
 
-The `subject` element and `content` elements are styled minimally, and the text content is given some basic font settings:
+The `subject` element and `content` elements are minimally styled and the text content is given some basic font settings:
 
 ```css
 .subject {
@@ -147,7 +147,7 @@ p {
 }
 ```
 
-To aid the understanding of the result, extra elements `subject-container`, `top`, and `bottom` have been used. The `subject-container` shows the bounds of the animation. And semi transparent overlays `top` and `bottom` mark inset offsetted scrollport.
+To aid the understanding of the result, extra elements `subject-container`, `top`, and `bottom` have been used. The `subject-container` shows the bounds of the animation. And semi-transparent `top` and `bottom` overlays mark inset offsetted scrollport.
 
 ```css
 .subject-container {
@@ -179,11 +179,11 @@ To aid the understanding of the result, extra elements `subject-container`, `top
 }
 ```
 
-In the following code, the `<div>` with the class of `subject` is also given a class of `animation`. The set animation `grow` causes the `subject` element to grow or shrink. The `animation-timeline: view(block 55% 10%)` is set to declare that it will be animated as it progresses through the view progress timeline provided by its scrolling ancestor (in this case the document's root element).
+In the following code, the `<div>` with the class of `subject` is also given a class of `animation`. The `grow` animation causes the `subject` element to grow or shrink. The `animation-timeline: view(block 55% 10%)` is set to declare that it will be animated as it progresses through the view progress timeline provided by its scrolling ancestor (in this case the document's root element).
 
-Note how the inset value of `50% 10%`, while scrolling down, causes the animation to start at 10% from the bottom and finish at 50% from the top. As animation moves forward the `subject` grows. Conversely, while scrolling up the animation starts, in reverse direction, at 50% from the top and ends at 10% from the bottom. So, as the animation happens backwards the `subject` shrinks.
+While scrolling down, note how the inset value of `50% 10%` causes the animation to start at 10% from the bottom and finish at 50% from the top. As animation moves forward along the timeline the `subject` grows. Conversely, when scrolling up the animation proceeds in the reverse direction, starting at 50% from the top, moving backward through the animation, and ending at 10% from the bottom. So, as the animation happens backwards the `subject` shrinks.
 
-Important point to remember is that the animation lasts as long as the `subject` element is in the view which has been offsetted using `50% 10%` inset values.
+An important point to remember is that the animation lasts as long as the `subject` element is in the view which has been set and to be offset using `50% 10%` inset values.
 
 ```css
 .animation {

--- a/files/en-us/web/css/animation-timeline/view/index.md
+++ b/files/en-us/web/css/animation-timeline/view/index.md
@@ -63,7 +63,12 @@ animation-timeline: view(x 200px auto);
 
 - inset
 
-  - : The inset value can be one or two values, which can be either `auto` or a {{cssxref("length-percentage")}}.
+  - : The inset value can be one or two values, which can be either `auto` or a {{cssxref("length-percentage")}}. It specifies an inset (positive) or outset (negative) adjustment of the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport). The inset is used to determine whether the element is in view which determines length of the animation timeline. In other words, the animation lasts as long as the element is in the inset adjusted view.
+
+    - start
+      - : Inward offset from beginning of the scrollport.
+    - end
+      - : Inward offset from end of the scrollport.
 
 > **Note:** The scroller and inset values can be specified in any order.
 
@@ -84,7 +89,6 @@ The HTML for the example is shown below.
 ```html
 <div class="content">
   <h1>Content</h1>
-
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Risus quis varius quam
@@ -101,7 +105,9 @@ The HTML for the example is shown below.
     arcu vitae elementum curabitur vitae nunc sed velit.
   </p>
 
-  <div class="subject animation"></div>
+  <div class="subject-container">
+    <div class="subject animation"></div>
+  </div>
 
   <p>
     Adipiscing enim eu turpis egestas pretium aenean pharetra magna ac. Arcu
@@ -114,17 +120,18 @@ The HTML for the example is shown below.
     scelerisque. Netus et malesuada fames ac.
   </p>
 </div>
+<div class="overlay top">inset start 50%</div>
+<div class="overlay bottom">inset end 10%</div>
 ```
 
 #### CSS
 
-The `subject` element and its containing `content` element are styled minimally, and the text content is given some basic font settings:
+The `subject` element and `content` elements are styled minimally, and the text content is given some basic font settings:
 
 ```css
 .subject {
   width: 300px;
   height: 200px;
-  margin: 0 auto;
   background-color: deeppink;
 }
 
@@ -134,43 +141,65 @@ The `subject` element and its containing `content` element are styled minimally,
   margin: 0 auto;
 }
 
-p,
-h1 {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
-h1 {
-  font-size: 3rem;
-}
-
 p {
   font-size: 1.5rem;
-  line-height: 1.5;
+  line-height: 1.8;
 }
 ```
 
-The `<div>` with the class of `subject` is also given a class of `animation` — this is where `animation-timeline: view(block 25% 25%)` is set to declare that it will be animated as it progresses through the view progress timeline provided by its scrolling ancestor (in this case the document's root element). Note how the inset value of `25% 25%` causes the animation to start 25% of the way up the viewport, and finish 25% from the top.
+To aid the understanding of the result, extra elements `subject-container`, `top`, and `bottom` have been used. The `subject-container` shows the bounds of the animation. And semi transparent overlays `top` and `bottom` mark inset offsetted scrollport.
 
-Last, an animation is specified on the element that animates its opacity and scale, causing it to fade in and size up as it moves up the scroller.
+```css
+.subject-container {
+  border: 2px dashed black;
+  width: 300px;
+  margin: 0 auto;
+}
+
+.overlay {
+  position: fixed;
+  width: 100%;
+  background-color: #f5deb3aa;
+  display: flex;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: red;
+  justify-content: flex-end;
+}
+
+.top {
+  top: 0;
+  height: 244px;
+  align-items: end;
+}
+
+.bottom {
+  top: 432px;
+  height: 48px;
+}
+```
+
+In the following code, the `<div>` with the class of `subject` is also given a class of `animation`. The set animation `grow` causes the `subject` element to grow or shrink. The `animation-timeline: view(block 55% 10%)` is set to declare that it will be animated as it progresses through the view progress timeline provided by its scrolling ancestor (in this case the document's root element).
+
+Note how the inset value of `50% 10%`, while scrolling down, causes the animation to start at 10% from the bottom and finish at 50% from the top. As animation moves forward the `subject` grows. Conversely, while scrolling up the animation starts, in reverse direction, at 50% from the top and ends at 10% from the bottom. So, as the animation happens backwards the `subject` shrinks.
+
+Important point to remember is that the animation lasts as long as the `subject` element is in the view which has been offsetted using `50% 10%` inset values.
 
 ```css
 .animation {
-  animation-timeline: view(block 25% 25%);
+  animation-timeline: view(block 50% 10%);
 
-  animation-name: appear;
+  animation-name: grow;
   animation-fill-mode: both;
   animation-duration: 1ms; /* Firefox requires this to apply the animation */
-
 }
 
-@keyframes appear {
+@keyframes grow {
   from {
-    opacity: 0;
     transform: scaleX(0);
   }
 
   to {
-    opacity: 1,
     transform: scaleX(1);
   }
 }


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/28366

The example is confusing because:
- Same values `25% 25%` have been used for both the offsets.
- Use of opacity in the animation makes it hard to find where exactly the animation started.
- It is obvious to think the first value sets the animation start, without knowing the inset is offset for the scrollport.