### PR TITLE
remove boolean glossary link

### DIFF
--- a/files/en-us/web/html/attributes/required/index.md
+++ b/files/en-us/web/html/attributes/required/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.attributes.required
 
 {{HTMLSidebar}}
 
-The [Boolean](/en-US/docs/Glossary/Boolean/HTML) **`required`** attribute, if present, indicates that the user must specify a value for the input before the owning form can be submitted.
+The **`required`** attribute, if present, indicates that the user must specify a value for the input before the owning form can be submitted.
 
 The `required` attribute is supported by `{{HTMLElement("input/text","text")}}`, `{{HTMLElement("input/search","search")}}`, `{{HTMLElement("input/url","url")}}`, `{{HTMLElement("input/tel","tel")}}`, `{{HTMLElement("input/email","email")}}`, `{{HTMLElement("input/password","password")}}`, `{{HTMLElement("input/date","date")}}`, `{{HTMLElement("input/month","month")}}`, `{{HTMLElement("input/week","week")}}`, `{{HTMLElement("input/time","time")}}`, `{{HTMLElement("input/datetime-local","datetime-local")}}`, `{{HTMLElement("input/number","number")}}`, `{{HTMLElement("input/checkbox","checkbox")}}`, `{{HTMLElement("input/radio","radio")}}`, `{{HTMLElement("input/file","file")}}`, {{HTMLElement("input")}} types along with the {{HTMLElement("select")}} and {{HTMLElement("textarea")}} form control elements. If present on any of these input types and elements, the {{cssxref(':required')}} pseudo class will match. If the attribute is not included, the {{cssxref(':optional')}} pseudo class will match.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Respecting to this #25595 

The required attribute on the input element was set to false, but the input still required a value to be submitted. Adding a link to the boolean documentation about the required attribute may be misleading, as the behavior here contradicts the expected behavior when required is false.

### Motivation

```html
<!-- Required -->
<input type="text" name="name" required />

<!-- Required -->
<input type="text" name="username" required="true" />

<!-- Required -->
<input type="text" name="id" required="" />

<!-- Not Required -->
<input type="email" name="email" />

<!-- Required -->
<input type="password" name="password" required="false" />
```

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required

