### PR TITLE
Fix SVG keypoints attribute - href not xlink href

### DIFF
--- a/files/en-us/web/svg/attribute/clip-rule/index.md
+++ b/files/en-us/web/svg/attribute/clip-rule/index.md
@@ -74,13 +74,13 @@ As a presentation attribute, it also can be used as a property directly inside a
 
   <!-- Left: evenodd -->
   <clipPath id="emptyStar">
-    <use xlink:href="#star" clip-rule="evenodd" />
+    <use href="#star" clip-rule="evenodd" />
   </clipPath>
   <rect clip-path="url(#emptyStar)" width="50" height="90" fill="blue" />
 
   <!-- Right: nonzero -->
   <clipPath id="filledStar">
-    <use xlink:href="#star" clip-rule="nonzero" />
+    <use href="#star" clip-rule="nonzero" />
   </clipPath>
   <rect clip-path="url(#filledStar)" width="50" height="90" x="50" fill="red" />
 </svg>

--- a/files/en-us/web/svg/attribute/d/index.md
+++ b/files/en-us/web/svg/attribute/d/index.md
@@ -678,7 +678,7 @@ svg {
     <circle cx="50" cy="10" r="1.5" />
     <circle cx="90" cy="90" r="1.5" />
   </g>
-  <use xlink:href="#ControlPoints" x="100" />
+  <use href="#ControlPoints" x="100" />
 </svg>
 ```
 
@@ -897,9 +897,9 @@ svg {
       <circle cx="100" cy="50" r="1.5" />
     </g>
 
-    <use xlink:href="#SmoothQuadraticDown" x="60" />
-    <use xlink:href="#SmoothQuadraticUp" x="60" />
-    <use xlink:href="#SmoothQuadraticDown" x="120" />
+    <use href="#SmoothQuadraticDown" x="60" />
+    <use href="#SmoothQuadraticUp" x="60" />
+    <use href="#SmoothQuadraticDown" x="120" />
   </g>
 </svg>
 ```

--- a/files/en-us/web/svg/attribute/divisor/index.md
+++ b/files/en-us/web/svg/attribute/divisor/index.md
@@ -35,12 +35,12 @@ svg {
   </filter>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix1);" />
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix2); transform:translateX(220px);" />

--- a/files/en-us/web/svg/attribute/in/index.md
+++ b/files/en-us/web/svg/attribute/in/index.md
@@ -93,7 +93,7 @@ You can use this attribute with the following SVG elements:
       </filter>
     </defs>
     <image
-      xlink:href="mdn_logo_only_color.png"
+      href="mdn_logo_only_color.png"
       x="10%"
       y="10%"
       width="80%"
@@ -114,7 +114,7 @@ You can use this attribute with the following SVG elements:
       <filter id="imageMultiply">
         <!-- This is a workaround. -->
         <feImage
-          xlink:href="mdn_logo_only_color.png"
+          href="mdn_logo_only_color.png"
           x="10%"
           y="10%"
           width="80%"

--- a/files/en-us/web/svg/attribute/index.md
+++ b/files/en-us/web/svg/attribute/index.md
@@ -320,7 +320,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 - {{SVGAttr("xChannelSelector")}}
 - {{SVGAttr("xlink:actuate")}}
 - {{SVGAttr("xlink:arcrole")}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}}{{deprecated_inline}}
 - {{SVGAttr("xlink:role")}}
 - {{SVGAttr("xlink:show")}}
 - {{SVGAttr("xlink:title")}}
@@ -362,7 +362,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 
 ### XLink attributes
 
