### PR TITLE
Fix LockManager.request()

### DIFF
--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -83,7 +83,7 @@ This method may return a promise rejected with a {{domxref("DOMException")}} of 
 - `SecurityError` {{domxref("DOMException")}}
   - : If a lock manager cannot be obtained for the current environment.
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : If `names` starts with a hyphen (`-`), both options `steal` and `ifAvailable` are `true`, or if option `signal` exists and _either_ option `steal` or `ifAvailable` is `true`.
+  - : If `name` starts with a hyphen (`-`), both options `steal` and `ifAvailable` are `true`, or if option `signal` exists and _either_ option `steal` or `ifAvailable` is `true`.
 - `AbortError` {{domxref("DOMException")}}
   - : If the option `signal` exists and is aborted.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Parameter `names` doesn't exist. Changing to an existing parameter `name`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[Web Locks API](https://w3c.github.io/web-locks/#api-lock-manager-request)

> If name starts with U+002D HYPHEN-MINUS (-), then return [a promise rejected with](https://webidl.spec.whatwg.org/#a-promise-rejected-with) a "[NotSupportedError](https://webidl.spec.whatwg.org/#notsupportederror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException).

Here we can confirm that `name`, not `names`, is checked.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
