### PR TITLE
Fixes input event type

### DIFF
--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.md
@@ -26,7 +26,7 @@ onbeforeinput = (event) => {};
 
 ## Event type
 
-An {{domxref("InputEvent")}}. Inherits from {{domxref("Event")}}.
+An {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("InputEvent")}}
 

--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.md
@@ -35,11 +35,11 @@ An {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
 _This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and {{DOMxRef("Event")}}._
 
 - {{DOMxRef("InputEvent.data")}} {{ReadOnlyInline}}
-  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
+  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (for example, when deleting characters).
 - {{DOMxRef("InputEvent.dataTransfer")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DataTransfer")}} object containing information about richtext or plaintext data being added to or removed from editable content.
 - {{DOMxRef("InputEvent.inputType")}} {{ReadOnlyInline}}
-  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text. See the property page for a complete list of input types.
+  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text.
 - {{DOMxRef("InputEvent.isComposing")}} {{ReadOnlyInline}}
   - : Returns a {{JSxRef("Boolean")}} value indicating if the event is fired after {{domxref("Element/compositionstart_event", "compositionstart")}} and before {{domxref("Element/compositionend_event", "compositionend")}}.
 

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -47,7 +47,6 @@ _This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and
 - {{DOMxRef("InputEvent.isComposing")}} {{ReadOnlyInline}}
   - : Returns a {{JSxRef("Boolean")}} value indicating if the event is fired after {{domxref("Element/compositionstart_event", "compositionstart")}} and before {{domxref("Element/compositionend_event", "compositionend")}}.
 
-
 ## Examples
 
 This example logs the value whenever you change the value of the {{HtmlElement("input")}} element.

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -39,11 +39,11 @@ An {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
 _This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and {{DOMxRef("Event")}}._
 
 - {{DOMxRef("InputEvent.data")}} {{ReadOnlyInline}}
-  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
+  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (for example, when deleting characters).
 - {{DOMxRef("InputEvent.dataTransfer")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DataTransfer")}} object containing information about richtext or plaintext data being added to or removed from editable content.
 - {{DOMxRef("InputEvent.inputType")}} {{ReadOnlyInline}}
-  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text. See the property page for a complete list of input types.
+  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text.
 - {{DOMxRef("InputEvent.isComposing")}} {{ReadOnlyInline}}
   - : Returns a {{JSxRef("Boolean")}} value indicating if the event is fired after {{domxref("Element/compositionstart_event", "compositionstart")}} and before {{domxref("Element/compositionend_event", "compositionend")}}.
 

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -34,6 +34,20 @@ A {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("InputEvent")}}
 
+## Event properties
+
+_This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and {{DOMxRef("Event")}}._
+
+- {{DOMxRef("InputEvent.data")}} {{ReadOnlyInline}}
+  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
+- {{DOMxRef("InputEvent.dataTransfer")}} {{ReadOnlyInline}}
+  - : Returns a {{DOMxRef("DataTransfer")}} object containing information about richtext or plaintext data being added to or removed from editable content.
+- {{DOMxRef("InputEvent.inputType")}} {{ReadOnlyInline}}
+  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text. See the property page for a complete list of input types.
+- {{DOMxRef("InputEvent.isComposing")}} {{ReadOnlyInline}}
+  - : Returns a {{JSxRef("Boolean")}} value indicating if the event is fired after {{domxref("Element/compositionstart_event", "compositionstart")}} and before {{domxref("Element/compositionend_event", "compositionend")}}.
+
+
 ## Examples
 
 This example logs the value whenever you change the value of the {{HtmlElement("input")}} element.

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -30,7 +30,7 @@ oninput = (event) => {};
 
 ## Event type
 
-A {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
+An {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("InputEvent")}}
 

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -30,7 +30,9 @@ oninput = (event) => {};
 
 ## Event type
 
-A generic {{domxref("Event")}}.
+A {{domxref("InputEvent")}}. Inherits from {{domxref("UIEvent")}}.
+
+{{InheritanceDiagram("InputEvent")}}
 
 ## Examples
 

--- a/files/en-us/web/api/inputevent/index.md
+++ b/files/en-us/web/api/inputevent/index.md
@@ -21,11 +21,11 @@ The **`InputEvent`** interface represents an event notifying the user of editabl
 _This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and {{DOMxRef("Event")}}._
 
 - {{DOMxRef("InputEvent.data")}} {{ReadOnlyInline}}
-  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
+  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (for example, when deleting characters).
 - {{DOMxRef("InputEvent.dataTransfer")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DataTransfer")}} object containing information about richtext or plaintext data being added to or removed from editable content.
 - {{DOMxRef("InputEvent.inputType")}} {{ReadOnlyInline}}
-  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text. See the property page for a complete list of input types.
+  - : Returns the type of change for editable content such as, for example, inserting, deleting, or formatting text.
 - {{DOMxRef("InputEvent.isComposing")}} {{ReadOnlyInline}}
   - : Returns a {{JSxRef("Boolean")}} value indicating if the event is fired after {{domxref("Element/compositionstart_event", "compositionstart")}} and before {{domxref("Element/compositionend_event", "compositionend")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes `input` event type to `InputEvent` (instead of generic `Event`) to match the [specs from the end of the page](https://w3c.github.io/uievents/#event-type-input)

Along the way I changed typo in `beforeinput` event.

