### PR TITLE
Update index.md - Incorrect variable name in comment

### DIFF
--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -111,7 +111,7 @@ console.log(typeof undeclaredVariable); // "undefined"
 ```js-nolint example-bad
 {
   let foo;
-  let foo; // SyntaxError: Identifier 'a' has already been declared
+  let foo; // SyntaxError: Identifier 'foo' has already been declared
 }
 ```
 


### PR DESCRIPTION
In example of re-declaring variable, foo is declared twice but comment of error message is "'a' has already been declared"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct incorrect variable name in comment of error message in example

### Motivation

Improved accuracy and reduced confusion about results of code

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
