### PR TITLE
`EncodedAudioChunk` and `EncodedVideoChunk` should be invoked with the `new` operator.

### DIFF
--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -46,7 +46,7 @@ const init = {
   timestamp: 23000000,
   duration: 2000000,
 };
-chunk = EncodedAudioChunk(init);
+chunk = new EncodedAudioChunk(init);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -44,7 +44,7 @@ const init = {
   timestamp: 23000000,
   duration: 2000000,
 };
-chunk = EncodedVideoChunk(init);
+chunk = new EncodedVideoChunk(init);
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`EncodedAudioChunk` and `EncodedVideoChunk` should be invoked with the `new` operator.
![{7D92808B-C509-42f0-82E7-399AC68C3BB0}](https://github.com/mdn/content/assets/79316659/374d484f-5186-4396-935f-dfd
![{A0F3B103-F681-459b-9E43-634AF5817A2F}](https://github.com/mdn/content/assets/79316659/5bce968d-9e40-4794-9438-df79058f2cae)
03878bdb0)


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
