### PR TITLE
relnote(117): Range is CORS-safelisted request header

### DIFF
--- a/files/en-us/glossary/cors-safelisted_request_header/index.md
+++ b/files/en-us/glossary/cors-safelisted_request_header/index.md
@@ -11,19 +11,22 @@ A [CORS-safelisted request header](https://fetch.spec.whatwg.org/#cors-safeliste
 - {{HTTPHeader("Accept")}},
 - {{HTTPHeader("Accept-Language")}},
 - {{HTTPHeader("Content-Language")}},
-- {{HTTPHeader("Content-Type")}}.
+- {{HTTPHeader("Content-Type")}},
+- {{HTTPHeader("Range")}}.
 
 When containing only these headers (and values that meet the additional requirements laid out below), a request doesn't need to send a {{glossary("preflight request")}} in the context of [CORS](/en-US/docs/Glossary/CORS).
 
-You can safelist more headers using the {{HTTPHeader("Access-Control-Allow-Headers")}} header and also list the above headers there to circumvent the following additional restrictions:
+You can safelist more headers using the {{HTTPHeader("Access-Control-Allow-Headers")}} header and also list the above headers there to circumvent the following additional restrictions.
 
-#### Additional restrictions
+## Additional restrictions
 
 CORS-safelisted headers must also fulfill the following requirements in order to be a CORS-safelisted request header:
 
-- For {{HTTPHeader("Accept-Language")}} and {{HTTPHeader("Content-Language")}}: can only have values consisting of `0-9`, `A-Z`, `a-z`, space or `*,-.;=`.
-- For {{HTTPHeader("Accept")}} and {{HTTPHeader("Content-Type")}}: can't contain a _CORS-unsafe request header byte_: `0x00-0x1F` (except for `0x09 (HT)`, which is allowed), `"():<>?@[\]{}`, and `0x7F (DEL)`.
-- For {{HTTPHeader("Content-Type")}}: needs to have a MIME type of its parsed value (ignoring parameters) of either `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
+- {{HTTPHeader("Accept-Language")}} and {{HTTPHeader("Content-Language")}} can only have values consisting of `0-9`, `A-Z`, `a-z`, space or `*,-.;=`.
+- {{HTTPHeader("Accept")}} and {{HTTPHeader("Content-Type")}} can't contain a _CORS-unsafe request header byte_: `0x00-0x1F` (except for `0x09 (HT)`, which is allowed), `"():<>?@[\]{}`, and `0x7F (DEL)`.
+- {{HTTPHeader("Content-Type")}} needs to have a MIME type of its parsed value (ignoring parameters) of either `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
+- {{HTTPHeader("Range")}} needs to have a value of a single byte range in the form of `bytes=[0-9]+-[0-9]*`.
+  See the {{HTTPHeader("Range")}} header documentation for more details.
 - For any header: the value's length can't be greater than 128.
 
 ## See also

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -42,7 +42,7 @@ This article provides information about the changes in Firefox 117 that affect d
   The behavior now matches the specification where `default-src` directive values are used as a fallback when `script-src` is not provided ([Firefox bug 1313937](https://bugzil.la/1313937)).
 
 - The `Range` header is now a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the value is a single byte range (e.g., `bytes=100-200`).
-  This allows for using the `Range` header in cross-origin requests without triggering a preflight request which is useful for requesting media and resuming downloads ([Firefox bug 1733981](https://bugzil.la/1733981)).
+  This allows the `Range` header to be used in cross-origin requests without triggering a preflight request, which is useful for requesting media and resuming downloads ([Firefox bug 1733981](https://bugzil.la/1733981)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -41,6 +41,9 @@ This article provides information about the changes in Firefox 117 that affect d
 - Fixed a bug where the [Content-Security-Policy](/en-US/docs/Web/HTTP/CSP) `'strict-dynamic'` source expression was not being enforced in `default-src` directives.
   The behavior now matches the specification where `default-src` directive values are used as a fallback when `script-src` is not provided ([Firefox bug 1313937](https://bugzil.la/1313937)).
 
+- The `Range` header is now a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the value is a single byte range (e.g., `bytes=100-200`).
+  This allows for using the `Range` header in cross-origin requests without triggering a preflight request which is useful for requesting media and resuming downloads ([Firefox bug 1733981](https://bugzil.la/1733981)).
+
 #### Removals
 
 ### Security

--- a/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -107,6 +107,7 @@ This works better with longer pieces of audio or video, but press play and click
 ## Seekable
 
 The `seekable` attribute returns a {{ domxref("TimeRanges") }} object and tells us which parts of the media can be played without delay; this is irrespective of whether that part has been downloaded or not. Some parts of the media may be seekable but not buffered if byte-range requests are enabled on the server. Byte range requests allow parts of the media file to be delivered from the server and so can be ready to play almost immediately — thus they are seekable.
+For more information on byte range requests see [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests).
 
 ```js
 const seekableTimeRanges = audio.seekable;

--- a/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -35,7 +35,7 @@ For live services streaming, the LIVE profile is a requirement. The stream switc
 
 Other reasons to use LIVE profile over Ondemand for VOD content may be:
 
-1. Your client or server does not support range requests
+1. Your client or server does not support [range requests](/en-US/docs/Web/HTTP/Range_requests)
 2. Your server cannot cache range requests efficiently
 3. Your server cannot prefetch range requests efficiently
 4. The SIDX\* is large and having to load it first slows down startup a little

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -30,7 +30,7 @@ You can find specific information about possible media file types and the codecs
 
 ## Handle HTTP 1.1 byte range requests correctly
 
-In order to support seeking and playing back regions of the media that aren't yet downloaded, Firefox uses HTTP 1.1 byte-range requests to retrieve the media from the seek target position. 
+In order to support seeking and playing back regions of the media that aren't yet downloaded, Firefox uses HTTP 1.1 byte-range requests to retrieve the media from the seek target position.
 In addition, it uses byte-range requests to seek to the end of the media (assuming you serve the {{HTTPHeader("Content-Length")}} header) in order to determine the duration of the media.
 
 Your server should accept the {{HTTPHeader("Accept-Ranges")}}`: bytes` HTTP header if it can accept byte-range requests. It must return {{HTTPStatus("206")}}`: Partial content` to all byte range requests; otherwise, browsers can't be sure you actually support byte range requests.

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -30,7 +30,8 @@ You can find specific information about possible media file types and the codecs
 
 ## Handle HTTP 1.1 byte range requests correctly
 
-In order to support seeking and playing back regions of the media that aren't yet downloaded, Gecko uses HTTP 1.1 byte-range requests to retrieve the media from the seek target position. In addition, Gecko uses byte-range requests to seek to the end of the media (assuming you serve the {{HTTPHeader("Content-Length")}} header) in order to determine the duration of the media.
+In order to support seeking and playing back regions of the media that aren't yet downloaded, Firefox uses HTTP 1.1 byte-range requests to retrieve the media from the seek target position. 
+In addition, it uses byte-range requests to seek to the end of the media (assuming you serve the {{HTTPHeader("Content-Length")}} header) in order to determine the duration of the media.
 
 Your server should accept the {{HTTPHeader("Accept-Ranges")}}`: bytes` HTTP header if it can accept byte-range requests. It must return {{HTTPStatus("206")}}`: Partial content` to all byte range requests; otherwise, browsers can't be sure you actually support byte range requests.
 Your server must also return `206: Partial Content` for the request `Range: bytes=0-` as well.

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -33,8 +33,9 @@ You can find specific information about possible media file types and the codecs
 In order to support seeking and playing back regions of the media that aren't yet downloaded, Gecko uses HTTP 1.1 byte-range requests to retrieve the media from the seek target position. In addition, Gecko uses byte-range requests to seek to the end of the media (assuming you serve the {{HTTPHeader("Content-Length")}} header) in order to determine the duration of the media.
 
 Your server should accept the {{HTTPHeader("Accept-Ranges")}}`: bytes` HTTP header if it can accept byte-range requests. It must return {{HTTPStatus("206")}}`: Partial content` to all byte range requests; otherwise, browsers can't be sure you actually support byte range requests.
-
 Your server must also return `206: Partial Content` for the request `Range: bytes=0-` as well.
+
+For more information, see [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests).
 
 ## Include regular key frames
 

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -54,10 +54,10 @@ Range: <unit>=-<suffix-length>
 The following examples show how to make requests using the `Range` header for CORS-safelisted requests, and for requesting multiple ranges.
 Other examples can be found in the [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests) guide.
 
-### Making cors-safelisted requests
+### Making CORS-safelisted requests
 
 The `Range` header is a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the value is a single byte range.
-This means that it can be used in cross-origin requests without triggering a [preflight](/en-US/docs/Glossary/Preflight_request) request which is useful for requesting media and resuming downloads.
+This means that it can be used in cross-origin requests without triggering a [preflight](/en-US/docs/Glossary/Preflight_request) request, which is useful for requesting media and resuming downloads.
 
 This example requests the bytes from 100 to 200 of the resource:
 

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -45,15 +45,34 @@ Range: <unit>=-<suffix-length>
 
 ## Examples
 
-Requesting three ranges from the file.
+### Making cors-safelisted requests
+
+The `Range` header is a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the value is a single byte range.
+This means that it can be used in cross-origin requests without triggering a [preflight](/en-US/docs/Glossary/Preflight_request) request which is useful for requesting media and resuming downloads.
+
+This example requests the bytes from 100 to 200 of the resource:
+
+```http
+Range: bytes=100-200
+```
+
+The following example requests the last 500 bytes of the resource:
+
+```http
+Range: bytes=-500
+```
+
+### Requesting multiple ranges
+
+The following example requests three separate parts of a file, from `200`-`1000` (the first 800 bytes), `2000`-`6576` (the bytes from 2000 to 6576), and finally `19000-`.
+The ranges-specifier value `19000-` specifies `19000` as the first position, and omits any last position in order to indicate that all bytes from 19000 onward are part of the third range.
 
 ```http
 Range: bytes=200-1000, 2000-6576, 19000-
 ```
 
-The ranges-specifier value `19000-` specifies `19000` as the first position, and omits any last position — in order to indicate that all bytes from 19000 onward are part of the third range.
-
-Requesting the first 500 and last 500 bytes of the file. The request may be rejected by the server if the ranges overlap.
+This example requests the first 500 and last 500 bytes of the file.
+The request may be rejected by the server if these ranges overlap (i.e. the file is less than 1000 bytes long).
 
 ```http
 Range: bytes=0-499, -500
@@ -74,3 +93,4 @@ Range: bytes=0-499, -500
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPStatus("206", "206 Partial Content")}}
 - {{HTTPStatus("416", "416 Range Not Satisfiable")}}
+- [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header)

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -12,6 +12,7 @@ Several parts can be requested at the same time in one `Range` header, and the s
 If the server sends back ranges, it uses the {{HTTPStatus("206", "206 Partial Content")}} for the response.
 If the ranges are invalid, the server returns the {{HTTPStatus("416", "416 Range Not Satisfiable")}} error.
 The server can also ignore the `Range` header and return the whole document with a {{HTTPStatus("200")}} status code.
+The header is a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the directive specifies a single byte range.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -40,7 +40,7 @@ Range: <unit>=-<suffix-length>
 
 - \<unit>
   - : The unit in which ranges are specified.
-    This is usually `bytes`.
+    This `bytes` for byte ranges (currently no other [range units are registered](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units)).
 - \<range-start>
   - : An integer indicating the beginning of the request range, in the given unit.
 - \<range-end>

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -7,7 +7,11 @@ browser-compat: http.headers.Range
 
 {{HTTPSidebar}}
 
-The **`Range`** HTTP request header indicates the part of a document that the server should return. Several parts can be requested with one `Range` header at once, and the server may send back these ranges in a multipart document. If the server sends back ranges, it uses the {{HTTPStatus("206", "206 Partial Content")}} for the response. If the ranges are invalid, the server returns the {{HTTPStatus("416", "416 Range Not Satisfiable")}} error. The server can also ignore the `Range` header and return the whole document with a {{HTTPStatus("200")}} status code.
+The **`Range`** HTTP request header indicates the parts of a document that the server should return.
+Several parts can be requested at the same time in one `Range` header, and the server may send back these ranges in a multipart document.
+If the server sends back ranges, it uses the {{HTTPStatus("206", "206 Partial Content")}} for the response.
+If the ranges are invalid, the server returns the {{HTTPStatus("416", "416 Range Not Satisfiable")}} error.
+The server can also ignore the `Range` header and return the whole document with a {{HTTPStatus("200")}} status code.
 
 <table class="properties">
   <tbody>
@@ -35,13 +39,15 @@ Range: <unit>=-<suffix-length>
 ## Directives
 
 - \<unit>
-  - : The unit in which ranges are specified. This is usually `bytes`.
+  - : The unit in which ranges are specified.
+    This is usually `bytes`.
 - \<range-start>
-  - : An integer in the given unit indicating the beginning of the request range.
+  - : An integer indicating the beginning of the request range, in the given unit.
 - \<range-end>
-  - : An integer in the given unit indicating the end of the requested range. This value is optional and, if omitted, the end of the document is taken as the end of the range.
+  - : An integer indicating the end of the requested range, in the given unit.
+    This value is optional and, if omitted, the end of the document is taken as the end of the range.
 - \<suffix-length>
-  - : An integer in the given unit indicating the number of units at the end of the file to return.
+  - : An integer indicating the number of (given) units at the end of the file to return.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -45,6 +45,9 @@ Range: <unit>=-<suffix-length>
 
 ## Examples
 
+The following examples show how to make requests using the `Range` header for CORS-safelisted requests, and for requesting multiple ranges.
+Other examples can be found in the [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests) guide.
+
 ### Making cors-safelisted requests
 
 The `Range` header is a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header) when the value is a single byte range.
@@ -93,4 +96,5 @@ Range: bytes=0-499, -500
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPStatus("206", "206 Partial Content")}}
 - {{HTTPStatus("416", "416 Range Not Satisfiable")}}
+- [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests) guide
 - [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safelisted_request_header)

--- a/files/en-us/web/http/range_requests/index.md
+++ b/files/en-us/web/http/range_requests/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{HTTPSidebar}}
 
-An HTTP range request asks the server to send only a portion of an HTTP message back to a client. Range requests are useful for clients like media players that support random access, data tools that know they need only part of a large file, and download managers that let the user pause and resume the download.
+An HTTP {{HTTPHeader("Range")}} request asks the server to send only a portion of an HTTP message back to a client. Range requests are useful for clients like media players that support random access, data tools that know they need only part of a large file, and download managers that let the user pause and resume the download.
 
 ## Checking if a server supports partial requests
 


### PR DESCRIPTION
The Range header is a cors-safelisted request header when there is a single range value. This is used for fetching media or resuming downloads and doesn't require sending preflight requests.

__Docs:__

- [Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) HTTP header reference
- [Range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) guide

__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/28281
- [x] BCD https://github.com/mdn/browser-compat-data/pull/20605

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1733981

__Resources:__
- WPT: https://wpt.fyi/results/cors/cors-safelisted-request-header.any.html?label=master&label=experimental&aligned
  - src: https://github.com/rayankans/wpt/blob/master/cors/cors-safelisted-request-header.any.js
- https://fetch.spec.whatwg.org/#concept-request-add-range-header