### PR TITLE
Fix Promise.prototype.then's parameter description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -31,7 +31,7 @@ then(onFulfilled, onRejected)
 
 - `onRejected` {{optional_inline}}
 
-  - : A function to asynchronously execute when this promise becomes rejected. Its return value becomes the fulfillment value of the promise returned by `catch()`. The function is called with the following arguments:
+  - : A function to asynchronously execute when this promise becomes rejected. Its return value becomes the fulfillment value of the promise returned by `then()`. The function is called with the following arguments:
 
     - `reason`
       - : The value that the promise was rejected with.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

It seems like that the description of `onRejected`, which is the second parameter of `Promise.prototype.then`, was copied from the `Promise.prototype.catch` page.
However, the original author forgot to replace `catch` in the description with `then`.
This PR fixes this minor issue.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was confused when reading the page because of wrong description. Other readers might suffer the same.