### PR TITLE
Fix title of <ins> element reference page

### DIFF
--- a/files/en-us/web/html/element/ins/index.md
+++ b/files/en-us/web/html/element/ins/index.md
@@ -1,5 +1,5 @@
 ---
-title: <ins>
+title: "<ins>: The Inserted Text element"
 slug: Web/HTML/Element/ins
 page-type: html-element
 browser-compat: html.elements.ins


### PR DESCRIPTION
### Description

The title of the [<ins> reference page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins) is just saying "`<ins>`". But it's common for reference pages of HTML elements to include a written-out name of the tag like "`<del>`: The Deleted Text element".

### Motivation

To keep the pages consistent and definitely not bad in terms of SEO.

### Additional details

I don't know where the naming in the titles come from, but I took this [W3C document](https://www.w3.org/TR/2011/WD-html-markup-20110525/ins.html#ins) as a reference.

### Related issues and pull requests

/


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