-{{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:type")}}, {{SVGAttr("xlink:role")}}, {{SVGAttr("xlink:arcrole")}}, {{SVGAttr("xlink:title")}}, {{SVGAttr("xlink:show")}}, {{SVGAttr("xlink:actuate")}}
+{{SVGAttr("xlink:href")}}{{deprecated_inline}} , {{SVGAttr("xlink:type")}}, {{SVGAttr("xlink:role")}}, {{SVGAttr("xlink:arcrole")}}, {{SVGAttr("xlink:title")}}, {{SVGAttr("xlink:show")}}, {{SVGAttr("xlink:actuate")}}
 
 ### Presentation attributes
 

--- a/files/en-us/web/svg/attribute/kernelmatrix/index.md
+++ b/files/en-us/web/svg/attribute/kernelmatrix/index.md
@@ -35,12 +35,12 @@ svg {
   </filter>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix1);" />
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix2); transform:translateX(220px);" />

--- a/files/en-us/web/svg/attribute/keypoints/index.md
+++ b/files/en-us/web/svg/attribute/keypoints/index.md
@@ -47,7 +47,7 @@ svg {
       keyPoints="0;0.5;1"
       keyTimes="0;0.15;1"
       calcMode="linear">
-      <mpath xlink:href="#motionPath" />
+      <mpath href="#motionPath" />
     </animateMotion>
   </circle>
 </svg>

--- a/files/en-us/web/svg/attribute/mode/index.md
+++ b/files/en-us/web/svg/attribute/mode/index.md
@@ -49,12 +49,12 @@ svg {
   </filter>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#blending1);" />
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#blending2); transform:translateX(220px);" />

--- a/files/en-us/web/svg/attribute/preservealpha/index.md
+++ b/files/en-us/web/svg/attribute/preservealpha/index.md
@@ -35,12 +35,12 @@ svg {
   </filter>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix1);" />
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     width="200"
     height="200"
     style="filter:url(#convolveMatrix2); transform:translateX(220px);" />

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.md
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.md
@@ -100,10 +100,10 @@ svg {
     <circle cx="3" cy="2" r="0.05" fill="pink" />
     <circle cx="5" cy="5.5" r="0.05" fill="pink" />
   </g>
-  <use xlink:href="#highlight" x="6" />
-  <use xlink:href="#highlight" x="12" />
-  <use xlink:href="#highlight" x="2" y="6" />
-  <use xlink:href="#highlight" x="8" y="6" />
+  <use href="#highlight" x="6" />
+  <use href="#highlight" x="12" />
+  <use href="#highlight" x="2" y="6" />
+  <use href="#highlight" x="8" y="6" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/transform/index.md
+++ b/files/en-us/web/svg/attribute/transform/index.md
@@ -42,7 +42,7 @@ svg {
       d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
   </g>
 
-  <use xlink:href="#heart" fill="none" stroke="red" />
+  <use href="#heart" fill="none" stroke="red" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/xchannelselector/index.md
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.md
@@ -27,7 +27,7 @@ svg {
 <svg viewBox="0 0 440 160" xmlns="http://www.w3.org/2000/svg">
   <filter id="displacementFilter">
     <feImage
-      xlink:href="mdn.svg"
+      href="mdn.svg"
       x="0"
       y="0"
       width="100%"
@@ -41,7 +41,7 @@ svg {
   </filter>
   <filter id="displacementFilter2">
     <feImage
-      xlink:href="mdn.svg"
+      href="mdn.svg"
       x="0"
       y="0"
       width="100%"

--- a/files/en-us/web/svg/attribute/ychannelselector/index.md
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.md
@@ -27,7 +27,7 @@ svg {
 <svg viewBox="0 0 440 160" xmlns="http://www.w3.org/2000/svg">
   <filter id="displacementFilter">
     <feImage
-      xlink:href="mdn.svg"
+      href="mdn.svg"
       x="0"
       y="0"
       width="100%"
@@ -41,7 +41,7 @@ svg {
   </filter>
   <filter id="displacementFilter2">
     <feImage
-      xlink:href="mdn.svg"
+      href="mdn.svg"
       x="0"
       y="0"
       width="100%"

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -170,7 +170,8 @@ SVG makes use of a number of data types. This article lists these types along wi
     http://example.com/someDrawing.svg#Lamppost
     ```
 
-    _IRIs_ are used in the {{SVGAttr("xlink:href")}} attribute. Some attributes allow both _IRIs_ and text strings as content. To disambiguate a text string from a relative IRI, the functional notation \<FuncIRI> is used. This is an _IRI_ delimited with a functional notation. Note: For historical reasons, the delimiters are "`url(`" and "`)`", for compatibility with the CSS specifications. The _FuncIRI_ form is used in presentation attributes .
+    _IRIs_ are used in the {{SVGAttr("href")}} attribute.
+    Some attributes allow both _IRIs_ and text strings as content. To disambiguate a text string from a relative IRI, the functional notation \<FuncIRI> is used. This is an _IRI_ delimited with a functional notation. Note: For historical reasons, the delimiters are "`url(`" and "`)`", for compatibility with the CSS specifications. The _FuncIRI_ form is used in presentation attributes .
 
     SVG makes extensive use of _IRI_ references, both absolute and relative, to other objects. For example, to fill a rectangle with a linear gradient, you first define a {{SVGElement("linearGradient")}} element and give it an ID, as in:
 

--- a/files/en-us/web/svg/element/cursor/index.md
+++ b/files/en-us/web/svg/element/cursor/index.md
@@ -31,7 +31,7 @@ The PNG format is recommended because it supports the ability to define a transp
 
 - {{SVGAttr("x")}} {{Deprecated_Inline}}
 - {{SVGAttr("y")}} {{Deprecated_Inline}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/fecomposite/index.md
+++ b/files/en-us/web/svg/element/fecomposite/index.md
@@ -159,51 +159,27 @@ This example defines filters for each of the supported operations (`over`, `atop
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <filter id="imageOver">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="over" />
     </filter>
     <filter id="imageIn">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="in" />
     </filter>
     <filter id="imageOut">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="out" />
     </filter>
     <filter id="imageAtop">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="atop" />
     </filter>
     <filter id="imageXor">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="xor" />
     </filter>
     <filter id="imageArithmetic">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite
         in2="SourceGraphic"
         operator="arithmetic"
@@ -213,11 +189,7 @@ This example defines filters for each of the supported operations (`over`, `atop
         k4="0.4" />
     </filter>
     <filter id="imageLighter">
-      <feImage
-        xlink:href="mdn_logo_only_color.png"
-        x="10px"
-        y="10px"
-        width="160px" />
+      <feImage href="mdn_logo_only_color.png" x="10px" y="10px" width="160px" />
       <feComposite in2="SourceGraphic" operator="lighter" />
     </filter>
   </defs>

--- a/files/en-us/web/svg/element/feimage/index.md
+++ b/files/en-us/web/svg/element/feimage/index.md
@@ -28,7 +28,7 @@ The **`<feImage>`** [SVG](/en-US/docs/Web/SVG) filter primitive fetches image da
 
 - {{SVGAttr("crossorigin")}}
 - {{SVGAttr("preserveAspectRatio")}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 
@@ -47,7 +47,7 @@ This element implements the {{domxref("SVGFEImageElement")}} interface.
   height="200">
   <defs>
     <filter id="image">
-      <feImage xlink:href="mdn_logo_only_color.png" />
+      <feImage href="mdn_logo_only_color.png" />
     </filter>
   </defs>
 

--- a/files/en-us/web/svg/element/fepointlight/index.md
+++ b/files/en-us/web/svg/element/fepointlight/index.md
@@ -60,7 +60,7 @@ This element implements the {{domxref("SVGFEPointLightElement")}} interface.
   </defs>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     x="10%"
     y="10%"
     width="80%"

--- a/files/en-us/web/svg/element/fespotlight/index.md
+++ b/files/en-us/web/svg/element/fespotlight/index.md
@@ -66,7 +66,7 @@ This element implements the {{domxref("SVGFESpotLightElement")}} interface.
   </defs>
 
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     x="10%"
     y="10%"
     width="80%"

--- a/files/en-us/web/svg/element/fetile/index.md
+++ b/files/en-us/web/svg/element/fetile/index.md
@@ -64,7 +64,7 @@ This element implements the {{domxref("SVGFETileElement")}} interface.
 
   <!-- Use the MDN logo as input to the filter -->
   <image
-    xlink:href="mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     x="10%"
     y="10%"
     width="80%"

--- a/files/en-us/web/svg/element/filter/index.md
+++ b/files/en-us/web/svg/element/filter/index.md
@@ -32,7 +32,7 @@ The **`<filter>`** [SVG](/en-US/docs/Web/SVG) element defines a custom filter ef
 - {{SVGAttr("filterRes")}} {{Deprecated_Inline}}
 - {{SVGAttr("filterUnits")}}
 - {{SVGAttr("primitiveUnits")}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/font-face-uri/index.md
+++ b/files/en-us/web/svg/element/font-face-uri/index.md
@@ -24,7 +24,7 @@ The **`<font-face-uri>`** [SVG](/en-US/docs/Web/SVG) element points to a remote 
 
 ### Specific attributes
 
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/glyphref/index.md
+++ b/files/en-us/web/svg/element/glyphref/index.md
@@ -33,7 +33,7 @@ The `glyphRef` element provides a single possible glyph to the referencing `<alt
 - {{SVGAttr("dy")}} {{Deprecated_Inline}}
 - {{SVGAttr("glyphRef")}} {{Deprecated_Inline}}
 - {{SVGAttr("format")}} {{Deprecated_Inline}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/element/image/index.md
+++ b/files/en-us/web/svg/element/image/index.md
@@ -38,7 +38,7 @@ SVG files displayed with `<image>` are [treated as an image](/en-US/docs/Web/SVG
 - {{SVGAttr("y")}}: Positions the image vertically from the origin.
 - {{SVGAttr("width")}}: The width the image renders at. Unlike HTML's `<img>`, this attribute is required.
 - {{SVGAttr("height")}}: The height the image renders at. Unlike HTML's `<img>`, this attribute is required.
-- {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}}: Points at a URL for the image file.
+- {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}}{{deprecated_inline}}: Points at a URL for the image file.
 - {{SVGAttr("preserveAspectRatio")}}: Controls how the image is scaled.
 - {{SVGAttr("crossorigin")}}: Defines the value of the credentials flag for CORS requests.
 - {{SVGAttr("decoding")}}: Provides a hint to the browser as to whether it should perform image decoding synchronously or asynchronously.

--- a/files/en-us/web/svg/element/lineargradient/index.md
+++ b/files/en-us/web/svg/element/lineargradient/index.md
@@ -58,8 +58,8 @@ svg {
 - {{SVGAttr("x2")}}
   - : This attribute defines the x coordinate of the ending point of the vector gradient along which the linear gradient is drawn.
     _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `100%`; _Animatable_: **yes**
-- {{SVGAttr("xlink:href")}}
-  - : {{Deprecated_Header}}An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<linearGradient>` element that will be used as a template.
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
+  - : An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<linearGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("y1")}}
   - : This attribute defines the y coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
@@ -79,7 +79,7 @@ svg {
 - [Presentation Attributes](/en-US/docs/Web/SVG/Attribute/Presentation)
   - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
 - XLink Attributes
-  - : {{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:title")}}
+  - : {{SVGAttr("xlink:href")}} {{deprecated_inline}}, {{SVGAttr("xlink:title")}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/element/metadata/index.md
+++ b/files/en-us/web/svg/element/metadata/index.md
@@ -98,23 +98,23 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
         <!-- five groups each using the defined socket -->
         <g id="sock1et" transform="translate(25 20)">
           <title>Socket 1</title>
-          <use xlink:href="#hubPlug" />
+          <use href="#hubPlug" />
         </g>
         <g id="socket2" transform="translate(70 20)">
           <title>Socket 2</title>
-          <use xlink:href="#hubPlug" />
+          <use href="#hubPlug" />
         </g>
         <g id="socket3" transform="translate(115 20)">
           <title>Socket 3</title>
-          <use xlink:href="#hubPlug" />
+          <use href="#hubPlug" />
         </g>
         <g id="socket4" transform="translate(160 20)">
           <title>Socket 4</title>
-          <use xlink:href="#hubPlug" />
+          <use href="#hubPlug" />
         </g>
         <g id="socket5" transform="translate(205 20)">
           <title>Socket 5</title>
-          <use xlink:href="#hubPlug" />
+          <use href="#hubPlug" />
         </g>
       </g>
     </symbol>
@@ -157,19 +157,19 @@ This element implements the {{domxref("SVGMetadataElement")}} interface.
   <!-- Use the hub symbol. -->
   <g id="Hub" transform="translate(80 45)">
     <title>Hub</title>
-    <use xlink:href="#hub" transform="scale(0.75)" />
+    <use href="#hub" transform="scale(0.75)" />
   </g>
 
   <!-- Use the computer symbol. -->
   <g id="ComputerA" transform="translate(20 170)">
     <title>Computer A</title>
-    <use xlink:href="#computer" transform="scale(0.5)" />
+    <use href="#computer" transform="scale(0.5)" />
   </g>
 
   <!-- Use the same computer symbol. -->
   <g id="ComputerB" transform="translate(300 170)">
     <title>Computer B</title>
-    <use xlink:href="#computer" transform="scale(0.5)" />
+    <use href="#computer" transform="scale(0.5)" />
   </g>
 
   <!-- Draw Cable A. -->

--- a/files/en-us/web/svg/element/radialgradient/index.md
+++ b/files/en-us/web/svg/element/radialgradient/index.md
@@ -72,8 +72,8 @@ svg {
 - {{SVGAttr("spreadMethod")}}
   - : This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.
     _Value type_: `pad`|`reflect`|`repeat` ; _Default value_: `pad`; _Animatable_: **yes**
-- {{SVGAttr("xlink:href")}}
-  - : {{Deprecated_Header}}An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
+  - : An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
 
 ### Global attributes
@@ -87,7 +87,7 @@ svg {
 - [Presentation Attributes](/en-US/docs/Web/SVG/Attribute/Presentation)
   - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
 - XLink Attributes
-  - : {{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:title")}}
+  - : {{SVGAttr("xlink:href")}} {{deprecated_inline}}, {{SVGAttr("xlink:title")}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/element/tref/index.md
+++ b/files/en-us/web/svg/element/tref/index.md
@@ -29,7 +29,7 @@ The textual content for a {{SVGElement("text")}} [SVG](/en-US/docs/Web/SVG) elem
 
 ### Specific attributes
 
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface
 
@@ -52,7 +52,7 @@ This element implements the {{domxref("SVGTRefElement")}} interface.
   </text>
 
   <text x="100" y="200" font-size="45" fill="red" >
-    <tref xlink:href="#ReferencedText"/>
+    <tref href="#ReferencedText"/>
   </text>
 
   <!-- Show outline of canvas using 'rect' element -->

--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -67,7 +67,7 @@ svg {
 - ARIA Attributes
   - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
 - XLink Attributes
-  - : {{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:title")}}
+  - : {{SVGAttr("xlink:href")}} {{deprecated_inline}}, {{SVGAttr("xlink:title")}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/linking/index.md
+++ b/files/en-us/web/svg/linking/index.md
@@ -24,7 +24,7 @@ button.svg:
 ```xml
 <?xml version="1.1" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg">
-  <a xlink:href="page2.html" target="_top">
+  <a href="page2.html" target="_top">
     <g>
       <!-- button graphical elements here -->
     </g>

--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -62,7 +62,7 @@ By default, parameters don't have a namespace at all. They are only known to be 
 <svg
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <script xlink:href="cool-script.js" type="text/ecmascript" />
+  <script href="cool-script.js" type="text/ecmascript" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -77,7 +77,7 @@ The `<linearGradient>` element also takes several other attributes, which specif
 <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"></linearGradient>
 ```
 
-> **Note:** You can also use the `xlink:href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
+> **Note:** You can also use the `href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
 >
 > ```html
 > <linearGradient id="Gradient1">
@@ -92,7 +92,7 @@ The `<linearGradient>` element also takes several other attributes, which specif
 >   y1="0"
 >   y2="1"
 >   xmlns:xlink="http://www.w3.org/1999/xlink"
->   xlink:href="#Gradient1" />
+>   href="#Gradient1" />
 > ```
 >
 > I've included the xlink namespace here directly on the node, although usually you would define it at the top of your document. More on that when we [talk about images](/en-US/docs/Web/SVG/Tutorial/Other_content_in_SVG).

--- a/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
+++ b/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
@@ -29,7 +29,7 @@ The embedded picture becomes a normal SVG element. This means, that you can use 
     width="128"
     height="146"
     transform="rotate(45)"
-    xlink:href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image/mdn_logo_only_color.png" />
+    href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image/mdn_logo_only_color.png" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/tutorial/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorial/svg_and_css/index.md
@@ -436,17 +436,17 @@ See below how the structure then looks like.
       <path class="segment-edge" d="M0,-200 a40,40 0 0,0 -62,10" />
     </g>
     <g id="quadrant">
-      <use xlink:href="#segment" />
-      <use xlink:href="#segment" transform="rotate(18)" />
-      <use xlink:href="#segment" transform="rotate(36)" />
-      <use xlink:href="#segment" transform="rotate(54)" />
-      <use xlink:href="#segment" transform="rotate(72)" />
+      <use href="#segment" />
+      <use href="#segment" transform="rotate(18)" />
+      <use href="#segment" transform="rotate(36)" />
+      <use href="#segment" transform="rotate(54)" />
+      <use href="#segment" transform="rotate(72)" />
     </g>
     <g id="petals">
-      <use xlink:href="#quadrant" />
-      <use xlink:href="#quadrant" transform="rotate(90)" />
-      <use xlink:href="#quadrant" transform="rotate(180)" />
-      <use xlink:href="#quadrant" transform="rotate(270)" />
+      <use href="#quadrant" />
+      <use href="#quadrant" transform="rotate(90)" />
+      <use href="#quadrant" transform="rotate(180)" />
+      <use href="#quadrant" transform="rotate(270)" />
     </g>
     <radialGradient
       id="fade"
@@ -472,11 +472,8 @@ See below how the structure then looks like.
       r="200"
       stroke="none"
       fill="url(#fade)" />
-    <use id="outer-petals" xlink:href="#petals" />
-    <use
-      id="inner-petals"
-      xlink:href="#petals"
-      transform="rotate(9) scale(0.33)" />
+    <use id="outer-petals" href="#petals" />
+    <use id="inner-petals" href="#petals" transform="rotate(9) scale(0.33)" />
   </g>
 </svg>
 ```

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -105,7 +105,7 @@ The above mentioned `font-face-uri` element allows you to reference an external 
 <font>
   <font-face font-family="Super Sans">
     <font-face-src>
-      <font-face-uri xlink:href="fonts.svg#Super_Sans" />
+      <font-face-uri href="fonts.svg#Super_Sans" />
     </font-face-src>
   </font-face>
 </font>

--- a/files/en-us/web/svg/tutorial/texts/index.md
+++ b/files/en-us/web/svg/tutorial/texts/index.md
@@ -69,13 +69,13 @@ The `tspan` element has the following custom attributes:
 
 ### textPath
 
-This element fetches via its `xlink:href` attribute an arbitrary path and aligns the characters, which it encircles, along this path:
+This element fetches via its `href` attribute an arbitrary path and aligns the characters, which it encircles, along this path:
 
 ```html
 <svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
   <path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" />
   <text>
-    <textPath xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#my_path">
+    <textPath xmlns:xlink="http://www.w3.org/1999/xlink" href="#my_path">
       A curve.
     </textPath>
   </text>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28749

This is caused by browsers no longer supporting `xlink:href` (deprecated)

I thought I'd already replaces all instances of `xlink:href` deprecated with `href` but it seems not. This fixes up the remaining cases under the svg tree, and also adds the deprecated inline macro next to most uses.

