### PR TITLE
Workers - remove confusion around suspended threads

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
@@ -28,9 +28,11 @@ In the first article of this module, we saw what happens when you have a long-ru
 
 Workers give you the ability to run some tasks in a different thread, so you can start the task, then continue with other processing (such as handling user actions).
 
-But there's a price to pay for this. With multithreaded code, you never know when your thread will be suspended and the other thread will get a chance to run. So if both threads have access to the same variables, it's possible for a variable to change unexpectedly at any time, and this causes bugs that are hard to find.
+One concern from all this is that if multiple threads can have access to the same shared data, it's possible for them to change it independently and unexpectedly (with respect to each otehr).
+This can cause bugs that are hard to find.
 
-To avoid these problems on the web, your main code and your worker code never get direct access to each other's variables. Workers and the main code run in completely separate worlds, and only interact by sending each other messages. In particular, this means that workers can't access the DOM (the window, document, page elements, and so on).
+To avoid these problems on the web, your main code and your worker code never get direct access to each other's variables, and can only truly "share" data in very specific cases.
+Workers and the main code run in completely separate worlds, and only interact by sending each other messages. In particular, this means that workers can't access the DOM (the window, document, page elements, and so on).
 
 There are three different sorts of workers:
 

--- a/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
@@ -28,7 +28,7 @@ In the first article of this module, we saw what happens when you have a long-ru
 
 Workers give you the ability to run some tasks in a different thread, so you can start the task, then continue with other processing (such as handling user actions).
 
-One concern from all this is that if multiple threads can have access to the same shared data, it's possible for them to change it independently and unexpectedly (with respect to each otehr).
+One concern from all this is that if multiple threads can have access to the same shared data, it's possible for them to change it independently and unexpectedly (with respect to each other).
 This can cause bugs that are hard to find.
 
 To avoid these problems on the web, your main code and your worker code never get direct access to each other's variables, and can only truly "share" data in very specific cases.


### PR DESCRIPTION
Fixes #28719

The text was conflating thread idle time while a thread is not being executed with concurrent access to shared data. This removes that, and also separates the discussion of data and variable (variables are not generally shared: data might be in the specific case of a shared buffer). I think this still holds together.